### PR TITLE
Recommend n over nvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install serverless -g
 
 ## Differences From JAWS:
 
-* **Node V4:**  The new Serverless Command Line Tool uses Node V4.  We recommend using Node Version Manager (NVM) to seamlessly upgrade your local version of Node.
+* **Node V4:**  The new Serverless Command Line Tool uses Node V4.  We recommend using [n](https://github.com/tj/n) to seamlessly upgrade your local version of Node.
 * **Name & Filename Changes:**  Having JAWS and AWSM was too confusing.  Now, we're just Serverless and Serverless modules.  Your project JSON is now `s-project.json`, your module JSON is now `s-module.json` and your function JSON is now `s-function.json`.
 * **New Function JSON Format:**  Our new function JSON format (`s-function.json`) helps reduce boilerplate.  You can still have 1 folder containing 1 Lambda w/ 1 Endpoint.  However, now you can have 1 folder containing 1 Lambda w/ multiple endpoints.  As well as 1 folder containing multiple Lambdas each with multiple endpoints.  You can point your multiple Lambdas to different handlers on a single file, or to different files within the folder.  It's flexible.
 * **One Set Of Lambdas Per Region:**  JAWS created a separate CloudFormation stack of Lambdas for each stage + region.  Serverless creates one set of Lambdas for all stages, and replicates them in every region used by your project.


### PR DESCRIPTION
Changed to recommend n vs nvm. Doesnt mess with your profiles or $PATH.  Its a much more popular module too.

http://www.mattpalmerlee.com/2013/03/23/installing-and-switching-between-multiple-versions-of-node-js-n-vs-nvm/