### PR TITLE
Added --stage parameter to Project Create action

### DIFF
--- a/lib/actions/ProjectCreate.js
+++ b/lib/actions/ProjectCreate.js
@@ -15,19 +15,20 @@
  * - notificationEmail    (String) email to use for AWS alarms
  * - profile              (String) an AWS profile to create the project in. Must be available in ~/.aws/credentials
  * - region               (String) the first region for your new project
+ * - stage                (String) the first stage for your new project
  * - noExeCf:             (Boolean) Don't execute CloudFormation
  */
 
 module.exports = function(SPlugin, serverlessPath) {
 
   const path   = require('path'),
-    SError     = require( path.join( serverlessPath, 'ServerlessError' ) ),
-    SCli       = require( path.join( serverlessPath, 'utils/cli' ) ),
-    SUtils     = require( path.join( serverlessPath, 'utils' ) ),
-    os         = require('os'),
-    fs         = require('fs'),
-    BbPromise  = require('bluebird'),
-    awsMisc    = require( path.join( serverlessPath, 'utils/aws/Misc' ) );
+      SError     = require( path.join( serverlessPath, 'ServerlessError' ) ),
+      SCli       = require( path.join( serverlessPath, 'utils/cli' ) ),
+      SUtils     = require( path.join( serverlessPath, 'utils' ) ),
+      os         = require('os'),
+      fs         = require('fs'),
+      BbPromise  = require('bluebird'),
+      awsMisc    = require( path.join( serverlessPath, 'utils/aws/Misc' ) );
 
   BbPromise.promisifyAll(fs);
 
@@ -64,6 +65,10 @@ module.exports = function(SPlugin, serverlessPath) {
             option:      'region',
             shortcut:    'r',
             description: 'Lambda supported region'
+          }, {
+            option:      'stage',
+            shortcut:    's',
+            description: 'Deployment stage'
           }, {
             option:      'notificationEmail',
             shortcut:    'e',
@@ -104,25 +109,25 @@ module.exports = function(SPlugin, serverlessPath) {
        */
 
       return BbPromise.try(function() {
-          if (_this.S.config.interactive) SCli.asciiGreeting();
-        })
-        .bind(_this)
-        .then(_this._prompt)
-        .then(_this._validateAndPrepare)
-        .then(_this._createProjectBucket)
-        .then(_this._createProjectScaffolding)
-        .then(_this._createStageAndRegion)
-        .then(function() {
+            if (_this.S.config.interactive) SCli.asciiGreeting();
+          })
+          .bind(_this)
+          .then(_this._prompt)
+          .then(_this._validateAndPrepare)
+          .then(_this._createProjectBucket)
+          .then(_this._createProjectScaffolding)
+          .then(_this._createStageAndRegion)
+          .then(function() {
 
-          SCli.log('Successfully created project: ' + _this.project.name);
+            SCli.log('Successfully created project: ' + _this.project.name);
 
-          /**
-           * Return EVT
-           */
+            /**
+             * Return EVT
+             */
 
-          _this.evt.data.projectPath = _this.S.config.projectPath;
-          return _this.evt;
-        });
+            _this.evt.data.projectPath = _this.S.config.projectPath;
+            return _this.evt;
+          });
     }
 
     /**
@@ -144,6 +149,7 @@ module.exports = function(SPlugin, serverlessPath) {
         name:              _this.evt.options.name,
         domain:            _this.evt.options.domain,
         notificationEmail: _this.evt.options.notificationEmail,
+        stage:             _this.evt.options.stage || 'development',
         awsAdminKeyId:     _this.evt.options.awsAdminKeyId,
         awsAdminSecretKey: _this.evt.options.awsAdminSecretKey
       };
@@ -209,56 +215,56 @@ module.exports = function(SPlugin, serverlessPath) {
       }
 
       return this.cliPromptInput(prompts, overrides)
-        .then(function(answers) {
+          .then(function(answers) {
 
-          // Set prompt values
-          _this.S.config.awsAdminKeyId        = answers.awsAdminKeyId;
-          _this.S.config.awsAdminSecretKey    = answers.awsAdminSecretKey;
-          _this.evt.options.name              = answers.name;
-          _this.evt.options.domain            = answers.domain;
-          _this.evt.options.notificationEmail = answers.notificationEmail;
+            // Set prompt values
+            _this.S.config.awsAdminKeyId        = answers.awsAdminKeyId;
+            _this.S.config.awsAdminSecretKey    = answers.awsAdminSecretKey;
+            _this.evt.options.name              = answers.name;
+            _this.evt.options.domain            = answers.domain;
+            _this.evt.options.notificationEmail = answers.notificationEmail;
 
-          // Show region prompt
-          if (!_this.evt.options.region) {
+            // Show region prompt
+            if (!_this.evt.options.region) {
 
-            // Prompt: region select
-            let choices = awsMisc.validLambdaRegions.map(r => {
-              return {
-                key:   '',
-                value: r,
-                label: r
-              };
+              // Prompt: region select
+              let choices = awsMisc.validLambdaRegions.map(r => {
+                    return {
+                      key:   '',
+                      value: r,
+                      label: r
+                    };
             });
 
-            return _this.cliPromptSelect('Select a region for your project: ', choices, false)
-              .then(results => {
+              return _this.cliPromptSelect('Select a region for your project: ', choices, false)
+                  .then(results => {
                 _this.evt.options.region = results[0].value;
+            });
+            }
+          })
+          .then(function() {
+
+            // If profile exists, skip select prompt
+            if (_this.profile) return;
+
+            // If aws credentials were passed, skip select prompt
+            if (_this.S.config.awsAdminKeyId && _this.S.config.awsAdminSecretKey) return;
+
+            // Prompt: profile select
+            let choices = [];
+            for (let i = 0; i < _this.profiles.length; i++) {
+              choices.push({
+                key:   '',
+                value: _this.profiles[i],
+                label: _this.profiles[i]
               });
-          }
-        })
-        .then(function() {
+            }
 
-          // If profile exists, skip select prompt
-          if (_this.profile) return;
-
-          // If aws credentials were passed, skip select prompt
-          if (_this.S.config.awsAdminKeyId && _this.S.config.awsAdminSecretKey) return;
-
-          // Prompt: profile select
-          let choices = [];
-          for (let i = 0; i < _this.profiles.length; i++) {
-            choices.push({
-              key:   '',
-              value: _this.profiles[i],
-              label: _this.profiles[i]
-            });
-          }
-
-          return _this.cliPromptSelect('Select an AWS profile for your project: ', choices, false)
-            .then(results => {
+            return _this.cliPromptSelect('Select an AWS profile for your project: ', choices, false)
+                .then(results => {
               _this.profile = results[0].value;
-            });
-        });
+          });
+          });
     }
 
     /**
@@ -314,6 +320,12 @@ module.exports = function(SPlugin, serverlessPath) {
         return BbPromise.reject(new SError('Invalid region. Lambda not supported in ' + this.evt.options.region, SError.errorCodes.UNKNOWN));
       }
 
+      // Validate Stage
+      let domainRegex = /^[a-z0-9-.]+$/;
+      if(!domainRegex.test(this.evt.options.stage)) {
+        return BbPromise.reject(new SError('Stage must only contain lowercase letters, numbers, periods and dashes'));
+      }
+
       return BbPromise.resolve();
     }
 
@@ -346,7 +358,7 @@ module.exports = function(SPlugin, serverlessPath) {
     _createProjectScaffolding() {
 
       let _this     = this,
-        projectPath = path.resolve(path.join(path.dirname('.'), _this.evt.options.name));
+          projectPath = path.resolve(path.join(path.dirname('.'), _this.evt.options.name));
 
       // Update Global Serverless Instance
       _this.S.updateConfig({
@@ -367,9 +379,9 @@ module.exports = function(SPlugin, serverlessPath) {
       // Save Project & Meta
       _this.S.state.set({ meta: _this.meta, project: _this.project });
       return _this.S.state.save()
-        .then(function() {
-          return _this.S.state.load();
-        });
+          .then(function() {
+            return _this.S.state.load();
+          });
     }
 
     /**
@@ -377,7 +389,6 @@ module.exports = function(SPlugin, serverlessPath) {
      */
 
     _createStageAndRegion() {
-      this.evt.options.stage = 'development';
       return this.S.actions.stageCreate({
         options: {
           stage:  this.evt.options.stage,


### PR DESCRIPTION
When creating the same project between AWS accounts*, one cannot run `sls project create` using the same stage value. Because that command defaults to `development` and doesn't allow one to change it; it became a problem.

*Our company manages a few different AWS accounts to segregate test, non-production and production.