### PR TITLE
Fix casing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dynamodb",
     "serverless.com"
   ],
-  "main": "lib/serverless.js",
+  "main": "lib/Serverless.js",
   "bin": {
     "serverless": "./bin/serverless",
     "slss": "./bin/serverless",


### PR DESCRIPTION
Sometimes causes an error when importing (e.g. for testing):

```
require('serverless');
```