### PR TITLE
Add support for setting API Keys for APIG

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -128,17 +128,17 @@ Here's an example configuration for setting API keys for your service Rest API:
 ```yaml
 service: my-service
 provider:
-    name: aws
-    apiKeys:
-            - myFirstKey
-            - ${mySecondSecretKey} # you can hide it in a serverless variable
+  name: aws
+  apiKeys:
+    - myFirstKey
+    - ${mySecondSecretKey} # you can hide it in a serverless variable
 functions:
-    hello:
-    events:
-        - http:
-            path: user/create
-            method: get
-            private: true
+  hello:
+  events:
+    - http:
+        path: user/create
+        method: get
+        private: true
 ```
 
 Clients connecting to this Rest API will then need to set any of these API keys in the `x-api-key` header of their request. That wouldn't be required if you hadn't set the `private` property to `true`.

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -120,5 +120,28 @@ functions:
                     identityValidationExpression: someRegex
 ```
 
+### Setting API keys for your Rest API
+You can specify a list of API keys to be used by your service Rest API by adding an `apiKeys` array property to the `provider` object in `serverless.yaml`. You'll also need to explicitly specify which endpoints are `private` and require one of the api keys to be included in the request by adding a `private` boolean property to the `http` event object you want to set as private.
+
+Here's an example configuration for setting API keys for your service Rest API:
+
+```yaml
+service: my-service
+provider:
+    name: aws
+    apiKeys:
+            - myFirstKey
+            - ${mySecondSecretKey} # you can hide it in a serverless variable
+functions:
+    hello:
+    events:
+        - http:
+            path: user/create
+            method: get
+            private: true
+```
+
+Clients connecting to this Rest API will then need to set any of these API keys in the `x-api-key` header of their request. That wouldn't be required if you hadn't set the `private` property to `true`.
+
 ### Setting an HTTP proxy on API Gateway
 Setting an API Gateway proxy can easily be done by adding two custom CloudFormation resource templates to your `serverless.yaml` file. [Check this guide for more info on how to set up a proxy using custom CloudFormation resources in `serverless.yaml`](https://github.com/serverless/serverless/blob/v1.0/docs/guide/custom-provider-resources.md).

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
@@ -5,6 +5,7 @@ const forEach = require('lodash').forEach;
 
 const validate = require('./lib/validate');
 const compileRestApi = require('./lib/restApi');
+const compileApiKeys = require('./lib/apiKeys');
 const compileResources = require('./lib/resources');
 const compileMethods = require('./lib/methods');
 const compileAuthorizers = require('./lib/authorizers');
@@ -21,6 +22,7 @@ class AwsCompileApigEvents {
       this,
       validate,
       compileRestApi,
+      compileApiKeys,
       compileResources,
       compileMethods,
       compileAuthorizers,
@@ -43,6 +45,7 @@ class AwsCompileApigEvents {
         return BbPromise.bind(this)
           .then(this.validate)
           .then(this.compileRestApi)
+          .then(this.compileApiKeys)
           .then(this.compileResources)
           .then(this.compileMethods)
           .then(this.compileAuthorizers)

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -5,10 +5,13 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileApiKeys() {
-    if (typeof this.serverless.service.provider === 'object' &&
-      this.serverless.service.provider.apiKeys) {
+    if (this.serverless.service.provider.apiKeys) {
+      if (this.serverless.service.provider.apiKeys.constructor !== Array) {
+        throw new this.serverless.classes.Error('apiKeys property must be an array');
+      }
+
       this.serverless.service.provider.apiKeys.forEach((apiKey, index) => {
-        if (typeof apikey !== 'string') {
+        if (typeof apiKey !== 'string') {
           throw new this.serverless.classes.Error('API Keys must be strings');
         }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  compileApiKeys() {
+    if (typeof this.serverless.service.provider === 'object' &&
+      this.serverless.service.provider.apiKeys) {
+      this.serverless.service.provider.apiKeys.forEach((apiKey, index) => {
+        if (typeof apikey !== 'string') {
+          throw new this.serverless.classes.Error('API Keys must be strings');
+        }
+
+        const apiKeysTemplate = `
+        {
+          "Type" : "AWS::ApiGateway::ApiKey",
+          "Properties" : {
+            "Enabled" : true,
+            "Name" : "${apiKey}",
+            "StageKeys" : [{
+              "RestApiId": { "Ref": "RestApiApigEvent" },
+              "StageName": "${this.options.stage}"
+            }]
+          }
+        }
+        `;
+
+        const newApiKeyObject = {
+          [`ApiKeyApigEvent${index}`]: JSON.parse(apiKeysTemplate),
+        };
+
+        _.merge(this.serverless.service.resources.Resources, newApiKeyObject);
+      });
+    }
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -150,6 +150,8 @@ module.exports = {
             methodTemplateJson.DependsOn = AuthorizerLogicalId;
           }
 
+          if (event.http.private) methodTemplateJson.Properties.ApiKeyRequired = true;
+
           const methodObject = {
             [`${normalizedMethod}MethodApigEvent${extractedResourceId}`]:
             methodTemplateJson,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/all.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/all.js
@@ -3,6 +3,7 @@
 require('./index');
 require('./validate');
 require('./restApi');
+require('./apiKeys');
 require('./resources');
 require('./methods');
 require('./authorizers');

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileApigEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+
+describe('#compileApiKeys()', () => {
+  let serverless;
+  let awsCompileApigEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.service.service = 'first-service';
+    serverless.service.provider = {
+      name: 'aws',
+      apiKeys: ['1234567890'],
+    };
+    serverless.service.resources = { Resources: {} };
+    serverless.service.environment = {
+      stages: {
+        dev: {
+          regions: {
+            'us-east-1': {
+              vars: {
+                iamRoleArnLambda:
+                  'arn:aws:iam::12345678:role/service-dev-IamRoleLambda-FOO12345678',
+              },
+            },
+          },
+        },
+      },
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              path: 'users/create',
+              method: 'POST',
+              private: true,
+            },
+          },
+        ],
+      },
+    };
+  });
+
+  it('should compile api key resource', () => awsCompileApigEvents
+    .compileApiKeys().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.ApiKeyApigEvent0.Type
+      ).to.equal('AWS::ApiGateway::ApiKey');
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.ApiKeyApigEvent0.Properties
+          .Enabled
+      ).to.equal(true);
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.ApiKeyApigEvent0.Properties
+          .Name
+      ).to.equal('1234567890');
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.ApiKeyApigEvent0.Properties
+          .StageKeys[0].RestApiId.Ref
+      ).to.equal('RestApiApigEvent');
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.ApiKeyApigEvent0.Properties
+          .StageKeys[0].StageName
+      ).to.equal('dev');
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.ApiKeyApigEvent0.Properties
+          .StageKeys[0].RestApiId.Ref
+      ).to.equal('RestApiApigEvent');
+    })
+  );
+
+  it('throw error if apiKey property is not an array', () => {
+    awsCompileApigEvents.serverless.service.provider.apiKeys = 2;
+    expect(() => awsCompileApigEvents.compileApiKeys()).to.throw(Error);
+  });
+
+  it('throw error if an apiKey is not a string', () => {
+    awsCompileApigEvents.serverless.service.provider.apiKeys = [2];
+    expect(() => awsCompileApigEvents.compileApiKeys()).to.throw(Error);
+  });
+});

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
@@ -9,6 +9,7 @@ const Serverless = require('../../../../../../../Serverless');
 describe('AwsCompileApigEvents', () => {
   const serverless = new Serverless();
   serverless.service.resources = { Resources: {} };
+  serverless.service.provider = { name: 'aws' };
   serverless.service.functions = {
     first: {
       events: [

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -149,6 +149,18 @@ describe('#compileMethods()', () => {
     });
   });
 
+  it('should set api key as required if private endpoint', () => {
+    awsCompileApigEvents.serverless.service.functions
+      .first.events[0].http.private = true;
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+          .PostMethodApigEvent0.Properties.ApiKeyRequired
+      ).to.equal(true);
+    });
+  });
+
   it('should set the correct lambdaUri', () => {
     const lambdaUri = `arn:aws:apigateway:${
       awsCompileApigEvents.options.region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${


### PR DESCRIPTION
Adds support for providing API Keys for APIG as described in [Issue 1595](https://github.com/serverless/serverless/issues/1595)

**Status:** G2M from my side