### PR TITLE
add shortcut -v, --version to get the version

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -153,7 +153,7 @@ class Serverless {
     SUtils.sDebug('CLI raw input: ', _this.cli.raw);
 
     // If version command, return version
-    if (_this.cli.raw._[0] === 'version') {
+    if (_this.cli.raw._[0] === 'version' || _this.cli.raw._[0] === 'v' | argv.v===true || argv.version===true)  {
       console.log(_this._version);
       return BbPromise.resolve();
     }


### PR DESCRIPTION
Serverless version is now available by:
`serverless v`
`serverless version`
`serverless -v`
`serverless --version`