### PR TITLE
Allow `serverless function run` from within a function path.

### DIFF
--- a/lib/actions/FunctionRun.js
+++ b/lib/actions/FunctionRun.js
@@ -75,12 +75,24 @@ module.exports = function(SPlugin, serverlessPath) {
       // Instantiate Classes
       _this.project  = _this.S.state.project.get();
 
-      if(!_this.evt.options.path) return BbPromise.reject(new SError('Missing required function path param. Add a function path in this format: component/module/function   '));
+      // If a function path was not specified.
+      if(!_this.evt.options.path) {
+        // If s-function.json exists in the current path, then use the current function path.
+        if(SUtils.fileExistsSync(path.join(process.cwd(), 's-function.json'))) {
+          let componentName = path.basename(path.join(process.cwd(), '..', '..'));
+          let moduleName    = path.basename(path.join(process.cwd(), '..'));
+          let functionName  = path.basename(process.cwd());
+          _this.evt.options.path = componentName + "/" + moduleName + "/" + functionName;
+        }
+        else {
+          return BbPromise.reject(new SError('Missing required function path param. Run from within a function directory, or add a function path in this format: componentName/moduleName/functionName'));
+        }
+      }
 
       _this.function = _this.S.state.getFunctions({ paths: [_this.evt.options.path] })[0];
 
       // Missing function
-      if (!_this.function) return BbPromise.reject(new SError('Function could not be found at the path you specified'));
+      if (!_this.function) return BbPromise.reject(new SError('Function could not be found at the path specified.'));
 
       // Flow
       return BbPromise.resolve(_this._fetchEnvFile())


### PR DESCRIPTION
Add functionality to allow `serverless function run` to use the current function path if one was not specified on the CLI.