### PR TITLE
Corrects for Windows path differences during JAWS execution

### DIFF
--- a/lib/commands/dash.js
+++ b/lib/commands/dash.js
@@ -166,7 +166,7 @@ CMD.prototype._prepareResources = Promise.method(function() {
             };
 
             // Create path
-            var paths = jsonPaths[i].split('/');
+            var paths = jsonPaths[i].split(path.sep);
             paths = paths[paths.length - 3] + '/' + paths[paths.length - 2];
             module.lambda.path = chalk.grey(paths);
           }
@@ -182,7 +182,7 @@ CMD.prototype._prepareResources = Promise.method(function() {
             };
 
             // Create path
-            var paths = jsonPaths[i].split('/');
+            var paths = jsonPaths[i].split(path.sep);
             paths = paths[paths.length - 3] + '/' + paths[paths.length - 2];
             module.endpoint.path = chalk.grey(paths);
           }

--- a/lib/commands/deploy_lambda.js
+++ b/lib/commands/deploy_lambda.js
@@ -495,7 +495,11 @@ Packager.prototype._createDistFolder = Promise.method(function() {
               prefix.replace(_this._distDir, ''), name);
 
           return _this._excludePatterns.some(function(sRegex) {
-            relPath = (relPath.charAt(0) == path.sep) ? relPath.substr(1) : relPath;
+            // nb: will fail if absolute Windows paths are used for exclusion
+            //     which should never happen.
+            relPath = path.isAbsolute(relPath)
+                    ? relPath.substr(1)
+                    : relPath;
 
             var re = new RegExp(sRegex),
                 matches = re.exec(relPath);
@@ -706,7 +710,7 @@ Packager.prototype._generateIncludePaths = function() {
               if (file.toLowerCase().indexOf(ignore[i]) > -1) return;
             }
 
-            var filePath = [fullPath, file].join('/');
+            var filePath = path.join(fullPath, file);
             if (fs.lstatSync(filePath).isFile()) {
               var pathInZip = path.join('node_modules', dirname, file);
               utils.jawsDebug('Adding', pathInZip);

--- a/lib/commands/module_create.js
+++ b/lib/commands/module_create.js
@@ -177,7 +177,7 @@ CMD.prototype._createPackageMgrSkeleton = function() {
           actionTemplateJson.apiGateway.cloudFormation.Method = 'GET';
           actionTemplateJson.apiGateway.cloudFormation.Type = 'AWS';
           actionTemplateJson.lambda.cloudFormation.Runtime = 'nodejs';
-          actionTemplateJson.lambda.cloudFormation.Handler = path.join(
+          actionTemplateJson.lambda.cloudFormation.Handler = path.posix.join(
               'aws_modules',
               _this._module.name,
               _this._module.action,
@@ -279,7 +279,7 @@ CMD.prototype._createSkeleton = Promise.method(function() {
 
         // Edit awsm.json
         actionTemplateJson.lambda.cloudFormation.Runtime = 'nodejs';
-        actionTemplateJson.lambda.cloudFormation.Handler = path.join(
+        actionTemplateJson.lambda.cloudFormation.Handler = path.posix.join(
             'aws_modules',
             _this._module.name,
             _this._module.action,


### PR DESCRIPTION
Fixes #217: jaws CLI w.r.t. differences in POSIX/Windows path separators. All paths for local usage use `path.*`. All paths for AWS usage use `path.posix.*`. One notable difference is in `deploy_lambda.js` which has an absolute path check that fails because `path.sep` is `'\\'` on Windows (in this case the test is switched to `path.isAbsolute`).