### PR TITLE
Fix version comparison operation

### DIFF
--- a/lib/actions/FunctionRollback.js
+++ b/lib/actions/FunctionRollback.js
@@ -193,7 +193,7 @@ module.exports = function(S) {
 
           return BbPromise.try(() => {
             if (this.evt.options.version) {
-              return _.find(versions, {Version: this.evt.options.version})
+              return _.find(versions, {Version: this.evt.options.version.toString()})
             } else {
               let choices = _.map(versions, (v) => {
                 let isCurrentText = '';


### PR DESCRIPTION
If you pass in a specific version using the command line, javascript parses it as a `number` which is unsuccessfully compared to the string `Version` returned from the AWS SDK.

The issue can be fixed multiple ways, this has the least side effects but consider alternatively passing in the version like "v3" instead because that's how the interactive version displays it.