### PR TITLE
Fixed credential providing to include session token

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -113,6 +113,7 @@ class ServerlessProviderAws {
       credentials = {
         accessKeyId:     process.env['AWS_ACCESS_KEY_ID_' + stage],
         secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY_' + stage],
+        sessionToken:    process.env['AWS_SESSION_TOKEN_' + stage],
         region: region
       };
 
@@ -123,24 +124,10 @@ class ServerlessProviderAws {
       credentials = {
         accessKeyId:     process.env['AWS_ACCESS_KEY_ID'] || process.env['SERVERLESS_ADMIN_AWS_ACCESS_KEY_ID'],
         secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'] || process.env['SERVERLESS_ADMIN_AWS_SECRET_ACCESS_KEY'],
-        region: region
-      };
-
-    } else if (process.env['AWS_SESSION_TOKEN_' + stage]) {
-
-      // Session Token w/ Stage Suffix
-      credentials = {
-        sessionToken:    process.env['AWS_SESSION_TOKEN_' + stage],
-        region: region
-      };
-
-    } else if (process.env['AWS_SESSION_TOKEN']) {
-
-      // Session Token Plain
-      credentials = {
         sessionToken:    process.env['AWS_SESSION_TOKEN'],
         region: region
       };
+      
     } else if (this._S.config.awsAdminKeyId) {
 
       // Access Keys from the config


### PR DESCRIPTION
As it was a session token would never be included in the configuration unless only the session token was present, but key id, secret key and session token must be present to use a session token.

If the session token is undefined the aws-sdk just ignores it.