### PR TITLE
Update YAML indentations

### DIFF
--- a/lib/templates/serverless.env.yaml
+++ b/lib/templates/serverless.env.yaml
@@ -1,7 +1,7 @@
 vars:
 stages:
-  dev:
-    vars:
-    regions:
-      us-east-1:
+    dev:
         vars:
+        regions:
+            us-east-1:
+                vars:

--- a/lib/templates/serverless.yaml
+++ b/lib/templates/serverless.yaml
@@ -1,5 +1,5 @@
 service: myService
 provider: aws
 functions:
-  hello:
-    handler: handler.hello
+    hello:
+        handler: handler.hello


### PR DESCRIPTION
YAML supports different indentations however dicts (which we use for events)
need a 4 level deep indentation to work correctly. The YAML files are updated so
that the user knows that he should always use a 4 level deep indentation.