### PR TITLE
Rename coreBucket name to be more meaningful

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -25,7 +25,7 @@ class AwsCompileFunctions {
         "Type": "AWS::Lambda::Function",
         "Properties": {
           "Code": {
-            "S3Bucket": { "Ref": "coreBucket" },
+            "S3Bucket": { "Ref": "ServerlessDeploymentBucket" },
             "S3Key": "S3Key"
           },
           "FunctionName": "FunctionName",

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -39,7 +39,7 @@ describe('AwsCompileFunctions', () => {
         Type: 'AWS::Lambda::Function',
         Properties: {
           Code: {
-            S3Bucket: { Ref: 'coreBucket' },
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
             S3Key: 'artifact.zip',
           },
           FunctionName: 'new-service-dev-first',
@@ -54,7 +54,7 @@ describe('AwsCompileFunctions', () => {
         Type: 'AWS::Lambda::Function',
         Properties: {
           Code: {
-            S3Bucket: { Ref: 'coreBucket' },
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
             S3Key: 'artifact.zip',
           },
           FunctionName: 'new-service-dev-second',

--- a/lib/plugins/aws/deploy/lib/uploadDeploymentPackage.js
+++ b/lib/plugins/aws/deploy/lib/uploadDeploymentPackage.js
@@ -6,8 +6,8 @@ const BbPromise = require('bluebird');
 const _ = require('lodash');
 
 module.exports = {
-  setCoreBucketName() {
-    return this.sdk.getCoreBucketName(this.options.stage, this.options.region)
+  setServerlessDeploymentBucketName() {
+    return this.sdk.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
       .then((bucketName) => {
         this.bucketName = bucketName;
       });
@@ -82,7 +82,7 @@ module.exports = {
 
   uploadDeploymentPackage() {
     return BbPromise.bind(this)
-      .then(this.setCoreBucketName)
+      .then(this.setServerlessDeploymentBucketName)
       .then(this.getServiceObjectsFromS3Bucket)
       .then(this.cleanupS3Bucket)
       .then(this.uploadZipFileToS3Bucket);

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -45,7 +45,7 @@ describe('updateStack', () => {
           Timeout: 6,
         },
       },
-      coreBucket: {
+      ServerlessDeploymentBucket: {
         Type: 'AWS::S3::Bucket',
       },
     },

--- a/lib/plugins/aws/deploy/tests/uploadDeploymentPackage.js
+++ b/lib/plugins/aws/deploy/tests/uploadDeploymentPackage.js
@@ -22,18 +22,18 @@ describe('uploadDeploymentPackage', () => {
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });
 
-  describe('#setCoreBucketName()', () => {
-    it('should store the name of the core bucket in the "this" variable', () => {
-      const getCoreBucketNameStub = sinon
-        .stub(awsDeploy.sdk, 'getCoreBucketName')
+  describe('#setServerlessDeploymentBucketName()', () => {
+    it('should store the name of the Serverless deployment bucket in the "this" variable', () => {
+      const getServerlessDeploymentBucketNameStub = sinon
+        .stub(awsDeploy.sdk, 'getServerlessDeploymentBucketName')
         .returns(BbPromise.resolve('new-service-dev-us-east-1-12345678'));
 
-      return awsDeploy.setCoreBucketName().then(() => {
+      return awsDeploy.setServerlessDeploymentBucketName().then(() => {
         expect(awsDeploy.bucketName).to.equal('new-service-dev-us-east-1-12345678');
-        expect(getCoreBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getCoreBucketNameStub
+        expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
+        expect(getServerlessDeploymentBucketNameStub
           .calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.sdk.getCoreBucketName.restore();
+        awsDeploy.sdk.getServerlessDeploymentBucketName.restore();
       });
     });
   });

--- a/lib/plugins/aws/index.js
+++ b/lib/plugins/aws/index.js
@@ -88,7 +88,7 @@ class SDK {
     return credentials;
   }
 
-  getCoreBucketName(stage, region) {
+  getServerlessDeploymentBucketName(stage, region) {
     const stackName = `${this.serverless.service.service}-${stage}`;
 
     return this.request('CloudFormation',
@@ -97,7 +97,7 @@ class SDK {
       stage,
       region
     ).then((result) => _.find(result.Stacks[0].Outputs,
-      { OutputKey: 'CoreBucketName' }).OutputValue);
+      { OutputKey: 'ServerlessDeploymentBucketName' }).OutputValue);
   }
 }
 

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -3,8 +3,8 @@
 const BbPromise = require('bluebird');
 
 module.exports = {
-  setCoreBucketName() {
-    return this.sdk.getCoreBucketName(this.options.stage, this.options.region)
+  setServerlessDeploymentBucketName() {
+    return this.sdk.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
       .then((bucketName) => {
         this.bucketName = bucketName;
       });
@@ -44,7 +44,7 @@ module.exports = {
 
   emptyS3Bucket() {
     return BbPromise.bind(this)
-      .then(this.setCoreBucketName)
+      .then(this.setServerlessDeploymentBucketName)
       .then(this.listObjects)
       .then(this.deleteObjects);
   },

--- a/lib/plugins/aws/remove/tests/bucket.js
+++ b/lib/plugins/aws/remove/tests/bucket.js
@@ -20,18 +20,18 @@ describe('emptyS3Bucket', () => {
     awsRemove.serverless.cli = new serverless.classes.CLI();
   });
 
-  describe('#setCoreBucketName()', () => {
-    it('should store the name of the core bucket in the "this" variable', () => {
-      const getCoreBucketNameStub = sinon
-        .stub(awsRemove.sdk, 'getCoreBucketName')
+  describe('#setServerlessDeploymentBucketName()', () => {
+    it('should store the name of the Serverless deployment bucket in the "this" variable', () => {
+      const getServerlessDeploymentBucketNameStub = sinon
+        .stub(awsRemove.sdk, 'getServerlessDeploymentBucketName')
         .returns(BbPromise.resolve('new-service-dev-us-east-1-12345678'));
 
-      return awsRemove.setCoreBucketName().then(() => {
+      return awsRemove.setServerlessDeploymentBucketName().then(() => {
         expect(awsRemove.bucketName).to.equal('new-service-dev-us-east-1-12345678');
-        expect(getCoreBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getCoreBucketNameStub
+        expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
+        expect(getServerlessDeploymentBucketNameStub
           .calledWith(awsRemove.options.stage, awsRemove.options.region));
-        awsRemove.sdk.getCoreBucketName.restore();
+        awsRemove.sdk.getServerlessDeploymentBucketName.restore();
       });
     });
   });

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -130,8 +130,8 @@ describe('AWS SDK', () => {
     });
   });
 
-  describe('#getCoreBucketName', () => {
-    it('should return the name of the core bucket', () => {
+  describe('#getServerlessDeploymentBucketName', () => {
+    it('should return the name of the serverless deployment bucket', () => {
       const serverless = new Serverless();
       const awsSdk = new AwsSdk(serverless);
       const options = {
@@ -139,17 +139,18 @@ describe('AWS SDK', () => {
         region: 'us-east-1',
       };
 
-      const getCoreBucketNameStub = sinon
-        .stub(awsSdk, 'getCoreBucketName')
+      const getServerlessDeploymentBucketNameStub = sinon
+        .stub(awsSdk, 'getServerlessDeploymentBucketName')
         .returns(BbPromise.resolve('new-service-dev-us-east-1-12345678'));
 
-      return awsSdk.getCoreBucketName(options.stage, options.region).then((bucketName) => {
-        expect(bucketName).to.equal('new-service-dev-us-east-1-12345678');
-        expect(getCoreBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getCoreBucketNameStub
-          .calledWith(options.stage, options.region));
-        awsSdk.getCoreBucketName.restore();
-      });
+      return awsSdk.getServerlessDeploymentBucketName(options.stage, options.region)
+        .then((bucketName) => {
+          expect(bucketName).to.equal('new-service-dev-us-east-1-12345678');
+          expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
+          expect(getServerlessDeploymentBucketNameStub
+            .calledWith(options.stage, options.region));
+          awsSdk.getServerlessDeploymentBucketName.restore();
+        });
     });
   });
 });

--- a/lib/templates/core-cf.json
+++ b/lib/templates/core-cf.json
@@ -2,7 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "The AWS CloudFormation template for this Serverless application's resources outside of Lambdas and Api Gateway",
   "Resources": {
-    "coreBucket": {
+    "ServerlessDeploymentBucket": {
       "Type" : "AWS::S3::Bucket"
     },
     "IamRoleLambda": {
@@ -63,9 +63,9 @@
         ]
       }
     },
-    "CoreBucketName": {
+    "ServerlessDeploymentBucketName": {
       "Value": {
-        "Ref": "coreBucket"
+        "Ref": "ServerlessDeploymentBucket"
       }
     }
   }


### PR DESCRIPTION
The bucket which is used for deployment should be more meaningful (as discussed in https://github.com/serverless/serverless/issues/1516).