### PR TITLE
First iteration on `jaws serve` to expose all lambdas on localhost

### DIFF
--- a/bin/jaws
+++ b/bin/jaws
@@ -134,6 +134,21 @@ program
       execute(runner.run(JAWS));
     });
 
+/**
+ * Serve
+ */
+
+program
+  .command('serve')
+  .description('Simulate API Gateway to serve lambdas locally')
+  .option('-i, --init <file>', 'JS file to run as custom initialization code')
+  .option('-p, --prefix <path>', 'add URL prefix to each lambda')
+  .action(function(options) {
+    var runner = require('../lib/commands/serve');
+    execute(runner.run(JAWS, options.init, options.prefix));
+  });
+
+
 program
     .command('module <cmd> [params]')
     .description('aws-module commands\n\nValid <cmd>\'s: create' +

--- a/bin/jaws
+++ b/bin/jaws
@@ -143,9 +143,10 @@ program
   .description('Simulate API Gateway to serve lambdas locally')
   .option('-i, --init <file>', 'JS file to run as custom initialization code')
   .option('-p, --prefix <path>', 'add URL prefix to each lambda')
+  .option('-P, --port <port>', 'HTTP port to use, default: 1465')
   .action(function(options) {
     var runner = require('../lib/commands/serve');
-    execute(runner.run(JAWS, options.init, options.prefix));
+    execute(runner.run(JAWS, options.init, options.prefix, options.port));
   });
 
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -71,6 +71,16 @@ module.exports.run = function(JAWS, init, prefix, port) {
             cfPath = cfPath.substr( cfPath.length - 1 );
           }
 
+          var cfPathParts = cfPath.split( '/' );
+          cfPathParts = cfPathParts.map(function(part){
+            if( part.length > 0 ) {
+              if( (part[ 0 ] == '{') && (part[ part.length - 1 ] == '}') ) {
+                return( ":" + part.substr( 1, part.length - 2 ) );
+              }
+            }
+            return( part );
+          });
+
           JawsCLI.log( "Route: " + cf.Method + " " + cfPath );
 
           var lambdaPathParts = ljp.split('/');
@@ -88,13 +98,28 @@ module.exports.run = function(JAWS, init, prefix, port) {
             throw e ;
           }
 
-          app[ cf.Method.toLocaleLowerCase() ]( cfPath, function(req, res, next){
+          app[ cf.Method.toLocaleLowerCase() ]( cfPathParts.join('/'), function(req, res, next){
             JawsCLI.log("Serving: " + cf.Method + " " + cfPath);
 
             var result = new Promise(function(resolve, reject) {
               var lambdaName = utils.generateLambdaName(awsmJson);
 
-              handler(req.body, context(lambdaName, function(err, result) {
+              var event = {};
+              var prop;
+
+              for( prop in req.body ) {
+                if( req.body.hasOwnProperty( prop ) ){
+                  event[ prop ] = req.body.prop;
+                }
+              }
+
+              for( prop in req.params ) {
+                if( req.params.hasOwnProperty( prop ) ){
+                  event[ prop ] = req.params[ prop ];
+                }
+              }
+
+              handler(event, context(lambdaName, function(err, result) {
                 if (err) {
                   JawsCLI.log(err);
                   return reject(err);

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -81,7 +81,7 @@ module.exports.run = function(JAWS, init, prefix, port) {
             return( part );
           });
 
-          JawsCLI.log( "Route: " + cf.Method + " " + cfPath );
+          //JawsCLI.log( "Route: " + cf.Method + " " + cfPath );
 
           var lambdaPathParts = ljp.split('/');
           lambdaPathParts.pop();

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -91,12 +91,6 @@ module.exports.run = function(JAWS, init, prefix, port) {
           var handlerParts = awsmJson.lambda.cloudFormation.Handler.split('/').pop().split('.');
           var handler;
           var handlerPath = lambdaPath + '/' + handlerParts[0] + '.js';
-          try {
-            handler = require( handlerPath )[handlerParts[1]];
-          } catch( e ) {
-            JawsCLI.log( "Unable to load " + handlerPath + ": " + e );
-            throw e ;
-          }
 
           app[ cf.Method.toLocaleLowerCase() ]( cfPathParts.join('/'), function(req, res, next){
             JawsCLI.log("Serving: " + cf.Method + " " + cfPath);
@@ -119,6 +113,14 @@ module.exports.run = function(JAWS, init, prefix, port) {
                 }
               }
 
+              if( !handler ) {
+                try {
+                  handler = require( handlerPath )[handlerParts[1]];
+                } catch( e ) {
+                  JawsCLI.log( "Unable to load " + handlerPath + ": " + e );
+                  throw e ;
+                }
+              }
               handler(event, context(lambdaName, function(err, result) {
                 if (err) {
                   JawsCLI.log(err);

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -109,7 +109,7 @@ module.exports.run = function(JAWS, init, prefix, port) {
 
               for( prop in req.body ) {
                 if( req.body.hasOwnProperty( prop ) ){
-                  event[ prop ] = req.body.prop;
+                  event[ prop ] = req.body[ prop ];
                 }
               }
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -45,8 +45,9 @@ module.exports.run = function(JAWS, init, prefix, port) {
       server.close();
     });
 
-    server = app.listen( port, function(){
-      JawsCLI.log( "Jaws API Gateway simulator listening on http://localhost:" + port );
+    app.use( function(req, res, next) {
+      res.header('Access-Control-Allow-Origin', '*');
+      next();
     });
 
     utils.findAllLambdas(rootPath).then(function(lambdaPaths){
@@ -63,7 +64,7 @@ module.exports.run = function(JAWS, init, prefix, port) {
           }
 
           // In worst case we have two slashes at the end (one from prefix, one from "/" lambda mount point)
-          while( (cfPath.length > 0) && (cfPath[ cfPath.length - 1] == '/') ){
+          while( (cfPath.length > 1) && (cfPath[ cfPath.length - 1 ] == '/') ){
             cfPath = cfPath.substr( cfPath.length - 1 );
           }
 
@@ -103,6 +104,24 @@ module.exports.run = function(JAWS, init, prefix, port) {
         }
       });
 
+      app.use( function(req, res, next){
+        res.header( 'Access-Control-Allow-Methods', 'GET,PUT,HEAD,POST,DELETE,OPTIONS' );
+        res.header( 'Access-Control-Allow-Headers', 'Authorization,Content-Type,x-amz-date,x-amz-security-token' );
+
+        if( req.method != 'OPTIONS' ) {
+          next()
+        } else {
+          res.status(200).end()
+        }
+      });
+
+      server = app.listen( port, function(){
+        JawsCLI.log( "Jaws API Gateway simulator listening on http://localhost:" + port );
+      });
+
+    })
+    .catch(function(err){
+      JawsCLI.log("FAIL:", err);
     });
 
   }) );

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -79,7 +79,14 @@ module.exports.run = function(JAWS, init, prefix, port) {
           var lambdaPath = lambdaPathParts.join('/');
 
           var handlerParts = awsmJson.lambda.cloudFormation.Handler.split('/').pop().split('.');
-          var handler = require(lambdaPath + '/' + handlerParts[0] + '.js')[handlerParts[1]];
+          var handler;
+          var handlerPath = lambdaPath + '/' + handlerParts[0] + '.js';
+          try {
+            handler = require( handlerPath )[handlerParts[1]];
+          } catch( e ) {
+            JawsCLI.log( "Unable to load " + handlerPath + ": " + e );
+            throw e ;
+          }
 
           app[ cf.Method.toLocaleLowerCase() ]( cfPath, function(req, res, next){
             JawsCLI.log("Serving: " + cf.Method + " " + cfPath);

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * JAWS Command: serve
+ */
+
+var JawsCLI = require('../utils/cli');
+var Promise = require('bluebird');
+var utils = require('../utils');
+var path = require('path');
+var context = require('../utils/context');
+var express = require('express');
+
+/**
+ *
+ * @param {Jaws} JAWS
+ */
+
+module.exports.run = function(JAWS, init, prefix) {
+  var app = express();
+  var port = 1465;
+  var server;
+  var rootPath = path.join(JAWS._meta.projectRootPath, 'aws_modules');
+
+  if( !prefix ){
+    prefix = "";
+  }
+
+  if( (prefix.length > 0) && (prefix[prefix.length-1] != '/') ) {
+    prefix = prefix + "/";
+  }
+
+  return( Promise.try(function(){
+    if( init ){
+      var handler = require(init);
+      return( handler( JAWS, app ) );
+    }
+  }).then(function(){
+    app.get( '/__quit', function(req, res, next){
+      JawsCLI.log('Quit request received, quitting.');
+      res.send({ok: true});
+      server.close();
+    });
+
+    server = app.listen( port, function(){
+      JawsCLI.log( "Jaws API Gateway simulator listening on " +  port );
+    });
+
+    utils.findAllLambdas(rootPath).then(function(lambdaPaths){
+      lambdaPaths.forEach(function(ljp) {
+        var awsmJson = require(ljp);
+
+        if( awsmJson.lambda.cloudFormation.Runtime == 'nodejs' ) {
+          var cf = awsmJson.apiGateway.cloudFormation;
+
+          var cfPath = prefix + cf.Path;
+
+          if( cfPath[ 0 ] != '/' ) {
+            cfPath = "/" + cfPath;
+          }
+
+          // In worst case we have two slashes at the end (one from prefix, one from "/" lambda mount point)
+          while( (cfPath.length > 0) && (cfPath[ cfPath.length - 1] == '/') ){
+            cfPath = cfPath.substr( cfPath.length - 1 );
+          }
+
+          JawsCLI.log( "Route: " + cf.Method + " " + cfPath );
+
+          var lambdaPathParts = ljp.split('/');
+          lambdaPathParts.pop();
+
+          var lambdaPath = lambdaPathParts.join('/');
+
+          var handlerParts = awsmJson.lambda.cloudFormation.Handler.split('/').pop().split('.');
+          var handler = require(lambdaPath + '/' + handlerParts[0] + '.js')[handlerParts[1]];
+
+          app[ cf.Method.toLocaleLowerCase() ]( cfPath, function(req, res, next){
+            JawsCLI.log("Serving: " + cf.Method + " " + cfPath);
+
+            var result = new Promise(function(resolve, reject) {
+              var lambdaName = utils.generateLambdaName(awsmJson);
+
+              var event = {};
+              handler(event, context(lambdaName, function(err, result) {
+                if (err) {
+                  JawsCLI.log(err);
+                  return reject(err);
+                }
+                resolve(result);
+              }));
+            });
+
+            result.then(function(r){
+              res.send(r);
+            }, function(err){
+              JawsCLI.log(err);
+              res.status(500).send(err);
+            });
+          } );
+        }
+      });
+
+    });
+
+  }) );
+};

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -10,6 +10,7 @@ var utils = require('../utils');
 var path = require('path');
 var context = require('../utils/context');
 var express = require('express');
+var bodyParser = require('body-parser');
 
 /**
  *
@@ -50,6 +51,8 @@ module.exports.run = function(JAWS, init, prefix, port) {
       next();
     });
 
+    app.use(bodyParser.json());
+
     utils.findAllLambdas(rootPath).then(function(lambdaPaths){
       lambdaPaths.forEach(function(ljp) {
         var awsmJson = require(ljp);
@@ -84,8 +87,7 @@ module.exports.run = function(JAWS, init, prefix, port) {
             var result = new Promise(function(resolve, reject) {
               var lambdaName = utils.generateLambdaName(awsmJson);
 
-              var event = {};
-              handler(event, context(lambdaName, function(err, result) {
+              handler(req.body, context(lambdaName, function(err, result) {
                 if (err) {
                   JawsCLI.log(err);
                   return reject(err);

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -16,11 +16,14 @@ var express = require('express');
  * @param {Jaws} JAWS
  */
 
-module.exports.run = function(JAWS, init, prefix) {
+module.exports.run = function(JAWS, init, prefix, port) {
   var app = express();
-  var port = 1465;
   var server;
   var rootPath = path.join(JAWS._meta.projectRootPath, 'aws_modules');
+
+  if( !port ){
+    port = 1465;
+  }
 
   if( !prefix ){
     prefix = "";
@@ -43,7 +46,7 @@ module.exports.run = function(JAWS, init, prefix) {
     });
 
     server = app.listen( port, function(){
-      JawsCLI.log( "Jaws API Gateway simulator listening on " +  port );
+      JawsCLI.log( "Jaws API Gateway simulator listening on http://localhost:" + port );
     });
 
     utils.findAllLambdas(rootPath).then(function(lambdaPaths){

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "debug": "^2.2.0",
     "dotenv": "^1.2.0",
     "download": "^4.2.0",
+    "express": "^4.13.3",
     "insert-module-globals": "^6.5.2",
     "jaws-api-gateway-client": "0.11.0",
     "keypress": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "aws-sdk": "^2.2.4",
     "babelify": "^6.3.0",
     "bluebird": "^2.9.34",
+    "body-parser": "^1.14.1",
     "browserify": "^11.0.1",
     "chalk": "^1.1.0",
     "cli-spinner": "^0.2.1",


### PR DESCRIPTION
This is basically a simplistic API Gateway simulator. It exposes all lambdas via local http endpoint, allowing for faster local development of applications.
