### PR TITLE
Generate patch for authorizer's authorizerCredentials property on

### DIFF
--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -392,6 +392,11 @@ module.exports = function(S) {
         path:  "/authorizerResultTtlInSeconds",
         value: authorizer.authorizerResultTtlInSeconds
       });
+      if (authorizer.authorizerCredentials) params.patchOperations.push({
+        op:    "replace",
+        path:  "/authorizerCredentials",
+        value: authorizer.authorizerCredentials
+      });
 
       // Perform update
       return _this.provider.request('APIGateway', 'updateAuthorizer', params, _this.evt.options.stage, region)


### PR DESCRIPTION
update.

* If the authorizer specifies authorizerCredentials generate a patch
  operation in order to persist on update.