### PR TITLE
added Alexa Skills Kit event

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -126,3 +126,16 @@ functions:
                 topic_name: aggregate
                 display_name: Data aggregation pipeline
 ```
+
+### Alexa Skills Kit
+
+This will create a permission to allow the function to be invoke the
+function when the skill is spoken
+
+```yaml
+functions:
+    resize:
+        handler: quiz.handler
+        events:
+            - ask
+```

--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -43,6 +43,7 @@ functions:
                 path: users/create
                 method: get
             - sns: topic-name
+            - ask # Alexa Skills Kit
 
 resources:
     Resources:

--- a/docs/using-plugins/core-plugins.md
+++ b/docs/using-plugins/core-plugins.md
@@ -15,6 +15,7 @@ see the corresponding source code.
   - [Compile Scheduled Events](/lib/plugins/aws/deploy/compile/events/schedule)
   - [Compile Api Gateway Events](/lib/plugins/aws/deploy/compile/events/apiGateway)
   - [Compile SNS Events](lib/plugins/aws/deploy/compile/events/sns)
+  - [Compile Alexa Skills Kit Events](lib/plugins/aws/deploy/compile/events/alexaSkillsKit)
   - [Deploy](/lib/plugins/aws/deploy)
   - [Invoke](/lib/plugins/aws/invoke)
   - [Remove](/lib/plugins/aws/remove)

--- a/lib/plugins/Plugins.json
+++ b/lib/plugins/Plugins.json
@@ -12,6 +12,7 @@
     "./aws/deploy/compile/events/schedule/index.js",
     "./aws/deploy/compile/events/s3/index.js",
     "./aws/deploy/compile/events/apiGateway/index.js",
-    "./aws/deploy/compile/events/sns/index.js"
+    "./aws/deploy/compile/events/sns/index.js",
+    "./aws/deploy/compile/events/alexaSkillsKit/index.js"
   ]
 }

--- a/lib/plugins/aws/deploy/compile/events/alexaSkillsKit/README.md
+++ b/lib/plugins/aws/deploy/compile/events/alexaSkillsKit/README.md
@@ -1,0 +1,26 @@
+# Compile Alexa Skills Kit Events
+
+This plugins compiles the Alexa Skills Kit event to a CloudFormation resource.
+
+## How it works
+
+`Compile Alexa Skills Kit Events` hooks into the [`deploy:compileEvents`](/lib/plugins/deploy) lifecycle.
+
+It loops over all functions which are defined in `serverless.yaml`. For each function that has an `ask`
+event defined, a lambda permission for the current function is created which makes is possible to invoke the
+function when the skill is spoken.
+
+Take a look at the [Event syntax examples](#event-syntax-examples) below to see how you can setup an Alexa Skills Kit event.
+
+The resource is then merged into the `serverless.service.resources.Resources` section.
+
+## Event syntax examples
+
+```yaml
+# serverless.yaml
+functions:
+    greet:
+        handler: handler.hello
+        events:
+            - ask
+```

--- a/lib/plugins/aws/deploy/compile/events/alexaSkillsKit/index.js
+++ b/lib/plugins/aws/deploy/compile/events/alexaSkillsKit/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const _ = require('lodash');
+
+class AwsCompileAlexaSkillsKitEvents {
+  constructor(serverless) {
+    this.serverless = serverless;
+    this.provider = 'aws';
+
+    this.hooks = {
+      'deploy:compileEvents': this.compileAlexaSkillsKitEvents.bind(this),
+    };
+  }
+
+  compileAlexaSkillsKitEvents() {
+    if (!this.serverless.service.resources.Resources) {
+      throw new this.serverless.classes
+        .Error('This plugin needs access to Resources section of the AWS CloudFormation template');
+    }
+
+    this.serverless.service.getAllFunctions().forEach((functionName) => {
+      const functionObj = this.serverless.service.getFunction(functionName);
+
+      if (functionObj.events) {
+        for (let i = 0; i < functionObj.events.length; i++) {
+          const event = functionObj.events[i];
+          if (event === 'ask') {
+            const permissionTemplate = `
+              {
+                "Type": "AWS::Lambda::Permission",
+                "Properties": {
+                  "FunctionName": { "Fn::GetAtt": ["${functionName}", "Arn"] },
+                  "Action": "lambda:InvokeFunction",
+                  "Principal": "alexa-appkit.amazon.com"
+                }
+              }
+            `;
+
+            const newPermissionObject = {
+              [`${functionName}AlexaSkillsKitEventPermission${i}`]: JSON.parse(permissionTemplate),
+            };
+
+            _.merge(this.serverless.service.resources.Resources,
+              newPermissionObject);
+          }
+        }
+      }
+    });
+  }
+}
+
+module.exports = AwsCompileAlexaSkillsKitEvents;

--- a/lib/plugins/aws/deploy/compile/events/alexaSkillsKit/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/alexaSkillsKit/tests/index.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileAlexaSkillsKitEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+
+describe('AwsCompileAlexaSkillsKitEvents', () => {
+  let serverless;
+  let awsCompileAlexaSkillsKitEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.service.resources = { Resources: {} };
+    awsCompileAlexaSkillsKitEvents = new AwsCompileAlexaSkillsKitEvents(serverless);
+    awsCompileAlexaSkillsKitEvents.serverless.service.service = 'new-service';
+  });
+
+  describe('#constructor()', () => {
+    it('should set the provider variable to "aws"', () =>
+      expect(
+        awsCompileAlexaSkillsKitEvents.provider
+      ).to.equal('aws'));
+  });
+
+  describe('#compileAlexaSkillsKitEvents()', () => {
+    it('should throw an error if the resource section is not available', () => {
+      awsCompileAlexaSkillsKitEvents.serverless.service.resources.Resources = false;
+      expect(() => awsCompileAlexaSkillsKitEvents.compileAlexaSkillsKitEvents()).to.throw(Error);
+    });
+
+    it('should create corresponding resources when ask events are given', () => {
+      awsCompileAlexaSkillsKitEvents.serverless.service.functions = {
+        first: {
+          events: [
+            'ask',
+          ],
+        },
+      };
+
+      awsCompileAlexaSkillsKitEvents.compileAlexaSkillsKitEvents();
+
+      expect(awsCompileAlexaSkillsKitEvents.serverless.service
+        .resources.Resources.firstAlexaSkillsKitEventPermission0.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
+    it('should not create corresponding resources when ask events are not given', () => {
+      awsCompileAlexaSkillsKitEvents.serverless.service.functions = {
+        first: {
+          events: [],
+        },
+      };
+
+      awsCompileAlexaSkillsKitEvents.compileAlexaSkillsKitEvents();
+
+      expect(
+        awsCompileAlexaSkillsKitEvents.serverless.service.resources.Resources
+      ).to.deep.equal({});
+    });
+  });
+});

--- a/lib/templates/serverless.yaml
+++ b/lib/templates/serverless.yaml
@@ -39,6 +39,7 @@ functions:
 #           - s3: ${bucket}
 #           - schedule: rate(10 minutes)
 #           - sns: greeter-topic
+#           - ask # Alexa Skills Kit
 
 # you can add CloudFormation resource templates here
 #resources:

--- a/tests/all.js
+++ b/tests/all.js
@@ -24,4 +24,5 @@ require('../lib/plugins/aws/deploy/tests/all');
 require('../lib/plugins/aws/deploy/compile/functions/tests');
 require('../lib/plugins/aws/deploy/compile/events/s3/tests');
 require('../lib/plugins/aws/deploy/compile/events/schedule/tests');
+require('../lib/plugins/aws/deploy/compile/events/alexaSkillsKit/tests');
 require('../lib/plugins/aws/deploy/compile/events/apiGateway/tests/all');


### PR DESCRIPTION
##### Status:

In Development

##### Description:

Adds the basic policy required for a lambda function to be invoked from the Alexa Skills Kit (Echo). This is a completely different event than the additional "Alexa Smart Home" event that will also eventually be required. Part of issue #1409

I used the verbose name `alexaSkillsKit` nearly everywhere except in the YAML configuration where it is `ask` to match `apiGateway` and `http`. ASK is an abbreviation used by Amazon, but I could easily switch it to  `alexaSkillsKit` (looks weird in YAML), `alexa-skills-kit` (somewhat popular), or  `alexa_skills_kit`

##### Todos:

- [x] Write tests
- [ ] Discuss event naming convention