### PR TITLE
use templates in subfolder without templates in function root

### DIFF
--- a/lib/Serializer.js
+++ b/lib/Serializer.js
@@ -215,13 +215,11 @@ module.exports = function(S) {
           // Load Templates
           let templatesFilePath = func.getRootPath('s-templates.json');
 
-          if (S.utils.fileExistsSync(templatesFilePath)) {
-            let template = new S.classes.Templates({}, templatesFilePath);
-            return template.load()
-              .then(function (template) {
-                func.setTemplate(template);
-              });
-          }
+          let template = new S.classes.Templates({}, templatesFilePath);
+          return template.load()
+            .then(function (template) {
+              func.setTemplate(template);
+            });
         })
         .then(function () {
           return func;
@@ -427,7 +425,10 @@ module.exports = function(S) {
           if (!S.hasProject()) throw new SError('Templates could not be loaded because no project path has been set on Serverless instance');
 
           // Set Data
-          templates.fromObject(S.utils.readFileSync(templates.getFilePath()));
+          const templateFilePath = templates.getFilePath();
+          if (S.utils.fileExistsSync(templateFilePath)) {
+            templates.fromObject(S.utils.readFileSync(templateFilePath));
+          }
         })
         .then(function () {
 


### PR DESCRIPTION
It looks like that `<function root>/s-templates.json` is required to use definitions in `<function subfolder>/s-templates.json` as following.

```
project/
  s-project.json
  s-templates.json
  subfolder/
    s-templates.json
    get/
      s-function.json # use `project/s-templates.json`, `project/subfolder/s-templates.json` and `project/subfolder/get/s-templates.json`
      s-templates.json
    post/
      s-function.json # use `project/s-templates.json` only
```

Workaround is to place empty json file as `<function root>/s-templates.json` but I tried to avoid it.
This PR makes it possibles to use `<function subfolder>/s-templates.json` without `<function root>/s-templates.json`.