### PR TITLE
fix issue #1380 - remove ascii greeting from all serverless CLI comma…

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -63,20 +63,17 @@ class CLI {
     // if only "help" or "h" was entered
     if ((commands.length === 0 && (options.help || options.h)) ||
       (commands.length === 1 && (commands.indexOf('help') > -1))) {
-      this.asciiGreeting();
       this.generateMainHelp();
       return true;
     }
     // if only "version" or "v" was entered
     if ((commands.length === 0 && (options.version || options.v)) ||
       (commands.length === 1 && (commands.indexOf('version') > -1))) {
-      this.asciiGreeting();
       this.getVersionNumber();
       return true;
     }
     // if "help" was entered in combination with commands (or one command)
     if (commands.length >= 1 && (options.help || options.h)) {
-      this.asciiGreeting();
       this.generateCommandsHelp(commands);
       return true;
     }

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -9,7 +9,7 @@ const chalk = require('chalk');
 class CLI {
   constructor(serverless, inputArray) {
     this.serverless = serverless;
-    this.inputArray = (typeof inputArray !== 'undefined' ? inputArray : []);
+    this.inputArray = inputArray || undefined;
     this.loadedPlugins = [];
   }
 
@@ -22,7 +22,7 @@ class CLI {
 
     // check if commands are passed externally (e.g. used by tests)
     // otherwise use process.argv to receive the commands
-    if (this.inputArray.length) {
+    if (typeof this.inputArray !== 'undefined') {
       inputArray = this.inputArray;
     } else {
       inputArray = process.argv.slice(2);
@@ -60,18 +60,21 @@ class CLI {
     const commands = processedInput.commands;
     const options = processedInput.options;
 
-    // if only "help" or "h" was entered
-    if ((commands.length === 0 && (options.help || options.h)) ||
-      (commands.length === 1 && (commands.indexOf('help') > -1))) {
-      this.generateMainHelp();
-      return true;
-    }
     // if only "version" or "v" was entered
     if ((commands.length === 0 && (options.version || options.v)) ||
-      (commands.length === 1 && (commands.indexOf('version') > -1))) {
+        (commands.length === 1 && (commands.indexOf('version') > -1))) {
       this.getVersionNumber();
       return true;
     }
+
+    // if only "help" or "h" was entered
+    if ((commands.length === 0) ||
+        (commands.length === 0 && (options.help || options.h)) ||
+        (commands.length === 1 && (commands.indexOf('help') > -1))) {
+      this.generateMainHelp();
+      return true;
+    }
+
     // if "help" was entered in combination with commands (or one command)
     if (commands.length >= 1 && (options.help || options.h)) {
       this.generateCommandsHelp(commands);

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -87,6 +87,7 @@ class Create {
   }
 
   finish() {
+    this.serverless.cli.asciiGreeting();
     this.serverless.cli.log(`Successfully created service "${this.options.name}"`);
     this.serverless.cli.log('  |- serverless.yaml');
     this.serverless.cli.log('  |- serverless.env.yaml');

--- a/lib/plugins/create/tests/create.js
+++ b/lib/plugins/create/tests/create.js
@@ -88,6 +88,12 @@ describe('Create', () => {
   });
 
   describe('#finish()', () => {
+    it('should display ascii greeting', () => {
+      const greetingStub = sinon.stub(create.serverless.cli, 'asciiGreeting');
+      create.finish();
+      expect(greetingStub.callCount).to.be.equal(1);
+    });
+
     it('should log 4 messages', () => {
       const logStub = sinon.stub(create.serverless.cli, 'log');
       create.finish();

--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -27,9 +27,9 @@ describe('CLI', () => {
       expect(cli.loadedPlugins.length).to.equal(0);
     });
 
-    it('should set an empty inputArray when none is provided', () => {
+    it('should set an undefined inputArray when none is provided', () => {
       cli = new CLI(serverless);
-      expect(cli.inputArray.length).to.equal(0);
+      expect(cli.inputArray).to.be.an('undefined');
     });
 
     it('should set the inputObject when provided', () => {
@@ -58,6 +58,14 @@ describe('CLI', () => {
   });
 
   describe('#displayHelp()', () => {
+    it('should return true when no command is given', () => {
+      cli = new CLI(serverless, []);
+      const processedInput = cli.processInput();
+      const helpDisplayed = cli.displayHelp(processedInput);
+
+      expect(helpDisplayed).to.equal(true);
+    });
+
     it('should return true when the "help" parameter is given', () => {
       cli = new CLI(serverless, ['help']);
       const processedInput = cli.processInput();


### PR DESCRIPTION
##### Status:
Ready

##### Description:
* Removed ascii greeting from all displayHelp calls
* Added the greeting to create.finish()
* Added test to create.js
* **Didn't** remove the reference to the docs mentioned in #1380 as I find it useful for now. WDYT?