### PR TITLE
add default output for AWS account Id variable in CF template as discussed in #820

### DIFF
--- a/lib/templates/core-cf.json
+++ b/lib/templates/core-cf.json
@@ -57,6 +57,12 @@
     }
   },
   "Outputs": {
+    "AccountId": {
+      "Description": "Outputs AWS AccountId as variable. This is used by Serverless to build resource ARNs when required. It should not be deleted.",
+      "Value": {
+        "Ref": "AWS::AccountId"
+      }
+    },
     "IamRoleArnLambda": {
       "Description": "ARN of the lambda IAM role",
       "Value": {


### PR DESCRIPTION
Pull Request Template ------------------------
* Check out our Pull Request Guidelines here: https://github.com/serverless/serverless/blob/v1.0/CONTRIBUTING.md

##### Status:

Ready/In Development/Hold

##### Description:

##### Todos:

- [ ] Write tests

…iable is filled correctly when generating default template. Thanks to @erikerikson for all support.