### PR TITLE
Ensure files uploaded to lambda are world-readable

### DIFF
--- a/lib/actions/CodeDeployLambda.js
+++ b/lib/actions/CodeDeployLambda.js
@@ -116,7 +116,7 @@ module.exports   = function(S) {
 
             if (item.stats.isFile() || symbolicLink) {
               let name = path.relative(_this.evt.options.pathDist, item.path);
-              let permissions = fs.statSync(item.path).mode;
+              let permissions = fs.statSync(item.path).mode | 0o444;
 
               // Exclude certain files
               if (name.indexOf('DS_Store') == -1) {


### PR DESCRIPTION
When using Serverless in a Virtual Box environment (e.g. a Windows system hosting an Ubuntu VM), the file permissions might be something like 0770 - readable only by the user and the group, but not by everyone. Due to the nature of sharing file system across the VM, these permissions cannot be changed. However, this causes issues when zipping and uploading the code to Lambda in the latest Serverless 0.5.3 release. AWS will fail to run the code and throw the following error message instead:
```
EACCES, permission denied '/var/task/<my-path>/_serverless_handler.js'
```

This small patch fixes this by enforcing all files to be at least world-readable. Thus it ensures that the code can run as expected.