### PR TITLE
Remove namespacing of S3 event bucket

### DIFF
--- a/lib/plugins/awsCompileS3Events/awsCompileS3Events.js
+++ b/lib/plugins/awsCompileS3Events/awsCompileS3Events.js
@@ -3,9 +3,8 @@
 const merge = require('lodash').merge;
 
 class AwsCompileS3Events {
-  constructor(serverless, options) {
+  constructor(serverless) {
     this.serverless = serverless;
-    this.options = options;
 
     this.hooks = {
       'deploy:compileEvents': this.compileS3Events.bind(this),
@@ -48,8 +47,7 @@ class AwsCompileS3Events {
         s3BucketObject.events.aws.s3.forEach((bucketName) => {
           // 1. create the S3 bucket with the corresponding notification
           const newS3Bucket = JSON.parse(bucketTemplate);
-          newS3Bucket.Properties.BucketName = `${this.serverless.service.service}-${bucketName}-${
-            this.options.stage}-${this.options.region}`;
+          newS3Bucket.Properties.BucketName = bucketName;
           newS3Bucket.Properties.NotificationConfiguration = {
             LambdaConfigurations: [
               {

--- a/lib/plugins/awsCompileS3Events/tests/awsCompileS3Events.js
+++ b/lib/plugins/awsCompileS3Events/tests/awsCompileS3Events.js
@@ -12,11 +12,7 @@ describe('awsCompileS3Events', () => {
     serverless = new Serverless();
     serverless.init();
     serverless.service.resources = { aws: { Resources: {} } };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    awsCompileS3Events = new AwsCompileS3Events(serverless, options);
+    awsCompileS3Events = new AwsCompileS3Events(serverless);
     awsCompileS3Events.serverless.service.service = 'new-service';
   });
 
@@ -55,7 +51,7 @@ describe('awsCompileS3Events', () => {
           firstfunctionbucket1: {
             Type: 'AWS::S3::Bucket',
             Properties: {
-              BucketName: 'new-service-first-function-bucket1-dev-us-east-1',
+              BucketName: 'first-function-bucket1',
               NotificationConfiguration: {
                 LambdaConfigurations: [
                   {
@@ -88,7 +84,7 @@ describe('awsCompileS3Events', () => {
           firstfunctionbucket2: {
             Type: 'AWS::S3::Bucket',
             Properties: {
-              BucketName: 'new-service-first-function-bucket2-dev-us-east-1',
+              BucketName: 'first-function-bucket2',
               NotificationConfiguration: {
                 LambdaConfigurations: [
                   {
@@ -121,7 +117,7 @@ describe('awsCompileS3Events', () => {
           secondfunctionbucket1: {
             Type: 'AWS::S3::Bucket',
             Properties: {
-              BucketName: 'new-service-second-function-bucket1-dev-us-east-1',
+              BucketName: 'second-function-bucket1',
               NotificationConfiguration: {
                 LambdaConfigurations: [
                   {
@@ -154,7 +150,7 @@ describe('awsCompileS3Events', () => {
           secondfunctionbucket2: {
             Type: 'AWS::S3::Bucket',
             Properties: {
-              BucketName: 'new-service-second-function-bucket2-dev-us-east-1',
+              BucketName: 'second-function-bucket2',
               NotificationConfiguration: {
                 LambdaConfigurations: [
                   {


### PR DESCRIPTION
This way users are not confused if they won't find their bucket because of the
namespacing that was previously applied.