### PR TITLE
Refactor PluginManager functionality / Add option validation in plugin manager

### DIFF
--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -142,17 +142,47 @@ class Deploy {
 module.exports = Deploy;
 ```
 
+### Serverless instance
+
+The serverless instance which enables access to the whole Serverless setup during runtime is passed as the first
+parameter of the plugin constructor.
+
+class MyPlugin {
+  constructor(serverless) {
+    this.serverless = serverless;
+
+    this.commands = {
+      log: {
+        lifecycleEvents: [
+          'serverless'
+        ],
+      },
+    };
+
+    this.hooks = {
+      'log:serverless': this.logServerless
+    }
+  }
+
+  deployFunction() {
+    console.log('Serverless instance: ', this.serverless);
+  }
+}
+```
+
+
 ### Options
 
 Each (sub)command can have multiple options. Options are passed with a single dash (`-`) or a double dash (`--`) like
 this: `serverless function deploy --function functionName` or `serverless resource deploy -r resourceName`.
-The `options` object will be passed in as the first parameter to your hook function where you can access it.
+The `options` object will be passed in as the second parameter to the constructor of your plugin.
 
 ```javascript
 'use strict';
 
 class Deploy {
-  constructor() {
+  constructor(serverless, options) {
+    this.options = options;
     this.commands = {
       deploy: {
         lifecycleEvents: [
@@ -171,14 +201,11 @@ class Deploy {
     }
   }
 
-  deployFunction(options) {
-    console.log('Deploying function: ', options.function);
+  deployFunction() {
+    console.log('Deploying function: ', this.options.function);
   }
 }
 ```
-
-Options can be accessed with the help of the `options` object which will be automatically passed as the first parameter
-of the corresponding hook function.
 
 ## Registering plugins for hooks and commands
 

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -207,6 +207,40 @@ class Deploy {
 }
 ```
 
+Options can be marked as required. This way the plugin manager will automatically raise an error if a required option
+is not passed in via the CLI. You can mark options as required with the help of `required: true` inside the commands object:
+
+```javascript
+'use strict';
+
+class Deploy {
+  constructor(serverless, options) {
+    this.options = options;
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'functions'
+        ],
+        options: {
+          function: {
+            required: true,
+            usage: 'Specify the function you want to deploy (e.g. "--function myFunction")'
+          }
+        }
+      },
+    };
+
+    this.hooks = {
+      'deploy:functions': this.deployFunction
+    }
+  }
+
+  deployFunction() {
+    console.log('Deploying function: ', this.options.function);
+  }
+}
+```
+
 ## Registering plugins for hooks and commands
 
 A user has to define the plugins they want to use in the root level of the serverless.yaml file:

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -148,8 +148,9 @@ The serverless instance which enables access to the whole Serverless setup durin
 parameter of the plugin constructor.
 
 class MyPlugin {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
 
     this.commands = {
       log: {
@@ -182,7 +183,9 @@ The `options` object will be passed in as the second parameter to the constructo
 
 class Deploy {
   constructor(serverless, options) {
+    this.serverless = serverless;
     this.options = options;
+
     this.commands = {
       deploy: {
         lifecycleEvents: [
@@ -216,6 +219,7 @@ is not passed in via the CLI. You can mark options as required with the help of 
 class Deploy {
   constructor(serverless, options) {
     this.options = options;
+
     this.commands = {
       deploy: {
         lifecycleEvents: [

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -49,22 +49,22 @@ class Serverless {
         // get an array of commands and options that should be processed
         this.inputToBeProcessed = this.cli.processInput();
 
+        // set the options
+        this.pluginManager.setOptions(this.inputToBeProcessed.options);
+
         // load all plugins
         this.pluginManager.loadAllPlugins();
 
         // give the CLI the plugins so that it can print out plugin information
         // such as options when the user enters --help
-        this.cli.setLoadedPlugins(this.pluginManager.getPlugins);
+        this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
       });
   }
 
   run() {
     if (this.inputToBeProcessed.commands.length) {
       // trigger the plugin lifecycle when there's something which should be processed
-      this.pluginManager.run(
-        this.inputToBeProcessed.commands,
-        this.inputToBeProcessed.options
-      );
+      this.pluginManager.run(this.inputToBeProcessed.commands);
     }
   }
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -40,20 +40,27 @@ class Serverless {
   init() {
     return this.service.load()
       .then(() => {
-        this.pluginManager.loadAllPlugins();
-
+        // create a new CLI instance
         this.cli = new CLI(
           this,
-          this.config.interactive,
-          this.pluginManager.getPlugins()
+          this.config.interactive
         );
 
+        // get an array of commands and options that should be processed
         this.inputToBeProcessed = this.cli.processInput();
+
+        // load all plugins
+        this.pluginManager.loadAllPlugins();
+
+        // give the CLI the plugins so that it can print out plugin information
+        // such as options when the user enters --help
+        this.cli.setLoadedPlugins(this.pluginManager.getPlugins);
       });
   }
 
   run() {
     if (this.inputToBeProcessed.commands.length) {
+      // trigger the plugin lifecycle when there's something which should be processed
       this.pluginManager.run(
         this.inputToBeProcessed.commands,
         this.inputToBeProcessed.options

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -47,10 +47,10 @@ class Serverless {
         );
 
         // get an array of commands and options that should be processed
-        this.inputToBeProcessed = this.cli.processInput();
+        this.processedInput = this.cli.processInput();
 
         // set the options
-        this.pluginManager.setOptions(this.inputToBeProcessed.options);
+        this.pluginManager.setOptions(this.processedInput.options);
 
         // load all plugins
         this.pluginManager.loadAllPlugins();
@@ -62,9 +62,9 @@ class Serverless {
   }
 
   run() {
-    if (this.inputToBeProcessed.commands.length) {
+    if (!this.cli.displayHelp(this.processedInput) && this.processedInput.commands.length) {
       // trigger the plugin lifecycle when there's something which should be processed
-      this.pluginManager.run(this.inputToBeProcessed.commands);
+      this.pluginManager.run(this.processedInput.commands);
     }
   }
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -11,6 +11,10 @@ const Service = require('./classes/Service');
 const SError = require('./classes/Error');
 const Version = require('./../package.json').version;
 
+process.on('unhandledRejection', (e) => {
+  throw new SError(e);
+});
+
 class Serverless {
   constructor(config) {
     let configObject = config;

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -8,11 +8,15 @@ const os = require('os');
 const chalk = require('chalk');
 
 class CLI {
-  constructor(serverless, interactive, loadedPlugins, inputArray) {
+  constructor(serverless, interactive, inputArray) {
     this.serverless = serverless;
     this.interactive = interactive;
-    this.loadedPlugins = (typeof loadedPlugins !== 'undefined' ? loadedPlugins : []);
     this.inputArray = (typeof inputArray !== 'undefined' ? inputArray : []);
+    this.loadedPlugins = [];
+  }
+
+  setLoadedPlugins(plugins) {
+    this.loadedPlugins = plugins;
   }
 
   processInput() {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -19,6 +19,30 @@ class CLI {
     this.loadedPlugins = plugins;
   }
 
+  displayHelp(processedInput) {
+    const commands = processedInput.commands;
+    const options = processedInput.options;
+
+    // if only "help" or "h" was entered
+    if ((commands.length === 0 && (options.help || options.h)) ||
+      (commands.length === 1 && (commands.indexOf('help') > -1))) {
+      this.generateMainHelp();
+      return true;
+    }
+    // if only "version" or "v" was entered
+    if ((commands.length === 0 && (options.version || options.v)) ||
+      (commands.length === 1 && (commands.indexOf('version') > -1))) {
+      this.getVersionNumber();
+      return true;
+    }
+    // if "help" was entered in combination with commands (or one command)
+    if (commands.length >= 1 && (options.help || options.h)) {
+      this.generateCommandsHelp(commands);
+      return true;
+    }
+    return false;
+  }
+
   processInput() {
     let inputArray;
 
@@ -35,25 +59,6 @@ class CLI {
     const commandsAndOptions = {};
     commandsAndOptions.commands = [];
     commandsAndOptions.options = {};
-
-    // if only "help" or "h" was entered
-    if ((argv._.length === 0 && (argv.help || argv.h)) ||
-      (argv._.length === 1 && (argv._.indexOf('help') > -1))) {
-      this.generateMainHelp();
-      return commandsAndOptions;
-    }
-    // if only "version" or "v" was entered
-    if ((argv._.length === 0 && (argv.version || argv.v)) ||
-      (argv._.length === 1 && (argv._.indexOf('version') > -1))) {
-      this.getVersionNumber();
-      return commandsAndOptions;
-    }
-    // if "help" was entered in combination with commands (or one command)
-    if (argv._.length >= 1 && (argv.help || argv.h)) {
-      const commands = argv._;
-      this.generateCommandsHelp(commands);
-      return commandsAndOptions;
-    }
 
     const commands = [];
     const options = {};

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -23,7 +23,27 @@ class PluginManager {
     this.loadServicePlugins(servicePlugins);
   }
 
+  validateOptions(commandsArray) {
+    let options;
+
+    // TODO: implement an option to get deeper that two levels
+    if (commandsArray.length === 1) {
+      options = this.commands[commandsArray[0]].options;
+    } else {
+      options = this.commands[commandsArray[0]].commands[commandsArray[1]].options;
+    }
+
+    forEach(options, (value, key) => {
+      if (value.required && (this.options[key] === true || !(this.options[key]))) {
+        throw new Error(`Please provide the "${key}" option`);
+      }
+    });
+  }
+
   run(commandsArray) {
+    // check if all options are passed
+    this.validateOptions(commandsArray);
+
     const events = this.getEvents(commandsArray, this.commands);
     // collect all relevant hooks
     let hooks = [];

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -53,7 +53,7 @@ class PluginManager {
         forEach(pluginInstance.hooks, (hook, hookKey) => {
           if (hookKey === event) {
             // use arrow fn. to pass the hook with options rather than calling it
-            hooksForEvent.push(() => hook(optionsArray));
+            hooksForEvent.push(() => hook());
           }
         });
       });

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -35,7 +35,7 @@ class PluginManager {
 
     forEach(options, (value, key) => {
       if (value.required && (this.options[key] === true || !(this.options[key]))) {
-        throw new Error(`Please provide the "${key}" option`);
+        throw new this.serverless.classes.Error(`Please provide the "${key}" option`);
       }
     });
   }
@@ -61,7 +61,8 @@ class PluginManager {
     });
 
     if (hooks.length === 0) {
-      throw new Error('The command you entered was not found. Did you spell it correctly?');
+      throw new this.serverless.classes.Error('The command you entered was not found. ' +
+        'Did you spell it correctly?');
     }
 
     // using arr.reduce to sequentially run promises in array in order

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -11,6 +11,11 @@ class PluginManager {
     this.plugins = [];
     this.commandsList = [];
     this.commands = {};
+    this.options = {};
+  }
+
+  setOptions(options) {
+    this.options = options;
   }
 
   loadAllPlugins(servicePlugins) {
@@ -18,7 +23,7 @@ class PluginManager {
     this.loadServicePlugins(servicePlugins);
   }
 
-  run(commandsArray, optionsArray) {
+  run(commandsArray) {
     const events = this.getEvents(commandsArray, this.commands);
     // collect all relevant hooks
     let hooks = [];
@@ -46,7 +51,7 @@ class PluginManager {
   }
 
   addPlugin(Plugin) {
-    this.plugins.push(new Plugin(this.serverless));
+    this.plugins.push(new Plugin(this.serverless, this.options));
 
     this.loadCommands(Plugin);
   }

--- a/lib/plugins/awsCompileFunctions/awsCompileFunctions.js
+++ b/lib/plugins/awsCompileFunctions/awsCompileFunctions.js
@@ -3,25 +3,16 @@
 const merge = require('lodash').merge;
 
 class AwsCompileFunctions {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
 
     this.hooks = {
       'deploy:compileFunctions': this.compileFunctions.bind(this),
     };
   }
 
-  compileFunctions(options) {
-    this.options = options;
-
-    if (!options.stage) {
-      throw new this.serverless.Error('Please provide a stage');
-    }
-
-    if (!options.region) {
-      throw new this.serverless.Error('Please provide a region');
-    }
-
+  compileFunctions() {
     if (!this.serverless.service.resources.aws.Resources) {
       throw new this.serverless.Error(
         'This plugin needs access to Resources section of the AWS CloudFormation template');

--- a/lib/plugins/awsCompileFunctions/tests/awsCompileFunctions.js
+++ b/lib/plugins/awsCompileFunctions/tests/awsCompileFunctions.js
@@ -71,30 +71,24 @@ describe('awsCompileFunctions', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.init();
-    awsCompileFunctions = new AwsCompileFunctions(serverless);
+    const options = {
+      stage: 'dev',
+      region: 'aws_useast1',
+    };
+    awsCompileFunctions = new AwsCompileFunctions(serverless, options);
     serverless.service.resources = { aws: { Resources: {} } };
     awsCompileFunctions.serverless.service.functions = functionsObjectMock;
     awsCompileFunctions.serverless.service.service = 'new-service';
   });
 
   describe('#compileFunctions()', () => {
-    const options = { stage: 'dev', region: 'aws_useast1' };
-
-    it('should throw an error if the stage option is not given', () => {
-      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
-    });
-
-    it('should throw an error if the region option is not given', () => {
-      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
-    });
-
     it('should throw an error if the aws resource is not available', () => {
       awsCompileFunctions.serverless.service.resources.aws.Resources = false;
       expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
     });
 
     it('should create corresponding function resources', () => {
-      awsCompileFunctions.compileFunctions(options);
+      awsCompileFunctions.compileFunctions();
 
       expect(
         JSON.stringify(awsCompileFunctions.serverless.service.resources.aws.Resources)

--- a/lib/plugins/awsCompileS3Events/awsCompileS3Events.js
+++ b/lib/plugins/awsCompileS3Events/awsCompileS3Events.js
@@ -3,25 +3,16 @@
 const merge = require('lodash').merge;
 
 class AwsCompileS3Events {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
 
     this.hooks = {
       'deploy:compileEvents': this.compileS3Events.bind(this),
     };
   }
 
-  compileS3Events(options) {
-    this.options = options;
-
-    if (!options.stage) {
-      throw new this.serverless.Error('Please provide a stage');
-    }
-
-    if (!options.region) {
-      throw new this.serverless.Error('Please provide a region');
-    }
-
+  compileS3Events() {
     if (!this.serverless.service.resources.aws.Resources) {
       throw new this.serverless.Error(
         'This plugin needs access to Resources section of the AWS CloudFormation template');

--- a/lib/plugins/awsCompileS3Events/tests/awsCompileS3Events.js
+++ b/lib/plugins/awsCompileS3Events/tests/awsCompileS3Events.js
@@ -171,29 +171,23 @@ describe('awsCompileS3Events', () => {
     serverless = new Serverless();
     serverless.init();
     serverless.service.resources = { aws: { Resources: {} } };
-    awsCompileS3Events = new AwsCompileS3Events(serverless);
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileS3Events = new AwsCompileS3Events(serverless, options);
     awsCompileS3Events.serverless.service.service = 'new-service';
     awsCompileS3Events.serverless.service.functions = functionsObjectMock;
   });
 
   describe('#compileS3Events()', () => {
-    const options = { stage: 'dev', region: 'us-east-1' };
-
-    it('should throw an error if the stage option is not given', () => {
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
-    });
-
-    it('should throw an error if the region option is not given', () => {
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
-    });
-
     it('should throw an error if the aws resource is not available', () => {
       awsCompileS3Events.serverless.service.resources.aws.Resources = false;
       expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
     });
 
     it('should create corresponding S3 bucket and permission resources', () => {
-      awsCompileS3Events.compileS3Events(options);
+      awsCompileS3Events.compileS3Events();
 
       expect(
         JSON.stringify(awsCompileS3Events.serverless.service.resources.aws.Resources)

--- a/lib/plugins/awsDeploy/awsDeploy.js
+++ b/lib/plugins/awsDeploy/awsDeploy.js
@@ -10,8 +10,9 @@ const updateStack = require('./lib/updateStack');
 const AWS = require('aws-sdk');
 
 class AwsDeploy {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
 
     Object.assign(
       this,
@@ -23,9 +24,7 @@ class AwsDeploy {
     );
 
     this.hooks = {
-      'before:deploy:initializeResources': (options) => {
-        this.options = options || {};
-
+      'before:deploy:initializeResources': () => {
         const config = {
           region: this.options.region,
         };

--- a/lib/plugins/awsDeploy/lib/validateInput.js
+++ b/lib/plugins/awsDeploy/lib/validateInput.js
@@ -4,14 +4,6 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   validateInput() {
-    if (!this.options.stage) {
-      throw new this.serverless.classes.Error('Please provide a stage name');
-    }
-
-    if (!this.options.region) {
-      throw new this.serverless.classes.Error('Please provide a region name');
-    }
-
     if (!this.serverless.config.servicePath) {
       throw new this.serverless.classes.Error('This command can only be run inside a service');
     }

--- a/lib/plugins/awsDeploy/tests/awsDeploy.js
+++ b/lib/plugins/awsDeploy/tests/awsDeploy.js
@@ -9,7 +9,11 @@ const sinon = require('sinon');
 describe('AwsDeploy', () => {
   const serverless = new Serverless();
   serverless.init();
-  const awsDeploy = new AwsDeploy(serverless);
+  const options = {
+    stage: 'dev',
+    region: 'us-east-1',
+  };
+  const awsDeploy = new AwsDeploy(serverless, options);
 
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsDeploy.hooks).to.be.not.empty);

--- a/lib/plugins/awsDeploy/tests/validateInput.js
+++ b/lib/plugins/awsDeploy/tests/validateInput.js
@@ -40,16 +40,6 @@ describe('#validateInput()', () => {
     };
   });
 
-  it('should throw error if stage option not provided', () => {
-    awsDeploy.options.stage = false;
-    expect(() => awsDeploy.validateInput()).to.throw(Error);
-  });
-
-  it('should throw error if region option not provided', () => {
-    awsDeploy.options.region = false;
-    expect(() => awsDeploy.validateInput()).to.throw(Error);
-  });
-
   it('should throw error if stage does not exist in service', () => {
     awsDeploy.options.stage = 'prod';
     expect(() => awsDeploy.validateInput()).to.throw(Error);

--- a/lib/plugins/awsInvoke/awsInvoke.js
+++ b/lib/plugins/awsInvoke/awsInvoke.js
@@ -7,14 +7,12 @@ const AWS = require('aws-sdk');
 const moment = require('moment');
 
 class AwsInvoke {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
-    this.options = {};
+    this.options = options;
 
     this.hooks = {
-      'invoke:invoke': (options) => {
-        this.options = options;
-
+      'invoke:invoke': () => {
         return BbPromise.bind(this)
           .then(this.validate)
           .then(this.invoke)
@@ -26,18 +24,6 @@ class AwsInvoke {
   validate() {
     if (!this.serverless.config.servicePath) {
       throw new this.serverless.classes.Error('This command can only be run inside a service.');
-    }
-
-    if (!this.options.function) {
-      throw new this.serverless.classes.Error('Please provide a function name.');
-    }
-
-    if (!this.options.stage) {
-      throw new this.serverless.classes.Error('Please provide a stage name.');
-    }
-
-    if (!this.options.region) {
-      throw new this.serverless.classes.Error('Please provide a region name.');
     }
 
     // validate stage/region/function exists in service

--- a/lib/plugins/awsInvoke/tests/awsInvoke.js
+++ b/lib/plugins/awsInvoke/tests/awsInvoke.js
@@ -83,24 +83,6 @@ describe('awsInvoke', () => {
       });
     });
 
-    it('it should throw error if function is missing', () => {
-      awsInvoke.options.function = false;
-      expect(() => awsInvoke.validate()).to.throw(Error);
-      awsInvoke.options.function = 'hello';
-    });
-
-    it('it should throw error if stage is missing', () => {
-      awsInvoke.options.stage = null;
-      expect(() => awsInvoke.validate()).to.throw(Error);
-      awsInvoke.options.stage = 'dev';
-    });
-
-    it('it should throw error if region is missing', () => {
-      awsInvoke.options.region = null;
-      expect(() => awsInvoke.validate()).to.throw(Error);
-      awsInvoke.options.region = 'us-east-1';
-    });
-
     it('it should throw error if service path is not set', () => {
       serverless.config.servicePath = false;
       expect(() => awsInvoke.validate()).to.throw(Error);

--- a/lib/plugins/awsRemoveResources/awsRemoveResources.js
+++ b/lib/plugins/awsRemoveResources/awsRemoveResources.js
@@ -8,15 +8,14 @@ const removeStack = require('./lib/removeStack');
 const AWS = require('aws-sdk');
 
 class AwsRemoveResources {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
 
     Object.assign(this, validateInput, emptyS3Bucket, removeStack);
 
     this.hooks = {
-      'remove:remove': (options) => {
-        this.options = options || {};
-
+      'remove:remove': () => {
         const config = {
           region: this.options.region,
         };

--- a/lib/plugins/awsRemoveResources/lib/validateInput.js
+++ b/lib/plugins/awsRemoveResources/lib/validateInput.js
@@ -4,14 +4,6 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   validateInput() {
-    if (!this.options.stage) {
-      throw new this.serverless.classes.Error('Please provide a stage name.');
-    }
-
-    if (!this.options.region) {
-      throw new this.serverless.classes.Error('Please provide a region name.');
-    }
-
     if (!this.serverless.config.servicePath) {
       throw new this.serverless.classes.Error('This command can only be run inside a service.');
     }

--- a/lib/plugins/awsRemoveResources/tests/awsRemoveResources.js
+++ b/lib/plugins/awsRemoveResources/tests/awsRemoveResources.js
@@ -6,11 +6,15 @@ const sinon = require('sinon');
 const AwsRemoveResources = require('../awsRemoveResources');
 const Serverless = require('../../../Serverless');
 
-const serverless = new Serverless();
-serverless.init();
-const awsRemoveResources = new AwsRemoveResources(serverless);
-
 describe('AwsRemoveResources', () => {
+  const serverless = new Serverless();
+  serverless.init();
+  const options = {
+    stage: 'dev',
+    region: 'us-east-1',
+  };
+  const awsRemoveResources = new AwsRemoveResources(serverless, options);
+
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsRemoveResources.hooks).to.be.not.empty);
 

--- a/lib/plugins/awsRemoveResources/tests/validateInput.js
+++ b/lib/plugins/awsRemoveResources/tests/validateInput.js
@@ -20,16 +20,6 @@ describe('#validateInput()', () => {
     };
   });
 
-  it('should throw an error if the stage option is not provided', () => {
-    awsRemoveResources.options.stage = false;
-    expect(() => awsRemoveResources.validateInput()).to.throw(Error);
-  });
-
-  it('should throw an error if the region option is not provided', () => {
-    awsRemoveResources.options.region = false;
-    expect(() => awsRemoveResources.validateInput()).to.throw(Error);
-  });
-
   it('should throw an error if not inside a service (servicePath not defined)', () => {
     awsRemoveResources.serverless.config.servicePath = false;
     expect(() => awsRemoveResources.validateInput()).to.throw(Error);

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -5,22 +5,27 @@ const fse = require('fs-extra');
 const path = require('path');
 
 class Create {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
-    this.options = {};
+    this.options = options;
+
     this.commands = {
       create: {
         usage: 'create new Serverless Service.',
         lifecycleEvents: [
           'create',
         ],
+        options: {
+          name: {
+            usage: 'Name of the service',
+            required: true,
+          },
+        },
       },
     };
 
     this.hooks = {
-      'create:create': (options) => {
-        this.options = options;
-
+      'create:create': () => {
         return BbPromise.bind(this)
           .then(this.prompt)
           .then(this.validate)
@@ -42,6 +47,8 @@ class Create {
   }
 
   validate() {
+    // TODO remove once options validation in plugin manager works
+    /*
     if (!this.options.name) {
       throw new this.serverless.classes.Error('Please provide a service name.');
     }
@@ -53,6 +60,7 @@ class Create {
     if (!this.options.region) {
       throw new this.serverless.classes.Error('Please provide a region name.');
     }
+    */
 
     // Validate Name - AWS only allows Alphanumeric and - in name
     const nameOk = /^([a-zA-Z0-9-]+)$/.exec(this.options.name);

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -20,6 +20,14 @@ class Create {
             usage: 'Name of the service',
             required: true,
           },
+          stage: {
+            usage: 'Stage of the service',
+            required: true,
+          },
+          region: {
+            usage: 'Region of the service',
+            required: true,
+          },
         },
       },
     };
@@ -47,21 +55,6 @@ class Create {
   }
 
   validate() {
-    // TODO remove once options validation in plugin manager works
-    /*
-    if (!this.options.name) {
-      throw new this.serverless.classes.Error('Please provide a service name.');
-    }
-
-    if (!this.options.stage) {
-      throw new this.serverless.classes.Error('Please provide a stage name.');
-    }
-
-    if (!this.options.region) {
-      throw new this.serverless.classes.Error('Please provide a region name.');
-    }
-    */
-
     // Validate Name - AWS only allows Alphanumeric and - in name
     const nameOk = /^([a-zA-Z0-9-]+)$/.exec(this.options.name);
     if (!nameOk) {

--- a/lib/plugins/create/tests/create.js
+++ b/lib/plugins/create/tests/create.js
@@ -13,8 +13,8 @@ describe('Create', () => {
   before(() => {
     const serverless = new Serverless();
     serverless.init();
-
-    create = new Create(serverless);
+    const options = {};
+    create = new Create(serverless, options);
   });
 
   describe('#constructor()', () => {
@@ -61,27 +61,6 @@ describe('Create', () => {
       create.options.name = 'invalid_service_name';
       create.options.stage = 'dev';
       create.options.region = 'aws_useast1';
-      expect(() => create.validate()).to.throw(Error);
-    });
-
-    it('it should throw error if name is missing', () => {
-      create.options.name = null;
-      create.options.stage = 'dev';
-      create.options.region = 'aws_useast1';
-      expect(() => create.validate()).to.throw(Error);
-    });
-
-    it('it should throw error if stage is missing', () => {
-      create.options.name = 'valid-service-name';
-      create.options.stage = null;
-      create.options.region = 'aws_useast1';
-      expect(() => create.validate()).to.throw(Error);
-    });
-
-    it('it should throw error if region is missing', () => {
-      create.options.name = 'valid-service-name';
-      create.options.stage = 'dev';
-      create.options.region = null;
       expect(() => create.validate()).to.throw(Error);
     });
 

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -14,6 +14,16 @@ class Deploy {
           'compileEvents',
           'deploy',
         ],
+        options: {
+          stage: {
+            usage: 'Stage of the service',
+            required: true,
+          },
+          region: {
+            usage: 'Region of the service',
+            required: true,
+          },
+        },
       },
     };
   }

--- a/lib/plugins/helloWorld/helloWorld.js
+++ b/lib/plugins/helloWorld/helloWorld.js
@@ -1,7 +1,10 @@
 'use strict';
 
 class HelloWorld {
-  constructor() {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
     this.commands = {
       greet: {
         usage: 'Run this command to get greeted.',
@@ -19,31 +22,31 @@ class HelloWorld {
     };
 
     this.hooks = {
-      'before:greet:printHello': this.printGoodMorning,
-      'greet:printHello': this.printHello,
-      'after:greet:printHello': this.printGoodEvening,
+      'before:greet:printHello': this.printGoodMorning.bind(this),
+      'greet:printHello': this.printHello.bind(this),
+      'after:greet:printHello': this.printGoodEvening.bind(this),
     };
   }
 
-  printGoodMorning(options) {
+  printGoodMorning() {
     let message = 'Good morning madam';
-    if (options.gender === 'male') {
+    if (this.options.gender === 'male') {
       message = 'Good morning sir';
     }
     return message;
   }
 
-  printHello(options) {
+  printHello() {
     let message = 'Hello madam';
-    if (options.gender === 'male') {
+    if (this.options.gender === 'male') {
       message = 'Hello sir';
     }
     return message;
   }
 
-  printGoodEvening(options) {
+  printGoodEvening() {
     let message = 'Good evening madam';
-    if (options.gender === 'male') {
+    if (this.options.gender === 'male') {
       message = 'Good evening sir';
     }
     return message;

--- a/lib/plugins/helloWorld/tests/helloWorld.js
+++ b/lib/plugins/helloWorld/tests/helloWorld.js
@@ -8,23 +8,30 @@ const expect = require('chai').expect;
 const HelloWorld = require('../helloWorld');
 
 describe('HelloWorld', () => {
-  let helloWorld;
-
-  beforeEach(() => {
-    helloWorld = new HelloWorld();
-  });
+  const serverlessMock = {};
 
   describe('#constructor()', () => {
+    let helloWorld;
+
+    beforeEach(() => {
+      helloWorld = new HelloWorld();
+    });
+
     it('should have commands', () => expect(helloWorld.commands).to.be.not.empty);
 
     it('should have hooks', () => expect(helloWorld.hooks).to.be.not.empty);
   });
 
   describe('when gender is "female"', () => {
+    let helloWorld;
+
+    beforeEach(() => {
+      helloWorld = new HelloWorld(serverlessMock, { gender: 'female' });
+    });
+
     describe('#printGoodMorning()', () => {
       it('should print "Good morning madam"', () => {
-        const optionsMock = { gender: 'female' };
-        const greeting = helloWorld.printGoodMorning(optionsMock);
+        const greeting = helloWorld.printGoodMorning();
 
         expect(greeting).to.equal('Good morning madam');
       });
@@ -32,8 +39,7 @@ describe('HelloWorld', () => {
 
     describe('#printHello()', () => {
       it('should print "Hello madam"', () => {
-        const optionsMock = { gender: 'female' };
-        const greeting = helloWorld.printHello(optionsMock);
+        const greeting = helloWorld.printHello();
 
         expect(greeting).to.equal('Hello madam');
       });
@@ -41,8 +47,7 @@ describe('HelloWorld', () => {
 
     describe('#printGoodEvening()', () => {
       it('should print "Good evening madam"', () => {
-        const optionsMock = { gender: 'female' };
-        const greeting = helloWorld.printGoodEvening(optionsMock);
+        const greeting = helloWorld.printGoodEvening();
 
         expect(greeting).to.equal('Good evening madam');
       });
@@ -50,6 +55,12 @@ describe('HelloWorld', () => {
   });
 
   describe('when gender is "male"', () => {
+    let helloWorld;
+
+    beforeEach(() => {
+      helloWorld = new HelloWorld(serverlessMock, { gender: 'male' });
+    });
+
     describe('#printGoodMorning()', () => {
       it('should print "Good morning sir"', () => {
         const optionsMock = { gender: 'male' };
@@ -76,33 +87,36 @@ describe('HelloWorld', () => {
         expect(greeting).to.equal('Good evening sir');
       });
     });
+  });
 
-    describe('when gender is not given', () => {
-      describe('#printGoodMorning()', () => {
-        it('should print "Good morning madam"', () => {
-          const optionsMock = { gender: '' };
-          const greeting = helloWorld.printGoodMorning(optionsMock);
+  describe('when gender is not given', () => {
+    let helloWorld;
 
-          expect(greeting).to.equal('Good morning madam');
-        });
+    beforeEach(() => {
+      helloWorld = new HelloWorld(serverlessMock, {});
+    });
+
+    describe('#printGoodMorning()', () => {
+      it('should print "Good morning madam"', () => {
+        const greeting = helloWorld.printGoodMorning();
+
+        expect(greeting).to.equal('Good morning madam');
       });
+    });
 
-      describe('#printHello()', () => {
-        it('should print "Hello madam"', () => {
-          const optionsMock = { gender: '' };
-          const greeting = helloWorld.printHello(optionsMock);
+    describe('#printHello()', () => {
+      it('should print "Hello madam"', () => {
+        const greeting = helloWorld.printHello();
 
-          expect(greeting).to.equal('Hello madam');
-        });
+        expect(greeting).to.equal('Hello madam');
       });
+    });
 
-      describe('#printGoodEvening()', () => {
-        it('should print "Good evening madam"', () => {
-          const optionsMock = { gender: '' };
-          const greeting = helloWorld.printGoodEvening(optionsMock);
+    describe('#printGoodEvening()', () => {
+      it('should print "Good evening madam"', () => {
+        const greeting = helloWorld.printGoodEvening();
 
-          expect(greeting).to.equal('Good evening madam');
-        });
+        expect(greeting).to.equal('Good evening madam');
       });
     });
   });

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -3,12 +3,36 @@
 class Invoke {
   constructor(serverless) {
     this.serverless = serverless;
+
     this.commands = {
       invoke: {
         usage: 'Invokes a deployed function.',
         lifecycleEvents: [
           'invoke',
         ],
+        options: {
+          function: {
+            usage: 'The function name',
+            required: true,
+          },
+          stage: {
+            usage: 'Stage of the service',
+            required: true,
+          },
+          region: {
+            usage: 'Region of the service',
+            required: true,
+          },
+          path: {
+            usage: 'Path to JSON file holding input data',
+          },
+          type: {
+            usage: 'Type of invocation',
+          },
+          log: {
+            usage: 'Trigger logging data output',
+          },
+        },
       },
     };
   }

--- a/lib/plugins/remove/remove.js
+++ b/lib/plugins/remove/remove.js
@@ -10,6 +10,16 @@ class Remove {
         lifecycleEvents: [
           'remove',
         ],
+        options: {
+          stage: {
+            usage: 'Stage of the service',
+            required: true,
+          },
+          region: {
+            usage: 'Region of the service',
+            required: true,
+          },
+        },
       },
     };
   }

--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -64,49 +64,57 @@ describe('CLI', () => {
     });
   });
 
-  describe('#processInput()', () => {
-    it('should return an "empty" object when the "help" parameter is given', () => {
+  describe('#displayHelp()', () => {
+    it('should return true when the "help" parameter is given', () => {
       cli = new CLI(serverless, interactive, ['help']);
-      const inputToBeProcessed = cli.processInput();
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
 
-      expect(inputToBeProcessed).to.deep.equal({ commands: [], options: {} });
+      expect(helpDisplayed).to.equal(true);
     });
 
-    it('should return an "empty" object when the "--help" parameter is given', () => {
+    it('should return true when the "--help" parameter is given', () => {
       cli = new CLI(serverless, interactive, ['--help']);
-      const inputToBeProcessed = cli.processInput();
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
 
-      expect(inputToBeProcessed).to.deep.equal(emptyObject);
+      expect(helpDisplayed).to.equal(true);
     });
 
-    it('should return an "empty" object when the "--h" parameter is given', () => {
+    it('should return truewhen the "--h" parameter is given', () => {
       cli = new CLI(serverless, interactive, ['--h']);
-      const inputToBeProcessed = cli.processInput();
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
 
-      expect(inputToBeProcessed).to.deep.equal(emptyObject);
+      expect(helpDisplayed).to.equal(true);
     });
 
-    it('should return an "empty" object when the "version" parameter is given', () => {
+    it('should return true when the "version" parameter is given', () => {
       cli = new CLI(serverless, interactive, ['version']);
-      const inputToBeProcessed = cli.processInput();
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
 
-      expect(inputToBeProcessed).to.deep.equal(emptyObject);
+      expect(helpDisplayed).to.equal(true);
     });
 
-    it('should return an "empty" object when the "--version" parameter is given', () => {
+    it('should return true when the "--version" parameter is given', () => {
       cli = new CLI(serverless, interactive, ['--version']);
-      const inputToBeProcessed = cli.processInput();
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
 
-      expect(inputToBeProcessed).to.deep.equal(emptyObject);
+      expect(helpDisplayed).to.equal(true);
     });
 
-    it('should return an "empty" object when the "--v" parameter is given', () => {
+    it('should return true when the "--v" parameter is given', () => {
       cli = new CLI(serverless, interactive, ['--v']);
-      const inputToBeProcessed = cli.processInput();
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
 
-      expect(inputToBeProcessed).to.deep.equal(emptyObject);
+      expect(helpDisplayed).to.equal(true);
     });
+  });
 
+  describe('#processInput()', () => {
     it('should only return the commands when only commands are given', () => {
       cli = new CLI(serverless, interactive, ['deploy', 'functions']);
       const inputToBeProcessed = cli.processInput();

--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -29,19 +29,9 @@ describe('CLI', () => {
       expect(cli.interactive).to.equal(interactive);
     });
 
-    it('should set an empty loadedPlugins array when none is provided', () => {
+    it('should set an empty loadedPlugins array', () => {
       cli = new CLI(serverless, interactive);
       expect(cli.loadedPlugins.length).to.equal(0);
-    });
-
-    it('should set a loadedPlugins array when provided', () => {
-      class PluginMock {}
-
-      const pluginMock = new PluginMock();
-      const plugins = [pluginMock];
-
-      cli = new CLI(serverless, interactive, plugins);
-      expect(cli.loadedPlugins[0]).to.equal(pluginMock);
     });
 
     it('should set an empty inputArray when none is provided', () => {
@@ -50,7 +40,7 @@ describe('CLI', () => {
     });
 
     it('should set the inputObject when provided', () => {
-      cli = new CLI(serverless, interactive, [], ['foo', 'bar', '--baz', '-qux']);
+      cli = new CLI(serverless, interactive, ['foo', 'bar', '--baz', '-qux']);
 
       expect(cli.inputArray[0]).to.equal('foo');
       expect(cli.inputArray[1]).to.equal('bar');
@@ -59,51 +49,66 @@ describe('CLI', () => {
     });
   });
 
+  describe('#setLoadedPlugins()', () => {
+    it('should set the loadedPlugins array with the given plugin instances', () => {
+      class PluginMock {}
+
+      const pluginMock = new PluginMock();
+      const plugins = [pluginMock];
+
+      cli = new CLI(serverless, interactive);
+
+      cli.setLoadedPlugins(plugins);
+
+      expect(cli.loadedPlugins[0]).to.equal(pluginMock);
+    });
+  });
+
   describe('#processInput()', () => {
     it('should return an "empty" object when the "help" parameter is given', () => {
-      cli = new CLI(serverless, interactive, [], ['help']);
+      cli = new CLI(serverless, interactive, ['help']);
       const inputToBeProcessed = cli.processInput();
 
       expect(inputToBeProcessed).to.deep.equal({ commands: [], options: {} });
     });
 
     it('should return an "empty" object when the "--help" parameter is given', () => {
-      cli = new CLI(serverless, interactive, [], ['--help']);
+      cli = new CLI(serverless, interactive, ['--help']);
       const inputToBeProcessed = cli.processInput();
 
       expect(inputToBeProcessed).to.deep.equal(emptyObject);
     });
 
     it('should return an "empty" object when the "--h" parameter is given', () => {
-      cli = new CLI(serverless, interactive, [], ['--h']);
+      cli = new CLI(serverless, interactive, ['--h']);
       const inputToBeProcessed = cli.processInput();
 
       expect(inputToBeProcessed).to.deep.equal(emptyObject);
     });
 
     it('should return an "empty" object when the "version" parameter is given', () => {
-      cli = new CLI(serverless, interactive, [], ['version']);
+      cli = new CLI(serverless, interactive, ['version']);
       const inputToBeProcessed = cli.processInput();
 
       expect(inputToBeProcessed).to.deep.equal(emptyObject);
     });
 
     it('should return an "empty" object when the "--version" parameter is given', () => {
-      cli = new CLI(serverless, interactive, [], ['--version']);
+      cli = new CLI(serverless, interactive, ['--version']);
       const inputToBeProcessed = cli.processInput();
 
       expect(inputToBeProcessed).to.deep.equal(emptyObject);
     });
 
     it('should return an "empty" object when the "--v" parameter is given', () => {
-      cli = new CLI(serverless, interactive, [], ['--v']);
+      cli = new CLI(serverless, interactive, ['--v']);
       const inputToBeProcessed = cli.processInput();
 
       expect(inputToBeProcessed).to.deep.equal(emptyObject);
     });
 
     it('should only return the commands when only commands are given', () => {
-      cli = new CLI(serverless, interactive, [], ['deploy', 'functions']);
+      cli = new CLI(serverless, interactive, ['deploy', 'functions']);
       const inputToBeProcessed = cli.processInput();
 
       const expectedObject = { commands: ['deploy', 'functions'], options: {} };
@@ -112,8 +117,7 @@ describe('CLI', () => {
     });
 
     it('should only return the options when only options are given', () => {
-      cli = new CLI(serverless, interactive,
-        [], ['-f', 'function1', '-r', 'resource1']);
+      cli = new CLI(serverless, interactive, ['-f', 'function1', '-r', 'resource1']);
       const inputToBeProcessed = cli.processInput();
 
       const expectedObject = { commands: [], options: { f: 'function1', r: 'resource1' } };
@@ -122,8 +126,7 @@ describe('CLI', () => {
     });
 
     it('should return commands and options when both are given', () => {
-      cli = new CLI(serverless, interactive,
-        [], ['deploy', 'functions', '-f', 'function1']);
+      cli = new CLI(serverless, interactive, ['deploy', 'functions', '-f', 'function1']);
       const inputToBeProcessed = cli.processInput();
 
       const expectedObject = { commands: ['deploy', 'functions'], options: { f: 'function1' } };

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -311,6 +311,42 @@ describe('PluginManager', () => {
     });
   });
 
+  describe('#validateOptions()', () => {
+    it('should throw an error if a required option is not set in a plain commands object', () => {
+      pluginManager.commands = {
+        foo: {
+          options: {
+            bar: {
+              required: true,
+            },
+          },
+        },
+      };
+      const commandsArray = ['foo'];
+
+      expect(() => { pluginManager.validateOptions(commandsArray); }).to.throw(Error);
+    });
+
+    it('should throw an error if a required option is not set in a nested commands object', () => {
+      pluginManager.commands = {
+        foo: {
+          commands: {
+            bar: {
+              options: {
+                baz: {
+                  required: true,
+                },
+              },
+            },
+          },
+        },
+      };
+      const commandsArray = ['foo', 'bar'];
+
+      expect(() => { pluginManager.validateOptions(commandsArray); }).to.throw(Error);
+    });
+  });
+
   describe('#run()', () => {
     it('should throw an error when the given command is not available', () => {
       pluginManager.addPlugin(SynchronousPluginMock);


### PR DESCRIPTION
The PluginManager now attaches the options to the constructor rather than the hooks of the plugins.

Furthermore the PluginManager will check if the passed options are required.