### PR TITLE
Support authorizerId parameter in s-function.json endpoints for CUSTOM authorizers

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -479,6 +479,7 @@ module.exports = function(SPlugin, serverlessPath) {
 
               let params = {
                 authorizationType:  _this.endpoint.authorizationType, /* required */
+                authorizerId:       _this.endpoint.authorizerId, /* optional */
                 httpMethod:         _this.endpoint.method, /* required */
                 resourceId:         _this.resource.id, /* required */
                 restApiId:          _this.restApi.id, /* required */
@@ -496,6 +497,7 @@ module.exports = function(SPlugin, serverlessPath) {
 
           let params = {
             authorizationType:  _this.endpoint.authorizationType, /* required */
+            authorizerId:       _this.endpoint.authorizerId, /* optional */
             httpMethod:         _this.endpoint.method, /* required */
             resourceId:         _this.resource.id, /* required */
             restApiId:          _this.restApi.id, /* required */


### PR DESCRIPTION
This is a simple patch just to allow specifying authorizerId in s-function.json endpoints:

    "authorizationType": "CUSTOM"
    "authorizerId": "<id from api gateway console>"

Without this, there's no way to specify the authorizerId and deploying the endpoint will remove the custom authorization that was configured in API Gateway console.

I propose this as a temporary quick fix until more comprehensive custom authorizer support is available (https://github.com/serverless/serverless/issues/626).