### PR TITLE
Refs #524 #525 Add plugin manager

### DIFF
--- a/lib/Actions.json
+++ b/lib/Actions.json
@@ -34,6 +34,10 @@
     "./actions/ProjectRemove.js",
     "./actions/FunctionLogs.js",
     "./actions/ResourcesDiff.js",
-    "./actions/PluginCreate"
+    "./actions/PluginCreate.js",
+    "./actions/PluginSearch.js",
+    "./actions/PluginAdd.js",
+    "./actions/PluginRemove.js",
+    "./actions/PluginList.js"
   ]
 }

--- a/lib/actions/PluginAdd.js
+++ b/lib/actions/PluginAdd.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * Action: Plugin add
+ * - Adds the plugin to the project
+ *
+ * Event Options:
+ * - pluginName:      (String) The name of the plugin
+ */
+
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
+    BbPromise  = require('bluebird'),
+    _          = require('lodash'),
+    https       = require('https'),
+    execSync   = require('child_process').execSync;
+
+  /**
+   * PluginAdd Class
+   */
+
+  class PluginAdd extends SPlugin {
+
+    constructor(S, config) {
+      super(S, config);
+    }
+
+    static getName() {
+      return 'serverless.core.' + PluginAdd.name;
+    }
+
+    registerActions() {
+      this.S.addAction(this.pluginAdd.bind(this), {
+        handler:       'pluginAdd',
+        description:   `Adds the Serverless plugin to your project.
+usage: "serverless plugin add <plugin-name>" or "serverless plugin add <git-url>"`,
+        context:       'plugin',
+        contextAction: 'add',
+        options:       [],
+        parameters: [
+          {
+            parameter: 'nameOrGitUrl',
+            description: 'The plugins name or git url',
+            position: '0'
+          }
+        ]
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+
+    pluginAdd(evt) {
+
+      let _this   = this;
+      _this.evt   = evt;
+
+      return _this._addPlugin()
+        .then(function() {
+
+          /**
+           * Return Event
+           */
+
+          return _this.evt;
+
+        });
+    }
+
+    /**
+     * Add plugin
+     */
+
+    _addPlugin() {
+      let spinner = SCli.spinner();
+      let nameOrGitUrl = this.evt.options.nameOrGitUrl;
+      // TODO: Replace this endpoint later on with the new one from Serverless
+      let pluginJsonEndpoint = 'https://raw.githubusercontent.com/JustServerless/serverless-registry/gh-pages/plugins.json';
+
+      return new BbPromise(function(resolve, reject) {
+        if (!nameOrGitUrl) {
+          SCli.log('Please enter a valid plugin name or git url');
+          return resolve();
+        }
+        spinner.start();
+        // check if it's a plugins name or git url
+        if (nameOrGitUrl.match(/[a-zA-Z0-9]+:[a-zA-Z0-9]+/)) {
+          let pluginName = nameOrGitUrl;
+          https.get(pluginJsonEndpoint, (result) => {
+            spinner.stop(true);
+            if (result.statusCode == 200) {
+              result.setEncoding('utf8');
+              result.on('data', (pluginsJson) => {
+                let availablePlugins = JSON.parse(pluginsJson).plugins;
+                let plugin = _.find(availablePlugins, { name: pluginName });
+                if (plugin) {
+                  SCli.log(`Adding plugin "${pluginName}"`);
+                  execSync(`npm install --save ${plugin.npmName}`);
+                  SCli.log(`Successfully added "${pluginName}"`);
+                } else {
+                  SCli.log(`The plugin "${pluginName}" does not exist`);
+                }
+              });
+            } else {
+              SCli.log('An error occurred while accessing the plugin registry');
+            }
+          });
+        } else if (nameOrGitUrl.match(/((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:/\-~]+)(\.git)(\/)?/)) {
+          let gitUrl = nameOrGitUrl;
+          SCli.log(`Adding the plugin "${gitUrl}"`);
+          execSync(`npm install --save ${gitUrl}`);
+          SCli.log(`Successfully added "${gitUrl}"`);
+        } else {
+          SCli.log('Please enter a valid plugin name or git url');
+        }
+        spinner.stop(true);
+        resolve();
+      });
+    };
+  }
+
+  return( PluginAdd );
+};

--- a/lib/actions/PluginList.js
+++ b/lib/actions/PluginList.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * Action: Plugin list
+ * - Lists all installed Serverless plugins
+ */
+
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
+    BbPromise  = require('bluebird'),
+    https      = require('https'),
+    fs         = require('fs'),
+  execSync   = require('child_process').execSync;
+
+  /**
+   * PluginList Class
+   */
+
+  class PluginList extends SPlugin {
+
+    constructor(S, config) {
+      super(S, config);
+    }
+
+    static getName() {
+      return 'serverless.core.' + PluginList.name;
+    }
+
+    registerActions() {
+      this.S.addAction(this.pluginList.bind(this), {
+        handler:       'pluginList',
+        description:   `Lists all installed Serverless plugins`,
+        context:       'plugin',
+        contextAction: 'list',
+        options:       [],
+        parameters: []
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+
+    pluginList(evt) {
+
+      let _this   = this;
+      _this.evt   = evt;
+
+      return _this._listPlugins()
+        .then(function() {
+
+          /**
+           * Return Event
+           */
+
+          return _this.evt;
+
+        });
+    }
+
+    /**
+     * List all plugins
+     */
+
+    _listPlugins() {
+      let spinner = SCli.spinner();
+      // TODO: Replace this endpoint later on with the new one from Serverless
+      let pluginJsonEndpoint = 'https://raw.githubusercontent.com/JustServerless/serverless-registry/gh-pages/plugins.json';
+
+      return new BbPromise((resolve, reject) => {
+        spinner.start();
+        https.get(pluginJsonEndpoint, (result) => {
+          spinner.stop(true);
+          if (result.statusCode == 200) {
+            result.setEncoding('utf8');
+            result.on('data', (pluginsJson) => {
+              let availablePlugins = JSON.parse(pluginsJson).plugins;
+              let projectPath = this.S.getProject().getRootPath();
+              let dependencies = (JSON.parse(fs.readFileSync(`${projectPath}/package.json`))).dependencies;
+              let results = [];
+              availablePlugins.forEach((plugin) => {
+                if (plugin.npmName in dependencies) {
+                  results.push(plugin);
+                }
+              });
+              if (results.length === 0) {
+                SCli.log(`You have currently no Serverless plugins installed`);
+              } else {
+                SCli.log(`${results.length} plugin(s) installed: `);
+                results.forEach((plugin)=> {
+                  SCli.log(plugin.name);
+                });
+              }
+            });
+          } else {
+            SCli.log('An error occurred while accessing the plugin registry');
+          }
+          resolve();
+        });
+      });
+    };
+  }
+
+  return( PluginList );
+};

--- a/lib/actions/PluginRemove.js
+++ b/lib/actions/PluginRemove.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * Action: Plugin remove
+ * - Remove the plugin from the project
+ *
+ * Event Options:
+ * - pluginName:      (String) The name of the plugin
+ */
+
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
+    BbPromise  = require('bluebird'),
+    _          = require('lodash'),
+    https       = require('https'),
+    execSync   = require('child_process').execSync;
+
+  /**
+   * PluginRemove Class
+   */
+
+  class PluginRemove extends SPlugin {
+
+    constructor(S, config) {
+      super(S, config);
+    }
+
+    static getName() {
+      return 'serverless.core.' + PluginRemove.name;
+    }
+
+    registerActions() {
+      this.S.addAction(this.pluginRemove.bind(this), {
+        handler:       'pluginRemove',
+        description:   `Removes the Serverless plugin from your project.
+usage: "serverless plugin remove <plugin-name>" or "serverless plugin remove <git-url>"`,
+        context:       'plugin',
+        contextAction: 'remove',
+        options:       [],
+        parameters: [
+          {
+            parameter: 'nameOrGitUrl',
+            description: 'The plugins name or git url',
+            position: '0'
+          }
+        ]
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+
+    pluginRemove(evt) {
+
+      let _this   = this;
+      _this.evt   = evt;
+
+      return _this._removePlugin()
+        .then(function() {
+
+          /**
+           * Return Event
+           */
+
+          return _this.evt;
+
+        });
+    }
+
+    /**
+     * Remove plugin
+     */
+
+    _removePlugin() {
+      let spinner = SCli.spinner();
+      let nameOrGitUrl = this.evt.options.nameOrGitUrl;
+      // TODO: Replace this endpoint later on with the new one from Serverless
+      let pluginJsonEndpoint = 'https://raw.githubusercontent.com/JustServerless/serverless-registry/gh-pages/plugins.json';
+
+      return new BbPromise(function(resolve, reject) {
+        if (!nameOrGitUrl) {
+          SCli.log('Please enter a valid plugin name or git url');
+          return resolve();
+        }
+        spinner.start();
+        // check if it's a plugins name or git url
+        if (nameOrGitUrl.match(/[a-zA-Z0-9]+:[a-zA-Z0-9]+/)) {
+          let pluginName = nameOrGitUrl;
+          https.get(pluginJsonEndpoint, (result) => {
+            spinner.stop(true);
+            if (result.statusCode == 200) {
+              result.setEncoding('utf8');
+              result.on('data', (pluginsJson) => {
+                let availablePlugins = JSON.parse(pluginsJson).plugins;
+                let plugin = _.find(availablePlugins, { name: pluginName });
+                if (plugin) {
+                  SCli.log(`Removing the plugin "${pluginName}"`);
+                  execSync(`npm uninstall --save ${plugin.npmName}`);
+                  SCli.log(`Successfully removed "${pluginName}"`);
+                } else {
+                  SCli.log(`The plugin "${pluginName}" does not exist`);
+                }
+              });
+            } else {
+              SCli.log('An error occurred while accessing the plugin registry');
+            }
+          });
+        } else if (nameOrGitUrl.match(/((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:/\-~]+)(\.git)(\/)?/)) {
+          let gitUrl = nameOrGitUrl;
+          SCli.log(`Removing the plugin "${gitUrl}"`);
+          execSync(`npm uninstall --save ${gitUrl}`);
+          SCli.log(`Successfully removed "${gitUrl}"`);
+        } else {
+          SCli.log('Please enter a valid plugin name or git url');
+        }
+        spinner.stop(true);
+        resolve();
+      });
+    };
+  }
+
+  return( PluginRemove );
+};

--- a/lib/actions/PluginSearch.js
+++ b/lib/actions/PluginSearch.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * Action: Plugin search
+ * - looks up available plugins
+ *
+ * Event Options:
+ * - searchQuery:      (String) The search query for your plugin search
+ */
+
+module.exports = function(SPlugin, serverlessPath) {
+  const path   = require('path'),
+    SCli       = require(path.join(serverlessPath, 'utils/cli')),
+    BbPromise  = require('bluebird'),
+    https       = require('https');
+
+  /**
+   * PluginSearch Class
+   */
+
+  class PluginSearch extends SPlugin {
+
+    constructor(S, config) {
+      super(S, config);
+    }
+
+    static getName() {
+      return 'serverless.core.' + PluginSearch.name;
+    }
+
+    registerActions() {
+      this.S.addAction(this.pluginSearch.bind(this), {
+        handler:       'pluginSearch',
+        description:   `Searches the Serverless plugin registry for available plugins.
+usage: serverless plugin search <plugin>`,
+        context:       'plugin',
+        contextAction: 'search',
+        options:       [],
+        parameters: [
+          {
+            parameter: 'searchQuery',
+            description: 'The search query for your plugin search',
+            position: '0'
+          }
+        ]
+      });
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Action
+     */
+
+    pluginSearch(evt) {
+
+      let _this   = this;
+      _this.evt   = evt;
+
+      return _this._searchPlugin()
+        .then(function() {
+
+          /**
+           * Return Event
+           */
+
+          return _this.evt;
+
+        });
+    }
+
+    /**
+     * Search for plugins
+     */
+
+    _searchPlugin() {
+      let spinner = SCli.spinner();
+      let searchQuery = this.evt.options.searchQuery;
+      // TODO: Replace this endpoint later on with the new one from Serverless
+      let pluginJsonEndpoint = 'https://raw.githubusercontent.com/JustServerless/serverless-registry/gh-pages/plugins.json';
+
+      return new BbPromise((resolve, reject) => {
+        if (!searchQuery) {
+          SCli.log('Please enter a search query');
+          return resolve();
+        }
+        spinner.start();
+        SCli.log('Searching...');
+        https.get(pluginJsonEndpoint, (result) => {
+          spinner.stop(true);
+          if (result.statusCode == 200) {
+            result.setEncoding('utf8');
+            result.on('data', (pluginsJson) => {
+              let availablePlugins = JSON.parse(pluginsJson).plugins;
+              let results = [];
+              let searchQueryRegex = new RegExp(searchQuery);
+              availablePlugins.forEach((plugin) => {
+                if (plugin.name.match(searchQueryRegex) || plugin.description.match(searchQueryRegex)) {
+                  results.push(plugin);
+                }
+              });
+              if (results.length === 0) {
+                SCli.log(`No results found for your query "${searchQuery}"`);
+              } else {
+                SCli.log(`${results.length} plugin(s) found: `);
+                results.forEach((result) => {
+                  SCli.log(`${result.name} | ${result.description}`);
+                });
+              }
+            });
+          } else {
+            SCli.log('An error occurred while accessing the plugin registry');
+          }
+          resolve();
+        });
+      });
+    };
+  }
+
+  return( PluginSearch );
+};


### PR DESCRIPTION
Add a basic plugin management implementation.

Serverless users can use `serverless plugin search <query>`, `serverless plugin add <pluginname>`, `serverless plugin remove <pluginname>` or `serverless plugin list` to search, install, remove and list plugins. This makes it more convenient to add plugins for your Serverless project.
NPM is used under the hood.

Furthermore it's connected to [this](https://github.com/JustServerless/serverless-registry) Serverless plugin registry (connected to the plugin.json file). It's updated frequently with the latest plugins.

The name consists of two parts. `username:pluginname` (The GitHub username is used for the currently available Plugins which are listed in the [registry](http://justserverless.github.io/serverless-registry/)). This makes sure that plugins for the same purpose can be created without name collisions (inspired by the Meteor package management).