### PR TITLE
Fixed tests/all.js, updated wrong documentation

### DIFF
--- a/tests/all.js
+++ b/tests/all.js
@@ -28,5 +28,5 @@ describe('AllTests', function() {
    require('./cli/deploy_resources');
    require('./cli/deploy_endpoint');
    require('./cli/new_stage_region');
-   require('./cli/new_project');
+   require('./cli/project_new');
 });

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -12,11 +12,11 @@ var fs = require('fs'),
 /**
  * Create test project
  * @param projectName
- * @param projectRegion
  * @param projectStage
+ * @param projectRegion
+ * @param projectDomain
  * @param projectLambdaIAMRole
  * @param projectApiGIAMRole
- * @param projectRegionBucket
  * @param npmInstallDirs list of dirs relative to project root to execute npm install on
  * @returns {Promise} full path to proj temp dir that was just created
  */


### PR DESCRIPTION
The `npm test` script was throwing an error because of a wrong requirement.
The second fix updates the JSDoc for `tests/test_utils.js` which was not in sync with the provided parameters.
