### PR TITLE
Add RequestModel JSON Schema validation to handler.js

### DIFF
--- a/lib/templates/action.awsm.json
+++ b/lib/templates/action.awsm.json
@@ -41,8 +41,11 @@
             "application/json": ""
           }
         },
-        "400": {
+        "Request Validation Failed": {
           "statusCode": "400"
+        },
+        "404": {
+          "statusCode": "404"
         }
       }
     }

--- a/lib/templates/nodejs/handler.js
+++ b/lib/templates/nodejs/handler.js
@@ -10,9 +10,21 @@ require('jaws-core-js/env');
 
 // Modularized Code
 var action = require('./index.js');
+var validate = require('jsonschema').validate;
+var RequestModel = require('./awsm.json').apiGateway.cloudFormation.RequestModel || {};
 
 // Lambda Handler
 module.exports.handler = function(event, context) {
+  var validation = validate( event, RequestModel );
+
+  if( validation.errors.length ){
+    console.log('Event does not match RequestModel');
+    console.log('Event:', JSON.stringify(event, null, '  '));
+    console.log('Model:', JSON.stringify( RequestModel, null, '  '));
+    console.log('Validation:', JSON.stringify( validation, null, '  '));
+    return context.done('400');
+  }
+
   action.run(event, context, function(error, result) {
     return context.done(error, result);
   });

--- a/lib/templates/nodejs/handler.js
+++ b/lib/templates/nodejs/handler.js
@@ -22,7 +22,7 @@ module.exports.handler = function(event, context) {
     console.log('Event:', JSON.stringify(event, null, '  '));
     console.log('Model:', JSON.stringify( RequestModel, null, '  '));
     console.log('Validation:', JSON.stringify( validation, null, '  '));
-    return context.done('400');
+    return context.done('Request Validation Failed');
   }
 
   action.run(event, context, function(error, result) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "download": "^4.2.0",
     "insert-module-globals": "^6.5.2",
     "jaws-api-gateway-client": "0.11.0",
+    "jsonschema": "^1.0.2",
     "keypress": "^0.2.1",
     "mkdirp-then": "^1.1.0",
     "moment": "^2.10.6",


### PR DESCRIPTION
Though the AWS Console you can provide your API Gateway a JSON Schema model.  Unfortunately AWS doesn't use this model for any validation (its only used to help generate an SDK)

Until Amazon adds this functionality, this pull request allows JAWS to validate your API requests.  Invalid requests will return a '400' status response.

An example of the an AWSM.json file with a RequestModel


```
{
  "lambda": {
    "envVars": [],
    "deploy": true,
    "package": {},
    "cloudFormation": {
      "Description": "",
      "Handler": "aws_modules/test/endpoint/handler.handler",
      "MemorySize": 1024,
      "Runtime": "nodejs",
      "Timeout": 6
    }
  },
  "apiGateway": {
    "deploy": false,
    "cloudFormation": {
      "Type": "AWS",
      "Path": "test/endpoint",
      "Method": "POST",
      "AuthorizationType": "none",
      "ApiKeyRequired": false,
      "RequestTemplates": {},
      "RequestParameters": {},
      "RequestModel": {
        "title": "Example Schema",
        "type": "object",
        "properties": {
          "firstName": {
            "type": "string"
          },
          "lastName": {
            "type": "string"
          },
          "age": {
            "description": "Age in years",
            "type": "integer",
            "minimum": 0
          }
        },
        "required": [
          "firstName",
          "lastName"
        ]
      }
    }
  }
}
```
