### PR TITLE
Added support for custom stage deployment descriptions

### DIFF
--- a/lib/actions/EndpointDeploy.js
+++ b/lib/actions/EndpointDeploy.js
@@ -69,6 +69,10 @@ module.exports = function(SPlugin, serverlessPath) {
             option:      'all',
             shortcut:    'a',
             description: 'Optional - Select all Functions in your project for deployment'
+          }, {
+            option:      'description',
+            shortcut:    'd',
+            description: 'Optional - Provide custom description string for API Gateway stage deployment description'
           }
         ],
       });
@@ -108,6 +112,7 @@ module.exports = function(SPlugin, serverlessPath) {
       evt.all                 = evt.all ? true : false;
       evt.aliasEndpoint       = evt.aliasEndpoint ? evt.aliasEndpoint : null;
       evt.aliasRestApi        = evt.aliasRestApi ? evt.aliasRestApi : null;
+      evt.description         = evt.description ? evt.description : null;
       evt.endpoints           = [];
       evt.deployed            = {};
 
@@ -367,7 +372,8 @@ module.exports = function(SPlugin, serverlessPath) {
 
                   let newEvent = {
                     stage:  evt.stage,
-                    region: regionConfig
+                    region: regionConfig,
+                    description: evt.description
                   };
 
                   return _this.S.actions.endpointDeployApiGateway(newEvent);

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -82,7 +82,7 @@ module.exports = function(SPlugin, serverlessPath) {
             stageName:    evt.stage, /* required */
             //cacheClusterEnabled:  false, TODO: Implement
             //cacheClusterSize: '0.5 | 1.6 | 6.1 | 13.5 | 28.4 | 58.2 | 118 | 237', TODO: Implement
-            description: 'Serverless deployment',
+            description: evt.description || 'Serverless deployment',
             stageDescription: evt.stage,
             variables: {
               functionAlias: evt.stage


### PR DESCRIPTION
Example usage:
```
sls endpoint deploy -a -s $SERVERLESS_STAGE -d "${SERVERLESS_STAGE} - CI build #${CIRCLE_BUILD_NUM} / ${CIRCLE_SHA1:0:7} by ${CIRCLE_USERNAME}: `git log --pretty=format:"%s" HEAD^..HEAD`"
```