### PR TITLE
Added proxy handling in the aws util

### DIFF
--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -11,7 +11,8 @@ var Promise = require('bluebird'),
     JawsError = require('../jaws-error/index'),
     utils = require('../utils'),
     async = require('async'),
-    fs = require('fs');
+    fs = require('fs'),
+    proxy = require('proxy-agent');
 
 Promise.promisifyAll(fs);
 
@@ -42,6 +43,18 @@ module.exports.configAWS = function(awsProfile, awsRegion) {
   AWS.config.update({
     region: awsRegion,
   });
+
+  // Set Proxy
+  var env = process.env;
+  if (env.HTTPS_PROXY) {
+    AWS.config.update({
+      httpOptions: { agent: proxy(env.HTTPS_PROXY) },
+    });
+  } else if (env.HTTP_PROXY) {
+    AWS.config.update({
+      httpOptions: { agent: proxy(env.HTTP_PROXY) },
+    });
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "node-uuid": "^1.4.2",
     "node-zip": "^1.1.0",
     "prompt": "^0.2.14",
+    "proxy-agent": "^2.0.0",
     "readdirp": "^1.4.0",
     "rimraf": "^2.4.3",
     "shelljs": "^0.5.3",


### PR DESCRIPTION
This adds proxy configurations checking the environment variables. Even if the name does not matter, I thank @sixlettervariables for the original idea.

Closes #223.