### PR TITLE
Add support to convert shortcut to options for two level deep commands

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -109,23 +109,45 @@ class PluginManager {
   }
 
   convertShortcutsIntoOptions(cliOptions, commands) {
-    forEach(commands, (command, commandKey) => {
-      // TODO: add support for nested commands
-      // check if the command entered is the one in the commands object which holds all commands
-      // this is necessary so that shortcuts are not treated like global citizens but command
-      // bound properties
-      if (includes(this.cliCommands, commandKey)) {
-        forEach(command.options, (optionObject, optionKey) => {
-          if (optionObject.shortcut && includes(Object.keys(cliOptions), optionObject.shortcut)) {
-            Object.keys(cliOptions).forEach((option) => {
-              if (option === optionObject.shortcut) {
-                this.cliOptions[optionKey] = this.cliOptions[option];
+    // TODO: implement an option to get deeper than two levels
+    if (this.cliCommands.length === 1) {
+      forEach(commands, (firstCommand, firstCommandKey) => {
+        // check if the command entered is the one in the commands object which holds all commands
+        // this is necessary so that shortcuts are not treated like global citizens but command
+        // bound properties
+        if (includes(this.cliCommands, firstCommandKey)) {
+          forEach(firstCommand.options, (optionObject, optionKey) => {
+            if (optionObject.shortcut && includes(Object.keys(cliOptions), optionObject.shortcut)) {
+              Object.keys(cliOptions).forEach((option) => {
+                if (option === optionObject.shortcut) {
+                  this.cliOptions[optionKey] = this.cliOptions[option];
+                }
+              });
+            }
+          });
+        }
+      });
+    } else if (this.cliCommands.length === 2) {
+      forEach(commands, (firstCommand) => {
+        forEach(firstCommand.commands, (secondCommand, secondCommandKey) => {
+          // check if the command entered is the one in the commands object which holds all commands
+          // this is necessary so that shortcuts are not treated like global citizens but command
+          // bound properties
+          if (includes(this.cliCommands, secondCommandKey)) {
+            forEach(secondCommand.options, (optionObject, optionKey) => {
+              if (optionObject.shortcut && includes(Object.keys(cliOptions),
+                  optionObject.shortcut)) {
+                Object.keys(cliOptions).forEach((option) => {
+                  if (option === optionObject.shortcut) {
+                    this.cliOptions[optionKey] = this.cliOptions[option];
+                  }
+                });
               }
             });
           }
         });
-      }
-    });
+      });
+    }
   }
 
   addPlugin(Plugin) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -110,11 +110,11 @@ class PluginManager {
 
   convertShortcutsIntoOptions(cliOptions, commands) {
     // TODO: implement an option to get deeper than two levels
+    // check if the command entered is the one in the commands object which holds all commands
+    // this is necessary so that shortcuts are not treated like global citizens but command
+    // bound properties
     if (this.cliCommands.length === 1) {
       forEach(commands, (firstCommand, firstCommandKey) => {
-        // check if the command entered is the one in the commands object which holds all commands
-        // this is necessary so that shortcuts are not treated like global citizens but command
-        // bound properties
         if (includes(this.cliCommands, firstCommandKey)) {
           forEach(firstCommand.options, (optionObject, optionKey) => {
             if (optionObject.shortcut && includes(Object.keys(cliOptions), optionObject.shortcut)) {
@@ -130,9 +130,6 @@ class PluginManager {
     } else if (this.cliCommands.length === 2) {
       forEach(commands, (firstCommand) => {
         forEach(firstCommand.commands, (secondCommand, secondCommandKey) => {
-          // check if the command entered is the one in the commands object which holds all commands
-          // this is necessary so that shortcuts are not treated like global citizens but command
-          // bound properties
           if (includes(this.cliCommands, secondCommandKey)) {
             forEach(secondCommand.options, (optionObject, optionKey) => {
               if (optionObject.shortcut && includes(Object.keys(cliOptions),

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -250,9 +250,9 @@ describe('PluginManager', () => {
   });
 
   describe('#convertShortcutsIntoOptions()', () => {
-    it('should convert shortcuts into options when the command matches', () => {
+    it('should convert shortcuts into options when a one level deep command matches', () => {
       const cliOptionsMock = { r: 'eu-central-1', region: 'us-east-1' };
-      const cliCommandsMock = ['deploy'];
+      const cliCommandsMock = ['deploy']; // command with one level deepness
       const commandsMock = {
         deploy: {
           options: {
@@ -268,6 +268,30 @@ describe('PluginManager', () => {
       pluginManager.convertShortcutsIntoOptions(cliOptionsMock, commandsMock);
 
       expect(pluginManager.cliOptions.region).to.equal(cliOptionsMock.r);
+    });
+
+    it('should convert shortcuts into options when a two level deep command matches', () => {
+      const cliOptionsMock = { f: 'function-1', function: 'function-2' };
+      const cliCommandsMock = ['deploy', 'function']; // command with two level deepness
+      const commandsMock = {
+        deploy: {
+          commands: {
+            function: {
+              options: {
+                function: {
+                  shortcut: 'f',
+                },
+              },
+            },
+          },
+        },
+      };
+      pluginManager.setCliCommands(cliCommandsMock);
+      pluginManager.setCliOptions(cliOptionsMock);
+
+      pluginManager.convertShortcutsIntoOptions(cliOptionsMock, commandsMock);
+
+      expect(pluginManager.cliOptions.function).to.equal(cliOptionsMock.f);
     });
 
     it('should not convert shortcuts into options when the command does not match', () => {


### PR DESCRIPTION
Corresponding issue: https://github.com/serverless/serverless/issues/1695

This PR adds a quick fix to support two level deep shortcut to option conversion (so that you can enter `serverless deploy function -f hello`).

Moving forward we may refactor the PluginManager code to support more infinitely nested commands via recursions (but this should be an extra issue IMHO --> See https://github.com/serverless/serverless/issues/1716).

/cc @eahefnawy @flomotlik 