### PR TITLE
Fix bug with ambiguous function paths

### DIFF
--- a/lib/ServerlessState.js
+++ b/lib/ServerlessState.js
@@ -261,7 +261,7 @@ class ServerlessState {
 
       let func = allFunctions[i];
       for (let j = 0; j < options.paths.length; j++) {
-        if (func._config.sPath.indexOf(options.paths[j]) !== -1) {
+        if (func._config.sPath === options.paths[j]) {
           foundFunctions.push(options.returnPaths ? func._config.sPath : func);
           break;
         }


### PR DESCRIPTION
If there are two functions named "abc" and "abcd" in the same directory,
`getFunctions` will mistakenly match both for a shorter name "abc".
It will result in an error: "You must be in a function folder to run it"