### PR TITLE
Fix 886 resource output values not updating

### DIFF
--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -211,12 +211,10 @@ usage: serverless resources deploy`,
                           // Lowercase first letter
                           let varName = _.lowerFirst(cfStackData.Outputs[i].OutputKey);
 
-                          // Add variable if does not exist
-                          if (!regionVariables[varName]) {
-                            let v = {};
-                            v[varName] = cfStackData.Outputs[i].OutputValue;
-                            region.addVariables(v);
-                          }
+                          // Add/Update variable
+                          let v = {};
+                          v[varName] = cfStackData.Outputs[i].OutputValue;
+                          region.addVariables(v);
 
                           // Add OutputKey
                           if (cfStackData.Outputs[i].OutputKey === 'IamRoleArnLambda') {


### PR DESCRIPTION
Removed conditional check on adding the variable to the file. We should be updating the variable value even if the variable exists. It's value will be old and from a previous deployment.