### PR TITLE
Issue #657: Condense CLI output to fit in a single screen

### DIFF
--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -33,8 +33,7 @@ module.exports  = function(S) {
     registerActions() {
       S.addAction(this.functionCreate.bind(this), {
         handler:       'functionCreate',
-        description:   `Creates scaffolding for a new function.
-usage: serverless function create <function>`,
+        description:   'Creates scaffolding for a new function. Usage: serverless function create <function>',
         context:       'function',
         contextAction: 'create',
         options:       [

--- a/lib/actions/PluginCreate.js
+++ b/lib/actions/PluginCreate.js
@@ -34,8 +34,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.pluginCreate.bind(this), {
         handler:       'pluginCreate',
-        description:   `Creates scaffolding for a new plugin.
-usage: serverless plugin create <plugin>`,
+        description:   'Creates scaffolding for a new plugin. Usage: serverless plugin create <plugin>',
         context:       'plugin',
         contextAction: 'create',
         options:       [

--- a/lib/actions/ProjectRemove.js
+++ b/lib/actions/ProjectRemove.js
@@ -30,8 +30,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.projectRemove.bind(this), {
         handler:       'projectRemove',
-        description:   `Removes a project
-usage: serverless project remove`,
+        description:   'Removes a project. Usage: serverless project remove',
         context:       'project',
         contextAction: 'remove',
         options:       [

--- a/lib/actions/RegionCreate.js
+++ b/lib/actions/RegionCreate.js
@@ -34,9 +34,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.regionCreate.bind(this), {
         handler:       'regionCreate',
-        description:   `Creates new region for a stage in a project
-usage: serverless region create`,
-
+        description:   'Creates new region for a stage in a project. Usage: serverless region create',
         context:       'region',
         contextAction: 'create',
         options:       [

--- a/lib/actions/RegionRemove.js
+++ b/lib/actions/RegionRemove.js
@@ -35,8 +35,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.regionRemove.bind(this), {
         handler:       'regionRemove',
-        description:   `Removes a region from a stage in a project
-usage: serverless region remove`,
+        description:   'Removes a region from a stage in a project. Usage: serverless region remove',
 
         context:       'region',
         contextAction: 'remove',

--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -33,8 +33,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.resourcesDeploy.bind(this), {
         handler:       'resourcesDeploy',
-        description:   `Provision AWS resources (s-resources-cf.json).
-usage: serverless resources deploy`,
+        description:   'Provision AWS resources (s-resources-cf.json). Usage: serverless resources deploy',
         context:       'resources',
         contextAction: 'deploy',
         options:       [

--- a/lib/actions/ResourcesRemove.js
+++ b/lib/actions/ResourcesRemove.js
@@ -31,8 +31,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.resourcesRemove.bind(this), {
         handler:       'resourcesRemove',
-        description:   `Remove AWS resources (resources-cf.json).
-usage: serverless resources remove`,
+        description:   'Remove AWS resources (resources-cf.json). Usage: serverless resources remove',
         context:       'resources',
         contextAction: 'remove',
         options:       [

--- a/lib/actions/StageCreate.js
+++ b/lib/actions/StageCreate.js
@@ -34,8 +34,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.stageCreate.bind(this), {
         handler:       'stageCreate',
-        description:   `Creates new stage for project
-usage: serverless stage create`,
+        description:   'Creates new stage for project. Usage: serverless stage create',
         context:       'stage',
         contextAction: 'create',
         options:       [

--- a/lib/actions/StageRemove.js
+++ b/lib/actions/StageRemove.js
@@ -30,8 +30,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.stageRemove.bind(this), {
         handler:       'stageRemove',
-        description:   `Removes a stage from project
-usage: serverless stage remove`,
+        description:   'Removes a stage from project. Usage: serverless stage remove',
         context:       'stage',
         contextAction: 'remove',
         options:       [

--- a/lib/actions/VariablesList.js
+++ b/lib/actions/VariablesList.js
@@ -33,8 +33,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.variablesList.bind(this), {
         handler:       'variablesList',
-        description:   `List all variables defined in your project.
-usage: serverless variables list`,
+        description:   'List all variables defined in your project. Usage: serverless variables list',
         context:       'variables',
         contextAction: 'list',
         options:       [

--- a/lib/actions/VariablesSet.js
+++ b/lib/actions/VariablesSet.js
@@ -33,8 +33,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.variablesSet.bind(this), {
         handler:       'variablesSet',
-        description:   `Defines a new variable that can be used in any of your project's configuration files.
-usage: serverless variables set`,
+        description:   'Defines a new variable that can be used in any of your project\'s configuration files. Usage: serverless variables set',
         context:       'variables',
         contextAction: 'set',
         options:       [

--- a/lib/actions/VariablesUnset.js
+++ b/lib/actions/VariablesUnset.js
@@ -33,8 +33,7 @@ module.exports = function(S) {
     registerActions() {
       S.addAction(this.variablesUnset.bind(this), {
         handler:       'variablesUnset',
-        description:   `Removes a variable from your project's configuration files.
-usage: serverless variables unset`,
+        description:   'Removes a variable from your project\'s configuration files. Usage: serverless variables unset',
         context:       'variables',
         contextAction: 'unset',
         options:       [

--- a/lib/utils/cli.js
+++ b/lib/utils/cli.js
@@ -7,6 +7,7 @@
 let Promise   = require('bluebird'),
     prompt    = require('prompt'),
     path      = require('path'),
+    _         = require('lodash'),
     os        = require('os'),
     SError    = require('../Error'),
     fs        = require('fs'),
@@ -465,11 +466,13 @@ exports.generateMainHelp = function(allCommands) {
   console.log(chalk.dim('* You can run commands with "serverless" or the shortcut "sls"'));
   console.log(chalk.dim('* Pass "--help" after any <context> <action> for contextual help'));
 
+  console.log('');
+
   for (let cmdContext in allCommands) {
-    console.log('\n"%s" actions:', cmdContext);
-    for (let cmdAction in allCommands[cmdContext]) {
-      console.log(chalk.yellow('  %s'), cmdAction);
-    }
+    let dots    = _.repeat('.', 15 - cmdContext.length);
+    let actions = _.keys( allCommands[cmdContext] ).sort().join(', ');
+
+    console.log('%s %s %s', chalk.yellow(cmdContext), chalk.dim(dots), actions);
   }
 
   console.log('');
@@ -482,12 +485,18 @@ exports.generateMainHelp = function(allCommands) {
  */
 
 exports.generateContextHelp = function(cmdContext, allCommands) {
-  console.log(chalk.dim('Note: pass "--help" after any <context> <action> for contextual help'));
-  console.log(chalk.yellow.underline('\n"%s" command actions:'), cmdContext);
+  console.log(chalk.yellow.underline('\nActions for the \'%s\' context:'), cmdContext);
+  console.log(chalk.dim('Note: pass "--help" after any <context> <action> for contextual help\n'));
+
 
   for (let cmdAction in allCommands[cmdContext]) {
-    console.log('\n%s', cmdAction);
+    let dots         = _.repeat('.', 15 - cmdAction.length);
+    let actionConfig = allCommands[cmdContext][cmdAction];
+
+    console.log('%s %s %s', chalk.yellow(cmdAction), chalk.dim(dots), actionConfig.description);
   }
+
+  console.log('');
 
   return Promise.resolve();
 };
@@ -497,12 +506,11 @@ exports.generateContextHelp = function(cmdContext, allCommands) {
  */
 
 exports.generateActionHelp = function(cmdConfig) {
-  console.log(chalk.yellow('%s'), cmdConfig.description);
-
-  console.log('');
+  console.log(chalk.yellow.underline('\n%s\n'), cmdConfig.description);
 
   for (let opt of cmdConfig.options) {
-    console.log(chalk.yellow('  -%s, --%s \n\t%s'), opt.shortcut, opt.option, opt.description);
+    console.log(chalk.yellow('  -%s, --%s'), opt.shortcut, opt.option);
+    console.log('\t%s', opt.description);
     console.log('');
   }
 


### PR DESCRIPTION
Addressing #657 -- discussion and screenshots are in the referenced issue.

There are a few pieces of future work I intend to tackle next:

1. Referencing loaded plugins in the top-level version of this screen
2. Find some way to have the color scheme work across light and dark background terminals.

I didn't find much in the way of test infrastructure for the CLI, and to be honest, I'm not even sure what tests would be meaningful for something like this. Open to suggestions here, please do let me know if you have ideas.

I did notice that some action descriptions had embedded new-lines. Not sure how best to handle that -- thoughts? I can obviously strip out the embedded new-lines, but not sure if that's the right move here.

Thanks!

Ankur