### PR TITLE
Add service bound runtime functionality

### DIFF
--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -10,6 +10,8 @@ service: first_service
 
 provider: aws
 
+runtime: nodejs4.3
+
 plugins:
     - additional_plugin
     - another_plugin

--- a/docs/understanding-serverless/services-and-functions.md
+++ b/docs/understanding-serverless/services-and-functions.md
@@ -10,6 +10,7 @@ Each *Serverless service* contains two configuration files:
   - Declares a Serverless service
   - Defines one or multiple functions in the service
   - Defines the provider the service will be deployed to
+  - Defines the runtime of the whole service
   - Defines custom plugins to be used
   - Defines events that trigger each function to execute (e.g. HTTP requests)
   - Defines one set of resources (e.g. 1 AWS CloudFormation stack) required by the functions in this service
@@ -41,6 +42,7 @@ users
 ```yaml
 service: users
 provider: aws
+runtime: nodejs4.3
 defaults: # overwrite defaults
     memory: ${memoryVar} # reference a Serverless variable
 functions:

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -15,6 +15,7 @@ class Service {
     // Default properties
     this.service = null;
     this.provider = null;
+    this.runtime = null;
     this.defaults = {
       stage: 'dev',
       region: 'us-east-1',
@@ -51,6 +52,9 @@ class Service {
         if (!serverlessYaml.provider) {
           throw new SError('"provider" property is missing in serverless.yaml');
         }
+        if (!serverlessYaml.runtime) {
+          throw new SError('"runtime" property is missing in serverless.yaml');
+        }
         if (!serverlessYaml.functions) {
           throw new SError('"functions" property is missing in serverless.yaml');
         }
@@ -66,6 +70,7 @@ class Service {
 
         that.service = serverlessYaml.service;
         that.provider = serverlessYaml.provider;
+        that.runtime = serverlessYaml.runtime;
         that.variableSyntax = serverlessYaml.variableSyntax;
         that.custom = serverlessYaml.custom;
         that.plugins = serverlessYaml.plugins;

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -65,12 +65,13 @@ class AwsCompileFunctions {
       const Timeout = Number(functionObject.timeout)
         || Number(this.serverless.service.defaults.timeout)
         || 6;
+      const Runtime = this.serverless.service.runtime;
 
       newFunction.Properties.Handler = Handler;
       newFunction.Properties.FunctionName = FunctionName;
       newFunction.Properties.MemorySize = MemorySize;
       newFunction.Properties.Timeout = Timeout;
-      newFunction.Properties.Runtime = 'nodejs4.3';
+      newFunction.Properties.Runtime = Runtime;
       newFunction.Properties.Role = { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] };
 
       const newFunctionObject = {

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -9,27 +9,16 @@ describe('AwsCompileFunctions', () => {
   let awsCompileFunctions;
 
   const functionsObjectMock = {
+    // function with overwritten config
     first: {
-      name_template: 'name-template-name',
+      name: 'customized-first-function',
       handler: 'first.function.handler',
-      provider: {
-        aws: {
-          timeout: 6,
-          memorySize: 1024,
-          runtime: 'nodejs4.3',
-        },
-      },
+      memory: 128,
+      timeout: 10,
     },
+    // function without overwritten config
     second: {
-      name_template: 'name-template-name',
       handler: 'second.function.handler',
-      provider: {
-        aws: {
-          timeout: 6,
-          memorySize: 1024,
-          runtime: 'nodejs4.3',
-        },
-      },
     },
   };
 
@@ -42,12 +31,12 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
             S3Key: 'artifact.zip',
           },
-          FunctionName: 'new-service-dev-first',
+          FunctionName: 'customized-first-function',
           Handler: 'first.function.handler',
-          MemorySize: 1024,
+          MemorySize: 128,
           Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
           Runtime: 'nodejs4.3',
-          Timeout: 6,
+          Timeout: 10,
         },
       },
       second: {
@@ -78,6 +67,7 @@ describe('AwsCompileFunctions', () => {
     serverless.service.resources = { Resources: {} };
     awsCompileFunctions.serverless.service.functions = functionsObjectMock;
     awsCompileFunctions.serverless.service.service = 'new-service';
+    awsCompileFunctions.serverless.service.runtime = 'nodejs4.3';
     awsCompileFunctions.serverless.service.package.artifact = 'artifact.zip';
   });
 

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yaml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yaml
@@ -13,6 +13,7 @@
 
 service: aws-nodejs
 provider: aws
+runtime: nodejs4.3
 
 # you can overwrite defaults here
 #defaults:

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -21,6 +21,9 @@ describe('Service', () => {
       const serviceInstance = new Service(serverless);
 
       expect(serviceInstance.service).to.be.equal(null);
+      expect(serviceInstance.provider).to.be.equal(null);
+      expect(serviceInstance.runtime).to.be.equal(null);
+      expect(serviceInstance.variableSyntax).to.be.equal(null);
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);
       expect(serviceInstance.functions).to.deep.equal({});
@@ -32,6 +35,8 @@ describe('Service', () => {
     it('should construct with data', () => {
       const data = {
         service: 'testService',
+        provider: 'testProvider',
+        runtime: 'testRuntime',
         custom: {
           customProp: 'value',
         },
@@ -56,6 +61,8 @@ describe('Service', () => {
       const serviceInstance = new Service(serverless, data);
 
       expect(serviceInstance.service).to.be.equal('testService');
+      expect(serviceInstance.provider).to.be.equal('testProvider');
+      expect(serviceInstance.runtime).to.be.equal('testRuntime');
       expect(serviceInstance.custom).to.deep.equal({ customProp: 'value' });
       expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
       expect(serviceInstance.functions).to.deep.equal({ functionA: {} });
@@ -85,6 +92,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: '${testVar}',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         defaults: {
           stage: 'dev',
           region: 'us-east-1',
@@ -143,6 +151,8 @@ describe('Service', () => {
       };
       return serviceInstance.load().then((loadedService) => {
         expect(loadedService.service).to.be.equal('commonVar');
+        expect(loadedService.provider).to.be.equal('aws');
+        expect(loadedService.runtime).to.be.equal('nodejs4.3');
         expect(loadedService.plugins).to.deep.equal(['testPlugin']);
         expect(loadedService.environment.vars).to.deep.equal(commonVars);
         expect(serviceInstance.environment.stages.dev.regions['us-east-1'].vars)
@@ -164,6 +174,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: '${testVar}',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         functions: {},
       };
       const serverlessEnvYaml = {
@@ -202,6 +213,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: '${testVar}',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         plugins: ['testPlugin'],
         functions: {},
       };
@@ -244,6 +256,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           digit: '${testDigit}',
         },
@@ -285,6 +298,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           object: '${testObject}',
         },
@@ -328,6 +342,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           object: '${testObject.subProperty.deepSubProperty}',
         },
@@ -373,6 +388,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           substring: 'Hello ${testSubstring.subProperty.deepSubProperty}',
         },
@@ -418,6 +434,7 @@ describe('Service', () => {
         service: '${{testVar}}',
         variableSyntax: '\\${{([\\s\\S]+?)}}',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         functions: {},
       };
       const serverlessEnvYaml = {
@@ -455,6 +472,7 @@ describe('Service', () => {
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
       const serverlessYaml = {
         provider: 'aws',
+        runtime: 'nodejs4.3',
         functions: {},
       };
       const serverlessEnvYaml = {
@@ -493,6 +511,7 @@ describe('Service', () => {
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
       const serverlessYaml = {
         service: 'service-name',
+        runtime: 'nodejs4.3',
         functions: {},
       };
       const serverlessEnvYaml = {
@@ -532,6 +551,46 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'invalid',
+        runtime: 'nodejs4.3',
+        functions: {},
+      };
+      const serverlessEnvYaml = {
+        vars: {},
+        stages: {
+          dev: {
+            vars: {},
+            regions: {},
+          },
+        },
+      };
+
+      serverlessEnvYaml.stages.dev.regions['us-east-1'] = {
+        vars: {},
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yaml'),
+        YAML.dump(serverlessYaml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.env.yaml'),
+        YAML.dump(serverlessEnvYaml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load().then(() => {
+        // if we reach this, then no error was thrown as expected
+        // so make assertion fail intentionally to let us know something is wrong
+        expect(1).to.equal(2);
+      }).catch(e => {
+        expect(e.name).to.be.equal('ServerlessError');
+      });
+    });
+
+    it('should throw error if runtime property is missing', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const serverlessYaml = {
+        service: 'service-name',
+        provider: 'aws',
         functions: {},
       };
       const serverlessEnvYaml = {
@@ -570,6 +629,7 @@ describe('Service', () => {
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
       const serverlessYaml = {
         service: 'service-name',
+        runtime: 'nodejs4.3',
         provider: 'aws',
       };
       const serverlessEnvYaml = {
@@ -607,6 +667,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           object: '${testVar}',
         },
@@ -649,6 +710,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           testVar: '${testVar.subProperty}',
         },
@@ -693,6 +755,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           testVar: '${testVar.subProperty}',
         },
@@ -737,6 +800,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           testObject: '${testObject.subProperty.deepSubProperty}',
         },
@@ -783,6 +847,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           testVar: '${testVar} String',
         },
@@ -827,6 +892,7 @@ describe('Service', () => {
       const serverlessYaml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           testObject: '${testObject.subProperty} String',
         },
@@ -1142,4 +1208,3 @@ describe('Service', () => {
     });
   });
 });
-


### PR DESCRIPTION
This implements the functionality that the service defines which runtime is used (see https://github.com/serverless/serverless/issues/1517 for more details).