### PR TITLE
Move David Guetta campaign link to original version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We love our contributors! If you'd like to contribute to the project, feel free 
 ## Consultants
 These consultants use the Serverless Framework and can help you build your serverless projects.
 * [Trek10](https://www.trek10.com/)
-* [Parallax](https://parall.ax/) – they also built the [David Guetta Campaign](http://highscalability.com/blog/2016/1/20/building-an-infinitely-scaleable-online-recording-campaign-f.html)
+* [Parallax](https://parall.ax/) – they also built the [David Guetta Campaign](https://serverlesscode.com/post/david-guetta-online-recording-with-lambda/)
 * [Just Serverless](http://justserverless.com)
 * [SC5 Online](https://sc5.io)
 * [Carrot Creative](https://carrot.is)


### PR DESCRIPTION
The David Guetta article originally appeared on serverlesscode.com, change the link in the README to the original version.