### PR TITLE
added docs for default function config properties

### DIFF
--- a/docs/understanding-serverless/serverless-yml.md
+++ b/docs/understanding-serverless/serverless-yml.md
@@ -36,6 +36,8 @@ functions:
     # Deployed Lambda name with a prefix
     name: ${prefix}-lambdaName # You have to provide that variable in serverless.env.yml
     handler: handler.hello
+    memorySize: 512 # optional, default is 1024
+    timeout: 10 # optional, default is 6
     events:
       - s3: bucketName
       - schedule: rate(10 minutes)


### PR DESCRIPTION
Added `memorySize` and `timeout` property to function configuration docs so that user knows how to overwrite the defaults. Resolves issue #1534.