### PR TITLE
Allow other endpoint types

### DIFF
--- a/lib/ServerlessEndpoint.js
+++ b/lib/ServerlessEndpoint.js
@@ -32,6 +32,7 @@ class ServerlessEndpoint {
     // Default properties
     _this.path                 = config.endpointPath;
     _this.method               = config.endpointMethod;
+    _this.type                 = _this._config.type;
     _this.authorizationType    = 'none';
     _this.apiKeyRequired       = false;
     _this.requestParameters    = {};
@@ -66,6 +67,7 @@ class ServerlessEndpoint {
       this._config.function       = config.function;
       this._config.endpointPath   = config.endpointPath;
       this._config.endpointMethod = config.endpointMethod;
+      this._config.type           = config.type ? config.type : 'AWS';
       this._config.sPath          = SUtils.buildSPath({
         component:      config.component,
         module:         config.module,

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -542,7 +542,7 @@ module.exports = function(SPlugin, serverlessPath) {
         httpMethod:             _this.endpoint.method, /* required */
         resourceId:             _this.resource.id, /* required */
         restApiId:              _this.restApi.id, /* required */
-        type:                   'AWS', /* required */
+        type:                   _this.endpoint.type, /* required */
         cacheKeyParameters:     _this.endpoint.cacheKeyParameters || [],
         cacheNamespace:         _this.endpoint.cacheNamespace     || null,
         // Due to a bug in API Gateway reported here: https://github.com/awslabs/aws-apigateway-swagger-importer/issues/41
@@ -579,7 +579,7 @@ module.exports = function(SPlugin, serverlessPath) {
             + _this.evt.options.stage + ' - '
             + _this.evt.options.region
             + ' - ' + _this.endpoint.path + '": '
-            + 'created integration with the type: AWS');
+            + 'created integration with the type: ' + response.type);
         })
         .catch(function(error) {
           throw new SError(


### PR DESCRIPTION
Enables support for endpoint type ("AWS" by default).