### PR TITLE
Cached REST APIs

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -59,6 +59,7 @@ module.exports = function(S) {
         'ap-northeast-1'  // Tokyo
       ];
 
+      this.apisCache = {};
     }
 
     /**
@@ -445,6 +446,11 @@ module.exports = function(S) {
       // Sanitize
       apiName = apiName.trim();
 
+      if (this.apisCache[ apiName ] && this.apisCache[ apiName ][ region ] && this.apisCache[ apiName ][ region ][ stage ]) {
+        S.utils.sDebug( "" + stage + " - " + region + ": Found cached REST API on AWS API Gateway with name: " + apiName );
+        return BbPromise.resolve( this.apisCache[ apiName ][ region ][ stage ] );
+      }
+
       let params = {
         limit: 500
       };
@@ -480,7 +486,12 @@ module.exports = function(S) {
             throw new SError('You have multiple API Gateway REST APIs in the region ' + region + ' with this name: ' + apiName);
           }
 
-          if (restApi) return restApi;
+          if (restApi) {
+            if (!_this.apisCache[ apiName ]) _this.apisCache[ apiName ] = {};
+            if (!_this.apisCache[ apiName ][ region ]) _this.apisCache[ apiName ][ region ] = {};
+            if (!_this.apisCache[ apiName ][ region ][ stage ]) _this.apisCache[ apiName ][ region ][ stage ] = restApi;
+            return restApi;
+          }
         });
     }
 


### PR DESCRIPTION
Feature: REST API identifier are cached, instead of being resolved in each endpoint deploy.
When deploying many endpoints in once, this speeds up the process and reduces rate of TooManyRequests failures.