### PR TITLE
Falsy event has no name attribute bugfix

### DIFF
--- a/lib/actions/EventRemove.js
+++ b/lib/actions/EventRemove.js
@@ -188,7 +188,7 @@ class EventRemover extends S.classes.Plugin {
     }
 
     _eventRemove(event, region) {
-      if(!event) throw new SError(`Event could not be found: ${event.name}`);
+      if(!event) throw new SError(`Event could not be found in region ${region}`);
 
       let eventType = event.type.toLowerCase();
 


### PR DESCRIPTION
Because it is falsy, event cannot have the attribute "name".  As such, a misleading `Cannot read property 'name' of undefined` error is thrown rather than the more instructive error that the event couldn't be found for the region.  This leaves the actual identification of which event couldn't be found up to a good guess, unfortunately.

Fixes:
```
TypeError: Cannot read property 'name' of undefined
    at EventRemover._eventRemove (/src/serverless/lib/actions/EventRemove.js:191:69)
    at BbPromise.map.concurrency (/src/serverless/lib/actions/EventRemove.js:187:58)
From previous event:
    at EventRemover._removeByRegion (/src/serverless/lib/actions/EventRemove.js:187:24)
From previous event:
    at EventRemover._processRemoval (/src/serverless/lib/actions/EventRemove.js:182:10)
From previous event:
    at EventRemover.eventRemove (/src/serverless/lib/actions/EventRemove.js:96:10)
    at Function.run (/src/serverless/lib/actions/EventRemove.js:83:22)
    at EventRemove.eventRemove (/src/serverless/lib/actions/EventRemove.js:65:27)
From previous event:
    at /src/serverless/lib/Serverless.js:186:31
    at Array.reduce (native)
    at /src/serverless/lib/Serverless.js:185:32
From previous event:
    at Serverless._execute (/src/serverless/lib/Serverless.js:183:12)
    at Serverless.actions.(anonymous function) (/src/serverless/lib/Serverless.js:429:20)
    at Serverless.command (/src/serverless/lib/Serverless.js:398:38)
    at /src/serverless/bin/serverless:19:16
    at processImmediate [as _immediateCallback] (timers.js:383:17)
From previous event:
    at Object.<anonymous> (/src/serverless/bin/serverless:18:4)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
    at node.js:963:3
```