### PR TITLE
Allow variable declaration of AWS account ID

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -335,12 +335,16 @@ module.exports = function(S) {
     }
 
     getAccountId(stage, region) {
-      return S.getProject()
+      let vars = S.getProject()
         .getRegion(stage, region)
-        .getVariables()
-        .iamRoleArnLambda
-        .replace('arn:aws:iam::', '')
-        .split(':')[0];
+        .getVariables();
+      if(vars.accountId) {
+        return vars.accountId;
+      } else {
+        return vars.iamRoleArnLambda
+            .replace('arn:aws:iam::', '')
+            .split(':')[0];
+      }
     }
   }
 

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -131,7 +131,7 @@ module.exports = function(S) {
 
       // If no iamRoleLambda, throw error
       if (!_this.awsAccountNumber) {
-        throw new SError('No Lambda IAM Role found');
+        throw new SError('Neither an accountId variable nor a Lambda IAM Role variable containing the account ID were found');
       }
 
       // Get populated endpoint

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -119,11 +119,6 @@ module.exports = function(S) {
       _this.project    = S.getProject();
       _this.aws        = S.getProvider();
 
-      // If no iamRoleLambda, throw error
-      if (!_this.project.getRegion(_this.evt.options.stage, _this.evt.options.region).getVariables().iamRoleArnLambda) {
-        throw new SError('No Lambda IAM Role found');
-      }
-
       // Define useful variables
       _this.awsAccountNumber     = _this.aws.getAccountId(_this.evt.options.stage, _this.evt.options.region);
       _this.restApiName          = _this.project.getRegion(_this.evt.options.stage, _this.evt.options.region).getVariables().apiGatewayApi;
@@ -133,6 +128,11 @@ module.exports = function(S) {
       _this.integration          = null;
       _this.lambda               = null;
       _this.apiResources         = null;
+
+      // If no iamRoleLambda, throw error
+      if (!_this.awsAccountNumber) {
+        throw new SError('No Lambda IAM Role found');
+      }
 
       // Get populated endpoint
       _this.endpoint = _this.project.getEndpoint(_this.evt.options.name);


### PR DESCRIPTION
Allow AWS account ID to be defined in the variables files by using it as the preferred source of the account ID.

Move the check for a valid account ID until after contingent loading of the ID has been executed and clarify the error message.

This pull request resolves https://github.com/serverless/serverless/issues/790