### PR TITLE
Streamline plugin creation

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -6,6 +6,7 @@ const path      = require('path'),
     SUtils      = require('./utils/index'),
     SCli        = require('./utils/cli'),
     SError      = require('./ServerlessError'),
+    SPlugin     = require('./ServerlessPlugin'),
     SAwsMisc    = require('./utils/aws/Misc'),
     BbPromise   = require('bluebird'),
     dotenv      = require('dotenv');
@@ -294,10 +295,10 @@ class Serverless {
         // Load plugin from either custom or node_modules in plugins folder
         if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path))) {
           PluginClass = require(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path));
-          PluginClass = PluginClass(__dirname);
+          PluginClass = PluginClass(SPlugin, __dirname);
         } else if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path))) {
           PluginClass = require(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path));
-          PluginClass = PluginClass(__dirname);
+          PluginClass = PluginClass(SPlugin, __dirname);
         }
       }
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -36,6 +36,7 @@ class Serverless {
     this.actions            = {};
     this.hooks              = {};
     this.commands           = {};
+    this.utils              = SUtils;
 
     // If within project, add further queued data
     if (this._projectRootPath) {
@@ -295,10 +296,10 @@ class Serverless {
         // Load plugin from either custom or node_modules in plugins folder
         if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path))) {
           PluginClass = require(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path));
-          PluginClass = PluginClass(SPlugin, SUtils, __dirname);
+          PluginClass = PluginClass(SPlugin, __dirname);
         } else if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path))) {
           PluginClass = require(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path));
-          PluginClass = PluginClass(SPlugin, SUtils, __dirname);
+          PluginClass = PluginClass(SPlugin, __dirname);
         }
       }
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -295,10 +295,10 @@ class Serverless {
         // Load plugin from either custom or node_modules in plugins folder
         if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path))) {
           PluginClass = require(path.join(relDir, 'plugins', 'custom', pluginMetadatum.path));
-          PluginClass = PluginClass(SPlugin, __dirname);
+          PluginClass = PluginClass(SPlugin, SUtils, __dirname);
         } else if (SUtils.dirExistsSync(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path))) {
           PluginClass = require(path.join(relDir, 'plugins', 'node_modules', pluginMetadatum.path));
-          PluginClass = PluginClass(SPlugin, __dirname);
+          PluginClass = PluginClass(SPlugin, SUtils, __dirname);
         }
       }
 


### PR DESCRIPTION
99% of the time, custom plugins will require either the SPlugin and/or SUtils classes. By not providing these classes, we create unnecessary boilerplate for developers.

This is a breaking change for existing plugins, but I feel that the order of arguments is important as this pull request will put them in order of how commonly they are used.