### PR TITLE
Provider property can be an object

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -54,7 +54,7 @@ class Serverless {
       .then(() => {
         // set the provider of the service (so that the PluginManager takes care to
         // execute the correct provider specific plugins)
-        this.pluginManager.setProvider(this.service.provider);
+        this.pluginManager.setProvider(this.service.provider.name);
 
         // load all plugins
         this.pluginManager.loadAllPlugins(this.service.plugins);

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -44,7 +44,8 @@ class Service {
 
     return that.serverless.yamlParser
       .parse(path.join(servicePath, 'serverless.yaml'))
-      .then((serverlessYaml) => {
+      .then((serverlessYamlParam) => {
+        const serverlessYaml = serverlessYamlParam;
         // basic service level validation
         if (!serverlessYaml.service) {
           throw new SError('"service" property is missing in serverless.yaml');
@@ -59,9 +60,16 @@ class Service {
           throw new SError('"functions" property is missing in serverless.yaml');
         }
 
-        if (['aws', 'azure', 'google', 'ibm'].indexOf(serverlessYaml.provider)) {
+        if (typeof serverlessYaml.provider !== 'object') {
+          const providerName = serverlessYaml.provider;
+          serverlessYaml.provider = {
+            name: providerName,
+          };
+        }
+
+        if (['aws', 'azure', 'google', 'ibm'].indexOf(serverlessYaml.provider.name)) {
           const errorMessage = [
-            `Provider "${serverlessYaml.provider}" is not supported.`,
+            `Provider "${serverlessYaml.provider.name}" is not supported.`,
             ' Valid values for provider are: aws, azure, google, ibm.',
             ' Please provide one of those values to the "provider" property in serverless.yaml.',
           ].join('');

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -14,7 +14,7 @@ class Service {
 
     // Default properties
     this.service = null;
-    this.provider = null;
+    this.provider = {};
     this.runtime = null;
     this.defaults = {
       stage: 'dev',

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -21,7 +21,7 @@ describe('Service', () => {
       const serviceInstance = new Service(serverless);
 
       expect(serviceInstance.service).to.be.equal(null);
-      expect(serviceInstance.provider).to.be.equal(null);
+      expect(serviceInstance.provider).to.deep.equal({});
       expect(serviceInstance.runtime).to.be.equal(null);
       expect(serviceInstance.variableSyntax).to.be.equal(null);
       expect(serviceInstance.custom).to.deep.equal({});
@@ -151,7 +151,7 @@ describe('Service', () => {
       };
       return serviceInstance.load().then((loadedService) => {
         expect(loadedService.service).to.be.equal('commonVar');
-        expect(loadedService.provider).to.be.equal('aws');
+        expect(loadedService.provider).to.deep.equal({ name: 'aws' });
         expect(loadedService.runtime).to.be.equal('nodejs4.3');
         expect(loadedService.plugins).to.deep.equal(['testPlugin']);
         expect(loadedService.environment.vars).to.deep.equal(commonVars);


### PR DESCRIPTION
Allows for `provider` property to be an object to hold provider specific config as discussed in [Issue 1567](https://github.com/serverless/serverless/issues/1567)