### PR TITLE
Add Python support for AWS

### DIFF
--- a/lib/plugins/create/README.md
+++ b/lib/plugins/create/README.md
@@ -14,6 +14,7 @@ Creates a new service in the current working directory based on the provided tem
 
 ## Available Templates
 - aws-nodejs
+- aws-python
 
 ## Examples
 
@@ -23,7 +24,8 @@ Creates a new service in the current working directory based on the provided tem
 serverless create --template aws-nodejs
 ```
 
-This example will generate scaffolding for a service with `AWS` as a provider and `nodejs` as runtime. The scaffolding will be generated in the current working directory.
+This example will generate scaffolding for a service with `AWS` as a provider and `nodejs` as runtime. The scaffolding
+will be generated in the current working directory.
 
 Your new service will have a default stage called `dev` and a default region inside that stage called `us-east-1`.
 The provider which is used for deployment later on is AWS (Amazon web services).

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -38,10 +38,13 @@ class Create {
       'aws-python',
     ];
 
+    const humanReadableTemplateList = `${validTemplates.slice(0, -1)
+      .join(', ')} and ${validTemplates.slice(-1)}`;
+
     if (validTemplates.indexOf(this.options.template) === -1) {
       const errorMessage = [
         `Template "${this.options.template}" is not supported.`,
-        ' Supported templates are: "aws-nodejs" and "aws-python".',
+        ` Supported templates are: ${humanReadableTemplateList}.`,
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -16,7 +16,7 @@ class Create {
         ],
         options: {
           template: {
-            usage: 'Template for the service. Available templates: aws-nodejs',
+            usage: 'Template for the service. Available templates: "aws-nodejs" and "aws-python"',
             required: true,
             shortcut: 't',
           },
@@ -35,12 +35,13 @@ class Create {
 
     const validTemplates = [
       'aws-nodejs',
+      'aws-python',
     ];
 
-    if (validTemplates.indexOf(this.options.template)) {
+    if (validTemplates.indexOf(this.options.template) === -1) {
       const errorMessage = [
         `Template "${this.options.template}" is not supported.`,
-        ' Supported templates are: aws-nodejs.',
+        ' Supported templates are: "aws-nodejs" and "aws-python".',
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/create/templates/aws-python/handler.py
+++ b/lib/plugins/create/templates/aws-python/handler.py
@@ -1,0 +1,2 @@
+def hello(event, context):
+    return { "message": "Go Serverless v1.0! Your function executed successfully!", "event": event }

--- a/lib/plugins/create/templates/aws-python/serverless.env.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.env.yaml
@@ -1,0 +1,15 @@
+# This is the Serverles Environment File
+#
+# It contains listing of your stages, and their regions
+# It also manages serverless variables at 3 levels:
+#    - common variables: variables that apply to all stages/regions
+#    - stage variables: variables that apply to a specific stage
+#    - region variables: variables that apply to a specific region
+
+vars:
+stages:
+    dev:
+        vars:
+        regions:
+            us-east-1:
+                vars:

--- a/lib/plugins/create/templates/aws-python/serverless.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.yaml
@@ -1,0 +1,52 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    v1.docs.serverless.com
+#
+# Happy Coding!
+
+service: aws-python
+provider: aws
+runtime: python2.7
+
+# you can overwrite defaults here
+#defaults:
+#    stage: dev
+#    region: us-east-1
+
+# you can add packaging information here
+#package:
+#    include:
+#        - include-me.js
+#    exclude:
+#        - exclude-me.js
+#    artifact: my-service-code.zip
+
+functions:
+    hello:
+        handler: handler.hello
+
+#       you can add any of the following events
+#       events:
+#           - http:
+#               path: users/create
+#               method: get
+#           - s3: ${bucket}
+#           - schedule: rate(10 minutes)
+#           - sns: greeter-topic
+
+# you can add CloudFormation resource templates here
+#resources:
+#    Resources:
+#      newResource:
+#        Type: AWS::S3::Bucket
+#        Properties:
+#          BucketName: newBucket
+
+

--- a/lib/plugins/create/tests/create.js
+++ b/lib/plugins/create/tests/create.js
@@ -41,7 +41,7 @@ describe('Create', () => {
       });
     });
 
-    it('should generate scaffolding for aws-nodejs template', () => {
+    it('should generate scaffolding for "aws-nodejs" template', () => {
       const tmpDir = path.join(os.tmpdir(), (new Date).getTime().toString());
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
@@ -54,6 +54,25 @@ describe('Create', () => {
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.env.yaml')))
           .to.be.equal(true);
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.js')))
+          .to.be.equal(true);
+
+        process.chdir(cwd);
+      });
+    });
+
+    it('should generate scaffolding for "aws-python" template', () => {
+      const tmpDir = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const cwd = process.cwd();
+      fse.mkdirsSync(tmpDir);
+      process.chdir(tmpDir);
+      create.options.template = 'aws-python';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yaml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.env.yaml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.py')))
           .to.be.equal(true);
 
         process.chdir(cwd);


### PR DESCRIPTION
This PR adds Python support for AWS (it uses the recently introduced templating mechanism).

See #1552 and #1247