### PR TITLE
[strawman] fall back to attempting EC2 Metadata Service

### DIFF
--- a/lib/ProviderAws.js
+++ b/lib/ProviderAws.js
@@ -217,6 +217,12 @@ module.exports = function(S) {
         .then(() => this.addProfileCredentials(credentials, 'AWS_' + stage))                            // allow for *stage specific* Amazon standard prefix based profile declaration
         .then(() => this.addProfileCredentials(credentials, 'SERVERLESS_ADMIN_AWS_' + stage))           // allow for *stage specific* Serverless standard prefix based profile declaration
         .then(() => {
+          if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+            // fall back to attempting EC2 Metadata Service (this is a fallback
+            // because it involves an http call that may time out on the order
+            // of seconds in case this is not an EC2 instance)
+            this.addEc2MetadataCredentials(credentials, 'AWS')
+          }
 
           // if they aren't loaded now, the credentials weren't provided by a valid means
           if (!credentials.accessKeyId || !credentials.secretAccessKey) {


### PR DESCRIPTION
Before submitting a PR, please note the following:

[] Make sure that there's an issue opened that discuss this fix/feature. This is not required for simple PRs (ie. fixing a typo in README), but we just want to make sure you don't waste your time on a feature that we don't intend to support/maintain.
[] Make sure that you've tested your changes thoroughly.
[] If there are some side effects to your changes (whether positive or negative), please mention them in your PR so that we can discuss how to avoid them.


Above all, we thank you so much for your contribution! :)

I'll go with the env parameters instead.
Thanks @erikerikson

> @yegeniy it seems a reasonable enough PR. The team is working furiously on v1 so not sure the impl would stick around. There are a lot of ways to get credentials into SLS
> CI/CD use case?
> 
> Eugene Wolfson @yegeniy 22:41
> yeah
> I don't (currently) have access to get the credentials into ~/. aws/credentials, but the box is running on an EC2 node
> that has an instance profile set up
> 
> Erik Erikson @erikerikson 22:42
> Most have used the standard environment variables approach for supplying credentials for CI/CD
> 
> Eugene Wolfson @yegeniy 22:43
> Hmm.. Yeah that makes sense. I could query the endpoint, parse the JSON response and just provide them as env variables!
> Thanks @erikerikson !