### PR TITLE
Added the lambda path option to the "run" command

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -128,10 +128,17 @@ program
 
 program
     .command('run')
-    .description('Run the lambda in CWD locally')
-    .action(function() {
+    .description('Run the lambda')
+    .option('-l, --lambda <path>', 'Path to the lambda')
+    .action(function(options) {
       var runner = require('../lib/commands/run');
-      execute(runner.run(JAWS));
+      var path = process.cwd();
+
+      if (options.lambda) {
+        path = options.lambda;
+      }
+
+      execute(runner.run(JAWS, path));
     });
 
 program

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -31,17 +31,18 @@ function simulateNodeJs(awsmJson, handler, event) {
 /**
  *
  * @param {Jaws} JAWS
+ * @param {String} wd
  */
 
-module.exports.run = function(JAWS) {
-  var cwd = process.cwd(),
+module.exports.run = function (JAWS, wd) {
+  var cwd = wd ? fs.realpathSync(wd) : process.cwd(),
       event = utils.readAndParseJsonSync(path.join(cwd, 'event.json')),
       awsmJson = utils.readAndParseJsonSync(path.join(cwd, 'awsm.json'));
 
   if (awsmJson.lambda.cloudFormation.Runtime == 'nodejs') {
     var handlerParts = awsmJson.lambda.cloudFormation.Handler.split('/').pop().split('.');
     return simulateNodeJs(awsmJson, require(cwd + '/' + handlerParts[0] + '.js')[handlerParts[1]], event);
-  } else {
-    throw new JawsError('To simulate you must have an index.js that exports run(event,context', JawsError.errorCodes.UNKNOWN);
   }
+
+  throw new JawsError('To simulate you must have an index.js that exports run(event,context', JawsError.errorCodes.UNKNOWN);
 };

--- a/tests/cli/run.js
+++ b/tests/cli/run.js
@@ -41,7 +41,20 @@ describe('Test "run" command', function() {
     it('Test run command', function(done) {
       this.timeout(0);
 
-      CmdRun.run(JAWS, config.stage)
+      CmdRun.run(JAWS)
+          .then(function(d) {
+            done();
+          })
+          .error(function(e) {
+            done(e);
+          });
+    });
+
+    it('Test run command with the lambda path option', function(done) {
+      this.timeout(0);
+
+      var path = projPath + '/aws_modules/sessions/show';
+      CmdRun.run(JAWS, path)
           .then(function(d) {
             done();
           })


### PR DESCRIPTION
This adds a `--lambda` option to the `run` command.

If the option is not specified, then it acts the same as before. Otherwise, it uses the given path to run the lambda from.