### PR TITLE
Retrieve AWS credentials from environment variables

### DIFF
--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -210,8 +210,8 @@ function ApiDeployer(JAWS, stage, region, prjRootPath, prjJson, prjCreds) {
 
   // Instantiate API Gateway Client
   this.ApiClient = new JawsAPIClient({
-    accessKeyId: prjCreds.aws_access_key_id,
-    secretAccessKey: prjCreds.aws_secret_access_key,
+    accessKeyId: prjCreds.accessKeyId,
+    secretAccessKey: prjCreds.secretAccessKey,
     region: region.region,
   });
 }

--- a/lib/commands/project_new.js
+++ b/lib/commands/project_new.js
@@ -72,6 +72,7 @@ function CMD(name, stage, region, domain, notificationEmail, profile, noCf, runt
   this._stage = stage ? stage.toLowerCase().replace(/\W+/g, '').substring(0, 15) : null;
   this._notificationEmail = notificationEmail;
   this._region = region;
+  this._configureProfile = true;
   this._profile = profile;
   this._runtime = runtime;
   this._noCf = noCf;
@@ -214,37 +215,6 @@ CMD.prototype._prompt = Promise.method(function() {
     },
   };
 
-  // Prompt: API Keys - Create an AWS profile by entering API keys
-  if (!utils.fileExistsSync(path.join(AWSUtils.getConfigDir(), 'credentials'))) {
-
-    _this.Prompter.override.awsAdminKeyId = _this._awsAdminKeyId;
-
-    var apiKeyDescription = 'Enter the ACCESS KEY ID for your Admin AWS IAM User: ';
-
-    _this._prompts.properties.awsAdminKeyId = {
-      description: apiKeyDescription.yellow,
-      required: true,
-      message: 'Please enter a valid access key ID',
-      conform: function(key) {
-        if (!key) return false;
-        return true;
-      },
-    };
-    _this.Prompter.override.awsAdminSecretKey = _this._awsAdminSecretKey;
-
-    var apiSecretDescription = 'Enter the SECRET ACCESS KEY for your Admin AWS IAM User: ';
-
-    _this._prompts.properties.awsAdminSecretKey = {
-      description: apiSecretDescription.yellow,
-      required: true,
-      message: 'Please enter a valid secret access key',
-      conform: function(key) {
-        if (!key) return false;
-        return true;
-      },
-    };
-  }
-
   // Show Prompts
   return _this.Prompter.getAsync(_this._prompts)
       .then(function(answers) {
@@ -252,8 +222,60 @@ CMD.prototype._prompt = Promise.method(function() {
         _this._domain = answers.domain;
         _this._stage = answers.stage.toLowerCase();
         _this._notificationEmail = answers.notificationEmail;
-        _this._awsAdminKeyId = answers.awsAdminKeyId;
-        _this._awsAdminSecretKey = answers.awsAdminSecretKey;
+
+        return JawsCLI.select('Do you want to configure a AWS profile to use?' +
+                       ' (otherwise, credentials will used from environment variables)',
+                       [{ value: true, label: 'yes', key: ''}, { value: false, label: 'no', key: ''}],
+                       false)
+                .then(function(results) {
+                    _this._configureProfile = results[0].value;
+                });
+      })
+    .then(function() {
+      if (_this._configureProfile) {
+          var apiKeyPrompts = []
+
+          // Prompt: API Keys - Create an AWS profile by entering API keys
+          if (!utils.fileExistsSync(path.join(AWSUtils.getConfigDir(), 'credentials'))) {
+
+            _this.Prompter.override.awsAdminKeyId = _this._awsAdminKeyId;
+
+            var apiKeyDescription = 'Enter the ACCESS KEY ID for your Admin AWS IAM User: ';
+
+            apiKeyPrompts.awsAdminKeyId = {
+              description: apiKeyDescription.yellow,
+              required: true,
+              message: 'Please enter a valid access key ID',
+              conform: function(key) {
+                if (!key) return false;
+                return true;
+              },
+            };
+            _this.Prompter.override.awsAdminSecretKey = _this._awsAdminSecretKey;
+
+            var apiSecretDescription = 'Enter the SECRET ACCESS KEY for your Admin AWS IAM User: ';
+
+            apiKeyPrompts.properties.awsAdminSecretKey = {
+              description: apiSecretDescription.yellow,
+              required: true,
+              message: 'Please enter a valid secret access key',
+              conform: function(key) {
+                if (!key) return false;
+                return true;
+              },
+            };
+          }
+
+          return _this.Prompter.getAsync(apiKeyPrompts)
+                  .then(function(answers) {
+                      _this._awsAdminKeyId = answers.awsAdminKeyId;
+                      _this._awsAdminSecretKey = answers.awsAdminSecretKey;
+                  });
+      }
+
+      return Promise.resolve()
+    })
+    .then(function() {
 
         // If region exists, skip select prompt
         if (_this._region) return;
@@ -280,6 +302,9 @@ CMD.prototype._prompt = Promise.method(function() {
 
         // If aws credentials were passed, skip select prompt
         if (_this._awsAdminKeyId && _this._awsAdminSecretKey) return Promise.resolve();
+
+        // If no profile should be configured, skip select prompt
+        if (!_this._configureProfile) return Promise.resolve();
 
         // Prompt: profile select
         var profilesList = AWSUtils.profilesMap(),
@@ -336,7 +361,7 @@ CMD.prototype._prepareProjectData = Promise.method(function() {
   _this._jawsBucket = utils.generateJawsBucketName(_this._stage, _this._region, _this._domain);
 
   // Validate: If no profile, ensure access keys, create profile
-  if (!_this._profile) {
+  if (_this.configureProfile && !_this._profile) {
 
     if (!_this._awsAdminKeyId) {
       throw new JawsError(
@@ -369,7 +394,7 @@ CMD.prototype._createProjectDirectory = Promise.method(function() {
   _this._projectRootPath = path.resolve(path.join(path.dirname('.'), _this._name));
 
   // Prepare admin.env
-  var adminEnv = 'ADMIN_AWS_PROFILE=' + _this._profile + os.EOL;
+  var adminEnv = _this._configureProfile ? 'ADMIN_AWS_PROFILE=' + _this._profile + os.EOL : '';
 
   // Prepare README.md
   var readme = '#' + _this._name;

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ function Jaws() {
       path: path.join(_this._meta.projectRootPath, 'admin.env'),
     });
     _this._meta.profile = process.env.ADMIN_AWS_PROFILE;
-    _this._meta.credentials = AWSUtils.profilesGet(_this._meta.profile)[_this._meta.profile];
+    _this._meta.credentials = AWSUtils.getCredentials(_this._meta.profile)
   }
 }
 

--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -29,19 +29,32 @@ exports.validLambdaRegions = [
  * @param awsRegion
  */
 module.exports.configAWS = function(awsProfile, awsRegion) {
-
-  // Check Profile Exists
-  this.profilesGet(awsProfile);
-
-  // Set Credentials
-  AWS.config.credentials = new AWS.SharedIniFileCredentials({
-    profile: awsProfile,
-  });
+  AWS.config.credentials = this.getCredentials(awsProfile)
 
   // Set Region
   AWS.config.update({
     region: awsRegion,
   });
+};
+
+/**
+ * Retrieve AWS credentials either from a given profile
+ * or from the AWS_* environment variables
+ *
+ * @param awsProfile
+ * @returns {AWS.Credentials}
+ */
+module.exports.getCredentials = function(awsProfile) {
+  if (awsProfile != undefined && awsProfile != "") {
+    // Check Profile Exists
+    this.profilesGet(awsProfile);
+
+    return new AWS.SharedIniFileCredentials({
+      profile: awsProfile,
+    });
+  }
+
+  return new AWS.EnvironmentCredentials('AWS');
 };
 
 /**


### PR DESCRIPTION
This PR introduces two changes:

* Projects can be configured without an AWS profile
* If no AWS profile is configured, JAWS will try to pull AWS credentials from the environment variables
  * `AWS_ACCESS_KEY_ID`
  * `AWS_SECRET_ACCESS_KEY`
  * `AWS_SESSION_TOKEN`

The reason why I'd really love to see this feature in JAWS is that 

1. I don't use the `~/.aws/credentials` file for managing my AWS credentials (but [awsenv](https://github.com/Luzifer/awsenv) instead)
2. This allows the execution of JAWS in a CI environment like Travis or CircleCI where credentials are passed as environment variables.

If you guys like this feature, I'd be happy to write some documentation for it.