### PR TITLE
Refactor schedule and S3 events test

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const AwsCompileS3Events = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
-describe('awsCompileS3Events', () => {
+describe('AwsCompileS3Events', () => {
   let serverless;
   let awsCompileS3Events;
 
@@ -21,72 +21,16 @@ describe('awsCompileS3Events', () => {
       expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
     });
 
-    it('should create corresponding resources when S3 events are simple strings', () => {
-      const functionsObjectMock = {
+    it('should create corresponding resources when S3 events are given', () => {
+      awsCompileS3Events.serverless.service.functions = {
         first: {
           events: [
             {
-              s3: 'first-function-bucket',
+              s3: 'first-function-bucket-one',
             },
-          ],
-        },
-      };
-
-      const resourcesObjectMock = {
-        Resources: {
-          firstfunctionbucket0S3Event: {
-            Type: 'AWS::S3::Bucket',
-            Properties: {
-              BucketName: 'first-function-bucket0',
-              NotificationConfiguration: {
-                LambdaConfigurations: [
-                  {
-                    Event: 's3:ObjectCreated:*',
-                    Function: {
-                      'Fn::GetAtt': [
-                        'first',
-                        'Arn',
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
-          },
-          firstfunctionbucket0S3EventPermission: {
-            Type: 'AWS::Lambda::Permission',
-            Properties: {
-              FunctionName: {
-                'Fn::GetAtt': [
-                  'first',
-                  'Arn',
-                ],
-              },
-              Action: 'lambda:InvokeFunction',
-              Principal: 's3.amazonaws.com',
-            },
-          },
-        },
-      };
-
-      awsCompileS3Events.serverless.service.functions = functionsObjectMock;
-
-      awsCompileS3Events.compileS3Events();
-
-      expect(
-        awsCompileS3Events.serverless.service.resources.Resources
-      ).to.deep.equal(
-        resourcesObjectMock.Resources
-      );
-    });
-
-    it('should create corresponding resources when S3 events are given as objects', () => {
-      const functionsObjectMock = {
-        first: {
-          events: [
             {
               s3: {
-                bucket: 'first-function-bucket',
+                bucket: 'first-function-bucket-two',
                 event: 's3:ObjectCreated:Put',
               },
             },
@@ -94,75 +38,34 @@ describe('awsCompileS3Events', () => {
         },
       };
 
-      const resourcesObjectMock = {
-        Resources: {
-          firstfunctionbucket0S3Event: {
-            Type: 'AWS::S3::Bucket',
-            Properties: {
-              BucketName: 'first-function-bucket0',
-              NotificationConfiguration: {
-                LambdaConfigurations: [
-                  {
-                    Event: 's3:ObjectCreated:Put',
-                    Function: {
-                      'Fn::GetAtt': [
-                        'first',
-                        'Arn',
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
-          },
-          firstfunctionbucket0S3EventPermission: {
-            Type: 'AWS::Lambda::Permission',
-            Properties: {
-              FunctionName: {
-                'Fn::GetAtt': [
-                  'first',
-                  'Arn',
-                ],
-              },
-              Action: 'lambda:InvokeFunction',
-              Principal: 's3.amazonaws.com',
-            },
-          },
-        },
-      };
-
-      awsCompileS3Events.serverless.service.functions = functionsObjectMock;
-
       awsCompileS3Events.compileS3Events();
 
-      expect(
-        awsCompileS3Events.serverless.service.resources.Resources
-      ).to.deep.equal(
-        resourcesObjectMock.Resources
-      );
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbucketone0S3Event.Type
+      ).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbuckettwo1S3Event.Type
+      ).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbucketone0S3EventPermission.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbuckettwo1S3EventPermission.Type
+      ).to.equal('AWS::Lambda::Permission');
     });
 
     it('should not create corresponding resources when S3 events are not given', () => {
-      const functionsObjectMock = {
+      awsCompileS3Events.serverless.service.functions = {
         first: {
-          events: {
-          },
+          events: [],
         },
       };
-
-      const resourcesObjectMock = {
-        Resources: {},
-      };
-
-      awsCompileS3Events.serverless.service.functions = functionsObjectMock;
 
       awsCompileS3Events.compileS3Events();
 
       expect(
         awsCompileS3Events.serverless.service.resources.Resources
-      ).to.deep.equal(
-        resourcesObjectMock.Resources
-      );
+      ).to.deep.equal({});
     });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -21,60 +21,7 @@ describe('AwsCompileScheduledEvents', () => {
       expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
     });
 
-    it('should create corresponding resources when scheduled events are simple strings', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: 'rate(10 minutes)',
-            },
-          ],
-        },
-      };
-
-      const scheduleResource = `
-        {
-          "Type": "AWS::Events::Rule",
-          "Properties": {
-            "ScheduleExpression": "rate(10 minutes)",
-            "State": "ENABLED",
-            "Targets": [{
-              "Arn": {
-                "Fn::GetAtt": ["first", "Arn"]
-              },
-              "Id": "firstScheduleEvent"
-            }]
-          }
-        }
-      `;
-
-      const permissionResource = `
-        {
-          "Type": "AWS::Lambda::Permission",
-          "Properties": {
-            "FunctionName": {
-              "Fn::GetAtt": ["first", "Arn"]
-            },
-            "Action": "lambda:InvokeFunction",
-            "Principal": "events.amazonaws.com",
-            "SourceArn": {
-              "Fn::GetAtt": ["firstScheduleEvent0", "Arn"]
-            }
-          }
-        }
-      `;
-
-      awsCompileScheduledEvents.compileScheduledEvents();
-
-      expect(awsCompileScheduledEvents.serverless.service
-        .resources.Resources.firstScheduleEvent0)
-        .to.deep.equal(JSON.parse(scheduleResource));
-      expect(awsCompileScheduledEvents.serverless.service
-        .resources.Resources.firstScheduleEventPermission0)
-        .to.deep.equal(JSON.parse(permissionResource));
-    });
-
-    it('should create corresponding resources when S3 events are given as objects', () => {
+    it('should create corresponding resources when schedule events are given', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
           events: [
@@ -84,57 +31,33 @@ describe('AwsCompileScheduledEvents', () => {
                 enabled: false,
               },
             },
+            {
+              schedule: 'rate(10 minutes)',
+            },
           ],
         },
       };
 
-      const scheduleResource = `
-        {
-          "Type": "AWS::Events::Rule",
-          "Properties": {
-            "ScheduleExpression": "rate(10 minutes)",
-            "State": "DISABLED",
-            "Targets": [{
-              "Arn": {
-                "Fn::GetAtt": ["first", "Arn"]
-              },
-              "Id": "firstScheduleEvent"
-            }]
-          }
-        }
-      `;
-
-      const permissionResource = `
-        {
-          "Type": "AWS::Lambda::Permission",
-          "Properties": {
-            "FunctionName": {
-              "Fn::GetAtt": ["first", "Arn"]
-            },
-            "Action": "lambda:InvokeFunction",
-            "Principal": "events.amazonaws.com",
-            "SourceArn": {
-              "Fn::GetAtt": ["firstScheduleEvent0", "Arn"]
-            }
-          }
-        }
-      `;
-
       awsCompileScheduledEvents.compileScheduledEvents();
 
       expect(awsCompileScheduledEvents.serverless.service
-        .resources.Resources.firstScheduleEvent0)
-        .to.deep.equal(JSON.parse(scheduleResource));
+        .resources.Resources.firstScheduleEvent0.Type
+      ).to.equal('AWS::Events::Rule');
       expect(awsCompileScheduledEvents.serverless.service
-        .resources.Resources.firstScheduleEventPermission0)
-        .to.deep.equal(JSON.parse(permissionResource));
+        .resources.Resources.firstScheduleEvent1.Type
+      ).to.equal('AWS::Events::Rule');
+      expect(awsCompileScheduledEvents.serverless.service
+        .resources.Resources.firstScheduleEventPermission0.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileScheduledEvents.serverless.service
+        .resources.Resources.firstScheduleEventPermission1.Type
+      ).to.equal('AWS::Lambda::Permission');
     });
 
     it('should not create corresponding resources when scheduled events are not given', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
-          events: {
-          },
+          events: [],
         },
       };
 


### PR DESCRIPTION
So that they are in the same structure as the API Gateway event tests. Furthermore the tests are DRYed out so that we don't have code duplication / code smell.