### PR TITLE
Enable CORS configuration for APIGW

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -157,3 +157,40 @@ That wouldn't be required if you hadn't set the `private` property to `true`.
 Setting an API Gateway proxy can easily be done by adding two custom CloudFormation resource templates to your
 `serverless.yml` file. Check [this guide](https://github.com/serverless/serverless/blob/v1.0/docs/guide/custom-provider-resources.md)
 for more info on how to set up a proxy using custom CloudFormation resources in `serverless.yml`.
+
+### Enabling CORS for your endpoints
+To set CORS configurations for your HTTP endpoints, simply modify your event configurations as follows:
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+        path: user/create
+        method: get
+        cors: true
+```
+
+You can equally set your own attributes:
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+        path: user/create
+        method: get
+        cors:
+          origins:
+            - '*'
+          headers:
+            - Content-Type
+            - X-Amz-Date
+            - Authorization
+            - X-Api-Key
+            - X-Amz-Security-Token
+```
+
+This is example is the default setting and is exactly the same as the previous example. The `Access-Control-Allow-Methods` header is set automatically, based on the endpoints specified in your service configuration with CORS enabled.

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -5,13 +5,27 @@ const _ = require('lodash');
 
 module.exports = {
   compileMethods() {
+    const corsConfig = {};
     let endpointCounter = 1;
-
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       functionObject.events.forEach(event => {
         if (event.http) {
           let method;
           let path;
+          let corsEnabled = false;
+
+          const headers = [
+            'Content-Type',
+            'X-Amz-Date',
+            'Authorization',
+            'X-Api-Key',
+            'X-Amz-Security-Token'];
+
+          let cors = {
+            origins: ['*'],
+            methods: ['OPTIONS'],
+            headers,
+          };
 
           if (typeof event.http === 'object') {
             method = event.http.method;
@@ -23,11 +37,46 @@ module.exports = {
             const errorMessage = [
               `HTTP event of function ${functionName} is not an object nor a string.`,
               ' The correct syntax is: http: get users/list',
-              ' OR an object with "path" and "method" proeprties.',
+              ' OR an object with "path" and "method" properties.',
               ' Please check the docs for more info.',
             ].join('');
             throw new this.serverless.classes
               .Error(errorMessage);
+          }
+
+          // Setup cors.
+          if (!!event.http.cors) {
+            corsEnabled = true;
+            if (typeof event.http.cors === 'object') {
+              cors = event.http.cors;
+              cors.methods = [];
+              if (cors.headers && !Array.isArray(cors.headers)) {
+                const errorMessage = [
+                  'CORS header values must be provided as an array.',
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes
+                .Error(errorMessage);
+              } else {
+                cors.headers = headers;
+              }
+
+              if (!cors.methods.indexOf('OPTIONS') > -1) {
+                cors.methods.push('OPTIONS');
+              }
+
+              if (!cors.methods.indexOf(method.toUpperCase()) > -1) {
+                cors.methods.push(method.toUpperCase());
+              }
+            } else {
+              cors.methods.push(method.toUpperCase());
+            }
+
+            if (corsConfig[path]) {
+              corsConfig[path] = _.merge(corsConfig[path], cors);
+            } else {
+              corsConfig[path] = cors;
+            }
           }
 
           const resourceLogicalId = this.resourceLogicalIds[path];
@@ -72,6 +121,13 @@ module.exports = {
             }
           `;
 
+          const allowOrigin = '"method.response.header.Access-Control-Allow-Origin"';
+          const corsMethodResponseTemplate =
+          corsEnabled ? `${allowOrigin} : ${allowOrigin}` : '';
+
+          const corsMethodIntegrationTemplate =
+          corsEnabled ? `${allowOrigin}: "'${cors.origins.join(',')}'"` : '';
+
           const methodTemplate = `
             {
               "Type" : "AWS::ApiGateway::Method",
@@ -81,7 +137,9 @@ module.exports = {
                 "MethodResponses" : [
                   {
                     "ResponseModels" : {},
-                    "ResponseParameters" : {},
+                    "ResponseParameters" : {
+                      ${corsMethodResponseTemplate}
+                    },
                     "StatusCode" : "200"
                   }
                 ],
@@ -106,7 +164,9 @@ module.exports = {
                   "IntegrationResponses" : [
                     {
                       "StatusCode" : "200",
-                      "ResponseParameters" : {},
+                      "ResponseParameters" : {
+                        ${corsMethodIntegrationTemplate}
+                      },
                       "ResponseTemplates" : {
                         "application/json": ""
                       }
@@ -189,6 +249,78 @@ module.exports = {
         }
       });
     });
+
+    // If no paths have CORS settings, then CORS isn't required.
+    if (!_.isEmpty(corsConfig)) {
+      const allowOrigin = '"method.response.header.Access-Control-Allow-Origin"';
+      const allowHeaders = '"method.response.header.Access-Control-Allow-Headers"';
+      const allowMethods = '"method.response.header.Access-Control-Allow-Methods"';
+
+      const preflightMethodResponse = `
+        ${allowOrigin}: true,
+        ${allowHeaders}: true,
+        ${allowMethods}: true
+      `;
+
+      let configIndex = 0;
+      _.forOwn(corsConfig, (config, path) => {
+        const resourceLogicalId = this.resourceLogicalIds[path];
+        const preflightIntegrationResponse =
+        `
+          ${allowOrigin}: "'${config.origins.join(',')}'",
+          ${allowHeaders}: "'${config.headers.join(',')}'",
+          ${allowMethods}: "'${config.methods.join(',')}'"
+        `;
+
+        const preflightTemplate = `
+          {
+            "Type" : "AWS::ApiGateway::Method",
+            "Properties" : {
+              "AuthorizationType" : "NONE",
+              "HttpMethod" : "OPTIONS",
+              "MethodResponses" : [
+                {
+                  "ResponseModels" : {},
+                  "ResponseParameters" : {
+                    ${preflightMethodResponse}
+                  },
+                  "StatusCode" : "200"
+                }
+              ],
+              "RequestParameters" : {},
+              "Integration" : {
+                "Type" : "MOCK",
+                "RequestTemplates" : {
+                  "application/json": "{statusCode:200}"
+                },
+                "IntegrationResponses" : [
+                  {
+                    "StatusCode" : "200",
+                    "ResponseParameters" : {
+                      ${preflightIntegrationResponse}
+                    },
+                    "ResponseTemplates" : {
+                      "application/json": ""
+                    }
+                  }
+                ]
+              },
+              "ResourceId" : { "Ref": "${resourceLogicalId}" },
+              "RestApiId" : { "Ref": "RestApiApigEvent" }
+            }
+          }
+        `;
+
+        const preflightObject = {
+          [`PreflightMethodApigEvent${configIndex++}`]:
+            JSON.parse(preflightTemplate),
+        };
+
+        _.merge(this.serverless.service.resources.Resources,
+           preflightObject);
+      });
+    }
+
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -38,10 +38,21 @@ describe('#compileMethods()', () => {
             http: {
               path: 'users/create',
               method: 'POST',
+              cors: true,
             },
           },
           {
             http: 'GET users/list',
+          },
+          {
+            http: {
+              path: 'users/update',
+              method: 'PUT',
+              cors: {
+                origins: ['*'],
+                headers: ['Content-Type', 'X-Amz-Date', 'Authorization', 'X-Api-Key'],
+              },
+            },
           },
         ],
       },
@@ -49,6 +60,7 @@ describe('#compileMethods()', () => {
     awsCompileApigEvents.resourceLogicalIds = {
       'users/create': 'ResourceApigEvent0',
       'users/list': 'ResourceApigEvent1',
+      'users/update': 'ResourceApigEvent2',
     };
   });
 
@@ -59,6 +71,9 @@ describe('#compileMethods()', () => {
       ).to.equal('AWS::ApiGateway::Method');
       expect(
         awsCompileApigEvents.serverless.service.resources.Resources.GetMethodApigEvent1.Type
+      ).to.equal('AWS::ApiGateway::Method');
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.PutMethodApigEvent2.Type
       ).to.equal('AWS::ApiGateway::Method');
     })
   );
@@ -188,7 +203,7 @@ describe('#compileMethods()', () => {
     awsCompileApigEvents.serverless.service.resources.Outputs = false;
     awsCompileApigEvents.compileMethods().then(() => {
       expect(awsCompileApigEvents.serverless.service.resources.Outputs)
-        .to.have.all.keys('Endpoint1', 'Endpoint2');
+        .to.have.all.keys('Endpoint1', 'Endpoint2', 'Endpoint3');
     });
   });
 
@@ -203,6 +218,11 @@ describe('#compileMethods()', () => {
         Description: 'Endpoint info',
         Value: { 'Fn::Join': ['', ['GET - https://', { Ref: 'RestApiApigEvent' },
           '.execute-api.us-east-1.amazonaws.com/dev/users/list']] },
+      },
+      Endpoint3: {
+        Description: 'Endpoint info',
+        Value: { 'Fn::Join': ['', ['PUT - https://', { Ref: 'RestApiApigEvent' },
+          '.execute-api.us-east-1.amazonaws.com/dev/users/update']] },
       },
     };
 
@@ -216,7 +236,7 @@ describe('#compileMethods()', () => {
     awsCompileApigEvents.serverless.service.resources.Outputs = false;
     awsCompileApigEvents.compileMethods().then(() => {
       expect(awsCompileApigEvents.serverless.service.resources.Outputs)
-        .to.have.all.keys('Endpoint1', 'Endpoint2');
+        .to.have.all.keys('Endpoint1', 'Endpoint2', 'Endpoint3');
     });
   });
 
@@ -232,11 +252,85 @@ describe('#compileMethods()', () => {
         Value: { 'Fn::Join': ['', ['GET - https://', { Ref: 'RestApiApigEvent' },
           '.execute-api.us-east-1.amazonaws.com/dev/users/list']] },
       },
+      Endpoint3: {
+        Description: 'Endpoint info',
+        Value: { 'Fn::Join': ['', ['PUT - https://', { Ref: 'RestApiApigEvent' },
+          '.execute-api.us-east-1.amazonaws.com/dev/users/update']] },
+      },
     };
 
     awsCompileApigEvents.compileMethods().then(() => {
       expect(awsCompileApigEvents.serverless.service.resources.Outputs)
         .to.deep.equal(expectedOutputs);
+    });
+  });
+
+  it('should add CORS origins to method only when CORS is enabled', () => {
+    const origin = '\'*\'';
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      // Check origin.
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.PostMethodApigEvent0.Properties
+          .Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
+      ).to.equal(origin);
+
+      // CORS not enabled!
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.GetMethodApigEvent1.Properties
+          .Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
+      ).to.not.equal(origin);
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources.PutMethodApigEvent2.Properties
+          .Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
+      ).to.equal(origin);
+    });
+  });
+
+  it('should create preflight method for CORS enabled resource', () => {
+    const origin = '\'*\'';
+    const headers = '\'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token\'';
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+          .PreflightMethodApigEvent0.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
+      ).to.equal(origin);
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+          .PreflightMethodApigEvent0.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Headers']
+      ).to.equal(headers);
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+          .PreflightMethodApigEvent0.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Methods']
+      ).to.equal('\'OPTIONS,POST\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+          .PreflightMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
+      ).to.equal(origin);
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+          .PreflightMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Headers']
+      ).to.equal(headers);
+
+      expect(
+        awsCompileApigEvents.serverless.service.resources.Resources
+        .PreflightMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Methods']
+      ).to.equal('\'OPTIONS,PUT\'');
     });
   });
 });


### PR DESCRIPTION
PR for Issue https://github.com/serverless/serverless/issues/1596

##### Status:
In Development

##### Description:
I've added the origin headers to the methods that require it and the tests pass for those. Still need to add the preflight (OPTIONS) method as required. I was thinking that I should probably set this at the Resource level, as the preflight request needs to be able to assign the allow-methods setting, so will need to have a global view of all the methods that have CORS configurations applied. Feedback VERY welcome at this point! :)

##### Todos:

- [x] Add preflight.
- [x] Write tests for preflight.
