### PR TITLE
Support for tokens

### DIFF
--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -212,7 +212,8 @@ function ApiDeployer(JAWS, stage, region, prjRootPath, prjJson, prjCreds) {
   this.ApiClient = new JawsAPIClient({
     accessKeyId: prjCreds.aws_access_key_id,
     secretAccessKey: prjCreds.aws_secret_access_key,
-    region: region.region,
+    sessionToken : prjCreds.aws_session_token,
+    region: region.region
   });
 }
 


### PR DESCRIPTION
Allows usage of temporary tokes in API Gateway client. Depends on PR https://github.com/jaws-stack/jaws-api-gateway-client/pull/4