### PR TITLE
v0.5 sls function remove is not using the correct endpoint name

### DIFF
--- a/lib/actions/FunctionRemove.js
+++ b/lib/actions/FunctionRemove.js
@@ -198,7 +198,7 @@ module.exports = function(S) {
           options: {
             stage,
             region,
-            names:  _.map(func.getAllEndpoints(), (e) => e.path + '#' + e.method)
+            names:  _.map(func.getAllEndpoints(), (e) => e.path + '~' + e.method)
           }
         })
         .then(() => {


### PR DESCRIPTION
Here is a fix for issue #925.