### PR TITLE
Add travisci for jscs and jshint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+
+node_js:
+  - '4.2.3'
+
+sudo: false
+
+install:
+  - travis_retry npm install jshint jscs
+
+script:
+  - ./node_modules/jshint/bin/jshint .
+  - ./node_modules/jscs/bin/jscs .
+


### PR DESCRIPTION
This probably shouldn't be merged as-is, jscs currently raises 620 code style errors. For those of you keeping score at home, that means 7 percent of lines in the codebase have errors.