### PR TITLE
Changing how aws credentials are loaded

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -10,4 +10,6 @@ let Serverless      = require('../lib/Serverless'),
     ServerlessUtils = require('../lib/utils/index'),
     serverless      = new Serverless();
 
-ServerlessUtils.execute(serverless.command(argv));
+serverless.initialize(function (err) {
+	ServerlessUtils.execute(serverless.command(argv));
+})

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -8,8 +8,8 @@ const path      = require('path'),
     SError      = require('./ServerlessError'),
     SPlugin     = require('./ServerlessPlugin'),
     BbPromise   = require('bluebird'),
-    dotenv      = require('dotenv');
-
+    dotenv      = require('dotenv'),
+    AWS         = require('aws-sdk');
 // Global Bluebird Config
 BbPromise.onPossiblyUnhandledRejection(function(error) {
   throw error;
@@ -28,8 +28,8 @@ class Serverless {
 
     // Add Defaults
     this._interactive       = (config.interactive !== undefined) ? config.interactive : (process.stdout.isTTY && !process.env.CI);
-    this._awsAdminKeyId     = config.awsAdminKeyId;
-    this._awsAdminSecretKey = config.awsAdminSecretKey;
+    // this._a wsAdminKeyId     = config.awsAdminKeyId;
+    // this._awsAdminSecretKey = config.awsAdminSecretKey;
     this._version           = require('./../package.json').version;
     this._projectRootPath   = SUtils.findProjectRootPath(process.cwd());
     this._projectJson       = false;
@@ -49,8 +49,8 @@ class Serverless {
       });
 
       // Set Admin API Keys
-      this._awsAdminKeyId     = process.env.SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID;
-      this._awsAdminSecretKey = process.env.SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY;
+      // this._a wsAdminKeyId     = process.env.SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID;
+      // this._awsAdminSecretKey = process.env.SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY;
     }
 
     // Load Plugins: Defaults
@@ -61,6 +61,23 @@ class Serverless {
     if (this._projectRootPath && this._projectJson.plugins) {
       this._loadPlugins(this._projectRootPath, this._projectJson.plugins);
     }
+  }
+
+  /**
+   * Get credentials from aws credential provider
+   * allows aws credentials to be set.
+   * Adds a credential provider to the CredentialProviderChain to use variables from ADMIN.env
+   * Return error if no credentials are found
+   */
+
+  initialize(callback) {
+    let _this = this;
+    var cpc = new AWS.CredentialProviderChain()
+    cpc.providers.splice(0, 0, new AWS.EnvironmentCredentials('SERVERLESS_ADMIN_AWS'))
+    cpc.resolve(function (err, credentials) {
+      _this._awsCredentials = credentials
+      callback(null)
+    })
   }
 
   /**
@@ -108,7 +125,7 @@ class Serverless {
     }
 
     // Check for AWS API Keys
-    if (!this._awsAdminKeyId || !this._awsAdminSecretKey) {
+    if (!this._awsCredentials) {
       return BbPromise.reject(new SError(
           'Missing AWS API Keys',
           SError.errorCodes.INVALID_PROJECT_SERVERLESS
@@ -125,10 +142,8 @@ class Serverless {
    */
 
   command(argv) {
-
     // Set Debug to True
     if (argv && argv.d) process.env.DEBUG = true;
-
     SUtils.sDebug('Command raw argv: ', argv);
 
     // Handle version command

--- a/lib/actions/CodeDeployLambdaNodeJs.js
+++ b/lib/actions/CodeDeployLambdaNodeJs.js
@@ -66,8 +66,7 @@ module.exports = function(SPlugin, serverlessPath) {
       // Load AWS Service Instances
       let awsConfig = {
         region:          evt.region.region,
-        accessKeyId:     _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        credentials:     _this.S._awsCredentials
       };
       _this.S3         = require('../utils/aws/S3')(awsConfig);
       _this.Lambda     = require('../utils/aws/Lambda')(awsConfig);

--- a/lib/actions/CodeEventDeployLambda.js
+++ b/lib/actions/CodeEventDeployLambda.js
@@ -43,9 +43,8 @@ module.exports  = function(SPlugin, serverlessPath) {
 
       // Load AWS Service Instances
       let awsConfig = {
-        region: evt.region.region,
-        accessKeyId: _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        region:          evt.region.region,
+        credentials:     _this.S._awsCredentials
       };
 
       _this.Lambda = require('../utils/aws/Lambda')(awsConfig);

--- a/lib/actions/CodePackageLambdaNodeJs.js
+++ b/lib/actions/CodePackageLambdaNodeJs.js
@@ -68,8 +68,7 @@ module.exports = function(SPlugin, serverlessPath) {
       // Load AWS Service Instances
       let awsConfig = {
         region:          evt.region.region,
-        accessKeyId:     _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        credentials:     _this.S._awsCredentials
       };
       _this.S3 = require('../utils/aws/S3')(awsConfig);
 

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -148,8 +148,7 @@ module.exports = function(SPlugin, serverlessPath) {
       // Load AWS Service Instances
       let awsConfig = {
         region:          evt.region.region,
-        accessKeyId:     _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        credentials:     _this.S._awsCredentials
       };
 
       _this.CloudFormation = require('../utils/aws/CloudFormation')(awsConfig);

--- a/lib/actions/EndpointDeploy.js
+++ b/lib/actions/EndpointDeploy.js
@@ -306,8 +306,7 @@ module.exports = function(SPlugin, serverlessPath) {
       // Load AWS Service Instance for APIGateway
       let awsConfig    = {
         region:          region,
-        accessKeyId:     _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        credentials:     _this.S._awsCredentials
       };
       let ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);
 

--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -45,8 +45,7 @@ module.exports = function(SPlugin, serverlessPath) {
       // Load AWS Service Instances
       let awsConfig = {
         region:          evt.region.region,
-        accessKeyId:     _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        credentials:     _this.S._awsCredentials
       };
 
       _this.ApiGateway   = require('../utils/aws/ApiGateway')(awsConfig);

--- a/lib/actions/EnvSet.js
+++ b/lib/actions/EnvSet.js
@@ -212,8 +212,7 @@ usage: serverless env set`,
 
                 let awsConfig = {
                   region:          mapForRegion.regionName,
-                  accessKeyId:     _this.S._awsAdminKeyId,
-                  secretAccessKey: _this.S._awsAdminSecretKey,
+                  credentials:     _this.S._awsCredentials
                 };
 
                 let S3  = require('../utils/aws/S3')(awsConfig);

--- a/lib/actions/EnvUnset.js
+++ b/lib/actions/EnvUnset.js
@@ -201,8 +201,7 @@ usage: serverless env unset`,
 
                 let awsConfig = {
                   region:          mapForRegion.regionName,
-                  accessKeyId:     _this.S._awsAdminKeyId,
-                  secretAccessKey: _this.S._awsAdminSecretKey,
+                  credentials:     _this.S._awsCredentials
                 };
 
                 let S3  = require('../utils/aws/S3')(awsConfig);

--- a/lib/actions/FunctionRunLambdaNodeJs.js
+++ b/lib/actions/FunctionRunLambdaNodeJs.js
@@ -78,7 +78,7 @@ module.exports = function(SPlugin, serverlessPath) {
 
             // Show success response
             SCli.log(chalk.bold('Success! - This Response Was Returned:'));
-            SCli.log(JSON.stringify(result));
+            SCli.log(JSON.stringify(result,null,2));
             evt.result.status   = 'success';
             evt.result.response = result;
             return resolve(evt);

--- a/lib/actions/ProjectCreate.js
+++ b/lib/actions/ProjectCreate.js
@@ -292,6 +292,7 @@ module.exports = function(SPlugin, serverlessPath) {
         region:          this.evt.region,
         accessKeyId:     this.S._awsAdminKeyId,
         secretAccessKey: this.S._awsAdminSecretKey,
+        credentials:     this.S._awsCredentials,
       };
       this.S3  = require('../utils/aws/S3')(awsConfig);
       this.CF  = require('../utils/aws/CloudFormation')(awsConfig);

--- a/lib/actions/RegionCreate.js
+++ b/lib/actions/RegionCreate.js
@@ -179,8 +179,7 @@ usage: serverless region create`,
 
       let awsConfig = {
         region:          this.evt.region,
-        accessKeyId:     this.S._awsAdminKeyId,
-        secretAccessKey: this.S._awsAdminSecretKey,
+        credentials:     this.S._awsCredentials
       };
 
       this.CF  = require('../utils/aws/CloudFormation')(awsConfig);

--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -134,7 +134,7 @@ usage: serverless resources deploy`,
 
         // Check API Keys
         if (!_this.S._awsProfile) {
-          if (!_this.S._awsAdminKeyId || !_this.S._awsAdminSecretKey) {
+          if (!_this.S._awsCredentials) {
             return BbPromise.reject(new SError('Missing AWS Profile and/or API Key and/or AWS Secret Key'));
           }
         }
@@ -180,8 +180,7 @@ usage: serverless resources deploy`,
 
       let awsConfig = {
         region:          _this.evt.region.region,
-        accessKeyId:     _this.S._awsAdminKeyId,
-        secretAccessKey: _this.S._awsAdminSecretKey,
+        credentials:     _this.S._awsCredentials
       };
       _this.CF  = require('../utils/aws/CloudFormation')(awsConfig);
 

--- a/lib/actions/StageCreate.js
+++ b/lib/actions/StageCreate.js
@@ -202,8 +202,7 @@ usage: serverless stage create`,
 
       let awsConfig = {
         region:          this.evt.region,
-        accessKeyId:     this.S._awsAdminKeyId,
-        secretAccessKey: this.S._awsAdminSecretKey,
+        credentials:     this.S._awsCredentials
       };
 
       this.CF       = require('../utils/aws/CloudFormation')(awsConfig);

--- a/lib/utils/aws/Misc.js
+++ b/lib/utils/aws/Misc.js
@@ -128,8 +128,7 @@ module.exports.getEnvFileAsMap = function(Serverless, region, stage) {
 
     let awsConfig = {
       region:          region,
-      accessKeyId:     Serverless._awsAdminKeyId,
-      secretAccessKey: Serverless._awsAdminSecretKey,
+      credentials:     Serverless._awsCredentials
     };
 
     let S3 = require('./S3')(awsConfig);


### PR DESCRIPTION
I saw you are starting working on issue #381. This is what I did to work around it.

I updated all the actions to use variable S._awsConfiguration, instead of S._awsAdminKeyId and S._awsAdminSecretKey. This way you can include or not include a session token easily.

I also added an initialize method to the Serverless class that uses the aws-sdk credential provider chain with an additional credential provider to look for SERVERLESS_ADMIN_AWS environment variables as the highest priority. Unfortunately this broken the "project create" function, and I haven't had time to think through how it would best be changed.