### PR TITLE
Refactored internal plugins to be loaded just like the external ones.

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -294,6 +294,7 @@ class Serverless {
         let pluginAbsPath = path.join(relDir, pluginMetadatum.path);
         SUtils.sDebug('Attempting to load plugin from ' + pluginAbsPath);
         PluginClass = require(pluginAbsPath);
+        PluginClass = PluginClass(SPlugin, __dirname);
       } else {
 
         // Load plugin from either custom or node_modules in plugins folder

--- a/lib/actions/CodeDeployLambdaNodeJs.js
+++ b/lib/actions/CodeDeployLambdaNodeJs.js
@@ -7,321 +7,322 @@
  * - WARNING: This Action runs concurrently.
  */
 
-const SPlugin    = require('../ServerlessPlugin'),
-    SError       = require('../ServerlessError'),
-    SUtils       = require('../utils/index'),
+module.exports = function(SPlugin, serverlessPath) {
+  const path     = require('path'),
+    SError       = require(path.join(serverlessPath, 'ServerlessError')),
+    SUtils       = require(path.join(serverlessPath, 'utils/index')),
     BbPromise    = require('bluebird'),
-    path         = require('path'),
     Zip          = require('node-zip'),
     fs           = require('fs'),
     os           = require('os');
 
-// Promisify fs module
-BbPromise.promisifyAll(fs);
+  // Promisify fs module
+  BbPromise.promisifyAll(fs);
 
-class CodeDeployLambdaNodejs extends SPlugin {
+  class CodeDeployLambdaNodejs extends SPlugin {
 
-  constructor(S, config) {
-    super(S, config);
-  }
-
-  static getName() {
-    return 'serverless.core.' + CodeDeployLambdaNodejs.name;
-  }
-
-  registerActions() {
-
-    this.S.addAction(this.codeDeployLambdaNodejs.bind(this), {
-      handler:     'codeDeployLambdaNodejs',
-      description: 'Uploads a Lambda\'s code to S3'
-    });
-
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Deploy Code Lambda Node.Js
-   */
-
-  codeDeployLambdaNodejs(evt) {
-    let deployer = new Deployer(this.S);
-    return deployer.deploy(evt);
-  }
-}
-
-/**
- * Deployer
- * - Necessary for this action to run concurrently
- */
-
-class Deployer {
-
-  constructor(S) {
-    this.S = S;
-  }
-
-  deploy(evt) {
-    let _this = this;
-
-    // Load AWS Service Instances
-    let awsConfig = {
-      region:          evt.region.region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
-    _this.S3         = require('../utils/aws/S3')(awsConfig);
-    _this.Lambda     = require('../utils/aws/Lambda')(awsConfig);
-    _this.AwsMisc    = require('../utils/aws/Misc');
-
-    // Flow
-    return _this._validateAndPrepare(evt)
-        .bind(_this)
-        .then(_this._compress)
-        .then(_this._upload)
-        .then(_this._deploy)
-        .then(function() {
-          return evt;
-        });
-  }
-
-  /**
-   * Validate And Prepare
-   */
-
-  _validateAndPrepare(evt) {
-    return BbPromise.resolve(evt);
-  }
-
-  /**
-   * Compress
-   */
-
-  _compress(evt) {
-
-    let zip = new Zip();
-
-    evt.function.pathsPackaged.forEach(nc => {
-      zip.file(nc.fileName, nc.data);
-    });
-
-    let zipBuffer = zip.generate({
-      type:        'nodebuffer',
-      compression: 'DEFLATE',
-    });
-
-    if (zipBuffer.length > 52428800) {
-      Promise.reject(new SError(
-          'Zip file is > the 50MB Lambda queued limit (' + zipBuffer.length + ' bytes)',
-          SError.errorCodes.ZIP_TOO_BIG)
-      );
+    constructor(S, config) {
+      super(S, config);
     }
 
-    // Set path of compressed package
-    evt.function.pathCompressed = path.join(evt.function.pathDist, 'package.zip');
+    static getName() {
+      return 'serverless.core.' + CodeDeployLambdaNodejs.name;
+    }
 
-    // Create compressed package
-    fs.writeFileSync(
-        evt.function.pathCompressed,
-        zipBuffer);
+    registerActions() {
 
-    SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Compressed file created - ${evt.function.pathCompressed}`);
+      this.S.addAction(this.codeDeployLambdaNodejs.bind(this), {
+        handler:     'codeDeployLambdaNodejs',
+        description: 'Uploads a Lambda\'s code to S3'
+      });
 
-    return BbPromise.resolve(evt);
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Deploy Code Lambda Node.Js
+     */
+
+    codeDeployLambdaNodejs(evt) {
+      let deployer = new Deployer(this.S);
+      return deployer.deploy(evt);
+    }
   }
 
   /**
-   * Upload
-   * - Upload zip file to S3
+   * Deployer
+   * - Necessary for this action to run concurrently
    */
 
-  _upload(evt) {
+  class Deployer {
 
-    let _this = this;
+    constructor(S) {
+      this.S = S;
+    }
 
-    SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Uploading to - ${evt.region.regionBucket}`);
+    deploy(evt) {
+      let _this = this;
 
-    return _this.S3.sPutLambdaZip(
-        evt.region.regionBucket,
-        _this.S._projectJson.name,
-        evt.stage,
-        evt.function.name,
-        fs.createReadStream(evt.function.pathCompressed))
-        .then(function(s3Key) {
+      // Load AWS Service Instances
+      let awsConfig = {
+        region:          evt.region.region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
+      _this.S3         = require('../utils/aws/S3')(awsConfig);
+      _this.Lambda     = require('../utils/aws/Lambda')(awsConfig);
+      _this.AwsMisc    = require('../utils/aws/Misc');
 
-          // Store S3 Data
-          evt.function.s3Bucket = evt.region.regionBucket;
-          evt.function.s3Key    = s3Key;
+      // Flow
+      return _this._validateAndPrepare(evt)
+          .bind(_this)
+          .then(_this._compress)
+          .then(_this._upload)
+          .then(_this._deploy)
+          .then(function() {
+            return evt;
+          });
+    }
 
-          return BbPromise.resolve(evt);
-        });
-  }
+    /**
+     * Validate And Prepare
+     */
 
-  /**
-   * Deploy
-   * - Deploy Lambda from S3 to Lambda
-   */
+    _validateAndPrepare(evt) {
+      return BbPromise.resolve(evt);
+    }
 
-  _deploy(evt) {
+    /**
+     * Compress
+     */
 
-    let _this = this,
-        lambda,
-        lambdaVersion;
+    _compress(evt) {
+
+      let zip = new Zip();
+
+      evt.function.pathsPackaged.forEach(nc => {
+        zip.file(nc.fileName, nc.data);
+      });
+
+      let zipBuffer = zip.generate({
+        type:        'nodebuffer',
+        compression: 'DEFLATE',
+      });
+
+      if (zipBuffer.length > 52428800) {
+        Promise.reject(new SError(
+            'Zip file is > the 50MB Lambda queued limit (' + zipBuffer.length + ' bytes)',
+            SError.errorCodes.ZIP_TOO_BIG)
+        );
+      }
+
+      // Set path of compressed package
+      evt.function.pathCompressed = path.join(evt.function.pathDist, 'package.zip');
+
+      // Create compressed package
+      fs.writeFileSync(
+          evt.function.pathCompressed,
+          zipBuffer);
+
+      SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Compressed file created - ${evt.function.pathCompressed}`);
+
+      return BbPromise.resolve(evt);
+    }
+
+    /**
+     * Upload
+     * - Upload zip file to S3
+     */
+
+    _upload(evt) {
+
+      let _this = this;
+
+      SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Uploading to - ${evt.region.regionBucket}`);
+
+      return _this.S3.sPutLambdaZip(
+          evt.region.regionBucket,
+          _this.S._projectJson.name,
+          evt.stage,
+          evt.function.name,
+          fs.createReadStream(evt.function.pathCompressed))
+          .then(function(s3Key) {
+
+            // Store S3 Data
+            evt.function.s3Bucket = evt.region.regionBucket;
+            evt.function.s3Key    = s3Key;
+
+            return BbPromise.resolve(evt);
+          });
+    }
+
+    /**
+     * Deploy
+     * - Deploy Lambda from S3 to Lambda
+     */
+
+    _deploy(evt) {
+
+      let _this = this,
+          lambda,
+          lambdaVersion;
 
 
 
-    var params = {
-      FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.function),
-      Qualifier:    '$LATEST'
-    };
+      var params = {
+        FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.function),
+        Qualifier:    '$LATEST'
+      };
 
-    return _this.Lambda.getFunctionPromised(params)
-        .catch(function(e) {
-          lambda = null;
-        })
-        .then(function(data) {
-          lambda = data;
-        })
-        .then(function() {
+      return _this.Lambda.getFunctionPromised(params)
+          .catch(function(e) {
+            lambda = null;
+          })
+          .then(function(data) {
+            lambda = data;
+          })
+          .then(function() {
 
-          // Create or Update Lambda
+            // Create or Update Lambda
 
-          if (!lambda) {
+            if (!lambda) {
 
-            SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Creating Lambda function...`);
+              SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Creating Lambda function...`);
 
-            // Create Lambda
-            let params = {
-              Code: {
-                S3Bucket:   evt.function.s3Bucket,
-                S3Key:      evt.function.s3Key
-              },
-              FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.function), /* required */
-              Handler:      evt.function.handler, /* required */
-              Role:         evt.region.iamRoleArnLambda, /* required */
-              Runtime:      evt.function.module.runtime, /* required */
-              Description: 'Serverless Lambda function for project: ' + _this.S._projectJson.name,
-              MemorySize:   evt.function.memorySize,
-              Publish:      true, // Required by Serverless Framework & recommended by AWS
-              Timeout:      evt.function.timeout
+              // Create Lambda
+              let params = {
+                Code: {
+                  S3Bucket:   evt.function.s3Bucket,
+                  S3Key:      evt.function.s3Key
+                },
+                FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.function), /* required */
+                Handler:      evt.function.handler, /* required */
+                Role:         evt.region.iamRoleArnLambda, /* required */
+                Runtime:      evt.function.module.runtime, /* required */
+                Description: 'Serverless Lambda function for project: ' + _this.S._projectJson.name,
+                MemorySize:   evt.function.memorySize,
+                Publish:      true, // Required by Serverless Framework & recommended by AWS
+                Timeout:      evt.function.timeout
+              };
+
+              return _this.Lambda.createFunctionPromised(params)
+                  .then(function(data) {
+
+                    // Save Version
+                    lambdaVersion = data.Version;
+
+                    return data;
+                  })
+                  .catch(function(e){
+                    console.log(e)
+                  })
+
+            } else {
+
+              SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda function...`);
+
+              // Update Lambda Code
+              let params = {
+                FunctionName:  lambda.Configuration.FunctionName, /* required */
+                Publish:       true, // Required by Serverless Framework & recommended by AWS
+                S3Bucket:      evt.region.regionBucket,
+                S3Key:         evt.function.s3Key,
+              };
+              return _this.Lambda.updateFunctionCodePromised(params)
+                  .then(function(data) {
+
+                    // Save Version
+                    lambdaVersion = data.Version;
+
+                    // Check If Function Configuration needs to be updated
+
+                    let updateConfiguration = false;
+
+                    if (data.Runtime    !== evt.function.runtime) updateConfiguration = true;
+                    if (data.Handler    !== evt.function.handler) updateConfiguration = true;
+                    if (data.MemorySize !== evt.function.memorySize) updateConfiguration = true;
+                    if (data.Timeout    !== evt.function.timeout) updateConfiguration = true;
+
+                    if (updateConfiguration) {
+
+                      SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda configuration...`);
+
+                      let params = {
+                        FunctionName: data.FunctionName, /* required */
+                        Description:  'Serverless Lambda function for project: ' + _this.S._projectJson.name,
+                        Handler:      evt.function.handler,
+                        MemorySize:   evt.function.memorySize,
+                        Role:         evt.region.iamRoleArnLambda,
+                        Timeout:      evt.function.timeout
+                      };
+                      return _this.Lambda.updateFunctionConfigurationPromised(params);
+                    } else {
+                      return data;
+                    }
+                  });
+            }
+          })
+          .then(function(data) {
+
+            // Alias Lambda w/ Stage
+
+            let aliasedLambda = false;
+
+            var params = {
+              FunctionName: data.FunctionName, /* required */
+              Name: evt.stage.toLowerCase() /* required */
             };
 
-            return _this.Lambda.createFunctionPromised(params)
-                .then(function(data) {
-
-                  // Save Version
-                  lambdaVersion = data.Version;
-
-                  return data;
+            return _this.Lambda.getAliasPromised(params)
+                .then(function() {
+                  aliasedLambda = true;
                 })
-                .catch(function(e){
-                  console.log(e)
+                .catch(function(e) {
+                  aliasedLambda = false;
                 })
+                .then(function() {
 
-          } else {
+                  if (aliasedLambda) {
 
-            SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda function...`);
+                    // Update Existing Alias
 
-            // Update Lambda Code
-            let params = {
-              FunctionName:  lambda.Configuration.FunctionName, /* required */
-              Publish:       true, // Required by Serverless Framework & recommended by AWS
-              S3Bucket:      evt.region.regionBucket,
-              S3Key:         evt.function.s3Key,
-            };
-            return _this.Lambda.updateFunctionCodePromised(params)
-                .then(function(data) {
-
-                  // Save Version
-                  lambdaVersion = data.Version;
-
-                  // Check If Function Configuration needs to be updated
-
-                  let updateConfiguration = false;
-
-                  if (data.Runtime    !== evt.function.runtime) updateConfiguration = true;
-                  if (data.Handler    !== evt.function.handler) updateConfiguration = true;
-                  if (data.MemorySize !== evt.function.memorySize) updateConfiguration = true;
-                  if (data.Timeout    !== evt.function.timeout) updateConfiguration = true;
-
-                  if (updateConfiguration) {
-
-                    SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda configuration...`);
+                    SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda Alias for version - ${lambdaVersion}`);
 
                     let params = {
-                      FunctionName: data.FunctionName, /* required */
-                      Description:  'Serverless Lambda function for project: ' + _this.S._projectJson.name,
-                      Handler:      evt.function.handler,
-                      MemorySize:   evt.function.memorySize,
-                      Role:         evt.region.iamRoleArnLambda,
-                      Timeout:      evt.function.timeout
+                      FunctionName:     data.FunctionName, /* required */
+                      FunctionVersion:  lambdaVersion, /* required */
+                      Name:             evt.stage, /* required */
+                      Description:      'Project: ' + _this.S._projectJson.name + ' Stage: ' + evt.stage
                     };
-                    return _this.Lambda.updateFunctionConfigurationPromised(params);
+
+                    return _this.Lambda.updateAliasPromised(params);
+
                   } else {
-                    return data;
+
+                    // Create New Alias
+
+                    SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Creating New Lambda Alias for version - ${lambdaVersion}`);
+
+                    let params = {
+                      FunctionName:    data.FunctionName, /* required */
+                      FunctionVersion: lambdaVersion,     /* required */
+                      Name:            evt.stage,         /* required */
+                      Description:     'Project: ' + _this.S._projectJson.name + ' Stage: ' + evt.stage
+                    };
+
+                    return _this.Lambda.createAliasPromised(params);
                   }
+                })
+                .then(function(data) {
+                  // Add Version & Alias information to evt
+                  evt.function.deployedVersion   = data.FunctionVersion;
+                  evt.function.deployedAlias     = evt.stage;
+                  evt.function.deployedAliasArn  = data.AliasArn;
+                  return evt
                 });
-          }
-        })
-        .then(function(data) {
-
-          // Alias Lambda w/ Stage
-
-          let aliasedLambda = false;
-
-          var params = {
-            FunctionName: data.FunctionName, /* required */
-            Name: evt.stage.toLowerCase() /* required */
-          };
-
-          return _this.Lambda.getAliasPromised(params)
-              .then(function() {
-                aliasedLambda = true;
-              })
-              .catch(function(e) {
-                aliasedLambda = false;
-              })
-              .then(function() {
-
-                if (aliasedLambda) {
-
-                  // Update Existing Alias
-
-                  SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda Alias for version - ${lambdaVersion}`);
-
-                  let params = {
-                    FunctionName:     data.FunctionName, /* required */
-                    FunctionVersion:  lambdaVersion, /* required */
-                    Name:             evt.stage, /* required */
-                    Description:      'Project: ' + _this.S._projectJson.name + ' Stage: ' + evt.stage
-                  };
-
-                  return _this.Lambda.updateAliasPromised(params);
-
-                } else {
-
-                  // Create New Alias
-
-                  SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Creating New Lambda Alias for version - ${lambdaVersion}`);
-
-                  let params = {
-                    FunctionName:    data.FunctionName, /* required */
-                    FunctionVersion: lambdaVersion,     /* required */
-                    Name:            evt.stage,         /* required */
-                    Description:     'Project: ' + _this.S._projectJson.name + ' Stage: ' + evt.stage
-                  };
-
-                  return _this.Lambda.createAliasPromised(params);
-                }
-              })
-              .then(function(data) {
-                // Add Version & Alias information to evt
-                evt.function.deployedVersion   = data.FunctionVersion;
-                evt.function.deployedAlias     = evt.stage;
-                evt.function.deployedAliasArn  = data.AliasArn;
-                return evt
-              });
-        })
+          })
+    }
   }
-}
 
-module.exports = CodeDeployLambdaNodejs;
+  return( CodeDeployLambdaNodejs );
+};

--- a/lib/actions/CodePackageLambdaNodeJs.js
+++ b/lib/actions/CodePackageLambdaNodeJs.js
@@ -8,234 +8,235 @@
  * - WARNING: This Action runs concurrently
  */
 
-const SPlugin    = require('../ServerlessPlugin'),
-    SError       = require('../ServerlessError'),
-    SUtils       = require('../utils/index'),
-    BbPromise    = require('bluebird'),
-    path         = require('path'),
-    fs           = require('fs'),
-    os           = require('os'),
-    wrench       = require('wrench');
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError       = require(path.join(serverlessPath, 'ServerlessError')),
+      SUtils       = require(path.join(serverlessPath, 'utils/index')),
+      BbPromise    = require('bluebird'),
+      fs           = require('fs'),
+      os           = require('os'),
+      wrench       = require('wrench');
 
-// Promisify fs module
-BbPromise.promisifyAll(fs);
+  // Promisify fs module
+  BbPromise.promisifyAll(fs);
 
-class CodePackageLambdaNodejs extends SPlugin {
+  class CodePackageLambdaNodejs extends SPlugin {
 
-  constructor(S, config) {
-    super(S, config);
-  }
+    constructor(S, config) {
+      super(S, config);
+    }
 
-  static getName() {
-    return 'serverless.core.' + CodePackageLambdaNodejs.name;
-  }
+    static getName() {
+      return 'serverless.core.' + CodePackageLambdaNodejs.name;
+    }
 
-  registerActions() {
+    registerActions() {
 
-    this.S.addAction(this.codePackageLambdaNodejs.bind(this), {
-      handler:       'codePackageLambdaNodejs',
-      description:   'Deploys the code or endpoint of a function, or both'
-    });
+      this.S.addAction(this.codePackageLambdaNodejs.bind(this), {
+        handler:       'codePackageLambdaNodejs',
+        description:   'Deploys the code or endpoint of a function, or both'
+      });
 
-    return BbPromise.resolve();
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Code Package Lambda Node.Js
+     */
+
+    codePackageLambdaNodejs(evt) {
+      let packager = new Packager(this.S);
+      return packager.package(evt);
+    }
   }
 
   /**
-   * Code Package Lambda Node.Js
+   * Packager
+   * - Necessary for this action to run concurrently
    */
 
-  codePackageLambdaNodejs(evt) {
-    let packager = new Packager(this.S);
-    return packager.package(evt);
-  }
-}
+  class Packager {
 
-/**
- * Packager
- * - Necessary for this action to run concurrently
- */
-
-class Packager {
-
-  constructor(S) {
-    this.S = S;
-  }
-
-  package(evt) {
-
-    let _this = this;
-
-    // Load AWS Service Instances
-    let awsConfig = {
-      region:          evt.region.region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
-    _this.S3 = require('../utils/aws/S3')(awsConfig);
-
-    // Flow
-    return _this._validateAndPrepare(evt)
-        .bind(_this)
-        .then(_this._createDistFolder)
-        .then(_this._package)
-        .then(function() {
-          return evt;
-        });
-  }
-
-  /**
-   * Validate And Prepare
-   */
-
-  _validateAndPrepare(evt) {
-
-    // Validate
-    if (!evt.function.name) {
-      throw new SError('Function does not have a name property');
-    }
-    if (!evt.function.handler) {
-      throw new SError('Function does not have a handler property');
-    }
-    if (!evt.function.timeout) {
-      throw new SError('Function does not have a timeout property');
-    }
-    if (!evt.function.memorySize) {
-      throw new SError('Function does not have a memorySize property');
-    }
-    if (!evt.function.module.runtime) {
-      throw new SError('Function\'s parent module is missing a runtime property');
+    constructor(S) {
+      this.S = S;
     }
 
-    return BbPromise.resolve(evt);
-  }
+    package(evt) {
 
-  /**
-   * Create Distribution Folder
-   */
+      let _this = this;
 
-  _createDistFolder(evt) {
+      // Load AWS Service Instances
+      let awsConfig = {
+        region:          evt.region.region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
+      _this.S3 = require('../utils/aws/S3')(awsConfig);
 
-    let _this = this;
+      // Flow
+      return _this._validateAndPrepare(evt)
+          .bind(_this)
+          .then(_this._createDistFolder)
+          .then(_this._package)
+          .then(function() {
+            return evt;
+          });
+    }
 
-    // Create dist folder
-    let d                 = new Date();
-    evt.function.pathDist = path.join(os.tmpdir(), evt.function.name + '@' + d.getTime());
+    /**
+     * Validate And Prepare
+     */
 
-    // Status
-    SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Copying in dist dir ${evt.function.pathDist}`);
+    _validateAndPrepare(evt) {
 
-    // Copy entire test project to temp folder
-    let excludePatterns = evt.function.custom.excludePatterns || [];
+      // Validate
+      if (!evt.function.name) {
+        throw new SError('Function does not have a name property');
+      }
+      if (!evt.function.handler) {
+        throw new SError('Function does not have a handler property');
+      }
+      if (!evt.function.timeout) {
+        throw new SError('Function does not have a timeout property');
+      }
+      if (!evt.function.memorySize) {
+        throw new SError('Function does not have a memorySize property');
+      }
+      if (!evt.function.module.runtime) {
+        throw new SError('Function\'s parent module is missing a runtime property');
+      }
 
-    wrench.copyDirSyncRecursive(
-        path.join(_this.S._projectRootPath, 'back'),
-        evt.function.pathDist,
-        {
-          exclude: function(name, prefix) {
+      return BbPromise.resolve(evt);
+    }
 
-            if (!excludePatterns.length) {
-              return false;
-            }
+    /**
+     * Create Distribution Folder
+     */
 
-            let relPath = path.join(
-                prefix.replace(evt.function.pathDist, ''), name);
+    _createDistFolder(evt) {
 
-            return excludePatterns.some(sRegex => {
-              relPath = (relPath.charAt(0) == path.sep) ? relPath.substr(1) : relPath;
+      let _this = this;
 
-              let re          = new RegExp(sRegex),
-                  matches     = re.exec(relPath),
-                  willExclude = (matches && matches.length > 0);
+      // Create dist folder
+      let d                 = new Date();
+      evt.function.pathDist = path.join(os.tmpdir(), evt.function.name + '@' + d.getTime());
 
-              if (willExclude) {
-                SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Excluding - ${relPath}`);
+      // Status
+      SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Copying in dist dir ${evt.function.pathDist}`);
+
+      // Copy entire test project to temp folder
+      let excludePatterns = evt.function.custom.excludePatterns || [];
+
+      wrench.copyDirSyncRecursive(
+          path.join(_this.S._projectRootPath, 'back'),
+          evt.function.pathDist,
+          {
+            exclude: function(name, prefix) {
+
+              if (!excludePatterns.length) {
+                return false;
               }
 
-              return willExclude;
-            });
-          },
+              let relPath = path.join(
+                  prefix.replace(evt.function.pathDist, ''), name);
+
+              return excludePatterns.some(sRegex => {
+                relPath = (relPath.charAt(0) == path.sep) ? relPath.substr(1) : relPath;
+
+                let re          = new RegExp(sRegex),
+                    matches     = re.exec(relPath),
+                    willExclude = (matches && matches.length > 0);
+
+                if (willExclude) {
+                  SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Excluding - ${relPath}`);
+                }
+
+                return willExclude;
+              });
+            },
+          }
+      );
+
+      // Get ENV file from S3
+      return _this.S3.sGetEnvFile(
+          evt.region.regionBucket,
+          _this.S._projectJson.name,
+          evt.stage)
+          .then(function(s3ObjData) {
+
+            fs.writeFileSync(
+                path.join(evt.function.pathDist,'.env'),
+                s3ObjData.Body);
+
+            return evt;
+          });
+    }
+
+    /**
+     * Package
+     */
+
+    _package(evt) {
+
+      let _this = this;
+
+      // Zip up whatever is in back
+      evt.function.custom.includePaths = ['.'];
+
+      // Create pathsPackaged for each file ready to compress
+      evt.function.pathsPackaged    = _this._generateIncludePaths(evt);
+
+      return BbPromise.resolve(evt);
+    }
+
+    /**
+     * Generate Include Paths
+     */
+
+    _generateIncludePaths(evt) {
+
+      let compressPaths = [],
+          ignore        = ['.DS_Store'],
+          stats,
+          fullPath;
+
+     evt.function.custom.includePaths.forEach(p => {
+
+        try {
+          fullPath = path.resolve(path.join(evt.function.pathDist, p));
+          stats    = fs.lstatSync(fullPath);
+        } catch (e) {
+          console.error('Cant find includePath ', p, e);
+          throw e;
         }
-    );
 
-    // Get ENV file from S3
-    return _this.S3.sGetEnvFile(
-        evt.region.regionBucket,
-        _this.S._projectJson.name,
-        evt.stage)
-        .then(function(s3ObjData) {
+        if (stats.isFile()) {
+          compressPaths.push({fileName: p, data: fs.readFileSync(fullPath)});
+        } else if (stats.isDirectory()) {
 
-          fs.writeFileSync(
-              path.join(evt.function.pathDist,'.env'),
-              s3ObjData.Body);
+          let dirname = path.basename(p);
 
-          return evt;
-        });
+          wrench
+              .readdirSyncRecursive(fullPath)
+              .forEach(file => {
+
+                // Ignore certain files
+                for (let i = 0; i < ignore.length; i++) {
+                  if (file.toLowerCase().indexOf(ignore[i]) > -1) return;
+                }
+
+                let filePath = [fullPath, file].join('/');
+                if (fs.lstatSync(filePath).isFile()) {
+                  let pathInZip = path.join(dirname, file);
+                  compressPaths.push({fileName: pathInZip, data: fs.readFileSync(filePath)});
+                }
+             });
+        }
+      });
+
+      return compressPaths;
+    }
   }
 
-  /**
-   * Package
-   */
-
-  _package(evt) {
-
-    let _this = this;
-
-    // Zip up whatever is in back
-    evt.function.custom.includePaths = ['.'];
-
-    // Create pathsPackaged for each file ready to compress
-    evt.function.pathsPackaged    = _this._generateIncludePaths(evt);
-
-    return BbPromise.resolve(evt);
-  }
-
-  /**
-   * Generate Include Paths
-   */
-
-  _generateIncludePaths(evt) {
-
-    let compressPaths = [],
-        ignore        = ['.DS_Store'],
-        stats,
-        fullPath;
-
-   evt.function.custom.includePaths.forEach(p => {
-
-      try {
-        fullPath = path.resolve(path.join(evt.function.pathDist, p));
-        stats    = fs.lstatSync(fullPath);
-      } catch (e) {
-        console.error('Cant find includePath ', p, e);
-        throw e;
-      }
-
-      if (stats.isFile()) {
-        compressPaths.push({fileName: p, data: fs.readFileSync(fullPath)});
-      } else if (stats.isDirectory()) {
-
-        let dirname = path.basename(p);
-
-        wrench
-            .readdirSyncRecursive(fullPath)
-            .forEach(file => {
-
-              // Ignore certain files
-              for (let i = 0; i < ignore.length; i++) {
-                if (file.toLowerCase().indexOf(ignore[i]) > -1) return;
-              }
-
-              let filePath = [fullPath, file].join('/');
-              if (fs.lstatSync(filePath).isFile()) {
-                let pathInZip = path.join(dirname, file);
-                compressPaths.push({fileName: pathInZip, data: fs.readFileSync(filePath)});
-              }
-           });
-      }
-    });
-
-    return compressPaths;
-  }
-}
-
-module.exports = CodePackageLambdaNodejs;
+  return( CodePackageLambdaNodejs );
+};

--- a/lib/actions/CreateEventSourceLambdaNodejs.js
+++ b/lib/actions/CreateEventSourceLambdaNodejs.js
@@ -4,80 +4,81 @@
  * Action: FunctionRunLambdaNodeJs
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-  SError      = require('../ServerlessError'),
-  SCli        = require('../utils/cli'),
-  BbPromise   = require('bluebird');
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+    SCli        = require(path.join(serverlessPath, 'utils/cli')),
+    BbPromise   = require('bluebird');
 
 
-class CreateEventSourceLambdaNodejs extends SPlugin {
+  class CreateEventSourceLambdaNodejs extends SPlugin {
 
-  constructor(S, config) {
-    super(S, config);
-  }
+    constructor(S, config) {
+      super(S, config);
+    }
 
-  static getName() {
-    return 'serverless.core.' + CreateEventSourceLambdaNodejs.name;
-  }
+    static getName() {
+      return 'serverless.core.' + CreateEventSourceLambdaNodejs.name;
+    }
 
-  registerActions() {
+    registerActions() {
 
-    this.S.addAction(this.createEventSourceLambdaNodejs.bind(this), {
-      handler:       'createEventSourceLambdaNodejs',
-      description:   'Creates an event source for a lambda function.'
-    });
+      this.S.addAction(this.createEventSourceLambdaNodejs.bind(this), {
+        handler:       'createEventSourceLambdaNodejs',
+        description:   'Creates an event source for a lambda function.'
+      });
 
-    return BbPromise.resolve();
-  }
+      return BbPromise.resolve();
+    }
 
-  /**
-   * Create Event Source for a Lambda Function
-   */
+    /**
+     * Create Event Source for a Lambda Function
+     */
 
-  createEventSourceLambdaNodejs(evt) {
+    createEventSourceLambdaNodejs(evt) {
 
-    let _this = this;
+      let _this = this;
 
-    if (!evt.function.eventSourceArn) return evt;
+      if (!evt.function.eventSourceArn) return evt;
 
-    // Load AWS Service Instances
-    let awsConfig = {
-      region:          evt.region.region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
+      // Load AWS Service Instances
+      let awsConfig = {
+        region:          evt.region.region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
 
-    _this.Lambda = require('../utils/aws/Lambda')(awsConfig);
+      _this.Lambda = require('../utils/aws/Lambda')(awsConfig);
 
-    let params = {
-      FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.function),
-      EventSourceArn:    evt.function.eventSourceArn,
-      StartingPosition: 'LATEST'
-    };
+      let params = {
+        FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.function),
+        EventSourceArn:    evt.function.eventSourceArn,
+        StartingPosition: 'LATEST'
+      };
 
 
-    return _this.Lambda.createEventSourceMappingPromised(params)
-      .then(function(data) {
+      return _this.Lambda.createEventSourceMappingPromised(params)
+        .then(function(data) {
 
-        SCli.log('Created event source for lambda: ' + evt.function.name);
+          SCli.log('Created event source for lambda: ' + evt.function.name);
 
-        evt.function.EventSourceUUID = data.UUID;
-        return evt;
-      })
-      .catch(function(e) {
-        if (e.code === 'ResourceConflictException') {
-
-          SCli.log('Event source already exists for lambda: ' + evt.function.name);
-
+          evt.function.EventSourceUUID = data.UUID;
           return evt;
-        } else {
-          return evt;
-          //throw new SError(`Error setting lambda event source: ` + e);
-        }
-      })
+        })
+        .catch(function(e) {
+          if (e.code === 'ResourceConflictException') {
+
+            SCli.log('Event source already exists for lambda: ' + evt.function.name);
+
+            return evt;
+          } else {
+            return evt;
+            //throw new SError(`Error setting lambda event source: ` + e);
+          }
+        })
+
+    }
 
   }
 
-}
-
-module.exports = CreateEventSourceLambdaNodejs;
+  return( CreateEventSourceLambdaNodejs );
+};

--- a/lib/actions/DashDeploy.js
+++ b/lib/actions/DashDeploy.js
@@ -16,300 +16,300 @@
  * - deployed: (Object)  Contains regions and the code functions that have been uploaded to the S3 bucket in that region
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError       = require('../ServerlessError'),
-    SUtils       = require('../utils/index'),
-    SCli         = require('../utils/cli'),
-    BbPromise    = require('bluebird'),
-    async        = require('async'),
-    path         = require('path'),
-    fs           = require('fs'),
-    os           = require('os');
+module.exports = function(SPlugin, serverlessPath) {
+  const path       = require('path'),
+      SError       = require(path.join(serverlessPath, 'ServerlessError')),
+      SUtils       = require(path.join(serverlessPath, 'utils/index')),
+      SCli         = require(path.join(serverlessPath, 'utils/cli')),
+      BbPromise    = require('bluebird'),
+      async        = require('async'),
+      fs           = require('fs');
 
-// Promisify fs module
-BbPromise.promisifyAll(fs);
+  // Promisify fs module
+  BbPromise.promisifyAll(fs);
 
-class DashDeploy extends SPlugin {
+  class DashDeploy extends SPlugin {
 
-  /**
-   * Constructor
-   */
+    /**
+     * Constructor
+     */
 
-  constructor(S, config) {
-    super(S, config);
-  }
-
-  /**
-   * Get Name
-   */
-
-  static getName() {
-    return 'serverless.core.' + DashDeploy.name;
-  }
-
-  /**
-   * Register Plugin Actions
-   */
-
-  registerActions() {
-
-    this.S.addAction(this.dashDeploy.bind(this), {
-      handler:       'dashDeploy',
-      description:   'Serverless Dashboard - Deploys both code & endpoint',
-      context:       'dash',
-      contextAction: 'deploy',
-      options:       [
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'Optional if only one stage is defined in project'
-        }, {
-          option:      'region',
-          shortcut:    'r',
-          description: 'Optional - Target one region to deploy to'
-        }, {
-          option:      'aliasFunction', // TODO: Implement
-          shortcut:    'f',
-          description: 'Optional - Provide a custom Alias to your Functions'
-        }, {
-          option:      'aliasEndpoint', // TODO: Implement
-          shortcut:    'e',
-          description: 'Optional - Provide a custom Alias to your Endpoints'
-        }, {
-          option:      'aliasRestApi',  // TODO: Implement
-          shortcut:    'r',
-          description: 'Optional - Provide a custom Api Gateway Stage Variable for your REST API'
-        }
-      ]
-    });
-
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Function Deploy
-   */
-
-  dashDeploy(event) {
-
-    let _this = this,
-        evt   = {};
-
-    // If CLI - parse options
-    if (_this.S.cli) {
-
-      // Options
-      evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+    constructor(S, config) {
+      super(S, config);
     }
 
-    // If NO-CLI, add options
-    if (event) evt = event;
+    /**
+     * Get Name
+     */
 
-    // Add defaults
-    evt.stage               = evt.stage ? evt.stage : null;
-    evt.aliasFunction       = evt.aliasFunction ? evt.aliasFunction : null;
-    evt.aliasEndpoint       = evt.aliasEndpoint ? evt.aliasEndpoint : null;
-    evt.aliasRestApi        = evt.aliasRestApi ? evt.aliasRestApi : null;
-    evt.functionPaths       = [];
-    evt.endpointPaths       = [];
-    evt.deployedFunctions   = {};
-    evt.deployedEndpoints   = {};
+    static getName() {
+      return 'serverless.core.' + DashDeploy.name;
+    }
 
-    _this.evt = evt;
+    /**
+     * Register Plugin Actions
+     */
 
-    // Flow
-    return BbPromise.try(function() {
-          if (_this.S._interactive) {
-            SCli.asciiGreeting();
+    registerActions() {
+
+      this.S.addAction(this.dashDeploy.bind(this), {
+        handler:       'dashDeploy',
+        description:   'Serverless Dashboard - Deploys both code & endpoint',
+        context:       'dash',
+        contextAction: 'deploy',
+        options:       [
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'Optional if only one stage is defined in project'
+          }, {
+            option:      'region',
+            shortcut:    'r',
+            description: 'Optional - Target one region to deploy to'
+          }, {
+            option:      'aliasFunction', // TODO: Implement
+            shortcut:    'f',
+            description: 'Optional - Provide a custom Alias to your Functions'
+          }, {
+            option:      'aliasEndpoint', // TODO: Implement
+            shortcut:    'e',
+            description: 'Optional - Provide a custom Alias to your Endpoints'
+          }, {
+            option:      'aliasRestApi',  // TODO: Implement
+            shortcut:    'r',
+            description: 'Optional - Provide a custom Api Gateway Stage Variable for your REST API'
           }
-        })
-        .bind(_this)
-        .then(_this._validateAndPrepare)
-        .then(_this._prepareFunctions)
-        .then(_this._prepareEndpoints)
-        .then(_this._prompt)
-        .then(function() {
-          return _this.cliPromptSelectStage('Choose a Stage: ', _this.evt.stage, false)
-              .then(stage => {
-                _this.evt.stage = stage;
-              })
-        })
-        .then(function() {
-          return _this.cliPromptSelectRegion('Choose a Region in this Stage: ', true, _this.evt.region, _this.evt.stage)
-              .then(region => {
-                _this.evt.region = region;
-              })
-        })
-        .then(_this._deploy)
-        .then(function() {
-          return _this.evt;
-        });
-  }
+        ]
+      });
 
-  /**
-   * Validate And Prepare
-   * - If CLI, maps CLI input to event object
-   */
-
-  _validateAndPrepare() {
-
-    let _this = this;
-
-    // If not interactive, throw error
-    if (!this.S._interactive) {
-      return BbPromise.reject(new SError('Sorry, this is only available in interactive mode'));
+      return BbPromise.resolve();
     }
 
-    return BbPromise.resolve(_this.evt);
-  }
+    /**
+     * Function Deploy
+     */
 
-  /**
-   * Prepare Functions
-   */
+    dashDeploy(event) {
 
-  _prepareFunctions() {
+      let _this = this,
+          evt   = {};
 
-    let _this = this;
+      // If CLI - parse options
+      if (_this.S.cli) {
 
-    return SUtils.getFunctions(_this.S._projectRootPath, null)
-        .then(function (functions) {
-          _this.functions = functions;
-        });
-  }
+        // Options
+        evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+      }
 
-  /**
-   * Prepare Endpoints
-   */
+      // If NO-CLI, add options
+      if (event) evt = event;
 
-  _prepareEndpoints() {
+      // Add defaults
+      evt.stage               = evt.stage ? evt.stage : null;
+      evt.aliasFunction       = evt.aliasFunction ? evt.aliasFunction : null;
+      evt.aliasEndpoint       = evt.aliasEndpoint ? evt.aliasEndpoint : null;
+      evt.aliasRestApi        = evt.aliasRestApi ? evt.aliasRestApi : null;
+      evt.functionPaths       = [];
+      evt.endpointPaths       = [];
+      evt.deployedFunctions   = {};
+      evt.deployedEndpoints   = {};
 
-    let _this = this;
+      _this.evt = evt;
 
-    return SUtils.getEndpoints(_this.S._projectRootPath, null)
-        .then(function (endpoints) {
-          _this.endpoints = endpoints;
-        });
-  }
+      // Flow
+      return BbPromise.try(function() {
+            if (_this.S._interactive) {
+              SCli.asciiGreeting();
+            }
+          })
+          .bind(_this)
+          .then(_this._validateAndPrepare)
+          .then(_this._prepareFunctions)
+          .then(_this._prepareEndpoints)
+          .then(_this._prompt)
+          .then(function() {
+            return _this.cliPromptSelectStage('Choose a Stage: ', _this.evt.stage, false)
+                .then(stage => {
+                  _this.evt.stage = stage;
+                })
+          })
+          .then(function() {
+            return _this.cliPromptSelectRegion('Choose a Region in this Stage: ', true, _this.evt.region, _this.evt.stage)
+                .then(region => {
+                  _this.evt.region = region;
+                })
+          })
+          .then(_this._deploy)
+          .then(function() {
+            return _this.evt;
+          });
+    }
 
-  /**
-   * Prompt
-   */
+    /**
+     * Validate And Prepare
+     * - If CLI, maps CLI input to event object
+     */
 
-  _prompt() {
+    _validateAndPrepare() {
 
-    let _this = this,
-        data = {};
+      let _this = this;
 
-    // Loop through functions
-    _this.functions.forEach(function(func){
-      if (!data[func.module.name]) data[func.module.name] = {};
-      if (!data[func.module.name][func.name]) data[func.module.name][func.name] = {
-        function:  func,
-        endpoints: []
-      };
-    });
+      // If not interactive, throw error
+      if (!this.S._interactive) {
+        return BbPromise.reject(new SError('Sorry, this is only available in interactive mode'));
+      }
 
-    // Loop through endpoints
-    _this.endpoints.forEach(function(endpoint){
-      data[endpoint.module.name][endpoint.function.name].endpoints.push(endpoint);
-    });
+      return BbPromise.resolve(_this.evt);
+    }
 
-    // Prepare endpoints choices
-    let choices    = [];
-    for (let i = 0; i < Object.keys(data).length; i++) {
+    /**
+     * Prepare Functions
+     */
 
-      let module = Object.keys(data)[i];
+    _prepareFunctions() {
 
-      for (let j = 0; j < Object.keys(data[module]).length; j++) {
+      let _this = this;
 
-        let func = data[module][Object.keys(data[module])[j]];
+      return SUtils.getFunctions(_this.S._projectRootPath, null)
+          .then(function (functions) {
+            _this.functions = functions;
+          });
+    }
 
-        // Push module name as spacer
-        choices.push({
-          spacer: module + ' - ' + func.function.name
-        });
+    /**
+     * Prepare Endpoints
+     */
 
-        // Create function path and add it as a choice
-        let path = func.function.pathFunction.split('modules')[1];
-        if (['/', '\\'].indexOf(path.charAt(0)) !== -1) {
-          path = path.substring(1, path.length);
-        }
-        path = path + '#' + func.function.name;
+    _prepareEndpoints() {
 
-        choices.push({
-          key:        '  ',
-          value:      path,
-          label:      'function - ' + func.function.name,
-          type:       'function'
-        });
+      let _this = this;
 
-        // If no endpoints, skip iteration
-        if (!func.endpoints || !func.endpoints.length) continue;
+      return SUtils.getEndpoints(_this.S._projectRootPath, null)
+          .then(function (endpoints) {
+            _this.endpoints = endpoints;
+          });
+    }
 
-        // If endpoints, find them
-        for (let k = 0; k < func.endpoints.length; k++) {
+    /**
+     * Prompt
+     */
+
+    _prompt() {
+
+      let _this = this,
+          data = {};
+
+      // Loop through functions
+      _this.functions.forEach(function(func){
+        if (!data[func.module.name]) data[func.module.name] = {};
+        if (!data[func.module.name][func.name]) data[func.module.name][func.name] = {
+          function:  func,
+          endpoints: []
+        };
+      });
+
+      // Loop through endpoints
+      _this.endpoints.forEach(function(endpoint){
+        data[endpoint.module.name][endpoint.function.name].endpoints.push(endpoint);
+      });
+
+      // Prepare endpoints choices
+      let choices    = [];
+      for (let i = 0; i < Object.keys(data).length; i++) {
+
+        let module = Object.keys(data)[i];
+
+        for (let j = 0; j < Object.keys(data[module]).length; j++) {
+
+          let func = data[module][Object.keys(data[module])[j]];
+
+          // Push module name as spacer
+          choices.push({
+            spacer: module + ' - ' + func.function.name
+          });
+
+          // Create function path and add it as a choice
+          let path = func.function.pathFunction.split('modules')[1];
+          if (['/', '\\'].indexOf(path.charAt(0)) !== -1) {
+            path = path.substring(1, path.length);
+          }
+          path = path + '#' + func.function.name;
+
           choices.push({
             key:        '  ',
-            value:      path + '@' + func.endpoints[k].path + '~' + func.endpoints[k].method,
-            label:      'endpoint - ' + func.endpoints[k].path + ' - ' + func.endpoints[k].method,
-            type:       'endpoint'
+            value:      path,
+            label:      'function - ' + func.function.name,
+            type:       'function'
           });
+
+          // If no endpoints, skip iteration
+          if (!func.endpoints || !func.endpoints.length) continue;
+
+          // If endpoints, find them
+          for (let k = 0; k < func.endpoints.length; k++) {
+            choices.push({
+              key:        '  ',
+              value:      path + '@' + func.endpoints[k].path + '~' + func.endpoints[k].method,
+              label:      'endpoint - ' + func.endpoints[k].path + ' - ' + func.endpoints[k].method,
+              type:       'endpoint'
+            });
+          }
         }
       }
+
+      // Show select input
+      return _this.cliPromptSelect('Select the functions and endpoints you wish to deploy', choices, true, 'Deploy')
+          .then(function(items) {
+            // Retrieve only toggled items
+            let selectedItems = [];
+            for (let i = 0; i < items.length; i++) {
+              if (items[i].toggled) {
+                if(items[i].type === "function") _this.evt.functionPaths.push(items[i].value);
+                if(items[i].type === "endpoint") _this.evt.endpointPaths.push(items[i].value);
+              }
+            }
+          })
     }
 
-    // Show select input
-    return _this.cliPromptSelect('Select the functions and endpoints you wish to deploy', choices, true, 'Deploy')
-        .then(function(items) {
-          // Retrieve only toggled items
-          let selectedItems = [];
-          for (let i = 0; i < items.length; i++) {
-            if (items[i].toggled) {
-              if(items[i].type === "function") _this.evt.functionPaths.push(items[i].value);
-              if(items[i].type === "endpoint") _this.evt.endpointPaths.push(items[i].value);
-            }
-          }
-        })
-  }
+    /**
+     * Deploy
+     */
 
-  /**
-   * Deploy
-   */
+    _deploy() {
 
-  _deploy() {
+      let _this = this;
 
-    let _this = this;
+      return new BbPromise(function(resolve, reject) {
 
-    return new BbPromise(function(resolve, reject) {
+        // If user selected functions, deploy them
+        if (!_this.evt.functionPaths || !_this.evt.functionPaths.length) return resolve();
 
-      // If user selected functions, deploy them
-      if (!_this.evt.functionPaths || !_this.evt.functionPaths.length) return resolve();
+        return _this.S.actions.functionDeploy({
+              stage: _this.evt.stage,
+              region: _this.evt.region,
+              paths: _this.evt.functionPaths
+            })
+            .then(function(evt) {
+              _this.evt.deployedFunctions = evt.deployed;
+              return resolve();
+            });
+      })
+          .then(function() {
 
-      return _this.S.actions.functionDeploy({
-            stage: _this.evt.stage,
-            region: _this.evt.region,
-            paths: _this.evt.functionPaths
+            // If user selected functions, deploy them
+            if (!_this.evt.endpointPaths || !_this.evt.endpointPaths.length) return;
+
+            return _this.S.actions.endpointDeploy({
+                  stage: _this.evt.stage,
+                  region: _this.evt.region,
+                  paths: _this.evt.endpointPaths
+                })
+                .then(function(evt) {
+                  _this.evt.deployedEndpoints = evt.deployed;
+                });
           })
-          .then(function(evt) {
-            _this.evt.deployedFunctions = evt.deployed;
-            return resolve();
-          });
-    })
-        .then(function() {
-
-          // If user selected functions, deploy them
-          if (!_this.evt.endpointPaths || !_this.evt.endpointPaths.length) return;
-
-          return _this.S.actions.endpointDeploy({
-                stage: _this.evt.stage,
-                region: _this.evt.region,
-                paths: _this.evt.endpointPaths
-              })
-              .then(function(evt) {
-                _this.evt.deployedEndpoints = evt.deployed;
-              });
-        })
+    }
   }
-}
 
-module.exports = DashDeploy;
+  return( DashDeploy );
+};

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -6,791 +6,792 @@
  * - Handles one endpoint only in one region.  The FunctionDeploy Action orchestrates this.
  */
 
-const SPlugin       = require('../ServerlessPlugin'),
-    SError          = require('../ServerlessError'),
-    SUtils          = require('../utils/index'),
-    BbPromise       = require('bluebird'),
-    path            = require('path'),
-    async           = require('async'),
-    fs              = require('fs'),
-    os              = require('os');
+module.exports = function(SPlugin, serverlessPath) {
+  const path          = require('path'),
+      SError          = require(path.join(serverlessPath, 'ServerlessError')),
+      SUtils          = require(path.join(serverlessPath, 'utils/index')),
+      BbPromise       = require('bluebird'),
+      async           = require('async'),
+      fs              = require('fs'),
+      os              = require('os');
 
-// Promisify fs module.
-BbPromise.promisifyAll(fs);
+  // Promisify fs module.
+  BbPromise.promisifyAll(fs);
 
-class EndpointBuildApiGateway extends SPlugin {
-
-  /**
-   * Constructor
-   */
-
-  constructor(S, config) {
-    super(S, config);
-  }
-
-  /**
-   * Get Name
-   */
-
-  static getName() {
-    return 'serverless.core.' + EndpointBuildApiGateway.name;
-  }
-
-  /**
-   * Register Actions
-   */
-
-  registerActions() {
-    this.S.addAction(this.endpointBuildApiGateway.bind(this), {
-      handler:     'endpointBuildApiGateway',
-      description: 'Provision one or multiple endpoints on API Gateway',
-    });
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Endpoint Build ApiGateway
-   */
-
-  endpointBuildApiGateway(evt) {
-    let builder = new Builder(this.S);
-    return builder.build(evt);
-  }
-}
-
-/**
- * Builder
- * - Necessary for this action to run concurrently
- */
-
-class Builder {
-
-  constructor(S) {
-    this.S = S;
-  }
-
-  build(evt) {
-
-    let _this = this;
-
-    // Define useful variables
-    _this.awsAccountNumber;
-    _this.resource;
-    _this.resourceParent;
-    _this.prevIntegration;
-    _this.integration;
-    _this.lambda;
-    _this.apiResources;
-
-    return _this._validateAndPrepare(evt)
-        .bind(_this)
-        .then(_this._fetchDeployedLambda)
-        .then(_this._getApiResources)
-        .then(_this._createEndpointResources)
-        .then(_this._createEndpointMethod)
-        .then(_this._createEndpointIntegration)
-        .then(_this._createEndpointMethodResponses)
-        .then(_this._createEndpointMethodIntegResponses)
-        .then(_this._manageLambdaAccessPolicy)
-        .then(function() {
-
-          evt.endpoint.url = 'https://'
-              + evt.region.restApiId
-              + '.execute-api.'
-              +  evt.region.region
-              + '.amazonaws.com/'
-              + evt.stage
-              + evt.endpoint.path;
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage
-              + '" successfully built endpoint on API Gateway in the region "'
-              + evt.region.region
-              + '". Access it via '
-              + evt.endpoint.method
-              + ' @ '
-              + evt.endpoint.url);
-          return evt;
-        });
-  }
-
-  /**
-   * Validate And Prepare
-   */
-
-  _validateAndPrepare(evt) {
-
-    let _this = this;
-
-    // Get AWS Account Number
-    _this.awsAccountNumber = evt.region.iamRoleArnLambda.replace('arn:aws:iam::', '').split(':')[0];
-
-    // Load AWS Service Instances
-    let awsConfig = {
-      region:          evt.region.region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
-
-    _this.CloudFormation = require('../utils/aws/CloudFormation')(awsConfig);
-    _this.ApiGateway     = require('../utils/aws/ApiGateway')(awsConfig);
-    _this.Lambda         = require('../utils/aws/Lambda')(awsConfig);
-
-    // Validate and sanitize endpoint attributes
-    if (!evt.endpoint.path) {
-      throw new SError('Endpoint does not have a "path" property');
-    }
-    if (!evt.endpoint.method) {
-      throw new SError('Endpoint does not have a "method" property');
-    }
-    if (!evt.endpoint.authorizationType) {
-      throw new SError('Endpoint does not have a "authorizationType" property');
-    }
-    if (typeof evt.endpoint.apiKeyRequired === 'undefined') {
-      throw new SError('Endpoint does not have a "apiKeyRequired" property');
-    }
-    if (!evt.endpoint.requestTemplates) {
-      throw new SError('Endpoint does not have a "requestTemplates" property');
-    }
-    if (!evt.endpoint.requestParameters) {
-      throw new SError('Endpoint does not have a "requestParameters" property');
-    }
-    if (!evt.endpoint.responses) {
-      throw new SError('Endpoint does not have a "responses" property');
-    }
-
-    // Sanitize path - Remove excessive forward slashes
-    if (evt.endpoint.path.charAt(0) !== '/') evt.endpoint.path = '/' + evt.endpoint.path;
-    if (evt.endpoint.path.charAt(evt.endpoint.path.length) === '/') evt.endpoint.path = evt.endpoint.path.slice(0, -1);
-
-    // Sanitize method
-    evt.endpoint.method = evt.endpoint.method.toUpperCase();
-
-    return BbPromise.resolve(evt);
-  }
-
-  /**
-   * Fetch Deployed Lambda
-   * @private
-   */
-
-  _fetchDeployedLambda(evt) {
-
-    let _this = this;
-    let params = {
-      FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.endpoint.function), /* required */
-      Qualifier:    evt.stage
-    };
-
-    return _this.Lambda.getFunctionPromised(params)
-        .then(function(data) {
-
-          _this.deployedLambda = data.Configuration;
-
-          // Prepare StatementId
-          evt.endpoint.lambdaPolicyStatementId = ('s_apig' + evt.endpoint.path + '_' + evt.endpoint.method).replace(/\//g, '_');
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - ' + evt.endpoint.path
-              + '": found the target lambda with function name:'
-              + _this.deployedLambda.FunctionName);
-
-          return evt;
-        })
-        .catch(function(e) {
-          console.log(e)
-        });
-  }
-
-  /**
-   * Get API Resources
-   * @returns {Promise}
-   * @private
-   */
-
-  _getApiResources(evt) {
-
-    let _this = this;
-
-    let params = {
-      restApiId: evt.region.restApiId, /* required */
-      limit: 500
-    };
-
-    // List all Resources for this REST API
-    return _this.ApiGateway.getResourcesPromised(params)
-        .then(function(response) {
-
-          _this.apiResources = response.items;
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - ' + evt.endpoint.path + '": found '
-              + _this.apiResources.length
-              + ' existing Resources on API Gateway');
-
-          return evt;
-        });
-  }
-
-  /**
-   * Create Endpoint Resources
-   */
-
-  _createEndpointResources(evt) {
-
-    let _this = this;
+  class EndpointBuildApiGateway extends SPlugin {
 
     /**
-     * Find Parent
-     * - We always want to provide the parent resource on the EVENT object.
-     * - Here is a private, reusable function to find and add it
+     * Constructor
      */
 
-    let findParent = function(resource) {
-
-      let parentPath = resource.split('/');
-      if (parentPath.length > 1) {
-        parentPath.pop();
-        parentPath = '/' + parentPath.join('/');
-      } else {
-        parentPath = '/';
-      }
-
-      for (let i = 0; i < _this.apiResources.length; i++) {
-        if (_this.apiResources[i].path === parentPath) {
-          _this.resourceParent = _this.apiResources[i];
-          break;
-        }
-      }
-    };
-
-
-    // Check paths to see if resources need building
-    for (let i = 0; i < _this.apiResources.length; i++) {
-      if (_this.apiResources[i].path === evt.endpoint.path) {
-        _this.resource = _this.apiResources[i];
-        break;
-      }
+    constructor(S, config) {
+      super(S, config);
     }
 
-    // If all Endpoint resources exist already, load parent resource, skip the rest of this function
-    if (_this.resource) {
-      findParent(_this.resource.path);
+    /**
+     * Get Name
+     */
 
-      SUtils.sDebug(
-          '"'
-          + evt.stage + ' - '
-          + evt.region.region
-          + ' - ' + evt.endpoint.path + '": '
-          + '": no resources need to be created for this endpoint');
+    static getName() {
+      return 'serverless.core.' + EndpointBuildApiGateway.name;
+    }
+
+    /**
+     * Register Actions
+     */
+
+    registerActions() {
+      this.S.addAction(this.endpointBuildApiGateway.bind(this), {
+        handler:     'endpointBuildApiGateway',
+        description: 'Provision one or multiple endpoints on API Gateway',
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Endpoint Build ApiGateway
+     */
+
+    endpointBuildApiGateway(evt) {
+      let builder = new Builder(this.S);
+      return builder.build(evt);
+    }
+  }
+
+  /**
+   * Builder
+   * - Necessary for this action to run concurrently
+   */
+
+  class Builder {
+
+    constructor(S) {
+      this.S = S;
+    }
+
+    build(evt) {
+
+      let _this = this;
+
+      // Define useful variables
+      _this.awsAccountNumber;
+      _this.resource;
+      _this.resourceParent;
+      _this.prevIntegration;
+      _this.integration;
+      _this.lambda;
+      _this.apiResources;
+
+      return _this._validateAndPrepare(evt)
+          .bind(_this)
+          .then(_this._fetchDeployedLambda)
+          .then(_this._getApiResources)
+          .then(_this._createEndpointResources)
+          .then(_this._createEndpointMethod)
+          .then(_this._createEndpointIntegration)
+          .then(_this._createEndpointMethodResponses)
+          .then(_this._createEndpointMethodIntegResponses)
+          .then(_this._manageLambdaAccessPolicy)
+          .then(function() {
+
+            evt.endpoint.url = 'https://'
+                + evt.region.restApiId
+                + '.execute-api.'
+                +  evt.region.region
+                + '.amazonaws.com/'
+                + evt.stage
+                + evt.endpoint.path;
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage
+                + '" successfully built endpoint on API Gateway in the region "'
+                + evt.region.region
+                + '". Access it via '
+                + evt.endpoint.method
+                + ' @ '
+                + evt.endpoint.url);
+            return evt;
+          });
+    }
+
+    /**
+     * Validate And Prepare
+     */
+
+    _validateAndPrepare(evt) {
+
+      let _this = this;
+
+      // Get AWS Account Number
+      _this.awsAccountNumber = evt.region.iamRoleArnLambda.replace('arn:aws:iam::', '').split(':')[0];
+
+      // Load AWS Service Instances
+      let awsConfig = {
+        region:          evt.region.region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
+
+      _this.CloudFormation = require('../utils/aws/CloudFormation')(awsConfig);
+      _this.ApiGateway     = require('../utils/aws/ApiGateway')(awsConfig);
+      _this.Lambda         = require('../utils/aws/Lambda')(awsConfig);
+
+      // Validate and sanitize endpoint attributes
+      if (!evt.endpoint.path) {
+        throw new SError('Endpoint does not have a "path" property');
+      }
+      if (!evt.endpoint.method) {
+        throw new SError('Endpoint does not have a "method" property');
+      }
+      if (!evt.endpoint.authorizationType) {
+        throw new SError('Endpoint does not have a "authorizationType" property');
+      }
+      if (typeof evt.endpoint.apiKeyRequired === 'undefined') {
+        throw new SError('Endpoint does not have a "apiKeyRequired" property');
+      }
+      if (!evt.endpoint.requestTemplates) {
+        throw new SError('Endpoint does not have a "requestTemplates" property');
+      }
+      if (!evt.endpoint.requestParameters) {
+        throw new SError('Endpoint does not have a "requestParameters" property');
+      }
+      if (!evt.endpoint.responses) {
+        throw new SError('Endpoint does not have a "responses" property');
+      }
+
+      // Sanitize path - Remove excessive forward slashes
+      if (evt.endpoint.path.charAt(0) !== '/') evt.endpoint.path = '/' + evt.endpoint.path;
+      if (evt.endpoint.path.charAt(evt.endpoint.path.length) === '/') evt.endpoint.path = evt.endpoint.path.slice(0, -1);
+
+      // Sanitize method
+      evt.endpoint.method = evt.endpoint.method.toUpperCase();
 
       return BbPromise.resolve(evt);
     }
 
-    let eResources = evt.endpoint.path.split('/');
-    eResources[0] = '/'; // Our split removes the initial '/' and leaves an empty string, replace it
+    /**
+     * Fetch Deployed Lambda
+     * @private
+     */
 
-    return new BbPromise(function(resolve, reject) {
+    _fetchDeployedLambda(evt) {
 
-      // Loop through each resource in this Endpoint and create it if it is missing.
-      let incrementedPath = '';
-      async.eachSeries(eResources, function(eResource, cb) {
+      let _this = this;
+      let params = {
+        FunctionName: _this.Lambda.sGetLambdaName(_this.S._projectJson, evt.endpoint.function), /* required */
+        Qualifier:    evt.stage
+      };
 
-        // Build the path w/ new resource on each iteration
-        if (incrementedPath === '') {
-          incrementedPath = eResource;
-        } else if (incrementedPath === '/') {
-          incrementedPath = incrementedPath + eResource;
-        } else {
-          incrementedPath = incrementedPath + '/' + eResource;
-        }
+      return _this.Lambda.getFunctionPromised(params)
+          .then(function(data) {
 
-        // If exists in APIG resources, skip this
-        let parentPath = '';
-        let resourceExists = false;
+            _this.deployedLambda = data.Configuration;
 
-        for (let i = 0; i < _this.apiResources.length; i++) {
-          // Resource exists, save it to Event object, break loop
-          if (_this.apiResources[i].path === incrementedPath) {
-            resourceExists = true;
-            break;
-          }
-        }
+            // Prepare StatementId
+            evt.endpoint.lambdaPolicyStatementId = ('s_apig' + evt.endpoint.path + '_' + evt.endpoint.method).replace(/\//g, '_');
 
-        // Resource exists, skip this iteration
-        if (resourceExists) return cb();
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path
+                + '": found the target lambda with function name:'
+                + _this.deployedLambda.FunctionName);
 
-
-
-        // Find Parent
-        let parent = incrementedPath.split('/');
-        if (parent.length === 2) {
-          parent = '/';
-        } else {
-          parent = incrementedPath.substring(0, incrementedPath.lastIndexOf('/'));
-        }
-
-        for (let i = 0; i < _this.apiResources.length; i++) {
-          if (_this.apiResources[i].path === parent) {
-            parent = _this.apiResources[i];
-            break;
-          }
-        }
-        _this.resourceParent = parent;
-
-
-        // Resource doesn't exist, so make it
-        let params = {
-          parentId:  _this.resourceParent.id, /* required */
-          pathPart:  eResource, /* required */
-          restApiId: evt.region.restApiId /* required */
-        };
-
-        // Create Resource
-        return _this.ApiGateway.createResourcePromised(params)
-            .then(function(response) {
-
-              // Save resource
-              _this.resource = response;
-
-              // Add resource to _this.resources and callback
-              _this.apiResources.push(response);
-
-              SUtils.sDebug(
-                  '"'
-                  + evt.stage + ' - '
-                  + evt.region.region
-                  + ' - ' + evt.endpoint.path + '": '
-                  + 'created resource: '
-                  + response.pathPart);
-
-              // Return callback to iterate loop
-              return cb();
-            });
-      }, function() {
-        return resolve(evt);
-      }); // async.eachSeries
-    });
-  }
-
-  /**
-   * Create Endpoint Method
-   */
-
-  _createEndpointMethod(evt) {
-
-    let _this             = this,
-        requestParameters = {};
-
-    // If Request Params, add them
-    if (evt.endpoint.requestParameters) {
-
-      // Format them per APIG API's Expectations
-      for (let prop in evt.endpoint.requestParameters) {
-        let requestParam                = evt.endpoint.requestParameters[prop];
-        requestParameters[requestParam] = true;
-      }
+            return evt;
+          })
+          .catch(function(e) {
+            console.log(e)
+          });
     }
 
-    let params = {
-      httpMethod: evt.endpoint.method, /* required */
-      resourceId: _this.resource.id, /* required */
-      restApiId:  evt.region.restApiId /* required */
-    };
+    /**
+     * Get API Resources
+     * @returns {Promise}
+     * @private
+     */
 
-    return _this.ApiGateway.getMethodPromised(params)
-        .then(function(response) {
+    _getApiResources(evt) {
 
-          // Method exists.  Delete and recreate it.
+      let _this = this;
 
-          // First, save integration's Lambda aliasEndpoint, if any
-          if (response.methodIntegration) {
-            _this.prevIntegration = response.methodIntegration;
+      let params = {
+        restApiId: evt.region.restApiId, /* required */
+        limit: 500
+      };
+
+      // List all Resources for this REST API
+      return _this.ApiGateway.getResourcesPromised(params)
+          .then(function(response) {
+
+            _this.apiResources = response.items;
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path + '": found '
+                + _this.apiResources.length
+                + ' existing Resources on API Gateway');
+
+            return evt;
+          });
+    }
+
+    /**
+     * Create Endpoint Resources
+     */
+
+    _createEndpointResources(evt) {
+
+      let _this = this;
+
+      /**
+       * Find Parent
+       * - We always want to provide the parent resource on the EVENT object.
+       * - Here is a private, reusable function to find and add it
+       */
+
+      let findParent = function(resource) {
+
+        let parentPath = resource.split('/');
+        if (parentPath.length > 1) {
+          parentPath.pop();
+          parentPath = '/' + parentPath.join('/');
+        } else {
+          parentPath = '/';
+        }
+
+        for (let i = 0; i < _this.apiResources.length; i++) {
+          if (_this.apiResources[i].path === parentPath) {
+            _this.resourceParent = _this.apiResources[i];
+            break;
+          }
+        }
+      };
+
+
+      // Check paths to see if resources need building
+      for (let i = 0; i < _this.apiResources.length; i++) {
+        if (_this.apiResources[i].path === evt.endpoint.path) {
+          _this.resource = _this.apiResources[i];
+          break;
+        }
+      }
+
+      // If all Endpoint resources exist already, load parent resource, skip the rest of this function
+      if (_this.resource) {
+        findParent(_this.resource.path);
+
+        SUtils.sDebug(
+            '"'
+            + evt.stage + ' - '
+            + evt.region.region
+            + ' - ' + evt.endpoint.path + '": '
+            + '": no resources need to be created for this endpoint');
+
+        return BbPromise.resolve(evt);
+      }
+
+      let eResources = evt.endpoint.path.split('/');
+      eResources[0] = '/'; // Our split removes the initial '/' and leaves an empty string, replace it
+
+      return new BbPromise(function(resolve, reject) {
+
+        // Loop through each resource in this Endpoint and create it if it is missing.
+        let incrementedPath = '';
+        async.eachSeries(eResources, function(eResource, cb) {
+
+          // Build the path w/ new resource on each iteration
+          if (incrementedPath === '') {
+            incrementedPath = eResource;
+          } else if (incrementedPath === '/') {
+            incrementedPath = incrementedPath + eResource;
+          } else {
+            incrementedPath = incrementedPath + '/' + eResource;
           }
 
+          // If exists in APIG resources, skip this
+          let parentPath = '';
+          let resourceExists = false;
+
+          for (let i = 0; i < _this.apiResources.length; i++) {
+            // Resource exists, save it to Event object, break loop
+            if (_this.apiResources[i].path === incrementedPath) {
+              resourceExists = true;
+              break;
+            }
+          }
+
+          // Resource exists, skip this iteration
+          if (resourceExists) return cb();
+
+
+
+          // Find Parent
+          let parent = incrementedPath.split('/');
+          if (parent.length === 2) {
+            parent = '/';
+          } else {
+            parent = incrementedPath.substring(0, incrementedPath.lastIndexOf('/'));
+          }
+
+          for (let i = 0; i < _this.apiResources.length; i++) {
+            if (_this.apiResources[i].path === parent) {
+              parent = _this.apiResources[i];
+              break;
+            }
+          }
+          _this.resourceParent = parent;
+
+
+          // Resource doesn't exist, so make it
           let params = {
-            httpMethod: evt.endpoint.method, /* required */
-            resourceId: _this.resource.id, /* required */
-            restApiId:  evt.region.restApiId /* required */
+            parentId:  _this.resourceParent.id, /* required */
+            pathPart:  eResource, /* required */
+            restApiId: evt.region.restApiId /* required */
           };
 
-          return _this.ApiGateway.deleteMethodPromised(params)
+          // Create Resource
+          return _this.ApiGateway.createResourcePromised(params)
               .then(function(response) {
 
-                let params = {
-                  authorizationType:  evt.endpoint.authorizationType, /* required */
-                  httpMethod:         evt.endpoint.method, /* required */
-                  resourceId:         _this.resource.id, /* required */
-                  restApiId:          evt.region.restApiId, /* required */
-                  apiKeyRequired:     evt.endpoint.apiKeyRequired,
-                  requestModels:      evt.endpoint.requestModels,
-                  requestParameters:  requestParameters
-                };
-                return _this.ApiGateway.putMethodPromised(params);
+                // Save resource
+                _this.resource = response;
 
-              });
-        }, function(error) {
-
-          // Method does not exist.  Create it.
-
-          let params = {
-            authorizationType:  evt.endpoint.authorizationType, /* required */
-            httpMethod:         evt.endpoint.method, /* required */
-            resourceId:         _this.resource.id, /* required */
-            restApiId:          evt.region.restApiId, /* required */
-            apiKeyRequired:     evt.endpoint.apiKeyRequired,
-            requestModels:      evt.endpoint.requestModels,
-            requestParameters:  requestParameters
-          };
-
-          return _this.ApiGateway.putMethodPromised(params);
-        })
-        .then(function(response) {
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - ' + evt.endpoint.path + '": '
-              + 'created method: '
-              + evt.endpoint.method);
-
-          return evt;
-        });
-  }
-
-  /**
-   * Create Endpoint Integration
-   */
-
-  _createEndpointIntegration(evt) {
-
-    let _this           = this;
-
-    // Alias Lambda, default ot $LATEST
-    let alias;
-    if (evt.aliasEndpoint) alias  = evt.aliasEndpoint;
-    else alias = '${stageVariables.functionAlias}';
-
-    let params = {
-      httpMethod:             evt.endpoint.method, /* required */
-      resourceId:             _this.resource.id, /* required */
-      restApiId:              evt.region.restApiId, /* required */
-      type:                   'AWS', /* required */
-      cacheKeyParameters:     evt.endpoint.cacheKeyParameters || [],
-      cacheNamespace:         evt.endpoint.cacheNamespace     || null,
-      // Due to a bug in API Gateway reported here: https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41
-      // Specifying credentials within API Gateway causes extra latency (~500ms)
-      // Until API Gateway is fixed, we need to make a separate call to Lambda to add credentials to API Gateway
-      // Once API Gateway is fixed, we can use this in credentials:
-      // _this._regionJson.iamRoleArnApiGateway
-      credentials:            null,
-      integrationHttpMethod:  'POST',
-      requestParameters:      evt.endpoint.requestParameters || {},
-      requestTemplates:       evt.endpoint.requestTemplates  || {},
-      uri:                    'arn:aws:apigateway:' // Make ARN for apigateway - lambda
-                              + evt.region.region
-                              + ':lambda:path/2015-03-31/functions/arn:aws:lambda:'
-                              + evt.region.region
-                              + ':'
-                              + _this.awsAccountNumber
-                              + ':function:'
-                              + _this.deployedLambda.FunctionName
-                              + ':'
-                              + alias
-                              + '/invocations'
-    };
-
-    // Create Integration
-    return _this.ApiGateway.putIntegrationPromised(params)
-        .then(function(response) {
-
-          // Save integration
-          _this.integration = response;
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - ' + evt.endpoint.path + '": '
-              + 'created integration with the type: AWS');
-
-          return evt;
-        })
-        .catch(function(error) {
-          throw new SError(
-              error.message,
-              SError.errorCodes.UNKNOWN);
-        });
-  }
-
-  /**
-   * Create Endpoint Method Response
-   */
-
-  _createEndpointMethodResponses(evt) {
-
-    let _this           = this;
-
-    return BbPromise.try(function() {
-
-          // Collect Response Keys
-          if (evt.endpoint.responses) return Object.keys(evt.endpoint.responses);
-          else return [];
-
-        })
-        .each(function(responseKey) {
-
-          // Iterate through each response to be created
-
-          let thisResponse       = evt.endpoint.responses[responseKey];
-          let responseParameters = {};
-          let responseModels     = {};
-
-          // If Response Params, add them
-          if (thisResponse.responseParameters) {
-            // Format Response Parameters per APIG API's Expectations
-            for (let prop in thisResponse.responseParameters) {
-              responseParameters[prop] = true;
-            }
-          }
-
-          // If Request models, add them
-          if (thisResponse.responseModels) {
-            // Format Response Models per APIG API's Expectations
-            for (let name in thisResponse.responseModels) {
-              let value            = thisResponse.responseModels[name];
-              responseModels[name] = value;
-            }
-          }
-
-          let params = {
-            httpMethod:         evt.endpoint.method, /* required */
-            resourceId:         _this.resource.id, /* required */
-            restApiId:          evt.region.restApiId, /* required */
-            statusCode:         thisResponse.statusCode, /* required */
-            responseModels:     responseModels,
-            responseParameters: responseParameters
-          };
-
-          // Create Method Response
-          return _this.ApiGateway.putMethodResponsePromised(params)
-              .then(function() {
+                // Add resource to _this.resources and callback
+                _this.apiResources.push(response);
 
                 SUtils.sDebug(
                     '"'
                     + evt.stage + ' - '
                     + evt.region.region
                     + ' - ' + evt.endpoint.path + '": '
-                    + 'created method response');
+                    + 'created resource: '
+                    + response.pathPart);
 
-              })
-              .catch(function(error) {
-                throw new SError(error.message);
+                // Return callback to iterate loop
+                return cb();
               });
-        })
-        .then(function() {
-          return evt;
-        });
-  }
-
-  /**
-   * Create Method Integration Response
-   */
-
-  _createEndpointMethodIntegResponses(evt) {
-
-    let _this           = this;
-
-    return BbPromise.try(function() {
-
-          // Collect Response Keys
-          if (evt.endpoint.responses) return Object.keys(evt.endpoint.responses);
-          else return [];
-        })
-        .each(function(responseKey) {
-
-          let thisResponse       = evt.endpoint.responses[responseKey];
-
-          // Add Response Parameters
-          let responseParameters = thisResponse.responseParameters || {};
-
-          // Add Response Templates
-          let responseTemplates  = thisResponse.responseTemplates || {};
-
-          // Add SelectionPattern
-          let selectionPattern   = thisResponse.selectionPattern || (responseKey === 'default' ? null : responseKey);
-
-          let params = {
-            httpMethod:         evt.endpoint.method, /* required */
-            resourceId:         _this.resource.id, /* required */
-            restApiId:          evt.region.restApiId, /* required */
-            statusCode:         thisResponse.statusCode, /* required */
-            responseParameters: responseParameters,
-            responseTemplates:  responseTemplates,
-            selectionPattern:   selectionPattern,
-          };
-
-          // Create Integration Response
-          return _this.ApiGateway.putIntegrationResponsePromised(params)
-              .then(function() {
-
-                SUtils.sDebug(
-                    '"'
-                    + evt.stage + ' - '
-                    + evt.region.region
-                    + ' - ' + evt.endpoint.path + '": '
-                    + 'created method integration response');
-
-              }).catch(function(error) {
-                throw new SError(error.message);
-              });
-        })
-        .then(function() {
-          return evt;
-        });
-  }
-
-  /**
-   * Manage Lambda Access Policy
-   */
-
-  _manageLambdaAccessPolicy(evt) {
-
-    let _this = this;
-
-    // If method integration is not for a lambda, skip
-    if (!_this.deployedLambda) return Promise.resolve();
-
-    return _this._getLambdaAccessPolicy(evt)
-        .bind(_this)
-        .then(_this._removeLambdaPermissionForEndpoint)
-        .then(_this._addLambdaPermissionForEndpoint);
-  }
-
-  /**
-   * Get Lambda Access Policy
-   * - Since specifying credentials when creating the Method Integration results in ~500ms
-   * - of extra latency, this function updates the lambda's access policy instead
-   * - to grant API Gateway permission.  This is how the API Gateway console does it.
-   * - But this is not finished and the "getPolicy" method in the SDK is broken, so this
-   * - is currently impossible to implement.
-   */
-
-  _getLambdaAccessPolicy(evt) {
-
-    let _this  = this;
-
-    let params = {
-      FunctionName: _this.deployedLambda.FunctionArn, /* required */
-      //Qualifier: 'STRING_VALUE'
-    };
-
-    return _this.Lambda.getPolicyPromised(params)
-        .then(function(data) {
-          _this.deployedLambda.policy = JSON.parse(data.Policy);
-          return evt;
-        })
-        .catch(function(e) {
-          return evt;
-        });
-  }
-
-  /**
-   * Remove Lambda Access Policy
-   */
-
-  _removeLambdaPermissionForEndpoint(evt) {
-
-    let _this       = this,
-        statement;
-
-    if (_this.deployedLambda.policy) {
-      let policy = _this.deployedLambda.policy;
-      for (let i = 0; i < policy.Statement.length; i++) {
-        statement = policy.Statement[i];
-        if (statement.Sid && statement.Sid === evt.endpoint.lambdaPolicyStatementId) break;
-      }
+        }, function() {
+          return resolve(evt);
+        }); // async.eachSeries
+      });
     }
 
-    if (!statement) return BbPromise.resolve(evt);
+    /**
+     * Create Endpoint Method
+     */
 
-    let params = {
-      FunctionName: _this.deployedLambda.FunctionArn, /* required */
-      StatementId:  evt.endpoint.lambdaPolicyStatementId, /* required */
-      //Qualifier: 'STRING_VALUE'
-    };
+    _createEndpointMethod(evt) {
 
-    return _this.Lambda.removePermissionPromised(params)
-        .then(function(data) {
+      let _this             = this,
+          requestParameters = {};
 
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - ' + evt.endpoint.path + '": '
-              + 'removed existing lambda access policy statement');
+      // If Request Params, add them
+      if (evt.endpoint.requestParameters) {
 
-          return evt;
-        })
-        .catch(function(error) {
-          return evt;
-        });
+        // Format them per APIG API's Expectations
+        for (let prop in evt.endpoint.requestParameters) {
+          let requestParam                = evt.endpoint.requestParameters[prop];
+          requestParameters[requestParam] = true;
+        }
+      }
+
+      let params = {
+        httpMethod: evt.endpoint.method, /* required */
+        resourceId: _this.resource.id, /* required */
+        restApiId:  evt.region.restApiId /* required */
+      };
+
+      return _this.ApiGateway.getMethodPromised(params)
+          .then(function(response) {
+
+            // Method exists.  Delete and recreate it.
+
+            // First, save integration's Lambda aliasEndpoint, if any
+            if (response.methodIntegration) {
+              _this.prevIntegration = response.methodIntegration;
+            }
+
+            let params = {
+              httpMethod: evt.endpoint.method, /* required */
+              resourceId: _this.resource.id, /* required */
+              restApiId:  evt.region.restApiId /* required */
+            };
+
+            return _this.ApiGateway.deleteMethodPromised(params)
+                .then(function(response) {
+
+                  let params = {
+                    authorizationType:  evt.endpoint.authorizationType, /* required */
+                    httpMethod:         evt.endpoint.method, /* required */
+                    resourceId:         _this.resource.id, /* required */
+                    restApiId:          evt.region.restApiId, /* required */
+                    apiKeyRequired:     evt.endpoint.apiKeyRequired,
+                    requestModels:      evt.endpoint.requestModels,
+                    requestParameters:  requestParameters
+                  };
+                  return _this.ApiGateway.putMethodPromised(params);
+
+                });
+          }, function(error) {
+
+            // Method does not exist.  Create it.
+
+            let params = {
+              authorizationType:  evt.endpoint.authorizationType, /* required */
+              httpMethod:         evt.endpoint.method, /* required */
+              resourceId:         _this.resource.id, /* required */
+              restApiId:          evt.region.restApiId, /* required */
+              apiKeyRequired:     evt.endpoint.apiKeyRequired,
+              requestModels:      evt.endpoint.requestModels,
+              requestParameters:  requestParameters
+            };
+
+            return _this.ApiGateway.putMethodPromised(params);
+          })
+          .then(function(response) {
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path + '": '
+                + 'created method: '
+                + evt.endpoint.method);
+
+            return evt;
+          });
+    }
+
+    /**
+     * Create Endpoint Integration
+     */
+
+    _createEndpointIntegration(evt) {
+
+      let _this           = this;
+
+      // Alias Lambda, default ot $LATEST
+      let alias;
+      if (evt.aliasEndpoint) alias  = evt.aliasEndpoint;
+      else alias = '${stageVariables.functionAlias}';
+
+      let params = {
+        httpMethod:             evt.endpoint.method, /* required */
+        resourceId:             _this.resource.id, /* required */
+        restApiId:              evt.region.restApiId, /* required */
+        type:                   'AWS', /* required */
+        cacheKeyParameters:     evt.endpoint.cacheKeyParameters || [],
+        cacheNamespace:         evt.endpoint.cacheNamespace     || null,
+        // Due to a bug in API Gateway reported here: https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41
+        // Specifying credentials within API Gateway causes extra latency (~500ms)
+        // Until API Gateway is fixed, we need to make a separate call to Lambda to add credentials to API Gateway
+        // Once API Gateway is fixed, we can use this in credentials:
+        // _this._regionJson.iamRoleArnApiGateway
+        credentials:            null,
+        integrationHttpMethod:  'POST',
+        requestParameters:      evt.endpoint.requestParameters || {},
+        requestTemplates:       evt.endpoint.requestTemplates  || {},
+        uri:                    'arn:aws:apigateway:' // Make ARN for apigateway - lambda
+                                + evt.region.region
+                                + ':lambda:path/2015-03-31/functions/arn:aws:lambda:'
+                                + evt.region.region
+                                + ':'
+                                + _this.awsAccountNumber
+                                + ':function:'
+                                + _this.deployedLambda.FunctionName
+                                + ':'
+                                + alias
+                                + '/invocations'
+      };
+
+      // Create Integration
+      return _this.ApiGateway.putIntegrationPromised(params)
+          .then(function(response) {
+
+            // Save integration
+            _this.integration = response;
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path + '": '
+                + 'created integration with the type: AWS');
+
+            return evt;
+          })
+          .catch(function(error) {
+            throw new SError(
+                error.message,
+                SError.errorCodes.UNKNOWN);
+          });
+    }
+
+    /**
+     * Create Endpoint Method Response
+     */
+
+    _createEndpointMethodResponses(evt) {
+
+      let _this           = this;
+
+      return BbPromise.try(function() {
+
+            // Collect Response Keys
+            if (evt.endpoint.responses) return Object.keys(evt.endpoint.responses);
+            else return [];
+
+          })
+          .each(function(responseKey) {
+
+            // Iterate through each response to be created
+
+            let thisResponse       = evt.endpoint.responses[responseKey];
+            let responseParameters = {};
+            let responseModels     = {};
+
+            // If Response Params, add them
+            if (thisResponse.responseParameters) {
+              // Format Response Parameters per APIG API's Expectations
+              for (let prop in thisResponse.responseParameters) {
+                responseParameters[prop] = true;
+              }
+            }
+
+            // If Request models, add them
+            if (thisResponse.responseModels) {
+              // Format Response Models per APIG API's Expectations
+              for (let name in thisResponse.responseModels) {
+                let value            = thisResponse.responseModels[name];
+                responseModels[name] = value;
+              }
+            }
+
+            let params = {
+              httpMethod:         evt.endpoint.method, /* required */
+              resourceId:         _this.resource.id, /* required */
+              restApiId:          evt.region.restApiId, /* required */
+              statusCode:         thisResponse.statusCode, /* required */
+              responseModels:     responseModels,
+              responseParameters: responseParameters
+            };
+
+            // Create Method Response
+            return _this.ApiGateway.putMethodResponsePromised(params)
+                .then(function() {
+
+                  SUtils.sDebug(
+                      '"'
+                      + evt.stage + ' - '
+                      + evt.region.region
+                      + ' - ' + evt.endpoint.path + '": '
+                      + 'created method response');
+
+                })
+                .catch(function(error) {
+                  throw new SError(error.message);
+                });
+          })
+          .then(function() {
+            return evt;
+          });
+    }
+
+    /**
+     * Create Method Integration Response
+     */
+
+    _createEndpointMethodIntegResponses(evt) {
+
+      let _this           = this;
+
+      return BbPromise.try(function() {
+
+            // Collect Response Keys
+            if (evt.endpoint.responses) return Object.keys(evt.endpoint.responses);
+            else return [];
+          })
+          .each(function(responseKey) {
+
+            let thisResponse       = evt.endpoint.responses[responseKey];
+
+            // Add Response Parameters
+            let responseParameters = thisResponse.responseParameters || {};
+
+            // Add Response Templates
+            let responseTemplates  = thisResponse.responseTemplates || {};
+
+            // Add SelectionPattern
+            let selectionPattern   = thisResponse.selectionPattern || (responseKey === 'default' ? null : responseKey);
+
+            let params = {
+              httpMethod:         evt.endpoint.method, /* required */
+              resourceId:         _this.resource.id, /* required */
+              restApiId:          evt.region.restApiId, /* required */
+              statusCode:         thisResponse.statusCode, /* required */
+              responseParameters: responseParameters,
+              responseTemplates:  responseTemplates,
+              selectionPattern:   selectionPattern,
+            };
+
+            // Create Integration Response
+            return _this.ApiGateway.putIntegrationResponsePromised(params)
+                .then(function() {
+
+                  SUtils.sDebug(
+                      '"'
+                      + evt.stage + ' - '
+                      + evt.region.region
+                      + ' - ' + evt.endpoint.path + '": '
+                      + 'created method integration response');
+
+                }).catch(function(error) {
+                  throw new SError(error.message);
+                });
+          })
+          .then(function() {
+            return evt;
+          });
+    }
+
+    /**
+     * Manage Lambda Access Policy
+     */
+
+    _manageLambdaAccessPolicy(evt) {
+
+      let _this = this;
+
+      // If method integration is not for a lambda, skip
+      if (!_this.deployedLambda) return Promise.resolve();
+
+      return _this._getLambdaAccessPolicy(evt)
+          .bind(_this)
+          .then(_this._removeLambdaPermissionForEndpoint)
+          .then(_this._addLambdaPermissionForEndpoint);
+    }
+
+    /**
+     * Get Lambda Access Policy
+     * - Since specifying credentials when creating the Method Integration results in ~500ms
+     * - of extra latency, this function updates the lambda's access policy instead
+     * - to grant API Gateway permission.  This is how the API Gateway console does it.
+     * - But this is not finished and the "getPolicy" method in the SDK is broken, so this
+     * - is currently impossible to implement.
+     */
+
+    _getLambdaAccessPolicy(evt) {
+
+      let _this  = this;
+
+      let params = {
+        FunctionName: _this.deployedLambda.FunctionArn, /* required */
+        //Qualifier: 'STRING_VALUE'
+      };
+
+      return _this.Lambda.getPolicyPromised(params)
+          .then(function(data) {
+            _this.deployedLambda.policy = JSON.parse(data.Policy);
+            return evt;
+          })
+          .catch(function(e) {
+            return evt;
+          });
+    }
+
+    /**
+     * Remove Lambda Access Policy
+     */
+
+    _removeLambdaPermissionForEndpoint(evt) {
+
+      let _this       = this,
+          statement;
+
+      if (_this.deployedLambda.policy) {
+        let policy = _this.deployedLambda.policy;
+        for (let i = 0; i < policy.Statement.length; i++) {
+          statement = policy.Statement[i];
+          if (statement.Sid && statement.Sid === evt.endpoint.lambdaPolicyStatementId) break;
+        }
+      }
+
+      if (!statement) return BbPromise.resolve(evt);
+
+      let params = {
+        FunctionName: _this.deployedLambda.FunctionArn, /* required */
+        StatementId:  evt.endpoint.lambdaPolicyStatementId, /* required */
+        //Qualifier: 'STRING_VALUE'
+      };
+
+      return _this.Lambda.removePermissionPromised(params)
+          .then(function(data) {
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path + '": '
+                + 'removed existing lambda access policy statement');
+
+            return evt;
+          })
+          .catch(function(error) {
+            return evt;
+          });
+    }
+
+    /**
+     * Add Lambda Permission For Endpoint
+     */
+
+    _addLambdaPermissionForEndpoint(evt) {
+
+      let _this       = this;
+
+      // Sanitize Path - Remove first and last slashes, if any
+      evt.endpoint.path = evt.endpoint.path.split('/');
+      evt.endpoint.path = evt.endpoint.path.join('/');
+
+      // Create new access policy statement
+      let params          = {};
+      params.Action       = 'lambda:InvokeFunction';
+      params.FunctionName = _this.deployedLambda.FunctionArn;
+      params.Principal    = 'apigateway.amazonaws.com';
+      params.StatementId  = evt.endpoint.lambdaPolicyStatementId;
+      params.SourceArn    = 'arn:aws:execute-api:'
+          + evt.region.region
+          + ':'
+          + _this.awsAccountNumber
+          + ':'
+          + evt.region.restApiId
+          + '/*/'
+          + evt.endpoint.method
+          + evt.endpoint.path;
+
+      return _this.Lambda.addPermissionPromised(params)
+          .then(function(data) {
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path + '": '
+                + 'added permission to Lambda');
+
+            return evt;
+
+          })
+          .catch(function(error) {
+            throw new SError(error.message);
+          });
+    }
+
   }
 
-  /**
-   * Add Lambda Permission For Endpoint
-   */
-
-  _addLambdaPermissionForEndpoint(evt) {
-
-    let _this       = this;
-
-    // Sanitize Path - Remove first and last slashes, if any
-    evt.endpoint.path = evt.endpoint.path.split('/');
-    evt.endpoint.path = evt.endpoint.path.join('/');
-
-    // Create new access policy statement
-    let params          = {};
-    params.Action       = 'lambda:InvokeFunction';
-    params.FunctionName = _this.deployedLambda.FunctionArn;
-    params.Principal    = 'apigateway.amazonaws.com';
-    params.StatementId  = evt.endpoint.lambdaPolicyStatementId;
-    params.SourceArn    = 'arn:aws:execute-api:'
-        + evt.region.region
-        + ':'
-        + _this.awsAccountNumber
-        + ':'
-        + evt.region.restApiId
-        + '/*/'
-        + evt.endpoint.method
-        + evt.endpoint.path;
-
-    return _this.Lambda.addPermissionPromised(params)
-        .then(function(data) {
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - ' + evt.endpoint.path + '": '
-              + 'added permission to Lambda');
-
-          return evt;
-
-        })
-        .catch(function(error) {
-          throw new SError(error.message);
-        });
-  }
-
-}
-
-module.exports = EndpointBuildApiGateway;
+  return( EndpointBuildApiGateway );
+};

--- a/lib/actions/EndpointDeploy.js
+++ b/lib/actions/EndpointDeploy.js
@@ -18,348 +18,349 @@
  * - deployed: (Object)  Contains regions and the code functions that have been uploaded to the S3 bucket in that region
  */
 
-const SPlugin    = require('../ServerlessPlugin'),
-    SError       = require('../ServerlessError'),
-    SUtils       = require('../utils/index'),
-    SCli         = require('../utils/cli'),
-    BbPromise    = require('bluebird'),
-    async        = require('async'),
-    path         = require('path'),
-    fs           = require('fs'),
-    os           = require('os');
+module.exports = function(SPlugin, serverlessPath) {
+  const path       = require('path'),
+      SError       = require(path.join(serverlessPath, 'ServerlessError')),
+      SUtils       = require(path.join(serverlessPath, 'utils/index')),
+      SCli         = require(path.join(serverlessPath, 'utils/cli')),
+      BbPromise    = require('bluebird'),
+      async        = require('async'),
+      fs           = require('fs'),
+      os           = require('os');
 
-// Promisify fs module
-BbPromise.promisifyAll(fs);
+  // Promisify fs module
+  BbPromise.promisifyAll(fs);
 
-class EndpointDeploy extends SPlugin {
+  class EndpointDeploy extends SPlugin {
 
-  constructor(S, config) {
-    super(S, config);
-  }
-
-  static getName() {
-    return 'serverless.core.' + EndpointDeploy.name;
-  }
-
-  registerActions() {
-
-    this.S.addAction(this.endpointDeploy.bind(this), {
-      handler:       'endpointDeploy',
-      description:   'Deploys REST API endpoints',
-      context:       'endpoint',
-      contextAction: 'deploy',
-      options:       [
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'Optional if only one stage is defined in project'
-        }, {
-          option:      'region',
-          shortcut:    'r',
-          description: 'Optional - Target one region to deploy to'
-        }, {
-          option:      'aliasEndpoint', // TODO: Implement
-          shortcut:    'e',
-          description: 'Optional - Point Endpoint(s) to a specific Lambda alias'
-        }, {
-          option:      'aliasRestApi', // TODO: Implement
-          shortcut:    'r',
-          description: 'Optional - Override the API Gateway "functionAlias" Stage Variable'
-        }, {
-          option:      'all',
-          shortcut:    'a',
-          description: 'Optional - Select all Functions in your project for deployment'
-        }
-      ],
-    });
-
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Endpoint Deploy
-   */
-
-  endpointDeploy(event) {
-
-    let _this = this,
-        evt   = {};
-
-    // If CLI, parse options
-    if (_this.S.cli) {
-
-      // Options
-      evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-
-      // Option - Non-interactive
-      if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
-
-      // Endpoint paths - They should be all params
-      evt.paths  = _this.S.cli.params;
+    constructor(S, config) {
+      super(S, config);
     }
 
-    // If NO-CLI, add options
-    if (event) evt = event;
-
-    // Add defaults
-    evt.stage               = evt.stage ? evt.stage : null;
-    evt.regions             = evt.region ? [evt.region] : [];
-    evt.paths               = evt.paths ? evt.paths : [];
-    evt.all                 = evt.all ? true : false;
-    evt.aliasEndpoint       = evt.aliasEndpoint ? evt.aliasEndpoint : null;
-    evt.aliasRestApi        = evt.aliasRestApi ? evt.aliasRestApi : null;
-    evt.endpoints           = [];
-    evt.deployed            = {};
-
-    // Flow
-    return _this._validateAndPrepare(evt)
-        .bind(_this)
-        .then(_this._prepareEndpoints)
-        .then(function(evt) {
-            return _this.cliPromptSelectStage('Endpoint Deployer - Choose a stage: ', evt.stage, false)
-              .then(stage => {
-                  evt.stage = stage;
-                  return evt;
-              })
-        })
-        .then(_this._prepareRegions)
-        .then(_this._processDeployment)
-        .then(function(evt) {
-          return evt;
-        });
-  }
-
-  /**
-   * Validate And Prepare
-   * - If CLI, maps CLI input to event object
-   */
-
-  _validateAndPrepare(evt) {
-
-    let _this = this;
-
-    // If NO-CLI, validate paths
-    if (!_this.S.cli) {
-
-      // Validate Paths
-      if (!evt.paths.length && !evt.all) {
-        throw new SError(`One or multiple paths are required`);
-      }
-
-      // Validate Stage
-      if (!evt.stage) {
-        throw new SError(`Stage is required`);
-      }
+    static getName() {
+      return 'serverless.core.' + EndpointDeploy.name;
     }
 
-    return BbPromise.resolve(evt);
-  }
+    registerActions() {
 
-  /**
-   * Prepare Endpoints
-   */
-
-  _prepareEndpoints(evt) {
-
-    let _this = this;
-
-    // If NO-CLI - Get Endpoints from submitted paths
-    if (!_this.S.cli) {
-
-      return SUtils.getEndpoints(
-          _this.S._projectRootPath,
-          evt.all ? null : evt.paths)
-          .then(function (endpoints) {
-
-            if (!endpoints.length) throw new SError(`No endpoints found`);
-            evt.endpoints = endpoints;
-
-            // Delete Paths
-            if (evt.paths) delete evt.paths;
-            return evt;
-          });
-    }
-
-    // IF CLI + ALL/paths, get endpoints
-    if (_this.S.cli && (evt.all || evt.paths.length)) {
-
-      return SUtils.getEndpoints(
-          _this.S._projectRootPath,
-          evt.all ? null : evt.paths)
-          .then(function (endpoints) {
-
-            if (!endpoints.length) throw new SError(`No endpoints found`);
-            evt.endpoints = endpoints;
-
-            // Delete Paths
-            if (evt.paths) delete evt.paths;
-            return evt;
-          });
-    }
-
-    // IF CLI +  no ALL + no paths - prompt user to select endpoints
-    if (_this.S.cli && !evt.all && !evt.paths.length) {
-      return _this.cliPromptSelectEndpoints(
-          process.cwd(),
-          'Select the endpoints you wish to deploy:',
-          true,
-          true)
-          .then(function (selected) {
-            evt.endpoints = selected;
-            return evt;
-          });
-    }
-  }
-
-
-  /**
-   * Prepare Regions
-   */
-
-  _prepareRegions(evt) {
-
-    // If no region specified, deploy to all regions in stage
-    if (!evt.regions.length) {
-      evt.regions  = this.S._projectJson.stages[evt.stage].map(rCfg => {
-        return rCfg.region;
-      });
-    }
-
-    // Delete region for neatness
-    if (evt.region) delete evt.region;
-
-    return evt;
-  }
-
-  /**
-   * Process Deployment
-   */
-
-  _processDeployment(evt) {
-
-    let _this = this;
-
-    // Status
-    SCli.log('Deploying endpoints in "' + evt.stage + '" to the following regions: ' + evt.regions);
-    _this._spinner = SCli.spinner();
-    _this._spinner.start();
-
-    return BbPromise.try(function() {
-          return evt.regions;
-        })
-        .bind(_this)
-        .each(function(region) {
-
-          // Add Deployed Region
-          evt.deployed[region] = [];
-
-          // Deploy Endpoints in each region
-          return _this._deployEndpointsByRegion(evt, region)
-        })
-        .then(function() {
-
-          // Status
-          _this._spinner.stop(true);
-          SCli.log('Successfully deployed endpoints in "' + evt.stage + '" to the following regions:');
-
-          // Display Methods & URLS
-          for (let i = 0; i < Object.keys(evt.deployed).length; i++) {
-            let region = evt.deployed[Object.keys(evt.deployed)[i]];
-            SCli.log(Object.keys(evt.deployed)[i] + ' ------------------------');
-            for (let j = 0; j < region.length; j++) {
-              SCli.log('  ' + region[j].method + ' - ' + region[j].url);
-            }
+      this.S.addAction(this.endpointDeploy.bind(this), {
+        handler:       'endpointDeploy',
+        description:   'Deploys REST API endpoints',
+        context:       'endpoint',
+        contextAction: 'deploy',
+        options:       [
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'Optional if only one stage is defined in project'
+          }, {
+            option:      'region',
+            shortcut:    'r',
+            description: 'Optional - Target one region to deploy to'
+          }, {
+            option:      'aliasEndpoint', // TODO: Implement
+            shortcut:    'e',
+            description: 'Optional - Point Endpoint(s) to a specific Lambda alias'
+          }, {
+            option:      'aliasRestApi', // TODO: Implement
+            shortcut:    'r',
+            description: 'Optional - Override the API Gateway "functionAlias" Stage Variable'
+          }, {
+            option:      'all',
+            shortcut:    'a',
+            description: 'Optional - Select all Functions in your project for deployment'
           }
+        ],
+      });
 
-          return evt;
-        });
-  }
+      return BbPromise.resolve();
+    }
 
-  /**
-   * Deploy Endpoints By Region
-   * - Finds or creates a API Gateway in the region
-   * - Deploys all function endpoints queued in a specific region
-   */
+    /**
+     * Endpoint Deploy
+     */
 
-  _deployEndpointsByRegion(evt, region) {
+    endpointDeploy(event) {
 
-    let _this = this,
-        regionConfig = SUtils.getRegionConfig(
-        _this.S._projectJson,
-        evt.stage,
-        region);
+      let _this = this,
+          evt   = {};
 
-    // Load AWS Service Instance for APIGateway
-    let awsConfig    = {
-      region:          region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
-    let ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
+      // If CLI, parse options
+      if (_this.S.cli) {
 
-    // Get or Create REST API for Region
-    return ApiGateway.sFindOrCreateRestApi(
-        _this.S,
-        evt.stage,
-        region)
-        .then(function(restApi) {
+        // Options
+        evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
 
-          return new BbPromise(function(resolve, reject) {
+        // Option - Non-interactive
+        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
 
-            // A function can have multiple endpoints.  Process all endpoints for this Function
-            async.eachSeries(evt.endpoints, function(endpoint, eCb) {
+        // Endpoint paths - They should be all params
+        evt.paths  = _this.S.cli.params;
+      }
 
-              // Create new event object
-              let evtClone = {
-                stage:          evt.stage,
-                region:         regionConfig,
-                endpoint:       endpoint,
-                aliasEndpoint:  evt.aliasEndpoint,
-                aliasRestApi:   evt.aliasRestApi,
-              };
+      // If NO-CLI, add options
+      if (event) evt = event;
 
-              return _this.S.actions.endpointBuildApiGateway(evtClone)
-                  .then(function (evtProcessed) {
-                    // Add provisioned endpoint urls
-                    evt.deployed[region].push({
-                      function: evtProcessed.endpoint.function.name,
-                      method:   evtProcessed.endpoint.method,
-                      url:      evtProcessed.endpoint.url
-                    });
+      // Add defaults
+      evt.stage               = evt.stage ? evt.stage : null;
+      evt.regions             = evt.region ? [evt.region] : [];
+      evt.paths               = evt.paths ? evt.paths : [];
+      evt.all                 = evt.all ? true : false;
+      evt.aliasEndpoint       = evt.aliasEndpoint ? evt.aliasEndpoint : null;
+      evt.aliasRestApi        = evt.aliasRestApi ? evt.aliasRestApi : null;
+      evt.endpoints           = [];
+      evt.deployed            = {};
 
-                    return eCb();
-                  })
-                  .catch(function(e) {
-
-                    // Stash Failed Endpoint
-                    if (!evt.failed) evt.failed = {};
-                    if (!evt.failed[region]) evt.failed[region] = [];
-                    evt.failed[region].push({
-                      message:  e.message,
-                      stack:    e.stack,
-                      endpoint: endpoint
-                    });
-
-                    return eCb();
-                  });
-
-            }, function() {
-              return resolve(evt);
-            });
+      // Flow
+      return _this._validateAndPrepare(evt)
+          .bind(_this)
+          .then(_this._prepareEndpoints)
+          .then(function(evt) {
+              return _this.cliPromptSelectStage('Endpoint Deployer - Choose a stage: ', evt.stage, false)
+                .then(stage => {
+                    evt.stage = stage;
+                    return evt;
+                })
           })
-              .then(function(evt) {
+          .then(_this._prepareRegions)
+          .then(_this._processDeployment)
+          .then(function(evt) {
+            return evt;
+          });
+    }
 
-                // Deploy API Gateway Deployment in region
+    /**
+     * Validate And Prepare
+     * - If CLI, maps CLI input to event object
+     */
 
-                let newEvent = {
-                  stage:  evt.stage,
-                  region: regionConfig
+    _validateAndPrepare(evt) {
+
+      let _this = this;
+
+      // If NO-CLI, validate paths
+      if (!_this.S.cli) {
+
+        // Validate Paths
+        if (!evt.paths.length && !evt.all) {
+          throw new SError(`One or multiple paths are required`);
+        }
+
+        // Validate Stage
+        if (!evt.stage) {
+          throw new SError(`Stage is required`);
+        }
+      }
+
+      return BbPromise.resolve(evt);
+    }
+
+    /**
+     * Prepare Endpoints
+     */
+
+    _prepareEndpoints(evt) {
+
+      let _this = this;
+
+      // If NO-CLI - Get Endpoints from submitted paths
+      if (!_this.S.cli) {
+
+        return SUtils.getEndpoints(
+            _this.S._projectRootPath,
+            evt.all ? null : evt.paths)
+            .then(function (endpoints) {
+
+              if (!endpoints.length) throw new SError(`No endpoints found`);
+              evt.endpoints = endpoints;
+
+              // Delete Paths
+              if (evt.paths) delete evt.paths;
+              return evt;
+            });
+      }
+
+      // IF CLI + ALL/paths, get endpoints
+      if (_this.S.cli && (evt.all || evt.paths.length)) {
+
+        return SUtils.getEndpoints(
+            _this.S._projectRootPath,
+            evt.all ? null : evt.paths)
+            .then(function (endpoints) {
+
+              if (!endpoints.length) throw new SError(`No endpoints found`);
+              evt.endpoints = endpoints;
+
+              // Delete Paths
+              if (evt.paths) delete evt.paths;
+              return evt;
+            });
+      }
+
+      // IF CLI +  no ALL + no paths - prompt user to select endpoints
+      if (_this.S.cli && !evt.all && !evt.paths.length) {
+        return _this.cliPromptSelectEndpoints(
+            process.cwd(),
+            'Select the endpoints you wish to deploy:',
+            true,
+            true)
+            .then(function (selected) {
+              evt.endpoints = selected;
+              return evt;
+            });
+      }
+    }
+
+
+    /**
+     * Prepare Regions
+     */
+
+    _prepareRegions(evt) {
+
+      // If no region specified, deploy to all regions in stage
+      if (!evt.regions.length) {
+        evt.regions  = this.S._projectJson.stages[evt.stage].map(rCfg => {
+          return rCfg.region;
+        });
+      }
+
+      // Delete region for neatness
+      if (evt.region) delete evt.region;
+
+      return evt;
+    }
+
+    /**
+     * Process Deployment
+     */
+
+    _processDeployment(evt) {
+
+      let _this = this;
+
+      // Status
+      SCli.log('Deploying endpoints in "' + evt.stage + '" to the following regions: ' + evt.regions);
+      _this._spinner = SCli.spinner();
+      _this._spinner.start();
+
+      return BbPromise.try(function() {
+            return evt.regions;
+          })
+          .bind(_this)
+          .each(function(region) {
+
+            // Add Deployed Region
+            evt.deployed[region] = [];
+
+            // Deploy Endpoints in each region
+            return _this._deployEndpointsByRegion(evt, region)
+          })
+          .then(function() {
+
+            // Status
+            _this._spinner.stop(true);
+            SCli.log('Successfully deployed endpoints in "' + evt.stage + '" to the following regions:');
+
+            // Display Methods & URLS
+            for (let i = 0; i < Object.keys(evt.deployed).length; i++) {
+              let region = evt.deployed[Object.keys(evt.deployed)[i]];
+              SCli.log(Object.keys(evt.deployed)[i] + ' ------------------------');
+              for (let j = 0; j < region.length; j++) {
+                SCli.log('  ' + region[j].method + ' - ' + region[j].url);
+              }
+            }
+
+            return evt;
+          });
+    }
+
+    /**
+     * Deploy Endpoints By Region
+     * - Finds or creates a API Gateway in the region
+     * - Deploys all function endpoints queued in a specific region
+     */
+
+    _deployEndpointsByRegion(evt, region) {
+
+      let _this = this,
+          regionConfig = SUtils.getRegionConfig(
+          _this.S._projectJson,
+          evt.stage,
+          region);
+
+      // Load AWS Service Instance for APIGateway
+      let awsConfig    = {
+        region:          region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
+      let ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
+
+      // Get or Create REST API for Region
+      return ApiGateway.sFindOrCreateRestApi(
+          _this.S,
+          evt.stage,
+          region)
+          .then(function(restApi) {
+
+            return new BbPromise(function(resolve, reject) {
+
+              // A function can have multiple endpoints.  Process all endpoints for this Function
+              async.eachSeries(evt.endpoints, function(endpoint, eCb) {
+
+                // Create new event object
+                let evtClone = {
+                  stage:          evt.stage,
+                  region:         regionConfig,
+                  endpoint:       endpoint,
+                  aliasEndpoint:  evt.aliasEndpoint,
+                  aliasRestApi:   evt.aliasRestApi,
                 };
 
-                return _this.S.actions.endpointDeployApiGateway(newEvent);
-              });
-        });
-  }
-}
+                return _this.S.actions.endpointBuildApiGateway(evtClone)
+                    .then(function (evtProcessed) {
+                      // Add provisioned endpoint urls
+                      evt.deployed[region].push({
+                        function: evtProcessed.endpoint.function.name,
+                        method:   evtProcessed.endpoint.method,
+                        url:      evtProcessed.endpoint.url
+                      });
 
-module.exports = EndpointDeploy;
+                      return eCb();
+                    })
+                    .catch(function(e) {
+
+                      // Stash Failed Endpoint
+                      if (!evt.failed) evt.failed = {};
+                      if (!evt.failed[region]) evt.failed[region] = [];
+                      evt.failed[region].push({
+                        message:  e.message,
+                        stack:    e.stack,
+                        endpoint: endpoint
+                      });
+
+                      return eCb();
+                    });
+
+              }, function() {
+                return resolve(evt);
+              });
+            })
+                .then(function(evt) {
+
+                  // Deploy API Gateway Deployment in region
+
+                  let newEvent = {
+                    stage:  evt.stage,
+                    region: regionConfig
+                  };
+
+                  return _this.S.actions.endpointDeployApiGateway(newEvent);
+                });
+          });
+    }
+  }
+
+  return( EndpointDeploy );
+};

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -6,106 +6,106 @@
  * - Handles one region only.  The FunctionDeploy Action processes multiple regions by calling this multiple times.
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError     = require('../ServerlessError'),
-    SUtils     = require('../utils/index'),
-    BbPromise  = require('bluebird'),
-    path       = require('path'),
-    fs         = require('fs'),
-    os         = require('os');
+module.exports = function(SPlugin, serverlessPath) {
+  const path     = require('path'),
+      SError     = require(path.join(serverlessPath, 'ServerlessError')),
+      SUtils     = require(path.join(serverlessPath, 'utils/index')),
+      BbPromise  = require('bluebird'),
+      fs         = require('fs');
 
-// Promisify fs module
-BbPromise.promisifyAll(fs);
+  // Promisify fs module
+  BbPromise.promisifyAll(fs);
 
-class EndpointDeployApiGateway extends SPlugin {
+  class EndpointDeployApiGateway extends SPlugin {
 
-  constructor(S, config) {
-    super(S, config);
+    constructor(S, config) {
+      super(S, config);
+    }
+
+    static getName() {
+      return 'serverless.core.' + EndpointDeployApiGateway.name;
+    }
+
+    registerActions() {
+      this.S.addAction(this.endpointDeployApiGateway.bind(this), {
+        handler:     'endpointDeployApiGateway',
+        description: 'Creates an API Gateway deployment in a region',
+      });
+      return Promise.resolve();
+    }
+
+    /**
+     * Handler
+     */
+
+    endpointDeployApiGateway(evt) {
+
+      let _this = this;
+
+      // Load AWS Service Instances
+      let awsConfig = {
+        region:          evt.region.region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
+
+      _this.ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
+
+      return _this._validateAndPrepare(evt)
+          .bind(_this)
+          .then(_this._createDeployment)
+          .then(function() {
+            return evt
+          });
+    }
+
+    /**
+     * Validate And Prepare
+     */
+
+    _validateAndPrepare(evt) {
+      return BbPromise.resolve(evt);
+    }
+
+    /**
+     * Create Deployment
+     */
+
+    _createDeployment(evt) {
+
+      let _this       = this;
+
+      let params = {
+        restApiId:    evt.region.restApiId, /* required */
+        stageName:    evt.stage, /* required */
+        //cacheClusterEnabled:  false, TODO: Implement
+        //cacheClusterSize: '0.5 | 1.6 | 6.1 | 13.5 | 28.4 | 58.2 | 118 | 237', TODO: Implement
+        description: 'Serverless deployment',
+        stageDescription: evt.stage,
+        variables: {
+          functionAlias: evt.stage
+        }
+      };
+
+      return _this.ApiGateway.createDeploymentPromised(params)
+          .then(function(response) {
+            evt.deployment = response;
+
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - REST API: '
+                + 'created API Gateway deployment: '
+                + response.id);
+
+            return evt;
+          })
+          .catch(function(error) {
+            throw new SError(error.message);
+          });
+    }
   }
 
-  static getName() {
-    return 'serverless.core.' + EndpointDeployApiGateway.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.endpointDeployApiGateway.bind(this), {
-      handler:     'endpointDeployApiGateway',
-      description: 'Creates an API Gateway deployment in a region',
-    });
-    return Promise.resolve();
-  }
-
-  /**
-   * Handler
-   */
-
-  endpointDeployApiGateway(evt) {
-
-    let _this = this;
-
-    // Load AWS Service Instances
-    let awsConfig = {
-      region:          evt.region.region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
-
-    _this.ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
-
-    return _this._validateAndPrepare(evt)
-        .bind(_this)
-        .then(_this._createDeployment)
-        .then(function() {
-          return evt
-        });
-  }
-
-  /**
-   * Validate And Prepare
-   */
-
-  _validateAndPrepare(evt) {
-    return BbPromise.resolve(evt);
-  }
-
-  /**
-   * Create Deployment
-   */
-
-  _createDeployment(evt) {
-
-    let _this       = this;
-
-    let params = {
-      restApiId:    evt.region.restApiId, /* required */
-      stageName:    evt.stage, /* required */
-      //cacheClusterEnabled:  false, TODO: Implement
-      //cacheClusterSize: '0.5 | 1.6 | 6.1 | 13.5 | 28.4 | 58.2 | 118 | 237', TODO: Implement
-      description: 'Serverless deployment',
-      stageDescription: evt.stage,
-      variables: {
-        functionAlias: evt.stage
-      }
-    };
-
-    return _this.ApiGateway.createDeploymentPromised(params)
-        .then(function(response) {
-          evt.deployment = response;
-
-          SUtils.sDebug(
-              '"'
-              + evt.stage + ' - '
-              + evt.region.region
-              + ' - REST API: '
-              + 'created API Gateway deployment: '
-              + response.id);
-
-          return evt;
-        })
-        .catch(function(error) {
-          throw new SError(error.message);
-        });
-  }
-}
-
-module.exports = EndpointDeployApiGateway;
+  return( EndpointDeployApiGateway );
+};

--- a/lib/actions/EnvGet.js
+++ b/lib/actions/EnvGet.js
@@ -10,198 +10,199 @@
  * - key      (String) the env var key you want to get from region bucket
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-    SError  = require('../ServerlessError'),
-    SCli    = require('../utils/cli'),
-    chalk      = require('chalk'),
-    BbPromise  = require('bluebird'),
-    SUtils  = require('../utils'),
-    awsMisc    = require('../utils/aws/Misc');
-
-/**
- * EnvGet Class
- */
-
-class EnvGet extends SPlugin {
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError  = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli    = require(path.join(serverlessPath, 'utils/cli')),
+      chalk      = require('chalk'),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require(path.join(serverlessPath, 'utils/aws/Misc'));
 
   /**
-   * Constructor
+   * EnvGet Class
    */
 
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
+  class EnvGet extends SPlugin {
 
-  /**
-   * Define your plugins name
-   *
-   * @returns {string}
-   */
-  static getName() {
-    return 'serverless.core.' + EnvGet.name;
-  }
+    /**
+     * Constructor
+     */
 
-  /**
-   * @returns {Promise} upon completion of all registrations
-   */
-
-  registerActions() {
-    this.S.addAction(this.envGet.bind(this), {
-      handler:       'envGet',
-      description:   `Get env var value for stage and region. Region can be 'all'
-usage: serverless env get`,
-      context:       'env',
-      contextAction: 'get',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'region you want to get env var from'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'stage you want to get env var from'
-        },
-        {
-          option:      'key',
-          shortcut:    'k',
-          description: 'the key of the env var you want to get'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'i',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Action
-   */
-  envGet(evt) {
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
+    /**
+     * Define your plugins name
+     *
+     * @returns {string}
+     */
+    static getName() {
+      return 'serverless.core.' + EnvGet.name;
+    }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
+    /**
+     * @returns {Promise} upon completion of all registrations
+     */
 
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+    registerActions() {
+      this.S.addAction(this.envGet.bind(this), {
+        handler:       'envGet',
+        description:   `Get env var value for stage and region. Region can be 'all'
+  usage: serverless env get`,
+        context:       'env',
+        contextAction: 'get',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'region you want to get env var from'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'stage you want to get env var from'
+          },
+          {
+            option:      'key',
+            shortcut:    'k',
+            description: 'the key of the env var you want to get'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'i',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
+      return BbPromise.resolve();
+    }
 
-      if (_this.S.cli.options.nonInteractive) {
+    /**
+     * Action
+     */
+    envGet(evt) {
+      let _this = this;
+
+      if(evt) {
+        _this.evt = evt;
         _this.S._interactive = false;
       }
+
+
+      // If CLI, parse arguments
+      if (_this.S.cli) {
+
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
+        }
+      }
+
+      return _this.S.validateProject()
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(_this._getEnvVar)
+          .then(function() {
+            return _this.evt;
+          });
     }
 
-    return _this.S.validateProject()
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(_this._getEnvVar)
-        .then(function() {
-          return _this.evt;
-        });
-  }
+    /**
+     * Prompt key, stage and region
+     */
+    _prompt() {
+      let _this = this;
 
-  /**
-   * Prompt key, stage and region
-   */
-  _prompt() {
-    let _this = this;
-
-    return SCli.awsPromptInputEnvKey('Enter env var key to get its value: ', _this)
-      .then(key => {
-        _this.evt.key = key;
-        BbPromise.resolve();
-      })
-    .then(function(){
-      return _this.cliPromptSelectStage('Select a stage to get env var from: ', _this.evt.stage, true)
-        .then(stage => {
-          _this.evt.stage = stage;
+      return SCli.awsPromptInputEnvKey('Enter env var key to get its value: ', _this)
+        .then(key => {
+          _this.evt.key = key;
           BbPromise.resolve();
         })
-    })
-    .then(function(){
-        return _this.cliPromptSelectRegion('Select a region to get env var from: ', true, _this.evt.region, _this.evt.stage)
-          .then(region => {
-            _this.evt.region = region;
+      .then(function(){
+        return _this.cliPromptSelectStage('Select a stage to get env var from: ', _this.evt.stage, true)
+          .then(stage => {
+            _this.evt.stage = stage;
             BbPromise.resolve();
-          });
-    });
+          })
+      })
+      .then(function(){
+          return _this.cliPromptSelectRegion('Select a region to get env var from: ', true, _this.evt.region, _this.evt.stage)
+            .then(region => {
+              _this.evt.region = region;
+              BbPromise.resolve();
+            });
+      });
 
-  }
+    }
 
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare data
-   */
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare data
+     */
 
-  _validateAndPrepare(){
-    let _this = this;
+    _validateAndPrepare(){
+      let _this = this;
 
-    // non interactive validation
-    if (!_this.S._interactive) {
+      // non interactive validation
+      if (!_this.S._interactive) {
 
-      // Check Params
-      if (!_this.evt.stage || !_this.evt.region || !_this.evt.key) {
-        return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        // Check Params
+        if (!_this.evt.stage || !_this.evt.region || !_this.evt.key) {
+          return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        }
+      }
+
+      // validate stage: make sure stage exists
+      if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
+        return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+      }
+
+      // skip the next validation if stage is 'local' & region is 'all'
+      if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
+
+        // validate region: make sure region exists in stage
+        if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
+              return r.region == _this.evt.region;
+            })) {
+          return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
+        }
       }
     }
 
-    // validate stage: make sure stage exists
-    if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-    }
+    /**
+     * get env var based on data validated
+     */
 
-    // skip the next validation if stage is 'local' & region is 'all'
-    if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
+    _getEnvVar(){
+      let _this = this;
 
-      // validate region: make sure region exists in stage
-      if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
-            return r.region == _this.evt.region;
-          })) {
-        return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
-      }
-    }
-  }
+      return awsMisc.getEnvFiles(_this.S, _this.evt.region, _this.evt.stage)
+          .then(envMapsByRegion => {
+            let valByRegion = {};
 
-  /**
-   * get env var based on data validated
-   */
+            SCli.log(`Values for ${_this.evt.key} in stage ${_this.evt.stage} by region:`);
+            envMapsByRegion.forEach(mapForRegion => {
+              let value;
+              if (mapForRegion.vars && mapForRegion.vars[_this.evt.key]) {
+                value = mapForRegion.vars[_this.evt.key];
+                valByRegion[mapForRegion.regionName] = value;
+              } else {
+                value = chalk.red('NOT SET');
+              }
 
-  _getEnvVar(){
-    let _this = this;
+              console.log(chalk.underline.bold(mapForRegion.regionName) + `: ${value}`);
+            });
 
-    return awsMisc.getEnvFiles(_this.S, _this.evt.region, _this.evt.stage)
-        .then(envMapsByRegion => {
-          let valByRegion = {};
+            _this.evt.valByRegion = valByRegion;
 
-          SCli.log(`Values for ${_this.evt.key} in stage ${_this.evt.stage} by region:`);
-          envMapsByRegion.forEach(mapForRegion => {
-            let value;
-            if (mapForRegion.vars && mapForRegion.vars[_this.evt.key]) {
-              value = mapForRegion.vars[_this.evt.key];
-              valByRegion[mapForRegion.regionName] = value;
-            } else {
-              value = chalk.red('NOT SET');
-            }
-
-            console.log(chalk.underline.bold(mapForRegion.regionName) + `: ${value}`);
+            return BbPromise.resolve(_this.evt);
           });
-
-          _this.evt.valByRegion = valByRegion;
-
-          return BbPromise.resolve(_this.evt);
-        });
+    }
   }
-}
 
-module.exports = EnvGet;
+  return( EnvGet );
+};

--- a/lib/actions/EnvList.js
+++ b/lib/actions/EnvList.js
@@ -9,206 +9,207 @@
  * - region   (String) a region that is defined in the provided stage
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-    SError  = require('../ServerlessError'),
-    SCli    = require('../utils/cli'),
-    path       = require('path'),
-    chalk      = require('chalk'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc'),
-    SUtils  = require('../utils');
-
-/**
- * EnvList Class
- */
-
-class EnvList extends SPlugin {
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError  = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli    = require(path.join(serverlessPath, 'utils/cli')),
+      chalk      = require('chalk'),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require(path.join(serverlessPath, 'utils/aws/Misc')),
+      SUtils  = require(path.join(serverlessPath, 'utils'));
 
   /**
-   * Constructor
+   * EnvList Class
    */
 
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
+  class EnvList extends SPlugin {
 
-  /**
-   * Define your plugins name
-   */
+    /**
+     * Constructor
+     */
 
-  static getName() {
-    return 'serverless.core.' + EnvList.name;
-  }
-
-  /**
-   * @returns {Promise} upon completion of all registrations
-   */
-
-  registerActions() {
-    this.S.addAction(this.envList.bind(this), {
-      handler:       'envList',
-      description:   `List env vars for stage and region.  Region can be 'all'
-Usage: serverless env list`,
-      context:       'env',
-      contextAction: 'list',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'region you want to list env vars for'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'stage you want to list env vars for'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'i',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Action
-   */
-
-  envList(evt) {
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
+    /**
+     * Define your plugins name
+     */
 
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+    static getName() {
+      return 'serverless.core.' + EnvList.name;
+    }
 
-      if (_this.S.cli.options.nonInteractive) {
+    /**
+     * @returns {Promise} upon completion of all registrations
+     */
+
+    registerActions() {
+      this.S.addAction(this.envList.bind(this), {
+        handler:       'envList',
+        description:   `List env vars for stage and region.  Region can be 'all'
+  Usage: serverless env list`,
+        context:       'env',
+        contextAction: 'list',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'region you want to list env vars for'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'stage you want to list env vars for'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'i',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+
+    envList(evt) {
+      let _this = this;
+
+      if(evt) {
+        _this.evt = evt;
         _this.S._interactive = false;
       }
-    }
 
-    return _this.S.validateProject()
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(function(evt) {
-          return evt;
-        })
-  }
+      // If CLI, parse arguments
+      if (_this.S.cli) {
 
-  /**
-   * Prompt stage and region
-   */
-  _prompt() {
-    let _this = this;
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
 
-    return _this.cliPromptSelectStage('Select a stage to list env vars from: ', _this.evt.stage, true)
-        .then(stage => {
-          _this.evt.stage = stage;
-          BbPromise.resolve();
-        })
-        .then(function(){
-            return _this.cliPromptSelectRegion('Select a region to list env vars from: ', true, _this.evt.region, _this.evt.stage)
-              .then(region => {
-                 _this.evt.region = region;
-                 BbPromise.resolve();
-              });
-        });
-
-  }
-
-
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare data
-   */
-
-  _validateAndPrepare() {
-    let _this = this;
-
-    // non interactive validation
-    if (!_this.S._interactive) {
-
-      // Check Params
-      if (!_this.evt.stage || !_this.evt.region) {
-        return BbPromise.reject(new SError('Missing stage or region'));
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
+        }
       }
+
+      return _this.S.validateProject()
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(function(evt) {
+            return evt;
+          })
     }
 
-    // validate stage: make sure stage exists
-    if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-    }
+    /**
+     * Prompt stage and region
+     */
+    _prompt() {
+      let _this = this;
 
-    // skip the next validation if stage is 'local' & region is 'all'
-    if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
-      // validate region: make sure region exists in stage
-      if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
-            return r.region == _this.evt.region;
-          })) {
-        return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
-      }
-    }
-
-    return SUtils.getFunctions(_this.S._projectRootPath, null)
-        .then(functions => {
-          return [functions, awsMisc.getEnvFiles(_this.S, _this.evt.region, _this.evt.stage)];
-        })
-        .spread((functions, envMapsByRegion) => {
-
-          let envInBackMap = {};
-          SCli.log(`ENV vars for stage ${_this.evt.stage}:`);
-          envMapsByRegion.forEach(mapForRegion => {
-            SCli.log('------------------------------');
-            SCli.log(mapForRegion.regionName);
-            SCli.log('------------------------------');
-            console.log(chalk.bold(mapForRegion.raw + '') + '\n');
+      return _this.cliPromptSelectStage('Select a stage to list env vars from: ', _this.evt.stage, true)
+          .then(stage => {
+            _this.evt.stage = stage;
+            BbPromise.resolve();
+          })
+          .then(function(){
+              return _this.cliPromptSelectRegion('Select a region to list env vars from: ', true, _this.evt.region, _this.evt.stage)
+                .then(region => {
+                   _this.evt.region = region;
+                   BbPromise.resolve();
+                });
           });
 
-          // first build up a list of all env vars s-function say they need
-          functions.forEach(func => {
-            if (func.custom.envVars) {
-              func.custom.envVars.forEach(function(key) {
-                if (envInBackMap[key]) {
-                  envInBackMap[key].push(func.name);
-                } else {
-                  envInBackMap[key] = [func.name];
-                }
+    }
+
+
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare data
+     */
+
+    _validateAndPrepare() {
+      let _this = this;
+
+      // non interactive validation
+      if (!_this.S._interactive) {
+
+        // Check Params
+        if (!_this.evt.stage || !_this.evt.region) {
+          return BbPromise.reject(new SError('Missing stage or region'));
+        }
+      }
+
+      // validate stage: make sure stage exists
+      if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
+        return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+      }
+
+      // skip the next validation if stage is 'local' & region is 'all'
+      if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
+        // validate region: make sure region exists in stage
+        if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
+              return r.region == _this.evt.region;
+            })) {
+          return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
+        }
+      }
+
+      return SUtils.getFunctions(_this.S._projectRootPath, null)
+          .then(functions => {
+            return [functions, awsMisc.getEnvFiles(_this.S, _this.evt.region, _this.evt.stage)];
+          })
+          .spread((functions, envMapsByRegion) => {
+
+            let envInBackMap = {};
+            SCli.log(`ENV vars for stage ${_this.evt.stage}:`);
+            envMapsByRegion.forEach(mapForRegion => {
+              SCli.log('------------------------------');
+              SCli.log(mapForRegion.regionName);
+              SCli.log('------------------------------');
+              console.log(chalk.bold(mapForRegion.raw + '') + '\n');
+            });
+
+            // first build up a list of all env vars s-function say they need
+            functions.forEach(func => {
+              if (func.custom.envVars) {
+                func.custom.envVars.forEach(function(key) {
+                  if (envInBackMap[key]) {
+                    envInBackMap[key].push(func.name);
+                  } else {
+                    envInBackMap[key] = [func.name];
+                  }
+                });
+              }
+            });
+
+            let envKeys = Object.keys(envInBackMap);
+            if (envKeys.length) {
+              SCli.log('env vars in all s-function.json files and regions where they are used (red means NOT defined in region):');
+              envKeys.forEach(key => {
+                let regionNamesColored = envMapsByRegion.map(rMap => {
+                  return (!rMap.vars[key]) ? chalk.white.bgRed(rMap.regionName) : rMap.regionName;
+                });
+
+                SCli.log('------------------------------');
+                SCli.log(key);
+                SCli.log('------------------------------');
+
+                SCli.log(chalk.bold('used by functions') + ': ' + envInBackMap[key].join(','));
+                SCli.log(chalk.bold('regions') + ': ' + regionNamesColored.join(',') + '\n');
               });
             }
-          });
-
-          let envKeys = Object.keys(envInBackMap);
-          if (envKeys.length) {
-            SCli.log('env vars in all s-function.json files and regions where they are used (red means NOT defined in region):');
-            envKeys.forEach(key => {
-              let regionNamesColored = envMapsByRegion.map(rMap => {
-                return (!rMap.vars[key]) ? chalk.white.bgRed(rMap.regionName) : rMap.regionName;
+            _this.evt.envMapsByRegion = envMapsByRegion.map(r => {
+                return {regionName: r.regionName, vars: r.vars}
               });
 
-              SCli.log('------------------------------');
-              SCli.log(key);
-              SCli.log('------------------------------');
-
-              SCli.log(chalk.bold('used by functions') + ': ' + envInBackMap[key].join(','));
-              SCli.log(chalk.bold('regions') + ': ' + regionNamesColored.join(',') + '\n');
-            });
-          }
-          _this.evt.envMapsByRegion = envMapsByRegion.map(r => {
-              return {regionName: r.regionName, vars: r.vars}
-            });
-
-          return BbPromise.resolve(_this.evt);
-        });
+            return BbPromise.resolve(_this.evt);
+          });
+    }
   }
-}
 
-module.exports = EnvList;
+  return( EnvList );
+};

--- a/lib/actions/EnvSet.js
+++ b/lib/actions/EnvSet.js
@@ -11,220 +11,221 @@
  * - value    (String) the env var value you want to set to the provided key
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-    SError  = require('../ServerlessError'),
-    SCli    = require('../utils/cli'),
-    path       = require('path'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc'),
-    SUtils  = require('../utils');
-
-/**
- * EnvSet Class
- */
-
-class EnvSet extends SPlugin {
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError  = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli    = require(path.join(serverlessPath, 'utils/cli')),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require(path.join(serverlessPath, 'utils/aws/Misc')),
+      SUtils  = require(path.join(serverlessPath, 'utils'));
 
   /**
-   * Constructor
+   * EnvSet Class
    */
 
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
+  class EnvSet extends SPlugin {
 
-  /**
-   * Define your plugins name
-   */
+    /**
+     * Constructor
+     */
 
-  static getName() {
-    return 'serverless.core.' + EnvSet.name;
-  }
-
-  /**
-   * Register Actions
-   */
-
-  registerActions() {
-    this.S.addAction(this.envSet.bind(this), {
-      handler:       'envSet',
-      description:   `set var value for stage and region. Region can be 'all'
-usage: serverless env set`,
-      context:       'env',
-      contextAction: 'set',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'region you want to set env var in'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'stage you want to set env var in'
-        },
-        {
-          option:      'key',
-          shortcut:    'k',
-          description: 'the key of the env var you want to set'
-        },
-        {
-          option:      'value',
-          shortcut:    'v',
-          description: 'the value of the env var you want to set'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'i',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Action
-   */
-  envSet(evt) {
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
+    /**
+     * Define your plugins name
+     */
 
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+    static getName() {
+      return 'serverless.core.' + EnvSet.name;
+    }
 
-      if (_this.S.cli.options.nonInteractive) {
+    /**
+     * Register Actions
+     */
+
+    registerActions() {
+      this.S.addAction(this.envSet.bind(this), {
+        handler:       'envSet',
+        description:   `set var value for stage and region. Region can be 'all'
+  usage: serverless env set`,
+        context:       'env',
+        contextAction: 'set',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'region you want to set env var in'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'stage you want to set env var in'
+          },
+          {
+            option:      'key',
+            shortcut:    'k',
+            description: 'the key of the env var you want to set'
+          },
+          {
+            option:      'value',
+            shortcut:    'v',
+            description: 'the value of the env var you want to set'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'i',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+    envSet(evt) {
+      let _this = this;
+
+      if(evt) {
+        _this.evt = evt;
         _this.S._interactive = false;
       }
+
+      // If CLI, parse arguments
+      if (_this.S.cli) {
+
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
+        }
+      }
+
+      return _this.S.validateProject()
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(_this._setEnvVar)
+          .then(function() {
+            SCli.log('Successfully set env var: ' + _this.evt.key);
+            return BbPromise.resolve(_this.evt);
+          });
     }
 
-    return _this.S.validateProject()
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(_this._setEnvVar)
-        .then(function() {
-          SCli.log('Successfully set env var: ' + _this.evt.key);
-          return BbPromise.resolve(_this.evt);
-        });
-  }
+
+    /**
+     * Prompt key, value, stage and region
+     */
+    _prompt() {
+      let _this = this;
+
+      return SCli.awsPromptInputEnvKey('Enter env var key to set a value to: ', _this)
+          .then(key => {
+            _this.evt.key = key;
+            BbPromise.resolve();
+          })
+          .then(function(){
+            return SCli.awsPromptInputEnvValue('Enter env var value to set to the provided key: ', _this)
+                .then(value => {
+                  _this.evt.value = value;
+                  BbPromise.resolve();
+                })
+          })
+          .then(function(){
+            return _this.cliPromptSelectStage('Select a stage to set your env var in: ', _this.evt.stage, true)
+                .then(stage => {
+                  _this.evt.stage = stage;
+                  BbPromise.resolve();
+                })
+          })
+          .then(function(){
+            return _this.cliPromptSelectRegion('Select a region to set env var in: ', true, _this.evt.region, _this.evt.stage)
+                .then(region => {
+                  _this.evt.region = region;
+                  BbPromise.resolve();
+                });
+          });
+    }
 
 
-  /**
-   * Prompt key, value, stage and region
-   */
-  _prompt() {
-    let _this = this;
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare data
+     */
+    _validateAndPrepare(){
+      let _this = this;
 
-    return SCli.awsPromptInputEnvKey('Enter env var key to set a value to: ', _this)
-        .then(key => {
-          _this.evt.key = key;
-          BbPromise.resolve();
-        })
-        .then(function(){
-          return SCli.awsPromptInputEnvValue('Enter env var value to set to the provided key: ', _this)
-              .then(value => {
-                _this.evt.value = value;
-                BbPromise.resolve();
-              })
-        })
-        .then(function(){
-          return _this.cliPromptSelectStage('Select a stage to set your env var in: ', _this.evt.stage, true)
-              .then(stage => {
-                _this.evt.stage = stage;
-                BbPromise.resolve();
-              })
-        })
-        .then(function(){
-          return _this.cliPromptSelectRegion('Select a region to set env var in: ', true, _this.evt.region, _this.evt.stage)
-              .then(region => {
-                _this.evt.region = region;
-                BbPromise.resolve();
+      // non interactive validation
+      if (!_this.S._interactive) {
+        // Check Params
+        if (!_this.evt.stage || !_this.evt.region || !_this.evt.key || !_this.evt.value) {
+          return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        }
+      }
+
+      // validate stage: make sure stage exists
+      if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
+        return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+      }
+
+      // skip the next validation if stage is 'local' & region is 'all'
+      if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
+
+        // validate region: make sure region exists in stage
+        if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
+              return r.region == _this.evt.region;
+            })) {
+          return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
+        }
+      }
+    }
+
+    /**
+     * set env var based on data validated
+     */
+    _setEnvVar(){
+      let _this = this;
+
+      return awsMisc.getEnvFiles(this.S, _this.evt.region,  _this.evt.stage)
+          .then(envMapsByRegion => {
+            let putEnvQ = [];
+
+            envMapsByRegion.forEach(mapForRegion => {
+              if (!mapForRegion.vars) { //someone could have del the .env file..
+                mapForRegion.vars = {};
+              }
+
+              mapForRegion.vars[_this.evt.key] = _this.evt.value;
+
+              let contents = '';
+              Object.keys(mapForRegion.vars).forEach(newKey => {
+                contents += [newKey, mapForRegion.vars[newKey]].join('=') + '\n';
               });
-        });
-  }
 
+              if (_this.evt.stage == 'local') {
+                putEnvQ.push(SUtils.writeFile(path.join(this.S._projectRootPath, 'back', '.env'), contents));
+              } else {
 
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare data
-   */
-  _validateAndPrepare(){
-    let _this = this;
+                let awsConfig = {
+                  region:          mapForRegion.regionName,
+                  accessKeyId:     _this.S._awsAdminKeyId,
+                  secretAccessKey: _this.S._awsAdminSecretKey,
+                };
 
-    // non interactive validation
-    if (!_this.S._interactive) {
-      // Check Params
-      if (!_this.evt.stage || !_this.evt.region || !_this.evt.key || !_this.evt.value) {
-        return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
-      }
-    }
-
-    // validate stage: make sure stage exists
-    if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-    }
-
-    // skip the next validation if stage is 'local' & region is 'all'
-    if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
-
-      // validate region: make sure region exists in stage
-      if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
-            return r.region == _this.evt.region;
-          })) {
-        return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
-      }
-    }
-  }
-
-  /**
-   * set env var based on data validated
-   */
-  _setEnvVar(){
-    let _this = this;
-
-    return awsMisc.getEnvFiles(this.S, _this.evt.region,  _this.evt.stage)
-        .then(envMapsByRegion => {
-          let putEnvQ = [];
-
-          envMapsByRegion.forEach(mapForRegion => {
-            if (!mapForRegion.vars) { //someone could have del the .env file..
-              mapForRegion.vars = {};
-            }
-
-            mapForRegion.vars[_this.evt.key] = _this.evt.value;
-
-            let contents = '';
-            Object.keys(mapForRegion.vars).forEach(newKey => {
-              contents += [newKey, mapForRegion.vars[newKey]].join('=') + '\n';
+                let S3  = require('../utils/aws/S3')(awsConfig);
+                let bucket = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, mapForRegion.regionName).regionBucket;
+                putEnvQ.push(S3.sPutEnvFile(bucket, _this.S._projectJson.name, _this.evt.stage, contents));
+              }
             });
 
-            if (_this.evt.stage == 'local') {
-              putEnvQ.push(SUtils.writeFile(path.join(this.S._projectRootPath, 'back', '.env'), contents));
-            } else {
-
-              let awsConfig = {
-                region:          mapForRegion.regionName,
-                accessKeyId:     _this.S._awsAdminKeyId,
-                secretAccessKey: _this.S._awsAdminSecretKey,
-              };
-
-              let S3  = require('../utils/aws/S3')(awsConfig);
-              let bucket = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, mapForRegion.regionName).regionBucket;
-              putEnvQ.push(S3.sPutEnvFile(bucket, _this.S._projectJson.name, _this.evt.stage, contents));
-            }
+            return BbPromise.all(putEnvQ);
           });
-
-          return BbPromise.all(putEnvQ);
-        });
+    }
   }
-}
 
-module.exports = EnvSet;
+  return( EnvSet );
+};

--- a/lib/actions/EnvUnset.js
+++ b/lib/actions/EnvUnset.js
@@ -10,210 +10,211 @@
  * - key      (String) the env var key you want to unset from region bucket
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-    SError  = require('../ServerlessError'),
-    SCli    = require('../utils/cli'),
-    path       = require('path'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc'),
-    SUtils  = require('../utils');
-
-/**
- * EnvUnset Class
- */
-
-class EnvUnset extends SPlugin {
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError  = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli    = require(path.join(serverlessPath, 'utils/cli')),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require(path.join(serverlessPath, 'utils/aws/Misc')),
+      SUtils  = require(path.join(serverlessPath, 'utils'));
 
   /**
-   * Constructor
+   * EnvUnset Class
    */
 
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
+  class EnvUnset extends SPlugin {
 
-  /**
-   * Define your plugins name
-   */
+    /**
+     * Constructor
+     */
 
-  static getName() {
-    return 'serverless.core.' + EnvUnset.name;
-  }
-
-  /**
-   * Register Actions
-   */
-
-  registerActions() {
-    this.S.addAction(this.envUnset.bind(this), {
-      handler:       'envUnset',
-      description:   `unset var value for stage and region. Region can be 'all'
-usage: serverless env unset`,
-      context:       'env',
-      contextAction: 'unset',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'region you want to unset env var from'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'stage you want to unset env var from'
-        },
-        {
-          option:      'key',
-          shortcut:    'k',
-          description: 'the key of the env var you want to unset'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'i',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Action
-   */
-  envUnset(evt) {
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
+    /**
+     * Define your plugins name
+     */
 
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+    static getName() {
+      return 'serverless.core.' + EnvUnset.name;
+    }
 
-      if (_this.S.cli.options.nonInteractive) {
+    /**
+     * Register Actions
+     */
+
+    registerActions() {
+      this.S.addAction(this.envUnset.bind(this), {
+        handler:       'envUnset',
+        description:   `unset var value for stage and region. Region can be 'all'
+  usage: serverless env unset`,
+        context:       'env',
+        contextAction: 'unset',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'region you want to unset env var from'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'stage you want to unset env var from'
+          },
+          {
+            option:      'key',
+            shortcut:    'k',
+            description: 'the key of the env var you want to unset'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'i',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+    envUnset(evt) {
+      let _this = this;
+
+      if(evt) {
+        _this.evt = evt;
         _this.S._interactive = false;
       }
+
+      // If CLI, parse arguments
+      if (_this.S.cli) {
+
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
+        }
+      }
+
+      return _this.S.validateProject()
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(_this._unsetEnvVar)
+          .then(function() {
+            SCli.log('Successfully unset env var: ' + _this.evt.key);
+            return BbPromise.resolve(_this.evt);
+          });
     }
 
-    return _this.S.validateProject()
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(_this._unsetEnvVar)
-        .then(function() {
-          SCli.log('Successfully unset env var: ' + _this.evt.key);
-          return BbPromise.resolve(_this.evt);
-        });
-  }
+
+    /**
+     * Prompt key, stage and region
+     */
+    _prompt() {
+      let _this = this;
+
+      return SCli.awsPromptInputEnvKey('Enter env var key to unset its value: ', _this)
+          .then(key => {
+            _this.evt.key = key;
+            BbPromise.resolve();
+          })
+          .then(function(){
+            return _this.cliPromptSelectStage('Select a stage to unset env var from: ', _this.evt.stage, true)
+                .then(stage => {
+                  _this.evt.stage = stage;
+                  BbPromise.resolve();
+                })
+          })
+          .then(function(){
+            return _this.cliPromptSelectRegion('Select a region to unset env var from: ', true, _this.evt.region, _this.evt.stage)
+                .then(region => {
+                  _this.evt.region = region;
+                  BbPromise.resolve();
+                });
+          });
+    }
 
 
-  /**
-   * Prompt key, stage and region
-   */
-  _prompt() {
-    let _this = this;
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare data
+     */
 
-    return SCli.awsPromptInputEnvKey('Enter env var key to unset its value: ', _this)
-        .then(key => {
-          _this.evt.key = key;
-          BbPromise.resolve();
-        })
-        .then(function(){
-          return _this.cliPromptSelectStage('Select a stage to unset env var from: ', _this.evt.stage, true)
-              .then(stage => {
-                _this.evt.stage = stage;
-                BbPromise.resolve();
-              })
-        })
-        .then(function(){
-          return _this.cliPromptSelectRegion('Select a region to unset env var from: ', true, _this.evt.region, _this.evt.stage)
-              .then(region => {
-                _this.evt.region = region;
-                BbPromise.resolve();
+    _validateAndPrepare(){
+      let _this = this;
+
+      // non interactive validation
+      if (!_this.S._interactive) {
+
+        // Check Params
+        if (!_this.evt.stage || !_this.evt.region || !_this.evt.key) {
+          return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        }
+      }
+
+      // validate stage: make sure stage exists
+      if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
+        return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+      }
+
+      // skip the next validation if stage is 'local' & region is 'all'
+      if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
+
+        // validate region: make sure region exists in stage
+        if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
+              return r.region == _this.evt.region;
+            })) {
+          return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
+        }
+      }
+    }
+
+    /**
+     * unset env var based on data validated
+     */
+    _unsetEnvVar(){
+      let _this = this;
+
+      return awsMisc.getEnvFiles(_this.S, _this.evt.region, _this.evt.stage)
+          .then(envMapsByRegion => {
+            let putEnvQ = [];
+
+            envMapsByRegion.forEach(mapForRegion => {
+              if (!mapForRegion.vars) { //someone could have del the .env file..
+                mapForRegion.vars = {};
+              }
+
+              delete mapForRegion.vars[_this.evt.key];
+
+              let contents = '';
+              Object.keys(mapForRegion.vars).forEach(newKey => {
+                contents += [newKey, mapForRegion.vars[newKey]].join('=') + '\n';
               });
-        });
-  }
 
+              if (_this.evt.stage == 'local') {
+                putEnvQ.push(utils.writeFile(path.join(_this.S._projectRootPath, 'back', '.env'), contents));
+              } else {
 
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare data
-   */
+                let awsConfig = {
+                  region:          mapForRegion.regionName,
+                  accessKeyId:     _this.S._awsAdminKeyId,
+                  secretAccessKey: _this.S._awsAdminSecretKey,
+                };
 
-  _validateAndPrepare(){
-    let _this = this;
-
-    // non interactive validation
-    if (!_this.S._interactive) {
-
-      // Check Params
-      if (!_this.evt.stage || !_this.evt.region || !_this.evt.key) {
-        return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
-      }
-    }
-
-    // validate stage: make sure stage exists
-    if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-    }
-
-    // skip the next validation if stage is 'local' & region is 'all'
-    if (_this.evt.stage != 'local' && _this.evt.region != 'all') {
-
-      // validate region: make sure region exists in stage
-      if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
-            return r.region == _this.evt.region;
-          })) {
-        return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
-      }
-    }
-  }
-
-  /**
-   * unset env var based on data validated
-   */
-  _unsetEnvVar(){
-    let _this = this;
-
-    return awsMisc.getEnvFiles(_this.S, _this.evt.region, _this.evt.stage)
-        .then(envMapsByRegion => {
-          let putEnvQ = [];
-
-          envMapsByRegion.forEach(mapForRegion => {
-            if (!mapForRegion.vars) { //someone could have del the .env file..
-              mapForRegion.vars = {};
-            }
-
-            delete mapForRegion.vars[_this.evt.key];
-
-            let contents = '';
-            Object.keys(mapForRegion.vars).forEach(newKey => {
-              contents += [newKey, mapForRegion.vars[newKey]].join('=') + '\n';
+                let S3  = require('../utils/aws/S3')(awsConfig);
+                let bucket = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, mapForRegion.regionName).regionBucket;
+                putEnvQ.push(S3.sPutEnvFile(bucket, _this.S._projectJson.name, _this.evt.stage, contents));
+              }
             });
 
-            if (_this.evt.stage == 'local') {
-              putEnvQ.push(utils.writeFile(path.join(_this.S._projectRootPath, 'back', '.env'), contents));
-            } else {
-
-              let awsConfig = {
-                region:          mapForRegion.regionName,
-                accessKeyId:     _this.S._awsAdminKeyId,
-                secretAccessKey: _this.S._awsAdminSecretKey,
-              };
-
-              let S3  = require('../utils/aws/S3')(awsConfig);
-              let bucket = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, mapForRegion.regionName).regionBucket;
-              putEnvQ.push(S3.sPutEnvFile(bucket, _this.S._projectJson.name, _this.evt.stage, contents));
-            }
+            return BbPromise.all(putEnvQ);
           });
-
-          return BbPromise.all(putEnvQ);
-        });
+    }
   }
-}
 
-module.exports = EnvUnset;
+  return( EnvUnset );
+};

--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -13,262 +13,263 @@
  * - template:   (String) Name of the template to use to create the function JSON
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError     = require('../ServerlessError'),
-    SCli       = require('../utils/cli'),
-    path       = require('path'),
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SError     = require(path.join(serverlessPath, 'ServerlessError')),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
     BbPromise  = require('bluebird'),
-    SUtils     = require('../utils');
+    SUtils     = require(path.join(serverlessPath, 'utils'));
 
-let fs = require('fs');
-BbPromise.promisifyAll(fs);
-
-/**
- * FunctionCreate Class
- */
-
-class FunctionCreate extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-    this._templatesDir = path.join(__dirname, '..', 'templates');
-    this.evt = {};
-  }
-
-  static getName() {
-    return 'serverless.core.' + FunctionCreate.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.functionCreate.bind(this), {
-      handler:       'functionCreate',
-      description:   `Creates scaffolding for a new function.
-usage: serverless function create <function>`,
-      context:       'function',
-      contextAction: 'create',
-      options:       [
-        {
-          option:      'module',
-          shortcut:    'm',
-          description: 'The name of the module you want to create a function for'
-        },
-        {
-          option:      'function',
-          shortcut:    'f',
-          description: 'The name of your new function'
-        },
-        {
-          option:      'template',
-          shortcut:    't',
-          description: 'A template for a specific type of Function'
-        },
-        {
-          option:      'runtime',
-          shortcut:    'r',
-          description: 'Optional - Runtime of your new module. Default: nodejs'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'ni',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-
-      ],
-    });
-    return BbPromise.resolve();
-  }
-
+  let fs = require('fs');
+  BbPromise.promisifyAll(fs);
 
   /**
-   * Action
+   * FunctionCreate Class
    */
 
-  functionCreate(evt) {
+  class FunctionCreate extends SPlugin {
 
-    let _this = this;
-
-    if (evt) {
-      _this.evt            = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this._templatesDir = path.join(__dirname, '..', 'templates');
+      this.evt = {};
     }
 
-    // If CLI and not subaction, parse options
-    if (_this.S.cli && (!evt || !evt._subaction)) {
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-      if (_this.S.cli.options.nonInteractive) _this.S._interactive = false;
+    static getName() {
+      return 'serverless.core.' + FunctionCreate.name;
     }
 
-    return _this.S.validateProject()
-        .bind(_this)
-        .then(_this._promptModuleFunction)
-        .then(_this._validateAndPrepare)
-        .then(_this._createFunctionSkeleton)
-        .then(function() {
-          SCli.log('Successfully created function: "'  + _this.functionName + '"');
-          return _this.evt;
-        });
-  }
+    registerActions() {
+      this.S.addAction(this.functionCreate.bind(this), {
+        handler:       'functionCreate',
+        description:   `Creates scaffolding for a new function.
+  usage: serverless function create <function>`,
+        context:       'function',
+        contextAction: 'create',
+        options:       [
+          {
+            option:      'module',
+            shortcut:    'm',
+            description: 'The name of the module you want to create a function for'
+          },
+          {
+            option:      'function',
+            shortcut:    'f',
+            description: 'The name of your new function'
+          },
+          {
+            option:      'template',
+            shortcut:    't',
+            description: 'A template for a specific type of Function'
+          },
+          {
+            option:      'runtime',
+            shortcut:    'r',
+            description: 'Optional - Runtime of your new module. Default: nodejs'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'ni',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
 
-  /**
-   * Prompt module & function if they're missing
-   */
+        ],
+      });
+      return BbPromise.resolve();
+    }
 
-  _promptModuleFunction() {
 
-    let _this = this,
-        overrides = {};
+    /**
+     * Action
+     */
 
-    if (!_this.S._interactive) return BbPromise.resolve();
+    functionCreate(evt) {
 
-    ['module', 'function'].forEach(memberVarKey => {
-      overrides[memberVarKey] = _this['evt'][memberVarKey];
-    });
+      let _this = this;
 
-    let prompts = {
-      properties: {
-        module:              {
-          description: 'Enter the name of your existing module: '.yellow,
-          message:     'Module name is required.',
-          required:    true,
-        },
-        function:            {
-          description: 'Enter a new function name: '.yellow,
-          message:     'Function name is required',
-          required:    true,
-        },
+      if (evt) {
+        _this.evt            = evt;
+        _this.S._interactive = false;
       }
+
+      // If CLI and not subaction, parse options
+      if (_this.S.cli && (!evt || !evt._subaction)) {
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false;
+      }
+
+      return _this.S.validateProject()
+          .bind(_this)
+          .then(_this._promptModuleFunction)
+          .then(_this._validateAndPrepare)
+          .then(_this._createFunctionSkeleton)
+          .then(function() {
+            SCli.log('Successfully created function: "'  + _this.functionName + '"');
+            return _this.evt;
+          });
+    }
+
+    /**
+     * Prompt module & function if they're missing
+     */
+
+    _promptModuleFunction() {
+
+      let _this = this,
+          overrides = {};
+
+      if (!_this.S._interactive) return BbPromise.resolve();
+
+      ['module', 'function'].forEach(memberVarKey => {
+        overrides[memberVarKey] = _this['evt'][memberVarKey];
+      });
+
+      let prompts = {
+        properties: {
+          module:              {
+            description: 'Enter the name of your existing module: '.yellow,
+            message:     'Module name is required.',
+            required:    true,
+          },
+          function:            {
+            description: 'Enter a new function name: '.yellow,
+            message:     'Function name is required',
+            required:    true,
+          },
+        }
+      };
+
+      return _this.cliPromptInput(prompts, overrides)
+          .then(function(answers) {
+            _this.evt.module   = answers.module;
+            _this.evt.function = answers.function;
+          });
     };
 
-    return _this.cliPromptInput(prompts, overrides)
-        .then(function(answers) {
-          _this.evt.module   = answers.module;
-          _this.evt.function = answers.function;
-        });
-  };
 
+    /**
+     * Validate and prepare data before creating module
+     */
 
-  /**
-   * Validate and prepare data before creating module
-   */
-
-  _validateAndPrepare() {
-    // Non interactive validation
-    if (!this.S._interactive) {
-      if (!this.evt.module || !this.evt.function) {
-        return BbPromise.reject(new SError('Missing module or/and function names'));
+    _validateAndPrepare() {
+      // Non interactive validation
+      if (!this.S._interactive) {
+        if (!this.evt.module || !this.evt.function) {
+          return BbPromise.reject(new SError('Missing module or/and function names'));
+        }
       }
-    }
 
-    // Add default runtime
-    if (!this.evt.runtime) {
-      this.evt.runtime = 'nodejs';
-    }
+      // Add default runtime
+      if (!this.evt.runtime) {
+        this.evt.runtime = 'nodejs';
+      }
 
-    // Check if runtime is supported
-    if (!SUtils.supportedRuntimes[this.evt.runtime]) {
-      return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
-    }
+      // Check if runtime is supported
+      if (!SUtils.supportedRuntimes[this.evt.runtime]) {
+        return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
+      }
 
-    // Set default function template
-    if (!this.evt.template) this.evt.template = 's-function.json';
+      // Set default function template
+      if (!this.evt.template) this.evt.template = 's-function.json';
 
-    // Sanitize function folder name
-    this.evt.function = this.evt.function.toLowerCase().trim()
-        .replace(/\s/g, '-')
-        .replace(/[^a-zA-Z-\d:]/g, '')
-        .substring(0, 19);
+      // Sanitize function folder name
+      this.evt.function = this.evt.function.toLowerCase().trim()
+          .replace(/\s/g, '-')
+          .replace(/[^a-zA-Z-\d:]/g, '')
+          .substring(0, 19);
 
-    // If module does NOT exists, throw error
-    this.evt.module = this.evt.module.trim();
+      // If module does NOT exists, throw error
+      this.evt.module = this.evt.module.trim();
 
-    let moduleFullPath = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module);
-    if (!SUtils.dirExistsSync(moduleFullPath)) {
-      return BbPromise.reject(new SError('module ' + this.evt.module + ' does NOT exist',
-          SError.errorCodes.INVALID_PROJECT_SERVERLESS));
-    }
+      let moduleFullPath = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module);
+      if (!SUtils.dirExistsSync(moduleFullPath)) {
+        return BbPromise.reject(new SError('module ' + this.evt.module + ' does NOT exist',
+            SError.errorCodes.INVALID_PROJECT_SERVERLESS));
+      }
 
-    // If function already exists in module, throw error
-    let functionPath = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module, this.evt.function);
-    if (SUtils.dirExistsSync(functionPath)) {
-      return BbPromise.reject(new SError('function ' + this.evt.function + ' already exists in module ' + this.evt.module,
-          SError.errorCodes.INVALID_PROJECT_SERVERLESS
-      ));
-    }
+      // If function already exists in module, throw error
+      let functionPath = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module, this.evt.function);
+      if (SUtils.dirExistsSync(functionPath)) {
+        return BbPromise.reject(new SError('function ' + this.evt.function + ' already exists in module ' + this.evt.module,
+            SError.errorCodes.INVALID_PROJECT_SERVERLESS
+        ));
+      }
 
-    // Fetch Module Json
-    let moduleName             = this.evt.module;
+      // Fetch Module Json
+      let moduleName             = this.evt.module;
 
-    this.evt.module            = SUtils.readAndParseJsonSync(path.join(moduleFullPath, 's-module.json'));
-    this.evt.module.pathModule = path.join('back', 'modules', moduleName);
+      this.evt.module            = SUtils.readAndParseJsonSync(path.join(moduleFullPath, 's-module.json'));
+      this.evt.module.pathModule = path.join('back', 'modules', moduleName);
 
-    return BbPromise.resolve();
-  };
+      return BbPromise.resolve();
+    };
 
 
-  /**
-   * Create Function Skeleton
-   */
+    /**
+     * Create Function Skeleton
+     */
 
-  _createFunctionSkeleton() {
+    _createFunctionSkeleton() {
 
-    let _this                = this,
-        writeDeferred        = [],
-        eventJson            = {},
-        handlerJs            = fs.readFileSync(path.join(this._templatesDir, 'nodejs', 'handler.js'));
+      let _this                = this,
+          writeDeferred        = [],
+          eventJson            = {},
+          handlerJs            = fs.readFileSync(path.join(this._templatesDir, 'nodejs', 'handler.js'));
 
-    // Generate Function JSON
-    let functionShortName              = _this.evt.function;
-    let functionJson                   = _this._generateFunctionJson();
+      // Generate Function JSON
+      let functionShortName              = _this.evt.function;
+      let functionJson                   = _this._generateFunctionJson();
 
-    // Change EVT function to Object
-    _this.evt.function                 = functionJson.functions[Object.keys(functionJson.functions)[0]];
-    _this.pathFunction                 = path.join('back', 'modules', _this.evt.module.name, functionShortName);
+      // Change EVT function to Object
+      _this.evt.function                 = functionJson.functions[Object.keys(functionJson.functions)[0]];
+      _this.pathFunction                 = path.join('back', 'modules', _this.evt.module.name, functionShortName);
 
-    // Set function on event
-    eventJson[_this.functionName] = {};
+      // Set function on event
+      eventJson[_this.functionName] = {};
 
-    // Write function files: directory, handler, event.json, s-function.json
-    writeDeferred.push(
-        fs.mkdirSync(path.join(_this.S._projectRootPath, _this.pathFunction)),
-        SUtils.writeFile(path.join(path.join(_this.S._projectRootPath, _this.pathFunction), 'handler.js'), handlerJs),
-        SUtils.writeFile(path.join(_this.S._projectRootPath, _this.pathFunction, 'event.json'), JSON.stringify(eventJson, null, 2)),
-        SUtils.writeFile(path.join(_this.S._projectRootPath, _this.pathFunction, 's-function.json'), JSON.stringify(functionJson, null, 2))
-    );
+      // Write function files: directory, handler, event.json, s-function.json
+      writeDeferred.push(
+          fs.mkdirSync(path.join(_this.S._projectRootPath, _this.pathFunction)),
+          SUtils.writeFile(path.join(path.join(_this.S._projectRootPath, _this.pathFunction), 'handler.js'), handlerJs),
+          SUtils.writeFile(path.join(_this.S._projectRootPath, _this.pathFunction, 'event.json'), JSON.stringify(eventJson, null, 2)),
+          SUtils.writeFile(path.join(_this.S._projectRootPath, _this.pathFunction, 's-function.json'), JSON.stringify(functionJson, null, 2))
+      );
 
-    // Add path function to evt function
-    _this.evt.function.pathFunction = _this.pathFunction;
-    _this.evt.function.name         = _this.functionName;
+      // Add path function to evt function
+      _this.evt.function.pathFunction = _this.pathFunction;
+      _this.evt.function.name         = _this.functionName;
 
-    return BbPromise.all(writeDeferred);
-  };
+      return BbPromise.all(writeDeferred);
+    };
 
-  /*
-   * Generate s-function.json template (private)
-   */
+    /*
+     * Generate s-function.json template (private)
+     */
 
-  _generateFunctionJson() {
+    _generateFunctionJson() {
 
-    let _this = this;
+      let _this = this;
 
-    // Load s-function.json template
-    let functionJsonTemplate = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, _this.evt.template));
+      // Load s-function.json template
+      let functionJsonTemplate = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, _this.evt.template));
 
-    // Add Full Function Name (Include Module Name)
-    _this.functionName  = _this.evt.function;
-    functionJsonTemplate.functions[_this.functionName] = functionJsonTemplate.functions.functionTemplate;
+      // Add Full Function Name (Include Module Name)
+      _this.functionName  = _this.evt.function;
+      functionJsonTemplate.functions[_this.functionName] = functionJsonTemplate.functions.functionTemplate;
 
-    // Remove Template
-    delete functionJsonTemplate.functions.functionTemplate;
+      // Remove Template
+      delete functionJsonTemplate.functions.functionTemplate;
 
-    // Add Function Handler
-    functionJsonTemplate.functions[_this.functionName].handler = path.join('modules', _this.evt.module.name, _this.evt.function, 'handler.handler');
+      // Add Function Handler
+      functionJsonTemplate.functions[_this.functionName].handler = path.join('modules', _this.evt.module.name, _this.evt.function, 'handler.handler');
 
-    // Add endpoint path
-    functionJsonTemplate.functions[_this.functionName].endpoints[0].path = _this.evt.module.name + '/' + _this.evt.function;
+      // Add endpoint path
+      functionJsonTemplate.functions[_this.functionName].endpoints[0].path = _this.evt.module.name + '/' + _this.evt.function;
 
-    // Return
-    return functionJsonTemplate;
-  };
-}
+      // Return
+      return functionJsonTemplate;
+    };
+  }
 
-module.exports = FunctionCreate;
+  return( FunctionCreate );
+};

--- a/lib/actions/FunctionDeploy.js
+++ b/lib/actions/FunctionDeploy.js
@@ -18,314 +18,314 @@
  * - deployed: (Object)  Contains regions and the code functions that have been uploaded to the S3 bucket in that region
  */
 
-const SPlugin    = require('../ServerlessPlugin'),
-    SError       = require('../ServerlessError'),
-    SUtils       = require('../utils/index'),
-    SCli         = require('../utils/cli'),
-    BbPromise    = require('bluebird'),
-    async        = require('async'),
-    path         = require('path'),
-    fs           = require('fs'),
-    os           = require('os');
+module.exports = function(SPlugin, serverlessPath) {
+  const path       = require('path'),
+      SError       = require(path.join(serverlessPath, 'ServerlessError')),
+      SUtils       = require(path.join(serverlessPath, 'utils/index')),
+      SCli         = require(path.join(serverlessPath, 'utils/cli')),
+      BbPromise    = require('bluebird'),
+      async        = require('async'),
+      fs           = require('fs');
 
-// Promisify fs module
-BbPromise.promisifyAll(fs);
+  // Promisify fs module
+  BbPromise.promisifyAll(fs);
 
-class FunctionDeploy extends SPlugin {
+  class FunctionDeploy extends SPlugin {
 
-  /**
-   * Constructor
-   */
+    /**
+     * Constructor
+     */
 
-  constructor(S, config) {
-    super(S, config);
-  }
+    constructor(S, config) {
+      super(S, config);
+    }
 
-  /**
-   * Get Name
-   */
+    /**
+     * Get Name
+     */
 
-  static getName() {
-    return 'serverless.core.' + FunctionDeploy.name;
-  }
+    static getName() {
+      return 'serverless.core.' + FunctionDeploy.name;
+    }
 
-  /**
-   * Register Plugin Actions
-   */
+    /**
+     * Register Plugin Actions
+     */
 
-  registerActions() {
+    registerActions() {
 
-    this.S.addAction(this.functionDeploy.bind(this), {
-      handler:       'functionDeploy',
-      description:   'Deploys the code or endpoint of a function, or both',
-      context:       'function',
-      contextAction: 'deploy',
-      options:       [
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'Optional if only one stage is defined in project'
-        }, {
-          option:      'region',
-          shortcut:    'r',
-          description: 'Optional - Target one region to deploy to'
-        }, {
-          option:      'aliasFunction', // TODO: Implement
-          shortcut:    'af',
-          description: 'Optional - Provide a custom Alias to your Functions'
-        }, {
-          option:      'all',
-          shortcut:    'a',
-          description: 'Optional - Select all Functions in your project for deployment'
+      this.S.addAction(this.functionDeploy.bind(this), {
+        handler:       'functionDeploy',
+        description:   'Deploys the code or endpoint of a function, or both',
+        context:       'function',
+        contextAction: 'deploy',
+        options:       [
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'Optional if only one stage is defined in project'
+          }, {
+            option:      'region',
+            shortcut:    'r',
+            description: 'Optional - Target one region to deploy to'
+          }, {
+            option:      'aliasFunction', // TODO: Implement
+            shortcut:    'af',
+            description: 'Optional - Provide a custom Alias to your Functions'
+          }, {
+            option:      'all',
+            shortcut:    'a',
+            description: 'Optional - Select all Functions in your project for deployment'
+          }
+        ],
+      });
+
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Function Deploy
+     */
+
+    functionDeploy(event) {
+
+      let _this = this,
+          evt   = {};
+
+      // If CLI - parse options
+      if (_this.S.cli) {
+
+        // Options
+        evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+
+        // Option - Non-interactive
+        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
+
+        // Function paths - They should all be params
+        evt.paths  = _this.S.cli.params;
+      }
+
+      // If NO-CLI, add options
+      if (event) evt = event;
+
+      // Add defaults
+      evt.stage               = evt.stage ? evt.stage : null;
+      evt.regions             = evt.region ? [evt.region] : [];
+      evt.paths               = evt.paths ? evt.paths : [];
+      evt.all                 = evt.all ? true : false;
+      evt.aliasFunction       = evt.aliasFunction ? evt.aliasFunction : null;
+      evt.functions           = [];
+      evt.deployed            = {};
+
+      // Delete region for neatness
+      if (evt.region) delete evt.region;
+
+      // Flow
+      return _this._validateAndPrepare(evt)
+          .bind(_this)
+          .then(_this._prepareFunctions)
+          .then(function(evt) {
+            return _this.cliPromptSelectStage('Function Deployer - Choose a stage: ', evt.stage, false)
+              .then(stage => {
+                evt.stage = stage;
+                return evt;
+              })
+          })
+          .then(_this._prepareRegions)
+          .then(_this._processDeployment)
+          .then(function(evt) {
+            return evt;
+          });
+    }
+
+    /**
+     * Validate And Prepare
+     * - If CLI, maps CLI input to event object
+     */
+
+    _validateAndPrepare(evt) {
+
+      let _this = this;
+
+      if (!_this.S.cli) {
+
+        // Validate Paths
+        if (!evt.paths.length && !evt.all) {
+          throw new SError(`One or multiple paths are required`);
         }
-      ],
-    });
 
-    return BbPromise.resolve();
-  }
+        // Validate Stage
+        if (!evt.stage) {
+          throw new SError(`Stage is required`);
+        }
+      }
 
-  /**
-   * Function Deploy
-   */
-
-  functionDeploy(event) {
-
-    let _this = this,
-        evt   = {};
-
-    // If CLI - parse options
-    if (_this.S.cli) {
-
-      // Options
-      evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-
-      // Option - Non-interactive
-      if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
-
-      // Function paths - They should all be params
-      evt.paths  = _this.S.cli.params;
+      return BbPromise.resolve(evt);
     }
 
-    // If NO-CLI, add options
-    if (event) evt = event;
+    /**
+     * Prepare Functions
+     */
 
-    // Add defaults
-    evt.stage               = evt.stage ? evt.stage : null;
-    evt.regions             = evt.region ? [evt.region] : [];
-    evt.paths               = evt.paths ? evt.paths : [];
-    evt.all                 = evt.all ? true : false;
-    evt.aliasFunction       = evt.aliasFunction ? evt.aliasFunction : null;
-    evt.functions           = [];
-    evt.deployed            = {};
+    _prepareFunctions(evt) {
 
-    // Delete region for neatness
-    if (evt.region) delete evt.region;
+      let _this = this;
 
-    // Flow
-    return _this._validateAndPrepare(evt)
-        .bind(_this)
-        .then(_this._prepareFunctions)
-        .then(function(evt) {
-          return _this.cliPromptSelectStage('Function Deployer - Choose a stage: ', evt.stage, false)
-            .then(stage => {
-              evt.stage = stage;
+      // If NO-CLI - Get Functions from submitted paths
+      if (!_this.S.cli) {
+
+        return SUtils.getFunctions(
+            _this.S._projectRootPath,
+            evt.all ? null : evt.paths)
+            .then(function (functions) {
+
+              evt.functions = functions;
+              // Delete Paths
+              if (evt.paths) delete evt.paths;
               return evt;
-            })
-        })
-        .then(_this._prepareRegions)
-        .then(_this._processDeployment)
-        .then(function(evt) {
-          return evt;
-        });
-  }
-
-  /**
-   * Validate And Prepare
-   * - If CLI, maps CLI input to event object
-   */
-
-  _validateAndPrepare(evt) {
-
-    let _this = this;
-
-    if (!_this.S.cli) {
-
-      // Validate Paths
-      if (!evt.paths.length && !evt.all) {
-        throw new SError(`One or multiple paths are required`);
+            });
       }
 
-      // Validate Stage
-      if (!evt.stage) {
-        throw new SError(`Stage is required`);
+      // IF CLI + ALL/paths, get functions
+      if (_this.S.cli && (evt.all || evt.paths.length)) {
+
+        return SUtils.getFunctions(
+            _this.S._projectRootPath,
+            evt.all ? null : evt.paths)
+            .then(function (functions) {
+
+              if (!functions.length) throw new SError(`No functions found`);
+              evt.functions = functions;
+              // Delete Paths
+              if (evt.paths) delete evt.paths;
+              return evt;
+            });
+      }
+
+      // IF CLI +  no ALL + no paths - prompt user to select functions
+      if (_this.S.cli && !evt.all && !evt.paths.length) {
+
+        return _this.cliPromptSelectFunctions(
+            process.cwd(),
+            'Select the functions you wish to deploy:',
+            true,
+            true)
+            .then(function (selected) {
+              evt.functions = selected;
+              return evt;
+            });
       }
     }
 
-    return BbPromise.resolve(evt);
-  }
 
-  /**
-   * Prepare Functions
-   */
+    /**
+     * Prepare Regions
+     */
 
-  _prepareFunctions(evt) {
+    _prepareRegions(evt) {
 
-    let _this = this;
-
-    // If NO-CLI - Get Functions from submitted paths
-    if (!_this.S.cli) {
-
-      return SUtils.getFunctions(
-          _this.S._projectRootPath,
-          evt.all ? null : evt.paths)
-          .then(function (functions) {
-
-            evt.functions = functions;
-            // Delete Paths
-            if (evt.paths) delete evt.paths;
-            return evt;
-          });
-    }
-
-    // IF CLI + ALL/paths, get functions
-    if (_this.S.cli && (evt.all || evt.paths.length)) {
-
-      return SUtils.getFunctions(
-          _this.S._projectRootPath,
-          evt.all ? null : evt.paths)
-          .then(function (functions) {
-
-            if (!functions.length) throw new SError(`No functions found`);
-            evt.functions = functions;
-            // Delete Paths
-            if (evt.paths) delete evt.paths;
-            return evt;
-          });
-    }
-
-    // IF CLI +  no ALL + no paths - prompt user to select functions
-    if (_this.S.cli && !evt.all && !evt.paths.length) {
-
-      return _this.cliPromptSelectFunctions(
-          process.cwd(),
-          'Select the functions you wish to deploy:',
-          true,
-          true)
-          .then(function (selected) {
-            evt.functions = selected;
-            return evt;
-          });
-    }
-  }
-
-
-  /**
-   * Prepare Regions
-   */
-
-  _prepareRegions(evt) {
-
-    // If no region specified, deploy to all regions in stage
-    if (!evt.regions.length) {
-      evt.regions  = this.S._projectJson.stages[evt.stage].map(rCfg => {
-        return rCfg.region;
-      });
-    }
-
-    return evt;
-  }
-
-  /**
-   * Process Deployment
-   */
-
-  _processDeployment(evt) {
-
-    let _this = this;
-
-    // Status
-    SCli.log('Deploying functions in "' + evt.stage + '" to the following regions: ' + evt.regions);
-    _this._spinner = SCli.spinner();
-    _this._spinner.start();
-
-    return BbPromise.try(function() {
-          return evt.regions;
-        })
-        .bind(_this)
-        .each(function(region) {
-
-          // Add Deployed Region
-          evt.deployed[region] = [];
-
-          // Deploy Function Code in each region
-          return _this._deployCodeByRegion(evt, region);
-        })
-        .then(function() {
-
-          // Status
-          _this._spinner.stop(true);
-          SCli.log('Successfully deployed functions in "' + evt.stage + '" to the following regions: ' + evt.regions);
-          return evt;
+      // If no region specified, deploy to all regions in stage
+      if (!evt.regions.length) {
+        evt.regions  = this.S._projectJson.stages[evt.stage].map(rCfg => {
+          return rCfg.region;
         });
-  }
+      }
 
-  /**
-   * Deploy Code By Region
-   */
+      return evt;
+    }
 
-  _deployCodeByRegion(evt, region) {
+    /**
+     * Process Deployment
+     */
 
-    let _this = this;
+    _processDeployment(evt) {
 
-    return new BbPromise(function(resolve, reject) {
+      let _this = this;
 
-      /**
-       *  Package, Upload, Deploy, Alias functions' code concurrently
-       *  - Package must be redone for each region because ENV vars and IAM Roles are set for each region
-       */
+      // Status
+      SCli.log('Deploying functions in "' + evt.stage + '" to the following regions: ' + evt.regions);
+      _this._spinner = SCli.spinner();
+      _this._spinner.start();
 
-      async.eachLimit(evt.functions, 5, function(func, cb) {
+      return BbPromise.try(function() {
+            return evt.regions;
+          })
+          .bind(_this)
+          .each(function(region) {
 
-        // Create new evt object for concurrent operations
-        let evtClone = {
-          stage: evt.stage,
-          region: SUtils.getRegionConfig(
-              _this.S._projectJson,
-              evt.stage,
-              region),
-          function: func,
-        };
+            // Add Deployed Region
+            evt.deployed[region] = [];
 
-        // Process sub-Actions
-        return _this.S.actions.codePackageLambdaNodejs(evtClone)
-            .bind(_this)
-            .then(_this.S.actions.codeDeployLambdaNodejs)
-            //.then(_this.S.actions.createEventSourceLambdaNodejs)
-            .then(function(evtCloneProcessed) {
+            // Deploy Function Code in each region
+            return _this._deployCodeByRegion(evt, region);
+          })
+          .then(function() {
 
-              // Add Function and Region
-              evt.deployed[region].push(evtCloneProcessed.function);
-              return cb();
-            })
-            .catch(function(e) {
+            // Status
+            _this._spinner.stop(true);
+            SCli.log('Successfully deployed functions in "' + evt.stage + '" to the following regions: ' + evt.regions);
+            return evt;
+          });
+    }
 
-              // Stash Failed Function Code
-              if (!evt.failed) evt.failed = {};
-              if (!evt.failed[region]) evt.failed[region] = [];
-              evt.failed[region].push({
-                message:  e.message,
-                stack:    e.stack,
-                function: func.pathFunction + '-' + func.name,
-              });
+    /**
+     * Deploy Code By Region
+     */
 
-              return cb();
-            })
+    _deployCodeByRegion(evt, region) {
 
-      }, function() {
-        return resolve(evt, region);
+      let _this = this;
+
+      return new BbPromise(function(resolve, reject) {
+
+        /**
+         *  Package, Upload, Deploy, Alias functions' code concurrently
+         *  - Package must be redone for each region because ENV vars and IAM Roles are set for each region
+         */
+
+        async.eachLimit(evt.functions, 5, function(func, cb) {
+
+          // Create new evt object for concurrent operations
+          let evtClone = {
+            stage: evt.stage,
+            region: SUtils.getRegionConfig(
+                _this.S._projectJson,
+                evt.stage,
+                region),
+            function: func,
+          };
+
+          // Process sub-Actions
+          return _this.S.actions.codePackageLambdaNodejs(evtClone)
+              .bind(_this)
+              .then(_this.S.actions.codeDeployLambdaNodejs)
+              //.then(_this.S.actions.createEventSourceLambdaNodejs)
+              .then(function(evtCloneProcessed) {
+
+                // Add Function and Region
+                evt.deployed[region].push(evtCloneProcessed.function);
+                return cb();
+              })
+              .catch(function(e) {
+
+                // Stash Failed Function Code
+                if (!evt.failed) evt.failed = {};
+                if (!evt.failed[region]) evt.failed[region] = [];
+                evt.failed[region].push({
+                  message:  e.message,
+                  stack:    e.stack,
+                  function: func.pathFunction + '-' + func.name,
+                });
+
+                return cb();
+              })
+
+        }, function() {
+          return resolve(evt, region);
+        });
       });
-    });
+    }
   }
-}
 
-module.exports = FunctionDeploy;
+  return( FunctionDeploy );
+};

--- a/lib/actions/FunctionRun.js
+++ b/lib/actions/FunctionRun.js
@@ -5,199 +5,200 @@
  * - Runs the function in the CWD for local testing
  */
 
-const SPlugin   = require('../ServerlessPlugin'),
-    SError      = require('../ServerlessError'),
-    SUtils      = require('../utils'),
+module.exports = function(SPlugin, serverlessPath) {
+  const path    = require('path'),
+    SError      = require(path.join(serverlessPath, 'ServerlessError')),
+    SUtils      = require(path.join(serverlessPath, 'utils')),
     BbPromise   = require('bluebird'),
-    path        = require('path'),
     fs          = require('fs');
 
-BbPromise.promisifyAll(fs);
-
-/**
- * FunctionRun Class
- */
-
-class FunctionRun extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-  }
-
-  static getName() {
-    return 'serverless.core.' + FunctionRun.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.functionRun.bind(this), {
-      handler:       'functionRun',
-      description:   `Runs the service locally.  Reads the service’s runtime and passes it off to a runtime-specific runner`,
-      context:       'function',
-      contextAction: 'run',
-      options:       [
-        {
-          option:      'name',
-          shortcut:    'n',
-          description: 'Optional - Run a specific function by name in the current working directory'
-        }, {
-          option:      'path',
-          shortcut:    'p',
-          description: 'Optional - Run a specific function by path in the current working directory'
-        }
-      ],
-    });
-    return BbPromise.resolve();
-  }
+  BbPromise.promisifyAll(fs);
 
   /**
-   * Action
+   * FunctionRun Class
    */
 
-  functionRun(evt) {
+  class FunctionRun extends SPlugin {
 
-    let _this = this;
-
-    // If CLI, parse options
-    if (_this.S.cli) {
-
-      // Options
-      evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-
-      // Option - Non-interactive
-      if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
+    constructor(S, config) {
+      super(S, config);
     }
 
-    return _this._loadFunction(evt)
-        .bind(_this)
-        .then(_this._loadTestEvent)
-        .then(_this._runFunction)
-        .then(function(evt) {
-          return evt;
-        })
-  }
-
-  /**
-   * Load Function
-   */
-
-  _loadFunction(evt) {
-
-    let _this = this,
-        cwd   = process.cwd();
-
-    // If "path" is provided, find function by path
-    if (evt.path) {
-
-      return SUtils.getFunctions(_this.S._projectRootPath, [evt.path])
-          .then(function(functions) {
-
-            // If no functions found, throw error
-            if (!functions.length) {
-              throw new SError(`Could not find a function with the path: ${evt.path}`);
-            }
-
-            // Load event object
-            evt.function   = functions[0];
-
-            // Return
-            return evt;
-          });
+    static getName() {
+      return 'serverless.core.' + FunctionRun.name;
     }
 
-    // If "name" is provided, find function by name
-    if (evt.name) {
-
-      return SUtils.getFunctions(_this.S._projectRootPath, null)
-          .then(function(functions) {
-
-            // If no functions found, throw error
-            if (!functions.length) {
-              throw new SError(`Your project has no functions`);
-            }
-
-            for (let i = 0; i < functions.length; i++) {
-              if (functions[i].name === evt.name || functions[i].name === evt.name.toLowerCase()) {
-                evt.function = functions[i];
-                break;
-              }
-            }
-            if (!evt.function) throw new SError(`Could not find a function with the name ${evt.name}`);
-
-            // Return
-            return evt;
-          });
+    registerActions() {
+      this.S.addAction(this.functionRun.bind(this), {
+        handler:       'functionRun',
+        description:   `Runs the service locally.  Reads the service’s runtime and passes it off to a runtime-specific runner`,
+        context:       'function',
+        contextAction: 'run',
+        options:       [
+          {
+            option:      'name',
+            shortcut:    'n',
+            description: 'Optional - Run a specific function by name in the current working directory'
+          }, {
+            option:      'path',
+            shortcut:    'p',
+            description: 'Optional - Run a specific function by path in the current working directory'
+          }
+        ],
+      });
+      return BbPromise.resolve();
     }
 
-    // If interactive and no function name or path provided, show select screen
-    if (_this.S.cli && _this.S._interactive) {
+    /**
+     * Action
+     */
 
-      // Otherwise show select screen
-      return _this.cliPromptSelectFunctions(cwd, 'Select a function to run: ', false, true)
-          .then(function (selected) {
+    functionRun(evt) {
 
-            // If no functions found, throw error
-            if (!selected.length) {
-              throw new SError(`Could not find any functions.`);
-            }
+      let _this = this;
 
-            evt.function = selected[0];
+      // If CLI, parse options
+      if (_this.S.cli) {
 
-            return evt;
-          });
-    }
+        // Options
+        evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
 
-    // Otherwise, through error
-    throw new SError(`No function specified`);
-  }
+        // Option - Non-interactive
+        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
+      }
 
-  /**
-   * Populate the test event from the correct event.json file
-   */
-
-  _loadTestEvent(evt) {
-   
-    let _this = this,
-     eventPathSpecific  = path.join(_this.S._projectRootPath, evt.function.pathFunction.replace('s-function.json', ''), evt.function.name+'-event.json'),
-     eventPathGeneral  = path.join(_this.S._projectRootPath, evt.function.pathFunction.replace('s-function.json', ''), 'event.json'),
-     testEvent = {};
-
-    // check for a function specific json <function-name>.json
-    // otherwise check for a generic event.json file and look for a specific object node
-    // lastly populate it with an empty object
-    if (fs.existsSync(eventPathSpecific)) {
-      testEvent = SUtils.readAndParseJsonSync(eventPathSpecific);
-    } else if (fs.existsSync(eventPathGeneral)) {
-      testEvent = SUtils.readAndParseJsonSync(eventPathGeneral)[evt.function.name];
-      // Look for a property named after the function in the event object
-      if (testEvent[evt.function.name]) testEvent = testEvent[evt.function.name];
-    }
-    evt.function.event = testEvent;
-
-    return evt;
-  }
-
-  /**
-   * Run Function By Runtime
-   */
-
-  _runFunction(evt) {
-
-    let _this = this;
-
-    // Run by runtime
-    if (evt.function.module.runtime === 'nodejs') {
-
-      // Fire NodeJs subaction
-      let newEvent = {
-        function: evt.function,
-      };
-
-      return _this.S.actions.functionRunLambdaNodeJs(newEvent)
+      return _this._loadFunction(evt)
+          .bind(_this)
+          .then(_this._loadTestEvent)
+          .then(_this._runFunction)
           .then(function(evt) {
             return evt;
-          });
+          })
+    }
+
+    /**
+     * Load Function
+     */
+
+    _loadFunction(evt) {
+
+      let _this = this,
+          cwd   = process.cwd();
+
+      // If "path" is provided, find function by path
+      if (evt.path) {
+
+        return SUtils.getFunctions(_this.S._projectRootPath, [evt.path])
+            .then(function(functions) {
+
+              // If no functions found, throw error
+              if (!functions.length) {
+                throw new SError(`Could not find a function with the path: ${evt.path}`);
+              }
+
+              // Load event object
+              evt.function   = functions[0];
+
+              // Return
+              return evt;
+            });
+      }
+
+      // If "name" is provided, find function by name
+      if (evt.name) {
+
+        return SUtils.getFunctions(_this.S._projectRootPath, null)
+            .then(function(functions) {
+
+              // If no functions found, throw error
+              if (!functions.length) {
+                throw new SError(`Your project has no functions`);
+              }
+
+              for (let i = 0; i < functions.length; i++) {
+                if (functions[i].name === evt.name || functions[i].name === evt.name.toLowerCase()) {
+                  evt.function = functions[i];
+                  break;
+                }
+              }
+              if (!evt.function) throw new SError(`Could not find a function with the name ${evt.name}`);
+
+              // Return
+              return evt;
+            });
+      }
+
+      // If interactive and no function name or path provided, show select screen
+      if (_this.S.cli && _this.S._interactive) {
+
+        // Otherwise show select screen
+        return _this.cliPromptSelectFunctions(cwd, 'Select a function to run: ', false, true)
+            .then(function (selected) {
+
+              // If no functions found, throw error
+              if (!selected.length) {
+                throw new SError(`Could not find any functions.`);
+              }
+
+              evt.function = selected[0];
+
+              return evt;
+            });
+      }
+
+      // Otherwise, through error
+      throw new SError(`No function specified`);
+    }
+
+    /**
+     * Populate the test event from the correct event.json file
+     */
+
+    _loadTestEvent(evt) {
+
+      let _this = this,
+       eventPathSpecific  = path.join(_this.S._projectRootPath, evt.function.pathFunction.replace('s-function.json', ''), evt.function.name+'-event.json'),
+       eventPathGeneral  = path.join(_this.S._projectRootPath, evt.function.pathFunction.replace('s-function.json', ''), 'event.json'),
+       testEvent = {};
+
+      // check for a function specific json <function-name>.json
+      // otherwise check for a generic event.json file and look for a specific object node
+      // lastly populate it with an empty object
+      if (fs.existsSync(eventPathSpecific)) {
+        testEvent = SUtils.readAndParseJsonSync(eventPathSpecific);
+      } else if (fs.existsSync(eventPathGeneral)) {
+        testEvent = SUtils.readAndParseJsonSync(eventPathGeneral)[evt.function.name];
+        // Look for a property named after the function in the event object
+        if (testEvent[evt.function.name]) testEvent = testEvent[evt.function.name];
+      }
+      evt.function.event = testEvent;
+
+      return evt;
+    }
+
+    /**
+     * Run Function By Runtime
+     */
+
+    _runFunction(evt) {
+
+      let _this = this;
+
+      // Run by runtime
+      if (evt.function.module.runtime === 'nodejs') {
+
+        // Fire NodeJs subaction
+        let newEvent = {
+          function: evt.function,
+        };
+
+        return _this.S.actions.functionRunLambdaNodeJs(newEvent)
+            .then(function(evt) {
+              return evt;
+            });
+      }
     }
   }
-}
 
-module.exports = FunctionRun;
+  return( FunctionRun );
+};

--- a/lib/actions/FunctionRunLambdaNodeJs.js
+++ b/lib/actions/FunctionRunLambdaNodeJs.js
@@ -4,103 +4,103 @@
  * Action: FunctionRunLambdaNodeJs
  */
 
-const SPlugin   = require('../ServerlessPlugin'),
-    SError      = require('../ServerlessError'),
-    SUtils      = require('../utils/index'),
-    SCli        = require('../utils/cli'),
+module.exports = function(SPlugin, serverlessPath) {
+  const path    = require('path'),
+    SError      = require(path.join(serverlessPath, 'ServerlessError')),
+    SCli        = require(path.join(serverlessPath, 'utils/cli')),
     BbPromise   = require('bluebird'),
-    path        = require('path'),
     chalk       = require('chalk'),
-    context     = require('../utils/context');
+    context     = require(path.join(serverlessPath, 'utils/context'));
 
 
-class FunctionRunLambdaNodeJs extends SPlugin {
+  class FunctionRunLambdaNodeJs extends SPlugin {
 
-  constructor(S, config) {
-    super(S, config);
-  }
-
-  static getName() {
-    return 'serverless.core.' + FunctionRunLambdaNodeJs.name;
-  }
-
-  registerActions() {
-
-    this.S.addAction(this.functionRunLambdaNodeJs.bind(this), {
-      handler:       'functionRunLambdaNodeJs',
-      description:   'Runs a service that features a lambda using the nodejs runtime.'
-    });
-
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Function Run Lambda NodeJs
-   */
-
-  functionRunLambdaNodeJs(evt) {
-
-    let _this = this;
-
-    if (!evt.function || !evt.function.handler || !evt.function.event) {
-      return BbPromise.reject(new SError('Function Json, handler and event are required.'));
+    constructor(S, config) {
+      super(S, config);
     }
 
-    // Create result object on evt
-    evt.result = { status: false };
+    static getName() {
+      return 'serverless.core.' + FunctionRunLambdaNodeJs.name;
+    }
 
-    // Run Function
-    return new BbPromise(function(resolve, reject) {
+    registerActions() {
 
-      SCli.log(`Running ${evt.function.name}...`);
+      this.S.addAction(this.functionRunLambdaNodeJs.bind(this), {
+        handler:       'functionRunLambdaNodeJs',
+        description:   'Runs a service that features a lambda using the nodejs runtime.'
+      });
 
-      try {
+      return BbPromise.resolve();
+    }
 
-        // Load function file & handler
-        let functionFile    = evt.function.handler.split('/').pop().split('.')[1];
-        let functionHandler = evt.function.handler.split('/').pop().split('.')[0];
-        functionFile        = path.join(_this.S._projectRootPath, evt.function.pathFunction, (functionHandler + '.js'));
-        functionHandler     = require(functionFile)[functionHandler];
+    /**
+     * Function Run Lambda NodeJs
+     */
+
+    functionRunLambdaNodeJs(evt) {
+
+      let _this = this;
+
+      if (!evt.function || !evt.function.handler || !evt.function.event) {
+        return BbPromise.reject(new SError('Function Json, handler and event are required.'));
+      }
+
+      // Create result object on evt
+      evt.result = { status: false };
+
+      // Run Function
+      return new BbPromise(function(resolve, reject) {
+
+        SCli.log(`Running ${evt.function.name}...`);
+
+        try {
+
+          // Load function file & handler
+          let functionFile    = evt.function.handler.split('/').pop().split('.')[1];
+          let functionHandler = evt.function.handler.split('/').pop().split('.')[0];
+          functionFile        = path.join(_this.S._projectRootPath, evt.function.pathFunction, (functionHandler + '.js'));
+          functionHandler     = require(functionFile)[functionHandler];
 
 
-        // Fire function
-        functionHandler(evt.function.event, context(evt.function.name, function (err, result) {
+          // Fire function
+          functionHandler(evt.function.event, context(evt.function.name, function (err, result) {
+
+            SCli.log(`-----------------`);
+
+            // Show error
+            if (err) {
+              SCli.log(chalk.bold('Failed - This Error Was Returned:'));
+              SCli.log(err.message);
+              evt.result.status = 'error';
+              evt.result.response = err.message;
+              return resolve(evt);
+            }
+
+            // Show success response
+            SCli.log(chalk.bold('Success! - This Response Was Returned:'));
+            SCli.log(JSON.stringify(result));
+            evt.result.status   = 'success';
+            evt.result.response = result;
+            return resolve(evt);
+
+          }));
+
+        } catch(err) {
 
           SCli.log(`-----------------`);
 
           // Show error
           if (err) {
-            SCli.log(chalk.bold('Failed - This Error Was Returned:'));
-            SCli.log(err.message);
-            evt.result.status = 'error';
+            SCli.log(chalk.bold('Failed - This Error Was Thrown:'));
+            SCli.log(err);
+            evt.result.status   = 'error';
             evt.result.response = err.message;
             return resolve(evt);
           }
-
-          // Show success response
-          SCli.log(chalk.bold('Success! - This Response Was Returned:'));
-          SCli.log(JSON.stringify(result));
-          evt.result.status   = 'success';
-          evt.result.response = result;
-          return resolve(evt);
-
-        }));
-
-      } catch(err) {
-
-        SCli.log(`-----------------`);
-
-        // Show error
-        if (err) {
-          SCli.log(chalk.bold('Failed - This Error Was Thrown:'));
-          SCli.log(err);
-          evt.result.status   = 'error';
-          evt.result.response = err.message;
-          return resolve(evt);
         }
-      }
-    });
+      });
+    }
   }
-}
 
-module.exports = FunctionRunLambdaNodeJs;
+  return( FunctionRunLambdaNodeJs );
+};

--- a/lib/actions/ModuleCreate.js
+++ b/lib/actions/ModuleCreate.js
@@ -12,274 +12,276 @@
  * - function:  (String) Name of your first function in your new module
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError     = require('../ServerlessError'),
-    SCli       = require('../utils/cli'),
-    SUtils     = require('../utils'),
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SError     = require(path.join(serverlessPath, 'ServerlessError')),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
+    SUtils     = require(path.join(serverlessPath, 'utils')),
     BbPromise  = require('bluebird'),
-    fs         = require('fs'),
-    path       = require('path');
+    fs         = require('fs');
 
-BbPromise.promisifyAll(fs);
-
-/**
- * ModuleCreate Class
- */
-
-class ModuleCreate extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-    this._templatesDir  = path.join(__dirname, '..', 'templates');
-    this.evt            = {};
-  }
-
-  static getName() {
-    return 'serverless.core.' + ModuleCreate.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.moduleCreate.bind(this), {
-      handler:       'moduleCreate',
-      description:   `Creates scaffolding for a new serverless module.
-usage: serverless module create`,
-      context:       'module',
-      contextAction: 'create',
-      options:       [
-        {
-          option:      'module',
-          shortcut:    'm',
-          description: 'The name of your new module'
-        },
-        {
-          option:      'function',
-          shortcut:    'f',
-          description: 'The name of your first function for your new module'
-        },
-        {
-          option:      'template',
-          shortcut:    't',
-          description: 'A template for a specific type of Function'
-        },
-        {
-          option:      'runtime',
-          shortcut:    'r',
-          description: 'Optional - Runtime of your new module. Default: nodejs'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'ni',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-
-    return BbPromise.resolve();
-  };
+  BbPromise.promisifyAll(fs);
 
   /**
-   * Action
+   * ModuleCreate Class
    */
 
-  moduleCreate(evt) {
+  class ModuleCreate extends SPlugin {
 
-    let _this = this;
-
-    if (evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this._templatesDir  = path.join(__dirname, '..', 'templates');
+      this.evt            = {};
     }
 
-    // If CLI, parse options
-    if (_this.S.cli) {
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-
-      if (_this.S.cli.options.nonInteractive) {
-        _this.S._interactive = false;
-      }
+    static getName() {
+      return 'serverless.core.' + ModuleCreate.name;
     }
 
-    return _this.S.validateProject()
-        .bind(_this)
-        .then(_this._promptModuleFunction)
-        .then(_this._validateAndPrepare)
-        .then(_this._createModuleSkeleton)
-        .then(function() {
+    registerActions() {
+      this.S.addAction(this.moduleCreate.bind(this), {
+        handler:       'moduleCreate',
+        description:   `Creates scaffolding for a new serverless module.
+  usage: serverless module create`,
+        context:       'module',
+        contextAction: 'create',
+        options:       [
+          {
+            option:      'module',
+            shortcut:    'm',
+            description: 'The name of your new module'
+          },
+          {
+            option:      'function',
+            shortcut:    'f',
+            description: 'The name of your first function for your new module'
+          },
+          {
+            option:      'template',
+            shortcut:    't',
+            description: 'A template for a specific type of Function'
+          },
+          {
+            option:      'runtime',
+            shortcut:    'r',
+            description: 'Optional - Runtime of your new module. Default: nodejs'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'ni',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
 
-          let _this    = this,
-              evtClone = {
-                _subaction: true,
-                module:     _this.evt.module.name,
-                function:   _this.evt.function
-              };
-
-          return _this.S.actions.functionCreate(evtClone)
-              .then(function(evt) {
-                _this.evt.function              = evt.function;
-              });
-        })
-        .then(_this._installModuleDependencies)
-        .then(function() {
-
-          SCli.log('Successfully created new serverless module "' + _this.evt.module.name + '" with its first function "' + _this.evt.function.name + '"');
-          // Return Event
-          return _this.evt;
-        });
-  };
-
-  /**
-   * Prompt module & function if they're missing
-   */
-
-_promptModuleFunction() {
-
-    let _this = this,
-        overrides = {};
-
-    if (!_this.S._interactive) return BbPromise.resolve();
-
-    ['module', 'function'].forEach(memberVarKey => {
-      overrides[memberVarKey] = _this['evt'][memberVarKey];
-    });
-
-    let prompts = {
-      properties: {
-        module:              {
-          description: 'Enter a name for your new module: '.yellow,
-          message:     'Module name is required.',
-          required:    true,
-        },
-        function:            {
-          description: 'Enter a function name for your new module: '.yellow,
-          message:     'Function name is required',
-          required:    true,
-        },
-      }
+      return BbPromise.resolve();
     };
 
-    return _this.cliPromptInput(prompts, overrides)
-        .then(function(answers) {
-          _this.evt.module = answers.module;
-          _this.evt.function = answers.function;
-        });
-  };
+    /**
+     * Action
+     */
 
-  /**
-   * Validate and prepare data before creating module
-   */
+    moduleCreate(evt) {
 
-  _validateAndPrepare() {
+      let _this = this;
 
-    // non interactive validation
-    if (!this.S._interactive) {
-      if (!this.evt.module || !this.evt.function) {
-        return BbPromise.reject(new SError('Missing module or/and function names'));
+      if (evt) {
+        _this.evt = evt;
+        _this.S._interactive = false;
       }
-    }
 
-    // Add default runtime
-    if (!this.evt.runtime) {
-      this.evt.runtime = 'nodejs';
-    }
+      // If CLI, parse options
+      if (_this.S.cli) {
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
 
-    if (!SUtils.supportedRuntimes[this.evt.runtime]) {
-      return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
-    }
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
+        }
+      }
 
-    // Set default function template
-    if (!this.evt.template) this.evt.template = 's-function.json';
+      return _this.S.validateProject()
+          .bind(_this)
+          .then(_this._promptModuleFunction)
+          .then(_this._validateAndPrepare)
+          .then(_this._createModuleSkeleton)
+          .then(function() {
 
-    // Sanitize module
-    this.evt.module = this.evt.module.toLowerCase().trim()
-        .replace(/\s/g, '-')
-        .replace(/[^a-zA-Z-\d:]/g, '')
-        .substring(0, 19);
+            let _this    = this,
+                evtClone = {
+                  _subaction: true,
+                  module:     _this.evt.module.name,
+                  function:   _this.evt.function
+                };
 
-    // Sanitize function
-    this.evt.function = this.evt.function.toLowerCase().trim()
-        .replace(/\s/g, '-')
-        .replace(/[^a-zA-Z-\d:]/g, '')
-        .substring(0, 19);
+            return _this.S.actions.functionCreate(evtClone)
+                .then(function(evt) {
+                  _this.evt.function              = evt.function;
+                });
+          })
+          .then(_this._installModuleDependencies)
+          .then(function() {
 
-    // If module already exists, throw error
-    let pathModule = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module);
-    if (SUtils.dirExistsSync(pathModule)) {
-      return BbPromise.reject(new SError(
-          'Module ' + this.evt.module + ' already exists',
-          SError.errorCodes.INVALID_PROJECT_SERVERLESS
-      ));
-    }
+            SCli.log('Successfully created new serverless module "' + _this.evt.module.name + '" with its first function "' + _this.evt.function.name + '"');
+            // Return Event
+            return _this.evt;
+          });
+    };
 
-    return BbPromise.resolve();
-  };
+    /**
+     * Prompt module & function if they're missing
+     */
 
-  /**
-   * Create Module Skeleton
-   */
+  _promptModuleFunction() {
 
-  _createModuleSkeleton() {
+      let _this = this,
+          overrides = {};
 
-    let _this                = this,
-        writeDeferred        = [],
-        moduleJsonTemplate   = _this._generateModuleJson(),
-        packageJsonTemplate  = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, 'nodejs', 'package.json')),
-        libJs                = fs.readFileSync(path.join(this._templatesDir, 'nodejs', 'index.js'));
+      if (!_this.S._interactive) return BbPromise.resolve();
 
-    // Save Path
-    let pathModule           = path.join('back', 'modules', _this.evt.module);
+      ['module', 'function'].forEach(memberVarKey => {
+        overrides[memberVarKey] = _this['evt'][memberVarKey];
+      });
 
-    // Prep package.json
-    packageJsonTemplate.name        = _this.evt.module;
-    packageJsonTemplate.description = 'Dependencies for a Serverless Module written in Node.js';
+      let prompts = {
+        properties: {
+          module:              {
+            description: 'Enter a name for your new module: '.yellow,
+            message:     'Module name is required.',
+            required:    true,
+          },
+          function:            {
+            description: 'Enter a function name for your new module: '.yellow,
+            message:     'Function name is required',
+            required:    true,
+          },
+        }
+      };
 
-    // Write base module structure
-    writeDeferred.push(
-        fs.mkdirSync(path.join(_this.S._projectRootPath, pathModule)),
-        fs.mkdirSync(path.join(_this.S._projectRootPath, pathModule, 'lib')),
-        fs.mkdirSync(path.join(_this.S._projectRootPath, pathModule, 'package')),
-        SUtils.writeFile(path.join(_this.S._projectRootPath, pathModule, 'lib', 'index.js'), libJs),
-        SUtils.writeFile(path.join(_this.S._projectRootPath, pathModule, 'package.json'), JSON.stringify(packageJsonTemplate, null, 2)),
-        SUtils.writeFile(path.join(_this.S._projectRootPath, pathModule, 's-module.json'), JSON.stringify(moduleJsonTemplate, null, 2))
-    );
+      return _this.cliPromptInput(prompts, overrides)
+          .then(function(answers) {
+            _this.evt.module = answers.module;
+            _this.evt.function = answers.function;
+          });
+    };
 
-    // Set evt properties
-    let moduleName              = _this.evt.module;
-    _this.evt.module            = moduleJsonTemplate;
-    _this.evt.module.name       = moduleName;
-    _this.evt.module.pathModule = pathModule;
+    /**
+     * Validate and prepare data before creating module
+     */
 
-    return BbPromise.all(writeDeferred);
-  };
+    _validateAndPrepare() {
 
-  /*
-   * Generate s-module.json template (private)
-   */
+      // non interactive validation
+      if (!this.S._interactive) {
+        if (!this.evt.module || !this.evt.function) {
+          return BbPromise.reject(new SError('Missing module or/and function names'));
+        }
+      }
 
-  _generateModuleJson() {
+      // Add default runtime
+      if (!this.evt.runtime) {
+        this.evt.runtime = 'nodejs';
+      }
 
-    let _this = this;
-    let moduleJsonTemplate  = SUtils.readAndParseJsonSync(path.join(this._templatesDir, 's-module.json'));
-    moduleJsonTemplate.name = _this.evt.module;
-
-    // Add runtime
-    switch (_this.evt.runtime) {
-      case 'nodejs':
-        moduleJsonTemplate.runtime = 'nodejs';
-        break;
-      default:
+      if (!SUtils.supportedRuntimes[this.evt.runtime]) {
         return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
-        break;
+      }
+
+      // Set default function template
+      if (!this.evt.template) this.evt.template = 's-function.json';
+
+      // Sanitize module
+      this.evt.module = this.evt.module.toLowerCase().trim()
+          .replace(/\s/g, '-')
+          .replace(/[^a-zA-Z-\d:]/g, '')
+          .substring(0, 19);
+
+      // Sanitize function
+      this.evt.function = this.evt.function.toLowerCase().trim()
+          .replace(/\s/g, '-')
+          .replace(/[^a-zA-Z-\d:]/g, '')
+          .substring(0, 19);
+
+      // If module already exists, throw error
+      let pathModule = path.join(this.S._projectRootPath, 'back', 'modules', this.evt.module);
+      if (SUtils.dirExistsSync(pathModule)) {
+        return BbPromise.reject(new SError(
+            'Module ' + this.evt.module + ' already exists',
+            SError.errorCodes.INVALID_PROJECT_SERVERLESS
+        ));
+      }
+
+      return BbPromise.resolve();
+    };
+
+    /**
+     * Create Module Skeleton
+     */
+
+    _createModuleSkeleton() {
+
+      let _this                = this,
+          writeDeferred        = [],
+          moduleJsonTemplate   = _this._generateModuleJson(),
+          packageJsonTemplate  = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, 'nodejs', 'package.json')),
+          libJs                = fs.readFileSync(path.join(this._templatesDir, 'nodejs', 'index.js'));
+
+      // Save Path
+      let pathModule           = path.join('back', 'modules', _this.evt.module);
+
+      // Prep package.json
+      packageJsonTemplate.name        = _this.evt.module;
+      packageJsonTemplate.description = 'Dependencies for a Serverless Module written in Node.js';
+
+      // Write base module structure
+      writeDeferred.push(
+          fs.mkdirSync(path.join(_this.S._projectRootPath, pathModule)),
+          fs.mkdirSync(path.join(_this.S._projectRootPath, pathModule, 'lib')),
+          fs.mkdirSync(path.join(_this.S._projectRootPath, pathModule, 'package')),
+          SUtils.writeFile(path.join(_this.S._projectRootPath, pathModule, 'lib', 'index.js'), libJs),
+          SUtils.writeFile(path.join(_this.S._projectRootPath, pathModule, 'package.json'), JSON.stringify(packageJsonTemplate, null, 2)),
+          SUtils.writeFile(path.join(_this.S._projectRootPath, pathModule, 's-module.json'), JSON.stringify(moduleJsonTemplate, null, 2))
+      );
+
+      // Set evt properties
+      let moduleName              = _this.evt.module;
+      _this.evt.module            = moduleJsonTemplate;
+      _this.evt.module.name       = moduleName;
+      _this.evt.module.pathModule = pathModule;
+
+      return BbPromise.all(writeDeferred);
+    };
+
+    /*
+     * Generate s-module.json template (private)
+     */
+
+    _generateModuleJson() {
+
+      let _this = this;
+      let moduleJsonTemplate  = SUtils.readAndParseJsonSync(path.join(this._templatesDir, 's-module.json'));
+      moduleJsonTemplate.name = _this.evt.module;
+
+      // Add runtime
+      switch (_this.evt.runtime) {
+        case 'nodejs':
+          moduleJsonTemplate.runtime = 'nodejs';
+          break;
+        default:
+          return BbPromise.reject(new SError('Unsupported runtime ' + this.evt.runtime, SError.errorCodes.UNKNOWN));
+          break;
+      }
+
+      // Return
+      return moduleJsonTemplate;
+    };
+
+    _installModuleDependencies() {
+      SCli.log('Installing "serverless-helpers" for this module via NPM...');
+      SUtils.npmInstall(path.join(this.S._projectRootPath, this.evt.module.pathModule));
+      return BbPromise.resolve();
     }
-
-    // Return
-    return moduleJsonTemplate;
-  };
-
-  _installModuleDependencies() {
-    SCli.log('Installing "serverless-helpers" for this module via NPM...');
-    SUtils.npmInstall(path.join(this.S._projectRootPath, this.evt.module.pathModule));
-    return BbPromise.resolve();
   }
-}
 
-module.exports = ModuleCreate;
+  return( ModuleCreate );
+};
+

--- a/lib/actions/ModuleInstall.js
+++ b/lib/actions/ModuleInstall.js
@@ -12,260 +12,261 @@
  *                                 https://github.com/serverless/serverless
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError     = require('../ServerlessError'),
-    SCli       = require('../utils/cli'),
-    path       = require('path'),
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SError     = require(path.join(serverlessPath, 'ServerlessError')),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
     chalk      = require('chalk'),
     URL        = require('url'),
     Download   = require('download'),
     BbPromise  = require('bluebird'),
-    SUtils     = require('../utils');
+    SUtils     = require(path.join(serverlessPath, 'utils'));
 
-let fs         = require('fs'),
-    wrench     = require('wrench'),
-    temp       = require('temp');
+  let fs         = require('fs'),
+      wrench     = require('wrench'),
+      temp       = require('temp');
 
-BbPromise.promisifyAll(fs);
-BbPromise.promisifyAll(temp);
-BbPromise.promisifyAll(wrench);
+  BbPromise.promisifyAll(fs);
+  BbPromise.promisifyAll(temp);
+  BbPromise.promisifyAll(wrench);
 
-temp.track();
-
-
-/**
- * ModuleInstall Class
- */
-
-class ModuleInstall extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
-
-  static getName() {
-    return 'serverless.core.' + ModuleInstall.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.moduleInstall.bind(this), {
-      handler:       'moduleInstall',
-      description:   `Downloads and installs a new module from github.
-usage: serverless module install <github-url>`,
-      context:       'module',
-      contextAction: 'install',
-      options:       [],
-    });
-    return BbPromise.resolve();
-  }
+  temp.track();
 
 
   /**
-   * Action
+   * ModuleInstall Class
    */
 
-  moduleInstall(evt) {
+  class ModuleInstall extends SPlugin {
 
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse param
-    if (_this.S.cli) {
-      _this.evt.url = this.S.cli.params[0];
+    static getName() {
+      return 'serverless.core.' + ModuleInstall.name;
     }
 
-    return this.S.validateProject()
-        .bind(_this)
-        .then(_this._downloadModule)
-        .then(_this._validateAndPrepare)
-        .then(_this._installModule)
-        .then(_this._updateCfTemplate)
-        .then(function() {
-          SCli.log('Successfully installed ' + _this.evt.module.name + ' module.');
-          return _this.evt;
-        });
-  }
-
-
-  /**
-   * Downloads the module from github
-   */
-
-  _downloadModule() {
-    // If URL is not provided, throw error.
-    if(!this.evt.url) {
-      return BbPromise.reject(new SError('Github URL is required. (eg. serverless module install <github-url>)', SError.errorCodes.UNKNOWN));
+    registerActions() {
+      this.S.addAction(this.moduleInstall.bind(this), {
+        handler:       'moduleInstall',
+        description:   `Downloads and installs a new module from github.
+  usage: serverless module install <github-url>`,
+        context:       'module',
+        contextAction: 'install',
+        options:       [],
+      });
+      return BbPromise.resolve();
     }
 
-    let _this = this,
-        spinner = SCli.spinner(),
-        url = URL.parse(_this.evt.url),
-        parts = url.pathname.split('/'),
-        repo = {
-          owner: parts[1],
-          repo: parts[2],
-          branch: 'master'
-        };
 
+    /**
+     * Action
+     */
 
-    //TODO: support github tree URLS (branch): https://github.com/jaws-framework/JAWS/tree/cf-deploy
-    if (~repo.repo.indexOf('#')) {
-      url[2].split('#');
-      repo.repo = url[2].split('#')[0];
-      repo.branch = url[2].split('#')[1];
+    moduleInstall(evt) {
+
+      let _this = this;
+
+      if(evt) {
+        _this.evt = evt;
+      }
+
+      // If CLI, parse param
+      if (_this.S.cli) {
+        _this.evt.url = this.S.cli.params[0];
+      }
+
+      return this.S.validateProject()
+          .bind(_this)
+          .then(_this._downloadModule)
+          .then(_this._validateAndPrepare)
+          .then(_this._installModule)
+          .then(_this._updateCfTemplate)
+          .then(function() {
+            SCli.log('Successfully installed ' + _this.evt.module.name + ' module.');
+            return _this.evt;
+          });
     }
 
-    if (url.hostname !== 'github.com' || !repo.owner || !repo.repo) {
-      spinner.stop(true);
-      return BbPromise.reject(new SError('Must be a github url in this format: https://github.com/serverless/serverless', SError.errorCodes.UNKNOWN));
-    }
 
-    let downloadUrl = 'https://github.com/' + repo.owner + '/' + repo.repo + '/archive/' + repo.branch + '.zip';
+    /**
+     * Downloads the module from github
+     */
 
-    return temp.mkdirAsync('module')
-        .then(function(tempModulePath) {
-          return new BbPromise(function(resolve, reject) {
-            SCli.log('Downloading module ...');
-            spinner.start();
+    _downloadModule() {
+      // If URL is not provided, throw error.
+      if(!this.evt.url) {
+        return BbPromise.reject(new SError('Github URL is required. (eg. serverless module install <github-url>)', SError.errorCodes.UNKNOWN));
+      }
 
-            new Download({
-              timeout: 30000,
-              extract: true,
-              strip: 1,
-              mode: '755',
-            }).get(downloadUrl)
-              .dest(tempModulePath)
-              .run(function(error) {
-                spinner.stop(true);
-                if (error) {
-                  return BbPromise.reject(new SError('Module Download and installation failed: ' + error, SError.errorCodes.UNKNOWN));
-                }
-                _this.evt.pathTempModule = tempModulePath;
-                resolve();
+      let _this = this,
+          spinner = SCli.spinner(),
+          url = URL.parse(_this.evt.url),
+          parts = url.pathname.split('/'),
+          repo = {
+            owner: parts[1],
+            repo: parts[2],
+            branch: 'master'
+          };
+
+
+      //TODO: support github tree URLS (branch): https://github.com/jaws-framework/JAWS/tree/cf-deploy
+      if (~repo.repo.indexOf('#')) {
+        url[2].split('#');
+        repo.repo = url[2].split('#')[0];
+        repo.branch = url[2].split('#')[1];
+      }
+
+      if (url.hostname !== 'github.com' || !repo.owner || !repo.repo) {
+        spinner.stop(true);
+        return BbPromise.reject(new SError('Must be a github url in this format: https://github.com/serverless/serverless', SError.errorCodes.UNKNOWN));
+      }
+
+      let downloadUrl = 'https://github.com/' + repo.owner + '/' + repo.repo + '/archive/' + repo.branch + '.zip';
+
+      return temp.mkdirAsync('module')
+          .then(function(tempModulePath) {
+            return new BbPromise(function(resolve, reject) {
+              SCli.log('Downloading module ...');
+              spinner.start();
+
+              new Download({
+                timeout: 30000,
+                extract: true,
+                strip: 1,
+                mode: '755',
+              }).get(downloadUrl)
+                .dest(tempModulePath)
+                .run(function(error) {
+                  spinner.stop(true);
+                  if (error) {
+                    return BbPromise.reject(new SError('Module Download and installation failed: ' + error, SError.errorCodes.UNKNOWN));
+                  }
+                  _this.evt.pathTempModule = tempModulePath;
+                  resolve();
+                });
+            });
+          });
+    };
+
+    /**
+     * Validate and prepare data before installing the downloaded module
+     */
+
+    _validateAndPrepare() {
+      let _this = this,
+          srcModuleJsonPath = path.join(_this.evt.pathTempModule, 's-module.json');
+
+      // if s-module.json doesn't exist in downloaded module, throw error
+      if (!SUtils.fileExistsSync(srcModuleJsonPath)) {
+        return BbPromise.reject(new SError('Missing s-module.json file in module root', SError.errorCodes.UNKNOWN));
+      }
+
+      let srcModuleJson = SUtils.readAndParseJsonSync(srcModuleJsonPath);
+
+      // if name is missing from s-module.json, throw error
+      if (!srcModuleJson.name) {
+        return BbPromise.reject(new SError('s-module.json for downloaded module missing name attr', SError.errorCodes.UNKNOWN));
+      }
+
+      _this.evt.module = srcModuleJson;
+
+      _this.evt.module.pathModule = path.join(this.S._projectRootPath, 'back', 'modules', srcModuleJson.name);
+
+      // if same module name exists, throw error
+      if (SUtils.dirExistsSync(_this.evt.module.pathModule)) {
+        return BbPromise.reject(new SError(
+            'module ' + srcModuleJson.name + ' already exists',
+            SError.errorCodes.INVALID_PROJECT_SERVERLESS
+        ));
+      }
+
+      // if required cloudformation attrs are missing, throw error
+      if (
+          (!srcModuleJson.cloudFormation) ||
+          (!srcModuleJson.cloudFormation.lambdaIamPolicyDocumentStatements)
+         ) {
+           return BbPromise.reject(new SError('Module does not have required cloudFormation attributes', SError.errorCodes.UNKNOWN));
+      }
+
+      return BbPromise.resolve();
+    };
+
+
+    /**
+     * Installs the downloaded module
+     */
+
+    _installModule() {
+      let _this = this;
+
+      // all good! copy/install module
+      wrench.copyDirSyncRecursive(_this.evt.pathTempModule, _this.evt.module.pathModule, {
+        forceDelete: true,
+        excludeHiddenUnix: false,
+      });
+
+      // install deps if package.json exists
+      if (SUtils.fileExistsSync(path.join(_this.evt.module.pathModule, 'package.json'))) {
+        SUtils.npmInstall(_this.evt.module.pathModule);
+      }
+
+      return BbPromise.resolve();
+    };
+
+
+    /**
+     * Copy CF resources to the project CF template
+     */
+
+    _updateCfTemplate() {
+      let _this             = this,
+          projectCfPath     = path.join(_this.S._projectRootPath, 'cloudformation'),
+          cfExtensionPoints = SUtils.readAndParseJsonSync(path.join(_this.evt.pathTempModule, 's-module.json')).cloudFormation;
+
+      //Update every resources-cf.json for every stage and region. Deep breath...
+      return new BbPromise(function(resolve, reject) {
+        resolve(wrench.readdirSyncRecursive(projectCfPath))
+      })
+        .then(function(files) {
+          files.forEach(function(file) {
+
+            file = path.join(projectCfPath, file);
+            if (SUtils.endsWith(file, 'resources-cf.json')) {
+
+              let regionStageResourcesCfJson = SUtils.readAndParseJsonSync(file);
+
+              if (cfExtensionPoints.lambdaIamPolicyDocumentStatements.length > 0) {
+                SCli.log('Merging in Lambda IAM Policy statements from s-module');
+              }
+              cfExtensionPoints.lambdaIamPolicyDocumentStatements.forEach(function(policyStmt) {
+                regionStageResourcesCfJson.Resources.IamPolicyLambda.Properties.PolicyDocument.Statement.push(policyStmt);
               });
+
+              let cfResourceKeys = Object.keys(cfExtensionPoints.resources);
+
+              if (cfResourceKeys.length > 0) {
+                SCli.log('Merging in CF Resources from s-module');
+              }
+              cfResourceKeys.forEach(function(resourceKey) {
+                if (regionStageResourcesCfJson.Resources[resourceKey]) {
+                  SCli.log(
+                    chalk.bgYellow.white(' WARN ') +
+                    chalk.magenta(` Resource key ${resourceKey} already defined in ${file}. Overwriting...`)
+                  );
+                }
+
+                regionStageResourcesCfJson.Resources[resourceKey] = cfExtensionPoints.resources[resourceKey];
+              });
+
+              SUtils.writeFile(file, JSON.stringify(regionStageResourcesCfJson, null, 2));
+            }
           });
         });
-  };
+    };
+  }
 
-  /**
-   * Validate and prepare data before installing the downloaded module
-   */
-
-  _validateAndPrepare() {
-    let _this = this,
-        srcModuleJsonPath = path.join(_this.evt.pathTempModule, 's-module.json');
-
-    // if s-module.json doesn't exist in downloaded module, throw error
-    if (!SUtils.fileExistsSync(srcModuleJsonPath)) {
-      return BbPromise.reject(new SError('Missing s-module.json file in module root', SError.errorCodes.UNKNOWN));
-    }
-
-    let srcModuleJson = SUtils.readAndParseJsonSync(srcModuleJsonPath);
-
-    // if name is missing from s-module.json, throw error
-    if (!srcModuleJson.name) {
-      return BbPromise.reject(new SError('s-module.json for downloaded module missing name attr', SError.errorCodes.UNKNOWN));
-    }
-
-    _this.evt.module = srcModuleJson;
-
-    _this.evt.module.pathModule = path.join(this.S._projectRootPath, 'back', 'modules', srcModuleJson.name);
-
-    // if same module name exists, throw error
-    if (SUtils.dirExistsSync(_this.evt.module.pathModule)) {
-      return BbPromise.reject(new SError(
-          'module ' + srcModuleJson.name + ' already exists',
-          SError.errorCodes.INVALID_PROJECT_SERVERLESS
-      ));
-    }
-
-    // if required cloudformation attrs are missing, throw error
-    if (
-        (!srcModuleJson.cloudFormation) ||
-        (!srcModuleJson.cloudFormation.lambdaIamPolicyDocumentStatements)
-       ) {
-         return BbPromise.reject(new SError('Module does not have required cloudFormation attributes', SError.errorCodes.UNKNOWN));
-    }
-
-    return BbPromise.resolve();
-  };
-
-
-  /**
-   * Installs the downloaded module
-   */
-
-  _installModule() {
-    let _this = this;
-
-    // all good! copy/install module
-    wrench.copyDirSyncRecursive(_this.evt.pathTempModule, _this.evt.module.pathModule, {
-      forceDelete: true,
-      excludeHiddenUnix: false,
-    });
-
-    // install deps if package.json exists
-    if (SUtils.fileExistsSync(path.join(_this.evt.module.pathModule, 'package.json'))) {
-      SUtils.npmInstall(_this.evt.module.pathModule);
-    }
-
-    return BbPromise.resolve();
-  };
-
-
-  /**
-   * Copy CF resources to the project CF template
-   */
-
-  _updateCfTemplate() {
-    let _this             = this,
-        projectCfPath     = path.join(_this.S._projectRootPath, 'cloudformation'),
-        cfExtensionPoints = SUtils.readAndParseJsonSync(path.join(_this.evt.pathTempModule, 's-module.json')).cloudFormation;
-
-    //Update every resources-cf.json for every stage and region. Deep breath...
-    return new BbPromise(function(resolve, reject) {
-      resolve(wrench.readdirSyncRecursive(projectCfPath))
-    })
-      .then(function(files) {
-        files.forEach(function(file) {
-
-          file = path.join(projectCfPath, file);
-          if (SUtils.endsWith(file, 'resources-cf.json')) {
-
-            let regionStageResourcesCfJson = SUtils.readAndParseJsonSync(file);
-
-            if (cfExtensionPoints.lambdaIamPolicyDocumentStatements.length > 0) {
-              SCli.log('Merging in Lambda IAM Policy statements from s-module');
-            }
-            cfExtensionPoints.lambdaIamPolicyDocumentStatements.forEach(function(policyStmt) {
-              regionStageResourcesCfJson.Resources.IamPolicyLambda.Properties.PolicyDocument.Statement.push(policyStmt);
-            });
-
-            let cfResourceKeys = Object.keys(cfExtensionPoints.resources);
-
-            if (cfResourceKeys.length > 0) {
-              SCli.log('Merging in CF Resources from s-module');
-            }
-            cfResourceKeys.forEach(function(resourceKey) {
-              if (regionStageResourcesCfJson.Resources[resourceKey]) {
-                SCli.log(
-                  chalk.bgYellow.white(' WARN ') +
-                  chalk.magenta(` Resource key ${resourceKey} already defined in ${file}. Overwriting...`)
-                );
-              }
-
-              regionStageResourcesCfJson.Resources[resourceKey] = cfExtensionPoints.resources[resourceKey];
-            });
-
-            SUtils.writeFile(file, JSON.stringify(regionStageResourcesCfJson, null, 2));
-          }
-        });
-      });
-  };
-}
-
-module.exports = ModuleInstall;
+  return( ModuleInstall );
+};

--- a/lib/actions/ProjectCreate.js
+++ b/lib/actions/ProjectCreate.js
@@ -19,497 +19,498 @@
  * - noExeCf:             (Boolean) Don't execute CloudFormation
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError     = require('../ServerlessError'),
-    SCli       = require('../utils/cli'),
-    SUtils     = require('../utils'),
-    path       = require('path'),
-    os         = require('os'),
-    fs         = require('fs'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc');
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+    SError = require( path.join( serverlessPath, 'ServerlessError' ) ),
+    SCli = require( path.join( serverlessPath, 'utils/cli' ) ),
+    SUtils = require( path.join( serverlessPath, 'utils' ) ),
+    os = require('os'),
+    fs = require('fs'),
+    BbPromise = require('bluebird'),
+    awsMisc = require( path.join( serverlessPath, 'utils/aws/Misc' ) );
 
-BbPromise.promisifyAll(fs);
-
-/**
- * ProjectCreate Class
- */
-
-class ProjectCreate extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-    this._templatesDir = path.join(__dirname, '..', 'templates');
-    this.evt = {};
-  }
-
-  static getName() {
-    return 'serverless.core.' + ProjectCreate.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.createProject.bind(this), {
-      handler:       'projectCreate',
-      description:   'Creates scaffolding for a new Serverless project',
-      context:       'project',
-      contextAction: 'create',
-      options:       [
-        {
-          option:      'name',
-          shortcut:    'n',
-          description: 'Name of your new Serverless project',
-        }, {
-          option:      'domain',
-          shortcut:    'd',
-          description: 'Domain of your new Serverless project',
-        }, {
-          option:      'region',
-          shortcut:    'r',
-          description: 'Lambda supported region',
-        }, {
-          option:      'notificationEmail',
-          shortcut:    'e',
-          description: 'email to use for AWS alarms',
-        }, {
-          option:      'profile', // we need profile option for CLI API (non interactive)
-          shortcut:    'p',
-          description: 'AWS profile that is set in your aws config file',
-        }, {
-          option:      'runtime',
-          shortcut:    'rt',
-          description: 'Optional - Lambda supported runtime. Default: nodejs',
-        }, {
-          option:      'noExeCf',
-          shortcut:    'c',
-          description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false'
-        }, {
-          option:      'nonInteractive',
-          shortcut:    'i',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
+  BbPromise.promisifyAll(fs);
 
   /**
-   * Action
+   * ProjectCreate Class
    */
 
-  createProject(evt) {
+  class ProjectCreate extends SPlugin {
 
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this._templatesDir = path.join(__dirname, '..', 'templates');
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-      if (_this.S.cli.options.nonInteractive) {
-        _this.S._interactive = false;
-      }
+    static getName() {
+      return 'serverless.core.' + ProjectCreate.name;
     }
 
-    // Add default runtime
-    if (!_this.evt.runtime) {
-      _this.evt.runtime = 'nodejs';
+    registerActions() {
+      this.S.addAction(this.createProject.bind(this), {
+        handler:       'projectCreate',
+        description:   'Creates scaffolding for a new Serverless project',
+        context:       'project',
+        contextAction: 'create',
+        options:       [
+          {
+            option:      'name',
+            shortcut:    'n',
+            description: 'Name of your new Serverless project',
+          }, {
+            option:      'domain',
+            shortcut:    'd',
+            description: 'Domain of your new Serverless project',
+          }, {
+            option:      'region',
+            shortcut:    'r',
+            description: 'Lambda supported region',
+          }, {
+            option:      'notificationEmail',
+            shortcut:    'e',
+            description: 'email to use for AWS alarms',
+          }, {
+            option:      'profile', // we need profile option for CLI API (non interactive)
+            shortcut:    'p',
+            description: 'AWS profile that is set in your aws config file',
+          }, {
+            option:      'runtime',
+            shortcut:    'rt',
+            description: 'Optional - Lambda supported runtime. Default: nodejs',
+          }, {
+            option:      'noExeCf',
+            shortcut:    'c',
+            description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false'
+          }, {
+            option:      'nonInteractive',
+            shortcut:    'i',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
+      return BbPromise.resolve();
     }
-
-    // Always create "development" stage on ProjectCreate
-    _this.evt.stage = 'development';
-
-    // Check for AWS Profiles
-    let profilesList    = awsMisc.profilesMap();
-    _this.evt.profiles  = Object.keys(profilesList);
 
     /**
-     * Control Flow
+     * Action
      */
 
-    return BbPromise.try(function() {
-          if (_this.S._interactive) {
-            SCli.asciiGreeting();
-          }
-        })
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(_this._createProjectDirectory)
-        .then(_this._createProjectBucket)
-        .then(_this._putEnvFile)
-        .then(_this._putCfFile)
-        .then(_this._createCfStack)
-        .then(_this._createProjectJson)
-        .then(function() {
-          SCli.log('Successfully created project: ' + _this.evt.name);
-          // Return Event
-          return _this.evt;
-        });
-  }
+    createProject(evt) {
 
-  /**
-   * Prompt
-   */
+      let _this = this;
 
-  _prompt() {
-
-    let _this     = this,
-        overrides = {};
-    // Skip if non-interactive
-    if (!_this.S._interactive) return BbPromise.resolve();
-
-    //Setup overrides based off of member var values
-    ['name', 'domain', 'notificationEmail', 'awsAdminKeyId', 'awsAdminSecretKey']
-        .forEach(memberVarKey => {
-          overrides[memberVarKey] = _this['evt'][memberVarKey];
-        });
-
-    let prompts = {
-      properties: {
-        name:              {
-          description: 'Enter a project name: '.yellow,
-          default:     'serverless' + SUtils.generateShortId(19),
-          message:     'Name must be only letters, numbers or dashes',
-          required:    true,
-          conform:     function(name) {
-            let re = /^[a-zA-Z0-9-_]+$/;
-            return re.test(name);
-          },
-        },
-        domain:            {
-          description: 'Enter a project domain (used for serverless regional bucket names): '.yellow,
-          default:     'myapp.com',
-          message:     'Domain must only contain lowercase letters, numbers, periods and dashes',
-          required:    true,
-          conform:     function(bucket) {
-            let re = /^[a-z0-9-.]+$/;
-            return re.test(bucket);
-          },
-        },
-        notificationEmail: {
-          description: 'Enter an email to use for AWS alarms: '.yellow,
-          required:    true,
-          message:     'Please enter a valid email',
-          default:     'me@myapp.com',
-          conform:     function(email) {
-            let re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
-            return re.test(email);
-          },
-        },
+      if(evt) {
+        _this.evt = evt;
+        _this.S._interactive = false;
       }
-    };
 
-    if (!_this.evt.profiles || !_this.evt.profiles.length) {
-      prompts.properties.awsAdminKeyId = {
-        description: 'Enter the ACCESS KEY ID for your Admin AWS IAM User: '.yellow,
-        required:    true,
-        message:     'Please enter a valid access key ID',
-        conform:     function(key) {
-          return (key) ? true : false;
-        },
-      };
+      // If CLI, parse arguments
+      if (_this.S.cli) {
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
+        }
+      }
 
-      prompts.properties.awsAdminSecretKey = {
-        description: 'Enter the SECRET ACCESS KEY for your Admin AWS IAM User: '.yellow,
-        required:    true,
-        message:     'Please enter a valid secret access key',
-        conform:     function(key) {
-          return (key) ? true : false;
-        },
-      };
+      // Add default runtime
+      if (!_this.evt.runtime) {
+        _this.evt.runtime = 'nodejs';
+      }
+
+      // Always create "development" stage on ProjectCreate
+      _this.evt.stage = 'development';
+
+      // Check for AWS Profiles
+      let profilesList    = awsMisc.profilesMap();
+      _this.evt.profiles  = Object.keys(profilesList);
+
+      /**
+       * Control Flow
+       */
+
+      return BbPromise.try(function() {
+            if (_this.S._interactive) {
+              SCli.asciiGreeting();
+            }
+          })
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(_this._createProjectDirectory)
+          .then(_this._createProjectBucket)
+          .then(_this._putEnvFile)
+          .then(_this._putCfFile)
+          .then(_this._createCfStack)
+          .then(_this._createProjectJson)
+          .then(function() {
+            SCli.log('Successfully created project: ' + _this.evt.name);
+            // Return Event
+            return _this.evt;
+          });
     }
 
-    return this.cliPromptInput(prompts, overrides)
-        .then(function(answers) {
-          _this.evt.name               = answers.name;
-          _this.evt.domain             = answers.domain;
-          _this.evt.notificationEmail  = answers.notificationEmail;
-          _this.S._awsAdminKeyId       = answers.awsAdminKeyId;
-          _this.S._awsAdminSecretKey   = answers.awsAdminSecretKey;
+    /**
+     * Prompt
+     */
 
-          if (!_this.evt.region) {
-            // Prompt: region select
-            let choices = awsMisc.validLambdaRegions.map(r => {
-              return {
-                key:   '',
-                value: r,
-                label: r,
-              };
-            });
+    _prompt() {
 
-            return _this.cliPromptSelect('Select a region for your project: ', choices, false)
-                .then(results => {
-                  _this.evt.region = results[0].value;
-                });
-          }
-        })
-        .then(function() {
+      let _this     = this,
+          overrides = {};
+      // Skip if non-interactive
+      if (!_this.S._interactive) return BbPromise.resolve();
 
-          // If profile exists, skip select prompt
-          if (_this.evt.profile) return;
+      //Setup overrides based off of member var values
+      ['name', 'domain', 'notificationEmail', 'awsAdminKeyId', 'awsAdminSecretKey']
+          .forEach(memberVarKey => {
+            overrides[memberVarKey] = _this['evt'][memberVarKey];
+          });
 
-          // If aws credentials were passed, skip select prompt
-          if (_this.S._awsAdminKeyId && _this.S._awsAdminSecretKey) return;
+      let prompts = {
+        properties: {
+          name:              {
+            description: 'Enter a project name: '.yellow,
+            default:     'serverless' + SUtils.generateShortId(19),
+            message:     'Name must be only letters, numbers or dashes',
+            required:    true,
+            conform:     function(name) {
+              let re = /^[a-zA-Z0-9-_]+$/;
+              return re.test(name);
+            },
+          },
+          domain:            {
+            description: 'Enter a project domain (used for serverless regional bucket names): '.yellow,
+            default:     'myapp.com',
+            message:     'Domain must only contain lowercase letters, numbers, periods and dashes',
+            required:    true,
+            conform:     function(bucket) {
+              let re = /^[a-z0-9-.]+$/;
+              return re.test(bucket);
+            },
+          },
+          notificationEmail: {
+            description: 'Enter an email to use for AWS alarms: '.yellow,
+            required:    true,
+            message:     'Please enter a valid email',
+            default:     'me@myapp.com',
+            conform:     function(email) {
+              let re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+              return re.test(email);
+            },
+          },
+        }
+      };
 
-          // Prompt: profile select
-          let choices = [];
-          for (let i = 0; i < _this.evt.profiles.length; i++) {
-            choices.push({
-              key:   '',
-              value: _this.evt.profiles[i],
-              label: _this.evt.profiles[i]
-            });
-          }
+      if (!_this.evt.profiles || !_this.evt.profiles.length) {
+        prompts.properties.awsAdminKeyId = {
+          description: 'Enter the ACCESS KEY ID for your Admin AWS IAM User: '.yellow,
+          required:    true,
+          message:     'Please enter a valid access key ID',
+          conform:     function(key) {
+            return (key) ? true : false;
+          },
+        };
 
-          return _this.cliPromptSelect('Select an AWS profile for your project: ', choices, false)
-              .then(results => {
-                _this.evt.profile = results[0].value;
+        prompts.properties.awsAdminSecretKey = {
+          description: 'Enter the SECRET ACCESS KEY for your Admin AWS IAM User: '.yellow,
+          required:    true,
+          message:     'Please enter a valid secret access key',
+          conform:     function(key) {
+            return (key) ? true : false;
+          },
+        };
+      }
+
+      return this.cliPromptInput(prompts, overrides)
+          .then(function(answers) {
+            _this.evt.name               = answers.name;
+            _this.evt.domain             = answers.domain;
+            _this.evt.notificationEmail  = answers.notificationEmail;
+            _this.S._awsAdminKeyId       = answers.awsAdminKeyId;
+            _this.S._awsAdminSecretKey   = answers.awsAdminSecretKey;
+
+            if (!_this.evt.region) {
+              // Prompt: region select
+              let choices = awsMisc.validLambdaRegions.map(r => {
+                return {
+                  key:   '',
+                  value: r,
+                  label: r,
+                };
               });
-        });
-  }
 
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare project data
-   */
+              return _this.cliPromptSelect('Select a region for your project: ', choices, false)
+                  .then(results => {
+                    _this.evt.region = results[0].value;
+                  });
+            }
+          })
+          .then(function() {
 
-  _validateAndPrepare() {
+            // If profile exists, skip select prompt
+            if (_this.evt.profile) return;
 
-    // Initialize AWS Misc Service
-    this.AwsMisc = require('../utils/aws/Misc');
+            // If aws credentials were passed, skip select prompt
+            if (_this.S._awsAdminKeyId && _this.S._awsAdminSecretKey) return;
 
-    // If Profile, extract API Keys
-    if (this.evt.profile) {
-      this.S._awsAdminKeyId     = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_access_key_id;
-      this.S._awsAdminSecretKey = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_secret_access_key;
+            // Prompt: profile select
+            let choices = [];
+            for (let i = 0; i < _this.evt.profiles.length; i++) {
+              choices.push({
+                key:   '',
+                value: _this.evt.profiles[i],
+                label: _this.evt.profiles[i]
+              });
+            }
+
+            return _this.cliPromptSelect('Select an AWS profile for your project: ', choices, false)
+                .then(results => {
+                  _this.evt.profile = results[0].value;
+                });
+          });
     }
 
-    // Initialize Other AWS Services
-    let awsConfig = {
-      region:          this.evt.region,
-      accessKeyId:     this.S._awsAdminKeyId,
-      secretAccessKey: this.S._awsAdminSecretKey,
-    };
-    this.S3  = require('../utils/aws/S3')(awsConfig);
-    this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare project data
+     */
 
-    // Non interactive validation
-    if (!this.S._interactive) {
-      // Check Params
-      if (!this.evt.name || !this.evt.stage || !this.evt.region || !this.evt.domain || !this.evt.notificationEmail) {
-        return BbPromise.reject(new SError('Missing required properties'));
+    _validateAndPrepare() {
+
+      // Initialize AWS Misc Service
+      this.AwsMisc = require('../utils/aws/Misc');
+
+      // If Profile, extract API Keys
+      if (this.evt.profile) {
+        this.S._awsAdminKeyId     = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_access_key_id;
+        this.S._awsAdminSecretKey = this.AwsMisc.profilesGet(this.evt.profile)[this.evt.profile].aws_secret_access_key;
       }
-    }
 
-    // Validate: AWS only allows Alphanumeric and - in name
-    let nameOk = /^([a-zA-Z0-9-]+)$/.exec(this.evt.name);
-    if (!nameOk) {
-      return BbPromise.reject(new SError('Project names can only be alphanumeric and -'));
-    }
+      // Initialize Other AWS Services
+      let awsConfig = {
+        region:          this.evt.region,
+        accessKeyId:     this.S._awsAdminKeyId,
+        secretAccessKey: this.S._awsAdminSecretKey,
+      };
+      this.S3  = require('../utils/aws/S3')(awsConfig);
+      this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
 
-    // Append unique id if name is in use
-    if (SUtils.dirExistsSync(path.join(process.cwd(), this.evt.name))) {
-      let oldName = this.evt.name;
-      this.evt.name = this.evt.name + SUtils.generateShortId(19);
-      SCli.log(`Folder ${oldName} already exists, changing project name to ${this.evt.name}`);
-    }
+      // Non interactive validation
+      if (!this.S._interactive) {
+        // Check Params
+        if (!this.evt.name || !this.evt.stage || !this.evt.region || !this.evt.domain || !this.evt.notificationEmail) {
+          return BbPromise.reject(new SError('Missing required properties'));
+        }
+      }
 
-    // validate domain
-    let domainRegex = /^[a-z0-9-.]+$/;
-    if(!domainRegex.test(this.evt.domain)) {
-      return BbPromise.reject(new SError('Domain must only contain lowercase letters, numbers, periods and dashes'));
-    }
+      // Validate: AWS only allows Alphanumeric and - in name
+      let nameOk = /^([a-zA-Z0-9-]+)$/.exec(this.evt.name);
+      if (!nameOk) {
+        return BbPromise.reject(new SError('Project names can only be alphanumeric and -'));
+      }
 
-    // Append unique id if domain is default
-    if (this.evt.domain === 'myapp.com') {
-      this.evt.domain = 'myapp-' + SUtils.generateShortId(8).toLowerCase() + '.com';
-    }
+      // Append unique id if name is in use
+      if (SUtils.dirExistsSync(path.join(process.cwd(), this.evt.name))) {
+        let oldName = this.evt.name;
+        this.evt.name = this.evt.name + SUtils.generateShortId(19);
+        SCli.log(`Folder ${oldName} already exists, changing project name to ${this.evt.name}`);
+      }
 
-    // Validate email
-    let emailRegex = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
-    if(!emailRegex.test(this.evt.notificationEmail)) {
-      return BbPromise.reject(new SError('Please enter a valid email'));
-    }
+      // validate domain
+      let domainRegex = /^[a-z0-9-.]+$/;
+      if(!domainRegex.test(this.evt.domain)) {
+        return BbPromise.reject(new SError('Domain must only contain lowercase letters, numbers, periods and dashes'));
+      }
 
-    // Validate region
-    if (awsMisc.validLambdaRegions.indexOf(this.evt.region) == -1) {
-      return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.region, SError.errorCodes.UNKNOWN));
-    }
+      // Append unique id if domain is default
+      if (this.evt.domain === 'myapp.com') {
+        this.evt.domain = 'myapp-' + SUtils.generateShortId(8).toLowerCase() + '.com';
+      }
 
-    // Validate API Keys
-    if (!this.S._awsAdminKeyId || !this.S._awsAdminSecretKey) {
-      return BbPromise.reject(new SError('Missing AWS API Key and/or AWS Secret Key'));
-    }
+      // Validate email
+      let emailRegex = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+      if(!emailRegex.test(this.evt.notificationEmail)) {
+        return BbPromise.reject(new SError('Please enter a valid email'));
+      }
 
-    // Set Serverless Regional Bucket
-    this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.evt.domain);
+      // Validate region
+      if (awsMisc.validLambdaRegions.indexOf(this.evt.region) == -1) {
+        return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.region, SError.errorCodes.UNKNOWN));
+      }
 
-    return BbPromise.resolve();
-  }
+      // Validate API Keys
+      if (!this.S._awsAdminKeyId || !this.S._awsAdminSecretKey) {
+        return BbPromise.reject(new SError('Missing AWS API Key and/or AWS Secret Key'));
+      }
 
-  /**
-   * Create Project Directory
-   */
-
-  _createProjectDirectory() {
-
-    let _this = this;
-
-    _this._projectRootPath = path.resolve(path.join(path.dirname('.'), _this.evt.name));
-
-    // Prepare admin.env
-    let adminEnv = 'SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID=' + _this.S._awsAdminKeyId + os.EOL
-        + 'SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY=' + _this.S._awsAdminSecretKey + os.EOL;
-
-    // Prepare README.md
-    let readme = '#' + _this.evt.name;
-
-    // Create Project Scaffolding
-    return SUtils.writeFile(
-        path.join(_this._projectRootPath, 'back', '.env'),
-            'SERVERLESS_STAGE=' + _this.evt.stage
-            + '\nSERVERLESS_DATA_MODEL_STAGE=' + _this.evt.stage
-        )
-        .then(function() {
-
-          return BbPromise.all([
-            fs.mkdirAsync(path.join(_this._projectRootPath, 'back', 'modules')),
-            fs.mkdirAsync(path.join(_this._projectRootPath, 'plugins')).then(function(){
-              return fs.mkdirAsync(path.join(_this._projectRootPath, 'plugins', 'custom'));
-            }),
-            SUtils.writeFile(path.join(_this._projectRootPath, 'admin.env'), adminEnv),
-            SUtils.writeFile(path.join(_this._projectRootPath, 'README.md'), readme),
-            SUtils.generateResourcesCf(
-                _this._projectRootPath,
-                _this.evt.name,
-                _this.evt.domain,
-                _this.evt.stage,
-                _this.evt.region,
-                _this.evt.notificationEmail
-            ),
-            fs.writeFileAsync(path.join(_this._projectRootPath, '.gitignore'), fs.readFileSync(path.join(_this._templatesDir, 'gitignore'))),
-          ]);
-        });
-  }
-
-  /**
-   * Create Serverless bucket if it does not exist
-   */
-
-  _createProjectBucket() {
-    SCli.log('Creating a project region bucket on S3: ' + this.evt.regionBucket + '...');
-    return this.S3.sCreateBucket(this.evt.regionBucket);
-  }
-
-  /**
-   * Put ENV File
-   * - Creates ENV file in serverless stage/region bucket
-   */
-
-  _putEnvFile() {
-    let envFileContents = `SERVERLESS_STAGE=${this.evt.stage}
-SERVERLESS_DATA_MODEL_STAGE=${this.evt.stage}`;
-
-    return this.S3.sPutEnvFile(
-        this.evt.regionBucket,
-        this.evt.name,
-        this.evt.stage,
-        envFileContents);
-  }
-
-  /**
-   * Put CF File
-   */
-
-  _putCfFile() {
-    return this.CF.sPutCfFile(
-        this._projectRootPath,
-        this.evt.regionBucket,
-        this.evt.name,
-        this.evt.stage,
-        'resources');
-  }
-
-  /**
-   * Create CloudFormation Stack
-   */
-
-  _createCfStack(cfTemplateURL) {
-    let _this = this;
-
-    if (_this.evt.noExeCf) {
-      SUtils.sDebug('No execute CF was specified, skipping');
-
-      let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.evt.name);
-
-      SCli.log(`Remember to run CloudFormation manually to create stack with name: ${stackName}`);
-      SCli.log('After creating CF stack, remember to put the IAM role outputs and Serverless Bucket in your project s-project.json in the correct stage/region.');
+      // Set Serverless Regional Bucket
+      this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.evt.domain);
 
       return BbPromise.resolve();
     }
 
-    SCli.log('Creating CloudFormation Stack for your new project (~5 mins)...');
+    /**
+     * Create Project Directory
+     */
 
-    // Start spinner
-    _this._spinner = SCli.spinner();
-    _this._spinner.start();
+    _createProjectDirectory() {
 
-    // Create CF stack
-    return _this.CF.sCreateResourcesStack(
-        _this._projectRootPath,
-        _this.evt.name,
-        _this.evt.stage,
-        _this.evt.domain,
-        _this.evt.notificationEmail,
-        cfTemplateURL
-        )
-        .then(cfData => {
-          return _this.CF.sMonitorCf(cfData, 'create')
-              .then(cfStackData => {
-                _this._spinner.stop(true);
-                return cfStackData;
-              });
-        });
-  }
+      let _this = this;
 
-  /**
-   * Create Project JSON
-   */
+      _this._projectRootPath = path.resolve(path.join(path.dirname('.'), _this.evt.name));
 
-  _createProjectJson(cfStackData) {
+      // Prepare admin.env
+      let adminEnv = 'SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID=' + _this.S._awsAdminKeyId + os.EOL
+          + 'SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY=' + _this.S._awsAdminSecretKey + os.EOL;
 
-    let _this = this;
+      // Prepare README.md
+      let readme = '#' + _this.evt.name;
 
-    if (cfStackData) {
-      for (let i = 0; i < cfStackData.Outputs.length; i++) {
-        if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
-          _this.evt.iamRoleLambdaArn = cfStackData.Outputs[i].OutputValue;
-        }
-      }
+      // Create Project Scaffolding
+      return SUtils.writeFile(
+          path.join(_this._projectRootPath, 'back', '.env'),
+              'SERVERLESS_STAGE=' + _this.evt.stage
+              + '\nSERVERLESS_DATA_MODEL_STAGE=' + _this.evt.stage
+          )
+          .then(function() {
 
-      // Save StackName to Evt
-      _this.evt.stageCfStack = cfStackData.StackName;
+            return BbPromise.all([
+              fs.mkdirAsync(path.join(_this._projectRootPath, 'back', 'modules')),
+              fs.mkdirAsync(path.join(_this._projectRootPath, 'plugins')).then(function(){
+                return fs.mkdirAsync(path.join(_this._projectRootPath, 'plugins', 'custom'));
+              }),
+              SUtils.writeFile(path.join(_this._projectRootPath, 'admin.env'), adminEnv),
+              SUtils.writeFile(path.join(_this._projectRootPath, 'README.md'), readme),
+              SUtils.generateResourcesCf(
+                  _this._projectRootPath,
+                  _this.evt.name,
+                  _this.evt.domain,
+                  _this.evt.stage,
+                  _this.evt.region,
+                  _this.evt.notificationEmail
+              ),
+              fs.writeFileAsync(path.join(_this._projectRootPath, '.gitignore'), fs.readFileSync(path.join(_this._templatesDir, 'gitignore'))),
+            ]);
+          });
     }
 
-    let prjJson = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, 's-project.json'));
+    /**
+     * Create Serverless bucket if it does not exist
+     */
 
-    prjJson.stages[_this.evt.stage] = [{
-      region:           _this.evt.region,
-      iamRoleArnLambda: _this.evt.iamRoleLambdaArn || '',
-      regionBucket:     _this.evt.regionBucket
-    }];
+    _createProjectBucket() {
+      SCli.log('Creating a project region bucket on S3: ' + this.evt.regionBucket + '...');
+      return this.S3.sCreateBucket(this.evt.regionBucket);
+    }
 
-    prjJson.name   = _this.evt.name;
-    prjJson.domain = _this.evt.domain;
+    /**
+     * Put ENV File
+     * - Creates ENV file in serverless stage/region bucket
+     */
 
-    fs.writeFileSync(path.join(_this._projectRootPath, 's-project.json'),
-        JSON.stringify(prjJson, null, 2));
+    _putEnvFile() {
+      let envFileContents = `SERVERLESS_STAGE=${this.evt.stage}
+  SERVERLESS_DATA_MODEL_STAGE=${this.evt.stage}`;
 
-    return prjJson;
+      return this.S3.sPutEnvFile(
+          this.evt.regionBucket,
+          this.evt.name,
+          this.evt.stage,
+          envFileContents);
+    }
+
+    /**
+     * Put CF File
+     */
+
+    _putCfFile() {
+      return this.CF.sPutCfFile(
+          this._projectRootPath,
+          this.evt.regionBucket,
+          this.evt.name,
+          this.evt.stage,
+          'resources');
+    }
+
+    /**
+     * Create CloudFormation Stack
+     */
+
+    _createCfStack(cfTemplateURL) {
+      let _this = this;
+
+      if (_this.evt.noExeCf) {
+        SUtils.sDebug('No execute CF was specified, skipping');
+
+        let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.evt.name);
+
+        SCli.log(`Remember to run CloudFormation manually to create stack with name: ${stackName}`);
+        SCli.log('After creating CF stack, remember to put the IAM role outputs and Serverless Bucket in your project s-project.json in the correct stage/region.');
+
+        return BbPromise.resolve();
+      }
+
+      SCli.log('Creating CloudFormation Stack for your new project (~5 mins)...');
+
+      // Start spinner
+      _this._spinner = SCli.spinner();
+      _this._spinner.start();
+
+      // Create CF stack
+      return _this.CF.sCreateResourcesStack(
+          _this._projectRootPath,
+          _this.evt.name,
+          _this.evt.stage,
+          _this.evt.domain,
+          _this.evt.notificationEmail,
+          cfTemplateURL
+          )
+          .then(cfData => {
+            return _this.CF.sMonitorCf(cfData, 'create')
+                .then(cfStackData => {
+                  _this._spinner.stop(true);
+                  return cfStackData;
+                });
+          });
+    }
+
+    /**
+     * Create Project JSON
+     */
+
+    _createProjectJson(cfStackData) {
+
+      let _this = this;
+
+      if (cfStackData) {
+        for (let i = 0; i < cfStackData.Outputs.length; i++) {
+          if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
+            _this.evt.iamRoleLambdaArn = cfStackData.Outputs[i].OutputValue;
+          }
+        }
+
+        // Save StackName to Evt
+        _this.evt.stageCfStack = cfStackData.StackName;
+      }
+
+      let prjJson = SUtils.readAndParseJsonSync(path.join(_this._templatesDir, 's-project.json'));
+
+      prjJson.stages[_this.evt.stage] = [{
+        region:           _this.evt.region,
+        iamRoleArnLambda: _this.evt.iamRoleLambdaArn || '',
+        regionBucket:     _this.evt.regionBucket
+      }];
+
+      prjJson.name   = _this.evt.name;
+      prjJson.domain = _this.evt.domain;
+
+      fs.writeFileSync(path.join(_this._projectRootPath, 's-project.json'),
+          JSON.stringify(prjJson, null, 2));
+
+      return prjJson;
+    }
   }
-}
 
-module.exports = ProjectCreate;
+  return( ProjectCreate );
+};

--- a/lib/actions/RegionCreate.js
+++ b/lib/actions/RegionCreate.js
@@ -15,290 +15,291 @@
  * - noExeCf:             (Boolean) Don't execute CloudFormation
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-    SError  = require('../ServerlessError'),
-    SCli    = require('../utils/cli'),
-    path       = require('path'),
-    os         = require('os'),
-    fs         = require('fs'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc'),
-    SUtils  = require('../utils');
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError  = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli    = require(path.join(serverlessPath, 'utils/cli')),
+      os         = require('os'),
+      fs         = require('fs'),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require(path.join(serverlessPath, 'utils/aws/Misc')),
+      SUtils  = require(path.join(serverlessPath, 'utils'));
 
-BbPromise.promisifyAll(fs);
-
-/**
- * RegionCreate Class
- */
-
-class RegionCreate extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
-
-  static getName() {
-    return 'serverless.core.' + RegionCreate.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.regionCreate.bind(this), {
-      handler:       'regionCreate',
-      description:   `Creates new region for a stage in a project
-usage: serverless region create`,
-
-      context:       'region',
-      contextAction: 'create',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'AWS lambda supported region for a stage.'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'The stage your want to create a region for.'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'ni',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false.'
-        },
-        {
-          option:      'noExeCf',
-          shortcut:    'c',
-          description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false.'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
+  BbPromise.promisifyAll(fs);
 
   /**
-   * Action
+   * RegionCreate Class
    */
-  regionCreate(evt) {
 
-    let _this = this;
+  class RegionCreate extends SPlugin {
 
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
-
-      if (_this.S.cli.options.nonInteractive) {
-        _this.S._interactive = false;
-      }
+    static getName() {
+      return 'serverless.core.' + RegionCreate.name;
     }
 
-    return _this.S.validateProject()
-      .bind(_this)
-      .then(_this._prompt)
-      .then(_this._validateAndPrepare)
-      .then(_this._initAWS)
-      .then(_this._createRegionBucket)
-      .then(_this._putEnvFile)
-      .then(_this._putCfFile)
-      .then(_this._createCfStack)
-      .then(_this._updateProjectJson)
-      .then(function() {
-        SCli.log('Successfully created region ' + _this.evt.region + ' within stage ' + _this.evt.stage);
-        return _this.evt;
+    registerActions() {
+      this.S.addAction(this.regionCreate.bind(this), {
+        handler:       'regionCreate',
+        description:   `Creates new region for a stage in a project
+  usage: serverless region create`,
+
+        context:       'region',
+        contextAction: 'create',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'AWS lambda supported region for a stage.'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'The stage your want to create a region for.'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'ni',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false.'
+          },
+          {
+            option:      'noExeCf',
+            shortcut:    'c',
+            description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false.'
+          },
+        ],
       });
-  }
-
-  /**
-   * Prompt stage and region
-   */
-  _prompt() {
-    let _this = this;
-
-    return _this.cliPromptSelectStage('Select an existing stage for your new region: ', _this.evt.stage, false)
-      .then(stage => {
-
-        _this.evt.stage = stage;
-        BbPromise.resolve();
-      })
-      .then(function(){
-        return _this.cliPromptSelectRegion('Select a new region for your existing stage: ', false, _this.evt.region, _this.evt.stage)
-          .then(region => {
-            _this.evt.region = region;
-            BbPromise.resolve();
-          });
-      });
-
-  }
-
-
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare data
-   */
-  _validateAndPrepare() {
-    let _this = this;
-
-    // non interactive validation
-    if (!_this.S._interactive) {
-
-      // Check Params
-      if (!_this.evt.stage || !_this.evt.region) {
-        return BbPromise.reject(new SError('Missing stage or region'));
-      }
-    }
-
-    // validate stage: make sure stage exists
-    if (!_this.S._projectJson.stages[_this.evt.stage]) {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-    }
-
-
-    // validate region: make sure Lambda is supported in that region
-    if (awsMisc.validLambdaRegions.indexOf(_this.evt.region) == -1) {
-      return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + _this.evt.region, SError.errorCodes.UNKNOWN));
-    }
-
-    // validate region: make sure region is not already defined
-    if (_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
-          return r.region == _this.evt.region;
-        })) {
-      return BbPromise.reject(new SError('Region "' + _this.evt.region + '" is already defined in the stage "' + _this.evt.stage + '"'));
-    }
-  }
-
-  /**
-   * Initialize needed AWS classes
-   */
-
-  _initAWS() {
-
-    let awsConfig = {
-      region:          this.evt.region,
-      accessKeyId:     this.S._awsAdminKeyId,
-      secretAccessKey: this.S._awsAdminSecretKey,
-    };
-
-    this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
-    this.Lambda  = require('../utils/aws/Lambda')(awsConfig);
-    this.S3  = require('../utils/aws/S3')(awsConfig);
-  }
-
-  /**
-   * Create Project Bucket
-   * - If it does not exist
-   */
-
-  _createRegionBucket() {
-    this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.S._projectJson.domain);
-    SCli.log('Creating a region bucket on S3: ' + this.evt.regionBucket + '...');
-    return this.S3.sCreateBucket(this.evt.regionBucket);
-  }
-
-  /**
-   * Put ENV File
-   * - Creates ENV file in Serverless stage/region bucket
-   */
-
-  _putEnvFile() {
-    let stage = this.evt.stage;
-
-    let envFileContents = `SERVERLESS_STAGE=${stage}
-SERVERLESS_DATA_MODEL_STAGE=${stage}`;
-
-    return this.S3.sPutEnvFile(
-        this.evt.regionBucket,
-        this.S._projectJson.name,
-        this.evt.stage,
-        envFileContents);
-  }
-
-  /**
-   * Put CF File
-   */
-
-  _putCfFile() {
-    return this.CF.sPutCfFile(
-        this.S._projectRootPath,
-        this.evt.regionBucket,
-        this.S._projectJson.name,
-        this.evt.stage,
-        'resources');
-  }
-
-  /**
-   * Create CloudFormation Stack
-   */
-
-  _createCfStack(cfTemplateUrl) {
-    let _this = this;
-
-    if (_this.evt.noExeCf) {
-      let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.S._projectJson.name);
-
-      SCli.log(`Remember to run CloudFormation manually to create stack with name: ${stackName}`);
-      SCli.log('After creating CF stack, remember to put the IAM role outputs and serverlessBucket in your project s-project.json in the correct stage/region.');
-
       return BbPromise.resolve();
     }
 
-    SCli.log('Creating CloudFormation Stack for your new region (~5 mins)...');
-    this._spinner = SCli.spinner();
-    this._spinner.start();
+    /**
+     * Action
+     */
+    regionCreate(evt) {
 
-    // Create CF stack
-    return _this.CF.sCreateResourcesStack(
-        _this.S._projectRootPath,
-        _this.S._projectJson.name,
-        _this.evt.stage,
-        _this.S._projectJson.domain,
-        '',
-        cfTemplateUrl
-        )
-        .then(cfData => {
-          return _this.CF.sMonitorCf(cfData, 'create')
-              .then(cfStackData => {
-                _this._spinner.stop(true);
-                return cfStackData;
-              });
-        });
-  }
+      let _this = this;
 
-  /**
-   * Update Project JSON
-   */
+      if(evt) {
+        _this.evt = evt;
+        _this.S._interactive = false;
+      }
 
-  _updateProjectJson(cfStackData) {
-    let _this     = this;
-    let regionObj = {
-          region:               _this.evt.region,
-          iamRoleArnLambda:     '',
-          regionBucket:           _this.evt.regionBucket,
-        };
+      // If CLI, parse arguments
+      if (_this.S.cli) {
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
 
-    if (cfStackData) {
-      for (let i = 0; i < cfStackData.Outputs.length; i++) {
-        if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
-          regionObj.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
-          _this.evt.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
         }
       }
 
-      // Save StackName to Evt
-      _this.evt.stageCfStack = cfStackData.StackName;
+      return _this.S.validateProject()
+        .bind(_this)
+        .then(_this._prompt)
+        .then(_this._validateAndPrepare)
+        .then(_this._initAWS)
+        .then(_this._createRegionBucket)
+        .then(_this._putEnvFile)
+        .then(_this._putCfFile)
+        .then(_this._createCfStack)
+        .then(_this._updateProjectJson)
+        .then(function() {
+          SCli.log('Successfully created region ' + _this.evt.region + ' within stage ' + _this.evt.stage);
+          return _this.evt;
+        });
     }
 
-    _this.S._projectJson.stages[_this.evt.stage].push(regionObj);
+    /**
+     * Prompt stage and region
+     */
+    _prompt() {
+      let _this = this;
 
-    return SUtils.writeFile(
-        path.join(_this.S._projectRootPath, 's-project.json'),
-        JSON.stringify(_this.S._projectJson, null, 2)
-    );
+      return _this.cliPromptSelectStage('Select an existing stage for your new region: ', _this.evt.stage, false)
+        .then(stage => {
+
+          _this.evt.stage = stage;
+          BbPromise.resolve();
+        })
+        .then(function(){
+          return _this.cliPromptSelectRegion('Select a new region for your existing stage: ', false, _this.evt.region, _this.evt.stage)
+            .then(region => {
+              _this.evt.region = region;
+              BbPromise.resolve();
+            });
+        });
+
+    }
+
+
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare data
+     */
+    _validateAndPrepare() {
+      let _this = this;
+
+      // non interactive validation
+      if (!_this.S._interactive) {
+
+        // Check Params
+        if (!_this.evt.stage || !_this.evt.region) {
+          return BbPromise.reject(new SError('Missing stage or region'));
+        }
+      }
+
+      // validate stage: make sure stage exists
+      if (!_this.S._projectJson.stages[_this.evt.stage]) {
+        return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+      }
+
+
+      // validate region: make sure Lambda is supported in that region
+      if (awsMisc.validLambdaRegions.indexOf(_this.evt.region) == -1) {
+        return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + _this.evt.region, SError.errorCodes.UNKNOWN));
+      }
+
+      // validate region: make sure region is not already defined
+      if (_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
+            return r.region == _this.evt.region;
+          })) {
+        return BbPromise.reject(new SError('Region "' + _this.evt.region + '" is already defined in the stage "' + _this.evt.stage + '"'));
+      }
+    }
+
+    /**
+     * Initialize needed AWS classes
+     */
+
+    _initAWS() {
+
+      let awsConfig = {
+        region:          this.evt.region,
+        accessKeyId:     this.S._awsAdminKeyId,
+        secretAccessKey: this.S._awsAdminSecretKey,
+      };
+
+      this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
+      this.Lambda  = require('../utils/aws/Lambda')(awsConfig);
+      this.S3  = require('../utils/aws/S3')(awsConfig);
+    }
+
+    /**
+     * Create Project Bucket
+     * - If it does not exist
+     */
+
+    _createRegionBucket() {
+      this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.S._projectJson.domain);
+      SCli.log('Creating a region bucket on S3: ' + this.evt.regionBucket + '...');
+      return this.S3.sCreateBucket(this.evt.regionBucket);
+    }
+
+    /**
+     * Put ENV File
+     * - Creates ENV file in Serverless stage/region bucket
+     */
+
+    _putEnvFile() {
+      let stage = this.evt.stage;
+
+      let envFileContents = `SERVERLESS_STAGE=${stage}
+  SERVERLESS_DATA_MODEL_STAGE=${stage}`;
+
+      return this.S3.sPutEnvFile(
+          this.evt.regionBucket,
+          this.S._projectJson.name,
+          this.evt.stage,
+          envFileContents);
+    }
+
+    /**
+     * Put CF File
+     */
+
+    _putCfFile() {
+      return this.CF.sPutCfFile(
+          this.S._projectRootPath,
+          this.evt.regionBucket,
+          this.S._projectJson.name,
+          this.evt.stage,
+          'resources');
+    }
+
+    /**
+     * Create CloudFormation Stack
+     */
+
+    _createCfStack(cfTemplateUrl) {
+      let _this = this;
+
+      if (_this.evt.noExeCf) {
+        let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.S._projectJson.name);
+
+        SCli.log(`Remember to run CloudFormation manually to create stack with name: ${stackName}`);
+        SCli.log('After creating CF stack, remember to put the IAM role outputs and serverlessBucket in your project s-project.json in the correct stage/region.');
+
+        return BbPromise.resolve();
+      }
+
+      SCli.log('Creating CloudFormation Stack for your new region (~5 mins)...');
+      this._spinner = SCli.spinner();
+      this._spinner.start();
+
+      // Create CF stack
+      return _this.CF.sCreateResourcesStack(
+          _this.S._projectRootPath,
+          _this.S._projectJson.name,
+          _this.evt.stage,
+          _this.S._projectJson.domain,
+          '',
+          cfTemplateUrl
+          )
+          .then(cfData => {
+            return _this.CF.sMonitorCf(cfData, 'create')
+                .then(cfStackData => {
+                  _this._spinner.stop(true);
+                  return cfStackData;
+                });
+          });
+    }
+
+    /**
+     * Update Project JSON
+     */
+
+    _updateProjectJson(cfStackData) {
+      let _this     = this;
+      let regionObj = {
+            region:               _this.evt.region,
+            iamRoleArnLambda:     '',
+            regionBucket:           _this.evt.regionBucket,
+          };
+
+      if (cfStackData) {
+        for (let i = 0; i < cfStackData.Outputs.length; i++) {
+          if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
+            regionObj.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
+            _this.evt.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
+          }
+        }
+
+        // Save StackName to Evt
+        _this.evt.stageCfStack = cfStackData.StackName;
+      }
+
+      _this.S._projectJson.stages[_this.evt.stage].push(regionObj);
+
+      return SUtils.writeFile(
+          path.join(_this.S._projectRootPath, 's-project.json'),
+          JSON.stringify(_this.S._projectJson, null, 2)
+      );
+    }
   }
-}
 
-module.exports = RegionCreate;
+  return( RegionCreate );
+};

--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -9,248 +9,248 @@
  * region    (String) the name of the region you want to deploy resources to. Must exist in provided stage.
  */
 
-const SPlugin  = require('../ServerlessPlugin'),
-    SError     = require('../ServerlessError'),
-    SCli       = require('../utils/cli'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc'),
-    path       = require('path'),
-    SUtils     = require('../utils/index');
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError     = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli       = require(path.join(serverlessPath, 'utils/cli')),
+      BbPromise  = require('bluebird'),
+      SUtils     = require(path.join(serverlessPath, 'utils/index'));
 
-class ResourcesDeploy extends SPlugin {
+  class ResourcesDeploy extends SPlugin {
 
-  /**
-   * Constructor
-   */
+    /**
+     * Constructor
+     */
 
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
-
-  /**
-   * Define your plugins name
-   */
-
-  static getName() {
-    return 'serverless.core.' + ResourcesDeploy.name;
-  }
-
-  /**
-   * @returns {Promise} upon completion of all registrations
-   */
-
-  registerActions() {
-    this.S.addAction(this.resourcesDeploy.bind(this), {
-      handler:       'resourcesDeploy',
-      description:   `Provision AWS resources (resources-cf.json).
-usage: serverless resources deploy`,
-      context:       'resources',
-      contextAction: 'deploy',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'region you want to deploy to'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'stage you want to deploy to'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'i',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false'
-        },
-      ],
-    });
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Action
-   */
-  resourcesDeploy(evt) {
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
+    /**
+     * Define your plugins name
+     */
 
-      _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
+    static getName() {
+      return 'serverless.core.' + ResourcesDeploy.name;
+    }
 
-      if (_this.S.cli.options.nonInteractive) {
+    /**
+     * @returns {Promise} upon completion of all registrations
+     */
+
+    registerActions() {
+      this.S.addAction(this.resourcesDeploy.bind(this), {
+        handler:       'resourcesDeploy',
+        description:   `Provision AWS resources (resources-cf.json).
+  usage: serverless resources deploy`,
+        context:       'resources',
+        contextAction: 'deploy',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'region you want to deploy to'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'stage you want to deploy to'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'i',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false'
+          },
+        ],
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+    resourcesDeploy(evt) {
+      let _this = this;
+
+      if(evt) {
+        _this.evt = evt;
         _this.S._interactive = false;
       }
-    }
 
+      // If CLI, parse arguments
+      if (_this.S.cli) {
 
-    return this.S.validateProject()
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(_this._updateResources)
-        .then(() => {
-          _this._spinner.stop(true);
-          SCli.log('Resource Deployer:  Successfully deployed ' + _this.evt.stage + ' resources to ' + _this.evt.region.region);
-          return _this.evt;
-        });
-  }
+        _this.evt = JSON.parse(JSON.stringify(this.S.cli.options)); // Important: Clone objects, don't refer to them
 
-  /**
-   * Prompt stage and region
-   */
-  _prompt() {
-    let _this = this;
-
-    return _this.cliPromptSelectStage('Which stage are you deploying to: ', _this.evt.stage, false)
-        .then(stage => {
-          _this.evt.stage = stage;
-          BbPromise.resolve();
-        })
-        .then(function(){
-          return _this.cliPromptSelectRegion('Which region are you deploying to: ', false, _this.evt.region, false)
-              .then(region => {
-                _this.evt.region = region;
-                BbPromise.resolve();
-              });
-        });
-
-  }
-
-
-  _validateAndPrepare(){
-
-    let _this = this;
-
-    // non interactive validation
-    if (!_this.S._interactive) {
-
-      // Check API Keys
-      if (!_this.S._awsProfile) {
-        if (!_this.S._awsAdminKeyId || !_this.S._awsAdminSecretKey) {
-          return BbPromise.reject(new SError('Missing AWS Profile and/or API Key and/or AWS Secret Key'));
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
         }
       }
-      // Check Params
-      if (!_this.evt.stage || !_this.evt.region) {
-        return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+
+
+      return this.S.validateProject()
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(_this._updateResources)
+          .then(() => {
+            _this._spinner.stop(true);
+            SCli.log('Resource Deployer:  Successfully deployed ' + _this.evt.stage + ' resources to ' + _this.evt.region.region);
+            return _this.evt;
+          });
+    }
+
+    /**
+     * Prompt stage and region
+     */
+    _prompt() {
+      let _this = this;
+
+      return _this.cliPromptSelectStage('Which stage are you deploying to: ', _this.evt.stage, false)
+          .then(stage => {
+            _this.evt.stage = stage;
+            BbPromise.resolve();
+          })
+          .then(function(){
+            return _this.cliPromptSelectRegion('Which region are you deploying to: ', false, _this.evt.region, false)
+                .then(region => {
+                  _this.evt.region = region;
+                  BbPromise.resolve();
+                });
+          });
+
+    }
+
+
+    _validateAndPrepare(){
+
+      let _this = this;
+
+      // non interactive validation
+      if (!_this.S._interactive) {
+
+        // Check API Keys
+        if (!_this.S._awsProfile) {
+          if (!_this.S._awsAdminKeyId || !_this.S._awsAdminSecretKey) {
+            return BbPromise.reject(new SError('Missing AWS Profile and/or API Key and/or AWS Secret Key'));
+          }
+        }
+        // Check Params
+        if (!_this.evt.stage || !_this.evt.region) {
+          return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        }
       }
+
+      // validate stage: make sure stage exists
+      if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
+        return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+      }
+
+      // validate region: make sure region exists in stage
+      if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
+            return r.region == _this.evt.region;
+          })) {
+        return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
+      }
+
+      // Get full region config
+      _this.evt.region = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, _this.evt.region);
     }
 
-    // validate stage: make sure stage exists
-    if (!_this.S._projectJson.stages[_this.evt.stage] && _this.evt.stage != 'local') {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-    }
+    /**
+     * Update CloudFormation Resources
+     */
 
-    // validate region: make sure region exists in stage
-    if (!_this.S._projectJson.stages[_this.evt.stage].some(function(r) {
-          return r.region == _this.evt.region;
-        })) {
-      return BbPromise.reject(new SError('Region "' + _this.evt.region + '" does not exist in stage "' + _this.evt.stage + '"'));
-    }
+    _updateResources() {
 
-    // Get full region config
-    _this.evt.region = SUtils.getRegionConfig(_this.S._projectJson, _this.evt.stage, _this.evt.region);
-  }
+      let _this = this;
 
-  /**
-   * Update CloudFormation Resources
-   */
+      SCli.log('Deploying resources to stage  "'
+          + _this.evt.stage
+          + '" and region "'
+          + _this.evt.region.region
+          + '" via Cloudformation.  This could take a while depending on how many resources you are updating...');
 
-  _updateResources() {
+      // Start spinner
+      _this._spinner = SCli.spinner();
+      _this._spinner.start();
 
-    let _this = this;
+      let awsConfig = {
+        region:          _this.evt.region.region,
+        accessKeyId:     _this.S._awsAdminKeyId,
+        secretAccessKey: _this.S._awsAdminSecretKey,
+      };
+      _this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
 
-    SCli.log('Deploying resources to stage  "'
-        + _this.evt.stage
-        + '" and region "'
-        + _this.evt.region.region
-        + '" via Cloudformation.  This could take a while depending on how many resources you are updating...');
+      return _this.CF.sUpdateResourcesStack(
+          _this.S,
+          _this.evt.stage,
+          _this.evt.region.region)
+          .then(cfData => {
+            return _this.CF.sMonitorCf(cfData, 'update');
+          })
+          .catch(function(e) {
 
-    // Start spinner
-    _this._spinner = SCli.spinner();
-    _this._spinner.start();
+            if (e.message.indexOf('does not exist') !== -1) {
 
-    let awsConfig = {
-      region:          _this.evt.region.region,
-      accessKeyId:     _this.S._awsAdminKeyId,
-      secretAccessKey: _this.S._awsAdminSecretKey,
-    };
-    _this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
+              // If Resources stack does not exit, create it.
+              return _this.CF.sPutCfFile(
+                  _this.S._projectRootPath,
+                  _this.evt.region.regionBucket,
+                  _this.S._projectJson.name,
+                  _this.evt.stage,
+                  'resources')
+                  .then(function(cfTemplateUrl) {
 
-    return _this.CF.sUpdateResourcesStack(
-        _this.S,
-        _this.evt.stage,
-        _this.evt.region.region)
-        .then(cfData => {
-          return _this.CF.sMonitorCf(cfData, 'update');
-        })
-        .catch(function(e) {
+                    let projResoucesCfPath = path.join(_this.S._projectRootPath, 'cloudformation', 'resources-cf.json'),
+                        cfTemplate         = SUtils.readAndParseJsonSync(projResoucesCfPath);
 
-          if (e.message.indexOf('does not exist') !== -1) {
+                    // Create CF resources stack
+                    return _this.CF.sCreateResourcesStack(
+                        _this.S._projectRootPath,
+                        _this.S._projectJson.name,
+                        _this.evt.stage,
+                        _this.S._projectJson.domain,
+                        '',
+                        cfTemplateUrl
+                        )
+                        .then(cfData => {
+                          return _this.CF.sMonitorCf(cfData, 'create')
+                              .then(cfStackData => {
 
-            // If Resources stack does not exit, create it.
-            return _this.CF.sPutCfFile(
-                _this.S._projectRootPath,
-                _this.evt.region.regionBucket,
-                _this.S._projectJson.name,
-                _this.evt.stage,
-                'resources')
-                .then(function(cfTemplateUrl) {
+                                _this._spinner.stop(true);
 
-                  let projResoucesCfPath = path.join(_this.S._projectRootPath, 'cloudformation', 'resources-cf.json'),
-                      cfTemplate         = SUtils.readAndParseJsonSync(projResoucesCfPath);
-
-                  // Create CF resources stack
-                  return _this.CF.sCreateResourcesStack(
-                      _this.S._projectRootPath,
-                      _this.S._projectJson.name,
-                      _this.evt.stage,
-                      _this.S._projectJson.domain,
-                      '',
-                      cfTemplateUrl
-                      )
-                      .then(cfData => {
-                        return _this.CF.sMonitorCf(cfData, 'create')
-                            .then(cfStackData => {
-
-                              _this._spinner.stop(true);
-
-                              if (cfStackData) {
-                                for (let i = 0; i < cfStackData.Outputs.length; i++) {
-                                  if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
-                                    _this.evt.region.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
+                                if (cfStackData) {
+                                  for (let i = 0; i < cfStackData.Outputs.length; i++) {
+                                    if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
+                                      _this.evt.region.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
+                                    }
                                   }
                                 }
-                              }
 
-                              // Save to s-project.json
-                              let regionExists = false
-                              for (let i = 0; i < _this.S._projectJson.stages[_this.evt.stage].length; i++) {
-                                if (_this.S._projectJson.stages[_this.evt.stage][i].region === _this.evt.region) {
-                                  _this.S._projectJson.stages[_this.evt.stage][i] = _this.evt.region;
-                                  regionExists = true;
+                                // Save to s-project.json
+                                let regionExists = false
+                                for (let i = 0; i < _this.S._projectJson.stages[_this.evt.stage].length; i++) {
+                                  if (_this.S._projectJson.stages[_this.evt.stage][i].region === _this.evt.region) {
+                                    _this.S._projectJson.stages[_this.evt.stage][i] = _this.evt.region;
+                                    regionExists = true;
+                                  }
                                 }
-                              }
-                              if (!regionExists) _this.S._projectJson.stages[_this.evt.stage].push(_this.evt.region);
+                                if (!regionExists) _this.S._projectJson.stages[_this.evt.stage].push(_this.evt.region);
 
-                              return SUtils.writeFile(
-                                  JSON.stringify(path.join(_this.S._projectRootPath, 's-project.json'), null, 2));
-                            });
-                      });
-                });
+                                return SUtils.writeFile(
+                                    JSON.stringify(path.join(_this.S._projectRootPath, 's-project.json'), null, 2));
+                              });
+                        });
+                  });
 
-          } else {
-            return new SError(e);
-          }
-        });
+            } else {
+              return new SError(e);
+            }
+          });
+    }
   }
-}
 
-module.exports = ResourcesDeploy;
+  return( ResourcesDeploy );
+};

--- a/lib/actions/StageCreate.js
+++ b/lib/actions/StageCreate.js
@@ -13,347 +13,348 @@
  * - noExeCf:             (Boolean) Don't execute CloudFormation
  */
 
-const SPlugin = require('../ServerlessPlugin'),
-    SError  = require('../ServerlessError'),
-    SCli    = require('../utils/cli'),
-    path       = require('path'),
-    os         = require('os'),
-    fs         = require('fs'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require('../utils/aws/Misc'),
-    SUtils  = require('../utils');
+module.exports = function(SPlugin, serverlessPath) {
+  const path = require('path'),
+      SError  = require(path.join(serverlessPath, 'ServerlessError')),
+      SCli    = require(path.join(serverlessPath, 'utils/cli')),
+      os         = require('os'),
+      fs         = require('fs'),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require(path.join(serverlessPath, 'utils/aws/Misc')),
+      SUtils  = require(path.join(serverlessPath, 'utils'));
 
-BbPromise.promisifyAll(fs);
-
-/**
- * StageCreate Class
- */
-
-class StageCreate extends SPlugin {
-
-  constructor(S, config) {
-    super(S, config);
-    this.evt = {};
-  }
-
-  static getName() {
-    return 'serverless.core.' + StageCreate.name;
-  }
-
-  registerActions() {
-    this.S.addAction(this.stageCreate.bind(this), {
-      handler:       'stageCreate',
-      description:   `Creates new stage for project
-usage: serverless stage create`,
-      context:       'stage',
-      contextAction: 'create',
-      options:       [
-        {
-          option:      'region',
-          shortcut:    'r',
-          description: 'AWS lambda supported region for your new stage.'
-        },
-        {
-          option:      'stage',
-          shortcut:    's',
-          description: 'new stage name.'
-        },
-        {
-          option:      'nonInteractive',
-          shortcut:    'ni',
-          description: 'Optional - Turn off CLI interactivity if true. Default: false.'
-        },
-        {
-          option:      'noExeCf',
-          shortcut:    'c',
-          description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false.'
-        },
-      ],
-    });
-
-    return BbPromise.resolve();
-  }
+  BbPromise.promisifyAll(fs);
 
   /**
-   * Action
+   * StageCreate Class
    */
 
-  stageCreate(evt) {
+  class StageCreate extends SPlugin {
 
-    let _this = this;
-
-    if(evt) {
-      _this.evt = evt;
-      _this.S._interactive = false;
+    constructor(S, config) {
+      super(S, config);
+      this.evt = {};
     }
 
-    // If CLI, parse arguments
-    if (_this.S.cli) {
-
-      _this.evt = JSON.parse(JSON.stringify(_this.S.cli.options)); // Important: Clone objects, don't refer to them
-
-      if (_this.S.cli.options.nonInteractive) {
-        _this.S._interactive = false;
-      }
+    static getName() {
+      return 'serverless.core.' + StageCreate.name;
     }
 
-    return _this.S.validateProject()
-      .bind(_this)
-      .then(_this._prompt)
-      .then(_this._validateAndPrepare)
-      .then(_this._initAWS)
-      .then(_this._updateCfTemplate)
-      .then(_this._createRegionBucket)
-      .then(_this._putEnvFile)
-      .then(_this._putCfFile)
-      .then(_this._createCfStack)
-      .then(_this._updateProjectJson)
-      .then(function() {
-        SCli.log('Successfully created stage ' + _this.evt.stage + ' with region ' + _this.evt.region);
-        return _this.evt;
+    registerActions() {
+      this.S.addAction(this.stageCreate.bind(this), {
+        handler:       'stageCreate',
+        description:   `Creates new stage for project
+  usage: serverless stage create`,
+        context:       'stage',
+        contextAction: 'create',
+        options:       [
+          {
+            option:      'region',
+            shortcut:    'r',
+            description: 'AWS lambda supported region for your new stage.'
+          },
+          {
+            option:      'stage',
+            shortcut:    's',
+            description: 'new stage name.'
+          },
+          {
+            option:      'nonInteractive',
+            shortcut:    'ni',
+            description: 'Optional - Turn off CLI interactivity if true. Default: false.'
+          },
+          {
+            option:      'noExeCf',
+            shortcut:    'c',
+            description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false.'
+          },
+        ],
       });
-  }
-
-  /**
-   * Prompt stage and region
-   */
-
-  _prompt() {
-    let _this = this;
-
-    // Skip if non-interactive or stage is provided
-    if (!_this.S._interactive || _this.evt.stage) return BbPromise.resolve();
-
-    let prompts = {
-      properties: {}
-    };
-
-    prompts.properties.stage = {
-      description: 'Enter a new stage name for this project: '.yellow,
-      required:    true,
-      message:     'Stage must be letters and numbers only',
-      conform:     function(stage) {
-        return SUtils.isStageNameValid(stage);
-      }
-    };
-
-    return _this.cliPromptInput(prompts, null)
-      .then(function(answers) {
-        _this.evt.stage = answers.stage.toLowerCase();
-        BbPromise.resolve();
-      })
-      .then(function(){
-        return _this.cliPromptSelectRegion('Select a region for your new stage: ', false, _this.evt.region, false)
-          .then(region => {
-            _this.evt.region = region;
-            BbPromise.resolve();
-          });
-      });
-  }
-
-  /**
-   * Validate all data from event, interactive CLI or non interactive CLI
-   * and prepare data
-   */
-
-  _validateAndPrepare() {
-
-    // non interactive validation
-    if (!this.S._interactive) {
-
-      // Check Params
-      if (!this.evt.stage || !this.evt.region) {
-        return BbPromise.reject(new SError('Missing stage or region'));
-      }
-    }
-
-    // validate stage
-    if (!SUtils.isStageNameValid(this.evt.stage)) {
-      return BbPromise.reject(new SError('Invalid stage name. Stage must be letters and numbers only.', SError.errorCodes.UNKNOWN));
-    }
-
-    // validate stage: Ensure stage isn't "local"
-    this.evt.stage = this.evt.stage.toLowerCase().replace(/\W+/g, '').substring(0, 15);
-    if (this.evt.stage == 'local') {
-      return BbPromise.reject(new SError('Stage ' + this.evt.stage + ' is reserved'));
-    }
-
-    // validate stage: Ensure stage doesn't already exist
-    if (this.S._projectJson.stages[this.evt.stage]) {
-      return BbPromise.reject(new SError('Stage ' + this.evt.stage + ' already exists', SError.errorCodes.UNKNOWN));
-    }
-
-    // validate region
-    if (awsMisc.validLambdaRegions.indexOf(this.evt.region) == -1) {
-      return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.region, SError.errorCodes.UNKNOWN));
-    }
-
-    // Status
-    SCli.log('Creating stage and region: ' + this.evt.stage + '/' + this.evt.region);
-
-    return BbPromise.resolve();
-  }
-
-  /**
-   * Initialize needed AWS classes
-   */
-
-  _initAWS() {
-
-    let awsConfig = {
-      region:          this.evt.region,
-      accessKeyId:     this.S._awsAdminKeyId,
-      secretAccessKey: this.S._awsAdminSecretKey,
-    };
-
-    this.CF       = require('../utils/aws/CloudFormation')(awsConfig);
-    this.Lambda   = require('../utils/aws/Lambda')(awsConfig);
-    this.S3       = require('../utils/aws/S3')(awsConfig);
-  }
-
-  /**
-   * Update CF Template
-   * - Add a stage to an existing project resources cloudformation template
-   */
-
-  _updateCfTemplate() {
-
-    let projResoucesCfPath  = path.join(this.S._projectRootPath, 'cloudformation', 'resources-cf.json'),
-        cfTemplate          = SUtils.readAndParseJsonSync(projResoucesCfPath);
-
-    // Add new stage to AllowedValues
-    cfTemplate.Parameters.Stage.AllowedValues.push(this.evt.stage);
-    cfTemplate.Parameters.DataModelStage.AllowedValues.push(this.evt.stage);
-
-    // Check if project name is in AllowedValues
-    if (cfTemplate.Parameters.ProjectName.AllowedValues.indexOf(this.S._projectJson.name) == -1) {
-      cfTemplate.Parameters.ProjectName.AllowedValues.push(this.S._projectJson.name);
-    }
-
-    // Write it
-    return SUtils.writeFile(
-        projResoucesCfPath,
-        JSON.stringify(cfTemplate, null, 2)
-    );
-  }
-
-  /**
-   * Create Project Bucket
-   * - if it does not exist
-   */
-
-  _createRegionBucket() {
-    this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.S._projectJson.domain);
-    SCli.log('Creating a region bucket on S3: ' + this.evt.regionBucket + '...');
-    return this.S3.sCreateBucket(this.evt.regionBucket);
-  }
-
-  /**
-   * Put ENV File
-   * - Creates ENV file in regional project bucket
-   */
-
-  _putEnvFile() {
-    let stage = this.evt.stage;
-
-    let envFileContents = `SERVERLESS_STAGE=${stage}
-SERVERLESS_DATA_MODEL_STAGE=${stage}`;
-
-    return this.S3.sPutEnvFile(
-        this.evt.regionBucket,
-        this.S._projectJson.name,
-        this.evt.stage,
-        envFileContents);
-  }
-
-  /**
-   * Put CF File
-   */
-
-  _putCfFile() {
-    return this.CF.sPutCfFile(
-        this.S._projectRootPath,
-        this.evt.regionBucket,
-        this.S._projectJson.name,
-        this.evt.stage,
-        'resources');
-  }
-
-
-  /**
-   * Create CloudFormation Stack
-   */
-
-  _createCfStack(cfTemplateUrl) {
-    let _this = this;
-
-    if (_this.evt.noExeCf) {
-      let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.S._projectJson.name);
-
-      SCli.log(`Remember to run CloudFormation manually to create stack with name: ${stackName}`);
-      SCli.log('After creating CF stack, remember to put the IAM role outputs and regionBucket in your project s-project.json in the correct stage/region.');
 
       return BbPromise.resolve();
     }
 
-    SCli.log('Creating CloudFormation Stack for your new stage (~5 mins)...');
-    _this._spinner = SCli.spinner();
-    _this._spinner.start();
+    /**
+     * Action
+     */
 
-    // Create CF stack
-    return _this.CF.sCreateResourcesStack(
-        _this.S._projectRootPath,
-        _this.S._projectJson.name,
-        _this.evt.stage,
-        _this.S._projectJson.domain,
-        '',
-        cfTemplateUrl
-        )
-        .then(cfData => {
-          return _this.CF.sMonitorCf(cfData, 'create')
-              .then(cfStackData => {
-                _this._spinner.stop(true);
-                return cfStackData;
-              });
-        });
-  }
+    stageCreate(evt) {
 
-  /**
-   * Update Project JSON
-   */
+      let _this = this;
 
-  _updateProjectJson(cfStackData) {
+      if(evt) {
+        _this.evt = evt;
+        _this.S._interactive = false;
+      }
 
-    let _this     = this,
-        regionObj = {
-          region:               _this.evt.region,
-          iamRoleArnLambda:     '',
-          regionBucket:           _this.evt.regionBucket,
-        };
+      // If CLI, parse arguments
+      if (_this.S.cli) {
 
-    if (cfStackData) {
-      for (let i = 0; i < cfStackData.Outputs.length; i++) {
-        if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
-          regionObj.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
-          _this.evt.iamRoleLambdaArn = cfStackData.Outputs[i].OutputValue;
+        _this.evt = JSON.parse(JSON.stringify(_this.S.cli.options)); // Important: Clone objects, don't refer to them
+
+        if (_this.S.cli.options.nonInteractive) {
+          _this.S._interactive = false;
         }
       }
 
-      // Save StackName to Evt
-      _this.evt.stageCfStack = cfStackData.StackName;
+      return _this.S.validateProject()
+        .bind(_this)
+        .then(_this._prompt)
+        .then(_this._validateAndPrepare)
+        .then(_this._initAWS)
+        .then(_this._updateCfTemplate)
+        .then(_this._createRegionBucket)
+        .then(_this._putEnvFile)
+        .then(_this._putCfFile)
+        .then(_this._createCfStack)
+        .then(_this._updateProjectJson)
+        .then(function() {
+          SCli.log('Successfully created stage ' + _this.evt.stage + ' with region ' + _this.evt.region);
+          return _this.evt;
+        });
     }
 
-    if (_this.S._projectJson.stages[_this.evt.stage]) {
-      _this.S._projectJson.stages[_this.evt.stage].push(regionObj);
-    } else {
-      _this.S._projectJson.stages[_this.evt.stage] = [regionObj];
+    /**
+     * Prompt stage and region
+     */
+
+    _prompt() {
+      let _this = this;
+
+      // Skip if non-interactive or stage is provided
+      if (!_this.S._interactive || _this.evt.stage) return BbPromise.resolve();
+
+      let prompts = {
+        properties: {}
+      };
+
+      prompts.properties.stage = {
+        description: 'Enter a new stage name for this project: '.yellow,
+        required:    true,
+        message:     'Stage must be letters and numbers only',
+        conform:     function(stage) {
+          return SUtils.isStageNameValid(stage);
+        }
+      };
+
+      return _this.cliPromptInput(prompts, null)
+        .then(function(answers) {
+          _this.evt.stage = answers.stage.toLowerCase();
+          BbPromise.resolve();
+        })
+        .then(function(){
+          return _this.cliPromptSelectRegion('Select a region for your new stage: ', false, _this.evt.region, false)
+            .then(region => {
+              _this.evt.region = region;
+              BbPromise.resolve();
+            });
+        });
     }
 
-    return SUtils.writeFile(
-        path.join(_this.S._projectRootPath, 's-project.json'),
-        JSON.stringify(_this.S._projectJson, null, 2)
-    );
+    /**
+     * Validate all data from event, interactive CLI or non interactive CLI
+     * and prepare data
+     */
+
+    _validateAndPrepare() {
+
+      // non interactive validation
+      if (!this.S._interactive) {
+
+        // Check Params
+        if (!this.evt.stage || !this.evt.region) {
+          return BbPromise.reject(new SError('Missing stage or region'));
+        }
+      }
+
+      // validate stage
+      if (!SUtils.isStageNameValid(this.evt.stage)) {
+        return BbPromise.reject(new SError('Invalid stage name. Stage must be letters and numbers only.', SError.errorCodes.UNKNOWN));
+      }
+
+      // validate stage: Ensure stage isn't "local"
+      this.evt.stage = this.evt.stage.toLowerCase().replace(/\W+/g, '').substring(0, 15);
+      if (this.evt.stage == 'local') {
+        return BbPromise.reject(new SError('Stage ' + this.evt.stage + ' is reserved'));
+      }
+
+      // validate stage: Ensure stage doesn't already exist
+      if (this.S._projectJson.stages[this.evt.stage]) {
+        return BbPromise.reject(new SError('Stage ' + this.evt.stage + ' already exists', SError.errorCodes.UNKNOWN));
+      }
+
+      // validate region
+      if (awsMisc.validLambdaRegions.indexOf(this.evt.region) == -1) {
+        return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.region, SError.errorCodes.UNKNOWN));
+      }
+
+      // Status
+      SCli.log('Creating stage and region: ' + this.evt.stage + '/' + this.evt.region);
+
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Initialize needed AWS classes
+     */
+
+    _initAWS() {
+
+      let awsConfig = {
+        region:          this.evt.region,
+        accessKeyId:     this.S._awsAdminKeyId,
+        secretAccessKey: this.S._awsAdminSecretKey,
+      };
+
+      this.CF       = require('../utils/aws/CloudFormation')(awsConfig);
+      this.Lambda   = require('../utils/aws/Lambda')(awsConfig);
+      this.S3       = require('../utils/aws/S3')(awsConfig);
+    }
+
+    /**
+     * Update CF Template
+     * - Add a stage to an existing project resources cloudformation template
+     */
+
+    _updateCfTemplate() {
+
+      let projResoucesCfPath  = path.join(this.S._projectRootPath, 'cloudformation', 'resources-cf.json'),
+          cfTemplate          = SUtils.readAndParseJsonSync(projResoucesCfPath);
+
+      // Add new stage to AllowedValues
+      cfTemplate.Parameters.Stage.AllowedValues.push(this.evt.stage);
+      cfTemplate.Parameters.DataModelStage.AllowedValues.push(this.evt.stage);
+
+      // Check if project name is in AllowedValues
+      if (cfTemplate.Parameters.ProjectName.AllowedValues.indexOf(this.S._projectJson.name) == -1) {
+        cfTemplate.Parameters.ProjectName.AllowedValues.push(this.S._projectJson.name);
+      }
+
+      // Write it
+      return SUtils.writeFile(
+          projResoucesCfPath,
+          JSON.stringify(cfTemplate, null, 2)
+      );
+    }
+
+    /**
+     * Create Project Bucket
+     * - if it does not exist
+     */
+
+    _createRegionBucket() {
+      this.evt.regionBucket = SUtils.generateRegionBucketName(this.evt.region, this.S._projectJson.domain);
+      SCli.log('Creating a region bucket on S3: ' + this.evt.regionBucket + '...');
+      return this.S3.sCreateBucket(this.evt.regionBucket);
+    }
+
+    /**
+     * Put ENV File
+     * - Creates ENV file in regional project bucket
+     */
+
+    _putEnvFile() {
+      let stage = this.evt.stage;
+
+      let envFileContents = `SERVERLESS_STAGE=${stage}
+  SERVERLESS_DATA_MODEL_STAGE=${stage}`;
+
+      return this.S3.sPutEnvFile(
+          this.evt.regionBucket,
+          this.S._projectJson.name,
+          this.evt.stage,
+          envFileContents);
+    }
+
+    /**
+     * Put CF File
+     */
+
+    _putCfFile() {
+      return this.CF.sPutCfFile(
+          this.S._projectRootPath,
+          this.evt.regionBucket,
+          this.S._projectJson.name,
+          this.evt.stage,
+          'resources');
+    }
+
+
+    /**
+     * Create CloudFormation Stack
+     */
+
+    _createCfStack(cfTemplateUrl) {
+      let _this = this;
+
+      if (_this.evt.noExeCf) {
+        let stackName = _this.CF.sGetResourcesStackName(_this.evt.stage, _this.S._projectJson.name);
+
+        SCli.log(`Remember to run CloudFormation manually to create stack with name: ${stackName}`);
+        SCli.log('After creating CF stack, remember to put the IAM role outputs and regionBucket in your project s-project.json in the correct stage/region.');
+
+        return BbPromise.resolve();
+      }
+
+      SCli.log('Creating CloudFormation Stack for your new stage (~5 mins)...');
+      _this._spinner = SCli.spinner();
+      _this._spinner.start();
+
+      // Create CF stack
+      return _this.CF.sCreateResourcesStack(
+          _this.S._projectRootPath,
+          _this.S._projectJson.name,
+          _this.evt.stage,
+          _this.S._projectJson.domain,
+          '',
+          cfTemplateUrl
+          )
+          .then(cfData => {
+            return _this.CF.sMonitorCf(cfData, 'create')
+                .then(cfStackData => {
+                  _this._spinner.stop(true);
+                  return cfStackData;
+                });
+          });
+    }
+
+    /**
+     * Update Project JSON
+     */
+
+    _updateProjectJson(cfStackData) {
+
+      let _this     = this,
+          regionObj = {
+            region:               _this.evt.region,
+            iamRoleArnLambda:     '',
+            regionBucket:           _this.evt.regionBucket,
+          };
+
+      if (cfStackData) {
+        for (let i = 0; i < cfStackData.Outputs.length; i++) {
+          if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
+            regionObj.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
+            _this.evt.iamRoleLambdaArn = cfStackData.Outputs[i].OutputValue;
+          }
+        }
+
+        // Save StackName to Evt
+        _this.evt.stageCfStack = cfStackData.StackName;
+      }
+
+      if (_this.S._projectJson.stages[_this.evt.stage]) {
+        _this.S._projectJson.stages[_this.evt.stage].push(regionObj);
+      } else {
+        _this.S._projectJson.stages[_this.evt.stage] = [regionObj];
+      }
+
+      return SUtils.writeFile(
+          path.join(_this.S._projectRootPath, 's-project.json'),
+          JSON.stringify(_this.S._projectJson, null, 2)
+      );
+    }
   }
-}
 
-module.exports = StageCreate;
+  return( StageCreate );
+};


### PR DESCRIPTION
Currently internal plugins/actions are having `module.exports = ProjectCreate;` kind of code, whereas all external plugins have to use `module.exports = function(SPlugin, serverlessPath) {}` approach. This change makes them equal.

Important side effect of this, is that plugins, whose path is relative (like `../../../node_modules/my_plugin`) can be loaded from outside of the project.