### PR TITLE
Add "restApiId" variable to region variables. This variable is necess…

### DIFF
--- a/lib/actions/EndpointDeployApiGateway.js
+++ b/lib/actions/EndpointDeployApiGateway.js
@@ -127,7 +127,8 @@ module.exports = function(S) {
 
           let regionInstance = _this.project.getRegion(_this.evt.options.stage, region);
           regionInstance.addVariables({
-            apiGatewayApi: restApiData.name
+            apiGatewayApi: restApiData.name,
+            restApiId: restApiData.id
           });
 
           return regionInstance.save();


### PR DESCRIPTION

Add "restApiId" variable to region variables. This variable is necessary when you create API keys in "s-resorces-cf.json"
...
    "MyApiKey":{
      "Type" : "AWS::ApiGateway::ApiKey",
      "Properties" : {
        "Description" : "My API Key for ${stage}",
        "Enabled" : true,
        "Name" : "MyKey-${stage}",
        "StageKeys" : [
          {
            "RestApiId" : "${restApiId}",
            "StageName" : "${stage}"
          }
         ]
      }
    }
...