### PR TITLE
Skeleton Python2.7 Support

### DIFF
--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -185,11 +185,11 @@ usage: serverless function create <function>`,
       ));
     } else {
       this.evt.module = SUtils.readAndParseJsonSync(path.join(moduleFullPath, 's-module.json'));
-      this.evt.module.pathModule = path.join('back', 'modules', this.evt.module);
+      this.evt.module.pathModule = path.join('back', 'modules', this.evt.module.name);
     }
 
     // If function already exists in module, throw error
-    let functionPath = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module, this.evt.function);
+    let functionPath = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module.name, this.evt.function);
     if (SUtils.dirExistsSync(functionPath)) {
       return BbPromise.reject(new SError(
           'function ' + this.evt.function + ' already exists in module ' + this.evt.module.name,

--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -22,14 +22,6 @@ const SPlugin  = require('../ServerlessPlugin'),
 let fs = require('fs');
 BbPromise.promisifyAll(fs);
 
-const supportedRuntimes = {
-  nodejs: {
-    defaultPkgMgr: 'npm',
-    validPkgMgrs:  ['npm'],
-  },
-};
-
-
 /**
  * FunctionCreate Class
  */
@@ -168,7 +160,7 @@ usage: serverless function create <function>`,
       this.evt.runtime = 'nodejs';
     }
 
-    if (!supportedRuntimes[this.evt.runtime]) {
+    if (!SUtils.supportedRuntimes[this.evt.runtime]) {
       return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
     }
 
@@ -218,7 +210,9 @@ usage: serverless function create <function>`,
     let _this                = this,
         writeDeferred        = [],
         eventJson            = {},
-        handlerJs            = fs.readFileSync(path.join(this._templatesDir, 'nodejs', 'handler.js'));
+        handlerFile          = fs.readFileSync(path.join(this._templatesDir,
+                                               SUtils.supportedRuntimes[this.evt.runtime].templateSubDir,
+                                               SUtils.supportedRuntimes[this.evt.runtime].templateHandler));
 
     // Set function on event
     let functionJson                   = _this._generateFunctionJson();
@@ -230,10 +224,10 @@ usage: serverless function create <function>`,
     // Write function structure
     writeDeferred.push(
         fs.mkdirSync(_this.evt.function.pathFunction.replace('/s-function.json','')),
-        SUtils.writeFile(path.join(_this.evt.function.pathFunction.replace('s-function.json', ''), 'handler.js'), handlerJs),
+        SUtils.writeFile(path.join(_this.evt.function.pathFunction.replace('s-function.json', ''), SUtils.supportedRuntimes[this.evt.runtime].templateHandler), handlerFile),
         SUtils.writeFile(path.join(_this.evt.function.pathFunction.replace('s-function.json', ''), 'event.json'), JSON.stringify(eventJson, null, 2)),
         SUtils.writeFile(_this.evt.function.pathFunction, JSON.stringify(functionJson, null, 2))
-    ); 
+    );
 
     return BbPromise.all(writeDeferred);
   };

--- a/lib/actions/FunctionRun.js
+++ b/lib/actions/FunctionRun.js
@@ -180,15 +180,19 @@ class FunctionRun extends SPlugin {
     // Look for a property named after the function in the event object
     if (evt.function.event[evt.function.name]) evt.function.event = evt.function.event[evt.function.name];
 
+    // Fire subaction
+    let newEvent = {
+      function: evt.function,
+    };
     // Run by runtime
     if (evt.function.module.runtime === 'nodejs') {
-
-      // Fire NodeJs subaction
-      let newEvent = {
-        function: evt.function,
-      };
-
       return _this.S.actions.functionRunLambdaNodeJs(newEvent)
+          .then(function(evt) {
+            return evt;
+          });
+    }
+    if (evt.function.module.runtime === 'python2.7') {
+      return _this.S.actions.functionRunLambdaPython2(newEvent)
           .then(function(evt) {
             return evt;
           });

--- a/lib/actions/ModuleCreate.js
+++ b/lib/actions/ModuleCreate.js
@@ -114,7 +114,11 @@ usage: serverless module create`,
               };
           return _this.S.actions.functionCreate(evtClone)
         })
-        .then(_this._installModuleDependencies)
+        .then(function(){
+            if (this.evt.runtime === 'nodejs') {
+                return _this._installModuleDependencies()
+            }
+        })
         .then(function() {
           SCli.log('Successfully created new serverless module "' + _this.evt.module.name + '" with its first function "' + _this.evt.function.name + '"');
           // Return Event

--- a/lib/actions/ModuleCreate.js
+++ b/lib/actions/ModuleCreate.js
@@ -22,13 +22,6 @@ const SPlugin  = require('../ServerlessPlugin'),
 let fs = require('fs');
 BbPromise.promisifyAll(fs);
 
-const supportedRuntimes = {
-  nodejs: {
-    defaultPkgMgr: 'npm',
-    validPkgMgrs:  ['npm'],
-  },
-};
-
 /**
  * ModuleCreate Class
  */
@@ -173,13 +166,13 @@ usage: serverless module create`,
         return BbPromise.reject(new SError('Missing module or/and function names'));
       }
     }
-    
+
     // Add default runtime
     if (!this.evt.runtime) {
       this.evt.runtime = 'nodejs';
     }
 
-    if (!supportedRuntimes[this.evt.runtime]) {
+    if (!SUtils.supportedRuntimes[this.evt.runtime]) {
       return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
     }
 
@@ -217,8 +210,9 @@ usage: serverless module create`,
         writeDeferred        = [],
         moduleJsonTemplate   = _this._generateModuleJson(),
         packageJsonTemplate  = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, 'nodejs', 'package.json')),
-        libJs                = fs.readFileSync(path.join(this._templatesDir, 'nodejs', 'index.js'));
-
+        libFile              = fs.readFileSync(path.join(this._templatesDir,
+                                               SUtils.supportedRuntimes[this.evt.runtime].templateSubDir,
+                                               SUtils.supportedRuntimes[this.evt.runtime].templateLibFile));
 
     // Save Paths
     _this.evt.pathModule     = path.join(this.S._projectRootPath, 'back', 'modules', _this.evt.module);
@@ -233,10 +227,14 @@ usage: serverless module create`,
         fs.mkdirSync(_this.evt.pathModule),
         fs.mkdirSync(path.join(_this.evt.pathModule, 'lib')),
         fs.mkdirSync(path.join(_this.evt.pathModule, 'package')),
-        SUtils.writeFile(path.join(_this.evt.pathModule, 'lib', 'index.js'), libJs),
-        SUtils.writeFile(path.join(_this.evt.pathModule, 'package.json'), JSON.stringify(packageJsonTemplate, null, 2)),
+        SUtils.writeFile(path.join(_this.evt.pathModule, 'lib', SUtils.supportedRuntimes[this.evt.runtime].templateLibFile), libFile),
         SUtils.writeFile(path.join(_this.evt.pathModule, 's-module.json'), JSON.stringify(moduleJsonTemplate, null, 2))
     );
+    if (this.evt.runtime === 'nodejs') {
+      writeDeferred.push(
+          SUtils.writeFile(path.join(_this.evt.pathModule, 'package.json'), JSON.stringify(packageJsonTemplate, null, 2))
+      );
+    }
 
     return BbPromise.all(writeDeferred);
   };
@@ -255,6 +253,9 @@ usage: serverless module create`,
     switch (_this.evt.runtime) {
       case 'nodejs':
         moduleJsonTemplate.runtime = 'nodejs';
+        break;
+      case 'python2.7':
+        moduleJsonTemplate.runtime = 'python2.7';
         break;
       default:
         return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));

--- a/lib/templates/python2.7/__init__.py
+++ b/lib/templates/python2.7/__init__.py
@@ -1,0 +1,1 @@
+# shared logic goes here

--- a/lib/templates/python2.7/handler.py
+++ b/lib/templates/python2.7/handler.py
@@ -1,0 +1,11 @@
+from __future__ import print_function
+import logging
+
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+import json
+
+def handler_function(event, context):
+    log.debug("Received event {}".format(json.dumps(event)))
+    return {}

--- a/lib/templates/python2.7/handler.py
+++ b/lib/templates/python2.7/handler.py
@@ -6,6 +6,6 @@ log.setLevel(logging.DEBUG)
 
 import json
 
-def handler_function(event, context):
+def handler(event, context):
     log.debug("Received event {}".format(json.dumps(event)))
     return {}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -644,3 +644,21 @@ function getStack() {
   
   return stack;
 }
+
+
+exports.supportedRuntimes = {
+  nodejs: {
+    defaultPkgMgr: 'npm',
+    validPkgMgrs:  ['npm'],
+    templateSubDir: 'nodejs',
+    templateHandler: 'handler.js',
+    templateLibFile: 'index.js'
+  },
+  "python2.7": {
+    defaultPkgMgr: 'pip',
+    validPkgMgrs:  ['pip'],
+    templateSubDir: 'python2.7',
+    templateHandler: 'handler.py',
+    templateLibFile: '__init__.py'
+  }
+};


### PR DESCRIPTION
This adds support for:

- Creating modules with the Python2.7 Lambda runtime
- Creating new functions with python handlers

This still needs:

- Ability to load/run Python functions locally
- Ability to package Python deps (probably with virtualenv under the hood)