### PR TITLE
Fixed endpoint deploy support for paths like `/foo/bar/foo`

### DIFF
--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -496,31 +496,26 @@ ApiDeployer.prototype._createEndpointResources = Promise.method(function(endpoin
   /**
    * Private Function to find resource
    * @param resource
+   * @param index
    * @param parent
    * @returns {*}
    */
 
-  var findEndpointResource = function(resource, parent) {
-
+  var findEndpointResource = function(resource, index, parent) {
+    var resourcePath = '/';
     // Replace slashes in resource
-    resource = resource.replace(/\//g, '');
-    var index = eResources.indexOf(resource);
 
     if (parent)  {
       index = index - 1;
-      resource = eResources[index];
     }
 
-    if (index < 0) {
-      resourcePath = '/';
-    } else {
-      var resourceIndex = endpoint.apiGateway.cloudFormation.Path.indexOf(resource);
-      var resourcePath = '/' + endpoint.apiGateway.cloudFormation.Path.substring(0, resourceIndex + resource.length);
+    if (index >= 0) {
+      var ancestors = eResources.slice( 0, index + 1 );
+      resourcePath = '/' + ancestors.join("/");
     }
 
     // If resource has already been created, skip it
     for (var i = 0; i < _this._resources.length; i++) {
-
       // Check if path matches, in case there are duplicate resources (users/list, org/list)
       if (_this._resources[i].path === resourcePath) {
         return _this._resources[i];
@@ -535,17 +530,17 @@ ApiDeployer.prototype._createEndpointResources = Promise.method(function(endpoin
 
     return eResources;
 
-  }).each(function(eResource) {
+  }).each(function(eResource, index) {
 
     // Remove slashes in resource
     eResource = eResource.replace(/\//g, '');
 
     // If resource exists, skip it
-    var resource = findEndpointResource(eResource);
+    var resource = findEndpointResource(eResource, index);
     if (resource) return resource;
 
     // Get Parent Resource
-    endpoint.apiGateway.apig.parentResourceId = findEndpointResource(eResource, true).id;
+    endpoint.apiGateway.apig.parentResourceId = findEndpointResource(eResource, index, true).id;
 
     // Create Resource
     return _this.ApiClient.createResource(
@@ -568,8 +563,9 @@ ApiDeployer.prototype._createEndpointResources = Promise.method(function(endpoin
   }).then(function() {
 
     // Attach the last resource to endpoint for later use
-    var endpointResource = endpoint.apiGateway.cloudFormation.Path.split('/').pop().replace(/\//g, '');
-    endpoint.apiGateway.apig.resource = findEndpointResource(endpointResource);
+    var index = eResources.length - 1;
+    var endpointResource = eResources[ index ];
+    endpoint.apiGateway.apig.resource = findEndpointResource(endpointResource, index);
     return endpoint;
   });
 });


### PR DESCRIPTION
I've got endpoint path like `/payments/bill/pay` and it resulted in a problems on Jaws side, as it used to `.indexOf( 'pay' )` and was finding wrong occurence of the string. I rewrote the endpoint deploy to not use `.indexOf` at all but base on indexes, which I guess is much more reliable now.