### PR TITLE
Added support for detecting symlinks as existing folders

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -484,7 +484,7 @@ exports.getRegionConfig = function(projectJawsJson, stage, regionName) {
 
 exports.dirExistsSync = function(path) {
   try {
-    let stats = fs.lstatSync(path);
+    let stats = fs.statSync(path);
     return stats.isDirectory();
   }
   catch (e) {


### PR DESCRIPTION
So, this one is more tricky. I was developing a plugin, as my own module, so for development I did `npm link my-plugin` in `plugins`. It correctly created `node_modules/my-plugin` symlink, but SL didnt managed to recognize it as existing plugin. Changing `lstat` to `stat` did the right thing.

I've checked other usages of `dirExistsSync`, and it seem that all of them will have this problem. If user will e.g. create module as a symlink, at best SL will ignore the symlink and either fail or try to create folder with that name (which will fail, due to existing symlink).

Therefore, I think it is better to always use `stat` instead of `lstat`. Or, if that is not desired for any other reason, consciously make the call, provide 2 versions and then use them appropriately across the codebase.