### PR TITLE
Remove `sl` command because it tramples other commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   ],
   "main": "lib/serverless.js",
   "bin": {
-    "serverless": "./bin/serverless",
-    "sl": "./bin/serverless"
+    "serverless": "./bin/serverless"
   },
   "scripts": {
     "test": "mocha tests/all"


### PR DESCRIPTION
Users can add aliases if they like, but `sl` conflicts, and is easy to mistype when you mean `ls`.

Closes #345 