### PR TITLE
Remove hard service runtime dependency

### DIFF
--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -9,8 +9,8 @@ Here's an example `serverless.yaml` file that touches on all the config details.
 service: first_service
 
 provider:
-    name: aws
-    runtime: nodejs4.3
+  name: aws
+  runtime: nodejs4.3
 
 plugins:
   - additional_plugin

--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -8,9 +8,9 @@ Here's an example `serverless.yaml` file that touches on all the config details.
 ```yaml
 service: first_service
 
-provider: aws
-
-runtime: nodejs4.3
+provider:
+    name: aws
+    runtime: nodejs4.3
 
 plugins:
   - additional_plugin

--- a/docs/understanding-serverless/services-and-functions.md
+++ b/docs/understanding-serverless/services-and-functions.md
@@ -41,8 +41,8 @@ users
 ```yaml
 service: users
 provider:
-    name: aws
-    runtime: nodejs4.3
+  name: aws
+  runtime: nodejs4.3
 defaults: # overwrite defaults
   memory: ${memoryVar} # reference a Serverless variable
 functions:

--- a/docs/understanding-serverless/services-and-functions.md
+++ b/docs/understanding-serverless/services-and-functions.md
@@ -9,8 +9,7 @@ Each *Serverless service* contains two configuration files:
 ### [`serverless.yaml`](./serverless-yaml.md)
   - Declares a Serverless service
   - Defines one or multiple functions in the service
-  - Defines the provider the service will be deployed to
-  - Defines the runtime of the whole service
+  - Defines the provider the service will be deployed to (and the runtime if provided)
   - Defines custom plugins to be used
   - Defines events that trigger each function to execute (e.g. HTTP requests)
   - Defines one set of resources (e.g. 1 AWS CloudFormation stack) required by the functions in this service
@@ -41,8 +40,9 @@ users
 
 ```yaml
 service: users
-provider: aws
-runtime: nodejs4.3
+provider:
+    name: aws
+    runtime: nodejs4.3
 defaults: # overwrite defaults
   memory: ${memoryVar} # reference a Serverless variable
 functions:

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -54,7 +54,7 @@ class Serverless {
       .then(() => {
         // set the provider of the service (so that the PluginManager takes care to
         // execute the correct provider specific plugins)
-        this.pluginManager.setProvider(this.service.provider.name);
+        this.pluginManager.setProvider(this.service.provider.name || this.service.provider);
 
         // load all plugins
         this.pluginManager.loadAllPlugins(this.service.plugins);

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -15,7 +15,6 @@ class Service {
     // Default properties
     this.service = null;
     this.provider = {};
-    this.runtime = null;
     this.defaults = {
       stage: 'dev',
       region: 'us-east-1',
@@ -53,9 +52,6 @@ class Service {
         if (!serverlessYaml.provider) {
           throw new SError('"provider" property is missing in serverless.yaml');
         }
-        if (!serverlessYaml.runtime) {
-          throw new SError('"runtime" property is missing in serverless.yaml');
-        }
         if (!serverlessYaml.functions) {
           throw new SError('"functions" property is missing in serverless.yaml');
         }
@@ -78,7 +74,6 @@ class Service {
 
         that.service = serverlessYaml.service;
         that.provider = serverlessYaml.provider;
-        that.runtime = serverlessYaml.runtime;
         that.variableSyntax = serverlessYaml.variableSyntax;
         that.custom = serverlessYaml.custom;
         that.plugins = serverlessYaml.plugins;

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -60,12 +60,13 @@ class AwsCompileFunctions {
       const FunctionName = functionObject.name
         || `${this.serverless.service.service}-${this.options.stage}-${functionName}`;
       const MemorySize = Number(functionObject.memory)
-        || Number(this.serverless.service.defaults.memory)
+        || Number(this.serverless.service.provider.memory)
         || 1024;
       const Timeout = Number(functionObject.timeout)
-        || Number(this.serverless.service.defaults.timeout)
+        || Number(this.serverless.service.provider.timeout)
         || 6;
-      const Runtime = this.serverless.service.runtime;
+      const Runtime = this.serverless.service.provider.runtime
+        || 'nodejs4.3';
 
       newFunction.Properties.Handler = Handler;
       newFunction.Properties.FunctionName = FunctionName;

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -8,55 +8,6 @@ describe('AwsCompileFunctions', () => {
   let serverless;
   let awsCompileFunctions;
 
-  const functionsObjectMock = {
-    // function with overwritten config
-    first: {
-      name: 'customized-first-function',
-      handler: 'first.function.handler',
-      memory: 128,
-      timeout: 10,
-    },
-    // function without overwritten config
-    second: {
-      handler: 'second.function.handler',
-    },
-  };
-
-  const serviceResourcesAwsResourcesObjectMock = {
-    Resources: {
-      first: {
-        Type: 'AWS::Lambda::Function',
-        Properties: {
-          Code: {
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-            S3Key: 'artifact.zip',
-          },
-          FunctionName: 'customized-first-function',
-          Handler: 'first.function.handler',
-          MemorySize: 128,
-          Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 10,
-        },
-      },
-      second: {
-        Type: 'AWS::Lambda::Function',
-        Properties: {
-          Code: {
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-            S3Key: 'artifact.zip',
-          },
-          FunctionName: 'new-service-dev-second',
-          Handler: 'second.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 6,
-        },
-      },
-    },
-  };
-
   beforeEach(() => {
     serverless = new Serverless();
     const options = {
@@ -65,9 +16,7 @@ describe('AwsCompileFunctions', () => {
     };
     awsCompileFunctions = new AwsCompileFunctions(serverless, options);
     serverless.service.resources = { Resources: {} };
-    awsCompileFunctions.serverless.service.functions = functionsObjectMock;
     awsCompileFunctions.serverless.service.service = 'new-service';
-    awsCompileFunctions.serverless.service.runtime = 'nodejs4.3';
     awsCompileFunctions.serverless.service.package.artifact = 'artifact.zip';
   });
 
@@ -82,14 +31,125 @@ describe('AwsCompileFunctions', () => {
       expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
     });
 
-    it('should create corresponding function resources', () => {
+    it('should create a simple function resource', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+      };
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact.zip',
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+        },
+      };
+
       awsCompileFunctions.compileFunctions();
 
       expect(
-        awsCompileFunctions.serverless.service.resources.Resources
-      ).to.deep.equal(
-        serviceResourcesAwsResourcesObjectMock.Resources
-      );
+        awsCompileFunctions.serverless.service.resources.Resources.func
+      ).to.deep.equal(compliedFunction);
+    });
+
+    it('should consider function based config when creating a function resource', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          name: 'customized-func-function',
+          handler: 'func.function.handler',
+          memory: 128,
+          timeout: 10,
+        },
+      };
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact.zip',
+          },
+          FunctionName: 'customized-func-function',
+          Handler: 'func.function.handler',
+          MemorySize: 128,
+          Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 10,
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.resources.Resources.func
+      ).to.deep.equal(compliedFunction);
+    });
+
+    it('should default to the nodejs4.3 runtime when no provider runtime is given', () => {
+      awsCompileFunctions.serverless.service.provider.runtime = null;
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+      };
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact.zip',
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.resources.Resources.func
+      ).to.deep.equal(compliedFunction);
+    });
+
+    it('should consider the providers runtime when creating a function resource', () => {
+      awsCompileFunctions.serverless.service.provider.runtime = 'python2.7';
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+      };
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact.zip',
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambda', 'Arn'] },
+          Runtime: 'python2.7',
+          Timeout: 6,
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.resources.Resources.func
+      ).to.deep.equal(compliedFunction);
     });
   });
 });

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yaml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yaml
@@ -12,8 +12,9 @@
 # Happy Coding!
 
 service: aws-nodejs
-provider: aws
-runtime: nodejs4.3
+provider:
+    name: aws
+    runtime: nodejs4.3
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yaml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yaml
@@ -13,8 +13,8 @@
 
 service: aws-nodejs
 provider:
-    name: aws
-    runtime: nodejs4.3
+  name: aws
+  runtime: nodejs4.3
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-python/serverless.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.yaml
@@ -12,8 +12,9 @@
 # Happy Coding!
 
 service: aws-python
-provider: aws
-runtime: python2.7
+provider:
+    name: aws
+    runtime: python2.7
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-python/serverless.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.yaml
@@ -13,8 +13,8 @@
 
 service: aws-python
 provider:
-    name: aws
-    runtime: python2.7
+  name: aws
+  runtime: python2.7
 
 # you can overwrite defaults here
 #defaults:


### PR DESCRIPTION
A service now has no hard runtime dependency. The runtime could now be stored in the provider object of the corresponding service.

Issue: https://github.com/serverless/serverless/issues/1565