### PR TITLE
Fixes 'file already exists' on install

### DIFF
--- a/lib/actions/ProjectInstall.js
+++ b/lib/actions/ProjectInstall.js
@@ -164,7 +164,7 @@ module.exports = function(S) {
         .then(() => fse.copyAsync(S.getServerlessPath('templates', 'nodejs', 'package.json'), path.join(tmpDir, 'package.json')))
         .then(() => BbPromise.fromCallback(cb => exec('npm install ' + projName, cb)))
         .then(() => fse.moveAsync(path.join(tmpDir, 'node_modules', projName), path.join(userCwd, projName)))
-        .then(() => fse.moveAsync(path.join(tmpDir, 'node_modules'), path.join(userCwd, projName, 'node_modules')))
+        .then(() => fse.copyAsync(path.join(tmpDir, 'node_modules'), path.join(userCwd, projName, 'node_modules')))
         .then(() => process.chdir(userCwd))
         .then(() => fse.removeAsync(tmpDir));
     }


### PR DESCRIPTION
This PR is intended to fix the error `EEXIST: file already exists` when running `serverless project install ...`.

This changes a move operation into a copy in _installNpmProject(), because the destination directory was already created. This should have no adverse effects since the copied files are later removed.

This is the error I currently see on a new project install:
```
$ serverless project install serverless-authentication-boilerplate
 _______                             __
|   _   .-----.----.--.--.-----.----|  .-----.-----.-----.
|   |___|  -__|   _|  |  |  -__|   _|  |  -__|__ --|__ --|
|____   |_____|__|  \___/|_____|__| |__|_____|_____|_____|
|   |   |             The Serverless Application Framework
|       |                           serverless.com, v0.5.2
`-------'

Serverless: Installing Serverless Project "serverless-authentication-boilerplate"...
Serverless: Downloading project and installing dependencies...
{ [Error: EEXIST: file already exists, link '/var/folders/h1/87dmvrjd1h99lj75531kflj00000gn/T/__sls_project_install_serverless-authentication-boilerplate_1459546861754/node_modules' -> '/Users/joe/Projects/serverless-authentication-boilerplate/node_modules']
  cause:
   { [Error: EEXIST: file already exists, link '/var/folders/h1/87dmvrjd1h99lj75531kflj00000gn/T/__sls_project_install_serverless-authentication-boilerplate_1459546861754/node_modules' -> '/Users/joe/Projects/serverless-authentication-boilerplate/node_modules']
     errno: -17,
     code: 'EEXIST',
     syscall: 'link',
     path: '/var/folders/h1/87dmvrjd1h99lj75531kflj00000gn/T/__sls_project_install_serverless-authentication-boilerplate_1459546861754/node_modules',
     dest: '/Users/joe/Projects/serverless-authentication-boilerplate/node_modules' },
  isOperational: true,
  errno: -17,
  code: 'EEXIST',
  syscall: 'link',
  path: '/var/folders/h1/87dmvrjd1h99lj75531kflj00000gn/T/__sls_project_install_serverless-authentication-boilerplate_1459546861754/node_modules',
  dest: '/Users/joe/Projects/serverless-authentication-boilerplate/node_modules' }
```
