### PR TITLE
Add binary for running Python functions to $PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "bin": {
     "serverless": "./bin/serverless",
     "slss": "./bin/serverless",
-    "sls": "./bin/serverless"
+    "sls": "./bin/serverless",
+    "serverless-run-python-handler": "./bin/serverless-run-python-handler"
   },
   "scripts": {
     "test": "DEBUG=\"*\" mocha tests/all"


### PR DESCRIPTION
The `serverless-run-python-handler` binary must be in the user's path in
order to run Python functions locally, and it wasn't in `package.json`
so users using `npm install` or `npm link` to get serverless wouldn't
have it in their $PATH.