### PR TITLE
Measure and display local function run Duration

### DIFF
--- a/lib/RuntimeNode.js
+++ b/lib/RuntimeNode.js
@@ -55,6 +55,9 @@ module.exports = function(S) {
             // to ensure that they are accessible in the global context.
             const functionCall = require(functionFile)[functionHandler];
 
+            // Start measuring run duration
+            const startTime = process.hrtime();
+
             return new BbPromise((resolve) => {
               // Call Function
               functionCall(event, context(func, (err, result) => {
@@ -81,6 +84,12 @@ module.exports = function(S) {
                   response: result
                 });
               }));
+            })
+            .tap(() => {
+              const endTime = process.hrtime(startTime);
+              // Convert from seconds and nanoseconds to milliseconds
+              const duration = endTime[0] * 1000 + endTime[1] / 1000000;
+              SCli.log("Duration: " + duration.toFixed(2) + " ms");
             })
           })
           .catch((err) => {

--- a/lib/RuntimeNode43.js
+++ b/lib/RuntimeNode43.js
@@ -35,6 +35,9 @@ module.exports = function(S) {
             // to ensure that they are accessible in the global context.
             const functionCall = require(functionFile)[functionHandler];
 
+            // Start measuring run duration
+            const startTime = process.hrtime();
+
             return new BbPromise((resolve) => {
               // Call Function
               const callback = (err, result) => {
@@ -63,6 +66,12 @@ module.exports = function(S) {
               }
 
               functionCall(event, context(func, callback), callback);
+            })
+            .tap(() => {
+              const endTime = process.hrtime(startTime);
+              // Convert from seconds and nanoseconds to milliseconds
+              const duration = endTime[0] * 1000 + endTime[1] / 1000000;
+              SCli.log("Duration: " + duration.toFixed(2) + " ms");
             })
           })
           .catch((err) => {


### PR DESCRIPTION
For example:
```
Serverless: Success! - This Response Was Returned:  
Serverless: "Completed!"  
Serverless: Duration: 273.15 ms 
```