### PR TITLE
Fixed function configuration during deploy.

### DIFF
--- a/lib/actions/CodeDeployLambdaNodeJs.js
+++ b/lib/actions/CodeDeployLambdaNodeJs.js
@@ -216,48 +216,37 @@ module.exports = function(SPlugin, serverlessPath) {
 
             } else {
 
-              SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda function...`);
+              SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda configuration...`);
 
-              // Update Lambda Code
               let params = {
-                FunctionName:  lambda.Configuration.FunctionName, /* required */
-                Publish:       true, // Required by Serverless Framework & recommended by AWS
-                S3Bucket:      evt.region.regionBucket,
-                S3Key:         evt.function.s3Key,
+                FunctionName: lambda.Configuration.FunctionName, /* required */
+                Description:  'Serverless Lambda function for project: ' + _this.S._projectJson.name,
+                Handler:      evt.function.handler,
+                MemorySize:   evt.function.memorySize,
+                Role:         evt.region.iamRoleArnLambda,
+                Timeout:      evt.function.timeout
               };
-              return _this.Lambda.updateFunctionCodePromised(params)
-                  .then(function(data) {
 
-                    // Save Version
-                    lambdaVersion = data.Version;
+              return _this.Lambda.updateFunctionConfigurationPromised(params)
+                .then(function(){
+                  SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda function...`);
 
-                    // Check If Function Configuration needs to be updated
+                  // Update Lambda Code
+                  let params = {
+                    FunctionName:  lambda.Configuration.FunctionName, /* required */
+                    Publish:       true, // Required by Serverless Framework & recommended by AWS
+                    S3Bucket:      evt.region.regionBucket,
+                    S3Key:         evt.function.s3Key,
+                  };
+                  return _this.Lambda.updateFunctionCodePromised(params)
+                      .then(function(data) {
 
-                    let updateConfiguration = false;
+                        // Save Version
+                        lambdaVersion = data.Version;
 
-                    if (data.Runtime    !== evt.function.runtime) updateConfiguration = true;
-                    if (data.Handler    !== evt.function.handler) updateConfiguration = true;
-                    if (data.MemorySize !== evt.function.memorySize) updateConfiguration = true;
-                    if (data.Timeout    !== evt.function.timeout) updateConfiguration = true;
-
-                    if (updateConfiguration) {
-
-                      SUtils.sDebug(`"${evt.stage} - ${evt.region.region} - ${evt.function.name}": Updating Lambda configuration...`);
-
-                      let params = {
-                        FunctionName: data.FunctionName, /* required */
-                        Description:  'Serverless Lambda function for project: ' + _this.S._projectJson.name,
-                        Handler:      evt.function.handler,
-                        MemorySize:   evt.function.memorySize,
-                        Role:         evt.region.iamRoleArnLambda,
-                        Timeout:      evt.function.timeout
-                      };
-
-                      return _this.Lambda.updateFunctionConfigurationPromised(params);
-                    } else {
-                      return data;
-                    }
-                  });
+                        return( data );
+                      });
+                });
             }
           })
           .then(function(data) {


### PR DESCRIPTION
In AWS Lambda, $LATEST is not referring to the version most recently created. It is kind of 'uncommitted head'. `updateFunctionCode` copies $LATEST to the new version and applies the config. The config of such created version cannot be changed anymore.

The old code was creating version, then updating config. So, if you had 2 stages, and stage A did the deploy the version was created with whatever was left over in $LATEST from previous deploy. Then, $LATEST was reconfigured to use stage A settings (e.g. IamRole). If stage B did the deploy in such situation, the new version was created, with stage A config, but stage B alias. And then $LATEST was reconfigured to use stage B settings. So, if stage A would deploy in this moment, bug would happen again.

This code reverses the operation, we first update $LATEST config, then make snapshot of it. This fixes the bug, but leaves small race condition window, which seems to be impossible to get rid of, without Lambda API changes.