### PR TITLE
Comment out S3 events in serverless.yaml

### DIFF
--- a/lib/plugins/awsCompileS3Events/awsCompileS3Events.js
+++ b/lib/plugins/awsCompileS3Events/awsCompileS3Events.js
@@ -43,49 +43,51 @@ class AwsCompileS3Events {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const s3BucketObject = this.serverless.service.getFunction(functionName);
 
-      // iterate over all defined buckets
-      s3BucketObject.events.aws.s3.forEach((bucketName) => {
-        // 1. create the S3 bucket with the corresponding notification
-        const newS3Bucket = JSON.parse(bucketTemplate);
-        newS3Bucket.Properties.BucketName = `${this.serverless.service.service}-${bucketName}-${
-          this.options.stage}-${this.options.region}`;
-        newS3Bucket.Properties.NotificationConfiguration = {
-          LambdaConfigurations: [
-            {
-              Event: 's3:ObjectCreated:*',
-              Function: {
-                'Fn::GetAtt': [
-                  functionName,
-                  'Arn',
-                ],
+      if (s3BucketObject.events.aws.s3) {
+        // iterate over all defined buckets
+        s3BucketObject.events.aws.s3.forEach((bucketName) => {
+          // 1. create the S3 bucket with the corresponding notification
+          const newS3Bucket = JSON.parse(bucketTemplate);
+          newS3Bucket.Properties.BucketName = `${this.serverless.service.service}-${bucketName}-${
+            this.options.stage}-${this.options.region}`;
+          newS3Bucket.Properties.NotificationConfiguration = {
+            LambdaConfigurations: [
+              {
+                Event: 's3:ObjectCreated:*',
+                Function: {
+                  'Fn::GetAtt': [
+                    functionName,
+                    'Arn',
+                  ],
+                },
               },
-            },
-          ],
-        };
+            ],
+          };
 
-        const bucketResourceKey = bucketName.replace(/-/g, '');
+          const bucketResourceKey = bucketName.replace(/-/g, '');
 
-        const newBucketObject = {
-          [bucketResourceKey]: newS3Bucket,
-        };
+          const newBucketObject = {
+            [bucketResourceKey]: newS3Bucket,
+          };
 
-        // 2. create the corresponding Lambda permissions
-        const newPermission = JSON.parse(permissionTemplate);
-        newPermission.Properties.FunctionName = {
-          'Fn::GetAtt': [
-            functionName,
-            'Arn',
-          ],
-        };
+          // 2. create the corresponding Lambda permissions
+          const newPermission = JSON.parse(permissionTemplate);
+          newPermission.Properties.FunctionName = {
+            'Fn::GetAtt': [
+              functionName,
+              'Arn',
+            ],
+          };
 
-        const newPermissionObject = {
-          [`${bucketResourceKey}Permission`]: newPermission,
-        };
+          const newPermissionObject = {
+            [`${bucketResourceKey}Permission`]: newPermission,
+          };
 
-        // merge the new bucket and permission objects into the Resources section
-        merge(this.serverless.service.resources.aws.Resources,
-          newBucketObject, newPermissionObject);
-      });
+          // merge the new bucket and permission objects into the Resources section
+          merge(this.serverless.service.resources.aws.Resources,
+            newBucketObject, newPermissionObject);
+        });
+      }
     });
   }
 }

--- a/lib/plugins/awsCompileS3Events/tests/awsCompileS3Events.js
+++ b/lib/plugins/awsCompileS3Events/tests/awsCompileS3Events.js
@@ -8,165 +8,6 @@ describe('awsCompileS3Events', () => {
   let serverless;
   let awsCompileS3Events;
 
-  const functionsObjectMock = {
-    first: {
-      events: {
-        aws: {
-          s3: [
-            'first-function-bucket1',
-            'first-function-bucket2',
-          ],
-        },
-      },
-    },
-    second: {
-      events: {
-        aws: {
-          s3: [
-            'second-function-bucket1',
-            'second-function-bucket2',
-          ],
-        },
-      },
-    },
-  };
-
-  const serviceResourcesAwsResourcesObjectMock = {
-    Resources: {
-      firstfunctionbucket1: {
-        Type: 'AWS::S3::Bucket',
-        Properties: {
-          BucketName: 'new-service-first-function-bucket1-dev-us-east-1',
-          NotificationConfiguration: {
-            LambdaConfigurations: [
-              {
-                Event: 's3:ObjectCreated:*',
-                Function: {
-                  'Fn::GetAtt': [
-                    'first',
-                    'Arn',
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      firstfunctionbucket1Permission: {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: {
-            'Fn::GetAtt': [
-              'first',
-              'Arn',
-            ],
-          },
-          Action: 'lambda:InvokeFunction',
-          Principal: 's3.amazonaws.com',
-        },
-      },
-
-      firstfunctionbucket2: {
-        Type: 'AWS::S3::Bucket',
-        Properties: {
-          BucketName: 'new-service-first-function-bucket2-dev-us-east-1',
-          NotificationConfiguration: {
-            LambdaConfigurations: [
-              {
-                Event: 's3:ObjectCreated:*',
-                Function: {
-                  'Fn::GetAtt': [
-                    'first',
-                    'Arn',
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      firstfunctionbucket2Permission: {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: {
-            'Fn::GetAtt': [
-              'first',
-              'Arn',
-            ],
-          },
-          Action: 'lambda:InvokeFunction',
-          Principal: 's3.amazonaws.com',
-        },
-      },
-
-      secondfunctionbucket1: {
-        Type: 'AWS::S3::Bucket',
-        Properties: {
-          BucketName: 'new-service-second-function-bucket1-dev-us-east-1',
-          NotificationConfiguration: {
-            LambdaConfigurations: [
-              {
-                Event: 's3:ObjectCreated:*',
-                Function: {
-                  'Fn::GetAtt': [
-                    'second',
-                    'Arn',
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      secondfunctionbucket1Permission: {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: {
-            'Fn::GetAtt': [
-              'second',
-              'Arn',
-            ],
-          },
-          Action: 'lambda:InvokeFunction',
-          Principal: 's3.amazonaws.com',
-        },
-      },
-
-      secondfunctionbucket2: {
-        Type: 'AWS::S3::Bucket',
-        Properties: {
-          BucketName: 'new-service-second-function-bucket2-dev-us-east-1',
-          NotificationConfiguration: {
-            LambdaConfigurations: [
-              {
-                Event: 's3:ObjectCreated:*',
-                Function: {
-                  'Fn::GetAtt': [
-                    'second',
-                    'Arn',
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      },
-      secondfunctionbucket2Permission: {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: {
-            'Fn::GetAtt': [
-              'second',
-              'Arn',
-            ],
-          },
-          Action: 'lambda:InvokeFunction',
-          Principal: 's3.amazonaws.com',
-        },
-      },
-    },
-  };
-
   beforeEach(() => {
     serverless = new Serverless();
     serverless.init();
@@ -177,7 +18,6 @@ describe('awsCompileS3Events', () => {
     };
     awsCompileS3Events = new AwsCompileS3Events(serverless, options);
     awsCompileS3Events.serverless.service.service = 'new-service';
-    awsCompileS3Events.serverless.service.functions = functionsObjectMock;
   });
 
   describe('#compileS3Events()', () => {
@@ -186,7 +26,192 @@ describe('awsCompileS3Events', () => {
       expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
     });
 
-    it('should create corresponding S3 bucket and permission resources', () => {
+    it('should create corresponding resources when S3 events given', () => {
+      const functionsObjectMock = {
+        first: {
+          events: {
+            aws: {
+              s3: [
+                'first-function-bucket1',
+                'first-function-bucket2',
+              ],
+            },
+          },
+        },
+        second: {
+          events: {
+            aws: {
+              s3: [
+                'second-function-bucket1',
+                'second-function-bucket2',
+              ],
+            },
+          },
+        },
+      };
+
+      const serviceResourcesAwsResourcesObjectMock = {
+        Resources: {
+          firstfunctionbucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'new-service-first-function-bucket1-dev-us-east-1',
+              NotificationConfiguration: {
+                LambdaConfigurations: [
+                  {
+                    Event: 's3:ObjectCreated:*',
+                    Function: {
+                      'Fn::GetAtt': [
+                        'first',
+                        'Arn',
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          firstfunctionbucket1Permission: {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+              FunctionName: {
+                'Fn::GetAtt': [
+                  'first',
+                  'Arn',
+                ],
+              },
+              Action: 'lambda:InvokeFunction',
+              Principal: 's3.amazonaws.com',
+            },
+          },
+
+          firstfunctionbucket2: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'new-service-first-function-bucket2-dev-us-east-1',
+              NotificationConfiguration: {
+                LambdaConfigurations: [
+                  {
+                    Event: 's3:ObjectCreated:*',
+                    Function: {
+                      'Fn::GetAtt': [
+                        'first',
+                        'Arn',
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          firstfunctionbucket2Permission: {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+              FunctionName: {
+                'Fn::GetAtt': [
+                  'first',
+                  'Arn',
+                ],
+              },
+              Action: 'lambda:InvokeFunction',
+              Principal: 's3.amazonaws.com',
+            },
+          },
+
+          secondfunctionbucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'new-service-second-function-bucket1-dev-us-east-1',
+              NotificationConfiguration: {
+                LambdaConfigurations: [
+                  {
+                    Event: 's3:ObjectCreated:*',
+                    Function: {
+                      'Fn::GetAtt': [
+                        'second',
+                        'Arn',
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          secondfunctionbucket1Permission: {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+              FunctionName: {
+                'Fn::GetAtt': [
+                  'second',
+                  'Arn',
+                ],
+              },
+              Action: 'lambda:InvokeFunction',
+              Principal: 's3.amazonaws.com',
+            },
+          },
+
+          secondfunctionbucket2: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'new-service-second-function-bucket2-dev-us-east-1',
+              NotificationConfiguration: {
+                LambdaConfigurations: [
+                  {
+                    Event: 's3:ObjectCreated:*',
+                    Function: {
+                      'Fn::GetAtt': [
+                        'second',
+                        'Arn',
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          secondfunctionbucket2Permission: {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+              FunctionName: {
+                'Fn::GetAtt': [
+                  'second',
+                  'Arn',
+                ],
+              },
+              Action: 'lambda:InvokeFunction',
+              Principal: 's3.amazonaws.com',
+            },
+          },
+        },
+      };
+
+      awsCompileS3Events.serverless.service.functions = functionsObjectMock;
+
+      awsCompileS3Events.compileS3Events();
+
+      expect(
+        JSON.stringify(awsCompileS3Events.serverless.service.resources.aws.Resources)
+      ).to.equal(
+        JSON.stringify(serviceResourcesAwsResourcesObjectMock.Resources)
+      );
+    });
+
+    it('should not create corresponding resources when S3 events not given', () => {
+      const functionsObjectMock = {
+        first: {
+          events: {
+            aws: {},
+          },
+        },
+      };
+
+      const serviceResourcesAwsResourcesObjectMock = {
+        Resources: {},
+      };
+
+      awsCompileS3Events.serverless.service.functions = functionsObjectMock;
+
       awsCompileS3Events.compileS3Events();
 
       expect(

--- a/lib/templates/serverless.yaml
+++ b/lib/templates/serverless.yaml
@@ -28,8 +28,8 @@ functions: # if this gets too big, you can always use JSON-REF
           <<: *default_providers
         events:
             aws:
-                s3:
-                    - first-bucket
+                # s3:
+                #     - first-bucket
                 http_endpoint:
                     post: users/create
                 scheduled: 5 * * * *


### PR DESCRIPTION
Comment out the S3 events as they may clash because of naming problems
(name should be globally unique) with the generated S3 buckets when running
integration tests in parallel.