### PR TITLE
Fix CloudWatch events target

### DIFF
--- a/lib/actions/EventLambdaSchedule.js
+++ b/lib/actions/EventLambdaSchedule.js
@@ -107,7 +107,7 @@ module.exports = function (S) {
           };
 
           if (populatedEvent.config.input) {
-            params.Targets[0].input = JSON.stringify(populatedEvent.config.input);
+            params.Targets[0].Input = JSON.stringify(populatedEvent.config.input);
           }
           return _this.aws.request('CloudWatchEvents', 'putTargets', params, _this.evt.options.stage, _this.evt.options.region);
         });


### PR DESCRIPTION
Fixes `Unexpected key 'input' found in params.Targets[0]`.