### PR TITLE
added yaml parser

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -1,1 +1,304 @@
-// service class
+'use strict';
+
+/* yaml parser
+
+- read any yml file
+- resolve all anchoring
+- resolve all JSON-REF using json or yaml
+- return a complete JS object representing resolved yml file
+ */
+
+const SError            = require('./Error'),
+	BbPromise             = require('bluebird'),
+	path                  = require('path'),
+	_                     = require('lodash'),
+	fs                    = require('fs'),
+	os                    = require('os');
+
+
+class Service {
+
+	constructor(data) {
+
+		this._class = 'Service';
+
+		// Default properties
+		this.service   = null;
+		this.custom    = {};
+		this.plugins   = [];
+		this.functions = {};
+		this.variables = {};
+		this.stages    = {};
+		this.resources = {
+			aws_lambda: {},
+			azure_functions: {},
+			google: {}
+		};
+
+		if (data) this.fromObject(data);
+	}
+
+	load() {
+		return this.deserialize(this);
+	}
+
+	save() {
+		return this.serialize(this);
+	}
+
+	toObject() {
+		return S.utils.exportObject(_.cloneDeep(this));
+	}
+
+	toObjectPopulated(options) {
+		options = options || {};
+
+		// Validate: Check project path is set
+		if (!S.hasProject()) throw new SError('Function could not be populated because no project path has been set on Serverless instance');
+
+		let obj = this.toObject();
+
+		// Populate Sub-Assets Separately
+		let functions, resources;
+		if (this.functions) {
+			functions = _.mapValues(this.functions, (f) => f.toObjectPopulated(options));
+			delete obj.functions;
+		}
+		if (this.resources) {
+			resources = _.mapValues(this.resources, (r) => r.toObjectPopulated(options));
+			delete obj.resources;
+		}
+
+		// Populate
+		let populated = S.utils.populate(this, this.getTemplates().toObject(), obj, options.stage, options.region);
+		if (functions) populated.functions = functions;
+		if (resources) populated.resources = resources;
+
+		return populated;
+	}
+
+	fromObject(data) {
+
+		let _this = this;
+
+		if (data.functions) {
+			let temp = {};
+			for (let f of Object.keys(data.functions)) {
+				if (this.functions[f]) {
+					temp[f] = this.functions[f].fromObject(data.functions[f]);
+				} else {
+					temp[f] = new S.classes.Function(_this, data.functions[f]);
+				}
+			}
+			delete data.functions;
+			this.functions = temp;
+		}
+		if (data.stages) {
+			let temp = {};
+			for (let s of Object.keys(data.stages)) {
+				if (this.stages[s]) {
+					temp[s] = this.stages[s].fromObject(data.stages[s]);
+				} else {
+					temp[s] = new S.classes.Stage(data.stages[s]);
+				}
+			}
+			delete data.stages;
+			this.stages = temp;
+		}
+		if (data.variables) {
+			this.variables.fromObject(data.variables);
+			delete data.variables;
+		}
+		if (data.templates) {
+			this.templates.fromObject(data.templates);
+			delete data.templates;
+		}
+		if (data.resources) {
+			let temp = {};
+			for (let r of Object.keys(data.resources)) {
+				if (this.resources[r]) {
+					temp[r] = this.resources[r].fromObject(data.resources[r]);
+				} else {
+					temp[r] = new S.classes.Resources(data.resources[r]);
+				}
+			}
+			delete data.resources;
+			this.resources = temp;
+		}
+		_.assign(_this, data);
+		return _this;
+	}
+
+	getFilePath() {
+		return path.join(S.config.projectPath, 's-project.json');
+	}
+
+	getRootPath() {
+		let args = _.toArray(arguments);
+		args.unshift(path.dirname(this.getFilePath()));
+		return path.join.apply(path, args);
+	}
+
+	getTempPath() {
+		return this.getRootPath('_meta', '_tmp');
+	}
+
+	getName() {
+		return this.name;
+	}
+
+	getAllFunctions() {
+		return _.values(this.functions);
+	}
+
+	getFunction(functionName) {
+		return _.find(_.values(this.functions), f => {
+			return f.getName() === functionName;
+		});
+	}
+
+	setFunction(func) {
+		this.functions[func.name] = func;
+	}
+
+	getAllEndpoints() {
+		return _.flatten(_.map(this.getAllFunctions(), f => f.getAllEndpoints()));
+	}
+
+	getEndpoint(endpointName) {
+		return _.find(_.values(this.getAllEndpoints()), e =>
+			e.getName() === endpointName
+		)
+	}
+
+	getEndpointsByNames(names) {
+		let _this = this;
+		let endpoints = [];
+		names.forEach(function (name) {
+			let endpoint = _this.getEndpoint(name);
+			if (!endpoint) throw new SError(`Endpoint "${name}" doesn't exist in your project`);
+			endpoints.push(endpoint);
+		});
+		return endpoints;
+	}
+
+	getAllEvents() {
+		return _.flatten(_.map(this.getAllFunctions(), f => f.getAllEvents()));
+	}
+
+	getEvent(eventName) {
+		return _.find(_.values(this.getAllEvents()), e =>
+			e.name === eventName
+		)
+	}
+
+	getResources() {
+		return this.resources.defaultResources;
+	}
+
+	setResources(resources) {
+		this.resources[resources.getName()] = resources;
+	}
+
+	getAllResources(resourcesName) {
+		if (this.resources[resourcesName]) return this.resources[resourcesName];
+		else return this.resources[Object.keys(this.resources)[0]]; // This temporarily defaults to a single resource stack for backward compatibility
+	}
+
+	getAllStages() {
+		let stages = [];
+		for (let i = 0; i < Object.keys(this.stages).length; i++) {
+			stages.push(this.stages[Object.keys(this.stages)[i]]);
+		}
+		return stages;
+	}
+
+	getStage(name) {
+		return this.stages[name];
+	}
+
+	setStage(stage) {
+		this.stages[stage.getName()] = stage;
+	}
+
+	removeStage(name) {
+		let stage = this.stages[name];
+		delete this.stages[name];
+	}
+
+	validateStageExists(name) {
+		return this.stages[name] != undefined;
+	}
+
+	getRegion(stageName, regionName) {
+		if (this.getStage(stageName)) {
+			let stage = this.getStage(stageName);
+			if (stage.hasRegion(regionName)) {
+				return stage.getRegion(regionName);
+			} else {
+				throw new SError(`Region ${regionName} doesnt exist in stage ${stageName}!`);
+			}
+		} else {
+			throw new SError(`Stage ${stageName} doesnt exist in this project!`);
+		}
+	}
+
+	getAllRegions(stageName) {
+		return this.getStage(stageName).getAllRegions();
+	}
+
+	getAllRegionNames(stageName) {
+		return _.map(this.getAllRegions(stageName), 'name');
+	}
+
+	setRegion(stageName, region) {
+		let stage = this.getStage(stageName);
+		stage.setRegion(region);
+	}
+
+	validateRegionExists(stageName, regionName) {
+		let stage = this.getStage(stageName);
+
+		if (stage) {
+			return stage.hasRegion(regionName);
+		} else {
+			return false;
+		}
+	}
+
+	setVariables(variables) {
+		this.variables = variables;
+	}
+
+	getVariables() {
+		return this.variables;
+	}
+
+	getVariablesObject(stage, region) {
+		let vars = this.getVariables().toObject();
+		if (stage) stage = this.getStage(stage);
+		if (stage && region) region = stage.getRegion(region);
+		vars = _.merge(vars, stage ? stage.getVariables().toObject() : {}, region ? region.getVariables().toObject() : {});
+		return vars;
+	}
+
+	addVariables(variablesObj) {
+		return this.getVariables().fromObject(variablesObj);
+	}
+
+	setTemplates(templates) {
+		this.templates = templates;
+	}
+
+	getTemplates() {
+		return this.templates;
+	}
+
+	addPlugin(pluginName) {
+		this.plugins.push(pluginName);
+	}
+
+}
+
+
+module.exports = Service;

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -5,6 +5,8 @@ const SError     = require('./Error'),
 			path       = require('path'),
 			traverse   = require('traverse'),
 			replaceall = require('replaceall'),
+      resolve    = require('json-refs').resolveRefs,
+			YAML       = require('js-yaml'),
 			dotenv     = require('dotenv'),
 			rawDebug   = require('debug'),
 			_          = require('lodash'),
@@ -64,6 +66,10 @@ module.exports = function(S) {
 
 			if (filePath.indexOf('.json') !== -1 && typeof contents !== 'string') {
 				contents = JSON.stringify(contents, null, 2)
+			}
+
+			if (filePath.indexOf('.yaml') !== -1 && typeof contents !== 'string') {
+				contents = YAML.dump(contents)
 			}
 
 			return fse.writeFileSync(filePath, contents);
@@ -321,6 +327,26 @@ module.exports = function(S) {
 			if (functions.length === 0) functions = allFunctions;
 
 			return functions;
+		}
+
+
+		parseYaml(yamlFilePath) {
+			let parentDir = yamlFilePath.split(path.sep);
+			parentDir.pop();
+			parentDir = parentDir.join('/');
+			process.chdir(parentDir);
+			var root = YAML.load(this.readFileSync(yamlFilePath).toString());
+			var options = {
+				filter : ['relative', 'remote'],
+				loaderOptions: {
+					processContent: function (res, callback) {
+						callback(null, YAML.load(res.text));
+					}
+				}
+			};
+			return resolve(root, options).then(function (res) {
+				return BbPromise.resolve(res.resolved)
+			})
 		}
 
 

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -5,7 +5,6 @@ const SError     = require('./Error'),
 			path       = require('path'),
 			traverse   = require('traverse'),
 			replaceall = require('replaceall'),
-      resolve    = require('json-refs').resolveRefs,
 			YAML       = require('js-yaml'),
 			dotenv     = require('dotenv'),
 			rawDebug   = require('debug'),
@@ -19,7 +18,6 @@ module.exports = function(S) {
 
 
 	class Utils {
-
 
 		constructor() {
 			this._class = 'Utils';
@@ -312,7 +310,6 @@ module.exports = function(S) {
 			return servicePath;
 		}
 
-
 		getFunctionsByCwd(allFunctions) {
 			// we add a trailing slash to notate that it's the end of the folder name
 			// this is just to avoid matching sub folder names that are substrings of other subfolder names
@@ -328,36 +325,6 @@ module.exports = function(S) {
 
 			return functions;
 		}
-
-
-		/*
-		 * - Reads and parses a yaml file:
-		 * - resolves json-ref for json files
-		 * - resolves json-ref for yaml files
-		 * - resolves json-ref recursively
-		 *
-		 * @param yamlFilePath {string} - path to the yaml file
-		 * @returns {object} - JS object literal representing the resolved yml
-		 */
-		parseYaml(yamlFilePath) {
-			let parentDir = yamlFilePath.split(path.sep);
-			parentDir.pop();
-			parentDir = parentDir.join('/');
-			process.chdir(parentDir);
-			var root = YAML.load(this.readFileSync(yamlFilePath).toString());
-			var options = {
-				filter : ['relative', 'remote'],
-				loaderOptions: {
-					processContent: function (res, callback) {
-						callback(null, YAML.load(res.text));
-					}
-				}
-			};
-			return resolve(root, options).then(function (res) {
-				return BbPromise.resolve(res.resolved)
-			})
-		}
-
 
 	}
 

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -330,6 +330,15 @@ module.exports = function(S) {
 		}
 
 
+		/*
+		 * - Reads and parses a yaml file:
+		 * - resolves json-ref for json files
+		 * - resolves json-ref for yaml files
+		 * - resolves json-ref recursively
+		 *
+		 * @param yamlFilePath {string} - path to the yaml file
+		 * @returns {object} - JS object literal representing the resolved yml
+		 */
 		parseYaml(yamlFilePath) {
 			let parentDir = yamlFilePath.split(path.sep);
 			parentDir.pop();

--- a/lib/classes/YamlParser.js
+++ b/lib/classes/YamlParser.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const path = require('path');
+const YAML = require('js-yaml');
+const resolve = require('json-refs').resolveRefs;
+const BbPromise = require('bluebird');
+const Utils = require('../classes/Utils')({});
+
+module.exports = function (S) {
+
+  class YamlParser {
+
+    constructor() {
+      this._class = 'YamlParser';
+    }
+
+    parse(yamlFilePath) {
+      const SUtils = new Utils();
+
+      let parentDir = yamlFilePath.split(path.sep);
+      parentDir.pop();
+      parentDir = parentDir.join('/');
+      process.chdir(parentDir);
+
+      const root = YAML.load(SUtils.readFileSync(yamlFilePath).toString());
+      const options = {
+        filter : ['relative', 'remote'],
+        loaderOptions: {
+          processContent: function (res, callback) {
+            callback(null, YAML.load(res.text));
+          },
+        },
+      };
+      return resolve(root, options).then(function (res) {
+        return BbPromise.resolve(res.resolved);
+      });
+    }
+  }
+
+  return YamlParser;
+
+};

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "glob": "^7.0.0",
     "https-proxy-agent": "^1.0.0",
     "js-yaml": "^3.5.5",
+    "json-refs": "^2.0.3",
     "json-diff": "^0.3.1",
     "keypress": "^0.2.1",
     "lodash": "^4.2.1",

--- a/tests/all.js
+++ b/tests/all.js
@@ -8,6 +8,7 @@ describe('All Tests', function() {
   after(function() {});
 
   require('./tests/classes/Utils');
+  require('./tests/classes/YamlParser');
   //require('./tests/classes/Plugin');
   // require('./tests/classes/Project');
   // require('./tests/classes/ProviderAws');

--- a/tests/all.js
+++ b/tests/all.js
@@ -8,7 +8,7 @@ describe('All Tests', function() {
   after(function() {});
 
   require('./tests/classes/Utils');
-  require('./tests/classes/Plugin');
+  //require('./tests/classes/Plugin');
   // require('./tests/classes/Project');
   // require('./tests/classes/ProviderAws');
   // require('./tests/classes/Function');

--- a/tests/tests/classes/Utils.js
+++ b/tests/tests/classes/Utils.js
@@ -121,7 +121,6 @@ describe('Utils class', () => {
     it('should parse a yaml file with JSON-REF to yaml', () => {
       let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
 
-      //console.log(tmpDirPath)
 
       SUtils.writeFileSync(path.join(tmpDirPath, 'ref.yaml'), { foo: 'bar' });
 

--- a/tests/tests/classes/Utils.js
+++ b/tests/tests/classes/Utils.js
@@ -6,178 +6,133 @@
 
 const path = require('path');
 const os = require('os');
-const YAML = require('js-yaml');
-const assert = require('chai').assert;
 const expect = require('chai').expect;
 const Utils = require('../../../lib/classes/Utils')({});
+const YamlParser = require('../../../lib/classes/YamlParser')({});
 
 const SUtils = new Utils();
+const SYamlParser = new YamlParser();
 
-describe('Utils class', () => {
+describe('Utils', () => {
 
-  after((done) => {
-    done();
-  });
+  describe('#exportObject()', () => {
+    it('should export an object', () => {
+      const data = {
+        _class: 'SampleClass',
+        publicProp: 'somethingPublic',
+        functionProp: () => {
+        },
+      };
 
-  it('should export an object', () => {
-    const data = {
-      _class: 'SampleClass',
-      publicProp: 'somethingPublic',
-      functionProp: () => {
-      }
-    };
-
-    const Obj = SUtils.exportObject(data);
-    assert.equal(Obj.publicProp, 'somethingPublic');
-    assert.equal(typeof Obj._class, 'undefined');
-    assert.equal(typeof Obj.functionProp, 'undefined');
-  });
-
-  it('should generate a shortId', () => {
-    const id = SUtils.generateShortId(6);
-    assert.equal(typeof id, 'string');
-    assert.equal(id.length, 6);
-  });
-
-  it('should check if a directory exists synchronously', () => {
-    const dir = SUtils.dirExistsSync(__dirname);
-    const noDir = SUtils.dirExistsSync(path.join(__dirname, '..', 'XYZ'));
-
-    assert.equal(dir, true);
-    assert.equal(noDir, false);
-  });
-
-  it('should check if a file exists synchronously', () => {
-    const file = SUtils.fileExistsSync(__filename);
-    const noFile = SUtils.fileExistsSync(path.join(__dirname, 'XYZ.json'));
-
-    assert.equal(file, true);
-    assert.equal(noFile, false);
-  });
-
-  it('should write a file synchronously', () => {
-    let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
-
-    SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
-    let obj = SUtils.readFileSync(tmpFilePath);
-
-    assert.equal(obj.foo, 'bar');
-  });
-
-  it('should write a yaml file synchronously', () => {
-    let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.yaml');
-
-    SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
-
-    return SUtils.parseYaml(tmpFilePath).then((obj) => {
-      expect(obj.foo).to.equal('bar');
+      const Obj = SUtils.exportObject(data);
+      expect(Obj.publicProp).to.equal('somethingPublic');
+      expect(Obj._class).to.be.an('undefined');
+      expect(Obj.functionProp).to.be.an('undefined');
     });
   });
 
-  it('should write a file asynchronously', () => {
-    let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
+  describe('#generateShortId()', () => {
+    it('should generate a shortId', () => {
+      const id = SUtils.generateShortId(6);
+      expect(id).to.be.a('string');
+    });
 
-    // note: use return when testing promises otherwise you'll have unhandled rejection errors
-    return SUtils.writeFile(tmpFilePath, { foo: 'bar' }).then(() => {
-      let obj = SUtils.readFileSync(tmpFilePath);
-
-      expect(obj.foo).to.equal('bar');
+    it('should generate a shortId for the given length', () => {
+      const id = SUtils.generateShortId(6);
+      expect(id.length).to.equal(6);
     });
   });
 
-  it('should read a file synchronously', () => {
-    let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
+  describe('#dirExistsSync()', () => {
 
-    SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
-    let obj = SUtils.readFileSync(tmpFilePath);
+    describe('When reading a directory', () => {
 
-    assert.equal(obj.foo, 'bar');
+      it('should detect if a directory exists', () => {
+        const dir = SUtils.dirExistsSync(__dirname);
+        expect(dir).to.equal(true);
+      });
+
+      it('should detect if a directory doesn\'t exist', () => {
+        const noDir = SUtils.dirExistsSync(path.join(__dirname, '..', 'XYZ'));
+        expect(noDir).to.equal(false);
+      });
+
+    });
+
   });
 
-  it('should read a file asynchronously', () => {
-    let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
+  describe('#fileExistsSync()', () => {
 
-    SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
+    describe('When reading a file', () => {
 
-    // note: use return when testing promises otherwise you'll have unhandled rejection errors
-    return SUtils.readFile(tmpFilePath).then((obj) => {
+      it('should detect if a file exists', () => {
+        const file = SUtils.fileExistsSync(__filename);
+        expect(file).to.equal(true);
+      });
+
+      it('should detect if a file doesn\'t exist', () => {
+        const noFile = SUtils.fileExistsSync(path.join(__dirname, 'XYZ.json'));
+        expect(noFile).to.equal(false);
+      });
+
+    });
+
+  });
+
+  describe('#writeFileSync()', () => {
+    it('should write a .json file synchronously', () => {
+      const tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
+
+      SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
+      const obj = SUtils.readFileSync(tmpFilePath);
+
       expect(obj.foo).to.equal('bar');
     });
-  });
 
+    it('should write a .yaml file synchronously', () => {
+      const tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.yaml');
 
-  describe('YAML Parser', () => {
+      SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
-    it('should parse a simple yaml file', () => {
-      let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'simple.yml');
-
-      SUtils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
-
-      return SUtils.parseYaml(tmpFilePath).then((obj) => {
+      return SYamlParser.parse(tmpFilePath).then((obj) => {
         expect(obj.foo).to.equal('bar');
       });
     });
+  });
 
-    it('should parse a yaml file with JSON-REF to yaml', () => {
-      let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+  describe('#writeFile()', () => {
+    it('should write a file asynchronously', () => {
+      const tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
 
+      // note: use return when testing promises otherwise you'll have unhandled rejection errors
+      return SUtils.writeFile(tmpFilePath, { foo: 'bar' }).then(() => {
+        const obj = SUtils.readFileSync(tmpFilePath);
 
-      SUtils.writeFileSync(path.join(tmpDirPath, 'ref.yaml'), { foo: 'bar' });
-
-      let testYaml = {
-        main: {
-          $ref: './ref.yaml'
-        }
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'test.yaml'), testYaml);
-
-      return SUtils.parseYaml(path.join(tmpDirPath, 'test.yaml')).then((obj) => {
-        expect(obj.main.foo).to.equal('bar');
+        expect(obj.foo).to.equal('bar');
       });
     });
+  });
 
-    it('should parse a yaml file with JSON-REF to json', () => {
-      let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+  describe('#readFileSync()', () => {
+    it('should read a file synchronously', () => {
+      const tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
 
-      SUtils.writeFileSync(path.join(tmpDirPath, 'ref.json'), { foo: 'bar' });
+      SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
+      const obj = SUtils.readFileSync(tmpFilePath);
 
-      let testYaml = {
-        main: {
-          $ref: './ref.json'
-        }
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'test.yaml'), testYaml);
-
-      return SUtils.parseYaml(path.join(tmpDirPath, 'test.yaml')).then((obj) => {
-        expect(obj.main.foo).to.equal('bar');
-      });
+      expect(obj.foo).to.equal('bar');
     });
+  });
 
-    it('should parse yaml file with recursive JSON-REF', () => {
-      let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+  describe('#readFile()', () => {
+    it('should read a file asynchronously', () => {
+      const tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
 
-      SUtils.writeFileSync(path.join(tmpDirPath, 'three.yaml'), { foo: 'bar' });
+      SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
-      let twoYaml = {
-        two: {
-          $ref: './three.yaml'
-        }
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'two.yaml'), twoYaml);
-
-      let oneYaml = {
-        one: {
-          $ref: './two.yaml'
-        }
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'one.yaml'), oneYaml);
-
-      return SUtils.parseYaml(path.join(tmpDirPath, 'one.yaml')).then((obj) => {
-        expect(obj.one.two.foo).to.equal('bar');
+      // note: use return when testing promises otherwise you'll have unhandled rejection errors
+      return SUtils.readFile(tmpFilePath).then((obj) => {
+        expect(obj.foo).to.equal('bar');
       });
     });
   });

--- a/tests/tests/classes/Utils.js
+++ b/tests/tests/classes/Utils.js
@@ -6,6 +6,7 @@
 
 const path = require('path');
 const os = require('os');
+const YAML = require('js-yaml');
 const assert = require('chai').assert;
 const expect = require('chai').expect;
 const Utils = require('../../../lib/classes/Utils')({});
@@ -63,6 +64,16 @@ describe('Utils class', () => {
     assert.equal(obj.foo, 'bar');
   });
 
+  it('should write a yaml file synchronously', () => {
+    let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.yaml');
+
+    SUtils.writeFileSync(tmpFilePath, { foo: 'bar' });
+
+    return SUtils.parseYaml(tmpFilePath).then((obj) => {
+      expect(obj.foo).to.equal('bar');
+    });
+  });
+
   it('should write a file asynchronously', () => {
     let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'anything.json');
 
@@ -91,6 +102,84 @@ describe('Utils class', () => {
     // note: use return when testing promises otherwise you'll have unhandled rejection errors
     return SUtils.readFile(tmpFilePath).then((obj) => {
       expect(obj.foo).to.equal('bar');
+    });
+  });
+
+
+  describe('YAML Parser', () => {
+
+    it('should parse a simple yaml file', () => {
+      let tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'simple.yml');
+
+      SUtils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
+
+      return SUtils.parseYaml(tmpFilePath).then((obj) => {
+        expect(obj.foo).to.equal('bar');
+      });
+    });
+
+    it('should parse a yaml file with JSON-REF to yaml', () => {
+      let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      //console.log(tmpDirPath)
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'ref.yaml'), { foo: 'bar' });
+
+      let testYaml = {
+        main: {
+          $ref: './ref.yaml'
+        }
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'test.yaml'), testYaml);
+
+      return SUtils.parseYaml(path.join(tmpDirPath, 'test.yaml')).then((obj) => {
+        expect(obj.main.foo).to.equal('bar');
+      });
+    });
+
+    it('should parse a yaml file with JSON-REF to json', () => {
+      let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'ref.json'), { foo: 'bar' });
+
+      let testYaml = {
+        main: {
+          $ref: './ref.json'
+        }
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'test.yaml'), testYaml);
+
+      return SUtils.parseYaml(path.join(tmpDirPath, 'test.yaml')).then((obj) => {
+        expect(obj.main.foo).to.equal('bar');
+      });
+    });
+
+    it('should parse yaml file with recursive JSON-REF', () => {
+      let tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'three.yaml'), { foo: 'bar' });
+
+      let twoYaml = {
+        two: {
+          $ref: './three.yaml'
+        }
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'two.yaml'), twoYaml);
+
+      let oneYaml = {
+        one: {
+          $ref: './two.yaml'
+        }
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'one.yaml'), oneYaml);
+
+      return SUtils.parseYaml(path.join(tmpDirPath, 'one.yaml')).then((obj) => {
+        expect(obj.one.two.foo).to.equal('bar');
+      });
     });
   });
 

--- a/tests/tests/classes/YamlParser.js
+++ b/tests/tests/classes/YamlParser.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Test: YamlParser Function Class
+ */
+
+const expect = require('chai').expect;
+const YAML = require('js-yaml');
+const path = require('path');
+const os = require('os');
+const YamlParser = require('../../../lib/classes/YamlParser')({});
+const Utils = require('../../../lib/classes/Utils')({});
+
+const SUtils = new Utils();
+const SYamlParser = new YamlParser();
+
+describe('YamlParser', () => {
+
+  describe('#parse()', () => {
+
+    it('should parse a simple yaml file', () => {
+      const tmpFilePath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'simple.yml');
+
+      SUtils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
+
+      return SYamlParser.parse(tmpFilePath).then((obj) => {
+        expect(obj.foo).to.equal('bar');
+      });
+    });
+
+    it('should parse a yaml file with JSON-REF to yaml', () => {
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'ref.yaml'), { foo: 'bar' });
+
+      const testYaml = {
+        main: {
+          $ref: './ref.yaml',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'test.yaml'), testYaml);
+
+      return SYamlParser.parse(path.join(tmpDirPath, 'test.yaml')).then((obj) => {
+        expect(obj.main.foo).to.equal('bar');
+      });
+    });
+
+    it('should parse a yaml file with JSON-REF to json', () => {
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'ref.json'), { foo: 'bar' });
+
+      const testYaml = {
+        main: {
+          $ref: './ref.json',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'test.yaml'), testYaml);
+
+      return SYamlParser.parse(path.join(tmpDirPath, 'test.yaml')).then((obj) => {
+        expect(obj.main.foo).to.equal('bar');
+      });
+    });
+
+    it('should parse yaml file with recursive JSON-REF', () => {
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'three.yaml'), { foo: 'bar' });
+
+      const twoYaml = {
+        two: {
+          $ref: './three.yaml',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'two.yaml'), twoYaml);
+
+      const oneYaml = {
+        one: {
+          $ref: './two.yaml',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'one.yaml'), oneYaml);
+
+      return SYamlParser.parse(path.join(tmpDirPath, 'one.yaml')).then((obj) => {
+        expect(obj.one.two.foo).to.equal('bar');
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
- Can parse yaml files and returns a JS object literal representing the resolved yaml file
- Can resolve any json-ref that is referring to a json file
- Can resolve any json-ref that is refering to a yaml file
- Can **recusively** resolve json-ref. Ie. `serverless.yaml` references `functions.yaml`, which references `events.yaml`
- Includes passing unit tests to assert the above statements

This parser will be used by the `Service.load()` method to load all Service data from `serverless.yaml` and `serverless.meta.yaml`.
