### PR TITLE
Bring back 2 level YAML indentation

### DIFF
--- a/docs/developing-plugins/building-plugins.md
+++ b/docs/developing-plugins/building-plugins.md
@@ -371,8 +371,8 @@ A user has to define the plugins they want to use in the root level of the
 
 ```yaml
 plugins:
-    - custom-plugin-1
-    - custom-plugin-2
+  - custom-plugin-1
+  - custom-plugin-2
 ```
 
 We do not auto-detect plugins from installed dependencies so users do not run into any surprises and we cut down on the
@@ -389,10 +389,10 @@ file provides the `custom` section where you can add options your plugin can use
 
 ```yaml
 plugins:
-    - my-greet-plugin
+  - my-greet-plugin
 
 custom:
-    greeting: hello
+  greeting: hello
 ```
 
 ## Plugin Order

--- a/docs/guide/custom-provider-resources.md
+++ b/docs/guide/custom-provider-resources.md
@@ -20,11 +20,11 @@ You can use this place to add custom provider resources by writing the resource 
 ```yaml
 # serverless.yaml
 resources:
-    Resources:
-        CustomProviderResource:
-            Type: ResourceType
-            Properties:
-                Key: Value
+  Resources:
+    CustomProviderResource:
+      Type: ResourceType
+      Properties:
+        Key: Value
 ```
 
 ## Referencing an external `.json` file
@@ -38,8 +38,8 @@ like this:
 
 ```yaml
 resources:
-    Resources:
-        $ref: ./cloudformation-resources.json
+  Resources:
+    $ref: ./cloudformation-resources.json
 ```
 
 The corresponding resources which are defined inside the `cloudformation-resources.json` file will be resolved and loaded

--- a/docs/guide/event-sources.md
+++ b/docs/guide/event-sources.md
@@ -14,9 +14,9 @@ function will have events attached:
 
 ```yaml
 functions:
-    hello:
-        handler: handler.hello
-        events:
+  hello:
+    handler: handler.hello
+    events:
 ```
 
 This `events` property is used to store all the event definitions for the function.
@@ -26,12 +26,12 @@ Let's add a `http` event with a path of `greet` and a method of `get`:
 
 ```yaml
 functions:
-    hello:
-        handler: handler.hello
-        events:
-            - http:
-                path: greet
-                method: get
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+        path: greet
+        method: get
 ```
 
 That's it. There's nothing more to do to setup a `http` event. Let's (re)deploy our service so that Serverless will

--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -17,10 +17,10 @@ This will create a `photos` bucket which fires the `resize` function when an obj
 
 ```yaml
 functions:
-    resize:
-        handler: resize
-        events:
-            - s3: photos
+  resize:
+    handler: resize
+    events:
+      - s3: photos
 ```
 
 #### Extended event definition
@@ -29,12 +29,12 @@ This will create a bucket `photos`. The `users` function is called whenever an o
 
 ```yaml
 functions:
-    users:
-        handler: users.handler
-        events:
-            - s3:
-                bucket: photos
-                event: s3:ObjectRemoved:*
+  users:
+    handler: users.handler
+    events:
+      - s3:
+        bucket: photos
+        event: s3:ObjectRemoved:*
 ```
 
 ### Schedule
@@ -45,10 +45,10 @@ This will attach a schedule event and causes the function `crawl` to be called e
 
 ```yaml
 functions:
-    crawl:
-        handler: crawl
-        events:
-            - schedule: rate(2 hours)
+  crawl:
+    handler: crawl
+    events:
+      - schedule: rate(2 hours)
 ```
 
 #### Extended event definition
@@ -58,12 +58,12 @@ the `aggregate` function every 10 minutes.
 
 ```yaml
 functions:
-    aggregate:
-        handler: statistics.handler
-        events:
-            - schedule:
-                rate: rate(10 minutes)
-                enabled: false
+  aggregate:
+    handler: statistics.handler
+    events:
+      - schedule:
+        rate: rate(10 minutes)
+        enabled: false
 ```
 
 ### HTTP endpoint
@@ -75,10 +75,10 @@ whenever the endpoint is accessed.
 
 ```yaml
 functions:
-    show:
-        handler: users.show
-        events:
-            - http: GET users/show
+  show:
+    handler: users.show
+    events:
+      - http: GET users/show
 ```
 
 #### Extended event definition
@@ -88,12 +88,12 @@ The function `create` is called every time someone visits this endpoint.
 
 ```yaml
 functions:
-    create:
-        handler: posts.create
-        events:
-            - http:
-                path: posts/create
-                method: POST
+  create:
+    handler: posts.create
+    events:
+      - http:
+        path: posts/create
+        method: POST
 ```
 
 ### SNS
@@ -105,10 +105,10 @@ called every time a message is sent to the `dispatch` topic.
 
 ```yaml
 functions:
-    dispatcher:
-        handler: dispatcher.dispatch
-        events:
-            - sns: dispatch
+  dispatcher:
+    handler: dispatcher.dispatch
+    events:
+      - sns: dispatch
 ```
 
 #### Extended event definition
@@ -119,10 +119,10 @@ SNS topic is used for.
 
 ```yaml
 functions:
-    aggregator:
-        handler: aggregator.handler
-        events:
-            - sns:
-                topic_name: aggregate
-                display_name: Data aggregation pipeline
+  aggregator:
+    handler: aggregator.handler
+    events:
+      - sns:
+        topic_name: aggregate
+        display_name: Data aggregation pipeline
 ```

--- a/docs/understanding-serverless/serverless-env-yaml.md
+++ b/docs/understanding-serverless/serverless-env-yaml.md
@@ -10,15 +10,15 @@ regions. It also manages variables at 3 levels ordered by priority:
 
 ```yaml
 vars:
-    someVar: 1
+  someVar: 1
 stages:
-    dev:
+  dev:
+    vars:
+      someVar: 2
+    regions:
+      us-east-1:
         vars:
-            someVar: 2
-        regions:
-            us-east-1:
-                vars:
-                  someVar: 3
+          someVar: 3
 ```
 
 Notice that you have the same variable defined in as common, stage and region variable. In that case the region variable

--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -13,40 +13,40 @@ provider: aws
 runtime: nodejs4.3
 
 plugins:
-    - additional_plugin
-    - another_plugin
+  - additional_plugin
+  - another_plugin
 
 defaults: # overwrite defaults
-    stage: dev
-    region: us-east-1
-    memory: 512
-    timeout: 3
+  stage: dev
+  region: us-east-1
+  memory: 512
+  timeout: 3
 
 package:
-    # only the following paths will be included in the resulting artifact which will be uploaded. Without specific include everything in the current folder will be included
-    include:
-        - lib
-        - functions
-    # The following paths will be excluded from the resulting artifact. If both include and exclude are defined we first apply the include, then the exclude so files are guaranteed to be excluded
-    exclude:
-        - tmp
-        - .git
-    artifact: path/to/my-artifact.zip # You can specify your own zip file for your service. Serverless won't zip your service if this is set
+  # only the following paths will be included in the resulting artifact which will be uploaded. Without specific include everything in the current folder will be included
+  include:
+    - lib
+    - functions
+  # The following paths will be excluded from the resulting artifact. If both include and exclude are defined we first apply the include, then the exclude so files are guaranteed to be excluded
+  exclude:
+    - tmp
+    - .git
+  artifact: path/to/my-artifact.zip # You can specify your own zip file for your service. Serverless won't zip your service if this is set
 
 functions:
-    hello:
-        # Deployed Lambda name with a prefix
-        name: ${prefix}-lambdaName # You have to provide that variable in serverless.env.yaml
-        handler: handler.hello
-        events:
-            - s3: bucketName
-            - schedule: rate(10 minutes)
-            - http:
-                path: users/create
-                method: get
-            - sns: topic-name
+  hello:
+    # Deployed Lambda name with a prefix
+    name: ${prefix}-lambdaName # You have to provide that variable in serverless.env.yaml
+    handler: handler.hello
+    events:
+      - s3: bucketName
+      - schedule: rate(10 minutes)
+      - http:
+        path: users/create
+        method: get
+      - sns: topic-name
 
 resources:
-    Resources:
-        $ref: ../custom_resources.json # you can use JSON-REF to ref other JSON files
+  Resources:
+    $ref: ../custom_resources.json # you can use JSON-REF to ref other JSON files
 ```

--- a/docs/understanding-serverless/services-and-functions.md
+++ b/docs/understanding-serverless/services-and-functions.md
@@ -44,21 +44,21 @@ service: users
 provider: aws
 runtime: nodejs4.3
 defaults: # overwrite defaults
-    memory: ${memoryVar} # reference a Serverless variable
+  memory: ${memoryVar} # reference a Serverless variable
 functions:
-    create:
-        handler: users.create
+  create:
+    handler: users.create
 ```
 
 ### [`serverless.env.yaml`](./serverless-env-yaml.md)
 
 ```yaml
 vars:
-    memoryVar: 512
+  memoryVar: 512
 stages:
-    dev:
+  dev:
+    vars:
+    regions:
+      us-east-1:
         vars:
-        regions:
-            us-east-1:
-                vars:
 ```

--- a/docs/using-plugins/adding-custom-plugins.md
+++ b/docs/using-plugins/adding-custom-plugins.md
@@ -22,7 +22,7 @@ of the plugin to the `plugins` section in the [`serverless.yaml`](../understandi
 
 ```yaml
 plugins:
-    - custom-serverless-plugin
+  - custom-serverless-plugin
 ```
 
 Plugins might want to add extra information which should be accessible to Serverless. The `custom` section in the
@@ -31,10 +31,10 @@ configurations for your plugins (the plugins author / documentation will tell yo
 
 ```yaml
 plugins:
-    - custom-serverless-plugin
+  - custom-serverless-plugin
 
 custom:
-    customkey: customvalue
+  customkey: customvalue
 ```
 
 ## Load order
@@ -44,8 +44,8 @@ plugins](core-plugins.md) and then the custom plugins in the order you've define
 
 ```yaml
 plugins:
-    - plugin1
-    - plugin2
+  - plugin1
+  - plugin2
 ```
 
 In this case `plugin1` is loaded before `plugin2`.

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -41,7 +41,7 @@ class Utils {
     }
 
     if (filePath.indexOf('.yaml') !== -1 && typeof contents !== 'string') {
-      contents = YAML.dump(contents, { indent: 4 });
+      contents = YAML.dump(contents);
     }
 
     return fse.writeFileSync(filePath, contents);

--- a/lib/plugins/create/templates/aws-nodejs/serverless.env.yaml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.env.yaml
@@ -8,8 +8,8 @@
 
 vars:
 stages:
-    dev:
+  dev:
+    vars:
+    regions:
+      us-east-1:
         vars:
-        regions:
-            us-east-1:
-                vars:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yaml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yaml
@@ -17,37 +17,34 @@ runtime: nodejs4.3
 
 # you can overwrite defaults here
 #defaults:
-#    stage: dev
-#    region: us-east-1
+#  stage: dev
+#  region: us-east-1
 
 # you can add packaging information here
 #package:
-#    include:
-#        - include-me.js
-#    exclude:
-#        - exclude-me.js
-#    artifact: my-service-code.zip
+#  include:
+#    - include-me.js
+#  exclude:
+#    - exclude-me.js
+#  artifact: my-service-code.zip
 
 functions:
-    hello:
-        handler: handler.hello
+  hello:
+    handler: handler.hello
 
-#       you can add any of the following events
-#       events:
-#           - http:
-#               path: users/create
-#               method: get
-#           - s3: ${bucket}
-#           - schedule: rate(10 minutes)
-#           - sns: greeter-topic
+#   you can add any of the following events
+#   events:
+#     - http:
+#       path: users/create
+#       method: get
+#     - s3: ${bucket}
+#     - schedule: rate(10 minutes)
+#     - sns: greeter-topic
 
 # you can add CloudFormation resource templates here
 #resources:
-#    Resources:
-#      newResource:
-#        Type: AWS::S3::Bucket
-#        Properties:
-#          BucketName: newBucket
-
-
-
+#  Resources:
+#    newResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: newBucket

--- a/lib/plugins/create/templates/aws-python/serverless.env.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.env.yaml
@@ -8,8 +8,8 @@
 
 vars:
 stages:
-    dev:
+  dev:
+    vars:
+    regions:
+      us-east-1:
         vars:
-        regions:
-            us-east-1:
-                vars:

--- a/lib/plugins/create/templates/aws-python/serverless.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.yaml
@@ -17,36 +17,34 @@ runtime: python2.7
 
 # you can overwrite defaults here
 #defaults:
-#    stage: dev
-#    region: us-east-1
+#  stage: dev
+#  region: us-east-1
 
 # you can add packaging information here
 #package:
-#    include:
-#        - include-me.js
-#    exclude:
-#        - exclude-me.js
-#    artifact: my-service-code.zip
+#  include:
+#    - include-me.js
+#  exclude:
+#    - exclude-me.js
+#  artifact: my-service-code.zip
 
 functions:
-    hello:
-        handler: handler.hello
+  hello:
+    handler: handler.hello
 
-#       you can add any of the following events
-#       events:
-#           - http:
-#               path: users/create
-#               method: get
-#           - s3: ${bucket}
-#           - schedule: rate(10 minutes)
-#           - sns: greeter-topic
+#   you can add any of the following events
+#   events:
+#     - http:
+#       path: users/create
+#       method: get
+#     - s3: ${bucket}
+#     - schedule: rate(10 minutes)
+#     - sns: greeter-topic
 
 # you can add CloudFormation resource templates here
 #resources:
-#    Resources:
-#      newResource:
-#        Type: AWS::S3::Bucket
-#        Properties:
-#          BucketName: newBucket
-
-
+#  Resources:
+#    newResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: newBucket


### PR DESCRIPTION
4 level indentation is really uncommon for YAML and may also cause some problems with the screen real estate. This PR brings back 2 level indentation.

Issue: https://github.com/serverless/serverless/issues/1514