### PR TITLE
Usage of numbers are now possible in stage name

### DIFF
--- a/lib/commands/new_stage_region.js
+++ b/lib/commands/new_stage_region.js
@@ -124,9 +124,9 @@ CMD.prototype._promptStage = Promise.method(function() {
     _this._prompts.properties.stage = {
       description: stageDescription.yellow,
       default: 'dev',
-      message: 'Stage must be letters only',
+      message: 'Stage must be letters and numbers only',
       conform: function(stage) {
-        var re = /^[a-zA-Z]+$/;
+        var re = /^[a-zA-Z0-9]+$/;
         return re.test(stage);
       },
     };


### PR DESCRIPTION
Numbers in stage names were forbidden but it's specially useful for api versioning (For example. execute-api.com/v1)

I tested this change and using numbers in stage names is not creating any problems.