### PR TITLE
Use universal /usr/bin/env path instead of /bin/env

### DIFF
--- a/bin/serverless-run-python-handler
+++ b/bin/serverless-run-python-handler
@@ -1,4 +1,4 @@
-#!/bin/env python2
+#!/usr/bin/env python2.7
 
 from __future__ import print_function
 


### PR DESCRIPTION
/bin/env isn't available on all linux distros, so use `/usr/bin/env` which is a more widely used standard.