### PR TITLE
Added link to boilerplate project for Python functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Refer to our [documentation](http://docs.serverless.com) for more info.  Enjoy!
 ## Projects
 Serverless Projects are shareable and installable.  You can publish them to npm and install them via the Serverless Framework CLI by using `$ serverless project install <project-name>`
 * [serverless-graphql](https://github.com/serverless/serverless-graphql) - Official Serverless boilerplate to kick start your project
-* [serverless-starter](https://github.com/serverless/serverless-starter) - A simple boilerplate for new projects with a few architectural options
+* [serverless-starter](https://github.com/serverless/serverless-starter) - A simple boilerplate for new projects (JavaScript) with a few architectural options
+* [serverless-starter-python](https://github.com/alexcasalboni/serverless-starter-python) - A simple boilerplate for new projects (Python) with a few architectural options
 * [serverless-graphql-blog](https://github.com/serverless/serverless-graphql-blog) - A blog boilerplate that leverages GraphQL in front of DynamoDB to offer a minimal REST API featuring only 1 endpoint
 * [serverless-authentication-boilerplate](https://github.com/laardee/serverless-authentication-boilerplate) - A generic authentication boilerplate for Serverless framework 
 * [sc5-serverless-boilerplate](https://github.com/SC5/sc5-serverless-boilerplate) - A boilerplate for test driven development of REST endpoints


### PR DESCRIPTION
The new project is [here](https://github.com/alexcasalboni/serverless-starter-python) ([npm](https://www.npmjs.com/package/serverless-starter-python)).
It's basically a clone of the [serverless-starter project](https://github.com/serverless/serverless-starter), but with Python functions.