### PR TITLE
Added 'dont monitor' support for CF resource deploy

### DIFF
--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -62,6 +62,11 @@ usage: serverless resources deploy`,
           shortcut:    'i',
           description: 'Optional - Turn off CLI interactivity if true. Default: false'
         },
+        {
+          option:      'dontMonitor',
+          shortcut:    'm',
+          description: 'Optional - Turn off CF monitoring, quit immediately after sending update. Default: false'
+        },
       ],
     });
     return BbPromise.resolve();
@@ -96,7 +101,11 @@ usage: serverless resources deploy`,
       .then(_this._updateResources)
       .then(() => {
         _this._spinner.stop(true);
-        SCli.log('Resource Deployer:  Successfully deployed ' + _this.evt.stage + ' resources to ' + _this.evt.region.region);
+        if( _this.evt.dontMonitor != true ){
+          SCli.log('Resource Deployer:  Successfully deployed ' + _this.evt.stage + ' resources to ' + _this.evt.region.region);
+        } else {
+          SCli.log('Resource Deployer:  Successfully scheduled deploy ' + _this.evt.stage + ' resources to ' + _this.evt.region.region);
+        }
         return _this.evt;
       });
   }
@@ -182,7 +191,9 @@ usage: serverless resources deploy`,
       _this.evt.stage,
       _this.evt.region.region)
       .then(cfData => {
-        return _this.CF.sMonitorCf(cfData, 'update');
+        if( _this.evt.dontMonitor != true ) {
+          return _this.CF.sMonitorCf(cfData, 'update');
+        }
       });
   }
 }


### PR DESCRIPTION
Sometimes it is useful to trigger deploys on several stages, and it could be done simultaneously.