### PR TITLE
Fixes ProjectInit logging; fixes #857

### DIFF
--- a/lib/actions/FunctionLogs.js
+++ b/lib/actions/FunctionLogs.js
@@ -110,7 +110,7 @@ module.exports = function(S) {
           throw new SError(`You must be in a function folder to run this command`);
         }
 
-        this.evt.options.name = process.cwd().split(path.sep)[process.cwd().split(path.sep).length - 1];
+        this.evt.options.name = SUtils.readFileSync(path.join(process.cwd(), 's-function.json')).name;
       }
 
       if (!S.cli && !this.evt.options.name) throw new SError(`Please provide a function name as a parameter`);

--- a/lib/actions/ProjectInit.js
+++ b/lib/actions/ProjectInit.js
@@ -108,7 +108,10 @@ module.exports   = function(S) {
 
       // Skip if name is provided, or project exists
       if (_this.evt.options.name) return BbPromise.resolve();
-      if (S.hasProject()) return BbPromise.resolve();
+      if (S.hasProject()) {
+        _this.evt.options.name = S.getProject().getName();
+        return BbPromise.resolve();
+      }
 
       name = _this.evt.options.name ? _this.evt.options.name : ('serverless-' + S.utils.generateShortId(6)).toLowerCase();
 


### PR DESCRIPTION
Fixes ProjectInit logging:
![screen shot 2016-03-23 at 4 07 25 pm](https://cloud.githubusercontent.com/assets/439309/13980554/d8789c64-f111-11e5-90eb-9033cd7e1b49.png)

Fixes #857, when run `sls function logs` within a function folder and the function name is different from its folder name. 