### PR TITLE
Added missing options for parsing of templates

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -201,6 +201,10 @@ class Service {
                * so we gotta clone otherwise we will
                * corrupt the passed-by-reference variables object
                */
+              if (variableName in options) {
+                value = _.cloneDeep(options[variableName]);
+              }
+
               if (variableName in commonVars) {
                 value = _.cloneDeep(commonVars[variableName]);
               }

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -433,6 +433,51 @@ describe('Service', () => {
         });
     });
 
+    it('should load and populate options for variables', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const serverlessYml = {
+        service: 'service-name',
+        provider: 'aws',
+        custom: {
+          stage: '${stage}',
+          region: '${region}',
+        },
+        functions: {},
+      };
+      const serverlessEnvYml = {
+        vars: {
+          testObject: {
+            subProperty: 'test',
+          },
+        },
+        stages: {
+          dev: {
+            vars: {},
+            regions: {},
+          },
+        },
+      };
+
+      serverlessEnvYml.stages.dev.regions['us-east-1'] = {
+        vars: {},
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.env.yml'),
+        YAML.dump(serverlessEnvYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load()
+        .then((loadedService) => {
+          expect(loadedService.custom.stage).to.deep.equal('dev');
+          expect(loadedService.custom.region).to.deep.equal('us-east-1');
+        });
+    });
+
     it('should load and populate object variables deep sub properties', () => {
       const SUtils = new Utils();
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());


### PR DESCRIPTION
See this issue: https://github.com/serverless/serverless/issues/1704, the `${stage}` and `${region}` variables were not available in the template parsing, I added the `options` hash to the variable parsing. I added them as first item, so other vars can override, if needed.

Now, you can dynamically create resources, based on the stage etc, eg:

```yml
resources:
  Resources:
    FoobarBucket:
      Type: AWS::S3::Bucket
      Properties:
       BucketName: ${stage}-foobar-bucket
```

Which would result in a `dev-foobar-bucket` and a `production-foobar-bucket`.