### PR TITLE
v0.5 - Fix error message on invalid s-project.json.

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -402,9 +402,10 @@ module.exports = {
     // Helper function
     let isProjectDir = function(dir) {
       let jsonName = 's-project.json';
+      let jsonFilePath = path.join(dir, jsonName);
 
-      if (_this.fileExistsSync(path.join(dir, jsonName))) {
-        let projectJson = require(path.join(dir, jsonName));
+      if (_this.fileExistsSync(jsonFilePath)) {
+        let projectJson = _this.readFileSync(jsonFilePath);
         if (typeof projectJson.name !== 'undefined') {
           return true;
         }


### PR DESCRIPTION
Update findProjectPath() to use readFileSync() so that a json error message is received if s-project.json is invalid.