### PR TITLE
Fix overwriting s-templates.json

### DIFF
--- a/lib/ServerlessComponent.js
+++ b/lib/ServerlessComponent.js
@@ -276,7 +276,7 @@ class ServerlessComponent {
 
                 // If templates, save templates
                 if (_this.templates && Object.keys(_this.templates).length) {
-                    return SUtils.writeFile(path.join(_this._config.fullPath, 's-templates.json'), _this.templates);
+                    return SUtils.writeFile(path.join(_this._config.fullPath, 's-templates.json'), JSON.stringify(_this.templates, null, 2));
                 }
             })
             .then(function() {

--- a/lib/ServerlessFunction.js
+++ b/lib/ServerlessFunction.js
@@ -354,7 +354,7 @@ class ServerlessFunction {
 
         // If templates, save templates
         if (_this.templates && Object.keys(_this.templates).length) {
-          return SUtils.writeFile(path.join(_this._config.fullPath, 's-templates.json'), _this.templates);
+          return SUtils.writeFile(path.join(_this._config.fullPath, 's-templates.json'), JSON.stringify(_this.templates, null, 2));
         }
       })
       .then(function() {


### PR DESCRIPTION
Deploying resources to AWS using `sls resources deploy` always leads to overwriting `s-templates.json` with `[object Object]` string. It's pretty annoying, because you have to revert these changes every time. The reason is that it tries to write object into file without converting it to JSON. Here's the fix for that.

Hope you can merge this PR soon. Thanks!