### PR TITLE
Slower endpoint deploy

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -18,6 +18,25 @@ module.exports = function(SPlugin, serverlessPath) {
   // Promisify fs module.
   BbPromise.promisifyAll(fs);
 
+  //Consider moving this to utils/
+  let slowdownRequests = function( f ){
+    return new BbPromise( function( resolve, reject ){
+      let doCall = function(){
+        f()
+        .then(resolve)
+        .catch(function(error) {
+          if( error.statusCode == 429 ) {
+            SUtils.sDebug("'Too many requests' received, sleeping 5 seconds");
+            setTimeout( doCall, 5000 );
+          } else
+            reject( error );
+        });
+      };
+
+      doCall();
+    });
+  };
+
   class EndpointBuildApiGateway extends SPlugin {
 
     /**
@@ -222,7 +241,7 @@ module.exports = function(SPlugin, serverlessPath) {
       };
 
       // List all Resources for this REST API
-      return _this.ApiGateway.getResourcesPromised(params)
+      return slowdownRequests( function(){ return _this.ApiGateway.getResourcesPromised(params); } )
           .then(function(response) {
 
             _this.apiResources = response.items;
@@ -352,7 +371,7 @@ module.exports = function(SPlugin, serverlessPath) {
           };
 
           // Create Resource
-          return _this.ApiGateway.createResourcePromised(params)
+          return slowdownRequests( function(){ return _this.ApiGateway.createResourcePromised(params); } )
               .then(function(response) {
 
                 // Save resource
@@ -403,7 +422,7 @@ module.exports = function(SPlugin, serverlessPath) {
         restApiId:  evt.region.restApiId /* required */
       };
 
-      return _this.ApiGateway.getMethodPromised(params)
+      return slowdownRequests( function(){ return _this.ApiGateway.getMethodPromised(params); } )
           .then(function(response) {
 
             // Method exists.  Delete and recreate it.
@@ -419,7 +438,7 @@ module.exports = function(SPlugin, serverlessPath) {
               restApiId:  evt.region.restApiId /* required */
             };
 
-            return _this.ApiGateway.deleteMethodPromised(params)
+            return slowdownRequests( function(){ return _this.ApiGateway.deleteMethodPromised(params); } )
                 .then(function(response) {
 
                   let params = {
@@ -431,7 +450,7 @@ module.exports = function(SPlugin, serverlessPath) {
                     requestModels:      evt.endpoint.requestModels,
                     requestParameters:  requestParameters
                   };
-                  return _this.ApiGateway.putMethodPromised(params);
+                  return slowdownRequests( function(){ return _this.ApiGateway.putMethodPromised(params); } )
 
                 });
           }, function(error) {
@@ -448,7 +467,7 @@ module.exports = function(SPlugin, serverlessPath) {
               requestParameters:  requestParameters
             };
 
-            return _this.ApiGateway.putMethodPromised(params);
+            return slowdownRequests( function(){ return _this.ApiGateway.putMethodPromised(params); } );
           })
           .then(function(response) {
 
@@ -525,7 +544,7 @@ module.exports = function(SPlugin, serverlessPath) {
       };
 
       // Create Integration
-      return _this.ApiGateway.putIntegrationPromised(params)
+      return slowdownRequests( function(){ return _this.ApiGateway.putIntegrationPromised(params); } )
           .then(function(response) {
 
             // Save integration
@@ -597,7 +616,7 @@ module.exports = function(SPlugin, serverlessPath) {
             };
 
             // Create Method Response
-            return _this.ApiGateway.putMethodResponsePromised(params)
+            return slowdownRequests( function(){ return _this.ApiGateway.putMethodResponsePromised(params); } )
                 .then(function() {
 
                   SUtils.sDebug(
@@ -655,7 +674,7 @@ module.exports = function(SPlugin, serverlessPath) {
             };
 
             // Create Integration Response
-            return _this.ApiGateway.putIntegrationResponsePromised(params)
+            return slowdownRequests( function(){ return _this.ApiGateway.putIntegrationResponsePromised(params); } )
                 .then(function() {
 
                   SUtils.sDebug(

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -75,7 +75,7 @@ module.exports = function(SPlugin, serverlessPath) {
 
       let _this       = this;
 
-      return new BbPromise( resolve, reject ){
+      return new BbPromise( function( resolve, reject ){
         let doDeploy = function(){
           let params = {
             restApiId:    evt.region.restApiId, /* required */
@@ -104,8 +104,7 @@ module.exports = function(SPlugin, serverlessPath) {
             return resolve( evt );
           })
           .catch(function(error) {
-            console.log( error );
-            if( error.message == 'Too many requests' ) {
+            if( error.statusCode == 429 ) {
               console.log("'Too many requests' received, sleeping 5 seconds");
               setTimeout( doDeploy, 5000 );
             } else
@@ -114,7 +113,7 @@ module.exports = function(SPlugin, serverlessPath) {
         };
 
         doDeploy();
-      }
+      });
     }
   }
 

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -75,35 +75,46 @@ module.exports = function(SPlugin, serverlessPath) {
 
       let _this       = this;
 
-      let params = {
-        restApiId:    evt.region.restApiId, /* required */
-        stageName:    evt.stage, /* required */
-        //cacheClusterEnabled:  false, TODO: Implement
-        //cacheClusterSize: '0.5 | 1.6 | 6.1 | 13.5 | 28.4 | 58.2 | 118 | 237', TODO: Implement
-        description: 'Serverless deployment',
-        stageDescription: evt.stage,
-        variables: {
-          functionAlias: evt.stage
-        }
-      };
+      return new BbPromise( resolve, reject ){
+        let doDeploy = function(){
+          let params = {
+            restApiId:    evt.region.restApiId, /* required */
+            stageName:    evt.stage, /* required */
+            //cacheClusterEnabled:  false, TODO: Implement
+            //cacheClusterSize: '0.5 | 1.6 | 6.1 | 13.5 | 28.4 | 58.2 | 118 | 237', TODO: Implement
+            description: 'Serverless deployment',
+            stageDescription: evt.stage,
+            variables: {
+              functionAlias: evt.stage
+            }
+          };
 
-      return _this.ApiGateway.createDeploymentPromised(params)
+          _this.ApiGateway.createDeploymentPromised(params)
           .then(function(response) {
             evt.deployment = response;
 
             SUtils.sDebug(
-                '"'
-                + evt.stage + ' - '
-                + evt.region.region
-                + ' - REST API: '
-                + 'created API Gateway deployment: '
-                + response.id);
+              '"'
+              + evt.stage + ' - '
+              + evt.region.region
+              + ' - REST API: '
+              + 'created API Gateway deployment: '
+              + response.id);
 
-            return evt;
+            return resolve( evt );
           })
           .catch(function(error) {
-            throw new SError(error.message);
+            console.log( error );
+            if( error.message == 'Too many requests' ) {
+              console.log("'Too many requests' received, sleeping 5 seconds");
+              setTimeout( doDeploy, 5000 );
+            } else
+              reject( new SError(error.message) );
           });
+        };
+
+        doDeploy();
+      }
     }
   }
 

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -105,7 +105,7 @@ module.exports = function(SPlugin, serverlessPath) {
           })
           .catch(function(error) {
             if( error.statusCode == 429 ) {
-              console.log("'Too many requests' received, sleeping 5 seconds");
+              SUtils.sDebug("'Too many requests' received, sleeping 5 seconds");
               setTimeout( doDeploy, 5000 );
             } else
               reject( new SError(error.message) );


### PR DESCRIPTION
During deploying large amount of endpoints APIG occasionally sends `Too many requests` error, and Serverless fails. This PR fixes this by sleeping for 5 seconds and re-trying.