### PR TITLE
Restore original directory properly in SUtils.npmInstall

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -370,13 +370,15 @@ module.exports = {
    */
 
   npmInstall: function(dir) {
+    let previousDir = process.cwd();
     process.chdir(dir);
 
     if (exec('npm install ', { silent: false }).code !== 0) {
+      process.chdir(previousDir);
       throw new SError(`Error executing NPM install on ${dir}`, SError.errorCodes.UNKNOWN);
     }
 
-    process.chdir(process.cwd());
+    process.chdir(previousDir);
   },
 
   /**


### PR DESCRIPTION
This fixes a small issue with the npmInstall function not restoring the current directory after npm install.