### PR TITLE
Added missing description field to the ApiGateway deploy method [Fixes #1019]

### DIFF
--- a/lib/actions/EndpointDeploy.js
+++ b/lib/actions/EndpointDeploy.js
@@ -205,7 +205,8 @@ module.exports = function(S) {
           region:         this.evt.options.region,
           names:          this.endpoints,
           aliasEndpoint:  this.evt.options.aliasEndpoint,
-          aliasRestApi:   this.evt.options.aliasRestApi
+          aliasRestApi:   this.evt.options.aliasRestApi,
+          description:    this.evt.options.description
         }
       };
 


### PR DESCRIPTION
The description of the API Gateway deployment was being captured but not used.

Fixes #1019