### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Serverless Projects are shareable and installable.  You can publish them to npm 
 Serverless is composed of Plugins.  A group of default Plugins ship with the Framework, and here are some others you can add to improve/help your workflow:
 * [Plugin Boilerplate](https://github.com/serverless/serverless-plugin-boilerplate) - Make a Serverless Plugin with this simple boilerplate.
 * [Serve](https://github.com/Nopik/serverless-serve) - Simulate API Gateway locally, so all function calls can be run via localhost.
+* [Offline](https://github.com/dherault/serverless-offline) - An alternative to the Serve plugin.
 * [Alerting](https://github.com/martinlindenberg/serverless-plugin-alerting) - This Plugin adds Cloudwatch Alarms with SNS notifications for your Lambda functions.
 * [Optimizer](https://github.com/serverless/serverless-optimizer-plugin) - Optimizes your code for performance in Lambda.
 * [CORS](https://github.com/joostfarla/serverless-cors-plugin) - Adds support for CORS (Cross-origin resource sharing).


### PR DESCRIPTION
Hi, 

I wrote an alternative to Nopik's wonderful Serve plugin. I believe Serve is close to Nopik's needs but I wanted something more generic that could work out of the box with `sls project create`.

I also wanted to support endpoints's request templates but I had issues using `.getPopulated`. I did not published an issue because I assumed I was doing something wrong. I'll try again another day.

This simply updates the README file to offer this alternative.

Thanks!