### PR TITLE
Added Webscale to the list of consulting companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,5 @@ These consultants use the Serverless Framework and can help you build your serve
 * [WhaleTech](https://whaletech.co/)
 * [CloudNative](http://cloudnative.io//)
 * [Hop Labs](http://www.hoplabs.com)
+* [Webscale](https://webscale.fi/briefly-in-english/)
+


### PR DESCRIPTION
Webscale is a consulting company specialized in AWS and cloud native applications. Serverless Framework fits very well in our toolset.

