### PR TITLE
Fix Plugin.cliPromptSelectRegion

### DIFF
--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -194,7 +194,7 @@ module.exports = function(S) {
         } else {
 
           // Make sure there are regions left in stage
-          if (S.getProject().getAllRegions(stage).length === 4) {
+          if (S.getProject().getAllRegions(stage).length === S.getProvider('aws').validRegions.length) {
             return BbPromise.reject(new SError('Stage ' + stage + ' already have all possible regions.', SError.errorCodes.UNKNOWN));
           }
 


### PR DESCRIPTION
Replace hardcoded amount of regions with a call to ProviderAws.

The hardcoded amount prevents creating > 4 regions (we have 5 now).