### PR TITLE
Bug: CLI does not handle options with value of zero correctly

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -373,7 +373,10 @@ class Serverless {
 
     // Options - parse using command config
     cmdConfig.options.map(opt => {
-      _this.cli.options[opt.option] = (_this.cli.raw[opt.option] ? _this.cli.raw[opt.option] : (_this.cli.raw[opt.shortcut] || null));
+      _this.cli.options[opt.option]
+        = (! _.isNil(_this.cli.raw[opt.option])) ? _this.cli.raw[opt.option]
+        : (! _.isNil(_this.cli.raw[opt.shortcut])) ? _this.cli.raw[opt.shortcut]
+        : null;
     });
 
     // Params - remove context and contextAction strings from params array


### PR DESCRIPTION
The CLI option parsing code did a truthy test to determine whether a user provided a value for an option.  This meant that values of 0 were being ignored.  This is an issue in particular for serverless-autoprune-plugin:

https://github.com/arabold/serverless-autoprune-plugin/issues/3

This PR fixes the bug by doing an explicit null/undefined check instead.