### PR TITLE
Backport 0.5 VPC support

### DIFF
--- a/lib/actions/CodeDeployLambda.js
+++ b/lib/actions/CodeDeployLambda.js
@@ -229,7 +229,11 @@ module.exports   = function(SPlugin, serverlessPath) {
               Description:  'Serverless Lambda function for project: ' + _this.project.name,
               MemorySize:   _this.function.memorySize,
               Publish:      true, // Required by Serverless Framework & recommended best practice by AWS
-              Timeout:      _this.function.timeout
+              Timeout:      _this.function.timeout,
+              VpcConfig: {
+                SecurityGroupIds: _this.function.vpc ? _this.function.vpc.securityGroupIds : [],
+                SubnetIds:        _this.function.vpc ? _this.function.vpc.subnetIds : []
+              }
             };
 
             return _this.Lambda.createFunctionPromised(params)
@@ -252,7 +256,11 @@ module.exports   = function(SPlugin, serverlessPath) {
               Handler:      _this.function.handler,
               MemorySize:   _this.function.memorySize,
               Role:         _this.function.customRole ? _this.function.customRole : _this.meta.stages[_this.evt.options.stage].regions[_this.evt.options.region].variables.iamRoleArnLambda,
-              Timeout:      _this.function.timeout
+              Timeout:      _this.function.timeout,
+              VpcConfig: {
+                SecurityGroupIds: _this.function.vpc ? _this.function.vpc.securityGroupIds : [],
+                SubnetIds:        _this.function.vpc ? _this.function.vpc.subnetIds : []
+              }
             };
 
             return _this.Lambda.updateFunctionConfigurationPromised(params)


### PR DESCRIPTION
Simple port of VPC support from 0.5 to 0.4.2 to support use of RDS (postgres) with lambda.
