### PR TITLE
Fix mis-reading of event contents for functions

### DIFF
--- a/lib/actions/FunctionRunLambdaNodeJs.js
+++ b/lib/actions/FunctionRunLambdaNodeJs.js
@@ -64,7 +64,7 @@ class FunctionRunLambdaNodeJs extends SPlugin {
 
 
         // Fire function
-        functionHandler(evt.function.event[evt.function.shortName], context(evt.function.name, function (err, result) {
+        functionHandler(evt.function.event, context(evt.function.name, function (err, result) {
 
           SCli.log(`-----------------`);
 


### PR DESCRIPTION
When calling functions in `function run` the event was being passed incorrectly. The function handler was being passed the contents of the function *key* in the event, not the loaded event JSON.
```
% serverless function run -m metrics -f cloudwatch
Serverless: Running MetricsCloudwatch...  
Received event: undefined
Serverless: -----------------  
Serverless: Success! - This Response Was Returned:  
Serverless: {"message":"Your Serverless function ran successfully!"}  
```
And after
```
% serverless function run -m metrics -f cloudwatch
Serverless: Running MetricsCloudwatch...  
Received event: {
  "Metrics": [
    "MemoryUtilization"
  ]
}
Serverless: -----------------  
Serverless: Success! - This Response Was Returned:  
Serverless: {"message":"Your Serverless function ran successfully!"}
```