### PR TITLE
fix typo to variable name 'functioName'

### DIFF
--- a/lib/actions/CodeDeployLambda.js
+++ b/lib/actions/CodeDeployLambda.js
@@ -65,7 +65,7 @@ module.exports   = function(S) {
            * Return EVT
            */
 
-          _this.evt.data.functioName      =   _this.functionName;
+          _this.evt.data.functionName      =   _this.functionName;
           _this.evt.data.pathCompressed   =   _this.pathCompressed;
           _this.evt.data.functionVersion  =   _this.functionVersion;
           _this.evt.data.functionAliasArn =   _this.functionAliasArn;

--- a/lib/actions/FunctionDeploy.js
+++ b/lib/actions/FunctionDeploy.js
@@ -278,7 +278,7 @@ module.exports = function(S) {
             if (!this.deployed[region]) this.deployed[region] = [];
 
             this.deployed[region].push({
-              lambdaName:   result.data.functioName,
+              lambdaName:   result.data.functionName,
               functionName: func.name,
               Arn:          result.data.functionAliasArn
             });


### PR DESCRIPTION
fix typo to variable name 'functioName'