### PR TITLE
Creating parent directories during project create

### DIFF
--- a/lib/actions/ProjectCreate.js
+++ b/lib/actions/ProjectCreate.js
@@ -376,9 +376,10 @@ class ProjectCreate extends SPlugin {
         .then(function() {
 
           return BbPromise.all([
-            fs.mkdirSync(path.join(_this._projectRootPath, 'plugins')),
-            fs.mkdirSync(path.join(_this._projectRootPath, 'back', 'modules')),
-            fs.mkdirSync(path.join(_this._projectRootPath, 'plugins', 'custom')),
+            fs.mkdirAsync(path.join(_this._projectRootPath, 'back', 'modules')),
+            fs.mkdirAsync(path.join(_this._projectRootPath, 'plugins')).then(function(){
+              return fs.mkdirAsync(path.join(_this._projectRootPath, 'plugins', 'custom'));
+            }),
             SUtils.writeFile(path.join(_this._projectRootPath, 'admin.env'), adminEnv),
             SUtils.writeFile(path.join(_this._projectRootPath, 'README.md'), readme),
             SUtils.generateResourcesCf(


### PR DESCRIPTION
Currently `sls project create` fails because it cant create `plugins/custom` folder.