### PR TITLE
Get rid of runtime property hardcoding

### DIFF
--- a/lib/ServerlessComponent.js
+++ b/lib/ServerlessComponent.js
@@ -29,7 +29,7 @@ class ServerlessComponent {
 
     // Default Properties
     _this.name           = _this._config.component || 'component' + SUtils.generateShortId(6);
-    _this.runtime        = 'nodejs';
+    _this.runtime        = config.runtime || 'nodejs';
     _this.custom         = {};
   }
 

--- a/lib/ServerlessFunction.js
+++ b/lib/ServerlessFunction.js
@@ -32,7 +32,6 @@ class ServerlessFunction {
     // Default properties
     _this.name       = _this._config.function || 'function' + SUtils.generateShortId(6);
     _this.handler    = path.posix.join(_this._config.module, _this._config.function, 'handler.handler');
-    _this.runtime    = _this._config.runtime || 'nodejs';
     _this.timeout    = 6;
     _this.memorySize = 1024;
     _this.custom     = {
@@ -263,7 +262,7 @@ class ServerlessFunction {
       let writeDeferred = [];
 
       // Runtime: nodejs
-      if (_this.runtime === 'nodejs') {
+      if (_this.getRuntime() === 'nodejs') {
         writeDeferred.push(
           fs.mkdirSync(_this._config.fullPath),
           SUtils.writeFile(path.join(_this._config.fullPath, 'handler.js'), fs.readFileSync(path.join(_this._S.config.serverlessPath, 'templates', 'nodejs', 'handler.js'))),
@@ -273,6 +272,14 @@ class ServerlessFunction {
 
       return BbPromise.all(writeDeferred);
     });
+  }
+
+  getRuntime() {
+    let _this = this;
+
+    let component = _this._S.state.getComponents({"paths": [_this._config.component]})[0];
+
+    return component.runtime || 'nodejs';
   }
 
   getModule() {

--- a/lib/ServerlessModule.js
+++ b/lib/ServerlessModule.js
@@ -35,7 +35,6 @@ class ServerlessModule {
     _this.location       = 'https://github.com/...';
     _this.author         = '';
     _this.description    = 'A Serverless Module';
-    _this.runtime        = 'nodejs';
     _this.custom         = {};
     _this.functions      = {};
     _this.cloudFormation = {

--- a/lib/actions/CodeDeployLambdaNodeJs.js
+++ b/lib/actions/CodeDeployLambdaNodeJs.js
@@ -218,7 +218,7 @@ module.exports   = function(SPlugin, serverlessPath) {
               FunctionName: _this.Lambda.sGetLambdaName(_this.project.name, _this.function._config.component, _this.function._config.module, _this.function.name), /* required */
               Handler:      _this.function.handler, /* required */
               Role:         _this.meta.stages[_this.evt.options.stage].regions[_this.evt.options.region].variables.iamRoleArnLambda, /* required */
-              Runtime:      _this.function.runtime, /* required */
+              Runtime:      _this.function.getRuntime(), /* required */
               Description:  'Serverless Lambda function for project: ' + _this.project.name,
               MemorySize:   _this.function.memorySize,
               Publish:      true, // Required by Serverless Framework & recommended best practice by AWS

--- a/lib/actions/CodePackageLambdaNodeJs.js
+++ b/lib/actions/CodePackageLambdaNodeJs.js
@@ -115,7 +115,7 @@ module.exports = function(SPlugin, serverlessPath) {
       if (!_this.function.memorySize) {
         throw new SError('Function does not have a memorySize property');
       }
-      if (!_this.function.runtime) {
+      if (!_this.function.getRuntime()) {
         throw new SError('Function does not have a runtime property');
       }
 

--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -5,7 +5,7 @@
  * - takes existing module name and new function name
  * - validates that module exists
  * - validates that function does NOT already exists in module
- * - generates function sturcture based on runtime
+ * - generates function structure based on runtime
  *
  * Event Options:
  * - module:     (String) Name of the existing module you want to create a function for

--- a/lib/actions/FunctionDeploy.js
+++ b/lib/actions/FunctionDeploy.js
@@ -270,7 +270,7 @@ module.exports = function(SPlugin, serverlessPath) {
               if (!func) throw new SError(`Function could not be found: ${path}`);
 
               // Nodejs
-              if (func.runtime = 'nodejs') {
+              if (func.getRuntime() = 'nodejs') {
 
                 let newEvt = {
                   options: {


### PR DESCRIPTION
This is part of preparation for Python support, and gets rid off runtime properties at the function and module levels. 

Don't merge until Austen has components automatically saving themselves to the state object at create-time, or this will break the component-create action.