### PR TITLE
Change memory to memorySize so that the config naming is consistent

### DIFF
--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -19,8 +19,6 @@ plugins:
 defaults: # overwrite defaults
   stage: dev
   region: us-east-1
-  memory: 512
-  timeout: 3
 
 package:
   # only the following paths will be included in the resulting artifact which will be uploaded. Without specific include everything in the current folder will be included

--- a/docs/understanding-serverless/services-and-functions.md
+++ b/docs/understanding-serverless/services-and-functions.md
@@ -43,8 +43,7 @@ service: users
 provider:
   name: aws
   runtime: nodejs4.3
-defaults: # overwrite defaults
-  memory: ${memoryVar} # reference a Serverless variable
+  memorySize: ${memoryVar} # reference a Serverless variable
 functions:
   create:
     handler: users.create

--- a/lib/plugins/aws/deploy/compile/functions/README.md
+++ b/lib/plugins/aws/deploy/compile/functions/README.md
@@ -14,7 +14,7 @@ Inside the function loop it creates corresponding CloudFormation lambda function
 The function will be called `<serviceName>-<stage>-<functionName>` by default but you can specify an alternative name
 with the help of the functions `name` property.
 
-The functions `MemorySize` is set to `1024` and `Timeout to `6`. You can overwrite those defaults by setting
-corresponding entries in the services `defaults` property.
+The functions `MemorySize` is set to `1024` and `Timeout` to `6`. You can overwrite those defaults by setting
+corresponding entries in the services `provider` or function property.
 
 At the end all CloudFormation function resources are merged inside the `serverless.service.resources.Resources` section.

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -59,8 +59,8 @@ class AwsCompileFunctions {
       const Handler = functionObject.handler;
       const FunctionName = functionObject.name
         || `${this.serverless.service.service}-${this.options.stage}-${functionName}`;
-      const MemorySize = Number(functionObject.memory)
-        || Number(this.serverless.service.provider.memory)
+      const MemorySize = Number(functionObject.memorySize)
+        || Number(this.serverless.service.provider.memorySize)
         || 1024;
       const Timeout = Number(functionObject.timeout)
         || Number(this.serverless.service.provider.timeout)

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -65,7 +65,7 @@ describe('AwsCompileFunctions', () => {
         func: {
           name: 'customized-func-function',
           handler: 'func.function.handler',
-          memory: 128,
+          memorySize: 128,
           timeout: 10,
         },
       };


### PR DESCRIPTION
Change the name to `memorySize` so that it's the same name as AWS suggests.