### PR TITLE
Add shortcut support for options

### DIFF
--- a/docs/developing-plugins/building-plugins.md
+++ b/docs/developing-plugins/building-plugins.md
@@ -184,11 +184,15 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-### Options
+### Options and shortcuts
 
-Each (sub)command can have multiple options. Options are passed with a double dash (`--`) like this:
-`serverless function deploy --function functionName`. The `options` object will be passed in as the second parameter to
-the constructor of your plugin.
+Each (sub)command can have multiple options (and corresponding shortcuts if available).
+
+Options are passed in with a double dash (`--`) like this: `serverless function deploy --function functionName`.
+
+Shortcuts are passed in with a single dash (`-`) like this: `serverless function deploy -f functionName`
+
+The `options` object will be passed in as the second parameter to the constructor of your plugin.
 
 ```javascript
 'use strict';
@@ -224,6 +228,8 @@ class Deploy {
 module.exports = Deploy;
 ```
 
+#### Mark options as required
+
 Options can be marked as required. This way the plugin manager will automatically raise an error if a required option
 is not passed in via the CLI. You can mark options as required with the help of `required: true` inside the options
 definition.
@@ -244,6 +250,51 @@ class Deploy {
           function: {
             usage: 'Specify the function you want to deploy (e.g. "--function myFunction")',
             required: true
+          }
+        }
+      },
+    };
+
+    this.hooks = {
+      'deploy:functions': this.deployFunction
+    }
+  }
+
+  deployFunction() {
+    console.log('Deploying function: ', this.options.function);
+  }
+}
+
+module.exports = Deploy;
+```
+
+#### Define shortcuts for options
+
+Options can also provide shortcuts. Shortcuts make it more convenient to enter long commands. Serverless will
+translate shortcuts into options under the hood which means that the option the shortcut belongs to will be replaced
+with the value of the shortcut (if the shortcut is given).
+
+You can define shortcuts by setting the `shortcut` property in the options definition.
+
+**Note:** A shortcut should be unique inside of a plugin.
+
+```javascript
+'use strict';
+
+class Deploy {
+  constructor(serverless, options) {
+    this.options = options;
+
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'functions'
+        ],
+        options: {
+          function: {
+            usage: 'Specify the function you want to deploy (e.g. "--function myFunction" or "-f myFunction")',
+            required: true,
+            shortcut: 'f'
           }
         }
       },

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -45,8 +45,9 @@ class Serverless {
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();
 
-    // set the options
-    this.pluginManager.setOptions(this.processedInput.options);
+    // set the options and commands which were processed by the CLI
+    this.pluginManager.setCliOptions(this.processedInput.options);
+    this.pluginManager.setCliCommands(this.processedInput.commands);
 
     return this.service.load(this.processedInput.options)
       .then(() => {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -163,10 +163,23 @@ class CLI {
                 } else {
                   optionsDots = optionsDots.slice(0, optionsDots.length - 7);
                 }
+                if (optionsObject.shortcut) {
+                  optionsDots = optionsDots.slice(0, optionsDots.length - 5);
+                }
 
-                this.consoleLog(`${chalk
-                  .yellow(`    --${option} ${optionsObject.required ? '(required)' : ''}`)} ${chalk
-                  .dim(optionsDots)} ${optionsUsage}`);
+                const optionInfo = `    --${option}`;
+                let shortcutInfo = '';
+                let requiredInfo = '';
+                if (optionsObject.shortcut) {
+                  shortcutInfo = ` / -${optionsObject.shortcut}`;
+                }
+                if (optionsObject.required) {
+                  requiredInfo = ' (required)';
+                }
+
+                const thingsToLog = `${optionInfo}${shortcutInfo}${requiredInfo} ${
+                  chalk.dim(optionsDots)} ${optionsUsage}`;
+                this.consoleLog(chalk.yellow(thingsToLog));
               });
             }
           }
@@ -199,11 +212,23 @@ class CLI {
                         } else {
                           optionsDots = optionsDots.slice(0, optionsDots.length - 7);
                         }
+                        if (optionsObject.shortcut) {
+                          optionsDots = optionsDots.slice(0, optionsDots.length - 5);
+                        }
 
-                        this.consoleLog(`${chalk
-                          .yellow(`    --${option} ${optionsObject
-                            .required ? '(required)' : ''}`)} ${chalk.dim(optionsDots)} ${
-                          optionsUsage}`);
+                        const optionInfo = `    --${option}`;
+                        let shortcutInfo = '';
+                        let requiredInfo = '';
+                        if (optionsObject.shortcut) {
+                          shortcutInfo = ` / -${optionsObject.shortcut}`;
+                        }
+                        if (optionsObject.required) {
+                          requiredInfo = ' (required)';
+                        }
+
+                        const thingsToLog = `${optionInfo}${shortcutInfo}${requiredInfo} ${
+                          chalk.dim(optionsDots)} ${optionsUsage}`;
+                        this.consoleLog(chalk.yellow(thingsToLog));
                       });
                     }
                   }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const has = require('lodash').has;
 const forEach = require('lodash').forEach;
+const includes = require('lodash').includes;
 const BbPromise = require('bluebird');
 
 class PluginManager {
@@ -11,11 +12,16 @@ class PluginManager {
     this.plugins = [];
     this.commandsList = [];
     this.commands = {};
-    this.options = {};
+    this.cliOptions = {};
+    this.cliCommands = [];
   }
 
-  setOptions(options) {
-    this.options = options;
+  setCliOptions(options) {
+    this.cliOptions = options;
+  }
+
+  setCliCommands(commands) {
+    this.cliCommands = commands;
   }
 
   loadAllPlugins(servicePlugins) {
@@ -41,9 +47,12 @@ class PluginManager {
     }
 
     forEach(options, (value, key) => {
-      if (value.required && (this.options[key] === true || !(this.options[key]))) {
-        const errorMessage = `This command requires the --${key} option. Please pass
-     it through. :)`;
+      if (value.required && (this.cliOptions[key] === true || !(this.cliOptions[key]))) {
+        let requiredThings = `the --${key} option`;
+        if (value.shortcut) {
+          requiredThings += ` / -${value.shortcut} shortcut`;
+        }
+        const errorMessage = `This command requires ${requiredThings}.`;
 
         throw new this.serverless.classes.Error(errorMessage);
       }
@@ -85,10 +94,34 @@ class PluginManager {
     return hooks.reduce((p, fn) => p.then(fn), BbPromise.resolve());
   }
 
-  addPlugin(Plugin) {
-    this.plugins.push(new Plugin(this.serverless, this.options));
+  convertShortcutsIntoOptions(cliOptions, commands) {
+    forEach(commands, (command, commandKey) => {
+      // TODO: add support for nested commands
+      // check if the command entered is the one in the commands object which holds all commands
+      // this is necessary so that shortcuts are not treated like global citizens but command
+      // bound properties
+      if (includes(this.cliCommands, commandKey)) {
+        forEach(command.options, (optionObject, optionKey) => {
+          if (optionObject.shortcut && includes(Object.keys(cliOptions), optionObject.shortcut)) {
+            Object.keys(cliOptions).forEach((option) => {
+              if (option === optionObject.shortcut) {
+                this.cliOptions[optionKey] = this.cliOptions[option];
+              }
+            });
+          }
+        });
+      }
+    });
+  }
 
+  addPlugin(Plugin) {
     this.loadCommands(Plugin);
+
+    // shortcuts should be converted into options so that the plugin
+    // author can use the option (instead of the shortcut)
+    this.convertShortcutsIntoOptions(this.cliOptions, this.commands);
+
+    this.plugins.push(new Plugin(this.serverless, this.cliOptions));
   }
 
   loadCorePlugins() {

--- a/lib/plugins/create/README.md
+++ b/lib/plugins/create/README.md
@@ -7,8 +7,8 @@ serverless create --name serviceName --provider providerName
 Creates a new service in the current working directory.
 
 ## Options
-- `--name` The name of your new service. **Required**.
-- `--provider` The provider you want your service to deploy to. **Required**.
+- `--name` or `-n` The name of your new service. **Required**.
+- `--provider` or `-p` The provider you want your service to deploy to. **Required**.
 
 ## Provided lifecycle events
 - `create:create`

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -19,10 +19,12 @@ class Create {
           name: {
             usage: 'Name of the service',
             required: true,
+            shortcut: 'n',
           },
           provider: {
             usage: 'Provider of the service',
             required: true,
+            shortcut: 'p',
           },
         },
       },

--- a/lib/plugins/deploy/README.md
+++ b/lib/plugins/deploy/README.md
@@ -7,8 +7,8 @@ serverless deploy --stage dev --region us-east-1
 Deploys your service.
 
 ## Options
-- `--stage` The stage in your service that you want to deploy to.
-- `--region` The region in that stage that you want to deploy to.
+- `--stage` or `-s` The stage in your service that you want to deploy to.
+- `--region` or `-r` The region in that stage that you want to deploy to.
 
 ## Provided lifecycle events
 - `deploy:initializeResources`

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -17,9 +17,11 @@ class Deploy {
         options: {
           stage: {
             usage: 'Stage of the service',
+            shortcut: 's',
           },
           region: {
             usage: 'Region of the service',
+            shortcut: 'r',
           },
         },
       },

--- a/lib/plugins/invoke/README.md
+++ b/lib/plugins/invoke/README.md
@@ -7,13 +7,13 @@ serverless invoke --function functionName --stage dev --region us-east-1
 Invokes your deployed function and outputs the results.
 
 ## Options
-- `--function` The name of the function in your service that you want to invoke. **Required**.
-- `--stage` The stage in your service you want to invoke your function in. **Required**.
-- `--region` The region in your stage that you want to invoke your function in. **Required**.
-- `--path` The path to a json file holding input data to be passed to the invoked function. This path is relative to the
+- `--function` or `-f` The name of the function in your service that you want to invoke. **Required**.
+- `--stage` or `-s` The stage in your service you want to invoke your function in. **Required**.
+- `--region` or `-r` The region in your stage that you want to invoke your function in. **Required**.
+- `--path` or `-p` The path to a json file holding input data to be passed to the invoked function. This path is relative to the
 root directory of the service.
-- `--type` The type of invocation. Either `RequestResponse`, `Event` or `DryRun`. Default is `RequestResponse`.
-- `--log` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation.
+- `--type` or `-t` The type of invocation. Either `RequestResponse`, `Event` or `DryRun`. Default is `RequestResponse`.
+- `--log` or `-l` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation.
 Default is `false`.
 
 ## Provided lifecycle events

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -34,7 +34,7 @@ class Invoke {
           },
           log: {
             usage: 'Trigger logging data output',
-            shortcut: 'l'
+            shortcut: 'l',
           },
         },
       },

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -14,21 +14,27 @@ class Invoke {
           function: {
             usage: 'The function name',
             required: true,
+            shortcut: 'f',
           },
           stage: {
             usage: 'Stage of the service',
+            shortcut: 's',
           },
           region: {
             usage: 'Region of the service',
+            shortcut: 'r',
           },
           path: {
             usage: 'Path to JSON file holding input data',
+            shortcut: 'p',
           },
           type: {
             usage: 'Type of invocation',
+            shortcut: 't',
           },
           log: {
             usage: 'Trigger logging data output',
+            shortcut: 'l'
           },
         },
       },

--- a/lib/plugins/remove/README.md
+++ b/lib/plugins/remove/README.md
@@ -7,8 +7,8 @@ serverless remove --stage dev --region us-east-1
 Removes the deployed service which is defined in your current working directory according to the stage and region.
 
 ## Options
-- `--stage` The name of the stage in service. **Required**.
-- `--region` The name of the region in stage. **Required**.
+- `--stage` or `-s` The name of the stage in service. **Required**.
+- `--region` or `-r` The name of the region in stage. **Required**.
 
 ## Provided lifecycle events
 - `remove:remove`

--- a/lib/plugins/remove/remove.js
+++ b/lib/plugins/remove/remove.js
@@ -13,9 +13,11 @@ class Remove {
         options: {
           stage: {
             usage: 'Stage of the service',
+            shortcut: 's',
           },
           region: {
             usage: 'Region of the service',
+            shortcut: 'r',
           },
         },
       },

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -158,17 +158,90 @@ describe('PluginManager', () => {
       expect(pluginManager.commands).to.deep.equal({});
     });
 
-    it('should create an empty options object', () => {
-      expect(pluginManager.options).to.deep.equal({});
+    it('should create an empty cliOptions object', () => {
+      expect(pluginManager.cliOptions).to.deep.equal({});
+    });
+
+    it('should create an emoty cliCommands array', () => {
+      expect(pluginManager.cliCommands.length).to.equal(0);
     });
   });
 
-  describe('#setOptions()', () => {
-    it('should set the options object', () => {
+  describe('#setCliOptions()', () => {
+    it('should set the cliOptions object', () => {
       const options = { foo: 'bar' };
-      pluginManager.setOptions(options);
+      pluginManager.setCliOptions(options);
 
-      expect(pluginManager.options).to.deep.equal(options);
+      expect(pluginManager.cliOptions).to.deep.equal(options);
+    });
+  });
+
+  describe('#setCliCOmmands()', () => {
+    it('should set the cliCommands array', () => {
+      const commands = ['foo', 'bar'];
+      pluginManager.setCliCommands(commands);
+
+      expect(pluginManager.cliCommands).to.equal(commands);
+    });
+  });
+
+  describe('#convertShortcutsIntoOptions()', () => {
+    it('should convert shortcuts into options when the command matches', () => {
+      const cliOptionsMock = { r: 'eu-central-1', region: 'us-east-1' };
+      const cliCommandsMock = ['deploy'];
+      const commandsMock = {
+        deploy: {
+          options: {
+            region: {
+              shortcut: 'r',
+            },
+          },
+        },
+      };
+      pluginManager.setCliCommands(cliCommandsMock);
+      pluginManager.setCliOptions(cliOptionsMock);
+
+      pluginManager.convertShortcutsIntoOptions(cliOptionsMock, commandsMock);
+
+      expect(pluginManager.cliOptions.region).to.equal(cliOptionsMock.r);
+    });
+
+    it('should not convert shortcuts into options when the command does not match', () => {
+      const cliOptionsMock = { r: 'eu-central-1', region: 'us-east-1' };
+      const cliCommandsMock = ['foo'];
+      const commandsMock = {
+        deploy: {
+          options: {
+            region: {
+              shortcut: 'r',
+            },
+          },
+        },
+      };
+      pluginManager.setCliCommands(cliCommandsMock);
+      pluginManager.setCliOptions(cliOptionsMock);
+
+      pluginManager.convertShortcutsIntoOptions(cliOptionsMock, commandsMock);
+
+      expect(pluginManager.cliOptions.region).to.equal(cliOptionsMock.region);
+    });
+
+    it('should not convert shortcuts into options when the shortcut is not given', () => {
+      const cliOptionsMock = { r: 'eu-central-1', region: 'us-east-1' };
+      const cliCommandsMock = ['deploy'];
+      const commandsMock = {
+        deploy: {
+          options: {
+            region: {},
+          },
+        },
+      };
+      pluginManager.setCliCommands(cliCommandsMock);
+      pluginManager.setCliOptions(cliOptionsMock);
+
+      pluginManager.convertShortcutsIntoOptions(cliOptionsMock, commandsMock);
+
+      expect(pluginManager.cliOptions.region).to.equal(cliOptionsMock.region);
     });
   });
 


### PR DESCRIPTION
Add shortcut support.

Here's how it works:
In your plugins `option` object define the shortcut you want to associate your option with. That's it.

```
options: {
  region: {
    usage: 'Specify the region you want to deploy to (e.g. "--region us-east-1" or "-r us-east-1")',
    required: true,
    shortcut: 'r'
  }
}
```

Serverless will covert `shortcuts` into `options` under the hood which means that this command: `serverless deploy -r eu-central-1` is the same as this: `serverless deploy --region eu-central-1`. The options property will include: `{ region: eu-central-1 }`.