### PR TITLE
Add travisci config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules
 #SERVERLESS STUFF
 admin.env
 .env
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: node_js
 
 node_js:
-  - '4.2.3'
+  - '4'
 
 sudo: false
 
 install:
-  - travis_retry npm install jshint jscs
+  - travis_retry npm install
 
 script:
-  - ./node_modules/jshint/bin/jshint .
-  - ./node_modules/jscs/bin/jscs .
-
+  - ./scripts/eslint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:4
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  node:
+    build: .
+    volumes:
+      - .:/app

--- a/scripts/eslint.sh
+++ b/scripts/eslint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p tmp
+
+npm run lint | tee tmp/lint-output
+
+problems=`cat tmp/lint-output | grep -oE '[0-9]* problems' | grep -o "[0-9]*"`
+ratchet="8256"
+
+echo "Problems found in current linting: $problems"
+
+if [ "$problems" -gt "$ratchet" ]
+then
+  echo "Linting issues above ratchet of $ratchet"
+  exit 1
+else
+  echo "Linting issues below ratchet of $ratchet"
+fi


### PR DESCRIPTION
We want to start using CI for Serverless so this introduces ESLint built on top of changes by @minibikini.

To introduce Eslint we don't want to kill our build immediately, but be able to improve it over time. I've implemented a ratchet so you can't add more issues and we can lower the ratchet over time until we've fixed everything.

I also added config for docker-compose to be able to run builds inside of docker-compose for various node versions if we want to.