### PR TITLE
Global template vars

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -93,6 +93,7 @@ class Service {
         that.plugins = serverlessYml.plugins;
         that.resources = serverlessYml.resources;
         that.functions = serverlessYml.functions;
+        that.runtime = serverlessYml.runtime;
 
         _.forEach(that.functions, (functionObj, index) => {
           if (!functionObj.events) {
@@ -151,6 +152,10 @@ class Service {
           options.region = this.defaults.region;
         }
 
+        // Copy the stage and region for templating
+        this.stage = options.stage;
+        this.region = options.region;
+
         // Validate: Check stage exists
         this.getStage(options.stage);
 
@@ -166,6 +171,7 @@ class Service {
           this.variableSyntax = true;
         }
 
+        const globalVars = this.getGlobalVariables();
         const commonVars = this.getVariables();
         const stageVars = this.getVariables(options.stage);
         const regionVars = this.getVariables(options.stage, options.region);
@@ -201,8 +207,8 @@ class Service {
                * so we gotta clone otherwise we will
                * corrupt the passed-by-reference variables object
                */
-              if (variableName in options) {
-                value = _.cloneDeep(options[variableName]);
+              if (variableName in globalVars) {
+                value = globalVars[variableName];
               }
 
               if (variableName in commonVars) {
@@ -368,6 +374,16 @@ class Service {
       return this.getStage(stageName).vars || {};
     }
     return this.environment.vars || {};
+  }
+
+  getGlobalVariables() {
+    return {
+      service: this.service,
+      stage: this.stage,
+      region: this.region,
+      runtime: this.runtime,
+      provider: this.provider.name,
+    };
   }
 }
 

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -201,6 +201,10 @@ class Service {
                * so we gotta clone otherwise we will
                * corrupt the passed-by-reference variables object
                */
+              if (variableName in options) {
+                value = _.cloneDeep(options[variableName]);
+              }
+
               if (variableName in commonVars) {
                 value = _.cloneDeep(commonVars[variableName]);
               }

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -433,6 +433,51 @@ describe('Service', () => {
         });
     });
 
+    it('should load and populate options for variables', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const serverlessYml = {
+        service: 'service-name',
+        provider: 'aws',
+        custom: {
+          stage: '${stage}',
+          region: '${region}',
+        },
+        functions: {},
+      };
+      const serverlessEnvYml = {
+        vars: {
+          testObject: {
+            subProperty: 'test',
+          },
+        },
+        stages: {
+          dev: {
+            vars: {},
+            regions: {},
+          },
+        },
+      };
+
+      serverlessEnvYml.stages.dev.regions['us-east-1'] = {
+        vars: {},
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.env.yml'),
+        YAML.dump(serverlessEnvYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load()
+        .then((loadedService) => {
+          expect(loadedService.custom.stage).to.deep.equal('dev');
+          expect(loadedService.custom.region).to.deep.equal('us-east-1');
+        });
+    });
+
     it('should load and populate object variables deep sub properties', () => {
       const SUtils = new Utils();
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -439,9 +439,13 @@ describe('Service', () => {
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
+        runtime: 'nodejs4.3',
         custom: {
           stage: '${stage}',
           region: '${region}',
+          service: '${service}',
+          provider: '${provider}',
+          runtime: '${runtime}',
         },
         functions: {},
       };
@@ -453,7 +457,9 @@ describe('Service', () => {
         },
         stages: {
           dev: {
-            vars: {},
+            vars: {
+              service: 'service-name-custom',
+            },
             regions: {},
           },
         },
@@ -475,6 +481,9 @@ describe('Service', () => {
         .then((loadedService) => {
           expect(loadedService.custom.stage).to.deep.equal('dev');
           expect(loadedService.custom.region).to.deep.equal('us-east-1');
+          expect(loadedService.custom.service).to.deep.equal('service-name-custom');
+          expect(loadedService.custom.provider).to.deep.equal('aws');
+          expect(loadedService.custom.runtime).to.deep.equal('nodejs4.3');
         });
     });
 


### PR DESCRIPTION
##### Status:

Ready

##### Description:

Based off @svdgraaf PR for #1706

Makes some config available as global template variables. These can be overridden by setting the same var name in the `serverless.env.yml` file

 * stage
 * service
 * provider
 * region
 * runtime

##### Todos:

- [*] Write tests
