### PR TITLE
Make sure permissions are saved in the zipfile

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -44,7 +44,8 @@ module.exports = {
         include.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
 
       if (!shouldBeExcluded || shouldBeIncluded) {
-        zip.file(relativeFilePath, fs.readFileSync(filePath));
+        let permissions = fs.statSync(filePath).mode;
+        zip.file(relativeFilePath, fs.readFileSync(filePath), {unixPermissions: permissions});
       }
     });
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -44,8 +44,8 @@ module.exports = {
         include.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
 
       if (!shouldBeExcluded || shouldBeIncluded) {
-        let permissions = fs.statSync(filePath).mode;
-        zip.file(relativeFilePath, fs.readFileSync(filePath), {unixPermissions: permissions});
+        const permissions = fs.statSync(filePath).mode;
+        zip.file(relativeFilePath, fs.readFileSync(filePath), { unixPermissions: permissions });
       }
     });
 

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -35,6 +35,14 @@ describe('#zipService()', () => {
     serverless.utils.writeFileSync(includeMeDirectoryPath, 'some-file content');
     const includeMeFilePath = path.join(tmpDirPath, 'include-me.js');
     serverless.utils.writeFileSync(includeMeFilePath, 'include-me.js file content');
+    // create a executable file
+    const executableFilePath = path.join(tmpDirPath, 'bin/some-binary');
+    serverless.utils.writeFileSync(executableFilePath, 'some-binary executable file content');
+    fs.chmodSync(executableFilePath, 777)
+    // create a readonly file
+    const readOnlyFilePath = path.join(tmpDirPath, 'bin/read-only');
+    serverless.utils.writeFileSync(readOnlyFilePath, 'read-only executable file content');
+    fs.chmodSync(readOnlyFilePath, 444)
     // a serverless plugin that should be included
     const includeMe2FilePath = path.join(tmpDirPath, 'a-serverless-plugin.js');
     serverless.utils.writeFileSync(includeMe2FilePath, 'a-serverless-plugin.js file content');
@@ -69,7 +77,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(7);
+      expect(Object.keys(unzippedFileData).length).to.equal(9);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
@@ -86,11 +94,36 @@ describe('#zipService()', () => {
       expect(unzippedFileData['include-me.js'].name)
         .to.equal('include-me.js');
 
+      expect(unzippedFileData['bin/some-binary'].name)
+        .to.equal('bin/some-binary');
+      expect(unzippedFileData['bin/read-only'].name)
+        .to.equal('bin/read-only');
+
       expect(unzippedFileData['include-me/some-file'].name)
         .to.equal('include-me/some-file');
 
       expect(unzippedFileData['a-serverless-plugin.js'].name)
         .to.equal('a-serverless-plugin.js');
+    })
+  );
+
+  it('should keep file permissions', () => packageService
+    .zipService().then(() => {
+      const artifact = packageService.serverless.service.package.artifact;
+      const data = fs.readFileSync(artifact);
+
+      const unzippedFileData = zip.load(data).files;
+
+      // binary file is set with chmod of 755
+      console.log(Object.keys(unzippedFileData['bin/some-binary']));
+      expect(unzippedFileData['bin/some-binary']['unixPermissions'])
+        .to.equal(Math.pow(2,15) + 777)
+
+      // read only file is set with chmod of 444
+      console.log(Object.keys(unzippedFileData['bin/read-only']));
+      expect(unzippedFileData['bin/read-only']['unixPermissions'])
+        .to.equal(Math.pow(2,15) + 444)
+
     })
   );
 
@@ -123,7 +156,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(5);
+      expect(Object.keys(unzippedFileData).length).to.equal(7);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
@@ -149,7 +182,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(7);
+      expect(Object.keys(unzippedFileData).length).to.equal(9);
 
       expect(unzippedFileData['.gitignore'])
         .to.be.equal(undefined);
@@ -178,7 +211,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      expect(Object.keys(unzippedFileData).length).to.equal(7);
+      expect(Object.keys(unzippedFileData).length).to.equal(9);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -114,7 +114,7 @@ describe('#zipService()', () => {
 
       const unzippedFileData = zip.load(data).files;
 
-      // binary file is set with chmod of 755
+      // binary file is set with chmod of 777
       expect(unzippedFileData['bin/some-binary'].unixPermissions)
         .to.equal(Math.pow(2, 15) + 777);
 

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -38,11 +38,11 @@ describe('#zipService()', () => {
     // create a executable file
     const executableFilePath = path.join(tmpDirPath, 'bin/some-binary');
     serverless.utils.writeFileSync(executableFilePath, 'some-binary executable file content');
-    fs.chmodSync(executableFilePath, 777)
+    fs.chmodSync(executableFilePath, 777);
     // create a readonly file
     const readOnlyFilePath = path.join(tmpDirPath, 'bin/read-only');
     serverless.utils.writeFileSync(readOnlyFilePath, 'read-only executable file content');
-    fs.chmodSync(readOnlyFilePath, 444)
+    fs.chmodSync(readOnlyFilePath, 444);
     // a serverless plugin that should be included
     const includeMe2FilePath = path.join(tmpDirPath, 'a-serverless-plugin.js');
     serverless.utils.writeFileSync(includeMe2FilePath, 'a-serverless-plugin.js file content');
@@ -115,15 +115,12 @@ describe('#zipService()', () => {
       const unzippedFileData = zip.load(data).files;
 
       // binary file is set with chmod of 755
-      console.log(Object.keys(unzippedFileData['bin/some-binary']));
-      expect(unzippedFileData['bin/some-binary']['unixPermissions'])
-        .to.equal(Math.pow(2,15) + 777)
+      expect(unzippedFileData['bin/some-binary'].unixPermissions)
+        .to.equal(Math.pow(2, 15) + 777);
 
       // read only file is set with chmod of 444
-      console.log(Object.keys(unzippedFileData['bin/read-only']));
-      expect(unzippedFileData['bin/read-only']['unixPermissions'])
-        .to.equal(Math.pow(2,15) + 444)
-
+      expect(unzippedFileData['bin/read-only'].unixPermissions)
+        .to.equal(Math.pow(2, 15) + 444);
     })
   );
 


### PR DESCRIPTION
When zipping binaries, the file permissions (eg: executable flags) are not stored, this PR makes sure that the flags do exists, so you can run your executables (within Lambda)

This is basically the same fix as in https://github.com/serverless/serverless/pull/960, the permissions need to be set correctly. This is a regression :)