### PR TITLE
add shortcut -v, --version to get Serveless version

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -132,7 +132,7 @@ class Serverless {
     SUtils.sDebug('Command raw argv: ', argv);
 
     // Handle version command
-    if (argv._[0] === 'version') {
+    if (argv._[0] === 'version' || argv._[0] === 'v' || argv.v===true || argv.version===true) {
       console.log(this._version);
       return BbPromise.resolve();
     }


### PR DESCRIPTION
Hi,

Small contribution here. I've found myself many times trying to get the version of Serverless using a common `-v` or `--version` command used by many other cli tool like node or npm.

Just wanted to add support for it.

Version is now available by:
`serverless v`
`serverless version`
`serverless -v`
`serverless --version`

Hopefully I can contribute to more meaningful things soon :laughing: 