### PR TITLE
adding principalId to request template

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -101,6 +101,7 @@ in the `event` object:
 
 - body
 - method
+- principalId
 - headers
 - query
 - path

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -18,7 +18,7 @@ Those resources are then merged into the `serverless.service.resources.Resources
 
 ## Universal JSON request template
 
-The API Gateway plugin implements a request template which provides `{body, method, headers, query, path, identity,
+The API Gateway plugin implements a request template which provides `{body, method, principalId, headers, query, path, identity,
 stageVariables} = event` as JavaScript objects. This way you don't have to define the template on your own but can use
 this default template to access the necessary variables in your code.
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -35,7 +35,8 @@ module.exports = {
           const extractedResourceId = resourceLogicalId.match(/\d+$/)[0];
 
           // universal velocity template
-          // provides `{body, method, headers, query, path, identity, stageVariables} = event`
+          // provides
+          // `{body, method, principalId, headers, query, path, identity, stageVariables} = event`
           // as js objects
           const DEFAULT_JSON_REQUEST_TEMPLATE = `
             #define( $loop )
@@ -50,19 +51,20 @@ module.exports = {
             {
               "body": $input.json("$"),
               "method": "$context.httpMethod",
-              
+              "principalId": "$context.authorizer.principalId",
+
               #set( $map = $input.params().header )
               "headers": $loop,
-  
+
               #set( $map = $input.params().querystring )
               "query": $loop,
-  
+
               #set( $map = $input.params().path )
               "path": $loop,
-  
+
               #set( $map = $context.identity )
               "identity": $loop,
-  
+
               #set( $map = $stageVariables )
               "stageVariables": $loop
             }


### PR DESCRIPTION
##### Status:

Ready

##### Description:

Adds the principal identifier to the default request template. Custom authorizers are returning a response that includes the principal identifier, which is usually needed in the backend ([Output from an Amazon API Gateway Custom Authorizer](http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output)).