### PR TITLE
"minify" value in awsm.json respected now

### DIFF
--- a/lib/commands/deploy_lambda.js
+++ b/lib/commands/deploy_lambda.js
@@ -655,7 +655,7 @@ Packager.prototype._browserifyBundle = Promise.method(function() {
         fs.writeFileSync(bundledFilePath, bundledBuf);
         JawsCLI.log('Lambda Deployer:  Bundled file written to ' + bundledFilePath);
 
-        if (_this._awsmJson.lambda.package.optimize.exclude) {
+        if (_this._awsmJson.lambda.package.optimize.minify) {
           var result = UglifyJS.minify(bundledFilePath, uglyOptions);
 
           if (!result || !result.code) {
@@ -667,7 +667,7 @@ Packager.prototype._browserifyBundle = Promise.method(function() {
           JawsCLI.log('Lambda Deployer:  Minified file written to ' + minifiedFilePath);
           resolve(result.code);
         } else {
-          resolve(bundledBuf);
+          resolve(bundledBuf.toString());
         }
       }
     });


### PR DESCRIPTION
Updates deploy_lambda.js to correctly skip minification if minify is set
to false in the awsm.json