### PR TITLE
Fix YAML indentation when dumping

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -40,7 +40,7 @@ class Utils {
     }
 
     if (filePath.indexOf('.yaml') !== -1 && typeof contents !== 'string') {
-      contents = YAML.dump(contents);
+      contents = YAML.dump(contents, { indent: 4 });
     }
 
     return fse.writeFileSync(filePath, contents);


### PR DESCRIPTION
This way all our YAML files follow the 4 spaces best practice.