### PR TITLE
Do not require unique event names for schedules

### DIFF
--- a/lib/Function.js
+++ b/lib/Function.js
@@ -196,6 +196,12 @@ module.exports = function(S) {
       return this.events;
     }
 
+    getEvent(eventName) {
+      return _.find(this.getAllEvents(), e =>
+        e.name === eventName
+      )
+    }
+
     getAllEndpoints() {
       return this.endpoints;
     }

--- a/lib/actions/DashDeploy.js
+++ b/lib/actions/DashDeploy.js
@@ -183,7 +183,7 @@ module.exports = function(S) {
         _.each( func.getAllEvents(), function(event){
           choices.push({
             key:        '  ',
-            value:      event.name,
+            value:      `${func.getName()}#${event.name}`,
             label:      `event - ${event.name} - ${event.type}`,
             type:       'event'
           });

--- a/lib/actions/EventDeploy.js
+++ b/lib/actions/EventDeploy.js
@@ -147,8 +147,10 @@ module.exports = function(S) {
       _this.regions            = _this.evt.options.region ? [_this.evt.options.region] : _this.project.getAllRegionNames(_this.evt.options.stage);
 
       if (_this.evt.options.names.length) {
-        _this.evt.options.names.forEach(function(eventName) {
-          _this.events.push(_this.project.getEvent(eventName));
+        _this.evt.options.names.forEach(function(event) {
+          let names = event.split("#", 2);
+          let func = _this.project.getFunction(names[0]);
+          _this.events.push(func.getEvent(names[1]));
         });
       }
 
@@ -227,9 +229,10 @@ module.exports = function(S) {
             subAction,
             newEvt = {
               options: {
-                stage:   _this.evt.options.stage,
-                region:  region,
-                name:    event.name
+                stage:    _this.evt.options.stage,
+                region:   region,
+                funcName: event.getFunction().getName(),
+                name:     event.name
               }
             };
 

--- a/lib/actions/EventLambdaS3.js
+++ b/lib/actions/EventLambdaS3.js
@@ -51,7 +51,8 @@ module.exports = function(S) {
 
       _this.aws = S.getProvider('aws');
 
-      let event          = S.getProject().getEvent( _this.evt.options.name ),
+      let func           = S.getProject().getFunction( _this.evt.options.funcName ),
+          event          = func.getEvent( _this.evt.options.name ),
           populatedEvent = event.toObjectPopulated({stage, region}),
           functionName   = event.getFunction().getDeployedName(_this.evt.options),
           statementId    = 'sEvents-' + functionName + '-' + event.name + '-' + stage,

--- a/lib/actions/EventLambdaSNS.js
+++ b/lib/actions/EventLambdaSNS.js
@@ -44,7 +44,8 @@ module.exports = function(S) {
 
       _this.aws = S.getProvider('aws');
 
-      let event          = S.getProject().getEvent( _this.evt.options.name ),
+      let func           = S.getProject().getFunction( _this.evt.options.funcName ),
+          event          = func.getEvent( _this.evt.options.name ),
           populatedEvent = event.toObjectPopulated({stage: _this.evt.options.stage, region: _this.evt.options.region}),
           functionName   = event.getFunction().getDeployedName(_this.evt.options),
           statementId    = 'sEvents-' + functionName + '-' + event.name + '-' + _this.evt.options.stage,

--- a/lib/actions/EventLambdaSchedule.js
+++ b/lib/actions/EventLambdaSchedule.js
@@ -43,7 +43,8 @@ module.exports = function (S) {
       }
       _this.aws = S.getProvider('aws');
 
-      let event          = S.getProject().getEvent( _this.evt.options.name ),
+      let func           = S.getProject().getFunction( _this.evt.options.funcName ),
+          event          = func.getEvent( _this.evt.options.name ),
           populatedEvent = event.toObjectPopulated({stage: _this.evt.options.stage, region: _this.evt.options.region}),
           functionName   = event.getFunction().getDeployedName(_this.evt.options),
           ruleName       = functionName + '-' + populatedEvent.name + '-' +  _this.evt.options.stage,

--- a/lib/actions/EventLambdaStream.js
+++ b/lib/actions/EventLambdaStream.js
@@ -47,7 +47,8 @@ module.exports = function(S) {
 
       _this.aws = S.getProvider('aws');
 
-      let event          = S.getProject().getEvent( _this.evt.options.name ),
+      let func           = S.getProject().getFunction( _this.evt.options.funcName ),
+          event          = func.getEvent( _this.evt.options.name ),
           populatedEvent = event.toObjectPopulated({stage: _this.evt.options.stage, region: _this.evt.options.region}),
           functionName   = event.getFunction().getDeployedName(_this.evt.options),
           regionVars     = S.getProject().getRegion(_this.evt.options.stage, _this.evt.options.region).getVariables(),


### PR DESCRIPTION
This is for issue #995

I allowed for both `dash deploy` and `event deploy --all` to use non-unique schedule names.

I'm not sure that I covered all use cases for event deploy as I'm pretty new to the serverless code base.