### PR TITLE
Fix wrong event indentation

### DIFF
--- a/docs/guide/event-sources.md
+++ b/docs/guide/event-sources.md
@@ -30,8 +30,8 @@ functions:
     handler: handler.hello
     events:
       - http:
-        path: greet
-        method: get
+          path: greet
+          method: get
 ```
 
 That's it. There's nothing more to do to setup a `http` event. Let's (re)deploy our service so that Serverless will

--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -33,8 +33,8 @@ functions:
     handler: users.handler
     events:
       - s3:
-        bucket: photos
-        event: s3:ObjectRemoved:*
+          bucket: photos
+          event: s3:ObjectRemoved:*
 ```
 
 ### Schedule
@@ -62,8 +62,8 @@ functions:
     handler: statistics.handler
     events:
       - schedule:
-        rate: rate(10 minutes)
-        enabled: false
+          rate: rate(10 minutes)
+          enabled: false
 ```
 
 ### HTTP endpoint
@@ -92,8 +92,8 @@ functions:
     handler: posts.create
     events:
       - http:
-        path: posts/create
-        method: POST
+          path: posts/create
+          method: POST
 ```
 
 **Note:** Serverless supports a built in, universal velocity request template which makes the following parameters available
@@ -136,6 +136,6 @@ functions:
     handler: aggregator.handler
     events:
       - sns:
-        topic_name: aggregate
-        display_name: Data aggregation pipeline
+          topic_name: aggregate
+          display_name: Data aggregation pipeline
 ```

--- a/docs/understanding-serverless/serverless-yaml.md
+++ b/docs/understanding-serverless/serverless-yaml.md
@@ -40,8 +40,8 @@ functions:
       - s3: bucketName
       - schedule: rate(10 minutes)
       - http:
-        path: users/create
-        method: get
+          path: users/create
+          method: get
       - sns: topic-name
 
 resources:

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -32,10 +32,10 @@ a `GET` request.
 ```yaml
 # serverless.yaml
 functions:
-    index:
-        handler: users.index
-        events:
-            - http: GET users/index
+  index:
+    handler: users.index
+    events:
+      - http: GET users/index
 ```
 
 ### Http setup with extended event options
@@ -45,83 +45,92 @@ Here we've defined an POST endpoint for the path `posts/create`.
 ```yaml
 # serverless.yaml
 functions:
-    create:
-        handler: posts.create
-        events:
-            - http:
-                path: posts/create
-                method: post
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
 ```
 
 ### Http setup with custom authorizer
-You can enable custom authorizers for your HTTP endpoint by setting the authorizer in your http event to another function in the same service, as shown in the following example
+You can enable custom authorizers for your HTTP endpoint by setting the authorizer in your http event to another function
+in the same service, as shown in the following example
 
-```yml
+```yaml
 # serverless.yaml
 functions:
-    create:
-        handler: posts.create
-        events:
-            - http:
-                path: posts/create
-                method: post
-                authorizer: authorizerFunc
-    authorizerFunc:
-        handler: handlers.authorizerFunc
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          authorizer: authorizerFunc
+  authorizerFunc:
+    handler: handlers.authorizerFunc
 ```
-Or, if you want to configure the authorizer with more options, you can turn the `authorizer` property into an object as shown in the following example:
+Or, if you want to configure the authorizer with more options, you can turn the `authorizer` property into an object as
+shown in the following example:
 
-```yml
+```yaml
 # serverless.yaml
 functions:
-    create:
-        handler: posts.create
-        events:
-            - http:
-                path: posts/create
-                method: post
-                authorizer:
-                    name: authorizerFunc
-                    resultTtlInSeconds: 0
-                    identitySource: method.request.header.Auth
-                    identityValidationExpression: someRegex
-    authorizerFunc:
-        handler: handlers.authorizerFunc
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          authorizer:
+            name: authorizerFunc
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Auth
+            identityValidationExpression: someRegex
+  authorizerFunc:
+    handler: handlers.authorizerFunc
 ```
 
 ### Http setup with custom authorizer (via ARN)
-If the authorizer function does not exist in your service but exists in AWS, you can provide the ARN of the Lambda function instead of the function name, as shown in the following example:
+If the authorizer function does not exist in your service but exists in AWS, you can provide the ARN of the Lambda
+function instead of the function name, as shown in the following example:
 
-```yml
+```yaml
 # serverless.yaml
 functions:
-    create:
-        handler: posts.create
-        events:
-            - http:
-                path: posts/create
-                method: post
-                authorizer: xxx:xxx:Lambda-Name
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          authorizer: xxx:xxx:Lambda-Name
 ```
-Or, if you want to configure the authorizer with more options, you can turn the `authorizer` property into an object as shown in the following example:
-```yml
+
+Or, if you want to configure the authorizer with more options, you can turn the `authorizer` property into an object as
+shown in the following example:
+
+```yaml
 # serverless.yaml
 functions:
-    create:
-        handler: posts.create
-        events:
-            - http:
-                path: posts/create
-                method: post
-                authorizer:
-                    arn: xxx:xxx:Lambda-Name
-                    resultTtlInSeconds: 0
-                    identitySource: method.request.header.Auth
-                    identityValidationExpression: someRegex
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          authorizer:
+            arn: xxx:xxx:Lambda-Name
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Auth
+            identityValidationExpression: someRegex
 ```
 
 ### Setting API keys for your Rest API
-You can specify a list of API keys to be used by your service Rest API by adding an `apiKeys` array property to the `provider` object in `serverless.yaml`. You'll also need to explicitly specify which endpoints are `private` and require one of the api keys to be included in the request by adding a `private` boolean property to the `http` event object you want to set as private.
+You can specify a list of API keys to be used by your service Rest API by adding an `apiKeys` array property to the
+`provider` object in `serverless.yaml`. You'll also need to explicitly specify which endpoints are `private` and require
+one of the api keys to be included in the request by adding a `private` boolean property to the `http` event object you
+want to set as private.
 
 Here's an example configuration for setting API keys for your service Rest API:
 
@@ -141,7 +150,10 @@ functions:
         private: true
 ```
 
-Clients connecting to this Rest API will then need to set any of these API keys in the `x-api-key` header of their request. That wouldn't be required if you hadn't set the `private` property to `true`.
+Clients connecting to this Rest API will then need to set any of these API keys in the `x-api-key` header of their request.
+That wouldn't be required if you hadn't set the `private` property to `true`.
 
 ### Setting an HTTP proxy on API Gateway
-Setting an API Gateway proxy can easily be done by adding two custom CloudFormation resource templates to your `serverless.yaml` file. [Check this guide for more info on how to set up a proxy using custom CloudFormation resources in `serverless.yaml`](https://github.com/serverless/serverless/blob/v1.0/docs/guide/custom-provider-resources.md).
+Setting an API Gateway proxy can easily be done by adding two custom CloudFormation resource templates to your
+`serverless.yaml` file. Check [this guide](https://github.com/serverless/serverless/blob/v1.0/docs/guide/custom-provider-resources.md)
+for more info on how to set up a proxy using custom CloudFormation resources in `serverless.yaml`.

--- a/lib/plugins/aws/deploy/compile/events/s3/README.md
+++ b/lib/plugins/aws/deploy/compile/events/s3/README.md
@@ -36,10 +36,10 @@ whenever something is uploaded or updated in the bucket.
 ```yaml
 # serverless.yaml
 functions:
-    user:
-        handler: user.update
-        events:
-            - s3: profile-pictures
+  user:
+    handler: user.update
+    events:
+      - s3: profile-pictures
 ```
 
 ### Bucket setup with extended event options
@@ -51,10 +51,10 @@ the bucket.
 ```yaml
 # serverless.yaml
 functions:
-    mail:
-        handler: mail.removal
-        events:
-            - s3:
-                bucket: confidential-information
-                event: s3:ObjectRemoved:*
+  mail:
+    handler: mail.removal
+    events:
+      - s3:
+          bucket: confidential-information
+          event: s3:ObjectRemoved:*
 ```

--- a/lib/plugins/aws/deploy/compile/events/schedule/README.md
+++ b/lib/plugins/aws/deploy/compile/events/schedule/README.md
@@ -31,10 +31,10 @@ This setup specifies that the `greet` function should be run every 10 minutes.
 ```yaml
 # serverless.yaml
 functions:
-    greet:
-        handler: handler.hello
-        events:
-            - schedule: rate(10 minutes)
+  greet:
+    handler: handler.hello
+    events:
+      - schedule: rate(10 minutes)
 ```
 
 ### Schedule setup with extended event options
@@ -45,10 +45,10 @@ enabled.
 ```yaml
 # serverless.yaml
 functions:
-    report:
-        handler: handler.error
-        events:
-            - schedule:
-                rate: rate(2 minutes)
-                enabled: false
+  report:
+    handler: handler.error
+    events:
+      - schedule:
+          rate: rate(2 minutes)
+          enabled: false
 ```

--- a/lib/plugins/aws/deploy/compile/events/sns/README.md
+++ b/lib/plugins/aws/deploy/compile/events/sns/README.md
@@ -32,10 +32,10 @@ This setup specifies that the `forward` function should be run every time a mess
 ```yaml
 # serverless.yaml
 functions:
-    forward:
-        handler: message.forward
-        events:
-            - sns: messages
+  forward:
+    handler: message.forward
+    events:
+      - sns: messages
 ```
 
 ### SNS setup with extended event options
@@ -46,10 +46,10 @@ lambda functions".  The `run` function is executed every time a message is sent 
 ```yaml
 # serverless.yaml
 functions:
-    run:
-        handler: event.run
-        events:
-            - sns:
-                topic_name: lambda-caller
-                display_name: Used to chain lambda functions
+  run:
+    handler: event.run
+    events:
+      - sns:
+          topic_name: lambda-caller
+          display_name: Used to chain lambda functions
 ```

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yaml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yaml
@@ -37,8 +37,8 @@ functions:
 #   you can add any of the following events
 #   events:
 #     - http:
-#       path: users/create
-#       method: get
+#         path: users/create
+#         method: get
 #     - s3: ${bucket}
 #     - schedule: rate(10 minutes)
 #     - sns: greeter-topic

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yaml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yaml
@@ -37,8 +37,8 @@ functions:
 #   you can add any of the following events
 #   events:
 #     - http:
-#       path: users/create
-#       method: get
+#         path: users/create
+#         method: get
 #     - s3: ${bucket}
 #     - schedule: rate(10 minutes)
 #     - sns: greeter-topic

--- a/lib/plugins/create/templates/aws-python/serverless.yaml
+++ b/lib/plugins/create/templates/aws-python/serverless.yaml
@@ -37,8 +37,8 @@ functions:
 #   you can add any of the following events
 #   events:
 #     - http:
-#       path: users/create
-#       method: get
+#         path: users/create
+#         method: get
 #     - s3: ${bucket}
 #     - schedule: rate(10 minutes)
 #     - sns: greeter-topic


### PR DESCRIPTION
Event indentations are now fixed so that users won't have trouble when they refer the docs or uncomment existing, nested event definitions in the `serverless.yaml` file.