### PR TITLE
Fix for TooManyRequests

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -16,6 +16,24 @@ const AWS          = require('aws-sdk');
 
 module.exports = function(S) {
 
+  function persistentRequest(f) {
+    return new BbPromise(function(resolve, reject){
+      let doCall = function(){
+        f()
+            .then(resolve)
+            .catch(function(error) {
+
+              if( error.statusCode == 429 ) {
+                S.utils.sDebug("'Too many requests' received, sleeping 5 seconds");
+                setTimeout( doCall, 5000 );
+              } else
+                reject( error );
+            });
+      };
+      return doCall();
+    });
+  };
+
   class ServerlessProviderAws {
 
     constructor(config) {
@@ -68,7 +86,7 @@ module.exports = function(S) {
 
     request(service, method, params, stage, region, options) {
       let _this = this;
-      return this.getCredentials(stage, region)
+      return persistentRequest( ()=> _this.getCredentials(stage, region)
         .then(function(credentials) {
           let awsService = new _this.sdk[service](credentials);
           let req = awsService[method](params);
@@ -85,7 +103,8 @@ module.exports = function(S) {
               }
             });
           });
-        });
+        })
+      )
     }
 
     /**


### PR DESCRIPTION
#993 
When deploying all endpoints, AWS SDK sometimes fails with 429 TooManyRequests, then the whole process fails.

With this fix, AWS requests are retried in such cases.