### PR TITLE
Add single function deployment plugin

### DIFF
--- a/docs/using-plugins/core-plugins.md
+++ b/docs/using-plugins/core-plugins.md
@@ -19,3 +19,4 @@ see the corresponding source code.
   - [Deploy](/lib/plugins/aws/deploy)
   - [Invoke](/lib/plugins/aws/invoke)
   - [Remove](/lib/plugins/aws/remove)
+  - [Deploy function](/lib/plugins/aws/deployFunction)

--- a/lib/plugins/Plugins.json
+++ b/lib/plugins/Plugins.json
@@ -17,6 +17,7 @@
     "./aws/deploy/compile/events/schedule/index.js",
     "./aws/deploy/compile/events/s3/index.js",
     "./aws/deploy/compile/events/apiGateway/index.js",
-    "./aws/deploy/compile/events/sns/index.js"
+    "./aws/deploy/compile/events/sns/index.js",
+    "./aws/deployFunction/index.js"
   ]
 }

--- a/lib/plugins/aws/deployFunction/README.md
+++ b/lib/plugins/aws/deployFunction/README.md
@@ -1,0 +1,13 @@
+# Deploy Function
+
+**Note:** This plugin should be used with caution. It will directly upload the lambda function code and bypasses
+the steps of updating the CloudFormation stack or the zip-File in S3. Never use this plugin if you're working on a
+production system. Use this plugin only for development to test how your code behaves on AWS.
+
+This plugin deploys a single function through the AWS SDK.
+
+## How it works
+
+`Deploy Function` hooks into the [`deploy:function:deploy`](/lib/plugins/deploy) lifecycle.
+It checks if the function exists in the service. After that it checks if the function was already deployed to AWS.
+Next up it zips the function and uploads the new function code directly to the corresponding lambda function.

--- a/lib/plugins/aws/deployFunction/README.md
+++ b/lib/plugins/aws/deployFunction/README.md
@@ -11,3 +11,6 @@ This plugin deploys a single function through the AWS SDK.
 `Deploy Function` hooks into the [`deploy:function:deploy`](/lib/plugins/deploy) lifecycle.
 It checks if the function exists in the service. After that it checks if the function was already deployed to AWS.
 Next up it zips the function and uploads the new function code directly to the corresponding lambda function.
+
+The `Deploy Function` plugin reuses the [Package plugin](/lib/plugins/package) under the hood to create the exact same
+deployment artifact which is also created when you run `serverless deploy`.

--- a/lib/plugins/aws/deployFunction/README.md
+++ b/lib/plugins/aws/deployFunction/README.md
@@ -1,6 +1,6 @@
 # Deploy Function
 
-**Note:** This plugin should be used with caution. It will directly upload the lambda function code and bypasses
+**Note:** This plugin should be used with caution. It will directly upload the lambda function code and bypass
 the steps of updating the CloudFormation stack or the zip-File in S3. Never use this plugin if you're working on a
 production system. Use this plugin only for development to test how your code behaves on AWS.
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -2,11 +2,11 @@
 
 const BbPromise = require('bluebird');
 const fs = require('fs');
-const path = require('path');
-const _ = require('lodash');
-const Zip = require('node-zip');
 const SDK = require('../');
 const validate = require('../lib/validate');
+
+// The Package plugin which is used to zip the service
+const Package = require('../../package');
 
 class AwsDeployFunction {
   constructor(serverless, options) {
@@ -18,6 +18,8 @@ class AwsDeployFunction {
     this.functionName =
       `${this.serverless.service.service}-${this.options.stage}-${this.options.function}`;
 
+    this.pkg = new Package(this.serverless, this.options);
+
     Object.assign(this, validate);
 
     this.hooks = {
@@ -25,7 +27,8 @@ class AwsDeployFunction {
         .then(this.validate)
         .then(this.checkIfFunctionExists)
         .then(this.zipFunction)
-        .then(this.deployFunction),
+        .then(this.deployFunction)
+        .then(this.cleanup),
     };
   }
 
@@ -58,42 +61,12 @@ class AwsDeployFunction {
   }
 
   zipFunction() {
-    this.serverless.cli.log('Zipping function...');
-    const zip = new Zip();
-
-    const servicePath = this.serverless.config.servicePath;
-    const func = this.serverless.service.functions[this.options.function];
-
-    const handler = (_.last(func.handler.split('/'))).replace(/\\g/, '/');
-    const handlerFullPath = path.join(servicePath, handler);
-
-    if (!handlerFullPath.endsWith(func.handler)) {
-      const errorMessage = [
-        `The handler ${func.handler} was not found.`,
-        ' Please make sure you have this handler in your service at the referenced location.',
-        ' Please check the docs for more info',
-      ].join('');
-      throw new this.serverless.classes.Error(errorMessage);
-    }
-
-    const packageRoot = handlerFullPath.replace(func.handler, '');
-
-    this.serverless.utils.walkDirSync(packageRoot).forEach((filePath) => {
-      const relativeFilePath = path.relative(packageRoot, filePath);
-      const permissions = fs.statSync(filePath).mode;
-      zip.file(relativeFilePath, fs.readFileSync(filePath), { unixPermissions: permissions });
-    });
-
-    const data = zip.generate({
-      type: 'nodebuffer',
-      compression: 'DEFLATE',
-      platform: process.platform,
-    });
-
-    return BbPromise.resolve(data);
+    return this.pkg.zipService();
   }
 
-  deployFunction(data) {
+  deployFunction() {
+    const data = fs.readFileSync(this.serverless.service.package.artifact);
+
     const params = {
       FunctionName: this.functionName,
       ZipFile: data,
@@ -109,6 +82,10 @@ class AwsDeployFunction {
     this.serverless.cli.log(`Successfully deployed function "${this.options.function}"`);
 
     return BbPromise.resolve();
+  }
+
+  cleanup() {
+    return this.pkg.cleanup();
   }
 }
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -107,14 +107,7 @@ class AwsDeployFunction {
       'updateFunctionCode',
       params,
       this.options.stage, this.options.region
-    ).catch(() => {
-      const errorMessage = [
-        `An error occurred whily deploying the function "${this.options.function}".`,
-        ' Please try again',
-      ].join('');
-      throw new this.serverless.classes
-        .Error(errorMessage);
-    });
+    );
 
     this.serverless.cli.log(`Successfully deployed function "${this.options.function}"`);
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+const Zip = require('node-zip');
+const SDK = require('../');
+const validate = require('../lib/validate');
+
+class AwsDeployFunction {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options || {};
+    this.provider = 'aws';
+    this.sdk = new SDK(serverless);
+
+    this.functionName =
+      `${this.serverless.service.service}-${this.options.stage}-${this.options.function}`;
+
+    Object.assign(this, validate);
+
+    this.hooks = {
+      'deploy:function:deploy': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.checkIfFunctionExistsInService)
+        .then(this.checkIfFunctionIsDeployed)
+        .then(this.zipFunction)
+        .then(this.deployFunction),
+    };
+  }
+
+  checkIfFunctionExistsInService() {
+    this.serverless.service.getFunction(this.options.function);
+
+    return BbPromise.resolve();
+  }
+
+  checkIfFunctionIsDeployed() {
+    const params = {
+      FunctionName: this.functionName,
+    };
+
+    this.sdk.request(
+      'Lambda',
+      'getFunction',
+      params,
+      this.options.stage, this.options.region
+    ).catch(() => {
+      const errorMessage = [
+        `The function "${this.options.function}" you want to update is not yet deployed.`,
+        ' Please run "serverless deploy" to deploy your service.',
+        ' After that you can redeploy your services functions with the',
+        ' "serverless deploy function" command.',
+      ].join('');
+      throw new this.serverless.classes
+        .Error(errorMessage);
+    });
+
+    return BbPromise.resolve();
+  }
+
+  zipFunction() {
+    this.serverless.cli.log('Zipping function...');
+    const zip = new Zip();
+
+    const servicePath = this.serverless.config.servicePath;
+    const func = this.serverless.service.functions[this.options.function];
+
+    const handler = (_.last(func.handler.split('/'))).replace(/\\g/, '/');
+    const handlerFullPath = path.join(servicePath, handler);
+
+    if (!handlerFullPath.endsWith(func.handler)) {
+      const errorMessage = [
+        `The handler ${func.handler} was not found.`,
+        ' Please make sure you have this handler in your service at the referenced location.',
+        ' Please check the docs for more info',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+
+    const packageRoot = handlerFullPath.replace(func.handler, '');
+
+    this.serverless.utils.walkDirSync(packageRoot).forEach((filePath) => {
+      const relativeFilePath = path.relative(packageRoot, filePath);
+      const permissions = fs.statSync(filePath).mode;
+      zip.file(relativeFilePath, fs.readFileSync(filePath), { unixPermissions: permissions });
+    });
+
+    const data = zip.generate({
+      type: 'nodebuffer',
+      compression: 'DEFLATE',
+      platform: process.platform,
+    });
+
+    return BbPromise.resolve(data);
+  }
+
+  deployFunction(data) {
+    const params = {
+      FunctionName: this.functionName,
+      ZipFile: data,
+    };
+
+    this.sdk.request(
+      'Lambda',
+      'updateFunctionCode',
+      params,
+      this.options.stage, this.options.region
+    ).catch(() => {
+      const errorMessage = [
+        `An error occurred whily deploying the function "${this.options.function}".`,
+        ' Please try again',
+      ].join('');
+      throw new this.serverless.classes
+        .Error(errorMessage);
+    });
+
+    this.serverless.cli.log(`Successfully deployed function "${this.options.function}"`);
+
+    return BbPromise.resolve();
+  }
+}
+
+module.exports = AwsDeployFunction;

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -23,20 +23,17 @@ class AwsDeployFunction {
     this.hooks = {
       'deploy:function:deploy': () => BbPromise.bind(this)
         .then(this.validate)
-        .then(this.checkIfFunctionExistsInService)
-        .then(this.checkIfFunctionIsDeployed)
+        .then(this.checkIfFunctionExists)
         .then(this.zipFunction)
         .then(this.deployFunction),
     };
   }
 
-  checkIfFunctionExistsInService() {
+  checkIfFunctionExists() {
+    // check if the function exists in the service
     this.serverless.service.getFunction(this.options.function);
 
-    return BbPromise.resolve();
-  }
-
-  checkIfFunctionIsDeployed() {
+    // check if function exists on AWS
     const params = {
       FunctionName: this.functionName,
     };

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const Zip = require('node-zip');
+const Package = require('../../../package');
 const AwsDeployFunction = require('../');
 const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
@@ -57,6 +57,8 @@ describe('AwsDeployFunction', () => {
         .stub(awsDeployFunction, 'zipFunction').returns(BbPromise.resolve());
       const deployFunctionStub = sinon
         .stub(awsDeployFunction, 'deployFunction').returns(BbPromise.resolve());
+      const cleanupStub = sinon
+        .stub(awsDeployFunction, 'cleanup').returns(BbPromise.resolve());
 
       return awsDeployFunction.hooks['deploy:function:deploy']().then(() => {
         expect(checkIfFunctionExistsStub.calledOnce).to.be.equal(true);
@@ -64,10 +66,13 @@ describe('AwsDeployFunction', () => {
           .to.be.equal(true);
         expect(deployFunctionStub.calledAfter(zipFunctionStub))
           .to.be.equal(true);
+        expect(cleanupStub.calledAfter(deployFunctionStub))
+          .to.be.equal(true);
 
         awsDeployFunction.checkIfFunctionExists.restore();
         awsDeployFunction.zipFunction.restore();
         awsDeployFunction.deployFunction.restore();
+        awsDeployFunction.cleanup.restore();
       });
     });
   });
@@ -103,135 +108,38 @@ describe('AwsDeployFunction', () => {
   });
 
   describe('#zipFunction()', () => {
-    let zip;
-    const functionFileNameBase = 'function';
-    const functionCodeMock = `
-      'use strict';
+    it('should zip the function', () => {
+      const pkg = new Package();
 
-      module.exports.handler = function(event, context, cb) {
-        return cb(null, {
-          message: 'First function'
-        });
-      };
-    `;
+      awsDeployFunction.pkg = pkg;
 
-    beforeEach(() => {
-      zip = new Zip();
-      awsDeployFunction.functionName = 'first';
-    });
+      const zipServiceStub = sinon
+        .stub(pkg, 'zipService').returns(BbPromise.resolve());
 
-    it('should zip a simple function', () => {
-      awsDeployFunction.serverless.service.functions = {
-        first: {
-          handler: 'handler.first',
-        },
-      };
-
-      // create a function in a temporary directory
-      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
-      const tmpFilePath = path.join(tmpDirPath, `${functionFileNameBase}.js`);
-      serverless.utils.writeFileSync(tmpFilePath, functionCodeMock);
-
-      // set the servicePath
-      serverless.config.servicePath = tmpDirPath;
-
-      return awsDeployFunction.zipFunction().then((data) => {
-        expect(typeof data).to.not.equal('undefined');
-
-        const unzippedFileData = zip.load(data);
-
-        expect(unzippedFileData.files[`${functionFileNameBase}.js`].name)
-          .to.equal(`${functionFileNameBase}.js`);
-        expect(unzippedFileData.files[`${functionFileNameBase}.js`].dir).to.equal(false);
-      });
-    });
-
-    it('should zip nested code', () => {
-      awsDeployFunction.serverless.service.functions = {
-        first: {
-          handler: 'nested/handler.first',
-        },
-      };
-
-      // create a function in a temporary directory --> nested/function.js
-      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'nested');
-      const tmpFilePath = path.join(tmpDirPath, `${functionFileNameBase}.js`);
-
-      serverless.utils.writeFileSync(tmpFilePath, functionCodeMock);
-
-      // add a lib directory on the same level where the "nested" directory lives --> lib/some-file
-      const libDirectory = path.join(tmpDirPath, '..', 'lib');
-      serverless.utils.writeFileSync(path.join(libDirectory, 'some-file'), 'content');
-
-      // set the servicePath
-      serverless.config.servicePath = tmpDirPath;
-
-      return awsDeployFunction.zipFunction().then((data) => {
-        expect(typeof data).to.not.equal('undefined');
-
-        const unzippedFileData = zip.load(data);
-
-        expect(unzippedFileData.files[`nested/${functionFileNameBase}.js`].name)
-          .to.equal(`nested/${functionFileNameBase}.js`);
-        expect(unzippedFileData.files[`nested/${functionFileNameBase}.js`].dir)
-          .to.equal(false);
-
-        expect(unzippedFileData.files['lib/some-file'].name)
-          .to.equal('lib/some-file');
-        expect(unzippedFileData.files['lib/some-file'].dir)
-          .to.equal(false);
-      });
-    });
-
-    it('should keep file permissions', () => {
-      awsDeployFunction.serverless.service.functions = {
-        first: {
-          handler: 'handler.first',
-        },
-      };
-
-      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
-
-      // create a function in a temporary directory
-      const tmpFilePath = path.join(tmpDirPath, `${functionFileNameBase}.js`);
-      serverless.utils.writeFileSync(tmpFilePath, functionCodeMock);
-
-      // create a executable file
-      const executableFilePath = path.join(tmpDirPath, 'some-binary');
-      serverless.utils.writeFileSync(executableFilePath, 'some-binary executable file content');
-      fs.chmodSync(executableFilePath, 777);
-
-      // create a readonly file
-      const readOnlyFilePath = path.join(tmpDirPath, 'read-only');
-      serverless.utils.writeFileSync(readOnlyFilePath, 'read-only executable file content');
-      fs.chmodSync(readOnlyFilePath, 444);
-
-      // set the servicePath
-      serverless.config.servicePath = tmpDirPath;
-
-      return awsDeployFunction.zipFunction().then((data) => {
-        expect(typeof data).to.not.equal('undefined');
-
-        const unzippedFileData = zip.load(data);
-
-        expect(unzippedFileData.files['some-binary'].unixPermissions)
-          .to.equal(Math.pow(2, 15) + 777);
-        expect(unzippedFileData.files['read-only'].unixPermissions)
-          .to.equal(Math.pow(2, 15) + 444);
+      return awsDeployFunction.zipFunction().then(() => {
+        expect(zipServiceStub.calledOnce).to.be.equal(true);
+        awsDeployFunction.pkg.zipService.restore();
       });
     });
   });
 
   describe('#deployFunction()', () => {
     it('should deploy the function', () => {
+      // write a file to disc to simulate that the deployment artifact exists
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
+      serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
+
+      awsDeployFunction.serverless.service.package.artifact = artifactFilePath;
+
       const updateFunctionCodeStub = sinon
         .stub(awsDeployFunction.sdk, 'request').returns(BbPromise.resolve());
 
       awsDeployFunction.functionName = 'first';
 
-      const data = 'some-buffer';
+      return awsDeployFunction.deployFunction().then(() => {
+        const data = fs.readFileSync(artifactFilePath);
 
-      return awsDeployFunction.deployFunction(data).then(() => {
         expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
         expect(updateFunctionCodeStub.calledWith(
           awsDeployFunction.options.stage, awsDeployFunction.options.region)
@@ -239,8 +147,24 @@ describe('AwsDeployFunction', () => {
         expect(updateFunctionCodeStub.args[0][0]).to.be.equal('Lambda');
         expect(updateFunctionCodeStub.args[0][1]).to.be.equal('updateFunctionCode');
         expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
-        expect(updateFunctionCodeStub.args[0][2].ZipFile).to.be.equal('some-buffer');
+        expect(updateFunctionCodeStub.args[0][2].ZipFile).to.deep.equal(data);
         awsDeployFunction.sdk.request.restore();
+      });
+    });
+  });
+
+  describe('#cleanup()', () => {
+    it('should remove the temporary .serverless directory', () => {
+      const pkg = new Package();
+
+      awsDeployFunction.pkg = pkg;
+
+      const cleanupStub = sinon
+        .stub(pkg, 'cleanup').returns(BbPromise.resolve());
+
+      return awsDeployFunction.cleanup().then(() => {
+        expect(cleanupStub.calledOnce).to.be.equal(true);
+        awsDeployFunction.pkg.cleanup.restore();
       });
     });
   });

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -51,47 +51,45 @@ describe('AwsDeployFunction', () => {
       .to.equal('aws'));
 
     it('should run promise chain in order', () => {
-      const checkIfFunctionExistsInServiceStub = sinon
-        .stub(awsDeployFunction, 'checkIfFunctionExistsInService').returns(BbPromise.resolve());
-      const checkIfFunctionIsDeployedStub = sinon
-        .stub(awsDeployFunction, 'checkIfFunctionIsDeployed').returns(BbPromise.resolve());
+      const checkIfFunctionExistsStub = sinon
+        .stub(awsDeployFunction, 'checkIfFunctionExists').returns(BbPromise.resolve());
       const zipFunctionStub = sinon
         .stub(awsDeployFunction, 'zipFunction').returns(BbPromise.resolve());
       const deployFunctionStub = sinon
         .stub(awsDeployFunction, 'deployFunction').returns(BbPromise.resolve());
 
       return awsDeployFunction.hooks['deploy:function:deploy']().then(() => {
-        expect(checkIfFunctionExistsInServiceStub.calledOnce).to.be.equal(true);
-        expect(checkIfFunctionIsDeployedStub.calledAfter(checkIfFunctionExistsInServiceStub))
-          .to.be.equal(true);
-        expect(zipFunctionStub.calledAfter(checkIfFunctionIsDeployedStub))
+        expect(checkIfFunctionExistsStub.calledOnce).to.be.equal(true);
+        expect(zipFunctionStub.calledAfter(checkIfFunctionExistsStub))
           .to.be.equal(true);
         expect(deployFunctionStub.calledAfter(zipFunctionStub))
           .to.be.equal(true);
 
-        awsDeployFunction.checkIfFunctionExistsInService.restore();
-        awsDeployFunction.checkIfFunctionIsDeployed.restore();
+        awsDeployFunction.checkIfFunctionExists.restore();
         awsDeployFunction.zipFunction.restore();
         awsDeployFunction.deployFunction.restore();
       });
     });
   });
 
-  describe('#checkIfFunctionExistsInService()', () => {
+  describe('#checkIfFunctionExists()', () => {
     it('it should throw error if function is not provided', () => {
       serverless.service.functions = null;
-      expect(() => awsDeployFunction.checkIfFunctionExistsInService()).to.throw(Error);
+      expect(() => awsDeployFunction.checkIfFunctionExists()).to.throw(Error);
     });
-  });
 
-  describe('#checkIfFunctionIsDeployed()', () => {
     it('should check if the function is deployed', () => {
       const getFunctionStub = sinon
         .stub(awsDeployFunction.sdk, 'request').returns(BbPromise.resolve());
 
       awsDeployFunction.functionName = 'first';
+      awsDeployFunction.serverless.service.functions = {
+        first: {
+          handler: 'handler.first',
+        },
+      };
 
-      return awsDeployFunction.checkIfFunctionIsDeployed().then(() => {
+      return awsDeployFunction.checkIfFunctionExists().then(() => {
         expect(getFunctionStub.calledOnce).to.be.equal(true);
         expect(getFunctionStub.calledWith(
           awsDeployFunction.options.stage, awsDeployFunction.options.region)

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -96,6 +96,8 @@ describe('AwsDeployFunction', () => {
         expect(getFunctionStub.calledWith(
           awsDeployFunction.options.stage, awsDeployFunction.options.region)
         );
+        expect(getFunctionStub.args[0][0]).to.be.equal('Lambda');
+        expect(getFunctionStub.args[0][1]).to.be.equal('getFunction');
         expect(getFunctionStub.args[0][2].FunctionName).to.be.equal('first');
         awsDeployFunction.sdk.request.restore();
       });
@@ -236,6 +238,8 @@ describe('AwsDeployFunction', () => {
         expect(updateFunctionCodeStub.calledWith(
           awsDeployFunction.options.stage, awsDeployFunction.options.region)
         );
+        expect(updateFunctionCodeStub.args[0][0]).to.be.equal('Lambda');
+        expect(updateFunctionCodeStub.args[0][1]).to.be.equal('uploadFunctionCode');
         expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
         expect(updateFunctionCodeStub.args[0][2].ZipFile).to.be.equal('some-buffer');
         awsDeployFunction.sdk.request.restore();

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -239,7 +239,7 @@ describe('AwsDeployFunction', () => {
           awsDeployFunction.options.stage, awsDeployFunction.options.region)
         );
         expect(updateFunctionCodeStub.args[0][0]).to.be.equal('Lambda');
-        expect(updateFunctionCodeStub.args[0][1]).to.be.equal('uploadFunctionCode');
+        expect(updateFunctionCodeStub.args[0][1]).to.be.equal('updateFunctionCode');
         expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
         expect(updateFunctionCodeStub.args[0][2].ZipFile).to.be.equal('some-buffer');
         awsDeployFunction.sdk.request.restore();

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const Zip = require('node-zip');
+const AwsDeployFunction = require('../');
+const Serverless = require('../../../../Serverless');
+const BbPromise = require('bluebird');
+
+describe('AwsDeployFunction', () => {
+  let serverless;
+  let awsDeployFunction;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.servicePath = true;
+    serverless.service.environment = {
+      vars: {},
+      stages: {
+        dev: {
+          vars: {},
+          regions: {
+            'us-east-1': {
+              vars: {},
+            },
+          },
+        },
+      },
+    };
+    serverless.service.functions = {
+      first: {
+        handler: true,
+      },
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+      function: 'first',
+    };
+    serverless.init();
+    awsDeployFunction = new AwsDeployFunction(serverless, options);
+  });
+
+  describe('#constructor()', () => {
+    it('should have hooks', () => expect(awsDeployFunction.hooks).to.be.not.empty);
+
+    it('should set the provider variable to "aws"', () => expect(awsDeployFunction.provider)
+      .to.equal('aws'));
+
+    it('should run promise chain in order', () => {
+      const checkIfFunctionExistsInServiceStub = sinon
+        .stub(awsDeployFunction, 'checkIfFunctionExistsInService').returns(BbPromise.resolve());
+      const checkIfFunctionIsDeployedStub = sinon
+        .stub(awsDeployFunction, 'checkIfFunctionIsDeployed').returns(BbPromise.resolve());
+      const zipFunctionStub = sinon
+        .stub(awsDeployFunction, 'zipFunction').returns(BbPromise.resolve());
+      const deployFunctionStub = sinon
+        .stub(awsDeployFunction, 'deployFunction').returns(BbPromise.resolve());
+
+      return awsDeployFunction.hooks['deploy:function:deploy']().then(() => {
+        expect(checkIfFunctionExistsInServiceStub.calledOnce).to.be.equal(true);
+        expect(checkIfFunctionIsDeployedStub.calledAfter(checkIfFunctionExistsInServiceStub))
+          .to.be.equal(true);
+        expect(zipFunctionStub.calledAfter(checkIfFunctionIsDeployedStub))
+          .to.be.equal(true);
+        expect(deployFunctionStub.calledAfter(zipFunctionStub))
+          .to.be.equal(true);
+
+        awsDeployFunction.checkIfFunctionExistsInService.restore();
+        awsDeployFunction.checkIfFunctionIsDeployed.restore();
+        awsDeployFunction.zipFunction.restore();
+        awsDeployFunction.deployFunction.restore();
+      });
+    });
+  });
+
+  describe('#checkIfFunctionExistsInService()', () => {
+    it('it should throw error if function is not provided', () => {
+      serverless.service.functions = null;
+      expect(() => awsDeployFunction.checkIfFunctionExistsInService()).to.throw(Error);
+    });
+  });
+
+  describe('#checkIfFunctionIsDeployed()', () => {
+    it('should check if the function is deployed', () => {
+      const getFunctionStub = sinon
+        .stub(awsDeployFunction.sdk, 'request').returns(BbPromise.resolve());
+
+      awsDeployFunction.functionName = 'first';
+
+      return awsDeployFunction.checkIfFunctionIsDeployed().then(() => {
+        expect(getFunctionStub.calledOnce).to.be.equal(true);
+        expect(getFunctionStub.calledWith(
+          awsDeployFunction.options.stage, awsDeployFunction.options.region)
+        );
+        expect(getFunctionStub.args[0][2].FunctionName).to.be.equal('first');
+        awsDeployFunction.sdk.request.restore();
+      });
+    });
+  });
+
+  describe('#zipFunction()', () => {
+    let zip;
+    const functionFileNameBase = 'function';
+    const functionCodeMock = `
+      'use strict';
+
+      module.exports.handler = function(event, context, cb) {
+        return cb(null, {
+          message: 'First function'
+        });
+      };
+    `;
+
+    beforeEach(() => {
+      zip = new Zip();
+      awsDeployFunction.functionName = 'first';
+    });
+
+    it('should zip a simple function', () => {
+      awsDeployFunction.serverless.service.functions = {
+        first: {
+          handler: 'handler.first',
+        },
+      };
+
+      // create a function in a temporary directory
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const tmpFilePath = path.join(tmpDirPath, `${functionFileNameBase}.js`);
+      serverless.utils.writeFileSync(tmpFilePath, functionCodeMock);
+
+      // set the servicePath
+      serverless.config.servicePath = tmpDirPath;
+
+      return awsDeployFunction.zipFunction().then((data) => {
+        expect(typeof data).to.not.equal('undefined');
+
+        const unzippedFileData = zip.load(data);
+
+        expect(unzippedFileData.files[`${functionFileNameBase}.js`].name)
+          .to.equal(`${functionFileNameBase}.js`);
+        expect(unzippedFileData.files[`${functionFileNameBase}.js`].dir).to.equal(false);
+      });
+    });
+
+    it('should zip nested code', () => {
+      awsDeployFunction.serverless.service.functions = {
+        first: {
+          handler: 'nested/handler.first',
+        },
+      };
+
+      // create a function in a temporary directory --> nested/function.js
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString(), 'nested');
+      const tmpFilePath = path.join(tmpDirPath, `${functionFileNameBase}.js`);
+
+      serverless.utils.writeFileSync(tmpFilePath, functionCodeMock);
+
+      // add a lib directory on the same level where the "nested" directory lives --> lib/some-file
+      const libDirectory = path.join(tmpDirPath, '..', 'lib');
+      serverless.utils.writeFileSync(path.join(libDirectory, 'some-file'), 'content');
+
+      // set the servicePath
+      serverless.config.servicePath = tmpDirPath;
+
+      return awsDeployFunction.zipFunction().then((data) => {
+        expect(typeof data).to.not.equal('undefined');
+
+        const unzippedFileData = zip.load(data);
+
+        expect(unzippedFileData.files[`nested/${functionFileNameBase}.js`].name)
+          .to.equal(`nested/${functionFileNameBase}.js`);
+        expect(unzippedFileData.files[`nested/${functionFileNameBase}.js`].dir)
+          .to.equal(false);
+
+        expect(unzippedFileData.files['lib/some-file'].name)
+          .to.equal('lib/some-file');
+        expect(unzippedFileData.files['lib/some-file'].dir)
+          .to.equal(false);
+      });
+    });
+
+    it('should keep file permissions', () => {
+      awsDeployFunction.serverless.service.functions = {
+        first: {
+          handler: 'handler.first',
+        },
+      };
+
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+
+      // create a function in a temporary directory
+      const tmpFilePath = path.join(tmpDirPath, `${functionFileNameBase}.js`);
+      serverless.utils.writeFileSync(tmpFilePath, functionCodeMock);
+
+      // create a executable file
+      const executableFilePath = path.join(tmpDirPath, 'some-binary');
+      serverless.utils.writeFileSync(executableFilePath, 'some-binary executable file content');
+      fs.chmodSync(executableFilePath, 777);
+
+      // create a readonly file
+      const readOnlyFilePath = path.join(tmpDirPath, 'read-only');
+      serverless.utils.writeFileSync(readOnlyFilePath, 'read-only executable file content');
+      fs.chmodSync(readOnlyFilePath, 444);
+
+      // set the servicePath
+      serverless.config.servicePath = tmpDirPath;
+
+      return awsDeployFunction.zipFunction().then((data) => {
+        expect(typeof data).to.not.equal('undefined');
+
+        const unzippedFileData = zip.load(data);
+
+        expect(unzippedFileData.files['some-binary'].unixPermissions)
+          .to.equal(Math.pow(2, 15) + 777);
+        expect(unzippedFileData.files['read-only'].unixPermissions)
+          .to.equal(Math.pow(2, 15) + 444);
+      });
+    });
+  });
+
+  describe('#deployFunction()', () => {
+    it('should deploy the function', () => {
+      const updateFunctionCodeStub = sinon
+        .stub(awsDeployFunction.sdk, 'request').returns(BbPromise.resolve());
+
+      awsDeployFunction.functionName = 'first';
+
+      const data = 'some-buffer';
+
+      return awsDeployFunction.deployFunction(data).then(() => {
+        expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
+        expect(updateFunctionCodeStub.calledWith(
+          awsDeployFunction.options.stage, awsDeployFunction.options.region)
+        );
+        expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
+        expect(updateFunctionCodeStub.args[0][2].ZipFile).to.be.equal('some-buffer');
+        awsDeployFunction.sdk.request.restore();
+      });
+    });
+  });
+});

--- a/lib/plugins/deploy/README.md
+++ b/lib/plugins/deploy/README.md
@@ -1,12 +1,14 @@
 # Deploy
 
 ```
-serverless deploy
+serverless deploy [function]
 ```
 
 Deploys your service.
 
 ## Options
+- `--function` or `-f` The name of the function which should be deployed (**Note:** only available when running
+`serverless deploy function`)
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 
@@ -17,6 +19,7 @@ Deploys your service.
 - `deploy:compileFunctions`
 - `deploy:compileEvents`
 - `deploy:deploy`
+- `deploy:function:deploy`
 
 ## Examples
 
@@ -37,3 +40,19 @@ serverless deploy --stage production --region eu-central-1
 
 With this example we've defined that we want our service to be deployed to the `production` stage in the region
 `eu-central-1`.
+
+### Deployment of a single function
+
+This command deploy the function `func` in the default stage (`dev`) of the default region (`us-east-1`).
+
+```
+serverless deploy function --function func
+```
+
+### Deployment of a single function with stage and region
+
+The function `func` will be deployed in the `production` stage of the `eu-central-1` region.
+
+```
+serverless deploy function --function func --stage production --region eu-central-1
+```

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -25,6 +25,29 @@ class Deploy {
             shortcut: 'r',
           },
         },
+        commands: {
+          function: {
+            usage: 'Deploys a single function from the service',
+            lifecycleEvents: [
+              'deploy',
+            ],
+            options: {
+              function: {
+                usage: 'Name of the function',
+                shortcut: 'f',
+                required: true,
+              },
+              stage: {
+                usage: 'Stage of the function',
+                shortcut: 's',
+              },
+              region: {
+                usage: 'Region of the function',
+                shortcut: 'r',
+              },
+            },
+          },
+        },
       },
     };
   }

--- a/tests/all.js
+++ b/tests/all.js
@@ -31,3 +31,4 @@ require('../lib/plugins/aws/deploy/compile/events/s3/tests');
 require('../lib/plugins/aws/deploy/compile/events/schedule/tests');
 require('../lib/plugins/aws/deploy/compile/events/apiGateway/tests/all');
 require('../lib/plugins/aws/deploy/compile/events/sns/tests');
+require('../lib/plugins/aws/deployFunction/tests/index');


### PR DESCRIPTION
This plugin makes it possible to deploy a single function from the service directly to the lambda function via the AWS SDK (bypassing CloudFormation and S3) which makes it ⚡ blazing fast ⚡ .

Corresponding issue: https://github.com/serverless/serverless/issues/1652

**Note:** Shortcuts for nested commands is not yet implemented (so you cannot use `serverless deploy function -f <name>` but you can use `serverless deploy --function <name>`). An issue was already created (see https://github.com/serverless/serverless/issues/1695). Will update the core in a separate PR so that this is also possible.

/cc @flomotlik @eahefnawy 