### PR TITLE
Dependencies are no longer module-level

### DIFF
--- a/lib/actions/ModuleInstall.js
+++ b/lib/actions/ModuleInstall.js
@@ -208,11 +208,6 @@ usage: serverless module install <github-url>`,
         excludeHiddenUnix: false
       });
 
-      // install deps if package.json exists
-      if (SUtils.fileExistsSync(path.join(_this.pathModule, 'package.json'))) {
-        SUtils.npmInstall(_this.pathModule);
-      }
-
       return BbPromise.resolve();
     };
 


### PR DESCRIPTION
Looks like ModuleInstall still tries to use package.json if it's available.