### PR TITLE
Implement workaround for the AWS quirk on $input.json()

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -523,6 +523,10 @@ module.exports = function(SPlugin, serverlessPath) {
         if (requestTemplates.hasOwnProperty(property)) {
           if(typeof requestTemplates[property] === 'object') { // this code adding a JSON object case for valid values of requestTemplates key's values.  If more variants are added, a more careful inspection of requestTemplates[property] will be important.
             ret[property] = JSON.stringify(requestTemplates[property]);
+            // This does a regex search and replace for the "$input.json()" value and removed the quotes.
+            // This is a workaround for the AWS quirk of requiring a value that is not JSON compliant, 
+            // which in turn forces us to use strings in our config instead of normal JSON. 
+            ret[property] = ret[property].replace(/"\$input\.json\(['\\"]+([^\\\)]+)['\\"]+\)"/g, "$input.json('$1')");
           } else {
             ret[property] = requestTemplates[property]; // do as before
           }

--- a/lib/actions/FunctionRun.js
+++ b/lib/actions/FunctionRun.js
@@ -75,12 +75,24 @@ module.exports = function(SPlugin, serverlessPath) {
       // Instantiate Classes
       _this.project  = _this.S.state.project.get();
 
-      if(!_this.evt.options.path) return BbPromise.reject(new SError('Missing required function path param. Add a function path in this format: component/module/function   '));
+      // If a function path was not specified.
+      if(!_this.evt.options.path) {
+        // If s-function.json exists in the current path, then use the current function path.
+        if(SUtils.fileExistsSync(path.join(process.cwd(), 's-function.json'))) {
+          let componentName = path.basename(path.join(process.cwd(), '..', '..'));
+          let moduleName    = path.basename(path.join(process.cwd(), '..'));
+          let functionName  = path.basename(process.cwd());
+          _this.evt.options.path = componentName + "/" + moduleName + "/" + functionName;
+        }
+        else {
+          return BbPromise.reject(new SError('Missing required function path param. Run from within a function directory, or add a function path in this format: componentName/moduleName/functionName'));
+        }
+      }
 
       _this.function = _this.S.state.getFunctions({ paths: [_this.evt.options.path] })[0];
 
       // Missing function
-      if (!_this.function) return BbPromise.reject(new SError('Function could not be found at the path you specified'));
+      if (!_this.function) return BbPromise.reject(new SError('Function could not be found at the path specified.'));
 
       // Flow
       return BbPromise.resolve(_this._fetchEnvFile())


### PR DESCRIPTION
This is at attempt at a workaround for the AWS quirk of requiring an invalid JSON string to use the `$input.json()` within a requestTemplate. After an object has been converted to a string within _prepareRequestTemplates(), this adds a regex search which removes the quotes around `$input.json()`. This will allow us to use the quoted string values like `"$input.json('$')"` or `"$input.json('$.pets')"`within our JSON, and eliminate the need for the big ugly stringified version.