### PR TITLE
Make cf outputs accessible as variables #618

### DIFF
--- a/lib/ServerlessProject.js
+++ b/lib/ServerlessProject.js
@@ -35,7 +35,7 @@ class ServerlessProject {
     _this.components      = {};
     _this.templates       = {};
     _this.plugins         = [];
-    _this.resourceVars    = [ 'iamRoleArnLambda' ];
+    _this.resourceVars    = [];
   }
 
   /**

--- a/lib/ServerlessProject.js
+++ b/lib/ServerlessProject.js
@@ -35,6 +35,7 @@ class ServerlessProject {
     _this.components      = {};
     _this.templates       = {};
     _this.plugins         = [];
+    _this.resourceVars    = [ 'iamRoleArnLambda' ];
   }
 
   /**

--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -155,6 +155,7 @@ usage: serverless resources deploy`,
 
       let _this     = this;
       let regionVars = _this.S.state.getMeta().stages[_this.evt.options.stage].regions[_this.evt.options.region].variables;
+      let resourceVars = _this.S.state.getProject().resourceVars;
 
       return _this.S.state.getResources({
           populate: true,
@@ -239,11 +240,12 @@ usage: serverless resources deploy`,
                       // Save stack name
                       regionVars.resourcesStackName = cfStackData.StackName;
 
-                      // Save IAM Role ARN for Project Lambdas
+                      // Save allowed (exported) CF output variables for Project Lambdas
                       for (let i = 0; i < cfStackData.Outputs.length; i++) {
-                        if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {
-                          regionVars.iamRoleArnLambda = cfStackData.Outputs[i].OutputValue;
-                        }
+                    	let varName = cfStackData.Outputs[i].OutputKey.charAt(0).toLowerCase() + cfStackData.Outputs[i].OutputKey.slice(1);
+                    	if (resourceVars.indexOf(varName) !== -1) {
+                          regionVars[varName] = cfStackData.Outputs[i].OutputValue;
+                    	}
                       }
                     })
                     .then(() => {

--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -12,6 +12,7 @@ module.exports = function(SPlugin, serverlessPath) {
     SError       = require(path.join(serverlessPath, 'ServerlessError')),
     SCli         = require(path.join(serverlessPath, 'utils/cli')),
     BbPromise    = require('bluebird'),
+    _            = require('lodash'),
     SUtils       = require(path.join(serverlessPath, 'utils/index'));
 
   class ResourcesDeploy extends SPlugin {
@@ -155,7 +156,7 @@ usage: serverless resources deploy`,
 
       let _this     = this;
       let regionVars = _this.S.state.getMeta().stages[_this.evt.options.stage].regions[_this.evt.options.region].variables;
-      let resourceVars = _this.S.state.getProject().resourceVars;
+      let resourceVars = [ 'iamRoleArnLambda' ].concat( _this.S.state.getProject().resourceVars);
 
       return _this.S.state.getResources({
           populate: true,
@@ -242,7 +243,7 @@ usage: serverless resources deploy`,
 
                       // Save allowed (exported) CF output variables for Project Lambdas
                       for (let i = 0; i < cfStackData.Outputs.length; i++) {
-                    	let varName = cfStackData.Outputs[i].OutputKey.charAt(0).toLowerCase() + cfStackData.Outputs[i].OutputKey.slice(1);
+                    	let varName = _.lowerFirst(cfStackData.Outputs[i].OutputKey);
                     	if (resourceVars.indexOf(varName) !== -1) {
                           regionVars[varName] = cfStackData.Outputs[i].OutputValue;
                     	}


### PR DESCRIPTION
Output variables from CF are persisted as template stage variables in the project. A whitelist can be defined in the s-project.json within an array named resourceVars. iamRoleArnLambda will be exported automatically to not break existing functionality.
See issue #618 