### PR TITLE
Fix bucket name collision in StageCreate test

### DIFF
--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -22,7 +22,7 @@ module.exports.createTestProject = function(config, npmInstallDirs) {
       projectStage         = config.stage,
       projectRegion        = config.region,
       projectLambdaIAMRole = config.iamRoleArnLambda,
-      projectDomain        = projectName + '.com';
+      projectDomain        = projectName + '-' + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36) + '.com';
 
   // Create Test Project
   let tmpProjectPath = path.join(os.tmpdir(), projectName);


### PR DESCRIPTION
Add random component to domain/bucket name in test

This fixes bucket name collision in StageCreate test (and possibly other tests too).

We need a random component in the domain name because it is used in bucket name and bucket names must be globally unique.

This uses a custom random number snippet. We can't use uuid because it would make the bucket name too long. Bucket name max length is 63 and uuid would result in a bucket name with ~70 characters.