### PR TITLE
fix(deploy): Apply second deploy to guarantee the stage is in sync

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
@@ -26,8 +26,8 @@ class AwsCompileApigEvents {
       compileResources,
       compileMethods,
       compileAuthorizers,
-      compileDeployment,
-      compilePermissions
+      compilePermissions,
+      compileDeployment
     );
 
     this.hooks = {
@@ -49,8 +49,8 @@ class AwsCompileApigEvents {
           .then(this.compileResources)
           .then(this.compileMethods)
           .then(this.compileAuthorizers)
-          .then(this.compileDeployment)
-          .then(this.compilePermissions);
+          .then(this.compilePermissions)
+          .then(this.compileDeployment);
       },
     };
   }

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -8,17 +8,19 @@ module.exports = {
     const deploymentTemplate = `
       {
         "Type" : "AWS::ApiGateway::Deployment",
-        "DependsOn" : "${this.methodDep}",
+        "DeletionPolicy": "Retain",
         "Properties" : {
           "RestApiId" : { "Ref": "RestApiApigEvent" },
-          "StageName" : "${this.options.stage}"
+          "StageName" : "${this.options.stage}",
+          "Description" : "${this.options.stage} created at ${new Date()}"
         }
       }
     `;
 
-    const newDeploymentObject = {
-      DeploymentApigEvent: JSON.parse(deploymentTemplate),
-    };
+    const newDeploymentObject = {};
+
+    newDeploymentObject[`DeploymentApigEvent${new Date().getTime()}`]
+      = JSON.parse(deploymentTemplate);
 
     _.merge(this.serverless.service.resources.Resources, newDeploymentObject);
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -179,12 +179,6 @@ module.exports = {
           this.serverless.service.resources.Outputs =
             this.serverless.service.resources.Outputs || {};
           _.merge(this.serverless.service.resources.Outputs, newOutputEndpointObject);
-
-          // store a method logical id in memory to be used
-          // by Deployment resources "DependsOn" property
-          if (!this.methodDep) {
-            this.methodDep = `${normalizedMethod}MethodApigEvent${extractedResourceId}`;
-          }
         }
       });
     });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
@@ -1,27 +1,37 @@
 'use strict';
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
 describe('#compileDeployment()', () => {
   let serverless;
   let awsCompileApigEvents;
+  let clock;
 
   const serviceResourcesAwsResourcesObjectMock = {
-    Resources: {
-      DeploymentApigEvent: {
-        Type: 'AWS::ApiGateway::Deployment',
-        DependsOn: 'method-dependency',
-        Properties: {
-          RestApiId: { Ref: 'RestApiApigEvent' },
-          StageName: 'dev',
-        },
-      },
-    },
+    Resources: {},
   };
 
   beforeEach(() => {
+    // Setup a fake timer so timed elements will match
+    clock = sinon.useFakeTimers();
+
+    const Resources = {};
+    Resources[`DeploymentApigEvent${new Date().getTime()}`] = {
+      Type: 'AWS::ApiGateway::Deployment',
+      DeletionPolicy: 'Retain',
+      Properties: {
+        Description: `dev created at ${new Date()}`,
+        RestApiId: { Ref: 'RestApiApigEvent' },
+        StageName: 'dev',
+      },
+    };
+
+    // Add the new mocked resource back into the main list
+    Object.assign(serviceResourcesAwsResourcesObjectMock.Resources, Resources);
+
     serverless = new Serverless();
     serverless.service.resources = { Resources: {} };
     const options = {
@@ -30,6 +40,10 @@ describe('#compileDeployment()', () => {
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.methodDep = 'method-dependency';
+  });
+
+  afterEach(() => {
+    clock.restore();
   });
 
   it('should create a deployment resource', () => awsCompileApigEvents

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
@@ -59,25 +59,25 @@ describe('AwsCompileApigEvents', () => {
         .stub(awsCompileApigEvents, 'compileResources').returns(BbPromise.resolve());
       const compileMethodsStub = sinon
         .stub(awsCompileApigEvents, 'compileMethods').returns(BbPromise.resolve());
-      const compileDeploymentStub = sinon
-        .stub(awsCompileApigEvents, 'compileDeployment').returns(BbPromise.resolve());
       const compilePermissionsStub = sinon
         .stub(awsCompileApigEvents, 'compilePermissions').returns(BbPromise.resolve());
+      const compileDeploymentStub = sinon
+        .stub(awsCompileApigEvents, 'compileDeployment').returns(BbPromise.resolve());
 
       return awsCompileApigEvents.hooks['deploy:compileEvents']().then(() => {
         expect(validateStub.calledOnce).to.be.equal(true);
         expect(compileRestApiStub.calledAfter(validateStub)).to.be.equal(true);
         expect(compileResourcesStub.calledAfter(compileRestApiStub)).to.be.equal(true);
         expect(compileMethodsStub.calledAfter(compileResourcesStub)).to.be.equal(true);
-        expect(compileDeploymentStub.calledAfter(compileMethodsStub)).to.be.equal(true);
-        expect(compilePermissionsStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compilePermissionsStub.calledAfter(compileMethodsStub)).to.be.equal(true);
+        expect(compileDeploymentStub.calledAfter(compilePermissionsStub)).to.be.equal(true);
 
         awsCompileApigEvents.validate.restore();
         awsCompileApigEvents.compileRestApi.restore();
         awsCompileApigEvents.compileResources.restore();
         awsCompileApigEvents.compileMethods.restore();
-        awsCompileApigEvents.compileDeployment.restore();
         awsCompileApigEvents.compilePermissions.restore();
+        awsCompileApigEvents.compileDeployment.restore();
       });
     });
 

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -2,10 +2,48 @@
 
 const BbPromise = require('bluebird');
 const async = require('async');
+const _ = require('lodash');
+
+const deleteDeployKey = function (resources) {
+  const deployResources = _.cloneDeep(resources);
+  const filter = /DeploymentApigEvent/;
+
+  Object.keys(deployResources.Resources).forEach((key) => {
+    if (deployResources.Resources.hasOwnProperty(key) && filter.test(key)) {
+      delete deployResources.Resources[key];
+    }
+  });
+
+  return deployResources;
+};
 
 module.exports = {
   update() {
     this.serverless.cli.log('Updating Stack...');
+
+    // Remove the deploy resource for the initial update
+    const updateResources = deleteDeployKey(this.serverless.service.resources);
+
+    const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+    const params = {
+      StackName: stackName,
+      Capabilities: [
+        'CAPABILITY_IAM',
+      ],
+      Parameters: [],
+      TemplateBody: JSON.stringify(updateResources),
+    };
+
+    return this.sdk.request('CloudFormation',
+      'updateStack',
+      params,
+      this.options.stage,
+      this.options.region);
+  },
+
+  deploy() {
+    this.serverless.cli.log('Deploying Stack...');
+
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
     const params = {
       StackName: stackName,
@@ -51,7 +89,6 @@ module.exports = {
                 stackStatus = stackData.Stacks[0].StackStatus;
 
                 this.serverless.cli.log('Checking stack update progress...');
-
                 if (!stackStatus || validStatuses.indexOf(stackStatus) === -1) {
                   return reject(new this.serverless.classes
                     .Error(`An error occurred while provisioning your cloudformation: ${stackData
@@ -68,6 +105,7 @@ module.exports = {
   updateStack() {
     return BbPromise.bind(this)
       .then(this.update)
-      .then(this.monitorUpdate);
+      .then(this.monitorUpdate)
+      .then(this.deploy);
   },
 };

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -157,13 +157,17 @@ describe('updateStack', () => {
         .stub(awsDeploy, 'update').returns(BbPromise.resolve());
       const monitorStub = sinon
         .stub(awsDeploy, 'monitorUpdate').returns(BbPromise.resolve());
+      const deployStub = sinon
+        .stub(awsDeploy, 'deploy').returns(BbPromise.resolve());
 
       return awsDeploy.updateStack().then(() => {
         expect(updateStub.calledOnce).to.be.equal(true);
         expect(monitorStub.calledAfter(updateStub)).to.be.equal(true);
+        expect(deployStub.calledAfter(monitorStub)).to.be.equal(true);
 
         awsDeploy.update.restore();
         awsDeploy.monitorUpdate.restore();
+        awsDeploy.deploy.restore();
       });
     });
   });


### PR DESCRIPTION
##### Status:

In Development

##### Description:

Applys the first updateStack without the Deployment resource. Waits for that to complete successfully then applys a second updateStack the same as the first with the Deployment resource added.

Adds DeletePolicy as Retain on the Deployment so rollbacks can be made in the API gateway interface.
##### Todos:

- [x] Write tests

Closes #1684 