### PR TITLE
Fix Validation for APIG method for upper and lower case

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -29,7 +29,7 @@ module.exports = {
           let path;
 
           if (typeof event.http === 'object') {
-            method = event.http.method;
+            method = event.http.method.toLowerCase();
             path = event.http.path;
           } else if (typeof event.http === 'string') {
             method = event.http.split(' ')[0];

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -32,7 +32,7 @@ module.exports = {
             method = event.http.method.toLowerCase();
             path = event.http.path;
           } else if (typeof event.http === 'string') {
-            method = event.http.split(' ')[0];
+            method = event.http.split(' ')[0].toLowerCase();
             path = event.http.split(' ')[1];
           }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
@@ -67,4 +67,27 @@ describe('#validate()', () => {
 
     expect(() => awsCompileApigEvents.validate()).to.throw(Error);
   });
+
+  it('should validate the http events "path" property', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'POST',
+              path: 'foo/bar',
+            },
+          },
+          {
+            http: {
+              method: 'post',
+              path: 'foo/bar',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.validate()).to.not.throw(Error);
+  });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
@@ -90,4 +90,20 @@ describe('#validate()', () => {
 
     expect(() => awsCompileApigEvents.validate()).to.not.throw(Error);
   });
+  it('should validate the http events "path" property', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: 'POST foo/bar',
+          },
+          {
+            http: 'post foo/bar',
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.validate()).to.not.throw(Error);
+  });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
@@ -68,7 +68,7 @@ describe('#validate()', () => {
     expect(() => awsCompileApigEvents.validate()).to.throw(Error);
   });
 
-  it('should validate the http events "path" property', () => {
+  it('should validate the http events object syntax method is case insensitive', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [
@@ -90,7 +90,8 @@ describe('#validate()', () => {
 
     expect(() => awsCompileApigEvents.validate()).to.not.throw(Error);
   });
-  it('should validate the http events "path" property', () => {
+
+  it('should validate the http events string syntax method is case insensitive', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [


### PR DESCRIPTION
##### Status:

Ready

##### Description:

HTTP Post functions shouldn't be limited to downcase. Tested with upper case and lower case, both work, but I'm still lower casing it just to make it simpler for us.

fixes #1548 
