### PR TITLE
fix(deploy): Functions no longer need to maintain order

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -31,8 +31,7 @@ module.exports = {
           const resourceLogicalId = this.resourceLogicalIds[path];
           const normalizedMethod = method[0].toUpperCase() +
             method.substr(1).toLowerCase();
-
-          const extractedResourceId = resourceLogicalId.match(/\d+$/)[0];
+          const extractedResourceId = resourceLogicalId.match(/ResourceApigEvent(.*)/)[1];
 
           // universal velocity template
           // provides

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -50,8 +50,8 @@ module.exports = {
       const resourceName = path.split('/')[path.split('/').length - 1];
       const resourcePath = path;
       const resourceIndex = this.resourcePaths.indexOf(resourcePath);
-      const resourceFunction = this.resourceFunctions[resourceIndex] +
-        path.replace(/\//g, '');
+      const resourceFunction = _.capitalize(this.resourceFunctions[resourceIndex]) +
+        resourcesArray.map(_.capitalize).join('');
       const resourceLogicalId = `ResourceApigEvent${resourceFunction}`;
       this.resourceLogicalIds[resourcePath] = resourceLogicalId;
       resourcesArray.pop();
@@ -62,8 +62,8 @@ module.exports = {
       } else {
         const resourceParentPath = resourcesArray.join('/');
         const resourceParentIndex = this.resourcePaths.indexOf(resourceParentPath);
-        const resourceParentFunction = this.resourceFunctions[resourceParentIndex] +
-          resourcesArray.join('');
+        const resourceParentFunction = _.capitalize(this.resourceFunctions[resourceParentIndex]) +
+          resourcesArray.map(_.capitalize).join('');
         resourceParentId = `{ "Ref" : "ResourceApigEvent${resourceParentFunction}" }`;
       }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -43,6 +43,10 @@ module.exports = {
       });
     });
 
+    const capitalizeAlphaNumericPath = (path => {
+      return _.capitalize(path.replace(/[^0-9A-Za-z]/g, ''));
+    });
+
     // ['users', 'users/create', 'users/create/something']
     this.resourcePaths.forEach(path => {
       const resourcesArray = path.split('/');
@@ -51,7 +55,7 @@ module.exports = {
       const resourcePath = path;
       const resourceIndex = this.resourcePaths.indexOf(resourcePath);
       const resourceFunction = _.capitalize(this.resourceFunctions[resourceIndex]) +
-        resourcesArray.map(_.capitalize).join('');
+        resourcesArray.map(capitalizeAlphaNumericPath).join('');
       const resourceLogicalId = `ResourceApigEvent${resourceFunction}`;
       this.resourceLogicalIds[resourcePath] = resourceLogicalId;
       resourcesArray.pop();
@@ -63,7 +67,7 @@ module.exports = {
         const resourceParentPath = resourcesArray.join('/');
         const resourceParentIndex = this.resourcePaths.indexOf(resourceParentPath);
         const resourceParentFunction = _.capitalize(this.resourceFunctions[resourceParentIndex]) +
-          resourcesArray.map(_.capitalize).join('');
+          resourcesArray.map(capitalizeAlphaNumericPath).join('');
         resourceParentId = `{ "Ref" : "ResourceApigEvent${resourceParentFunction}" }`;
       }
 
@@ -81,6 +85,7 @@ module.exports = {
       const resourceObject = {
         [resourceLogicalId]: JSON.parse(resourceTemplate),
       };
+
 
       _.merge(this.serverless.service.resources.Resources,
         resourceObject);

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 module.exports = {
   compileResources() {
+    this.resourceFunctions = [];
     this.resourcePaths = [];
     this.resourceLogicalIds = {};
 
@@ -31,6 +32,7 @@ module.exports = {
           while (path !== '') {
             if (this.resourcePaths.indexOf(path) === -1) {
               this.resourcePaths.push(path);
+              this.resourceFunctions.push(functionName);
             }
 
             const splittedPath = path.split('/');
@@ -48,7 +50,9 @@ module.exports = {
       const resourceName = path.split('/')[path.split('/').length - 1];
       const resourcePath = path;
       const resourceIndex = this.resourcePaths.indexOf(resourcePath);
-      const resourceLogicalId = `ResourceApigEvent${resourceIndex}`;
+      const resourceFunction = this.resourceFunctions[resourceIndex] +
+        path.replace(/\//g, '');
+      const resourceLogicalId = `ResourceApigEvent${resourceFunction}`;
       this.resourceLogicalIds[resourcePath] = resourceLogicalId;
       resourcesArray.pop();
 
@@ -58,7 +62,9 @@ module.exports = {
       } else {
         const resourceParentPath = resourcesArray.join('/');
         const resourceParentIndex = this.resourcePaths.indexOf(resourceParentPath);
-        resourceParentId = `{ "Ref" : "ResourceApigEvent${resourceParentIndex}" }`;
+        const resourceParentFunction = this.resourceFunctions[resourceParentIndex] +
+          resourcesArray.join('');
+        resourceParentId = `{ "Ref" : "ResourceApigEvent${resourceParentFunction}" }`;
       }
 
       const resourceTemplate = `

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -43,9 +43,7 @@ module.exports = {
       });
     });
 
-    const capitalizeAlphaNumericPath = (path => {
-      return _.capitalize(path.replace(/[^0-9A-Za-z]/g, ''));
-    });
+    const capitalizeAlphaNumericPath = (path) => _.capitalize(path.replace(/[^0-9A-Za-z]/g, ''));
 
     // ['users', 'users/create', 'users/create/something']
     this.resourcePaths.forEach(path => {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
@@ -39,10 +39,10 @@ describe('#compileResources()', () => {
   it('should construct the correct resourceLogicalIds object', () => awsCompileApigEvents
     .compileResources().then(() => {
       const expectedResourceLogicalIds = {
-        'foo/bar': 'ResourceApigEventfirstfoobar',
-        foo: 'ResourceApigEventfirstfoo',
-        'bar/foo': 'ResourceApigEventfirstbarfoo',
-        bar: 'ResourceApigEventfirstbar',
+        'foo/bar': 'ResourceApigEventFirstFooBar',
+        foo: 'ResourceApigEventFirstFoo',
+        'bar/foo': 'ResourceApigEventFirstBarFoo',
+        bar: 'ResourceApigEventFirstBar',
       };
       expect(awsCompileApigEvents.resourceLogicalIds).to.deep.equal(expectedResourceLogicalIds);
     })
@@ -51,16 +51,16 @@ describe('#compileResources()', () => {
   it('should create resource resources when http events are given', () => awsCompileApigEvents
     .compileResources().then(() => {
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEventfirstfoobar.Properties.PathPart)
+        .ResourceApigEventFirstFooBar.Properties.PathPart)
         .to.equal('bar');
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEventfirstfoobar.Properties.ParentId.Ref)
-        .to.equal('ResourceApigEventfirstfoo');
+        .ResourceApigEventFirstFooBar.Properties.ParentId.Ref)
+        .to.equal('ResourceApigEventFirstFoo');
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEventfirstfoo.Properties.ParentId['Fn::GetAtt'][0])
+        .ResourceApigEventFirstFoo.Properties.ParentId['Fn::GetAtt'][0])
         .to.equal('RestApiApigEvent');
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEventfirstbar.Properties.ParentId['Fn::GetAtt'][1])
+        .ResourceApigEventFirstBar.Properties.ParentId['Fn::GetAtt'][1])
         .to.equal('RootResourceId');
     })
   );

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
@@ -24,6 +24,18 @@ describe('#compileResources()', () => {
           {
             http: 'GET bar/foo',
           },
+          {
+            http: 'GET bar/{id}'
+          },
+          {
+            http: 'GET bar/{id}/foobar'
+          },
+          {
+            http: 'GET bar/{foo_id}'
+          },
+          {
+            http: 'GET bar/{foo_id}/foobar'
+          }
         ],
       },
     };
@@ -31,7 +43,8 @@ describe('#compileResources()', () => {
 
   it('should construct the correct resourcePaths array', () => awsCompileApigEvents
     .compileResources().then(() => {
-      const expectedResourcePaths = ['foo/bar', 'foo', 'bar/foo', 'bar'];
+      const expectedResourcePaths = ['foo/bar', 'foo', 'bar/foo', 'bar', 'bar/{id}',
+        'bar/{id}/foobar', 'bar/{foo_id}', 'bar/{foo_id}/foobar'];
       expect(awsCompileApigEvents.resourcePaths).to.deep.equal(expectedResourcePaths);
     })
   );
@@ -41,6 +54,10 @@ describe('#compileResources()', () => {
       const expectedResourceLogicalIds = {
         'foo/bar': 'ResourceApigEventFirstFooBar',
         foo: 'ResourceApigEventFirstFoo',
+        'bar/{id}/foobar': 'ResourceApigEventFirstBarIdFoobar',
+        'bar/{id}': 'ResourceApigEventFirstBarId',
+        'bar/{foo_id}/foobar': 'ResourceApigEventFirstBarFooidFoobar',
+        'bar/{foo_id}': 'ResourceApigEventFirstBarFooid',
         'bar/foo': 'ResourceApigEventFirstBarFoo',
         bar: 'ResourceApigEventFirstBar',
       };
@@ -62,6 +79,15 @@ describe('#compileResources()', () => {
       expect(awsCompileApigEvents.serverless.service.resources.Resources
         .ResourceApigEventFirstBar.Properties.ParentId['Fn::GetAtt'][1])
         .to.equal('RootResourceId');
+      expect(awsCompileApigEvents.serverless.service.resources.Resources
+        .ResourceApigEventFirstBarId.Properties.ParentId.Ref)
+        .to.equal('ResourceApigEventFirstBar');
+      expect(awsCompileApigEvents.serverless.service.resources.Resources
+        .ResourceApigEventFirstBarFooid.Properties.ParentId.Ref)
+        .to.equal('ResourceApigEventFirstBar');
+      expect(awsCompileApigEvents.serverless.service.resources.Resources
+        .ResourceApigEventFirstBarFooidFoobar.Properties.ParentId.Ref)
+        .to.equal('ResourceApigEventFirstBarFooid');
     })
   );
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
@@ -39,10 +39,10 @@ describe('#compileResources()', () => {
   it('should construct the correct resourceLogicalIds object', () => awsCompileApigEvents
     .compileResources().then(() => {
       const expectedResourceLogicalIds = {
-        'foo/bar': 'ResourceApigEvent0',
-        foo: 'ResourceApigEvent1',
-        'bar/foo': 'ResourceApigEvent2',
-        bar: 'ResourceApigEvent3',
+        'foo/bar': 'ResourceApigEventfirstfoobar',
+        foo: 'ResourceApigEventfirstfoo',
+        'bar/foo': 'ResourceApigEventfirstbarfoo',
+        bar: 'ResourceApigEventfirstbar',
       };
       expect(awsCompileApigEvents.resourceLogicalIds).to.deep.equal(expectedResourceLogicalIds);
     })
@@ -51,13 +51,17 @@ describe('#compileResources()', () => {
   it('should create resource resources when http events are given', () => awsCompileApigEvents
     .compileResources().then(() => {
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEvent0.Properties.PathPart).to.equal('bar');
+        .ResourceApigEventfirstfoobar.Properties.PathPart)
+        .to.equal('bar');
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEvent0.Properties.ParentId.Ref).to.equal('ResourceApigEvent1');
+        .ResourceApigEventfirstfoobar.Properties.ParentId.Ref)
+        .to.equal('ResourceApigEventfirstfoo');
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEvent1.Properties.ParentId['Fn::GetAtt'][0]).to.equal('RestApiApigEvent');
+        .ResourceApigEventfirstfoo.Properties.ParentId['Fn::GetAtt'][0])
+        .to.equal('RestApiApigEvent');
       expect(awsCompileApigEvents.serverless.service.resources.Resources
-        .ResourceApigEvent3.Properties.ParentId['Fn::GetAtt'][1]).to.equal('RootResourceId');
+        .ResourceApigEventfirstbar.Properties.ParentId['Fn::GetAtt'][1])
+        .to.equal('RootResourceId');
     })
   );
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
@@ -25,17 +25,17 @@ describe('#compileResources()', () => {
             http: 'GET bar/foo',
           },
           {
-            http: 'GET bar/{id}'
+            http: 'GET bar/{id}',
           },
           {
-            http: 'GET bar/{id}/foobar'
+            http: 'GET bar/{id}/foobar',
           },
           {
-            http: 'GET bar/{foo_id}'
+            http: 'GET bar/{foo_id}',
           },
           {
-            http: 'GET bar/{foo_id}/foobar'
-          }
+            http: 'GET bar/{foo_id}/foobar',
+          },
         ],
       },
     };


### PR DESCRIPTION
##### Status:

Ready

##### Description:

Resources and Methods were referenced by their index which made redeploying fail when you swapped the order of functions or added new ones anywhere bar the bottom of the object

Closes #1683