### PR TITLE
Handle error case where the failed function is undefined

### DIFF
--- a/lib/actions/FunctionDeploy.js
+++ b/lib/actions/FunctionDeploy.js
@@ -322,8 +322,8 @@ module.exports = function(SPlugin, serverlessPath) {
               if (!_this.failed)         _this.failed = {};
               if (!_this.failed[region]) _this.failed[region] = [];
               _this.failed[region].push({
-                function:   func.name,
-                sPath:      func._config.sPath,
+                function:   func ? func.name : null,
+                sPath:      func ? func._config.sPath : null,
                 message:    e.message,
                 stack:      e.stack
               });


### PR DESCRIPTION
Here's a small fix to avoid Serverless throwing ugly errors when deploying a function fails and func is undefined.