### PR TITLE
Fix issue finding handler when running on windows

### DIFF
--- a/lib/RuntimeBase.js
+++ b/lib/RuntimeBase.js
@@ -52,7 +52,7 @@ class ServerlessRuntimeBase {
       SUtils.sDebug(`"${stage} - ${region} - ${func.getName()}": Copying in dist dir ${pathDist}`);
 
       // Extract the root of the lambda package from the handler property
-      let handlerFullPath = func.getRootPath(func.handler.split('/')[func.handler.split('/').length - 1]);
+      let handlerFullPath = func.getRootPath(func.handler.split('/')[func.handler.split('/').length - 1]).replace(/\\/g, '/');
 
       // Check handler is correct
       if (handlerFullPath.indexOf(func.handler) == -1) {

--- a/lib/RuntimeNode.js
+++ b/lib/RuntimeNode.js
@@ -93,7 +93,7 @@ class ServerlessRuntimeNode extends RuntimeBase {
   }
 
   getHandler(func) {
-    return path.join(path.dirname(func.handler), "_serverless_handler.handler");
+    return path.join(path.dirname(func.handler), "_serverless_handler.handler").replace(/\\/g, '/');
   }
 
   _afterCopyDir(func, pathDist, stage, region) {

--- a/lib/RuntimePython27.js
+++ b/lib/RuntimePython27.js
@@ -97,7 +97,7 @@ class ServerlessRuntimePython27 extends RuntimeBase {
   }
 
   getHandler(func) {
-    return path.join(path.dirname(func.handler), "_serverless_handler.handler");
+    return path.join(path.dirname(func.handler), "_serverless_handler.handler").replace(/\\/g, '/');
   }
 
   _afterCopyDir(func, pathDist, stage, region) {


### PR DESCRIPTION
Hander is specified as "rootfolder/handler.handler", but checked against a path on windows which is along the lines of "C:\...\rootfolder\handler.handler" and so it doesn't work due to forward slashes instead of backslashes.

Windows paths work equally well with forward slashes, so I have replaced the backslashes with forwards ones in the check