### PR TITLE
Corrected case from "Resources" to "resources".

### DIFF
--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -42,6 +42,6 @@ functions:
                 method: get
 
 resources:
-    Resources:
+    resources:
         $ref: ../custom_resources.json # you can use JSON-REF to ref other JSON files
 ```


### PR DESCRIPTION
Changed from "resources:Resources" to "resources:resources", previous version generated error "ValidationError: Template format error: Every Resources member must be an object.", new version works as documented to update the CF stack.