### PR TITLE
[feature] Universal json request template

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -7,26 +7,34 @@ const SError            = require('./Error'),
   _                     = require('lodash');
 
 
-// Universal velocity template from http://kennbrodhagen.net/2015/12/06/how-to-create-a-request-object-for-your-lambda-event-from-api-gateway/
-// provides `{body, headers, method, params, query} = event` as js objects
-const DEFAULT_JSON_REQUEST_TEMPLATE = `{
+// Universal velocity template
+// provides `{body, method, path, querystring, header, context, stageVariables} = event` as js objects
+const DEFAULT_JSON_REQUEST_TEMPLATE = `
+#macro( loop $map )
+  #set( $i = 0 ) ## manual counter because $foreach.hasNext is broken for nested loops
+  #foreach($key in $map.keySet())
+      #set( $i = $i + 1 )
+      #set( $value = $map.get($key) )
+      "$key": 
+        #if( $value[0] ) ## test for a string
+          "$util.escapeJavaScript($value)"
+        #else ## value is a map
+          {
+            #set( $ii = $i ) ## saving counter
+            #loop( $value )  ## because recursive macro breaks it
+            #set( $i = $ii )
+          }
+        #end
+        
+        #if( $i < $map.keySet().size() ) , #end
+  #end
+#end
+{
   "body": $input.path("$"),
-  "headers": {
-    #foreach($header in $input.params().header.keySet())
-      "$header": "$util.escapeJavaScript($input.params().header.get($header))" #if($foreach.hasNext),#end
-    #end
-  },
   "method": "$context.httpMethod",
-  "params": {
-    #foreach($param in $input.params().path.keySet())
-      "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
-    #end
-  },
-  "query": {
-    #foreach($queryParam in $input.params().querystring.keySet())
-      "$queryParam": "$util.escapeJavaScript($input.params().querystring.get($queryParam))" #if($foreach.hasNext),#end
-    #end
-  }  
+  #loop( $input.params() ),
+  "context": { #loop( $context ) },
+  "stageVariables": { #loop( $stageVariables ) }
 }`;
 
 

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -8,34 +8,37 @@ const SError            = require('./Error'),
 
 
 // Universal velocity template
-// provides `{body, method, path, querystring, header, context, stageVariables} = event` as js objects
+// provides `{body, method, headers, query, path, identity, stageVariables} = event` as js objects
 const DEFAULT_JSON_REQUEST_TEMPLATE = `
-#macro( loop $map )
-  #set( $i = 0 ) ## manual counter because $foreach.hasNext is broken for nested loops
+#define( $loop )
+  {
   #foreach($key in $map.keySet())
-      #set( $i = $i + 1 )
-      #set( $value = $map.get($key) )
-      "$key": 
-        #if( $value[0] ) ## test for a string
-          "$util.escapeJavaScript($value)"
-        #else ## value is a map
-          {
-            #set( $ii = $i ) ## saving counter
-            #loop( $value )  ## because recursive macro breaks it
-            #set( $i = $ii )
-          }
-        #end
-        
-        #if( $i < $map.keySet().size() ) , #end
+      "$util.escapeJavaScript($key)":
+        "$util.escapeJavaScript($map.get($key))"
+        #if( $foreach.hasNext ) , #end
   #end
+  }
 #end
 {
   "body": $input.json("$"),
   "method": "$context.httpMethod",
-  #loop( $input.params() ),
-  "context": { #loop( $context ) },
-  "stageVariables": { #loop( $stageVariables ) }
-}`;
+  
+  #set( $map = $input.params().header )
+  "headers": $loop,
+  
+  #set( $map = $input.params().querystring )
+  "query": $loop,
+  
+  #set( $map = $input.params().path )
+  "path": $loop,
+  
+  #set( $map = $context.identity )
+  "identity": $loop,
+  
+  #set( $map = $stageVariables )
+  "stageVariables": $loop
+}
+`;
 
 
 module.exports = function(S) {

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -6,6 +6,30 @@ const SError            = require('./Error'),
   fs                    = require('fs'),
   _                     = require('lodash');
 
+
+// Universal velocity template from http://kennbrodhagen.net/2015/12/06/how-to-create-a-request-object-for-your-lambda-event-from-api-gateway/
+// provides `{body, headers, method, params, query} = event` as js objects
+const DEFAULT_JSON_REQUEST_TEMPLATE = `{
+  "body": $input.path("$"),
+  "headers": {
+    #foreach($header in $input.params().header.keySet())
+      "$header": "$util.escapeJavaScript($input.params().header.get($header))" #if($foreach.hasNext),#end
+    #end
+  },
+  "method": "$context.httpMethod",
+  "params": {
+    #foreach($param in $input.params().path.keySet())
+      "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
+    #end
+  },
+  "query": {
+    #foreach($queryParam in $input.params().querystring.keySet())
+      "$queryParam": "$util.escapeJavaScript($input.params().querystring.get($queryParam))" #if($foreach.hasNext),#end
+    #end
+  }  
+}`;
+
+
 module.exports = function(S) {
 
   class Endpoint extends S.classes.Serializer {
@@ -28,7 +52,7 @@ module.exports = function(S) {
       _this.apiKeyRequired = false;
       _this.requestParameters = {};
       _this.requestTemplates = {};
-      _this.requestTemplates['application/json'] = '';
+      _this.requestTemplates['application/json'] = DEFAULT_JSON_REQUEST_TEMPLATE;
       _this.responses = {};
       _this.responses['default'] = {
         statusCode: '200',

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -20,7 +20,7 @@ const DEFAULT_JSON_REQUEST_TEMPLATE = `
   }
 #end
 {
-  "body": $input.json("$"),
+  "body": $input.path("$"),
   "method": "$context.httpMethod",
   
   #set( $map = $input.params().header )

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -30,7 +30,7 @@ const DEFAULT_JSON_REQUEST_TEMPLATE = `
   #end
 #end
 {
-  "body": $input.path("$"),
+  "body": $input.json("$"),
   "method": "$context.httpMethod",
   #loop( $input.params() ),
   "context": { #loop( $context ) },


### PR DESCRIPTION
http://kennbrodhagen.net/2015/12/06/how-to-create-a-request-object-for-your-lambda-event-from-api-gateway/


@ac360 
[AWS GW docs](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html)
I've implemented a template that grabs all data from AWS GW `$input` and passes it as objects within lambda event.
Do we also want to grab by default all the params from `$context` like
```
{
"stage" : "$context.stage",
"request_id" : "$context.requestId",
"api_id" : "$context.apiId",
"resource_path" : "$context.resourcePath",
"resource_id" : "$context.resourceId",
"http_method" : "$context.httpMethod",
"source_ip" : "$context.identity.sourceIp",
"user-agent" : "$context.identity.userAgent",
"account_id" : "$context.identity.accountId",
"api_key" : "$context.identity.apiKey",
"caller" : "$context.identity.caller",
"user" : "$context.identity.user",
"user_arn" : "$context.identity.userArn"
}
```
and also `$stageVariables`