### PR TITLE
Change the serverless actions menu to horizontal

### DIFF
--- a/lib/utils/cli.js
+++ b/lib/utils/cli.js
@@ -467,9 +467,11 @@ exports.generateMainHelp = function(allCommands) {
 
   for (let cmdContext in allCommands) {
     console.log('\n"%s" actions:', cmdContext);
+    let cmdActions = "";
     for (let cmdAction in allCommands[cmdContext]) {
-      console.log(chalk.yellow('  %s'), cmdAction);
+      cmdActions += cmdAction + " ";
     }
+    console.log(chalk.yellow("%s"), cmdActions);
   }
 
   console.log('');

--- a/lib/utils/cli.js
+++ b/lib/utils/cli.js
@@ -471,7 +471,7 @@ exports.generateMainHelp = function(allCommands) {
     for (let cmdAction in allCommands[cmdContext]) {
       cmdActions += cmdAction + " ";
     }
-    console.log(chalk.yellow("%s"), cmdActions);
+    console.log(chalk.yellow("  %s"), cmdActions);
   }
 
   console.log('');


### PR DESCRIPTION
The actions menu is getting too long for those of us with smaller screens. This commit changes it from a vertical listing:

```
"function" actions:
  run
  create
  deploy
  logs
  remove
  rollback
```

to a horizontal listing:

```
"function" actions:
  run create deploy logs remove rollback
```