### PR TITLE
Fix empty string check in variables

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -340,7 +340,7 @@ module.exports = {
           if (variableName === 'eventName'    && data.eventName)    value = data.eventName;
 
           // Populate
-          if (!value && !value !== "") {
+          if (value !== "" && !value) {
             SCli.log('WARNING: This variable is not defined: ' + variableName);
           } else if (typeof value === 'string') {
 


### PR DESCRIPTION
Related to #1008 - providing an empty string as a variable doesn't work right now. This is a really quick fix to allow empty strings. It doesn't tackle passing false (or 0, or null) as I'm not sure what the status of non-string variable types is right now.