### PR TITLE
Fix error msg for server project install

### DIFF
--- a/lib/actions/ProjectInstall.js
+++ b/lib/actions/ProjectInstall.js
@@ -95,7 +95,7 @@ module.exports = function(S) {
 
       // Validate: Check for project name
       if (!_this.evt.options.project) {
-        return BbPromise.reject(new SError(`Please enter the name of the project you wish to install, like: serverless install project <projectname>`));
+        return BbPromise.reject(new SError(`Please enter the name of the project you wish to install, like: serverless project install <projectname>`));
       }
 
       _this.evt.options.name = _this.evt.options.name || _this.evt.options.project;


### PR DESCRIPTION
1. Run `serverless project install`
2. Get error: `ServerlessError: Please enter the name of the project you wish to install, like: serverless install project <projectname>`
3. Run `serverless install project <projectname>`, as directed
4. Get error: `ServerlessError: Command not found.  Enter "serverless help" to see all available commands.`
5. The proper command is `serverless project install <projectname>`