### PR TITLE
usage: clean up and improve the legibility of the default usage prompt

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -211,23 +211,23 @@ program
     .command('env <cmd> <stage> <region> [key] [val]')
     .description('Manage env vars for stage & region. <region> can be "all" <stage> can be "local"'+
 
-'\n\n\t '+chalk.white('list:')+' vars for stage and region. '+
-'\n\t\t Syntax: '+chalk.white('$ jaws env list <stage> <region>')+
-'\n\t\t Example: '+chalk.white('$ jaws env list prod all')+
+      '\n\n\t '+chalk.white('list:')+' vars for stage and region. '+
+      '\n\t\t Syntax: '+chalk.white('$ jaws env list <stage> <region>')+
+      '\n\t\t Example: '+chalk.white('$ jaws env list prod all')+
 
-'\n\n\t '+chalk.white('get:')+' var value for stage and region. '+
-'\n\t\t Syntax '+chalk.white('$ jaws env get <stage> <region> <key>')+
-'\n\t\t Example: '+chalk.white('$ jaws env get prod all JAWS_STAGE')+
+      '\n\n\t '+chalk.white('get:')+' var value for stage and region. '+
+      '\n\t\t Syntax '+chalk.white('$ jaws env get <stage> <region> <key>')+
+      '\n\t\t Example: '+chalk.white('$ jaws env get prod all JAWS_STAGE')+
 
-'\n\n\t '+chalk.white('set:')+' var value for stage and region. '+
-'\n\t\t Syntax: '+ chalk.white('$ jaws set env <stage> <region> <key> <val> ')+
-'\n\t\t Example: '+chalk.white('jaws env set prod us-east-1 TABLE_NAME users')+
+      '\n\n\t '+chalk.white('set:')+' var value for stage and region. '+
+      '\n\t\t Syntax: '+ chalk.white('$ jaws set env <stage> <region> <key> <val> ')+
+      '\n\t\t Example: '+chalk.white('jaws env set prod us-east-1 TABLE_NAME users')+
 
-'\n\n\t '+chalk.white('unset:')+' var value for stage and region. '+
-'\n\t\t Syntax: '+chalk.white('jaws env unset <stage> <region> <key> ')+
-'\n\t\t Example: ' +chalk.white('$ jaws unset prod us-east-1 TABLE_NAME')+
+      '\n\n\t '+chalk.white('unset:')+' var value for stage and region. '+
+      '\n\t\t Syntax: '+chalk.white('jaws env unset <stage> <region> <key> ')+
+      '\n\t\t Example: ' +chalk.white('$ jaws unset prod us-east-1 TABLE_NAME')+
 
-'\n\n'
+      '\n\n'
     )
     .action(function(cmd, stage, region, key, val) {
       let JawsEnv = require('../lib/commands/JawsEnv'),

--- a/bin/jaws
+++ b/bin/jaws
@@ -22,6 +22,30 @@ program
     .option('-v, --verbose')
     .version(JAWS._meta.version);
 
+/*
+ * Run
+ */
+
+program
+    .command('run')
+    .description('Run the lambda in CWD locally')
+    .action(function() {
+      let runner = require('../lib/commands/run');
+      execute(runner.run(JAWS));
+    });
+
+/*
+ * Dash
+ */
+
+program
+    .command('dash')
+    .description('View a project summary and select resources to deploy')
+    .action(function() {
+      let CmdDash = require('../lib/commands/dash');
+      execute(CmdDash.run(JAWS));
+    });
+
 /**
  * Project
  * - Create a new JAWS Project
@@ -125,30 +149,6 @@ program
           console.error('Something went very wrong. :O');
           process.exit(1);
       }
-    });
-
-/*
- * Dash
- */
-
-program
-    .command('dash')
-    .description('View a project summary and select resources to deploy')
-    .action(function() {
-      let CmdDash = require('../lib/commands/dash');
-      execute(CmdDash.run(JAWS));
-    });
-
-/*
- * Run
- */
-
-program
-    .command('run')
-    .description('Run the lambda in CWD locally')
-    .action(function() {
-      let runner = require('../lib/commands/run');
-      execute(runner.run(JAWS));
     });
 
 /* Module

--- a/bin/jaws
+++ b/bin/jaws
@@ -8,6 +8,7 @@ var JawsError = require('../lib/jaws-error'),
     program = require('commander'),
     utils = require('../lib/utils'),
     Promise = require('bluebird'),
+    chalk = require('chalk'),
     rawDebug = require('debug'),
     execute = utils.execute;
 
@@ -28,8 +29,8 @@ program
 
 program
     .command('project <cmd>')
-    .description(`Work with JAWS Project. Valid <cmd>'s: create`)
-    .option('-d, --dont-exe-cf', `Don't execute CloudFormation, just generate it`)
+    .description('Work with JAWS Project. Valid <cmd>\'s: create')
+    .option('-d, --dont-exe-cf', 'Don\'t execute CloudFormation, just generate it')
     .option('-s, --stage <name>', 'Name for the stage to create')
     .option('-r, --region <name>', 'Name of AWS region to use')
     .option('-u, --domain <name>', 'domain ex: myapp.com')
@@ -67,8 +68,8 @@ program
 
 program
     .command('region <cmd>')
-    .description(`Work with AWS Regions. Valid <cmd>'s: create`)
-    .option('-d, --dont-exe-cf', `Don't execute CloudFormation, just generate it`)
+    .description('Work with AWS Regions. Valid <cmd>\'s: create')
+    .option('-d, --dont-exe-cf', 'Don\'t execute CloudFormation, just generate it')
     .option('-s, --stage <name>', 'Name for the stage to be created in the region')
     .option('-r, --region <name>', 'Name of AWS region to use')
     .option('-p, --aws-profile <profileName>', 'Admin AWS profile as defined in ~/.aws/credentials to use')
@@ -100,8 +101,8 @@ program
 
 program
     .command('stage <cmd>')
-    .description(`Work with JAWS stages in a region. Valid <cmd>'s: create`)
-    .option('-d, --dont-exe-cf', `Don't execute CloudFormation, just generate it`)
+    .description('Work with JAWS stages in a region. Valid <cmd>\'s: create')
+    .option('-d, --dont-exe-cf', 'Don\'t execute CloudFormation, just generate it')
     .option('-s, --stage <name>', 'Name for the stage create')
     .option('-r, --region <name>', 'Name of aws region to use')
     .option('-p, --aws-profile <profileName>', 'Admin AWS profile as defined in ~/.aws/credentials to use')
@@ -126,6 +127,22 @@ program
       }
     });
 
+/*
+ * Dash
+ */
+
+program
+    .command('dash')
+    .description('View a project summary and select resources to deploy')
+    .action(function() {
+      let CmdDash = require('../lib/commands/dash');
+      execute(CmdDash.run(JAWS));
+    });
+
+/*
+ * Run
+ */
+
 program
     .command('run')
     .description('Run the lambda in CWD locally')
@@ -134,12 +151,16 @@ program
       execute(runner.run(JAWS));
     });
 
+/* Module
+ * - Manage AWS Modules
+ */
+
 program
     .command('module <cmd> [params]')
-    .description(`aws-module commands\n\nValid <cmd>'s: create
-
-create: create aws-module action. Module will be created if DNE. create <module resource> <action>
-\t Ex: jaws module create users list`
+    .description('Manage AWS Modules:'+
+      '\n\n\t'+chalk.white('create')+': Will create aws-module if it does not exist.'+
+      '\n\t\t Syntax: '+chalk.white('$ jaws create <module resource> <action>')+
+      '\n\t\t Example: '+chalk.white('$ jaws module create users list')+'\n'
     )
     .option('-l, --lambda', '[create]: create lambda. Default is create lambda and endpoint.')
     .option('-e, --endpoint', '[create]: create API Gateway endpoint. Default is create lambda and endpoint.')
@@ -176,83 +197,8 @@ create: create aws-module action. Module will be created if DNE. create <module 
 
         execute(theCmd.run(JAWS, name, action, runtime, pkgMgr, modType));
       } else {
-        console.error(`Unsupported cmd ${cmd}. Must be install|update|create`);
+        console.error('Unsupported cmd ${cmd}. Must be install|update|create');
         process.exit(1);
-      }
-    });
-
-/**
- * Tag
- * - Tag a lambda or endpoint for deployment
- */
-
-program
-    .command('tag [type]')
-    .description('Tag lambda function or api gateway resource (endpoint) for deployment ' +
-        'the next time deploy command is run. Type "lambda" is the default.')
-    .option('-u, --untag', 'un-tag lambda|endpoint')
-    .option('-a, --tag-all', 'tag all lambda|endpoint functions in project')
-    .option('-l, --list-all', 'list all tagged lambda|endpoint functions in project')
-    .option('-n, --untag-all', 'un-tag all lambda|endpoint functions in project')
-    .action(function(type, options) {
-      type = type || 'lambda';
-      type = type.toLowerCase();
-
-      if (-1 == ['endpoint', 'lambda'].indexOf(type)) {
-        console.error(`Unsupported type ${type}. Must be endpoint|lambda`);
-        process.exit(1);
-      }
-
-      let Tag = require('../lib/commands/Tag'),
-          CmdTag = new Tag(JAWS, type);
-
-      if (options.listAll) {
-        execute(CmdTag.listAll().then(function(relPaths) {
-          console.log(relPaths);
-        }));
-      } else if (options.tagAll || options.untagAll) {
-        let untag = (options.untagAll) ? true : false;
-        execute(CmdTag.tagAll(untag));
-      } else {
-        // If not tagging all, you have to be tagging whats in your CWD (null 1st param)
-        execute(Tag.tag(type, null, options.untag));
-      }
-    });
-
-/**
- * Deploy
- * - Deploy Lambda or Endpoint
- */
-
-program
-    .command('deploy <type> [stage] [region]')
-    .description('Deploy a lambda function (type lambda), a REST API (endpoint), or provision AWS resources (resources) for the specified stage.' +
-        ' By default will tag and deploy type at cwd')
-    .option('-t, --tags', 'Deploy all lambdas tagged as deployable in their jaws.json. Default is to just deploy cwd')
-    .option('-d, --dont-exe-cf', `Don't execute the lambda cloudformation, just generate it. Zips will be uploaded to s3`)
-    .action(function(type, stage, region, options) {
-
-      let allTagged = (options.tags) ? true : false,
-          theCmd;
-
-      type = type.toLowerCase();
-      switch (type) {
-        case 'endpoint':
-          theCmd = require('../lib/commands/DeployEndpoint');
-          execute(theCmd.run(JAWS, stage, region, allTagged));
-          break;
-        case 'lambda':
-          theCmd = require('../lib/commands/DeployLambda');
-          execute(theCmd.run(JAWS, stage, region, allTagged, options.dontExeCf));
-          break;
-        case 'resources':
-          theCmd = require('../lib/commands/DeployResources');
-          execute(theCmd.run(JAWS, stage, region));
-          break;
-        default:
-          console.error(`Unsupported type ${type}. Must be endpoint|lambda|resources`);
-          process.exit(1);
-          break;
       }
     });
 
@@ -263,22 +209,25 @@ program
 
 program
     .command('env <cmd> <stage> <region> [key] [val]')
-    .description(`Manage env vars for stage & region. <region> can be "all" <stage> can be "local"
+    .description('Manage env vars for stage & region. <region> can be "all" <stage> can be "local"'+
 
-Valid <cmd>'s:
+'\n\n\t '+chalk.white('list:')+' vars for stage and region. '+
+'\n\t\t Syntax: '+chalk.white('$ jaws env list <stage> <region>')+
+'\n\t\t Example: '+chalk.white('$ jaws env list prod all')+
 
-list: vars for stage and region. jaws env list <stage> <region>
+'\n\n\t '+chalk.white('get:')+' var value for stage and region. '+
+'\n\t\t Syntax '+chalk.white('$ jaws env get <stage> <region> <key>')+
+'\n\t\t Example: '+chalk.white('$ jaws env get prod all JAWS_STAGE')+
 
-\t Ex: jaws env list prod all
+'\n\n\t '+chalk.white('set:')+' var value for stage and region. '+
+'\n\t\t Syntax: '+ chalk.white('$ jaws set env <stage> <region> <key> <val> ')+
+'\n\t\t Example: '+chalk.white('jaws env set prod us-east-1 TABLE_NAME users')+
 
-get: var value for stage and region. jaws env get <stage> <region> <key>
-\t Ex: jaws env get prod all JAWS_STAGE
+'\n\n\t '+chalk.white('unset:')+' var value for stage and region. '+
+'\n\t\t Syntax: '+chalk.white('jaws env unset <stage> <region> <key> ')+
+'\n\t\t Example: ' +chalk.white('$ jaws unset prod us-east-1 TABLE_NAME')+
 
-set: var value for stage and region. jaws set env <stage> <region> <key> <val>
-\t Ex: jaws env set prod us-east-1 TABLE_NAME users
-
-unset: var value for stage and region. jaws env unset <stage> <region> <key>
-\t Ex: jaws unset prod us-east-1 TABLE_NAME`
+'\n\n'
     )
     .action(function(cmd, stage, region, key, val) {
       let JawsEnv = require('../lib/commands/JawsEnv'),
@@ -319,22 +268,83 @@ unset: var value for stage and region. jaws env unset <stage> <region> <key>
           execute(CmdEnv.setEnvKey(key));
           break;
         default:
-          console.error(`Unsupported cmd "${cmd}". Must be list|get|set|unset`);
+          console.error('Unsupported cmd "${cmd}". Must be list|get|set|unset');
           process.exit(1);
           break;
       }
     });
 
 /**
- * Dash
+ * Tag
+ * - Tag a lambda or endpoint for deployment
  */
 
 program
-    .command('dash')
-    .description('View a project summary and select resources to deploy.')
-    .action(function() {
-      let CmdDash = require('../lib/commands/dash');
-      execute(CmdDash.run(JAWS));
+    .command('tag [type]')
+    .description('Tag a lambda function or api gateway resource for deployment next time deploy cmd is run. [type] defaults to "lambda"')
+    .option('-u, --untag', 'un-tag lambda|endpoint')
+    .option('-a, --tag-all', 'tag all lambda|endpoint functions in project')
+    .option('-l, --list-all', 'list all tagged lambda|endpoint functions in project')
+    .option('-n, --untag-all', 'un-tag all lambda|endpoint functions in project')
+    .action(function(type, options) {
+      type = type || 'lambda';
+      type = type.toLowerCase();
+
+      if (-1 == ['endpoint', 'lambda'].indexOf(type)) {
+        console.error('Unsupported type ${type}. Must be endpoint|lambda');
+        process.exit(1);
+      }
+
+      let Tag = require('../lib/commands/Tag'),
+          CmdTag = new Tag(JAWS, type);
+
+      if (options.listAll) {
+        execute(CmdTag.listAll().then(function(relPaths) {
+          console.log(relPaths);
+        }));
+      } else if (options.tagAll || options.untagAll) {
+        let untag = (options.untagAll) ? true : false;
+        execute(CmdTag.tagAll(untag));
+      } else {
+        // If not tagging all, you have to be tagging whats in your CWD (null 1st param)
+        execute(Tag.tag(type, null, options.untag));
+      }
+    });
+
+/**
+ * Deploy
+ * - Deploy Lambda or Endpoint
+ */
+
+program
+    .command('deploy <type> [stage] [region]')
+    .description('Deploy a <lambda|endpoint|resources>. By default will tag and deploy type at cwd')
+    .option('-t, --tags', 'Deploy all lambdas tagged as deployable in their jaws.json. Default is to just deploy cwd')
+    .option('-d, --dont-exe-cf', 'Don\'t execute the lambda cloudformation, just generate it. Zips will be uploaded to s3')
+    .action(function(type, stage, region, options) {
+
+      let allTagged = (options.tags) ? true : false,
+          theCmd;
+
+      type = type.toLowerCase();
+      switch (type) {
+        case 'endpoint':
+          theCmd = require('../lib/commands/DeployEndpoint');
+          execute(theCmd.run(JAWS, stage, region, allTagged));
+          break;
+        case 'lambda':
+          theCmd = require('../lib/commands/DeployLambda');
+          execute(theCmd.run(JAWS, stage, region, allTagged, options.dontExeCf));
+          break;
+        case 'resources':
+          theCmd = require('../lib/commands/DeployResources');
+          execute(theCmd.run(JAWS, stage, region));
+          break;
+        default:
+          console.error('Unsupported type ${type}. Must be endpoint|lambda|resources');
+          process.exit(1);
+          break;
+      }
     });
 
 /**
@@ -352,6 +362,7 @@ program
 
 program
     .command('*')
+    .description('No command found')
     .action(function(cmd) {
       console.error('Unknown command:', cmd);
     });


### PR DESCRIPTION
### What is this?
I'm prosing a change to the default usage ui that I feel will make it easier for new adopters to grok the cmd hierarchy.

### Why did I do this?
My OCD has been going off the chart with the way that the usage prompt content is being laid out. I found that the content and structure was very hard to understand initially because of the word wrapping and somewhat buried structure of the sub-command information. 

I know that there are plans for a more robust dash and even some web based stuff, but I couldn't help myself but take a stab at trying to make the usage prompt a little more legible. At worst it'll help orient me with the project and make sure I'm clear on the contribution guidelines.

### What did I do?
I didn't do anything fancy smancy here, I just updated a bunch of the description strings to provide a bit more space and a little color to differentiate sub commands and examples. I find this a lot easier to grok now, but I'm open to input if someone has ideas for how this can be done better.

I also managed to clean up some hinting issues that my editor picked up. The only one I have left in this file will be resolved when we add `esnext` to `.jshintrc`. I figured I'd leave that to be done in the official `es6` branch. ***Note;*** I branched off `es6` and also staged this PR against it as well so that it won't be left behind in the switch to `es6` - so keep that in mind when reviewing. If you like this change, I'll leave it to you to decide if want to merge against that branch or wait till it lands and redo, but either way, this seemed like a starting point.

These are certainly some trivial changes, but I feel they will help with new adopters more easily grok the cmd hierarchy.

#### old usage ui
![screenshot 2015-10-12 21 50 35](https://cloud.githubusercontent.com/assets/18702/10445740/598e01d4-712b-11e5-9849-8c69a90a4ca5.png)
#### new usage ui
![screenshot 2015-10-12 22 11 09](https://cloud.githubusercontent.com/assets/18702/10445954/2b6f3c8e-712e-11e5-8a03-96b5ea2cfe4e.png)

