### PR TITLE
Allow handler ext configuration for typescript/coffeescript local function run

### DIFF
--- a/lib/RuntimeNode.js
+++ b/lib/RuntimeNode.js
@@ -27,7 +27,7 @@ module.exports = function(S) {
      */
 
     scaffold(func) {
-      const handlerPath = path.join(S.getServerlessPath(), 'templates', 'nodejs', this.getName() + '.js');
+      const handlerPath = path.join(S.getServerlessPath(), 'templates', 'nodejs', this.getName() + (func.handlerExt || '.js'));
 
       return fs.readFileAsync(handlerPath)
           .then(handlerJs => BbPromise.all([
@@ -48,7 +48,7 @@ module.exports = function(S) {
           .then(envVars => _.merge(process.env, envVars))
           .then(() => {
             const handlerArr  = func.handler.split('/').pop().split('.'),
-              functionFile    = func.getRootPath(handlerArr[0] + '.js'),
+              functionFile    = func.getRootPath(handlerArr[0] + (func.handlerExt || '.js')),
               functionHandler = handlerArr[1];
 
             // Load function handler. This has to be done after env vars are set

--- a/lib/RuntimeNode43.js
+++ b/lib/RuntimeNode43.js
@@ -28,7 +28,7 @@ module.exports = function(S) {
           .then(envVars => _.merge(process.env, envVars))
           .then(() => {
             const handlerArr  = func.handler.split('/').pop().split('.'),
-              functionFile    = func.getRootPath(handlerArr[0] + '.js'),
+              functionFile    = func.getRootPath(handlerArr[0] + (func.handlerExt || '.js')),
               functionHandler = handlerArr[1];
 
             // Load function handler. This has to be done after env vars are set


### PR DESCRIPTION
This simple change allows one to confiugure the handler extension much like the optimizer. Used w/ an include of `ts-node/require` functions can be run locally for debugging.