### PR TITLE
Fixes #813 and #814

### DIFF
--- a/lib/Runtime.js
+++ b/lib/Runtime.js
@@ -192,7 +192,7 @@ module.exports = function(S) {
       // Copy entire test project to temp folder, don't include anything in excludePatterns
       let excludePatterns = func.custom.excludePatterns || [];
 
-      excludePatterns = excludePatterns.concat(['_meta', 'admin.env', '.env']);
+      excludePatterns = excludePatterns.concat(['^_meta', '^admin\.env$', '^\.env$']);
 
       return function (name, prefix) {
 

--- a/lib/actions/CodeDeployLambda.js
+++ b/lib/actions/CodeDeployLambda.js
@@ -84,9 +84,9 @@ module.exports   = function(S) {
       // TODO: Validate Options
 
       // Instantiate Classes
-      _this.aws      = _this.S.getProvider();
-      _this.project  = _this.S.getProject();
-      _this.function = _this.S.getProject().getFunction( _this.evt.options.name );
+      _this.aws      = S.getProvider();
+      _this.project  = S.getProject();
+      _this.function = S.getProject().getFunction( _this.evt.options.name );
       _this.functionPopulated = _this.function.toObjectPopulated({ stage: _this.evt.options.stage, region: _this.evt.options.region });
 
       // Set default function name


### PR DESCRIPTION
* More narrowly define default function excludePatterns
* Correct reference to undefined properties in `Runtime._validateAndPrepare()`