### PR TITLE
Bugfixes for 'Too many requests' usage

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -60,24 +60,26 @@ class ServerlessProviderAws {
    */
 
   request(service, method, params, stage, region, options) {
-    let _this      = this;
+    let _this = this;
     let awsService = new this.sdk[service](_this.getCredentials(stage, region));
-    let req        = awsService[method](params);
+    let req = awsService[method](params);
 
     // Add listeners...
-    req.on('validate', function(r) {});
+    req.on('validate', function (r) {
+    });
 
-    return SUtils.persistentRequest(function(){
-      return new BbPromise(function(resolve, reject) {
-        req.send(function(err, data) {
+    return SUtils.persistentRequest(function () {
+      return new BbPromise(function (resolve, reject) {
+        req.send(function (err, data) {
           if (err) {
-            reject( err );
+            reject(err);
           } else {
-            resolve( data );
+            resolve(data);
           }
         });
       });
     });
+  }
 
   /**
    * Get Credentials

--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -67,23 +67,17 @@ class ServerlessProviderAws {
     // Add listeners...
     req.on('validate', function(r) {});
 
-    return new BbPromise(function(resolve, reject) {
-      let performRequest = function() {
+    return SUtils.persistentRequest(function(){
+      return new BbPromise(function(resolve, reject) {
         req.send(function(err, data) {
-          if (err && err.statusCode == 429) {
-            SUtils.sDebug("'Too many requests' received, sleeping 5 seconds, then retrying...");
-            return setTimeout( performRequest, 5000 );
-          } else if (err) {
-            return reject(err);
+          if (err) {
+            reject( err );
+          } else {
+            resolve( data );
           }
-
-          return resolve(data);
         });
-      };
-
-      performRequest();
+      });
     });
-  }
 
   /**
    * Get Credentials

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -262,7 +262,7 @@ module.exports = function(SPlugin, serverlessPath) {
       };
 
       // List all Resources for this REST API
-      return SUtils.persistentRequest(function() { return _this.aws.request('APIGateway', 'getResources', params, _this.evt.options.stage, _this.evt.options.region); })
+      return _this.aws.request('APIGateway', 'getResources', params, _this.evt.options.stage, _this.evt.options.region)
         .then(function(response) {
           _this.apiResources = response.items;
 
@@ -393,7 +393,7 @@ module.exports = function(SPlugin, serverlessPath) {
           };
 
           // Create Resource
-          return SUtils.persistentRequest(function() { return _this.aws.request('APIGateway', 'createResource', params, _this.evt.options.stage, _this.evt.options.region); } )
+          return _this.aws.request('APIGateway', 'createResource', params, _this.evt.options.stage, _this.evt.options.region)
             .then(function(response) {
 
               // Save resource
@@ -444,7 +444,7 @@ module.exports = function(SPlugin, serverlessPath) {
         restApiId:  _this.restApi.id /* required */
       };
 
-      return SUtils.persistentRequest( function(){ return _this.aws.request('APIGateway', 'getMethod', params, _this.evt.options.stage, _this.evt.options.region); } )
+      return _this.aws.request('APIGateway', 'getMethod', params, _this.evt.options.stage, _this.evt.options.region)
         .then(function(response) {
 
           // Method exists.  Delete and recreate it.
@@ -460,7 +460,7 @@ module.exports = function(SPlugin, serverlessPath) {
             restApiId:  _this.restApi.id /* required */
           };
 
-          return SUtils.persistentRequest( function(){ return _this.aws.request('APIGateway', 'deleteMethod', params, _this.evt.options.stage, _this.evt.options.region); } )
+          return _this.aws.request('APIGateway', 'deleteMethod', params, _this.evt.options.stage, _this.evt.options.region)
             .then(function(response) {
               let params = {
                 authorizationType:  _this.endpoint.authorizationType, /* required */
@@ -472,7 +472,7 @@ module.exports = function(SPlugin, serverlessPath) {
                 requestParameters:  requestParameters
               };
 
-              return SUtils.persistentRequest( function(){ return _this.aws.request('APIGateway', 'putMethod', params, _this.evt.options.stage, _this.evt.options.region); } )
+              return _this.aws.request('APIGateway', 'putMethod', params, _this.evt.options.stage, _this.evt.options.region);
 
             });
         }, function(error) {
@@ -489,7 +489,7 @@ module.exports = function(SPlugin, serverlessPath) {
             requestParameters:  requestParameters
           };
 
-          return SUtils.persistentRequest( function(){ return _this.aws.request('APIGateway', 'putMethod', params, _this.evt.options.stage, _this.evt.options.region); } );
+          return _this.aws.request('APIGateway', 'putMethod', params, _this.evt.options.stage, _this.evt.options.region);
         })
         .then(function(response) {
 
@@ -569,7 +569,7 @@ module.exports = function(SPlugin, serverlessPath) {
       };
 
       // Create Integration
-      return SUtils.persistentRequest( function() { return _this.aws.request('APIGateway', 'putIntegration', params, _this.evt.options.stage, _this.evt.options.region); } )
+      return _this.aws.request('APIGateway', 'putIntegration', params, _this.evt.options.stage, _this.evt.options.region)
         .then(function(response) {
 
           // Save integration
@@ -639,7 +639,7 @@ module.exports = function(SPlugin, serverlessPath) {
           };
 
           // Create Method Response
-          return SUtils.persistentRequest( function(){ return _this.aws.request('APIGateway', 'putMethodResponse', params, _this.evt.options.stage, _this.evt.options.region); } )
+          return _this.aws.request('APIGateway', 'putMethodResponse', params, _this.evt.options.stage, _this.evt.options.region)
             .then(function() {
 
               SUtils.sDebug(
@@ -695,7 +695,7 @@ module.exports = function(SPlugin, serverlessPath) {
           };
 
           // Create Integration Response
-          return SUtils.persistentRequest( function(){ return _this.aws.request('APIGateway', 'putIntegrationResponse', params, _this.evt.options.stage, _this.evt.options.region); } )
+          return _this.aws.request('APIGateway', 'putIntegrationResponse', params, _this.evt.options.stage, _this.evt.options.region)
             .then(function() {
 
               SUtils.sDebug(


### PR DESCRIPTION
Current implementation of 429 handling was totally flawed (many mistakes on promise usage, like resolving+rejection of the same promise, creating promise and throwing it away, 429 retry within 429 retry, etc.). This PR fixes this.