### PR TITLE
Pass through aws_session_token to allow temporary security credentials

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -26,15 +26,16 @@ class Serverless {
     config = config ? config : {};
 
     // Add Defaults
-    this._interactive       = (config.interactive !== undefined) ? config.interactive : (process.stdout.isTTY && !process.env.CI);
-    this._awsAdminKeyId     = config.awsAdminKeyId;
-    this._awsAdminSecretKey = config.awsAdminSecretKey;
-    this._version           = require('./../package.json').version;
-    this._projectRootPath   = SUtils.findProjectRootPath(process.cwd());
-    this._projectJson       = false;
-    this.actions            = {};
-    this.hooks              = {};
-    this.commands           = {};
+    this._interactive          = (config.interactive !== undefined) ? config.interactive : (process.stdout.isTTY && !process.env.CI);
+    this._awsAdminKeyId        = config.awsAdminKeyId;
+    this._awsAdminSecretKey    = config.awsAdminSecretKey;
+    this._awsAdminSessionToken = config.awsAdminSessionToken;
+    this._version              = require('./../package.json').version;
+    this._projectRootPath      = SUtils.findProjectRootPath(process.cwd());
+    this._projectJson          = false;
+    this.actions               = {};
+    this.hooks                 = {};
+    this.commands              = {};
 
     // If within project, add further queued data
     if (this._projectRootPath) {
@@ -48,8 +49,9 @@ class Serverless {
       });
 
       // Set Admin API Keys
-      this._awsAdminKeyId     = process.env.SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID;
-      this._awsAdminSecretKey = process.env.SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY;
+      this._awsAdminKeyId        = process.env.SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID;
+      this._awsAdminSecretKey    = process.env.SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY;
+      this._awsAdminSessionToken = process.env.SERVERLESS_ADMIN_AWS_SESSION_TOKEN;
     }
 
     // Load Plugins: Defaults

--- a/lib/actions/CodeDeployLambdaNodeJs.js
+++ b/lib/actions/CodeDeployLambdaNodeJs.js
@@ -69,6 +69,9 @@ class Deployer {
       accessKeyId:     _this.S._awsAdminKeyId,
       secretAccessKey: _this.S._awsAdminSecretKey,
     };
+    if (_this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+    }
     _this.S3         = require('../utils/aws/S3')(awsConfig);
     _this.Lambda     = require('../utils/aws/Lambda')(awsConfig);
     _this.AwsMisc    = require('../utils/aws/Misc');

--- a/lib/actions/CodePackageLambdaNodeJs.js
+++ b/lib/actions/CodePackageLambdaNodeJs.js
@@ -71,6 +71,9 @@ class Packager {
       accessKeyId:     _this.S._awsAdminKeyId,
       secretAccessKey: _this.S._awsAdminSecretKey,
     };
+    if (_this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+    }
     _this.S3 = require('../utils/aws/S3')(awsConfig);
 
     // Flow

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -124,6 +124,9 @@ class Builder {
       accessKeyId:     _this.S._awsAdminKeyId,
       secretAccessKey: _this.S._awsAdminSecretKey,
     };
+    if (_this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+    }
 
     _this.CloudFormation = require('../utils/aws/CloudFormation')(awsConfig);
     _this.ApiGateway     = require('../utils/aws/ApiGateway')(awsConfig);

--- a/lib/actions/EndpointDeploy.js
+++ b/lib/actions/EndpointDeploy.js
@@ -297,6 +297,9 @@ class EndpointDeploy extends SPlugin {
       accessKeyId:     _this.S._awsAdminKeyId,
       secretAccessKey: _this.S._awsAdminSecretKey,
     };
+    if (_this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+    }
     let ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
 
     // Get or Create REST API for Region

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -49,6 +49,9 @@ class EndpointDeployApiGateway extends SPlugin {
       accessKeyId:     _this.S._awsAdminKeyId,
       secretAccessKey: _this.S._awsAdminSecretKey,
     };
+    if (_this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+    }
 
     _this.ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
 

--- a/lib/actions/EnvSet.js
+++ b/lib/actions/EnvSet.js
@@ -98,12 +98,12 @@ usage: serverless env set`,
     // If CLI, parse arguments
     if (_this.S.cli) {
       _this.evt = _this.S.cli.options;
-      
+
       if (_this.S.cli.options.nonInteractive) {
         _this.S._interactive = false;
       }
     }
-    
+
     return _this.S.validateProject()
       .bind(_this)
       .then(_this._promptKeyVal)
@@ -116,7 +116,7 @@ usage: serverless env set`,
         return BbPromise.resolve(_this.evt);
       });
   }
-  
+
   /**
    * Prompt key & value if they're missing
    */
@@ -125,7 +125,7 @@ usage: serverless env set`,
       overrides = {};
 
     if (!_this.S._interactive) return BbPromise.resolve();
-    
+
     ['key', 'value'].forEach(memberVarKey => {
         overrides[memberVarKey] = _this['evt'][memberVarKey];
       });
@@ -144,14 +144,14 @@ usage: serverless env set`,
         },
       }
     };
-    
+
     return _this.promptInput(prompts, overrides)
       .then(function(answers) {
         _this.evt.key = answers.key;
         _this.evt.value = answers.value;
       });
   }
-  
+
   /**
    * Prompt stage if it's missing
    */
@@ -185,7 +185,7 @@ usage: serverless env set`,
         _this.evt.stage = results[0].value;
       });
   }
-  
+
   /**
    * Prompt region if it's missing
    */
@@ -199,7 +199,7 @@ usage: serverless env set`,
     }
 
     if (!_this.S._interactive || _this.evt.region) return BbPromise.resolve();
-    
+
     // TODO: list only regions defined in the provided stage
     //       this assumes that the provided stage is valid, we'll have to validate before getting here
     let choices = awsMisc.validLambdaRegions.map(r => {
@@ -209,13 +209,13 @@ usage: serverless env set`,
         label: r,
       };
     });
-    
+
     // adding all regions
     choices.push(
       {
         key:   '',
         value: 'all',
-        label: 'all',  
+        label: 'all',
       }
     );
 
@@ -224,7 +224,7 @@ usage: serverless env set`,
         _this.evt.region = results[0].value;
       });
   }
-  
+
   /**
    * Validate all data from event, interactive CLI or non interactive CLI
    * and prepare data
@@ -244,7 +244,7 @@ usage: serverless env set`,
     if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
       return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
     }
-    
+
     // skip the next validation if stage is 'local' & region is 'all'
     if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
 
@@ -256,7 +256,7 @@ usage: serverless env set`,
       }
     }
   }
-  
+
   /**
    * set env var based on data validated
    */
@@ -282,13 +282,16 @@ usage: serverless env set`,
           if (_this.evt.stage == 'local') {
             putEnvQ.push(SUtils.writeFile(path.join(this.S._projectRootPath, '.env'), contents));
           } else {
-            
+
             let awsConfig = {
               region:          mapForRegion.regionName,
               accessKeyId:     _this.S._awsAdminKeyId,
               secretAccessKey: _this.S._awsAdminSecretKey,
             };
-            
+            if (_this.S._awsAdminSessionToken) {
+              awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+            }
+
             let S3  = require('../utils/aws/S3')(awsConfig);
             let bucket = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, mapForRegion.regionName).regionBucket;
             putEnvQ.push(S3.sPutEnvFile(bucket, _this.S._projectJson.name, _this.evt.stage, contents));

--- a/lib/actions/EnvUnset.js
+++ b/lib/actions/EnvUnset.js
@@ -92,7 +92,7 @@ usage: serverless env unset`,
     // If CLI, parse arguments
     if (_this.S.cli) {
       _this.evt = _this.S.cli.options;
-      
+
       if (_this.S.cli.options.nonInteractive) {
         _this.S._interactive = false;
       }
@@ -108,10 +108,10 @@ usage: serverless env unset`,
       .then(function() {
         SCli.log('Successfully unset env var: ' + _this.evt.key);
         return BbPromise.resolve(_this.evt);
-      });  
+      });
   }
-  
-  
+
+
   /**
    * Prompt key if it's missing
    */
@@ -120,7 +120,7 @@ usage: serverless env unset`,
     let _this = this;
 
     if (!_this.S._interactive || _this.evt.key) return BbPromise.resolve();
-    
+
     let prompts = {
       properties: {},
     };
@@ -130,13 +130,13 @@ usage: serverless env unset`,
       required:    true,
       message:     'environment variable key is required.',
     };
-    
+
     return this.promptInput(prompts, null)
       .then(function(answers) {
         _this.evt.key = answers.key;
       })
   }
-  
+
   /**
    * Prompt stage if it's missing
    */
@@ -171,7 +171,7 @@ usage: serverless env unset`,
         _this.evt.stage = results[0].value;
       });
   }
-  
+
   /**
    * Prompt region if it's missing
    */
@@ -186,7 +186,7 @@ usage: serverless env unset`,
     }
 
     if (!_this.S._interactive || _this.evt.region) return BbPromise.resolve();
-    
+
     // TODO: list only regions defined in the provided Stage
     //       this assumres that the provided stage is valid, we'll have to validate before getting here
     let choices = awsMisc.validLambdaRegions.map(r => {
@@ -196,13 +196,13 @@ usage: serverless env unset`,
         label: r,
       };
     });
-    
+
     // adding all regions
     choices.push(
       {
         key:   '',
         value: 'all',
-        label: 'all',  
+        label: 'all',
       }
     );
 
@@ -211,7 +211,7 @@ usage: serverless env unset`,
         _this.evt.region = results[0].value;
       });
   }
-  
+
   /**
    * Validate all data from event, interactive CLI or non interactive CLI
    * and prepare data
@@ -239,7 +239,7 @@ usage: serverless env unset`,
     if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
       return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
     }
-    
+
     // skip the next validation if stage is 'local' & region is 'all'
     if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
 
@@ -251,7 +251,7 @@ usage: serverless env unset`,
       }
     }
   }
-  
+
   /**
    * unset env var based on data validated
    */
@@ -277,13 +277,16 @@ usage: serverless env unset`,
           if (_this.evt.stage == 'local') {
             putEnvQ.push(utils.writeFile(path.join(_this.S._projectRootPath, '.env'), contents));
           } else {
-            
+
             let awsConfig = {
               region:          mapForRegion.regionName,
               accessKeyId:     _this.S._awsAdminKeyId,
               secretAccessKey: _this.S._awsAdminSecretKey,
             };
-            
+            if (_this.S._awsAdminSessionToken) {
+              awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+            }
+
             let S3  = require('../utils/aws/S3')(awsConfig);
             let bucket = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, mapForRegion.regionName).regionBucket;
             putEnvQ.push(S3.sPutEnvFile(bucket, _this.S._projectJson.name, _this.evt.stage, contents));

--- a/lib/actions/ProjectCreate.js
+++ b/lib/actions/ProjectCreate.js
@@ -112,12 +112,12 @@ class ProjectCreate extends SPlugin {
         _this.S._interactive = false;
       }
     }
-    
+
     // Add default runtime
     if (!_this.evt.runtime) {
       _this.evt.runtime = 'nodejs';
     }
-    
+
     // Always create "development" stage on ProjectCreate
     _this.evt.stage = 'development';
 
@@ -288,16 +288,20 @@ class ProjectCreate extends SPlugin {
 
     // If Profile, extract API Keys
     if (this.evt.profile) {
-      this.S._awsAdminKeyId     = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_access_key_id;
-      this.S._awsAdminSecretKey = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_secret_access_key;
+      this.S._awsAdminKeyId        = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_access_key_id;
+      this.S._awsAdminSecretKey    = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_secret_access_key;
+      this.S._awsAdminSessionToken = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_session_token;
     }
 
     // Initialize Other AWS Services
     let awsConfig = {
       region:          this.evt.region,
       accessKeyId:     this.S._awsAdminKeyId,
-      secretAccessKey: this.S._awsAdminSecretKey,
+      secretAccessKey: this.S._awsAdminSecretKey
     };
+    if (this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = this.S._awsAdminSessionToken;
+    }
     this.S3  = require('../utils/aws/S3')(awsConfig);
     this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
 
@@ -319,13 +323,13 @@ class ProjectCreate extends SPlugin {
     if (SUtils.dirExistsSync(path.join(process.cwd(), this.evt.name))) {
       this.evt.name = this.evt.name + '-' + SUtils.generateShortId(19);
     }
-    
+
     // validate domain
     let domainRegex = /^(?!:\/\/)([a-zA-Z0-9][a-zA-Z0-9-]+\.)?[a-zA-Z0-9][a-zA-Z0-9-]+\.[a-zA-Z]{2,15}?$/i;
     if(!domainRegex.test(this.evt.domain)) {
       return BbPromise.reject(new SError('Please enter a valid domain'));
     }
-    
+
     // Append unique id if domain is default
     if (this.evt.domain === 'myapp.com') {
       this.evt.domain = 'myapp-' + SUtils.generateShortId(8).toLowerCase() + '.com';
@@ -336,7 +340,7 @@ class ProjectCreate extends SPlugin {
     if(!emailRegex.test(this.evt.notificationEmail)) {
       return BbPromise.reject(new SError('Please enter a valid email'));
     }
-    
+
     // Validate region
     if (awsMisc.validLambdaRegions.indexOf(this.evt.region) == -1) {
       return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.region, SError.errorCodes.UNKNOWN));
@@ -346,7 +350,7 @@ class ProjectCreate extends SPlugin {
     if (!this.S._awsAdminKeyId || !this.S._awsAdminSecretKey) {
       return BbPromise.reject(new SError('Missing AWS API Key and/or AWS Secret Key'));
     }
-    
+
     // Set Serverless Regional Bucket
     this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.evt.domain);
 
@@ -365,6 +369,9 @@ class ProjectCreate extends SPlugin {
     // Prepare admin.env
     let adminEnv = 'SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID=' + _this.S._awsAdminKeyId + os.EOL
         + 'SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY=' + _this.S._awsAdminSecretKey + os.EOL;
+    if (_this.S._awsAdminSessionToken) {
+      adminEnv += 'SERVERLESS_ADMIN_AWS_SESSION_TOKEN=' + _this.S._awsAdminSessionToken + os.EOL;
+    }
 
     // Prepare README.md
     let readme = '#' + _this.evt.name;
@@ -411,7 +418,7 @@ class ProjectCreate extends SPlugin {
   _putEnvFile() {
     let envFileContents = `SERVERLESS_STAGE=${this.evt.stage}
 SERVERLESS_DATA_MODEL_STAGE=${this.evt.stage}`;
-    
+
     return this.S3.sPutEnvFile(
         this.evt.regionBucket,
         this.evt.name,

--- a/lib/actions/RegionCreate.js
+++ b/lib/actions/RegionCreate.js
@@ -91,7 +91,7 @@ usage: serverless region create`,
     // If CLI, parse arguments
     if (_this.S.cli) {
       _this.evt = _this.S.cli.options;
-      
+
       if (_this.S.cli.options.nonInteractive) {
         _this.S._interactive = false;
       }
@@ -149,7 +149,7 @@ usage: serverless region create`,
         _this.evt.stage = results[0].value;
       });
   }
-  
+
   /**
    * Prompt region if it's missing
    * @returns {Promise}
@@ -159,7 +159,7 @@ usage: serverless region create`,
     let _this = this;
 
     if (!_this.S._interactive || _this.evt.region) return BbPromise.resolve();
-    
+
     let choices = awsMisc.validLambdaRegions.map(r => {
       return {
         key:   '',
@@ -196,17 +196,17 @@ usage: serverless region create`,
         return BbPromise.reject(new SError('Missing stage or region'));
       }
     }
-    
+
     // validate stage: make sure stage exists
     if (!_this.S._projectJson.stages[_this.evt.stage]) {
       return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
     }
-    
+
     // validate region: make sure Lambda is supported in that region
     if (awsMisc.validLambdaRegions.indexOf(_this.evt.region) == -1) {
       return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + _this.evt.region, SError.errorCodes.UNKNOWN));
     }
-    
+
     // validate region: make sure region is not already defined
     if (_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
           return r.region == _this.evt.region;
@@ -214,18 +214,21 @@ usage: serverless region create`,
       return BbPromise.reject(new SError('Region "' + _this.evt.region + '" is already defined in the stage "' + _this.evt.stage + '"'));
     }
   }
-  
+
   /**
    * Initialize needed AWS classes
    */
 
   _initAWS() {
-    
+
     let awsConfig = {
       region:          this.evt.region,
       accessKeyId:     this.S._awsAdminKeyId,
       secretAccessKey: this.S._awsAdminSecretKey,
     };
+    if (this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = this.S._awsAdminSessionToken;
+    }
 
     this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
     this.Lambda  = require('../utils/aws/Lambda')(awsConfig);
@@ -280,7 +283,7 @@ SERVERLESS_DATA_MODEL_STAGE=${stage}`;
 
   _createCfStack(cfTemplateUrl) {
     let _this = this;
-    
+
     if (_this.evt.noExeCf) {
       let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.S._projectJson.name);
 
@@ -335,7 +338,7 @@ SERVERLESS_DATA_MODEL_STAGE=${stage}`;
       // Save StackName to Evt
       _this.evt.stageCfStack = cfStackData.StackName;
     }
-    
+
     _this.S._projectJson.stages[_this.evt.stage].push(regionObj);
 
     return SUtils.writeFile(

--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -3,7 +3,7 @@
 /**
  * Action: ResourcesDeploy
  * - Deploys/Updates the cloudformation/resources-cf.json template to AWS
- * 
+ *
  * Event Properties:
  * stage     (String) the name of the stage you want to deploy resources to. Must exist in project.
  * region    (String) the name of the region you want to deploy resources to. Must exist in provided stage.
@@ -81,7 +81,7 @@ usage: serverless resources deploy`,
     // If CLI, parse arguments
     if (_this.S.cli) {
       _this.evt = _this.S.cli.options;
-      
+
       if (_this.S.cli.options.nonInteractive) {
         _this.S._interactive = false;
       }
@@ -100,7 +100,7 @@ usage: serverless resources deploy`,
         return _this.evt;
       });
   }
-  
+
   /**
    * Prompt stage if it's missing
    */
@@ -132,7 +132,7 @@ usage: serverless resources deploy`,
         _this.evt.stage = results[0].value;
       });
   }
-  
+
   /**
    * Prompt region if it's missing
    */
@@ -146,7 +146,7 @@ usage: serverless resources deploy`,
     }
 
     if (!_this.S._interactive || _this.evt.region) return BbPromise.resolve();
-    
+
     // TODO: list only regions defined in the provided stage
     //       this assumes that the provided stage is valid, we'll have to validate before getting here
     let choices = awsMisc.validLambdaRegions.map(r => {
@@ -162,7 +162,7 @@ usage: serverless resources deploy`,
         _this.evt.region = results[0].value;
       });
   }
-  
+
   _validateAndPrepare(){
     let _this = this;
 
@@ -193,10 +193,10 @@ usage: serverless resources deploy`,
       return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
     }
   }
-  
+
   _updateResources(){
     let _this = this;
-    
+
     SCli.log('Deploying resources to stage  "'
       + _this.evt.stage
       + '" and region "'
@@ -211,8 +211,11 @@ usage: serverless resources deploy`,
       accessKeyId:     _this.S._awsAdminKeyId,
       secretAccessKey: _this.S._awsAdminSecretKey,
     };
+    if (_this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = _this.S._awsAdminSessionToken;
+    }
     _this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
-    
+
     return _this.CF.sUpdateResourcesStack(
       _this.S,
       _this.evt.stage,

--- a/lib/actions/StageCreate.js
+++ b/lib/actions/StageCreate.js
@@ -90,12 +90,12 @@ usage: serverless stage create`,
     // If CLI, parse arguments
     if (_this.S.cli) {
       _this.evt = _this.S.cli.options;
-      
+
       if (_this.S.cli.options.nonInteractive) {
         _this.S._interactive = false;
       }
     }
-    
+
     return _this.S.validateProject()
       .bind(_this)
       .then(_this._promptStage)
@@ -122,7 +122,7 @@ usage: serverless stage create`,
 
   _promptStage() {
     let _this = this;
-    
+
     // Skip if non-interactive or stage is provided
     if (!_this.S._interactive || _this.evt.stage) return BbPromise.resolve();
 
@@ -139,7 +139,7 @@ usage: serverless stage create`,
         return SUtils.isStageNameValid(stage);
       },
     };
-    
+
     return _this.promptInput(prompts, null)
       .then(function(answers) {
         _this.evt.stage = answers.stage.toLowerCase();
@@ -154,7 +154,7 @@ usage: serverless stage create`,
     let _this = this;
 
     if (!_this.S._interactive || _this.evt.region) return BbPromise.resolve();
-    
+
     let choices = awsMisc.validLambdaRegions.map(r => {
       return {
         key:   '',
@@ -168,7 +168,7 @@ usage: serverless stage create`,
         _this.evt.region = results[0].value;
       });
   }
-  
+
   /**
    * Validate all data from event, interactive CLI or non interactive CLI
    * and prepare data
@@ -190,7 +190,7 @@ usage: serverless stage create`,
         return BbPromise.reject(new SError('Missing stage or region'));
       }
     }
-    
+
     // validate stage
     if (!SUtils.isStageNameValid(this.evt.stage)) {
       return BbPromise.reject(new SError('Invalid stage name. Stage must be letters and numbers only.', SError.errorCodes.UNKNOWN));
@@ -201,12 +201,12 @@ usage: serverless stage create`,
     if (this.evt.stage == 'local') {
       return BbPromise.reject(new SError('Stage ' + this.evt.stage + ' is reserved'));
     }
-    
+
     // validate stage: Ensure stage doesn't already exist
     if (this.S._projectJson.stages[this.evt.stage]) {
       return BbPromise.reject(new SError('Stage ' + this.evt.stage + ' already exists', SError.errorCodes.UNKNOWN));
     }
-    
+
     // validate region
     if (awsMisc.validLambdaRegions.indexOf(this.evt.region) == -1) {
       return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.region, SError.errorCodes.UNKNOWN));
@@ -217,7 +217,7 @@ usage: serverless stage create`,
 
     return BbPromise.resolve();
   }
-  
+
   /**
    * Initialize needed AWS classes
    * @returns {Promise}
@@ -230,12 +230,14 @@ usage: serverless stage create`,
       accessKeyId:     this.S._awsAdminKeyId,
       secretAccessKey: this.S._awsAdminSecretKey,
     };
-
+    if (this.S._awsAdminSessionToken) {
+      awsConfig.sessionToken = this.S._awsAdminSessionToken;
+    }
     this.CF       = require('../utils/aws/CloudFormation')(awsConfig);
     this.Lambda   = require('../utils/aws/Lambda')(awsConfig);
     this.S3       = require('../utils/aws/S3')(awsConfig);
   }
-  
+
   /**
    * Update CF Template
    * - Add a stage to an existing project resources cloudformation template

--- a/lib/utils/aws/Misc.js
+++ b/lib/utils/aws/Misc.js
@@ -117,13 +117,16 @@ module.exports.getEnvFileAsMap = function(Serverless, region, stage) {
     deferred = Promise.resolve(fs.readFileSync(path.join(Serverless._projectRootPath, 'back', '.env')));
   } else {
     let bucket = SUtils.getRegionConfig(Serverless._projectJson, stage, region).regionBucket;
-    
+
     let awsConfig = {
       region:          region,
       accessKeyId:     Serverless._awsAdminKeyId,
       secretAccessKey: Serverless._awsAdminSecretKey,
     };
-    
+    if (Serverless._awsAdminSessionToken) {
+      awsConfig.sessionToken = Serverless._awsAdminSessionToken;
+    }
+
     let S3 = require('./S3')(awsConfig);
 
     SCli.log(`Getting ENV file from S3 bucket: ${bucket} in ${region}`);


### PR DESCRIPTION
To make temporary security credentials work, this PR passes the optional `aws_session_token` defined in ~/.aws/credentials to the awsConfig variables in Serverless code. For more info about `aws_session_token`, please see: https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs

Additionally, in the `ProjectCreate` action, I added code to save `aws_session_token` as `SERVERLESS_ADMIN_AWS_SESSION_TOKEN` in admin.env for later references.

On a side note, because the aws_session_token will expire, and users have to get new credentials, it will be nice to have an action (e.g., AdminEnvSync) that will pull the credentials from ~/.aws/credentials and save them in admin.env. You already have the code to do that in ProjectCreate (around line 290).  But I'm thinking about externalizing the code to a separate action. (This PR didn't include this change.)