### PR TITLE
Fix to make invoke and log plugins aware of custom function name

### DIFF
--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -28,7 +28,9 @@ class AwsInvoke {
     this.validate();
 
     // validate function exists in service
-    this.serverless.service.getFunction(this.options.function);
+    const functionObj = this.serverless.service.getFunction(this.options.function);
+    this.options.lambdaName = functionObj.name || `${this.serverless.service.service}-${
+        this.options.stage}-${this.options.function}`;
 
     if (this.options.path) {
       if (!this.serverless.utils
@@ -52,8 +54,7 @@ class AwsInvoke {
     }
 
     const params = {
-      FunctionName: `${this.serverless.service.service}-${
-        this.options.stage}-${this.options.function}`,
+      FunctionName: this.options.lambdaName,
       InvocationType: invocationType,
       LogType: this.options.log,
       Payload: new Buffer(JSON.stringify(this.options.data || {})),

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -66,6 +66,15 @@ describe('AwsInvoke', () => {
       };
     });
 
+    it('should set custom function name if provided in config', () => {
+      serverless.service.functions.first.name = 'custom-name';
+
+      return awsInvoke.extendedValidate().then(() => {
+        expect(awsInvoke.options.lambdaName).to.equal('custom-name');
+        delete serverless.service.functions.first.name;
+      });
+    });
+
     it('it should throw error if function is not provided', () => {
       serverless.service.functions = null;
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);
@@ -113,6 +122,7 @@ describe('AwsInvoke', () => {
       awsInvoke.options = {
         stage: 'dev',
         function: 'first',
+        lambdaName: 'new-service-dev-first',
       };
     });
 

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -28,14 +28,13 @@ class AwsLogs {
   extendedValidate() {
     this.validate();
 
-    // validate function exists in service
-    this.serverless.service.getFunction(this.options.function);
+    const functionObj = this.serverless.service.getFunction(this.options.function);
+    const lambdaName = functionObj.name || `${this.serverless.service.service}-${
+        this.options.stage}-${this.options.function}`;
 
     this.options.interval = this.options.interval || 1000;
-    this.options.logGroupName = `/aws/lambda/${this.serverless.service
-      .service}-${this.options
-      .stage}-${this.options
-      .function}`;
+
+    this.options.logGroupName = `/aws/lambda/${lambdaName}`;
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -76,6 +76,14 @@ describe('AwsLogs', () => {
       expect(awsLogs.options.interval).to.be.equal(1000);
       expect(awsLogs.options.logGroupName).to.deep.equal('/aws/lambda/null-dev-first');
     }));
+
+    it('it should set custom function name if provided in config', () => {
+      serverless.service.functions.first.name = 'custom-name';
+      return awsLogs.extendedValidate().then(() => {
+        expect(awsLogs.options.logGroupName).to.equal('/aws/lambda/custom-name');
+        delete serverless.service.functions.first.name;
+      });
+    });
   });
 
   describe('#getLogStreams()', () => {


### PR DESCRIPTION
This fixes `invoke` and `log` plugins to be aware of custom function name. Resolves issue #1697.

cc/ @flomotlik @pmuens 