### PR TITLE
Fix #490: Connection timed out after 120000ms in function deployment

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -32,6 +32,12 @@ module.exports = function(S) {
         AWS.config.httpOptions.agent = new httpsProxyAgent(proxyOptions);
       }
 
+      // Configure the AWS Client timeout (Optional).  The default is 120000 (2 minutes)
+      let timeout = process.env.AWS_CLIENT_TIMEOUT || process.env.aws_client_timeout;
+      if (timeout) {
+        AWS.config.httpOptions.timeout = parseInt(timeout, 10);
+      }
+
       // Detect Profile Prefix. Useful for multiple projects (e.g., myproject_prod)
       this._config.profilePrefix = process.env['AWS_PROFILE_PREFIX'] ? process.env['AWS_PROFILE_PREFIX'] : null;
       if (this._config.profilePrefix && this._config.profilePrefix.charAt(this._config.profilePrefix.length - 1) !== '_') {


### PR DESCRIPTION
This allows users to work around a network with a slow upload speed by setting the `AWS_CLIENT_TIMEOUT` environment variable to something greater than 120000 (2 minutes).  If found, it sets the `AWS.client.httpOptions.timeout` value.

It follows the existing convention set by looking for `HTTP_PROXY/HTTPS_PROXY` in the environment.