### PR TITLE
Change plugins to load from root level node_modules folder

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -292,11 +292,11 @@ class Serverless {
       } else {
 
         // Load plugin from either custom or node_modules in plugins folder
-        if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path))) {
-          PluginClass = require(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path));
+        if (SUtils.dirExistsSync(path.join(relDir, 'plugins', pluginMetadatum.path))) {
+          PluginClass = require(path.join(relDir, 'plugins', pluginMetadatum.path));
           PluginClass = PluginClass(__dirname);
-        } else if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path))) {
-          PluginClass = require(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path));
+        } else if (SUtils.dirExistsSync(path.join(relDir, 'node_modules', pluginMetadatum.path))) {
+          PluginClass = require(path.join(relDir, 'node_modules', pluginMetadatum.path));
           PluginClass = PluginClass(__dirname);
         }
       }


### PR DESCRIPTION
This pull request introduces a workflow improvement for plugin dependancy management and allows Serverless projects to follow standard NodeJS project structure.  

As a developer if I run `npm install` from the root of my project, the expectation is that all my projects dependancies are installed and will be located in the root level node_modules folder. However since npm installed plugins must reside in `/project_root/plugins/node_modules'` they will not be included in the npm install or be installed in the wrong location.

This can be fixed via a `npmrc` file but is against standard practice and would move all npm modules used in lambda functions into the `plugins/node_modules folder`, or an even worse fix is to force the developer to use a second package.json file.

This pull request changes the plugin loading to check the root level node_modules, where it is standard practice to keep npm modules. It also removes the 'custom' folder as the plugin folder will just be used for custom plugins
