### PR TITLE
Issue #1015

### DIFF
--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -42,6 +42,11 @@ usage: serverless function create <function>`,
             option:      'runtime',
             shortcut:    'r',
             description: 'The function runtime. By default: `nodejs`.'
+          },
+          {
+            option:      'template',
+            shortcut:    't',
+            description: 'The function template. One of `function`, `endpoint` or `event`'
           }
         ],
         parameters: [
@@ -141,6 +146,8 @@ usage: serverless function create <function>`,
         .then(function() {
 
           // Prompt user with type of function to create
+          if (_this.evt.options.template) return BbPromise.resolve();
+
           let choices = [
             {
               key: '',
@@ -154,16 +161,13 @@ usage: serverless function create <function>`,
             },
             {
               key: '',
-              value: null,
+              value: 'function',
               label: 'Just the Function...'
             }
           ];
 
-          return _this.cliPromptSelect(`For this new Function, would you like to create an Endpoint, Event, or just the Function?`, choices, false);
-        })
-        .then(function(values) {
-          if (values[0].value === 'endpoint') _this.endpoint = true;
-          if (values[0].value === 'event') _this.event = true;
+          return _this.cliPromptSelect(`For this new Function, would you like to create an Endpoint, Event, or just the Function?`, choices, false)
+          .then(values => this.evt.options.template = values[0].value);
         });
     };
 
@@ -210,6 +214,16 @@ usage: serverless function create <function>`,
       // Check function name is unique
       if (S.getProject().getFunction( _this.functionName )) {
         return BbPromise.reject(new SError(`Please choose a unique function name. You already have a function named "${_this.functionName}"`));
+      }
+
+      if (_.indexOf([ 'function', 'endpoint', 'event' ], _this.evt.options.template) === -1) {
+        return BbPromise.reject(new SError(`Unknown template type ${_this.evt.options.template}`));
+      }
+      if (_this.evt.options.template === 'endpoint') {
+        _this.endpoint = true;
+      }
+      if (_this.evt.options.template === 'event') {
+        _this.event = true;
       }
 
       return BbPromise.resolve();


### PR DESCRIPTION
Fixes #1015 
Added `--template/-t` parameter to `function create` that sets the template type used for the created function. Accepted values are `function`, `endpoint` and `event` and behave exactly the same as when entered through the interactive prompt.