### PR TITLE
Add support for assuming a role like AWS CLI

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -60,23 +60,25 @@ module.exports = function(S) {
      */
 
     request(service, method, params, stage, region, options) {
-
       let _this = this;
-      let awsService = new this.sdk[service](_this.getCredentials(stage, region));
-      let req = awsService[method](params);
+      return this.getCredentials(stage, region)
+        .then(function(credentials) {
+          let awsService = new _this.sdk[service](credentials);
+          let req = awsService[method](params);
 
-      // TODO: Add listeners, put Debug statments here...
-      // req.on('send', function (r) {console.log(r)});
+          // TODO: Add listeners, put Debug statments here...
+          // req.on('send', function (r) {console.log(r)});
 
-      return new BbPromise(function (res, rej) {
-        req.send(function (err, data) {
-          if (err) {
-            rej(err);
-          } else {
-            res(data);
-          }
+          return new BbPromise(function (res, rej) {
+            req.send(function (err, data) {
+              if (err) {
+                rej(err);
+              } else {
+                res(data);
+              }
+            });
+          });
         });
-      });
     }
 
     /**
@@ -135,25 +137,27 @@ module.exports = function(S) {
      */
 
     addProfileCredentialsImpl(credentials, prefix) { // separate profile environment variable prefix from obtaining credentials from the profile.
-      let profile = process.env[prefix + '_PROFILE'],
-        profileCredentials;
+      let profile = process.env[prefix + '_PROFILE'];
       if (profile) {
-        profileCredentials = this.getProfile(profile, true);
-        if (profileCredentials) {
-          if (profileCredentials.aws_access_key_id) {
-            credentials.accessKeyId = profileCredentials.aws_access_key_id;
-          }
-          if (profileCredentials.aws_secret_access_key) {
-            credentials.secretAccessKey = profileCredentials.aws_secret_access_key;
-          }
-          if (profileCredentials.aws_session_token) { // node.js aws-sdk standard
-            credentials.sessionToken = profileCredentials.aws_session_token;
-          }
-          if (profileCredentials.aws_security_token) { // python boto standard
-            credentials.sessionToken = profileCredentials.aws_security_token;
-          }
-        }
+        return this.getProfile(profile, true)
+          .then((profileCredentials) => {
+            if (profileCredentials) {
+              if (profileCredentials.aws_access_key_id) {
+                credentials.accessKeyId = profileCredentials.aws_access_key_id;
+              }
+              if (profileCredentials.aws_secret_access_key) {
+                credentials.secretAccessKey = profileCredentials.aws_secret_access_key;
+              }
+              if (profileCredentials.aws_session_token) { // node.js aws-sdk standard
+                credentials.sessionToken = profileCredentials.aws_session_token;
+              }
+              if (profileCredentials.aws_security_token) { // python boto standard
+                credentials.sessionToken = profileCredentials.aws_security_token;
+              }
+            }
+          });
       }
+      return BbPromise.resolve(null);
     }
 
     /**
@@ -166,7 +170,7 @@ module.exports = function(S) {
       if (this._config.profilePrefix) {
         prefix = this._config.profilePrefix + prefix;
       }
-      this.addProfileCredentialsImpl(credentials, prefix);
+      return this.addProfileCredentialsImpl(credentials, prefix);
     }
 
     /**
@@ -181,26 +185,30 @@ module.exports = function(S) {
 
       stage = stage ? stage.toUpperCase() : null;
 
-      // implicitly already in the config...
+      return BbPromise.resolve(credentials)
 
-      this.addConfigurationCredentials(credentials, S.config);                      // use the given configuration credentials if they are the only available credentials.
-      // first from environment
-      this.addEnvironmentCredentials(credentials, 'AWS');                                 // allow for Amazon standard credential environment variable prefix.
-      this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS');                // but override with more specific credentials if these are also provided.
-      this.addEnvironmentCredentials(credentials, 'AWS_' + stage);                        // and also override these with the Amazon standard *stage specific* credential environment variable prefix.
-      this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage);       // finally override all prior with Serverless prefixed *stage specific* credentials if these are also provided.
-      // next from profile
-      this.addProfileCredentials(credentials, 'AWS');                                     // allow for generic Amazon standard prefix based profile declaration
-      this.addProfileCredentials(credentials, 'SERVERLESS_ADMIN_AWS');                    // allow for generic Serverless standard prefix based profile declaration
-      this.addProfileCredentials(credentials, 'AWS_' + stage);                            // allow for *stage specific* Amazon standard prefix based profile declaration
-      this.addProfileCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage);           // allow for *stage specific* Serverless standard prefix based profile declaration
-      // if they aren't loaded now, the credentials weren't provided by a valid means
+        // implicitly already in the config...
+        .then(() => this.addConfigurationCredentials(credentials, S.config))                      // use the given configuration credentials if they are the only available credentials.
 
-      if (!credentials.accessKeyId || !credentials.secretAccessKey) {
-        throw new SError('Cant find AWS credentials', SError.errorCodes.MISSING_AWS_CREDS);
-      }
+        // first from environment
+        .then(() => this.addEnvironmentCredentials(credentials, 'AWS'))                                 // allow for Amazon standard credential environment variable prefix.
+        .then(() => this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS'))                // but override with more specific credentials if these are also provided.
+        .then(() => this.addEnvironmentCredentials(credentials, 'AWS_' + stage))                        // and also override these with the Amazon standard *stage specific* credential environment variable prefix.
+        .then(() => this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage))       // finally override all prior with Serverless prefixed *stage specific* credentials if these are also provided.
 
-      return credentials;
+        // next from profile
+        .then(() => this.addProfileCredentials(credentials, 'AWS'))                                     // allow for generic Amazon standard prefix based profile declaration
+        .then(() => this.addProfileCredentials(credentials, 'SERVERLESS_ADMIN_AWS'))                    // allow for generic Serverless standard prefix based profile declaration
+        .then(() => this.addProfileCredentials(credentials, 'AWS_' + stage))                            // allow for *stage specific* Amazon standard prefix based profile declaration
+        .then(() => this.addProfileCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage))           // allow for *stage specific* Serverless standard prefix based profile declaration
+        .then(() => {
+
+          // if they aren't loaded now, the credentials weren't provided by a valid means
+          if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+            throw new SError("Cant find AWS credentials", SError.errorCodes.MISSING_AWS_CREDS);
+          }
+          return credentials;
+        });
     }
 
     /**
@@ -295,7 +303,7 @@ module.exports = function(S) {
       if (!optional && !profiles[awsProfile]) {
         throw new SError(`Cant find profile ${profile} in AWS credentials file`, awsProfile);
       }
-      return profiles[awsProfile];
+      return BbPromise.resolve(profiles[awsProfile]);
     }
 
     getLambdasStackName(stage, projectName) {

--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -210,8 +210,7 @@ module.exports = function(S) {
 
     saveCredentials(accessKeyId, secretKey, profileName, stage) {
 
-      let configDir = this.getConfigDir(),
-        credsPath = path.join(configDir, 'credentials');
+      let configDir = this.getConfigDir();
 
       // Create ~/.aws folder if does not exist
       if (!S.utils.dirExistsSync(configDir)) {
@@ -222,9 +221,9 @@ module.exports = function(S) {
 
       S.utils.sDebug('Setting new AWS profile:', profileName);
 
-      // Write to ~/.aws/credentials
+      // Write to AWS credentials file.
       fs.appendFileSync(
-        credsPath,
+        this.getAwsCredentialsFile(),
         os.EOL + '[' + profileName + ']' + os.EOL +
         'aws_access_key_id=' + accessKeyId + os.EOL +
         'aws_secret_access_key=' + secretKey + os.EOL);
@@ -248,12 +247,36 @@ module.exports = function(S) {
     }
 
     /**
+     * Get the path to the AWS credentials file
+     */
+    getAwsCredentialsFile() {
+      if (process.env.AWS_SHARED_CREDENTIALS_FILE) {
+        return process.env.AWS_SHARED_CREDENTIALS_FILE;
+      }
+
+      let configDir = this.getConfigDir();
+      return path.join(configDir, 'credentials');
+    }
+
+    /**
+     * Get the path to the AWS config file
+     */
+    getAwsConfigFile() {
+      if (process.env.AWS_CONFIG_FILE) {
+        return process.env.AWS_CONFIG_FILE;
+      }
+
+      let configDir = this.getConfigDir();
+      return path.join(configDir, 'config');
+    }
+
+    /**
      * Get All Profiles
-     * - Gets all profiles from ~/.aws/credentials
+     * - Gets all profiles from AWS credentials file.
      */
 
     getAllProfiles() {
-      let credsPath = path.join(this.getConfigDir(), 'credentials');
+      let credsPath = this.getAwsCredentialsFile();
       try {
         return AWS.util.ini.parse(AWS.util.readFileSync(credsPath));
       }
@@ -264,13 +287,13 @@ module.exports = function(S) {
 
     /**
      * Get Profile
-     * - Gets a single profile from ~/.aws/credentials
+     * - Gets a single profile from AWS credentials file.
      */
 
     getProfile(awsProfile, optional) {
       let profiles = this.getAllProfiles();
       if (!optional && !profiles[awsProfile]) {
-        throw new SError(`Cant find profile ${profile} in ~/.aws/credentials`, awsProfile);
+        throw new SError(`Cant find profile ${profile} in AWS credentials file`, awsProfile);
       }
       return profiles[awsProfile];
     }

--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -142,23 +142,10 @@ module.exports = function(S) {
       if (profile) {
         return this.getProfile(profile, true)
           .then((profileCredentials) => {
-            if (profileCredentials) {
-              if (profileCredentials.aws_access_key_id) {
-                credentials.accessKeyId = profileCredentials.aws_access_key_id;
-              }
-              if (profileCredentials.aws_secret_access_key) {
-                credentials.secretAccessKey = profileCredentials.aws_secret_access_key;
-              }
-              if (profileCredentials.aws_session_token) { // node.js aws-sdk standard
-                credentials.sessionToken = profileCredentials.aws_session_token;
-              }
-              if (profileCredentials.aws_security_token) { // python boto standard
-                credentials.sessionToken = profileCredentials.aws_security_token;
-              }
-            }
+            _.assign(credentials, profileCredentials || {});
           });
       } else {
-          return BbPromise.resolve(null);
+        return BbPromise.resolve(null);
       }
     }
 
@@ -331,15 +318,47 @@ module.exports = function(S) {
       let profiles = this.getAllProfiles();
       let profileConfig = profiles[awsProfile];
 
-      if (!optional && !profileConfig) {
-        throw new SError(`Cant find profile ${awsProfile} in AWS credential file and/or AWS config file`, awsProfile);
+      if (!profileConfig) {
+        if (optional) {
+          return BbPromise.resolve(null);
+        } else {
+          throw new SError(`Cant find profile ${awsProfile} in AWS credential file and/or AWS config file`, awsProfile);
+        }
       }
 
-      if (profileConfig && profileConfig.source_profile && profileConfig.role_arn) {
-        return this.getRoleCredentials(awsProfile, profiles);
-      } else {
-        return BbPromise.resolve(profileConfig);
-      }
+      var isRoleProfile = (
+        profileConfig.source_profile &&
+        profileConfig.role_arn
+      );
+
+      var getCredentials =
+        isRoleProfile ? this.getRoleCredentials(awsProfile, profiles)
+                      : BbPromise.resolve(profileConfig);
+
+      return getCredentials
+        .then(this.canonicalizeProfileCredentials);
+    }
+
+    /**
+     * Translate an object that holds credentials in "profile format" - i.e.
+     * populated by profile entries in AWS config files - into
+     * the credentials format used by the AWS SDK.  Any credentials already in
+     * the SDK format are preserved.
+     */
+    canonicalizeProfileCredentials(credentials) {
+      let result = {};
+
+      result.accessKeyId = credentials.accessKeyId
+        || credentials.aws_access_key_id;
+
+      result.secretAccessKey = credentials.secretAccessKey
+        || credentials.aws_secret_access_key;
+
+      result.sessionToken = credentials.sessionToken
+        || credentials.aws_session_token
+        || credentials.aws_security_token; // python boto standard
+
+      return _.omitBy(result, _.isNil);
     }
 
     /**
@@ -349,13 +368,17 @@ module.exports = function(S) {
     getRoleCredentials(profile, profiles) {
       const sourceProfile = profiles[profile].source_profile;
       const roleArn = profiles[profile].role_arn;
-      const sourceProfileCredentials = profiles[sourceProfile];
+      let sourceProfileCredentials = profiles[sourceProfile];
       if (!sourceProfileCredentials) {
         throw new SError(`Cant find source profile ${sourceProfile} in AWS credential file and/or AWS config file`, sourceProfile);
       }
 
-      const sourceAccessKeyId = sourceProfileCredentials.aws_access_key_id;
-      const sourceSecretAccessKey = sourceProfileCredentials.aws_secret_access_key;
+      sourceProfileCredentials = this.canonicalizeProfileCredentials(sourceProfileCredentials);
+
+      const sourceAccessKeyId = sourceProfileCredentials.accessKeyId;
+      const sourceSecretAccessKey = sourceProfileCredentials.secretAccessKey;
+      const sourceSessionToken = sourceProfileCredentials.sessionToken;
+
       if (!(sourceAccessKeyId && sourceSecretAccessKey)) {
         throw new SError(`Cant find credentials for source profile ${sourceProfile} in AWS credential file and/or AWS config file`, sourceProfile);
       }
@@ -364,6 +387,9 @@ module.exports = function(S) {
         accessKeyId: sourceAccessKeyId,
         secretAccessKey: sourceSecretAccessKey,
       };
+      if (sourceSessionToken) {
+        stsConfig[sessionToken] = sourceSessionToken;
+      }
 
       const STS = BbPromise.promisifyAll(new AWS.STS(stsConfig));
 

--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -383,13 +383,15 @@ module.exports = function(S) {
         throw new SError(`Cant find credentials for source profile ${sourceProfile} in AWS credential file and/or AWS config file`, sourceProfile);
       }
 
-      const stsConfig = {
+      const stsCredentials = {
         accessKeyId: sourceAccessKeyId,
         secretAccessKey: sourceSecretAccessKey,
       };
       if (sourceSessionToken) {
-        stsConfig[sessionToken] = sourceSessionToken;
+        stsCredentials[sessionToken] = sourceSessionToken;
       }
+
+      const stsConfig = _.assign(AWS.config, stsCredentials);
 
       const STS = BbPromise.promisifyAll(new AWS.STS(stsConfig));
 

--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -157,8 +157,9 @@ module.exports = function(S) {
               }
             }
           });
+      } else {
+          return BbPromise.resolve(null);
       }
-      return BbPromise.resolve(null);
     }
 
     /**
@@ -186,16 +187,16 @@ module.exports = function(S) {
 
       stage = stage ? stage.toUpperCase() : null;
 
+      // implicitly already in the config...
+
+      this.addConfigurationCredentials(credentials, S.config);                      // use the given configuration credentials if they are the only available credentials.
+      // first from environment
+      this.addEnvironmentCredentials(credentials, 'AWS');                                 // allow for Amazon standard credential environment variable prefix.
+      this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS');                // but override with more specific credentials if these are also provided.
+      this.addEnvironmentCredentials(credentials, 'AWS_' + stage);                        // and also override these with the Amazon standard *stage specific* credential environment variable prefix.
+      this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage);       // finally override all prior with Serverless prefixed *stage specific* credentials if these are also provided.
+
       return BbPromise.resolve(credentials)
-
-        // implicitly already in the config...
-        .then(() => this.addConfigurationCredentials(credentials, S.config))                      // use the given configuration credentials if they are the only available credentials.
-
-        // first from environment
-        .then(() => this.addEnvironmentCredentials(credentials, 'AWS'))                                 // allow for Amazon standard credential environment variable prefix.
-        .then(() => this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS'))                // but override with more specific credentials if these are also provided.
-        .then(() => this.addEnvironmentCredentials(credentials, 'AWS_' + stage))                        // and also override these with the Amazon standard *stage specific* credential environment variable prefix.
-        .then(() => this.addEnvironmentCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage))       // finally override all prior with Serverless prefixed *stage specific* credentials if these are also provided.
 
         // next from profile
         .then(() => this.addProfileCredentials(credentials, 'AWS'))                                     // allow for generic Amazon standard prefix based profile declaration

--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -8,7 +8,8 @@ const SError       = require('./Error'),
   url              = require('url'),
   fs               = require('fs'),
   fse              = require('fs-extra'),
-  os               = require('os');
+  os               = require('os'),
+  guid             = require('./utils/guid');
 
 // Load AWS Globally for the first time
 const AWS          = require('aws-sdk');
@@ -280,30 +281,107 @@ module.exports = function(S) {
 
     /**
      * Get All Profiles
-     * - Gets all profiles from AWS credentials file.
+     * - Gets all profiles from AWS credentials, config file
      */
 
     getAllProfiles() {
       let credsPath = this.getAwsCredentialsFile();
+      let configPath = this.getAwsConfigFile();
+
+      let creds;
       try {
-        return AWS.util.ini.parse(AWS.util.readFileSync(credsPath));
+        creds = AWS.util.ini.parse(AWS.util.readFileSync(credsPath));
       }
       catch (e) {
-        return null;
+        creds = {};
       }
+
+      let configs;
+      try {
+        configs = AWS.util.ini.parse(AWS.util.readFileSync(configPath));
+      }
+      catch (e) {
+        configs = {};
+      }
+
+      // First, load up all profile from config file.
+      var profiles = Object.keys(configs).reduce((obj, key) => {
+        const match = key.match(/^profile (.+)/);
+        if (match) {
+          obj[match[1]] = configs[key];
+        }
+        return obj;
+      }, {});
+
+      // Now, load profiles from credentials file (overriding any values found in config file)
+      Object.keys(creds).forEach((name) => {
+        profiles[name] = Object.assign(profiles[name] || {}, creds[name]);
+      });
+
+      return profiles;
     }
 
     /**
      * Get Profile
-     * - Gets a single profile from AWS credentials file.
+     * - Gets a single profile from AWS credentials, config files.
      */
 
     getProfile(awsProfile, optional) {
       let profiles = this.getAllProfiles();
-      if (!optional && !profiles[awsProfile]) {
-        throw new SError(`Cant find profile ${profile} in AWS credentials file`, awsProfile);
+      let profileConfig = profiles[awsProfile];
+
+      if (!optional && !profileConfig) {
+        throw new SError(`Cant find profile ${awsProfile} in AWS credential file and/or AWS config file`, awsProfile);
       }
-      return BbPromise.resolve(profiles[awsProfile]);
+
+      if (profileConfig && profileConfig.source_profile && profileConfig.role_arn) {
+        return this.getRoleCredentials(awsProfile, profiles);
+      } else {
+        return BbPromise.resolve(profileConfig);
+      }
+    }
+
+    /**
+     * Get Role Credentials
+     * - Gets temporary credentials via assuming a role
+     */
+    getRoleCredentials(profile, profiles) {
+      const sourceProfile = profiles[profile].source_profile;
+      const roleArn = profiles[profile].role_arn;
+      const sourceProfileCredentials = profiles[sourceProfile];
+      if (!sourceProfileCredentials) {
+        throw new SError(`Cant find source profile ${sourceProfile} in AWS credential file and/or AWS config file`, sourceProfile);
+      }
+
+      const sourceAccessKeyId = sourceProfileCredentials.aws_access_key_id;
+      const sourceSecretAccessKey = sourceProfileCredentials.aws_secret_access_key;
+      if (!(sourceAccessKeyId && sourceSecretAccessKey)) {
+        throw new SError(`Cant find credentials for source profile ${sourceProfile} in AWS credential file and/or AWS config file`, sourceProfile);
+      }
+
+      const stsConfig = {
+        accessKeyId: sourceAccessKeyId,
+        secretAccessKey: sourceSecretAccessKey,
+      };
+
+      const STS = BbPromise.promisifyAll(new AWS.STS(stsConfig));
+
+      const assumeRoleParams = {
+        RoleArn: roleArn,
+        RoleSessionName: profile+"-"+guid(),
+      };
+
+      return STS.assumeRoleAsync(assumeRoleParams)
+        .then((res) => {
+          return {
+            aws_access_key_id: res.Credentials.AccessKeyId,
+            aws_secret_access_key: res.Credentials.SecretAccessKey,
+            aws_session_token: res.Credentials.SessionToken
+          };
+        })
+        .catch((e) => {
+          throw new SError(`Failed to assume role ${roleArn}: ${e}`, roleArn, e);
+        });
     }
 
     getLambdasStackName(stage, projectName) {

--- a/lib/utils/context.js
+++ b/lib/utils/context.js
@@ -1,12 +1,4 @@
-function guid() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-        .toString(16)
-        .substring(1);
-  }
-
-  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
-}
+const guid = require('./guid');
 
 /**
  *

--- a/lib/utils/guid.js
+++ b/lib/utils/guid.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+        .toString(16)
+        .substring(1);
+  }
+
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+}


### PR DESCRIPTION
The AWS CLI allows you to have a profile that assumes a role when invoking commands, via a separate profile that you have configured:

  http://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html

e.g. I might have an ~/aws/credentials file that looks like:

```
[bob]
aws_access_key_id=XXXXXXX
aws_secret_access_key=XXXXX
```

and an ~/.aws/config file that looks like:
```
...
[profile bob]
region = us-east-1

[profile client_project_a]
role_arn = arn:aws:iam::012345678901:role/admin
source_profile=bob

[profile client_project_b]
role_arn = arn:aws:iam::012345678901:role/admin
source_profile=bob
```

This pull request adds support to serverless to make the necessary STS calls when the specified profile is a "role profile".

It also modified the credentials lookup so that it pays attention to the AWS_SHARED_CREDENTIALS_FILE and AWS_CONFIG_FILE environment variables, as specified here:

http://docs.aws.amazon.com/cli/latest/topic/config-vars.html