### PR TITLE
Stringify responseTemplate json object

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -533,7 +533,7 @@ module.exports = function(SPlugin, serverlessPath) {
           if(typeof requestTemplates[property] === 'object') { // this code adding a JSON object case for valid values of requestTemplates key's values.  If more variants are added, a more careful inspection of requestTemplates[property] will be important.
             ret[property] = JSON.stringify(requestTemplates[property]);
             // This does a regex search and replace for the "$input.json()" value and removes the surrounding quotes.
-            // This is a workaround for the AWS quirk of using the Apache Velocity syntax that is a superset of JSON. 
+            // This is a workaround for the AWS quirk of using the Apache Velocity syntax that is a superset of JSON.
             // This in turn forces us to use strings in our config instead of normal JSON.
             ret[property] = ret[property].replace(/"\$input\.json\(['\\"]+([^\\\)]+)['\\"]+\)"/g, "$input.json('$1')");
           } else {
@@ -675,6 +675,23 @@ module.exports = function(SPlugin, serverlessPath) {
     }
 
     /**
+     * Helper: stringify response template contents.
+     */
+    _prepareResponseTemplates(responseTemplates) {
+      let ret = {};
+      for (let property in responseTemplates) {
+        if (responseTemplates.hasOwnProperty(property)) {
+          if(typeof responseTemplates['application/json'][property] === 'object') {
+            ret[property] = JSON.stringify(responseTemplates['application/json'][property]);
+          } else {
+            ret[property] = responseTemplates[property]; // do as before
+          }
+        }
+      }
+      return ret;
+    }
+
+    /**
      * Create Method Integration Response
      */
 
@@ -696,7 +713,7 @@ module.exports = function(SPlugin, serverlessPath) {
           let responseParameters = thisResponse.responseParameters || {};
 
           // Add Response Templates
-          let responseTemplates  = thisResponse.responseTemplates || {};
+          let responseTemplates  = _this._prepareResponseTemplates(thisResponse.responseTemplates) || {};
 
           // Add SelectionPattern
           let selectionPattern   = thisResponse.selectionPattern || (responseKey === 'default' ? null : responseKey);

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -681,8 +681,8 @@ module.exports = function(SPlugin, serverlessPath) {
       let ret = {};
       for (let property in responseTemplates) {
         if (responseTemplates.hasOwnProperty(property)) {
-          if(typeof responseTemplates['application/json'][property] === 'object') {
-            ret[property] = JSON.stringify(responseTemplates['application/json'][property]);
+          if(typeof responseTemplates[property] === 'object') {
+            ret[property] = JSON.stringify(responseTemplates[property]);
           } else {
             ret[property] = responseTemplates[property]; // do as before
           }


### PR DESCRIPTION
Previously, a responseTemplate object would result in the following
when running “servers endpoint deploy”:

Expected params.responseTemplates['application/json'] to be a string

(issue #514)

Added processing with _prepareResponseTemplates to avoid this problem.