### PR TITLE
Allow topicArn config for sns event instead of topicName

### DIFF
--- a/lib/actions/EventLambdaSNS.js
+++ b/lib/actions/EventLambdaSNS.js
@@ -49,8 +49,10 @@ module.exports = function(S) {
           functionName   = event.getFunction().getDeployedName(_this.evt.options),
           statementId    = 'sEvents-' + functionName + '-' + event.name + '-' + _this.evt.options.stage,
           awsAccountId   = _this.aws.getAccountId(_this.evt.options.stage, _this.evt.options.region),
-          topicArn       = 'arn:aws:sns:' + _this.evt.options.region + ':' + awsAccountId + ':' + populatedEvent.config.topicName,
-          lambdaArn      = 'arn:aws:lambda:' + _this.evt.options.region + ':' + awsAccountId + ':function:' + functionName + ':' + _this.evt.options.stage;
+          lambdaArn      = 'arn:aws:lambda:' + _this.evt.options.region + ':' + awsAccountId + ':function:' + functionName + ':' + _this.evt.options.stage,
+          topic          = populatedEvent.config.topic || populatedEvent.config.topicName,
+          topicArn       = topic && topic.indexOf('arn:') === 0 ? topic : ('arn:aws:sns:' + _this.evt.options.region + ':' + awsAccountId + ':' + topic),
+          topicRegion    = /arn:aws:sns:(.*):(.*):(.*)/.exec(topicArn)[1];
 
       let params = {
         FunctionName: lambdaArn,
@@ -81,7 +83,7 @@ module.exports = function(S) {
             TopicArn: topicArn,
             Endpoint: lambdaArn
           };
-          return _this.aws.request('SNS', 'subscribe', params, _this.evt.options.stage, _this.evt.options.region)
+          return _this.aws.request('SNS', 'subscribe', params, _this.evt.options.stage, topicRegion)
         })
         .then(function(data){
           SUtils.sDebug(`Subscription to SNS topic ${topicArn} added for lambda ${lambdaArn}`);

--- a/lib/actions/EventRemove.js
+++ b/lib/actions/EventRemove.js
@@ -276,13 +276,15 @@ class EventRemover extends S.classes.Plugin {
             awsAccountId   = this.aws.getAccountId(stage, region),
             Endpoint       = 'arn:aws:lambda:' + region + ':' + awsAccountId + ':function:' + functionName + ':' + stage,
             populatedEvent = event.toObjectPopulated({stage, region}),
-            TopicArn       = 'arn:aws:sns:' + region + ':' + awsAccountId + ':' + populatedEvent.config.topicName;
+            topic = populatedEvent.config.topic || populatedEvent.config.topicName,
+            TopicArn       = topic && topic.indexOf('arn:') === 0 ? topic : ('arn:aws:sns:' + region + ':' + awsAccountId + ':' + topic),
+            TopicRegion    = /arn:aws:sns:(.*):(.*):(.*)/.exec(TopicArn)[1];
 
-      return this._SNSlistSubscriptionsByTopic(TopicArn, stage, region)
+      return this._SNSlistSubscriptionsByTopic(TopicArn, stage, TopicRegion)
         .then((subscriptions) => _.filter(subscriptions, {Endpoint}))
         .then((subscriptions) => subscriptions.length && subscriptions || BbPromise.reject(new SError(`Subscription for "${event.name}" is not found`)))
         .map((subscription) => subscription.SubscriptionArn)
-        .map((SubscriptionArn) => this.aws.request('SNS', 'unsubscribe', {SubscriptionArn}, stage, region));
+        .map((SubscriptionArn) => this.aws.request('SNS', 'unsubscribe', {SubscriptionArn}, stage, TopicRegion));
     }
 
     _SNSlistSubscriptionsByTopic(TopicArn, stage, region, NextToken, subscriptions) {


### PR DESCRIPTION
This should fix: https://github.com/serverless/serverless/issues/915

I implemented this with a new property called topicArn as in the original request rather than autodetecting whether it is a name or arn in a property called topic because I thought that the original way would be backwards compatible, whereas if I changed the name of the property it would break backwards compatibility

Happy to update this though if the autodetect way is preferred