### PR TITLE
When deploying functions, replace the variable placeholders with their values

### DIFF
--- a/lib/actions/CodeDeployLambda.js
+++ b/lib/actions/CodeDeployLambda.js
@@ -94,13 +94,13 @@ module.exports   = function(SPlugin, serverlessPath) {
     _validateAndPrepare() {
 
       let _this = this;
-
       // TODO: Validate Options
 
       // Instantiate Classes
       _this.aws      = _this.S.getProvider();
       _this.project  = _this.S.getProject();
       _this.function = _this.S.getProject().getFunction( _this.evt.options.name );
+      _this.functionPopulated = _this.function.toObjectPopulated({ stage: _this.evt.options.stage, region: _this.evt.options.region });
 
       // Set default function name
       _this.functionName = _this.function.getDeployedName({
@@ -181,15 +181,15 @@ module.exports   = function(SPlugin, serverlessPath) {
               },
               FunctionName: _this.functionName, /* required */
               Handler:      _this.function.getRuntime().getHandler(_this.function), /* required */
-              Role:         _this.function.customRole ? _this.function.customRole : _this.project.getVariablesObject(_this.evt.options.stage, _this.evt.options.region).iamRoleArnLambda, /* required */
+              Role:         _this.functionPopulated.customRole ? _this.functionPopulated.customRole : _this.project.getVariablesObject(_this.evt.options.stage, _this.evt.options.region).iamRoleArnLambda, /* required */
               Runtime:      _this.function.getRuntime().getName(), /* required */
               Description:  'Serverless Lambda function for project: ' + _this.project.name,
-              MemorySize:   _this.function.memorySize,
+              MemorySize:   _this.functionPopulated.memorySize,
               Publish:      true, // Required by Serverless Framework & recommended best practice by AWS
-              Timeout:      _this.function.timeout,
+              Timeout:      _this.functionPopulated.timeout,
               VpcConfig: {
-                SecurityGroupIds: _this.function.vpc.securityGroupIds,
-                SubnetIds:        _this.function.vpc.subnetIds
+                SecurityGroupIds: _this.functionPopulated.vpc.securityGroupIds,
+                SubnetIds:        _this.functionPopulated.vpc.subnetIds
               }
             };
 
@@ -206,17 +206,16 @@ module.exports   = function(SPlugin, serverlessPath) {
             SUtils.sDebug(`"${_this.evt.options.stage} - ${_this.evt.options.region} - ${_this.functionName}": Updating Lambda configuration...`);
 
             // Update Configuration
-
             let params = {
               FunctionName: _this.lambda.Configuration.FunctionName, /* required */
               Description: 'Serverless Lambda function for project: ' + _this.project.name,
               Handler:      _this.function.getRuntime().getHandler(_this.function),
-              MemorySize:   _this.function.memorySize,
-              Role:         _this.function.customRole ? _this.function.customRole : _this.project.getVariablesObject(_this.evt.options.stage, _this.evt.options.region).iamRoleArnLambda,
-              Timeout:      _this.function.timeout,
+              MemorySize:   _this.functionPopulated.memorySize,
+              Role:         _this.functionPopulated.customRole ? _this.functionPopulated.customRole : _this.project.getVariablesObject(_this.evt.options.stage, _this.evt.options.region).iamRoleArnLambda,
+              Timeout:      _this.functionPopulated.timeout,
               VpcConfig: {
-                SecurityGroupIds: _this.function.vpc.securityGroupIds,
-                SubnetIds: _this.function.vpc.subnetIds
+                SecurityGroupIds: _this.functionPopulated.vpc.securityGroupIds,
+                SubnetIds: _this.functionPopulated.vpc.subnetIds
               }
             };
 


### PR DESCRIPTION
Fixes:

The functions are being deployed without replacing the template placeholders with their values for example:

```  "vpc": {
    "securityGroupIds": [
      "${securityGroup}"
    ],
    "subnetIds": [
      "${subnetA}",
      "${subnetB}"
    ]
  }```

does not replace ${securityGroup} with my dev/prod values