### PR TITLE
Add additional hotkeys and instruction text to dash.

### DIFF
--- a/lib/actions/DashDeploy.js
+++ b/lib/actions/DashDeploy.js
@@ -248,6 +248,10 @@ module.exports = function(SPlugin, serverlessPath) {
       // Show ASCII
       SCli.asciiGreeting();
 
+      // Show quick help.
+      console.log(""); // Spacer line
+      SCli.quickHelp();
+
       // Blank space for neatness in the CLI
       console.log('');
 

--- a/lib/utils/cli.js
+++ b/lib/utils/cli.js
@@ -38,6 +38,20 @@ exports.asciiGreeting = function() {
 };
 
 /**
+ * Quick Help
+ */
+
+exports.quickHelp = function() {
+  let text = '';
+  text     = text + 'Use the <up>, <down>, <pageup>, <pagedown>, <home>, and <end> keys to navigate.' + os.EOL;
+  text     = text + 'Press <enter> to select/deselect, or <space> to select/deselect and move down.' + os.EOL;
+  text     = text + 'Press <ctrl> + <enter> to immediately deploy selected.' + os.EOL;
+
+  console.log(chalk.yellow(text));
+};
+
+
+/**
  * Spinner
  */
 
@@ -221,61 +235,114 @@ exports.select = function(message, choices, multi, doneLabel) {
   if (!Select.state) keypress(process.stdin);
 
   let keypressHandler = function(ch, key) {
+
+    // Move the selected choice up by x number of steps.
+    let selectStateUp = function(steps) {
+      // Set default steps.
+      if(steps === undefined)
+        steps = 1;
+
+      // Move number of times defined by steps.
+      for(let i = 0; i < steps; ++i)
+      {
+        // Proceed if not at top.
+        if(Select.state.index > 1) {
+          if (Select.state.index === 2 && Select.state.choices[0].spacer) {
+            // If first choice is spacer, do nothing
+            Select.state.index = 2;
+          } else if (Select.state.choices[Select.state.index - 2].spacer) {
+            // If next choice is spacer, move up 2
+            Select.state.index = Select.state.index - 2;
+          } else {
+            // Move up
+            Select.state.index = Select.state.index - 1;
+          }
+        }
+      }
+
+      // Render
+      return Select._render();
+    };
+
+    // Move the selected choice down by x number of steps.
+    let selectStateDown = function(steps) {
+      // Set default steps.
+      if(steps === undefined)
+        steps = 1;
+
+      // Move number of times defined by steps.
+      for(let i = 0; i < steps; ++i)
+      {
+        // Proceed if not at bottom.
+        if(Select.state.index < Select.state.choices.length) {
+          if (Select.state.choices[Select.state.index].spacer) {
+            // If next choice is spacer, move down 2
+            Select.state.index = Select.state.index + 2;
+          } else {
+            // Move down
+            Select.state.index = Select.state.index + 1;
+          }
+        }
+      }
+      
+      // Render
+      return Select._render();
+    };
+
+    // Move the selected choice to the first.
+    let selectStateTop = function() {
+      Select.state.index = 2;
+      return Select._render();
+    };
+
+    // Move selected choice to the last.
+    let selectStateBottom = function() {
+      Select.state.index = Select.state.choices.length;
+      return Select._render();
+    };
+
+    // Toggle the current choice.
+    let toggleOption = function() {
+      // Toggle option
+      Select.state.choices[Select.state.index - 1].toggled = Select.state.choices[Select.state.index - 1].toggled ? false : true;
+
+      // Render
+      return Select._render();
+    };
+
     if( !key ) return Select._render;
 
-    if (key && key.ctrl && key.name == 'c') {
+    // Handle ctrl + c.
+    if (key.ctrl && key.name == 'c') {
       process.stdin.pause();
 
-    } else if (key.name == 'up' && Select.state.index > 1) {
+    // Handle other key combinations.
+    } else if (key.name == 'home') {
+      selectStateTop();
+    } else if (key.name == 'end') {
+      selectStateBottom();
+    } else if (key.name == 'up') {
+      selectStateUp();
+    } else if (key.name == 'pageup') {
+      selectStateUp(4);
+    } else if (key.name == 'down') {
+      selectStateDown();
+    } else if (key.name == 'pagedown') {
+      selectStateDown(4);
+    } else if (key.name == 'return' || key.name == 'space' || key.name == 'enter') {
 
-      if (Select.state.index === 2 && Select.state.choices[0].spacer) {
-
-        // If first choice is spacer, do nothing
-        Select.state.index = 2;
-
-      } else if (Select.state.choices[Select.state.index - 2].spacer) {
-
-        // If next choice is spacer, move up 2
-        Select.state.index = Select.state.index - 2;
-
-      } else {
-
-        // Move up
-        Select.state.index = Select.state.index - 1;
-
-      }
-
-      // Render
-      return Select._render();
-
-    } else if (key.name == 'down' && Select.state.index < Select.state.choices.length) {
-
-      if (Select.state.choices[Select.state.index].spacer) {
-
-        // If next choice is spacer, move down 2
-        Select.state.index = Select.state.index + 2;
-
-      } else {
-
-        // Move down
-        Select.state.index = Select.state.index + 1;
-
-      }
-
-      // Render
-      return Select._render();
-
-    } else if (key.name == 'return') {
-
-      // Check if "done" option
-      if (Select.state.choices[Select.state.index - 1].action
-        && Select.state.choices[Select.state.index - 1].action.toLowerCase() === 'done') {
+      // Check if "done" option or ctrl was pressed.
+      if ((Select.state.choices[Select.state.index - 1].action
+        && Select.state.choices[Select.state.index - 1].action.toLowerCase() === 'done') || key.name == 'enter') {
         process.stdin.removeListener('keypress', keypressHandler);
         return Select._close();
       } else {
 
-        // Toggle option
-        Select.state.choices[Select.state.index - 1].toggled = Select.state.choices[Select.state.index - 1].toggled ? false : true;
+        toggleOption();
+
+        // If the key was <space>, then move to the next choice.
+        if(key.name == 'space')
+          selectStateDown();
 
         if (!Select.state.multi) {
           process.stdin.removeListener('keypress', keypressHandler);


### PR DESCRIPTION
This adds the following hotkeys to Dash:
- pageup, pagedown: Move choice up/down by 4 steps.
- home, end: Move to the first and last choice.
- space: Toggle the current choice and move to the next.
- ctrl + enter: Select deploy.