### PR TITLE
Allow responseTemplate values to *also* be objects...

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -503,7 +503,7 @@ module.exports = function(S) {
      such, this method enables the string to validly be of a different type.  In this expansion, an object.
      */
 
-    _prepareRequestTemplates(requestTemplates) {
+    _prepareTemplates(requestTemplates) {
       let ret = {};
       for (let property in requestTemplates) {
         if (requestTemplates.hasOwnProperty(property)) {
@@ -548,7 +548,7 @@ module.exports = function(S) {
         credentials:            null,
         integrationHttpMethod:  'POST',
         requestParameters:      _this.endpoint.requestParameters || {},
-        requestTemplates:       _this._prepareRequestTemplates(_this.endpoint.requestTemplates),
+        requestTemplates:       _this._prepareTemplates(_this.endpoint.requestTemplates),
         uri:                    'arn:aws:apigateway:' // Make ARN for apigateway - lambda
         + _this.evt.options.region
         + ':lambda:path/2015-03-31/functions/arn:aws:lambda:'
@@ -673,7 +673,7 @@ module.exports = function(S) {
           let responseParameters = thisResponse.responseParameters || {};
 
           // Add Response Templates
-          let responseTemplates  = thisResponse.responseTemplates || {};
+          let responseTemplates  = _this._prepareTemplates(thisResponse.responseTemplates);
 
           // Add SelectionPattern
           let selectionPattern   = thisResponse.selectionPattern || (responseKey === 'default' ? null : responseKey);


### PR DESCRIPTION
…Just like requestTemplates.  In fact, using the same logic.

Should we also do this with response models?  Not sure how to use that one.  Future [dev] can do that!