### PR TITLE
Add support for an IoT event source

### DIFF
--- a/lib/Actions.json
+++ b/lib/Actions.json
@@ -13,6 +13,7 @@
     "./actions/EventDeploy.js",
     "./actions/EventLambdaStream.js",
     "./actions/EventLambdaS3.js",
+    "./actions/EventIotRule.js",
     "./actions/EventLambdaSNS.js",
     "./actions/EventLambdaSchedule.js",
     "./actions/DashDeploy.js",

--- a/lib/actions/EventDeploy.js
+++ b/lib/actions/EventDeploy.js
@@ -237,6 +237,8 @@ module.exports = function(S) {
           subAction = 'eventLambdaStream';
         } else if (eventType === 's3') {
           subAction = 'eventLambdaS3';
+        } else if (eventType === 'iot') {
+          subAction = 'eventIotRule';
         } else if (eventType === 'sns') {
           subAction = 'eventLambdaSNS';
         } else if (eventType === 'schedule') {

--- a/lib/actions/EventIotRule.js
+++ b/lib/actions/EventIotRule.js
@@ -1,0 +1,141 @@
+'use strict';
+
+/**
+ * EventIotRule:
+ *     Deploys an S3 based event sources.
+ *
+ * Options:
+ *     - stage: stage to deploy event to
+ *     - region: region to deploy event to
+ *     - path: event path
+ */
+
+module.exports = function(S) {
+
+  const path   = require('path'),
+    SUtils     = S.utils,
+    SCli       = require(S.getServerlessPath('utils/cli')),
+    SError     = require(S.getServerlessPath('Error')),
+    BbPromise  = require('bluebird'),
+    _          = require('lodash');
+
+  class EventIotRule extends S.classes.Plugin {
+
+    static getName() {
+      return 'serverless.core.' + this.name;
+    }
+
+    registerActions() {
+
+      S.addAction(this.eventIotRule.bind(this), {
+        handler:       'eventIotRule',
+        description:   'Deploy an Iot Rule event source'
+      });
+
+      return BbPromise.resolve();
+    }
+
+    /**
+     * Code Package Lambda
+     */
+
+    eventIotRule(evt) {
+      let _this     = this;
+      _this.evt     = evt;
+
+      const stage  = this.evt.options.stage,
+            region = this.evt.options.region;
+
+      if (!stage || !region || !_this.evt.options.name) {
+        return BbPromise.reject(new SError(`Missing stage, region or event name.`));
+      }
+
+      _this.aws = S.getProvider('aws');
+      SUtils.sDebug(`AccountID: ${_this.aws.getAccountId(stage, region)}`);
+      let event          = S.getProject().getEvent( _this.evt.options.name ),
+          populatedEvent = event.toObjectPopulated({stage, region}),
+          functionName   = event.getFunction().getDeployedName(_this.evt.options),
+          statementId    = 'sEvents-' + functionName + '-' + event.name + '-' + stage,
+          awsAccountId   = _this.aws.getAccountId(stage, region),
+          lambdaArn      = 'arn:aws:lambda:' + region + ':' + awsAccountId + ':function:' + functionName + ':' + stage,
+          ruleName       = populatedEvent.config.rule.name,
+          rulesql        = populatedEvent.config.rule.sql,
+          description    = populatedEvent.config.rule.description ? populatedEvent.config.rule.description : 'Serverless IoT Rule',
+          iotSQLVersion  = populatedEvent.config.rule.iotSQLVersion ? populatedEvent.config.rule.iotSQLVersion : '2016-03-23-beta',
+          ruleDisabled   = populatedEvent.config.rule.ruleDisabled != null ? populatedEvent.config.rule.ruleDisabled : false;
+
+      let params = {
+        FunctionName: lambdaArn,
+        StatementId: statementId,
+        Qualifier: stage
+      };
+
+      return _this.aws.request('Lambda', 'removePermission', params, stage, region)
+        .then(function(data) {
+          SUtils.sDebug(`Removed lambda permission with statement ID: ${statementId}`);
+        })
+        .catch(function(error) {})
+        .then(function(data){
+          var params = {
+            ruleName: ruleName
+          };
+          SUtils.sDebug(`Checking for existing Iot Rule: ${ruleName}`);
+          return _this.aws.request('Iot', 'getTopicRule', params, stage, region);
+        })
+        .catch(function(error) {
+          SUtils.sDebug(`Error getting IoT Rule: ${error}`);
+        })
+        .then(function(data){
+          var params = {
+            ruleName: ruleName,
+            topicRulePayload: {
+              actions: [{
+                lambda: {
+                  functionArn: lambdaArn
+                }
+              }],
+              sql: rulesql,
+              awsIotSqlVersion: iotSQLVersion,
+              description: description,
+              ruleDisabled: ruleDisabled
+            }
+          };
+          if (data != null) {
+            SUtils.sDebug(`Overwriting existing IoT Rule ${ruleName}`);
+            return _this.aws.request('Iot', 'replaceTopicRule', params, stage, region);
+          } else {
+            SUtils.sDebug(`Creating new IoT Rule ${ruleName}`);
+            return _this.aws.request('Iot', 'createTopicRule', params, stage, region);
+          }
+
+        })
+        .catch(function(error) {
+          SUtils.sDebug(`Error creating or overwriting IoT Rule: ${error}`);
+        })
+        .then(function (data) {
+          SUtils.sDebug(`Adding lambda permission with statement ID: ${statementId}`);
+          let params = {
+            FunctionName: lambdaArn,
+            StatementId: statementId,
+            Action: 'lambda:InvokeFunction',
+            Principal: 'iot.amazonaws.com',
+            SourceArn: 'arn:aws:iot:::' + 'rule/'+ruleName,
+            Qualifier: stage
+          };
+          return _this.aws.request('Lambda', 'addPermission', params, stage, region)
+        })
+        .then(function(data) {
+          var params = {};
+          return _this.aws.request('Iot', 'describeEndpoint', params, stage, region)
+        })
+        .then(function(data) {
+          SCli.log('IoT Endpoint: "'  + data.endpointAddress + '"');
+        })
+        .then(function(data) {
+          SUtils.sDebug(`Created the Iot action and linked ${ruleName} to lambda ${lambdaArn}`);
+          return BbPromise.resolve(data);
+        })
+    }
+  }
+  return( EventIotRule );
+};

--- a/lib/actions/EventIotRule.js
+++ b/lib/actions/EventIotRule.js
@@ -2,7 +2,7 @@
 
 /**
  * EventIotRule:
- *     Deploys an S3 based event sources.
+ *     Deploys an IoT Rule and grants permission to the lambda function.
  *
  * Options:
  *     - stage: stage to deploy event to
@@ -35,10 +35,6 @@ module.exports = function(S) {
       return BbPromise.resolve();
     }
 
-    /**
-     * Code Package Lambda
-     */
-
     eventIotRule(evt) {
       let _this     = this;
       _this.evt     = evt;
@@ -58,11 +54,12 @@ module.exports = function(S) {
           statementId    = 'sEvents-' + functionName + '-' + event.name + '-' + stage,
           awsAccountId   = _this.aws.getAccountId(stage, region),
           lambdaArn      = 'arn:aws:lambda:' + region + ':' + awsAccountId + ':function:' + functionName + ':' + stage,
-          ruleName       = populatedEvent.config.rule.name,
-          rulesql        = populatedEvent.config.rule.sql,
-          description    = populatedEvent.config.rule.description ? populatedEvent.config.rule.description : 'Serverless IoT Rule',
-          iotSQLVersion  = populatedEvent.config.rule.iotSQLVersion ? populatedEvent.config.rule.iotSQLVersion : '2016-03-23-beta',
-          ruleDisabled   = populatedEvent.config.rule.ruleDisabled != null ? populatedEvent.config.rule.ruleDisabled : false;
+          rule           = populatedEvent.config.rule,
+          ruleName       = rule.name,
+          rulesql        = rule.sql,
+          description    = rule.description ? rule.description : 'Serverless IoT Rule',
+          iotSQLVersion  = rule.iotSQLVersion ? rule.iotSQLVersion : '2016-03-23-beta',
+          ruleDisabled   = rule.ruleDisabled != null ? rule.ruleDisabled : false;
 
       let params = {
         FunctionName: lambdaArn,
@@ -119,7 +116,7 @@ module.exports = function(S) {
             StatementId: statementId,
             Action: 'lambda:InvokeFunction',
             Principal: 'iot.amazonaws.com',
-            SourceArn: 'arn:aws:iot:::' + 'rule/'+ruleName,
+            SourceArn: 'arn:aws:iot:' + region + ':' + awsAccountId + ':' + 'rule/'+ruleName,
             Qualifier: stage
           };
           return _this.aws.request('Lambda', 'addPermission', params, stage, region)

--- a/lib/actions/FunctionCreate.js
+++ b/lib/actions/FunctionCreate.js
@@ -166,7 +166,7 @@ module.exports  = function(S) {
           ];
 
           return _this.cliPromptSelect(`For this new Function, would you like to create an Endpoint, Event, or just the Function?`, choices, false)
-          .then(values => this.evt.options.template = values[0].value);
+          .then(values => _this.evt.options.template = values[0].value);
         });
     };
 


### PR DESCRIPTION
This PR adds support for AWS IoT. Serverless users can specify an IoT rule as an event source.

This also allows users to support websockets. Once a Lambda function is connected to an IoT rule, it can be invoked by opening a websocket. For more information on how to setup websockets to your IoT endpoint, [click here](http://docs.aws.amazon.com/iot/latest/developerguide/protocols.html). 

Below is an example IoT event in **s-function.json**. The rule name and SQL are required. The SQL version, ruleDisabled flag and description are optional.

```
{
    "name": "iotInvokeLambda",
     "type": "iot",
     "config": {
        "rule": {
             "name": "invokeLambda",  
             "sql": "SELECT * from 'mytopic'",
             "iotSQLVersion": "2016-03-23-beta",
             "description": "Serverless invoke Lambda function rule.",
             "ruleDisabled": false
         }
     }
}
```