### PR TITLE
Fixing handling for profiles with uppercase characters

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -262,12 +262,11 @@ module.exports = function(S) {
      */
 
     getProfile(awsProfile, optional) {
-      let profile = awsProfile.toLowerCase(),
-        profiles = this.getAllProfiles();
-      if (!optional && !profiles[profile]) {
-        throw new SError(`Cant find profile ${profile} in ~/.aws/credentials`, profile);
+      let profiles = this.getAllProfiles();
+      if (!optional && !profiles[awsProfile]) {
+        throw new SError(`Cant find profile ${profile} in ~/.aws/credentials`, awsProfile);
       }
-      return profiles[profile];
+      return profiles[awsProfile];
     }
 
     getLambdasStackName(stage, projectName) {


### PR DESCRIPTION
Currently, getProfile() changes the profile name given to lowercase. If the profile name was stored with uppercase characters elsewhere (i.e. in the ~/.aws/credentials file), then this prevents a match.

This PR removes the code that changes the profile name provided to lowercase. This effectively makes the profile name case sensitive and the case must match between Serverless config files and the AWS config files.

This change could break existing installations if the profile name is stored as lowercase in the AWS credentials file but stored with mixed case in Serverless config files. An alternative fix would be to change all profile names to lowercase when loaded from the AWS credentials file.
