### PR TITLE
Add provider awareness for plugins

### DIFF
--- a/docs/developing-plugins/building-plugins.md
+++ b/docs/developing-plugins/building-plugins.md
@@ -313,6 +313,56 @@ class Deploy {
 module.exports = Deploy;
 ```
 
+## Provider specific plugins
+
+Plugins can be provider specific which means that they are bound to a provider.
+
+**Note:** Binding a plugin to a provider is optional. Serverless will always consider your plugin if you don't specify
+a `provider`.
+
+The provider definition should be added inside the plugins constructor:
+
+```javascript
+'use strict';
+
+class ProviderDeploy {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    // set the providers name here
+    this.provider = 'providerName';
+
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'functions'
+        ],
+        options: {
+          function: {
+            usage: 'Specify the function you want to deploy (e.g. "--function myFunction")',
+            required: true
+          }
+        }
+      },
+    };
+
+    this.hooks = {
+      'deploy:functions': this.deployFunction
+    }
+  }
+
+  deployFunction() {
+    console.log('Deploying function: ', this.options.function);
+  }
+}
+
+module.exports = ProviderDeploy;
+```
+
+The plugins functionality will now only be executed when the Serverless services provider matches the provider name which
+is defined inside the plugins constructor.
+
 ## Plugin registration process
 
 A user has to define the plugins they want to use in the root level of the

--- a/docs/developing-plugins/building-provider-integrations.md
+++ b/docs/developing-plugins/building-provider-integrations.md
@@ -1,10 +1,19 @@
 # Building provider integrations
 
-Integrating different infrastructure providers happens through the standard plugin setup. Infrastructure provider
-plugins should bind to specific lifecycle events of the `deploy` command to compile the function and their events
-to provider specific resources.
+Integrating different infrastructure providers happens through the standard plugin system.
+Take a look at the ["building plugins"](./building-plugins.md) documentation to understand how the plugin system works.
 
-## Deployment lifecycles
+## Provider specific plugins
+
+You can add the providers name inside the constructor of your plugin. This makes it possible to only execute your
+plugins logic when the Serverless service uses the provider you've specified in your plugin.
+
+## Deployment
+
+Infrastructure provider plugins should bind to specific lifecycle events of the `deploy` command to compile the function
+and their events to provider specific resources.
+
+### Deployment lifecycles
 
 Let's take a look at the [core `deploy` plugin](/lib/plugins/deploy) and the different lifecycle hooks it provides.
 
@@ -21,38 +30,38 @@ infrastructure.
 
 Let's take a closer look at each lifecycle event to understand what its purpose is and what it should be used for.
 
-### `deploy:initializeResources`
+#### `deploy:initializeResources`
 
 This lifecycle should be used to load the basic resources the provider needs into memory (e.g. parse a basic resource
 template skeleton such as a CloudFormation template).
 
-### `deploy:createProviderStacks`
+#### `deploy:createProviderStacks`
 
 The purpose of the `deploy:createProviderStacks` lifecycle is to take the basic resource template which was created in
 the previous lifecycle and deploy the rough skeleton on the cloud providers infrastructure (without any functions
 or events) for the first time.
 
-### `deploy:compileFunctions`
+#### `deploy:compileFunctions`
 
 Next up the functions inside the [`serverless.yaml`](../understanding-serverless/serverless-yaml.md) file should be
 compiled to provider specific resources and stored into memory.
 
-### `deploy:compileEvents`
+#### `deploy:compileEvents`
 
 After that the events which are defined in the [`serverless.yaml`](../understanding-serverless/serverless-yaml.md)
 file on a per function basis should be compiled to provider specific resources and also stored into memory.
 
-### `deploy:deploy`
+#### `deploy:deploy`
 
 The final lifecycle is the `deploy:deploy` lifecycle which should be used to deploy the previously compiled function and
 event resources to the providers infrastructure.
 
-## Amazon Web Services provider integration
+### Amazon Web Services provider integration
 
 Curious how this works for the Amazon Web Services (AWS) provider integration?
 Here are the steps the AWS plugins take to compile and deploy the service on the AWS infrastructure in detail.
 
-### The steps in detail
+#### The steps in detail
 
 1. The [`serverless.yaml`](../understanding-serverless/serverless-yaml.md) and
 [`serverless.env.yaml`](../understanding-serverless/serverless-env-yaml.md) files are loaded into memory
@@ -64,7 +73,7 @@ resources and stored into memory (`deploy:compileFunctions`)
 6. The compiled function and event resources are attached to the core CloudFormation template and the updated
 CloudFormation template gets redeployed (`deploy:deploy`)
 
-### The code
+#### The code
 
 You may also take a closer look at the corresponding plugin code to get a deeper knowledge about what's going on
 behind the scenes.

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -51,6 +51,10 @@ class Serverless {
 
     return this.service.load(this.processedInput.options)
       .then(() => {
+        // set the provider of the service (so that the PluginManager takes care to
+        // execute the correct provider specific plugins)
+        this.pluginManager.setProvider(this.service.provider);
+
         // load all plugins
         this.pluginManager.loadAllPlugins();
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -9,11 +9,17 @@ const BbPromise = require('bluebird');
 class PluginManager {
   constructor(serverless) {
     this.serverless = serverless;
+    this.provider = null;
+    this.cliOptions = {};
+    this.cliCommands = [];
+
     this.plugins = [];
     this.commandsList = [];
     this.commands = {};
-    this.cliOptions = {};
-    this.cliCommands = [];
+  }
+
+  setProvider(provider) {
+    this.provider = provider;
   }
 
   setCliOptions(options) {
@@ -72,19 +78,23 @@ class PluginManager {
     events.forEach((event) => {
       const hooksForEvent = [];
       this.plugins.forEach((pluginInstance) => {
-        forEach(pluginInstance.hooks, (hook, hookKey) => {
-          if (hookKey === event) {
-            // use arrow fn. to pass the hook with options rather than calling it
-            hooksForEvent.push(() => hook());
-          }
-        });
+        // if a provider is given it should only add the hook when the plugins provider matches
+        // the services provider
+        if (!pluginInstance.provider || (pluginInstance.provider === this.provider)) {
+          forEach(pluginInstance.hooks, (hook, hookKey) => {
+            if (hookKey === event) {
+              // use arrow fn. to pass the hook with options rather than calling it
+              hooksForEvent.push(() => hook());
+            }
+          });
+        }
       });
       hooks = hooks.concat(hooksForEvent);
     });
 
     if (hooks.length === 0) {
       const errorMessage = `The command you entered was not found.
-     Did you spell it correctly?`;
+        Did you spell it correctly?`;
       throw new this.serverless.classes.Error(errorMessage);
     }
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -94,7 +94,7 @@ class PluginManager {
 
     if (hooks.length === 0) {
       const errorMessage = `The command you entered was not found.
-        Did you spell it correctly?`;
+     Did you spell it correctly?`;
       throw new this.serverless.classes.Error(errorMessage);
     }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
@@ -14,6 +14,7 @@ class AwsCompileApigEvents {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
+    this.provider = 'aws';
 
     Object.assign(
       this,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
@@ -46,6 +46,9 @@ describe('AwsCompileApigEvents', () => {
 
     it('should have hooks', () => expect(awsCompileApigEvents.hooks).to.be.not.empty);
 
+    it('should set the provider variable to "aws"', () => expect(awsCompileApigEvents.provider)
+      .to.equal('aws'));
+
     it('should run promise chain in order', () => {
       const validateStub = sinon
         .stub(awsCompileApigEvents, 'validate').returns(BbPromise.resolve());

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 class AwsCompileS3Events {
   constructor(serverless) {
     this.serverless = serverless;
+    this.provider = 'aws';
 
     this.hooks = {
       'deploy:compileEvents': this.compileS3Events.bind(this),

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -15,6 +15,11 @@ describe('AwsCompileS3Events', () => {
     awsCompileS3Events.serverless.service.service = 'new-service';
   });
 
+  describe('#constructor()', () => {
+    it('should set the provider variable to "aws"', () => expect(awsCompileS3Events.provider)
+      .to.equal('aws'));
+  });
+
   describe('#compileS3Events()', () => {
     it('should throw an error if the resource section is not available', () => {
       awsCompileS3Events.serverless.service.resources.Resources = false;

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 class AwsCompileScheduledEvents {
   constructor(serverless) {
     this.serverless = serverless;
+    this.provider = 'aws';
 
     this.hooks = {
       'deploy:compileEvents': this.compileScheduledEvents.bind(this),

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -15,6 +15,11 @@ describe('AwsCompileScheduledEvents', () => {
     awsCompileScheduledEvents.serverless.service.service = 'new-service';
   });
 
+  describe('#constructor()', () => {
+    it('should set the provider variable to "aws"', () => expect(awsCompileScheduledEvents.provider)
+      .to.equal('aws'));
+  });
+
   describe('#compileScheduledEvents()', () => {
     it('should throw an error if the resource section is not available', () => {
       awsCompileScheduledEvents.serverless.service.resources.Resources = false;

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -6,6 +6,7 @@ class AwsCompileFunctions {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
+    this.provider = 'aws';
 
     this.hooks = {
       'deploy:compileFunctions': this.compileFunctions.bind(this),

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -80,6 +80,11 @@ describe('AwsCompileFunctions', () => {
     awsCompileFunctions.serverless.service.service = 'new-service';
   });
 
+  describe('#constructor()', () => {
+    it('should set the provider variable to "aws"', () => expect(awsCompileFunctions.provider)
+      .to.equal('aws'));
+  });
+
   describe('#compileFunctions()', () => {
     it('should throw an error if the resource section is not available', () => {
       awsCompileFunctions.serverless.service.resources.Resources = false;

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -13,6 +13,7 @@ class AwsDeploy {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
+    this.provider = 'aws';
     this.sdk = new SDK(serverless);
 
     Object.assign(

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -18,6 +18,9 @@ describe('AwsDeploy', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsDeploy.hooks).to.be.not.empty);
 
+    it('should set the provider variable to "aws"', () => expect(awsDeploy.provider)
+      .to.equal('aws'));
+
     it('should run "before:deploy:initializeResources" hook promise chain in order', () => {
       const validateStub = sinon
         .stub(awsDeploy, 'validate').returns(BbPromise.resolve());

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -9,8 +9,9 @@ const moment = require('moment');
 class AwsInvoke {
   constructor(serverless, options) {
     this.serverless = serverless;
-    this.sdk = new SDK(serverless);
     this.options = options || {};
+    this.provider = 'aws';
+    this.sdk = new SDK(serverless);
 
     this.options.stage = this.options.stage
       || (this.serverless.service.defaults && this.serverless.service.defaults.stage)

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -20,6 +20,9 @@ describe('AwsInvoke', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsInvoke.hooks).to.be.not.empty);
 
+    it('should set the provider variable to "aws"', () => expect(awsInvoke.provider)
+      .to.equal('aws'));
+
     it('should run promise chain in order', () => {
       const validateStub = sinon
         .stub(awsInvoke, 'validate').returns(BbPromise.resolve());

--- a/lib/plugins/aws/remove/index.js
+++ b/lib/plugins/aws/remove/index.js
@@ -9,8 +9,9 @@ const SDK = require('../');
 class AwsRemove {
   constructor(serverless, options) {
     this.serverless = serverless;
-    this.sdk = new SDK(serverless);
     this.options = options || {};
+    this.provider = 'aws';
+    this.sdk = new SDK(serverless);
 
     Object.assign(this, validate, emptyS3Bucket, removeStack);
 

--- a/lib/plugins/aws/remove/tests/index.js
+++ b/lib/plugins/aws/remove/tests/index.js
@@ -18,6 +18,9 @@ describe('AwsRemove', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsRemove.hooks).to.be.not.empty);
 
+    it('should set the provider variable to "aws"', () => expect(awsRemove.provider)
+      .to.equal('aws'));
+
     it('should have access to the serverless instance', () => {
       expect(awsRemove.serverless).to.deep.equal(serverless);
     });


### PR DESCRIPTION
Plugins can now have a `provider` definition inside the constructor.

If defined Serverless fill only consider the plugin if the `provider` definition of the service matches the one of the plugins.

All other plugins who have no provider definition will always be considered.