### PR TITLE
Addresses #279 configurable gateway credentials.

### DIFF
--- a/lib/ServerlessEndpoint.js
+++ b/lib/ServerlessEndpoint.js
@@ -34,6 +34,7 @@ class ServerlessEndpoint {
     _this.method               = _this._config.sPath.split('~')[1].toUpperCase();
     _this.type                 = _this._config.type || 'AWS';
     _this.authorizationType    = 'none';
+    _this.credentials          = null;
     _this.apiKeyRequired       = false;
     _this.requestParameters    = {};
     _this.requestTemplates     = {};

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -563,6 +563,8 @@ module.exports = function(SPlugin, serverlessPath) {
         type:                   _this.endpoint.type, /* required */
         cacheKeyParameters:     _this.endpoint.cacheKeyParameters || [],
         cacheNamespace:         _this.endpoint.cacheNamespace     || null,
+        // Due to a bug in API Gateway reported here: https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41
+        // Specifying credentials within API Gateway may cause extra latency (~500ms); Use at your own risk for now.
         credentials:            _this.endpoint.credentials || null,
         integrationHttpMethod:  'POST',
         requestParameters:      _this.endpoint.requestParameters || {},

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -563,12 +563,7 @@ module.exports = function(SPlugin, serverlessPath) {
         type:                   _this.endpoint.type, /* required */
         cacheKeyParameters:     _this.endpoint.cacheKeyParameters || [],
         cacheNamespace:         _this.endpoint.cacheNamespace     || null,
-        // Due to a bug in API Gateway reported here: https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41
-        // Specifying credentials within API Gateway causes extra latency (~500ms)
-        // Until API Gateway is fixed, we need to make a separate call to Lambda to add credentials to API Gateway
-        // Once API Gateway is fixed, we can use this in credentials:
-        // _this._regionJson.iamRoleArnApiGateway
-        credentials:            null,
+        credentials:            _this.endpoint.credentials || null,
         integrationHttpMethod:  'POST',
         requestParameters:      _this.endpoint.requestParameters || {},
         requestTemplates:       _this._prepareRequestTemplates(_this.endpoint.requestTemplates),


### PR DESCRIPTION
The changes address issue #279 by making apig endpoint credentials optionally configurable in s-function.json

Due to the resolution of https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41 which was referenced in a comment, it seems the project is ready for this?