### PR TITLE
Prompt for component name should reflect runtime.

### DIFF
--- a/lib/actions/ComponentCreate.js
+++ b/lib/actions/ComponentCreate.js
@@ -104,10 +104,14 @@ usage: serverless component create`,
         overrides[memberVarKey] = _this.evt.options[memberVarKey];
       });
 
+      // Add default runtime
+      if (!_this.evt.options.runtime)
+        _this.evt.options.runtime = 'nodejs';
+
       let prompts = {
         properties: {
           sPath: {
-            default:     'nodejscomponent',
+            default:     `${_this.evt.options.runtime.replace(/\./g, '')}component`,
             description: 'Enter a name for your new component: '.yellow,
             message:     'Component name must contain only letters, numbers, hyphens, or underscores.',
             required:    true,
@@ -135,11 +139,6 @@ usage: serverless component create`,
         if (!this.evt.options.sPath) {
           return BbPromise.reject(new SError('Component name is required.'));
         }
-      }
-
-      // Add default runtime
-      if (!this.evt.options.runtime) {
-        this.evt.options.runtime = 'nodejs';
       }
 
       if (!SUtils.supportedRuntimes[this.evt.options.runtime]) {


### PR DESCRIPTION
Makes it so that when you create a component with a python2.7 runtime
the default function name is "python27component" not "nodejscomponent".