### PR TITLE
Closes #1197 iamRoleArnLambda property missing from _meta/variables/s-variables-${stage}-${region}.json after project init

### DIFF
--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -303,7 +303,7 @@ module.exports = function(S) {
 
             // No updates are to be performed
             if (e.message == 'No updates are to be performed.') {
-              return 'No resource updates are to be performed.';
+              return aws.request('CloudFormation', 'describeStacks', {StackName: stackName}, stage, region);
             }
 
             // If does not exist, create stack


### PR DESCRIPTION
When doing ```sls project init``` for a project that has it's resources already deployed (in a clean checkout or after ```git clean -fdx```), the initialization doesn't get the iamRoleArnLambda from the existing stack and subsequent endpoint deployments fail with the message:
```
Serverless:   GET - ${function}: Cannot read property 'replace' of undefined
```