### PR TITLE
Added fix from https://github.com/NitorCreations/serverless/commit/d9…

### DIFF
--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -303,7 +303,7 @@ module.exports = function(S) {
 
             // No updates are to be performed
             if (e.message == 'No updates are to be performed.') {
-              return 'No resource updates are to be performed.';
+              return aws.request('CloudFormation', 'describeStacks', {StackName: stackName}, stage, region);
             }
 
             // If does not exist, create stack


### PR DESCRIPTION
This fix was originally developed at https://github.com/NitorCreations/serverless/commit/d93621a4b0fb0baa615347525bae2ff5cd9dbb14 by @nitorcreations

This fixes issues related to initializing an existing project in a new location, such as CI environment, that causes downstream issue with endpoint deployments. An example error message looks like the following:

```
Failed to deploy endpoints in "dev" to the following regions:  
us-east-1 ------------------------  
GET - foo: Cannot read property 'replace' of undefined  
Run this again with --debug to get more error information...  
```

This should close issue https://github.com/serverless/serverless/issues/1197 and probably more issues that were closed but not solved.
