### PR TITLE
Bug: function remove does not work for functions without an endpoint

### DIFF
--- a/lib/actions/FunctionRemove.js
+++ b/lib/actions/FunctionRemove.js
@@ -194,12 +194,14 @@ module.exports = function(S) {
 
       let functionVersion, lambdaAliasArn;
 
-      return func.getAllEndpoints().length && S.actions.endpointRemove({
-          options: {
-            stage,
-            region,
-            names:  _.map(func.getAllEndpoints(), (e) => e.path + '~' + e.method)
-          }
+      return BbPromise.try(() => {
+        return func.getAllEndpoints().length && S.actions.endpointRemove({
+            options: {
+              stage,
+              region,
+              names:  _.map(func.getAllEndpoints(), (e) => e.path + '~' + e.method)
+            }
+          })
         })
         .then(() => {
           return func.getAllEvents().length && S.actions.eventRemove({


### PR DESCRIPTION
Running:

`
sls function remove -a
`

was not doing anything for me, my function was still existing.  In researching it, I found a bug in lib/actions/FunctionRemove.js that aborted function removal if the function did not have any associated endpoints.

This PR fixes that bug and makes sure functions without endpoints get removed properly.