### PR TITLE
Add http method support to `module create`

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -144,6 +144,7 @@ program
     .option('-e, --endpoint', '[create]: create API Gateway endpoint. Default is create lambda and endpoint.')
     .option('-r, --runtime', '[create]: lambda runtime. Valid: nodejs')
     .option('-p, --package-manager <pm>', '[create]: Select package manager used when creating awsm for publishing. Valid options: npm')
+    .option('-m, --method <method>', '[create]: API Gateway HTTP method. E.g. GET, POST, PUT, etc.')
     .action(function(cmd, params, options) {
 
       var theParams = process.argv.slice(3);
@@ -165,7 +166,8 @@ program
             action = theParams[2],
             runtime = options.runtime || 'nodejs',
             pkgMgr = options.packageManager || false,
-            modType = 'both';
+            modType = 'both',
+            httpMethod = options.method || 'GET';
 
         if (options.lambda) {
           modType = 'lambda';
@@ -173,7 +175,7 @@ program
           modType = 'endpoint';
         }
 
-        execute(theCmd.run(JAWS, name, action, runtime, pkgMgr, modType));
+        execute(theCmd.run(JAWS, name, action, runtime, pkgMgr, modType, httpMethod));
       } else {
         console.error('Unsupported cmd ' + cmd + '. Must be install|update|create');
         process.exit(1);

--- a/bin/jaws
+++ b/bin/jaws
@@ -145,7 +145,7 @@ program
     .option('-r, --runtime', '[create]: lambda runtime. Valid: nodejs')
     .option('-p, --package-manager <pm>',
             '[create]: Select package manager used when creating awsm for publishing. Valid options: npm')
-    .option('-m, --method <method>', '[create]: API Gateway HTTP method. E.g. GET, POST, PUT, etc.')
+    .option('-m, --method <method>', '[create]: API Gateway HTTP method. E.g. GET, POST, PUT, etc. Default is GET.')
     .action(function(cmd, params, options) {
 
       var theParams = process.argv.slice(3);

--- a/bin/jaws
+++ b/bin/jaws
@@ -143,7 +143,8 @@ program
     .option('-l, --lambda', '[create]: create lambda. Default is create lambda and endpoint.')
     .option('-e, --endpoint', '[create]: create API Gateway endpoint. Default is create lambda and endpoint.')
     .option('-r, --runtime', '[create]: lambda runtime. Valid: nodejs')
-    .option('-p, --package-manager <pm>', '[create]: Select package manager used when creating awsm for publishing. Valid options: npm')
+    .option('-p, --package-manager <pm>',
+            '[create]: Select package manager used when creating awsm for publishing. Valid options: npm')
     .option('-m, --method <method>', '[create]: API Gateway HTTP method. E.g. GET, POST, PUT, etc.')
     .action(function(cmd, params, options) {
 
@@ -152,6 +153,7 @@ program
       if (!theParams) {
         throw new JawsError('Missing params', JawsError.errorCodes.UNKNOWN);
       }
+
       if (theParams[0][0] == '-') { //TODO: how do we get around this commander shortcoming?
         throw new JawsError('Specify options after cmd', JawsError.errorCodes.UNKNOWN);
       }
@@ -225,10 +227,11 @@ program
 
 program
     .command('deploy <type> [stage] [region]')
-    .description('Deploy a lambda function (type lambda), a REST API (endpoint), or provision AWS resources (resources) for the specified stage.' +
-        ' By default will tag and deploy type at cwd')
+    .description('Deploy a lambda function (type lambda), a REST API (endpoint), or provision AWS resources ' +
+        '(resources) for the specified stage. By default will tag and deploy type at cwd')
     .option('-t, --tags', 'Deploy all lambdas tagged as deployable in their jaws.json. Default is to just deploy cwd')
-    .option('-d, --dont-exe-cf', 'Don\'t execute the lambda cloudformation, just generate it. Zips will be uploaded to s3')
+    .option('-d, --dont-exe-cf',
+            'Don\'t execute the lambda cloudformation, just generate it. Zips will be uploaded to s3')
     .action(function(type, stage, region, options) {
 
       type = type.toLowerCase();
@@ -346,7 +349,7 @@ program
 
 program
     .command('*')
-    .action(function(cmd){
+    .action(function(cmd) {
       console.error('Unknown command:', cmd);
     });
 

--- a/lib/commands/module_create.js
+++ b/lib/commands/module_create.js
@@ -15,8 +15,8 @@ var JawsError = require('../jaws-error'),
 var supportedRuntimes = {
   nodejs: {
     defaultPkgMgr: 'npm',
-    validPkgMgrs: ['npm']
-  }
+    validPkgMgrs: ['npm'],
+  },
 };
 
 Promise.promisifyAll(fs);
@@ -59,9 +59,10 @@ function CMD(JAWS, name, action, runtime, pkgMgr, modType, httpMethod) {
   }
 
   httpMethod = httpMethod.toUpperCase();
-  var supportedHttpMethods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"];
+  var supportedHttpMethods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'];
   if (supportedHttpMethods.indexOf(httpMethod) === -1) {
-    throw new JawsError('Unsupported method "' + httpMethod + '". Must be one of ' + supportedHttpMethods.join(', ') + '.', JawsError.errorCodes.UNKNOWN);
+    throw new JawsError('Unsupported method "' + httpMethod + '". Must be one of ' + supportedHttpMethods.join(', ') +
+                        '.', JawsError.errorCodes.UNKNOWN);
   }
 
   var _this = this,
@@ -205,6 +206,7 @@ CMD.prototype._createPackageMgrSkeleton = function() {
           );
         }
       }
+
       break;
     default:
       break;
@@ -303,7 +305,8 @@ CMD.prototype._createSkeleton = Promise.method(function() {
         );
         break;
       default:
-        throw new JawsError('This runtime is not supported "' + _this._module.runtime + '"', JawsError.errorCodes.UNKNOWN);
+        throw new JawsError('This runtime is not supported "' + _this._module.runtime +
+                            '"', JawsError.errorCodes.UNKNOWN);
         break;
     }
   }
@@ -318,6 +321,7 @@ CMD.prototype._createSkeleton = Promise.method(function() {
   }
 
   // Write Files
-  writeFilesDeferred.push(utils.writeFile(path.join(actionPath, 'awsm.json'), JSON.stringify(actionTemplateJson, null, 2)));
+  writeFilesDeferred.push(utils.writeFile(path.join(actionPath, 'awsm.json'),
+                          JSON.stringify(actionTemplateJson, null, 2)));
   return Promise.all(writeFilesDeferred);
 });

--- a/lib/commands/module_create.js
+++ b/lib/commands/module_create.js
@@ -31,8 +31,8 @@ Promise.promisifyAll(fs);
  * @param moduleType 'lambda','endpoint','both'
  * @returns {*}
  */
-module.exports.run = function(JAWS, name, action, runtime, pkgMgr, moduleType) {
-  var command = new CMD(JAWS, name, action, runtime, pkgMgr, moduleType);
+module.exports.run = function(JAWS, name, action, runtime, pkgMgr, moduleType, httpMethod) {
+  var command = new CMD(JAWS, name, action, runtime, pkgMgr, moduleType, httpMethod);
   return command.run();
 };
 
@@ -46,16 +46,22 @@ module.exports.run = function(JAWS, name, action, runtime, pkgMgr, moduleType) {
  * @param modType
  * @constructor
  */
-function CMD(JAWS, name, action, runtime, pkgMgr, modType) {
+function CMD(JAWS, name, action, runtime, pkgMgr, modType, httpMethod) {
 
   if (!runtime) {
     runtime = 'nodejs';
   }
-  
+
   pkgMgr = pkgMgr || false;
 
   if (!supportedRuntimes[runtime]) {
     throw new JawsError('Unsupported runtime "' + runtime + '"', JawsError.errorCodes.UNKNOWN);
+  }
+
+  httpMethod = httpMethod.toUpperCase();
+  var supportedHttpMethods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"];
+  if (supportedHttpMethods.indexOf(httpMethod) === -1) {
+    throw new JawsError('Unsupported method "' + httpMethod + '". Must be one of ' + supportedHttpMethods.join(', ') + '.', JawsError.errorCodes.UNKNOWN);
   }
 
   var _this = this,
@@ -68,6 +74,7 @@ function CMD(JAWS, name, action, runtime, pkgMgr, modType) {
     action: action,
     pkgMgr: pkgMgr,
     modType: modType,
+    httpMethod: httpMethod,
   };
   this._prompts = {
     properties: {},
@@ -174,7 +181,7 @@ CMD.prototype._createPackageMgrSkeleton = function() {
 
           // Create action awsm.json
           actionTemplateJson.apiGateway.cloudFormation.Path = _this._module.name + '/' + _this._module.action;
-          actionTemplateJson.apiGateway.cloudFormation.Method = 'GET';
+          actionTemplateJson.apiGateway.cloudFormation.Method = _this._module.httpMethod;
           actionTemplateJson.apiGateway.cloudFormation.Type = 'AWS';
           actionTemplateJson.lambda.cloudFormation.Runtime = 'nodejs';
           actionTemplateJson.lambda.cloudFormation.Handler = path.join(
@@ -269,7 +276,7 @@ CMD.prototype._createSkeleton = Promise.method(function() {
 
   // Create action awsm.json
   actionTemplateJson.apiGateway.cloudFormation.Path = _this._module.name + '/' + _this._module.action;
-  actionTemplateJson.apiGateway.cloudFormation.Method = 'GET';
+  actionTemplateJson.apiGateway.cloudFormation.Method = _this._module.httpMethod;
   actionTemplateJson.apiGateway.cloudFormation.Type = 'AWS';
 
   if (['lambda', 'both'].indexOf(_this._module.modType) != -1) {

--- a/lib/commands/module_create.js
+++ b/lib/commands/module_create.js
@@ -18,6 +18,7 @@ var supportedRuntimes = {
     validPkgMgrs: ['npm'],
   },
 };
+var supportedHttpMethods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'];
 
 Promise.promisifyAll(fs);
 
@@ -59,7 +60,6 @@ function CMD(JAWS, name, action, runtime, pkgMgr, modType, httpMethod) {
   }
 
   httpMethod = httpMethod.toUpperCase();
-  var supportedHttpMethods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'];
   if (supportedHttpMethods.indexOf(httpMethod) === -1) {
     throw new JawsError('Unsupported method "' + httpMethod + '". Must be one of ' + supportedHttpMethods.join(', ') +
                         '.', JawsError.errorCodes.UNKNOWN);

--- a/tests/all.js
+++ b/tests/all.js
@@ -28,5 +28,5 @@ describe('AllTests', function() {
    require('./cli/deploy_resources');
    require('./cli/deploy_endpoint');
    require('./cli/new_stage_region');
-   require('./cli/new_project');
+   require('./cli/project_new');
 });

--- a/tests/cli/module_create.js
+++ b/tests/cli/module_create.js
@@ -16,7 +16,7 @@ var config = require('../config'),
     projPath,
     JAWS;
 
-describe('Test "new module" command', function() {
+describe.only('Test "new module" command', function() {
 
   before(function(done) {
     this.timeout(0);
@@ -46,14 +46,16 @@ describe('Test "new module" command', function() {
         action: 'list',
         runtime: 'nodejs',
         pkgMgr: false,
+        httpMethod: 'POST',
       };
 
-      CmdNewAction.run(JAWS, module.name, module.action, module.runtime, module.pkgMgr, module.type)
+      CmdNewAction.run(JAWS, module.name, module.action, module.runtime, module.pkgMgr, module.type, module.httpMethod)
           .then(function() {
             var jawsJson = require(path.join(process.cwd(), 'aws_modules/users/list/awsm.json'));
             assert.isTrue(typeof jawsJson.lambda.cloudFormation !== 'undefined');
             assert.isTrue(typeof jawsJson.apiGateway.cloudFormation !== 'undefined');
             assert.isTrue(jawsJson.apiGateway.cloudFormation.Path === 'users/list');
+            assert.isTrue(jawsJson.apiGateway.cloudFormation.Method === 'POST');
             done();
           })
           .catch(JawsError, function(e) {

--- a/tests/cli/module_create.js
+++ b/tests/cli/module_create.js
@@ -16,7 +16,7 @@ var config = require('../config'),
     projPath,
     JAWS;
 
-describe.only('Test "new module" command', function() {
+describe('Test "new module" command', function() {
 
   before(function(done) {
     this.timeout(0);


### PR DESCRIPTION
Before this change, the API Gateway HTTP method was hardcoded to 'GET'. This change
plumbs through support for an HTTP method parameter to be passed on the `module create`
command.

Example usage:
    `$ jaws module create users list --method POST`

The provided HTTP method is validated against the list of methods currently supported by API Gateway.

Meant to address #242 

I also made a pass through the jscs errors in the files that I changed to make them match the spec, so it may be helpful to view individual commits. Please let me know if there is something that I missed.