### PR TITLE
issue #836 - Switched error messages for context and command.

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -352,10 +352,10 @@ class Serverless {
 
     // If command not found, throw error
     if (!_this.commands[_this.cli.context]) {
-      return BbPromise.reject(new SError('In the command you just typed, the "' + _this.cli.context + '" is valid but "' + _this.cli.action + '" is not.  Enter "serverless help" to see the actions for this context.'));
+      return BbPromise.reject(new SError('Command not found.  Enter "serverless help" to see all available commands.'));
     }
     if (!_this.commands[_this.cli.context][_this.cli.action]) {
-      return BbPromise.reject(new SError('Command not found.  Enter "serverless help" to see all available commands.'));
+      return BbPromise.reject(new SError('In the command you just typed, the "' + _this.cli.context + '" is valid but "' + _this.cli.action + '" is not.  Enter "serverless help" to see the actions for this context.'));
     }
 
     // if not in project root and not creating project, throw error


### PR DESCRIPTION
The error messages for "invalid context" and "invalid command" were switched. Now the proper message is shown in each case.