### PR TITLE
minor fixed documentation on lowercase http methods

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -78,7 +78,7 @@ functions:
     show:
         handler: users.show
         events:
-            - http: GET users/show
+            - http: get users/show
 ```
 
 #### Extended event definition
@@ -93,7 +93,7 @@ functions:
         events:
             - http:
                 path: posts/create
-                method: POST
+                method: post
 ```
 
 ### SNS


### PR DESCRIPTION
##### Description:

Just a quick fix in the documentation. Capital letters for http methods doesn't work, needs to be lowercase. 