### PR TITLE
998 variables support stage vars

### DIFF
--- a/lib/actions/VariablesList.js
+++ b/lib/actions/VariablesList.js
@@ -88,7 +88,7 @@ usage: serverless variables list`,
           return _this.cliPromptSelectStage('Select a stage: ', _this.evt.options.stage, false)
                 .then(stage => {
                   _this.evt.options.stage = stage;
-                })
+                });
           })
           .then(function() {
             return _this.cliPromptSelectRegion('Select a region: ', false, true, _this.evt.options.region, _this.evt.options.stage)
@@ -144,22 +144,33 @@ usage: serverless variables list`,
           region = this.evt.options.region,
           all    = this.evt.options.all;
 
-      let listVariableHelper = (region) => {
+      let listRegionVariableHelper = (region) => {
 
         let variables = region.getVariables();
         SCli.log('  ' + region.getName() + ':');
         for (var variable in variables) {
-          if (!_.startsWith(variable, '_') && variables.hasOwnProperty(variable)) {
+          if (!_.startsWith(variable, '_') && _.has(variables, variable)) {
             SCli.log('    ' + variable + ' = "' + variables[variable] + '"');
+          }
+        }
+      };
+
+      let listStageVariableHelper = (stage) => {
+
+        let variables = stage.getVariables();
+        SCli.log(stage.getName());
+        for (var variable in variables) {
+          if (!_.startsWith(variable, '_') && _.has(variables, variable)) {
+            SCli.log('  ' + variable + ' = "' + variables[variable] + '"');
           }
         }
       };
 
       if (all) {
         S.getProject().getAllStages().forEach(stage => {
-          SCli.log(stage.getName());
+          listStageVariableHelper(stage);
           S.getProject().getAllRegions(stage.getName()).forEach(function (region) {
-            listVariableHelper(region);
+            listRegionVariableHelper(region);
           });
         });
       } else if (region != 'all' || stage == 'local') {  //single region
@@ -167,11 +178,13 @@ usage: serverless variables list`,
           region = 'local';
         }
 
-        listVariableHelper(S.getProject().getRegion(stage, region));
+        listStageVariableHelper(S.getProject().getStage(stage));
+        listRegionVariableHelper(S.getProject().getRegion(stage, region));
       } else {
         // All regions
+        listStageVariableHelper(S.getProject().getStage(stage));
         S.getProject().getAllRegions(stage).forEach(function (region) {
-          listVariableHelper(region);
+          listRegionVariableHelper(region);
         });
       }
     }

--- a/lib/actions/VariablesSet.js
+++ b/lib/actions/VariablesSet.js
@@ -39,6 +39,11 @@ usage: serverless variables set`,
         contextAction: 'set',
         options:       [
           {
+            option:      'type',
+            shortcut:    't',
+            description: 'variable type (common, stage or region)'
+          },
+          {
             option:      'region',
             shortcut:    'r',
             description: 'region you want to set the variable in'
@@ -131,12 +136,34 @@ usage: serverless variables set`,
                 });
           })
           .then(function() {
+            // Allow to dismiss region to set stage variables
+            const selection = [
+                             {key:"1) ", value:"common", label:"Common"},
+                             {key:"2) ", value:"stage", label:"Stage"},
+                             {key:"3) ", value:"region", label:"Region"}
+                            ];
+            if (_.indexOf(['common','stage','region'], _this.evt.options.type) !== -1) {
+              return BbPromise.resolve();
+            }
+            return _this.cliPromptSelect('Select variable type: ', selection, false)
+            .spread(function(selectType) {
+              _this.evt.options.type = selectType.value;
+              return BbPromise.resolve();
+            });
+          })
+          .then(function() {
+            if (_this.evt.options.type === 'common') {
+              return BbPromise.resolve();
+            }
             return _this.cliPromptSelectStage('Select a stage to set your variable in: ', _this.evt.options.stage, false)
                 .then(stage => {
                   _this.evt.options.stage = stage;
                 })
           })
           .then(function() {
+            if (_this.evt.options.type !== "region") {
+              return BbPromise.resolve();
+            }
             return _this.cliPromptSelectRegion('Select a region to set variable in: ', false, true, _this.evt.options.region, _this.evt.options.stage)
                 .then(region => {
                   _this.evt.options.region = region;
@@ -155,18 +182,23 @@ usage: serverless variables set`,
       // non interactive validation
       if (!S.config.interactive) {
         // Check Params
-        if (!_this.evt.options.stage || !_this.evt.options.region || !_this.evt.options.key || !_this.evt.options.value) {
-          return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        const paramsOk = (!!_this.evt.options.type && !!_this.evt.options.key && !!_this.evt.options.value) &&
+                         (_this.evt.options.type === 'common' || 
+                           (_this.evt.options.type === 'stage' && !!_this.evt.options.stage) ||
+                           (_this.evt.options.type === 'region' && !!_this.evt.options.stage && !!_this.evt.options.region));
+        
+        if (!paramsOk) {
+          return BbPromise.reject(new SError('Wrong parameter combination or missing key/value. See --help.'));
         }
       }
 
       // Validate stage: make sure stage exists
-      if (!S.getProject().validateStageExists(_this.evt.options.stage) && _this.evt.options.stage != 'local') {
+      if ((_this.evt.options.type !== 'common') && !S.getProject().validateStageExists(_this.evt.options.stage) && _this.evt.options.stage != 'local') {
         return BbPromise.reject(new SError('Stage ' + _this.evt.options.stage + ' does not exist in your project'));
       }
 
       // Skip the next validation if stage is 'local' & region is 'all'
-      if (_this.evt.options.stage != 'local' && _this.evt.options.region != 'all') {
+      if (_this.evt.options.type === 'region' && _this.evt.options.stage != 'local' && _this.evt.options.region != 'all') {
 
         // validate region: make sure region exists in stage
         if (!S.getProject().validateRegionExists(_this.evt.options.stage, _this.evt.options.region)) {
@@ -182,8 +214,10 @@ usage: serverless variables set`,
     _setVariable() {
 
       let _this  = this,
+          type  = this.evt.options.type,
           stage  = this.evt.options.stage,
-          region = this.evt.options.region;
+          region = this.evt.options.region,
+          project = S.getProject();
 
       let setVariableHelper = (region) => {
 
@@ -194,17 +228,22 @@ usage: serverless variables set`,
         region.save();
       };
 
-      if (region != 'all' || stage == 'local') {  //single region
-        if (stage == 'local') {
-          region = 'local';
-        }
+      let v = {};
+      v[_this.evt.options.key] = _this.evt.options.value;
 
-        setVariableHelper(S.getProject().getRegion(stage, region));
-      } else {
-        // All regions
-        S.getProject().getAllRegions(stage).forEach(function (region) {
-          setVariableHelper(region);
-        });
+      switch (type) {
+      case 'common':
+        project.addVariables(v);
+        project.save();
+        break;
+      case 'stage':
+        project.getStage(stage).addVariables(v);
+        project.getStage(stage).save();
+        break;
+      case 'region':
+        S.getProject().getRegion(stage, region).addVariables(v);
+        S.getProject().getRegion(stage, region).save();
+        break;
       }
     }
 

--- a/lib/actions/VariablesUnset.js
+++ b/lib/actions/VariablesUnset.js
@@ -39,6 +39,11 @@ usage: serverless variables unset`,
         contextAction: 'unset',
         options:       [
           {
+            option:      'type',
+            shortcut:    't',
+            description: 'variable type (common, stage or region)'
+          },
+          {
             option:      'region',
             shortcut:    'r',
             description: 'region you want to remove the variable from'
@@ -107,12 +112,34 @@ usage: serverless variables unset`,
                 });
           })
           .then(function() {
+            // Allow to dismiss region to set stage variables
+            const selection = [
+                             {key:"1) ", value:"common", label:"Common"},
+                             {key:"2) ", value:"stage", label:"Stage"},
+                             {key:"3) ", value:"region", label:"Region"}
+                            ];
+            if (_.indexOf(['common','stage','region'], _this.evt.options.type) !== -1) {
+              return BbPromise.resolve();
+            }
+            return _this.cliPromptSelect('Select variable type: ', selection, false)
+            .spread(function(selectType) {
+              _this.evt.options.type = selectType.value;
+              return BbPromise.resolve();
+            });
+          })
+          .then(function() {
+            if (_this.evt.options.type === 'common') {
+              return BbPromise.resolve();
+            }
             return _this.cliPromptSelectStage('Select a stage to remove your variable from: ', _this.evt.options.stage, false)
                 .then(stage => {
                   _this.evt.options.stage = stage;
                 })
           })
           .then(function() {
+            if (_this.evt.options.type !== "region") {
+              return BbPromise.resolve();
+            }
             return _this.cliPromptSelectRegion('Select a region to remove variable from: ', false, true, _this.evt.options.region, _this.evt.options.stage)
                 .then(region => {
                   _this.evt.options.region = region;
@@ -131,18 +158,23 @@ usage: serverless variables unset`,
       // non interactive validation
       if (!S.config.interactive) {
         // Check Params
-        if (!_this.evt.options.stage || !_this.evt.options.region || !_this.evt.options.key) {
-          return BbPromise.reject(new SError('Missing stage and/or region and/or key'));
+        const paramsOk = (!!_this.evt.options.type && !!_this.evt.options.key) &&
+        (_this.evt.options.type === 'common' || 
+          (_this.evt.options.type === 'stage' && !!_this.evt.options.stage) ||
+          (_this.evt.options.type === 'region' && !!_this.evt.options.stage && !!_this.evt.options.region));
+        
+        if (!paramsOk) {
+          return BbPromise.reject(new SError('Wrong parameter combination or missing key/value. See --help.'));
         }
       }
 
       // Validate stage: make sure stage exists
-      if (!S.getProject().validateStageExists(_this.evt.options.stage) && _this.evt.options.stage != 'local') {
+      if ((_this.evt.options.type !== 'common') && !S.getProject().validateStageExists(_this.evt.options.stage) && _this.evt.options.stage != 'local') {
         return BbPromise.reject(new SError('Stage ' + _this.evt.options.stage + ' does not exist in your project'));
       }
 
       // Skip the next validation if stage is 'local' & region is 'all'
-      if (_this.evt.options.stage != 'local' && _this.evt.options.region != 'all') {
+      if (_this.evt.options.type === 'region' && _this.evt.options.stage != 'local' && _this.evt.options.region != 'all') {
 
         // validate region: make sure region exists in stage
         if (!S.getProject().validateRegionExists(_this.evt.options.stage, _this.evt.options.region)) {
@@ -158,27 +190,26 @@ usage: serverless variables unset`,
     _removeVariable() {
 
       let _this  = this,
+          type   = this.evt.options.type,
           stage  = this.evt.options.stage,
-          region = this.evt.options.region;
+          region = this.evt.options.region,
+          project = S.getProject();
 
-      let unsetVariableHelper = (region) => {
-
-        _.unset(region.getVariables(), _this.evt.options.key);
-        region.save();
-      };
-
-      if (region != 'all' || stage == 'local') {  //single region
-        if (stage == 'local') {
-          region = 'local';
-        }
-
-        unsetVariableHelper(S.getProject().getRegion(stage, region));
-      } else {
-        // All regions
-        S.getProject().getAllRegions(stage).forEach(function (region) {
-          unsetVariableHelper(region);
-        });
+      switch (type) {
+      case 'common':
+        _.unset(project.getVariables(), _this.evt.options.key);
+        project.save();
+        break;
+      case 'stage':
+        _.unset(project.getStage(stage).getVariables(), _this.evt.options.key);
+        project.getStage(stage).save();
+        break;
+      case 'region':
+        _.unset(S.getProject().getRegion(stage, region).getVariables(), _this.evt.options.key);
+        S.getProject().getRegion(stage, region).save();
+        break;
       }
+
     }
 
   }


### PR DESCRIPTION
Fixes #998 
The `sls variables xxx` type commands now support the Serverless variable hierarchy (common, stage and region). You can now easily set a variable within the specified scope.