### PR TITLE
Fix syntaxerror introduced with blank __init__.py file

### DIFF
--- a/lib/ServerlessComponent.js
+++ b/lib/ServerlessComponent.js
@@ -283,7 +283,7 @@ class ServerlessComponent {
           );
         } else if (_this.runtime === 'python2.7') {
           let requirements = fs.readFileSync(path.join(_this._S.config.serverlessPath, 'templates', 'python2.7', 'requirements.txt')),
-            initPy = fs.readFileSync(path.join(_this._S.config.serverlessPath, 'templates', 'python2.7', '__init__.py'));
+            initPy = fs.readFileSync(path.join(_this._S.config.serverlessPath, 'templates', 'python2.7', '__init__.py')),
             blankInitPy = fs.readFileSync(path.join(_this._S.config.serverlessPath, 'templates', 'python2.7', 'blank__init__.py'));
 
           writeDeferred.push(


### PR DESCRIPTION
Looks like I missed a semicolon when adding a new template file. 