### PR TITLE
Fixes #838 - Removed default name from project instance. 

### DIFF
--- a/lib/Project.js
+++ b/lib/Project.js
@@ -18,7 +18,7 @@ module.exports = function(S) {
       this._class = 'Project';
 
       // Default properties
-      this.name      = 'serverless' + S.utils.generateShortId(6);
+      this.name      = null;
       this.custom    = {};
       this.functions = {};
       this.stages    = {};


### PR DESCRIPTION
Now project name check on `project init` and `project create` work again as expected.