### PR TITLE
Centralized and fixed event.json loading

### DIFF
--- a/lib/actions/FunctionRun.js
+++ b/lib/actions/FunctionRun.js
@@ -69,6 +69,7 @@ class FunctionRun extends SPlugin {
 
     return _this._loadFunction(evt)
         .bind(_this)
+        .then(_this._loadTestEvent)
         .then(_this._runFunction)
         .then(function(evt) {
           return evt;
@@ -97,12 +98,6 @@ class FunctionRun extends SPlugin {
 
             // Load event object
             evt.function   = functions[0];
-            let eventPath  = evt.function.pathFunction.replace('s-function.json', '');
-            if (fs.existsSync(path.join(eventPath, 'event.json'))) {
-              evt.function.event = SUtils.readAndParseJsonSync(path.join(eventPath, 'event.json'));
-            } else {
-              evt.function.event = {};
-            }
 
             // Return
             return evt;
@@ -122,19 +117,13 @@ class FunctionRun extends SPlugin {
 
             // Add function to evt
             for (let i = 0; i < functions.length; i++) {
+              SUtils.sDebug(functions[i].name+" :: "+evt.name);
+
               if (functions[i].name === evt.name || functions[i].name.toLowerCase() === evt.name) {
                 evt.function = functions[i];
               }
             }
             if (!evt.function) throw new SError(`Could not find a function with the name ${evt.name}`);
-
-            // Load event object
-            let eventPath  = evt.function.pathFunction.replace('s-function.json', '');
-            if (fs.existsSync(path.join(eventPath, 'event.json'))) {
-              evt.function.event    = SUtils.readAndParseJsonSync(path.join(eventPath, 'event.json'));
-            } else {
-              evt.function.event    = {};
-            }
 
             // Return
             return evt;
@@ -155,18 +144,30 @@ class FunctionRun extends SPlugin {
 
             evt.function = selected[0];
 
-            let eventPath  = evt.function.pathFunction.replace('s-function.json', '');
-            if (fs.existsSync(path.join(eventPath, 'event.json'))) {
-              evt.function.event    = SUtils.readAndParseJsonSync(path.join(eventPath, 'event.json'));
-            } else {
-              evt.function.event    = {};
-            }
             return evt;
           });
     }
 
     // Otherwise, through error
     throw new SError(`No function specified`);
+  }
+
+  /**
+   * Populate the test event from the correct event.json file
+   */
+
+  _loadTestEvent(evt) {
+   
+          let _this = this,
+              eventPath  = path.join(_this.S._projectRootPath, evt.function.pathFunction.replace('s-function.json', ''), 'event.json');
+
+            if (fs.existsSync(eventPath)) {
+              evt.function.event = SUtils.readAndParseJsonSync(eventPath);
+            } else {
+              evt.function.event = {};
+            }
+
+            return evt;
   }
 
   /**


### PR DESCRIPTION
Refactored event.json loading code to be a call to a central function as opposed to duplicating the same code. See _loadTestEvent on line 159 and line 72
Referenced absolute path to event.json file in order to correctly load the file. See 162.