### PR TITLE
Fixed function run to give event

### DIFF
--- a/lib/actions/FunctionRunLambdaNodeJs.js
+++ b/lib/actions/FunctionRunLambdaNodeJs.js
@@ -64,7 +64,7 @@ class FunctionRunLambdaNodeJs extends SPlugin {
 
 
         // Fire function
-        functionHandler(evt.function.event[evt.function.shortName], context(evt.function.name, function (err, result) {
+        functionHandler(evt.function.event, context(evt.function.name, function (err, result) {
 
           SCli.log(`-----------------`);
 


### PR DESCRIPTION
Removed the second place where Serverless tries to find the event data that corresponds to the function that is being run. This second lookup resulted in undefined always being sent as the event.