### PR TITLE
Deploy endpoint promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Once you become familiar with JAWS, you can read about [JAWS AWSM: Amazon Web Se
 ## Events
 
 * **9/24 - San Francisco, CA** @ the [Advanced AWS Meetup](http://www.meetup.com/AdvancedAWS/)
-* **10/7 - Las Vegas, NV** A Breakout Session @ the [AWS Re:invent Conference](https://www.portal.reinvent.awsevents.com/connect/search.ww#loadSearch-searchPhrase=jaws&searchType=session&tc=0&sortBy=abbreviationSort&p=)
+* **10/7 - Las Vegas, NV** A Breakout Session @ the AWS re:Invent Conference [watch video here](https://www.youtube.com/watch?v=D_U6luQ6I90&feature=youtu.be)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 JAWS V1 (BETA)
 =================================
 
-**Daily Status Reports are available in the Road Map at the link below.  Also, miss our breakout session @ RE:INVENT 2015?[watch it here](https://www.youtube.com/watch?v=D_U6luQ6I90&feature=youtu.be)**
+**Daily Status Reports are available in the Road Map at the link below.  Also, miss our breakout session @ RE:INVENT 2015? [Watch it here](https://www.youtube.com/watch?v=D_U6luQ6I90&feature=youtu.be)**
 
 JAWS is a 100% free and open-source framework for building serverless applications (web, mobile, IoT) using Amazon Web Services' Lambda, API Gateway, and more.  Lambda's event-driven model offers tremendous cost savings and colossal horizontal scaling ability.  Now, JAWS helps you build and maintain entire event-driven/serverless applications using Lambda.
 

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Once you become familiar with JAWS, you can read about [JAWS AWSM: Amazon Web Se
 ## Events
 
 * **9/24 - San Francisco, CA** @ the [Advanced AWS Meetup](http://www.meetup.com/AdvancedAWS/)
-* **10/7 - Las Vegas, NV** A Breakout Session @ the AWS re:Invent Conference [watch video here](https://www.youtube.com/watch?v=D_U6luQ6I90&feature=youtu.be)
+* **10/7 - Las Vegas, NV** A Breakout Session @ the AWS re:Invent Conference. [Watch video here](https://www.youtube.com/watch?v=D_U6luQ6I90&feature=youtu.be)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 JAWS V1 (BETA)
 =================================
 
-**Daily Status Reports are available in the Road Map at the link below.  [Also, we're doing a Breakout Session @ RE:INVENT 2015](https://www.portal.reinvent.awsevents.com/connect/sessionDetail.ww?SESSION_ID=5494)**
+**Daily Status Reports are available in the Road Map at the link below.  Also, miss our breakout session @ RE:INVENT 2015?[watch it here](https://www.youtube.com/watch?v=D_U6luQ6I90&feature=youtu.be)**
 
 JAWS is a 100% free and open-source framework for building serverless applications (web, mobile, IoT) using Amazon Web Services' Lambda, API Gateway, and more.  Lambda's event-driven model offers tremendous cost savings and colossal horizontal scaling ability.  Now, JAWS helps you build and maintain entire event-driven/serverless applications using Lambda.
 

--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -607,7 +607,7 @@ ApiDeployer.prototype._createEndpointMethod = Promise.method(function(endpoint) 
             endpoint.apiGateway.apig.resource.id,
             endpoint.apiGateway.cloudFormation.Method)
             .then(function() {
-              _this.ApiClient.putMethod(
+              return _this.ApiClient.putMethod(
                   _this._restApiId,
                   endpoint.apiGateway.apig.resource.id,
                   endpoint.apiGateway.cloudFormation.Method,

--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -433,10 +433,10 @@ ApiDeployer.prototype._listApiResources = Promise.method(function() {
 
   // List all Resources for this REST API
   return _this.ApiClient.listResources(_this._restApiId)
-      .then(function(resources) {
+      .then(function(response) {
 
         // Parse API Gateway's HAL response
-        _this._resources = resources;
+        _this._resources = response._embedded.item;
         if (!Array.isArray(_this._resources)) _this._resources = [_this._resources];
 
         // Get Parent Resource ID

--- a/lib/commands/deploy_endpoint.js
+++ b/lib/commands/deploy_endpoint.js
@@ -352,7 +352,7 @@ ApiDeployer.prototype._validateAndSantizeTaggedEndpoints = Promise.method(functi
     }
 
     // Sanitize path
-    if ((e.Path.charAt(0) === '/') && (e.Path !== '/')) e.Path = e.Path.substring(1);
+    if (e.Path.charAt(0) === '/') e.Path = e.Path.substring(1);
 
     // Sanitize method
     e.Method = e.Method.toUpperCase();
@@ -433,10 +433,10 @@ ApiDeployer.prototype._listApiResources = Promise.method(function() {
 
   // List all Resources for this REST API
   return _this.ApiClient.listResources(_this._restApiId)
-      .then(function(response) {
+      .then(function(resources) {
 
         // Parse API Gateway's HAL response
-        _this._resources = response._embedded.item;
+        _this._resources = resources;
         if (!Array.isArray(_this._resources)) _this._resources = [_this._resources];
 
         // Get Parent Resource ID

--- a/lib/commands/deploy_lambda.js
+++ b/lib/commands/deploy_lambda.js
@@ -694,7 +694,7 @@ Packager.prototype._generateIncludePaths = function() {
     }
 
     if (stats.isFile()) {
-      compressPaths.push({fileName: p, data: fullPath});
+      compressPaths.push({fileName: p, data: fs.readFileSync(fullPath)});
     } else if (stats.isDirectory()) {
       var dirname = path.basename(p);
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "download": "^4.2.0",
     "express": "^4.13.3",
     "insert-module-globals": "^6.5.2",
-    "jaws-api-gateway-client": "git@github.com:Nopik/jaws-api-gateway-client.git#list-paging",
+    "jaws-api-gateway-client": "git@github.com:Nopik/jaws-api-gateway-client.git#local",
     "keypress": "^0.2.1",
     "mkdirp-then": "^1.1.0",
     "moment": "^2.10.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "download": "^4.2.0",
     "express": "^4.13.3",
     "insert-module-globals": "^6.5.2",
-    "jaws-api-gateway-client": "0.11.0",
+    "jaws-api-gateway-client": "git@github.com:Nopik/jaws-api-gateway-client.git#list-paging",
     "keypress": "^0.2.1",
     "mkdirp-then": "^1.1.0",
     "moment": "^2.10.6",

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path = require('path'),
-    AWS = require('aws-sdk');
+  AWS = require('aws-sdk');
 
 // Require ENV vars, can also set ENV vars in your IDE
 require('dotenv').config({path: path.join(__dirname, '.env'), silent: true});
@@ -10,7 +10,7 @@ process.env.JAWS_VERBOSE = true;
 
 var config = {
   name: 'test-prj',
-  domain: 'test-prj.com',
+  domain: process.env.TEST_JAWS_DOMAIN,
   notifyEmail: 'tester@jawsstack.com',
   stage: 'unittest',
   region: 'us-east-1',


### PR DESCRIPTION
Very occasionally JAWS is failing on endpoint deploy with message:

```
{ [JawsError: Invalid Method identifier specified]
  name: 'JawsError',
  message: 'Invalid Method identifier specified',
  messageId: 1 }
```
It turns out, that when it decides to re-create parent resource, it wasn't waiting for the operation to complete, so we had race condition when child resources couldn't be added to parent resource. Handling promises properly fixed the problem.