### PR TITLE
Add argument support for CLI and plugins

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -21,4 +21,4 @@ if (process.argv.indexOf('--serverless-integration-test') > -1) {
   serverless.instances.pluginManager.addPlugin(TestsPlugin);
 }
 
-serverless.runCommand();
+serverless.run();

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -25,7 +25,7 @@ class HelloWorld {
   constructor() {
     this.commands = {
       deploy: {
-        lifeCycleEvents: [
+        lifecycleEvents: [
           'resources',
           'functions'
         ]
@@ -63,13 +63,13 @@ You can also nest commands, e.g. if you want to provide a command ```serverless 
 constructor() {
   this.commands = {
   deploy: {
-    lifeCycleEvents: [
+    lifecycleEvents: [
       'resources',
       'functions'
     ],
     commands: {
       single: {
-        lifeCycleEvents: [
+        lifecycleEvents: [
           'resources',
           'functions'
         ],
@@ -91,7 +91,7 @@ class Deploy {
   constructor() {
     this.commands = {
       deploy: {
-        lifeCycleEvents: [
+        lifecycleEvents: [
           'resources',
           'functions'
         ]

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -35,12 +35,13 @@ class Serverless {
 
     this.instances.cli = new CLI(this, configObj.interactive);
 
-    this.commandsToBeProcessed = this.instances.cli.processCommands();
+    this.inputToBeProcessed = this.instances.cli.processInput();
   }
 
-  runCommand() {
-    if (this.commandsToBeProcessed.length) {
-      this.instances.pluginManager.runCommand(this.commandsToBeProcessed);
+  run() {
+    if (this.inputToBeProcessed.commands.length) {
+      this.instances.pluginManager.run(this.inputToBeProcessed.commands,
+        this.inputToBeProcessed.args);
     }
   }
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -16,41 +16,58 @@ BbPromise.promisifyAll(fs);
 BbPromise.promisifyAll(prompt);
 
 class CLI {
-  constructor(serverless, isInteractive, argumentsArray) {
+  constructor(serverless, isInteractive, inputArray) {
     this.serverless = serverless;
     this.isInteractive = isInteractive;
-    this.argumentsArray = (typeof argumentsArray !== 'undefined' ? argumentsArray : []);
+    this.inputArray = (typeof inputArray !== 'undefined' ? inputArray : []);
   }
 
-  processCommands() {
-    let argumentsArray;
+  processInput() {
+    let inputArray;
 
     // check if arguments are passed externally (e.g. used by tests)
     // otherwise use process.argv to receive the commands
-    if (this.argumentsArray.length) {
-      argumentsArray = this.argumentsArray;
+    if (this.inputArray.length) {
+      inputArray = this.inputArray;
     } else {
-      argumentsArray = process.argv.slice(2);
+      inputArray = process.argv.slice(2);
     }
 
-    const argv = minimist(argumentsArray);
+    const argv = minimist(inputArray);
 
-    const commandsToBeProcessed = [];
+    const commandsAndArguments = {};
 
-    if (argv._.indexOf('help') > -1 || argv.help || argv.h) {
+    if ((argv._.length === 0 && (argv.help || argv.h)) ||
+      (argv._.length === 1 && (argv._.indexOf('help') > -1))) {
       this.generateMainHelp();
-      return commandsToBeProcessed;
+      return commandsAndArguments;
     }
-    if (argv._.indexOf('version') > -1 || argv.version || argv.v) {
+    if ((argv._.length === 0 && (argv.version || argv.v)) ||
+      (argv._.length === 1 && (argv._.indexOf('version') > -1))) {
       this.getVersionNumber();
-      return commandsToBeProcessed;
+      return commandsAndArguments;
     }
 
+    const commands = [];
+    const args = {};
+
+    // get all the commands
     argv._.forEach((command) => {
-      commandsToBeProcessed.push(command);
+      commands.push(command);
     });
 
-    return commandsToBeProcessed;
+    // remove the array which holds the commands from the argv object
+    const argsObject = _.omit(argv, ['_']);
+
+    // get all the arguments
+    _.forEach(argsObject, (value, key) => {
+      args[key] = value;
+    });
+
+    commandsAndArguments.commands = commands;
+    commandsAndArguments.args = args;
+
+    return commandsAndArguments;
   }
 
   generateMainHelp(allCommands) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -18,7 +18,7 @@ class PluginManager {
     this.loadServicePlugins(servicePlugins);
   }
 
-  runCommand(commandsArray) {
+  run(commandsArray, argumentsArray) {
     const events = this.getEvents(commandsArray, this.commands);
     // collect all relevant hooks
     let hooks = [];
@@ -40,7 +40,7 @@ class PluginManager {
 
     // run all relevant hooks one after another
     hooks.forEach((hook) => {
-      const returnValue = hook();
+      const returnValue = hook(argumentsArray);
 
       // check if a Promise is returned
       if (returnValue && returnValue.then instanceof Function) {
@@ -98,7 +98,7 @@ class PluginManager {
       const commandDetails = availableCommands[commandPart];
       if (commandsArray.length === 1) {
         const events = [];
-        commandDetails.lifeCycleEvents.forEach((event) => {
+        commandDetails.lifecycleEvents.forEach((event) => {
           events.push(`before:${prefix}${commandPart}:${event}`);
           events.push(`${prefix}${commandPart}:${event}`);
           events.push(`after:${prefix}${commandPart}:${event}`);

--- a/lib/plugins/HelloWorld/HelloWorld.js
+++ b/lib/plugins/HelloWorld/HelloWorld.js
@@ -5,11 +5,16 @@ class HelloWorld {
     this.commands = {
       greet: {
         usage: 'Run this command to get greeted.',
-        lifeCycleEvents: [
+        lifecycleEvents: [
           'printGoodMorning',
           'printHello',
-          'printGoodEvening'
-        ]
+          'printGoodEvening',
+        ],
+        arguments: {
+          gender: {
+            usage: 'Define what gender the user has (can be "male" or "female")',
+          },
+        },
       },
     };
 
@@ -20,20 +25,29 @@ class HelloWorld {
     };
   }
 
-  printGoodMorning() {
-    const message = 'Good morning';
+  printGoodMorning(args) {
+    let message = 'Good morning madam';
+    if (args.gender === 'male') {
+      message = 'Good morning sir';
+    }
     console.log(message);
     return message;
   }
 
-  printHello() {
-    const message = 'Hello';
+  printHello(args) {
+    let message = 'Hello madam';
+    if (args.gender === 'male') {
+      message = 'Hello sir';
+    }
     console.log(message);
     return message;
   }
 
-  printGoodEvening() {
-    const message = 'Good evening';
+  printGoodEvening(args) {
+    let message = 'Good evening madam';
+    if (args.gender === 'male') {
+      message = 'Good evening sir';
+    }
     console.log(message);
     return message;
   }

--- a/lib/plugins/Tests/Tests.js
+++ b/lib/plugins/Tests/Tests.js
@@ -7,7 +7,7 @@ class Tests {
         commands: {
           integration: {
             usage: 'Command for integration testing.',
-            lifeCycleEvents: [
+            lifecycleEvents: [
               'logCommandsOnConsole',
             ],
           },

--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -28,68 +28,91 @@ describe('CLI', () => {
       expect(cli.isInteractive).to.equal(isInteractive);
     });
 
-    it('should set an empty argumentsArray when none is provided', () => {
+    it('should set an empty inputArray when none is provided', () => {
       cli = new CLI(serverless, isInteractive);
-      expect(cli.argumentsArray.length).to.equal(0);
+      expect(cli.inputArray.length).to.equal(0);
     });
 
-    it('should set the argumentsArray when provided', () => {
-      const cliWithArguments = new CLI(serverless, isInteractive, ['foo', 'bar']);
+    it('should set the inputObject when provided', () => {
+      const cliWithArguments = new CLI(serverless, isInteractive, ['foo', 'bar', '--baz', '-qux']);
 
-      expect(cliWithArguments.argumentsArray[0]).to.equal('foo');
-      expect(cliWithArguments.argumentsArray[1]).to.equal('bar');
+      expect(cliWithArguments.inputArray[0]).to.equal('foo');
+      expect(cliWithArguments.inputArray[1]).to.equal('bar');
+      expect(cliWithArguments.inputArray[2]).to.equal('--baz');
+      expect(cliWithArguments.inputArray[3]).to.equal('-qux');
     });
   });
 
-  describe('#processCommands()', () => {
-    it('should return an empty array when the "help" parameter is given', () => {
+  describe('#processInput()', () => {
+    it('should return an empty object when the "help" parameter is given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['help']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed.length).to.equal(0);
+      expect(inputToBeProcessed).to.deep.equal({});
     });
 
-    it('should return an empty array when the "--help" parameter is given', () => {
+    it('should return an empty object when the "--help" parameter is given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['--help']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed.length).to.equal(0);
+      expect(inputToBeProcessed).to.deep.equal({});
     });
 
-    it('should return an empty array when the "--h" parameter is given', () => {
+    it('should return an empty object when the "--h" parameter is given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['--h']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed.length).to.equal(0);
+      expect(inputToBeProcessed).to.deep.equal({});
     });
 
-    it('should return an empty array when the "version" parameter is given', () => {
+    it('should return an empty object when the "version" parameter is given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['version']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed.length).to.equal(0);
+      expect(inputToBeProcessed).to.deep.equal({});
     });
 
-    it('should return an empty array when the "--version" parameter is given', () => {
+    it('should return an empty object when the "--version" parameter is given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['--version']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed.length).to.equal(0);
+      expect(inputToBeProcessed).to.deep.equal({});
     });
 
-    it('should return an empty array when the "--v" parameter is given', () => {
+    it('should return an empty object when the "--v" parameter is given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['--v']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed.length).to.equal(0);
+      expect(inputToBeProcessed).to.deep.equal({});
     });
 
-    it('should return the passed arguments as an array of commands', () => {
+    it('should only return the commands when only commands are given', () => {
       const cliWithExternalArguments = new CLI(serverless, isInteractive, ['deploy', 'functions']);
-      const commandsToBeProcessed = cliWithExternalArguments.processCommands();
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
 
-      expect(commandsToBeProcessed[0]).to.equal('deploy');
-      expect(commandsToBeProcessed[1]).to.equal('functions');
+      const expectedObject = { commands: ['deploy', 'functions'], args: {} };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
+    });
+
+    it('should only return the arguments when only arguments are given', () => {
+      const cliWithExternalArguments = new CLI(serverless, isInteractive,
+        ['-f', 'function1', '-r', 'resource1']);
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
+
+      const expectedObject = { commands: [], args: { f: 'function1', r: 'resource1' } };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
+    });
+
+    it('should return commands and arguments when both are given', () => {
+      const cliWithExternalArguments = new CLI(serverless, isInteractive,
+        ['deploy', 'functions', '-f', 'function1']);
+      const inputToBeProcessed = cliWithExternalArguments.processInput();
+
+      const expectedObject = { commands: ['deploy', 'functions'], args: { f: 'function1' } };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
     });
   });
 });


### PR DESCRIPTION
Add the possibility to access arguments inside plugins (e.g. "--function function1" or "-f function").
Additionally the "lifeCycleEvent" property is renamed to "lifecycleEvent".