### PR TITLE
Fixed error handling for deployments

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -320,6 +320,7 @@ module.exports = function(SPlugin, serverlessPath) {
 
         // Loop through each resource in this Endpoint and create it if it is missing.
         let incrementedPath = '';
+        let lastError = undefined;
         async.eachSeries(eResources, function(eResource, cb) {
 
           // Build the path w/ new resource on each iteration
@@ -371,28 +372,36 @@ module.exports = function(SPlugin, serverlessPath) {
           };
 
           // Create Resource
-          return slowdownRequests( function(){ return _this.ApiGateway.createResourcePromised(params); } )
-              .then(function(response) {
+          slowdownRequests( function(){ return _this.ApiGateway.createResourcePromised(params); } )
+          .then(function(response) {
 
-                // Save resource
-                _this.resource = response;
+            // Save resource
+            _this.resource = response;
 
-                // Add resource to _this.resources and callback
-                _this.apiResources.push(response);
+            // Add resource to _this.resources and callback
+            _this.apiResources.push(response);
 
-                SUtils.sDebug(
-                    '"'
-                    + evt.stage + ' - '
-                    + evt.region.region
-                    + ' - ' + evt.endpoint.path + '": '
-                    + 'created resource: '
-                    + response.pathPart);
+            SUtils.sDebug(
+                '"'
+                + evt.stage + ' - '
+                + evt.region.region
+                + ' - ' + evt.endpoint.path + '": '
+                + 'created resource: '
+                + response.pathPart);
 
-                // Return callback to iterate loop
-                return cb();
-              });
+            // Call callback to iterate loop
+            cb();
+          })
+          .catch(function(e){
+            lastError = e;
+            cb(e);
+          });
         }, function() {
-          return resolve(evt);
+          if( !lastError ) {
+            resolve(evt);
+          } else {
+            reject( lastError )
+          }
         }); // async.eachSeries
       });
     }

--- a/lib/actions/EndpointDeploy.js
+++ b/lib/actions/EndpointDeploy.js
@@ -354,24 +354,24 @@ module.exports = function(SPlugin, serverlessPath) {
                         endpoint: endpoint
                       });
 
-                      return eCb();
+                      eCb();
                     });
 
               }, function() {
-                return resolve(evt);
+                resolve(evt);
               });
             })
-                .then(function(evt) {
+            .then(function(evt) {
 
-                  // Deploy API Gateway Deployment in region
+              // Deploy API Gateway Deployment in region
 
-                  let newEvent = {
-                    stage:  evt.stage,
-                    region: regionConfig
-                  };
+              let newEvent = {
+                stage:  evt.stage,
+                region: regionConfig
+              };
 
-                  return _this.S.actions.endpointDeployApiGateway(newEvent);
-                });
+              return _this.S.actions.endpointDeployApiGateway(newEvent);
+            });
           });
     }
   }

--- a/lib/actions/FunctionDeploy.js
+++ b/lib/actions/FunctionDeploy.js
@@ -290,6 +290,7 @@ module.exports = function(SPlugin, serverlessPath) {
     _deployCodeByRegion(evt, region) {
 
       let _this = this;
+      let lastError = undefined;
 
       return new BbPromise(function(resolve, reject) {
 
@@ -331,11 +332,16 @@ module.exports = function(SPlugin, serverlessPath) {
                   function: func.pathFunction + '-' + func.name,
                 });
 
+                lastError = e;
                 return cb();
               })
 
         }, function() {
-          return resolve(evt, region);
+          if( !lastError ) {
+            return resolve(evt, region);
+          } else {
+            return reject(lastError);
+          }
         });
       });
     }


### PR DESCRIPTION
If there were errors during lambda deploy, the whole command exited with `0`, which caused any automation (like CI) to continue, instead of having chance to notice error.

In few places, uneccessary return was removed from `eachSeries` and `eachLimit` to avoid confusion (even comments suggested that return is necessary to make iteration working, which is not true).