### PR TITLE
allow to define custom variables from within the endpoint template. T…

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -41,6 +41,7 @@ module.exports = function(S) {
       _this.responses['400'] = {
         statusCode: '400'
       };
+      _this.customVars = {};
 
       if (data) _this.fromObject(data);
     }
@@ -64,7 +65,7 @@ module.exports = function(S) {
         this.getProject().getTemplates().toObject(),
         this.getTemplates().toObject());
 
-      // Clone 
+      // Clone
       let clone = this.toObject();
       clone.endpointName = this.getName(); // add reserved variables
       clone.name = this.getFunction().getName(); // TODO Remove, legacy tight coupling of functions with endpoints.  Make supplying this contingent on coupling?

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -339,6 +339,10 @@ module.exports = {
           if (variableName === 'endpointName' && data.endpointName) value = data.endpointName;
           if (variableName === 'eventName'    && data.eventName)    value = data.eventName;
 
+          if (data.customVars && variableName in data.customVars) {
+            value = data.customVars[variableName];
+          }
+
           // Populate
           if (!value && !value !== "") {
             SCli.log('WARNING: This variable is not defined: ' + variableName);


### PR DESCRIPTION
…his allows to insert custom parameters into reusable mapping templates

For example, i am reusing the same lambda function for multiple endpoints.
In AWS Gateway in my body mapping template I define a property that gets different values for each endpoint that goes to the same Lambda.

To have this logic with serverless, I need a way to define these custom variables from inside of the s-function. This is what this PR implements.

Example:
```
"endpoints": [
 {  ....
      "customVars": {
        "myparam": "myvalue"
      },
      "requestTemplates": "$${apiRequestTemplate}",
}]
```

In the template s-templates.yaml:
```
"params": {
    "type": "${myparam}",
    #foreach($param in $input.params().path.keySet())
    "$param": "$util.escapeJavaScript($input.params().path.get($param))"
    #if($foreach.hasNext),#end
    #end
}
```


 