### PR TITLE
Don't use regex to test file path in package plugin

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -37,17 +37,11 @@ module.exports = {
     this.serverless.utils.walkDirSync(servicePath).forEach((filePath) => {
       const relativeFilePath = path.relative(servicePath, filePath);
 
-      const shouldBeExcluded = exclude.some(sRegex => {
-        const regex = new RegExp(sRegex);
-        const matches = regex.exec(relativeFilePath);
-        return matches && matches.length > 0;
-      });
+      const shouldBeExcluded =
+        exclude.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
 
-      const shouldBeIncluded = include.some(sRegex => {
-        const regex = new RegExp(sRegex);
-        const matches = regex.exec(relativeFilePath);
-        return matches && matches.length > 0;
-      });
+      const shouldBeIncluded =
+        include.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
 
       if (!shouldBeExcluded || shouldBeIncluded) {
         zip.file(relativeFilePath, fs.readFileSync(filePath));

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -35,6 +35,9 @@ describe('#zipService()', () => {
     serverless.utils.writeFileSync(includeMeDirectoryPath, 'some-file content');
     const includeMeFilePath = path.join(tmpDirPath, 'include-me.js');
     serverless.utils.writeFileSync(includeMeFilePath, 'include-me.js file content');
+    // a serverless plugin that should be included
+    const includeMe2FilePath = path.join(tmpDirPath, 'a-serverless-plugin.js');
+    serverless.utils.writeFileSync(includeMe2FilePath, 'a-serverless-plugin.js file content');
     // create the files and folder which should be ignored by default
     // .gitignore
     const gitignoreFilePath = path.join(tmpDirPath, '.gitignore');
@@ -66,7 +69,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(6);
+      expect(Object.keys(unzippedFileData).length).to.equal(7);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
@@ -85,6 +88,9 @@ describe('#zipService()', () => {
 
       expect(unzippedFileData['include-me/some-file'].name)
         .to.equal('include-me/some-file');
+
+      expect(unzippedFileData['a-serverless-plugin.js'].name)
+        .to.equal('a-serverless-plugin.js');
     })
   );
 
@@ -117,7 +123,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(4);
+      expect(Object.keys(unzippedFileData).length).to.equal(5);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
@@ -130,6 +136,9 @@ describe('#zipService()', () => {
 
       expect(unzippedFileData['include-me/some-file'].name)
         .to.equal('include-me/some-file');
+
+      expect(unzippedFileData['a-serverless-plugin.js'].name)
+        .to.equal('a-serverless-plugin.js');
     });
   });
 
@@ -140,7 +149,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(6);
+      expect(Object.keys(unzippedFileData).length).to.equal(7);
 
       expect(unzippedFileData['.gitignore'])
         .to.be.equal(undefined);
@@ -169,7 +178,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(6);
+      expect(Object.keys(unzippedFileData).length).to.equal(7);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
@@ -188,6 +197,9 @@ describe('#zipService()', () => {
 
       expect(unzippedFileData['exclude-me/some-file'].name)
         .to.equal('exclude-me/some-file');
+
+      expect(unzippedFileData['a-serverless-plugin.js'].name)
+        .to.equal('a-serverless-plugin.js');
     });
   });
 });


### PR DESCRIPTION
##### Status:

Ready

##### Description:

##### Todos:

- [x] Write tests

In a regex, `.` means any character, so the default exclude list will
actually exclude more than intended (any path containing `.serverless`
for example).

Instead, use `String#indexOf()`

See #1549 