### PR TITLE
950 added apig proxy support

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -20,7 +20,8 @@ module.exports = function(S) {
     SError     = require(S.getServerlessPath('Error')),
     BbPromise  = require('bluebird'),
     async      = require('async'),
-    fs         = BbPromise.promisifyAll(require('fs'));
+    fs         = BbPromise.promisifyAll(require('fs')),
+    _          = require('lodash');
 
   class EndpointBuildApiGateway extends S.classes.Plugin {
 
@@ -170,6 +171,9 @@ module.exports = function(S) {
       if (!_this.endpoint.responses) {
         throw new SError('Endpoint does not have a "responses" property');
       }
+      if (_this.endpoint.type === 'HTTP' && (!_this.endpoint.uri || !_this.endpoint.targetMethod)) {
+        throw new SError('Proxy endpoints need an "uri" property.');
+      }
 
       // Sanitize path - Remove excessive forward slashes
       if (_this.endpoint.path.charAt(0) !== '/') _this.endpoint.path = '/' + _this.endpoint.path;
@@ -215,6 +219,20 @@ module.exports = function(S) {
         FunctionName: _this.functionName,
         Qualifier:    _this.evt.options.stage
       };
+
+      // Skip endpoint search for MOCK and HTTP endpoint types
+      if (_.includes(['MOCK', 'HTTP'], _this.endpoint.type)) {
+        SUtils.sDebug(
+            '"'
+            + _this.evt.options.stage
+            + ' - '
+            + _this.evt.options.region
+            + ' - '
+            + _this.endpoint
+            + '": Skipped fetch Lambda');
+
+        return BbPromise.resolve();
+      }
 
       return _this.aws.request('Lambda', 'getFunction', params, _this.evt.options.stage, _this.evt.options.region)
         .then(function(data) {
@@ -546,21 +564,28 @@ module.exports = function(S) {
         // Once API Gateway is fixed, we can use this in credentials:
         // _this._regionJson.iamRoleArnApiGateway
         credentials:            _this.endpoint.credentials || null,
-        integrationHttpMethod:  'POST',
         requestParameters:      _this.endpoint.requestParameters || {},
-        requestTemplates:       _this._prepareTemplates(_this.endpoint.requestTemplates),
-        uri:                    'arn:aws:apigateway:' // Make ARN for apigateway - lambda
-        + _this.evt.options.region
-        + ':lambda:path/2015-03-31/functions/arn:aws:lambda:'
-        + _this.evt.options.region
-        + ':'
-        + _this.awsAccountNumber
-        + ':function:'
-        + _this.deployedLambda.FunctionName
-        + ':'
-        + alias
-        + '/invocations'
+        requestTemplates:       _this._prepareTemplates(_this.endpoint.requestTemplates)
       };
+
+      // For proxy endpoints overwrite the uri
+      if (params.type === 'HTTP') {
+        params.uri = _this.endpoint.uri;
+        params.integrationHttpMethod = _this.endpoint.targetMethod;
+      } else {
+        params.uri = 'arn:aws:apigateway:' // Make ARN for apigateway - lambda
+          + _this.evt.options.region
+          + ':lambda:path/2015-03-31/functions/arn:aws:lambda:'
+          + _this.evt.options.region
+          + ':'
+          + _this.awsAccountNumber
+          + ':function:'
+          + _this.deployedLambda.FunctionName
+          + ':'
+          + alias
+          + '/invocations';
+        params.integrationHttpMethod = 'POST';
+      }
 
       // Create Integration
       return _this.aws.request('APIGateway', 'putIntegration', params, _this.evt.options.stage, _this.evt.options.region)

--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -569,10 +569,14 @@ module.exports = function(S) {
       };
 
       // For proxy endpoints overwrite the uri
-      if (params.type === 'HTTP') {
+      switch (params.type) {
+      case 'HTTP':
         params.uri = _this.endpoint.uri;
         params.integrationHttpMethod = _this.endpoint.targetMethod;
-      } else {
+        break;
+      case 'MOCK':
+        break;
+      default:
         params.uri = 'arn:aws:apigateway:' // Make ARN for apigateway - lambda
           + _this.evt.options.region
           + ':lambda:path/2015-03-31/functions/arn:aws:lambda:'


### PR DESCRIPTION
Fixed issues #517 and #950 .

HTTP proxy endpoints can now be specified like this in `s-function.json`:

```
  "endpoints": [
    {
      ...
      "type": "HTTP",
      "uri": "https://www.google.com",
      "targetMethod": "GET",
      ...
    }
  ]
```

The creation of HTTP will bail out if `uri` or `targetMethod` are missing.
All other endpoint properties continue to work as expected.