### PR TITLE
Closes #580 - Add package.json based plugin discovery

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -75,10 +75,20 @@ class Serverless {
     let defaults = require('./Actions.json');
     this._loadPlugins(__dirname, defaults.plugins);
 
+    // TODO: Remove in V1 because will result in breaking change
     // Load Plugins: Project
     if (this.config.projectPath && SUtils.fileExistsSync(path.join(this.config.projectPath, 's-project.json'))) {
       let projectJson = require(path.join(this.config.projectPath, 's-project.json'));
       if (projectJson.plugins) this._loadPlugins(this.config.projectPath, projectJson.plugins);
+    }
+
+    // Load Plugins: Check the dependencies in the package.json file for Serverless plugins
+    if (this.config.projectPath && SUtils.fileExistsSync(path.join(this.config.projectPath, 'package.json'))) {
+      let packageJson = require(path.join(this.config.projectPath, 'package.json'));
+      let pluginsArray = _.map(packageJson.dependencies, function (value, key) {
+        return key;
+      });
+      this._loadPlugins(this.config.projectPath, pluginsArray);
     }
   }
 
@@ -252,9 +262,14 @@ class Serverless {
       }
 
       // Load Plugin
-      if (PluginClass) {
-        SUtils.sDebug(PluginClass.getName() + ' plugin loaded');
-        this.addPlugin(new PluginClass(_this));
+      try {
+        if (PluginClass) {
+          SUtils.sDebug(PluginClass.getName() + ' plugin loaded');
+          this.addPlugin(new PluginClass(_this));
+        }
+      } catch (e) {
+        // this fails if it's not a Serverless plugin, but a normal NPM package.
+        // It's ok because the current NPM package will be skipped and the next plugin will be loaded
       }
     }
   }


### PR DESCRIPTION
Plugins are now discovered with the help of the projects package.json file. This makes it
possible to simply run 'npm install <pluginname> --save' to use plugins. No need to add the
plugin name to the plugins array in the s-project.json file (although this is still supported for backwards
compatibility).