### PR TITLE
Overwrite service name with random number

### DIFF
--- a/tests/integration_test.js
+++ b/tests/integration_test.js
@@ -17,14 +17,17 @@ const tmpDir = path.join(os.tmpdir(), (new Date).getTime().toString());
 fse.mkdirSync(tmpDir);
 process.chdir(tmpDir);
 
-const CF = new AWS.CloudFormation({ region: 'us-east-1' });
 const templateName = 'aws-nodejs';
+const newServiceName = `service-${(new Date).getTime().toString()}`;
+const stackName = `${newServiceName}-dev`;
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
 BbPromise.promisifyAll(CF, { suffix: 'Promised' });
 
 describe('Service Lifecyle Integration Test', () => {
   it('should create service in tmp directory', () => {
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
-    execSync(`sed -i "s/${templateName}/$RANDOM/g" serverless.yaml`);
+    execSync(`sed -i '' "s/${templateName}/${newServiceName}/g" serverless.yaml`);
     expect(serverless.utils
       .fileExistsSync(path.join(tmpDir, 'serverless.yaml'))).to.be.equal(true);
     expect(serverless.utils
@@ -37,7 +40,7 @@ describe('Service Lifecyle Integration Test', () => {
     this.timeout(0);
     execSync(`${serverlessExec} deploy`, { stdio: 'inherit' });
 
-    return CF.describeStacksPromised({ StackName: 'aws-nodejs-dev' })
+    return CF.describeStacksPromised({ StackName: stackName })
       .then(d => expect(d.Stacks[0].StackStatus).to.be.equal('UPDATE_COMPLETE'));
   });
 
@@ -74,7 +77,7 @@ describe('Service Lifecyle Integration Test', () => {
     this.timeout(0);
     execSync(`${serverlessExec} remove`, { stdio: 'inherit' });
 
-    return CF.describeStacksPromised({ StackName: 'aws-nodejs-dev' })
+    return CF.describeStacksPromised({ StackName: stackName })
       .then(d => expect(d.Stacks[0].StackStatus).to.be.equal('DELETE_COMPLETE'))
       .catch(e => {
         if (e.message.indexOf('does not exist') > -1) return BbPromise.resolve();

--- a/tests/integration_test.js
+++ b/tests/integration_test.js
@@ -24,7 +24,7 @@ BbPromise.promisifyAll(CF, { suffix: 'Promised' });
 describe('Service Lifecyle Integration Test', () => {
   it('should create service in tmp directory', () => {
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
-    execSync(`sed -i s/${templateName}/$RANDOM/g serverless.yaml`);
+    execSync(`sed -i "s/${templateName}/$RANDOM/g" serverless.yaml`);
     expect(serverless.utils
       .fileExistsSync(path.join(tmpDir, 'serverless.yaml'))).to.be.equal(true);
     expect(serverless.utils

--- a/tests/integration_test.js
+++ b/tests/integration_test.js
@@ -18,11 +18,13 @@ fse.mkdirSync(tmpDir);
 process.chdir(tmpDir);
 
 const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+const templateName = 'aws-nodejs';
 BbPromise.promisifyAll(CF, { suffix: 'Promised' });
 
 describe('Service Lifecyle Integration Test', () => {
   it('should create service in tmp directory', () => {
-    execSync(`${serverlessExec} create --template aws-nodejs`, { stdio: 'inherit' });
+    execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
+    execSync(`sed -i s/${templateName}/$RANDOM/g serverless.yaml`);
     expect(serverless.utils
       .fileExistsSync(path.join(tmpDir, 'serverless.yaml'))).to.be.equal(true);
     expect(serverless.utils
@@ -50,7 +52,7 @@ describe('Service Lifecyle Integration Test', () => {
     const newHandler =
       `
         'use strict';
-        
+
         module.exports.hello = (event, context, cb) => cb(null,
           { message: 'Service Update Succeeded' }
         );

--- a/tests/integration_test.js
+++ b/tests/integration_test.js
@@ -25,9 +25,10 @@ const CF = new AWS.CloudFormation({ region: 'us-east-1' });
 BbPromise.promisifyAll(CF, { suffix: 'Promised' });
 
 describe('Service Lifecyle Integration Test', () => {
-  it('should create service in tmp directory', () => {
+  it('should create service in tmp directory', function () {
+    this.timeout(10000);
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
-    execSync(`sed -i '' "s/${templateName}/${newServiceName}/g" serverless.yaml`);
+    execSync(`sed -i.bak s/${templateName}/${newServiceName}/g serverless.yaml`);
     expect(serverless.utils
       .fileExistsSync(path.join(tmpDir, 'serverless.yaml'))).to.be.equal(true);
     expect(serverless.utils


### PR DESCRIPTION
##### Status:

Ready

##### Description:

Make sure we set a random name when running the integration test for the service we create. Otherwise it will confuse the CF stacks