### PR TITLE
Closes #580 - Add package.json based plugin discovery

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -240,10 +240,13 @@ class Serverless {
 
   loadProjectPlugins() {
 
-    // Get s-project.json
-    let projectJson = require(path.join(this.config.projectPath, 's-project.json'));
-    this._loadPlugins(this.config.projectPath, projectJson.plugins || []);
+    // Get all installed NPM packages (some of those are plugins)
+    let projectPackageJson = require(path.join(this.config.projectPath, 'package.json'));
+    let pluginsArray = _.map(projectPackageJson.dependencies, (value, key) => {
+      return key;
+    });
 
+    this._loadPlugins(this.config.projectPath, pluginsArray || []);
   }
 
   /**
@@ -299,10 +302,15 @@ class Serverless {
         }
       }
 
-      // Load Plugin
-      if (PluginClass) {
-        _this.utils.sDebug(PluginClass.getName() + ' plugin loaded');
-        this.addPlugin(new PluginClass());
+      try {
+        // Load Plugin
+        if (PluginClass) {
+          _this.utils.sDebug(PluginClass.getName() + ' plugin loaded');
+          this.addPlugin(new PluginClass());
+        }
+      } catch (e) {
+        // this fails if it's not a Serverless plugin, but a normal NPM package.
+        // It's ok because the current NPM package will be skipped and the next plugin will be loaded
       }
     }
   }


### PR DESCRIPTION
Plugins are now discovered with the help of the projects package.json file. This makes it
possible to simply run "npm install --save" to use plugins. No need to add the
plugin name to the plugins array in the s-project.json file (it will be ignored from now on).

Refs #615