### PR TITLE
Added support for dot character in endpoint path

### DIFF
--- a/lib/actions/EndpointBuildApiGateway.js
+++ b/lib/actions/EndpointBuildApiGateway.js
@@ -240,7 +240,7 @@ module.exports = function(S) {
           _this.deployedLambda = data.Configuration;
 
           // Prepare StatementId
-          _this.lambdaPolicyStatementId = ('s_apig' + _this.endpoint.path + '_' + _this.endpoint.method).replace(/[\/{}]/g, '_');
+          _this.lambdaPolicyStatementId = ('s_apig' + _this.endpoint.path + '_' + _this.endpoint.method).replace(/[\/{}.]/g, '_');
 
           SUtils.sDebug(
             '"'


### PR DESCRIPTION
Using a `.` character in an endpoint like `"path": "/-/user/org.couchdb.user"` generate a invalid StatementId `s_apig_-_user_org.couchdb.user_GET`. A valid StatementId for that path could be `s_apig_-_user_org_couchdb_user_GET`.

The proposed change add `.` to the special character that get converted to `_` during the Lambda Policy StatementId genration.