### PR TITLE
Issue #839 - Use path.parse method to extract function name

### DIFF
--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -165,7 +165,8 @@ usage: serverless function create <function>`,
 
       if (_this.evt.options.path) {
         // extract function name from path regardless of how deep the path is
-        _this.functionName = _.last(_this.evt.options.path.split(path.sep));
+        let parsedPath = path.parse(_this.evt.options.path);
+        _this.functionName = parsedPath.base;
       } else {
 
         // generate path from function name regardless of how deep we are in cwd


### PR DESCRIPTION
On Windows systems the path gets parsed now, regardless if you use '/' or '\' as separator.