### PR TITLE
Add the ability to update the runtime of an existing lambda function

### DIFF
--- a/lib/actions/CodeDeployLambda.js
+++ b/lib/actions/CodeDeployLambda.js
@@ -221,6 +221,7 @@ module.exports   = function(S) {
               Handler:      _this.function.getRuntime().getHandler(_this.function),
               MemorySize:   _this.functionPopulated.memorySize,
               Role:         _this.functionPopulated.customRole ? _this.functionPopulated.customRole : _this.project.getVariablesObject(_this.evt.options.stage, _this.evt.options.region).iamRoleArnLambda,
+              Runtime:      _this.function.getRuntime().getName('aws'),
               Timeout:      _this.functionPopulated.timeout,
               VpcConfig: {
                 SecurityGroupIds: _this.functionPopulated.vpc ? _this.functionPopulated.vpc.securityGroupIds : [],

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "aws-sdk": "^2.2.40",
+    "aws-sdk": "^2.3.2",
     "bluebird": "^3.2.1",
     "chalk": "^1.1.0",
     "cli-spinner": "^0.2.1",


### PR DESCRIPTION
This feature was added in https://github.com/aws/aws-sdk-js/commit/9bf12ac2bb138eec3a547235ecb6d6a63bf4a65f and added to the aws-sdk 2.3.2 version.

I don't foresee any side effects to upgrading the `aws-sdk` dependency, but I'm not sure.