### PR TITLE
Added custom IAM role statements

### DIFF
--- a/docs/guide/custom-provider-resources.md
+++ b/docs/guide/custom-provider-resources.md
@@ -126,14 +126,10 @@ service: new-service
 provider:
   name: aws
   iamRoleStatements:
-    - "Effect": "Allow",
-       "Action": 
-          - "something:SomethingElse"
-       "Resource": "arn:aws:logs:xxx:*:*"
-    - "Effect": "Allow",
-       "Action": 
-          - "different:VeryDifferent"
-       "Resource": "arn:aws:logs:xxx:*:*"
+      -  Effect: "Allow"
+         Action:
+           - "s3:ListBucket"
+         Resource: "arn:aws:s3:::someBucket/*"
 ```
 
 On deployment, all these statements will be added to the IAM role that is assumed by your lambda functions.

--- a/docs/guide/custom-provider-resources.md
+++ b/docs/guide/custom-provider-resources.md
@@ -117,7 +117,7 @@ The corresponding resources which are defined inside the `cloudformation-resourc
 into the `Resources` section.
 
 ## Adding custom IAM role statements
-If you want to give permission to your functions to access certain resources on your AWS account, you can add custom IAM role statements to your service by adding the statements in the `iamRoleStatements` array in the `provider` object. As those statements will be merged into the CloudFormation template you can use Join, Ref or any other CloudFormation method or feature. Here's an example:
+If you want to give permission to your functions to access certain resources on your AWS account, you can add custom IAM role statements to your service by adding the statements in the `iamRoleStatements` array in the `provider` object. As those statements will be merged into the CloudFormation template you can use Join, Ref or any other CloudFormation method or feature. You're also able to either use YAML for defining the statement (including the methods) or use embedded JSON if you prefer it. Here's an example that uses all of the above:
 
 ```yml
 # serverless.yml
@@ -130,6 +130,14 @@ provider:
          Action:
            - "s3:ListBucket"
          Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket"} ] ] }
+      -  Effect: "Allow"
+         Action:
+           - "s3:PutObject"
+         Resource:
+           Fn::Join:
+             - ""
+             - - "arn:aws:s3:::"
+               - "Ref" : "ServerlessDeploymentBucket"
 ```
 
 On deployment, all these statements will be added to the IAM role that is assumed by your lambda functions.

--- a/docs/guide/custom-provider-resources.md
+++ b/docs/guide/custom-provider-resources.md
@@ -117,7 +117,7 @@ The corresponding resources which are defined inside the `cloudformation-resourc
 into the `Resources` section.
 
 ## Adding custom IAM role statements
-If you want to give permission to your functions to access certain resources on your AWS account, you can add custom IAM role statements to your service by adding the statements in the `iamRoleStatements` array in the `provider` object. Here's an example: 
+If you want to give permission to your functions to access certain resources on your AWS account, you can add custom IAM role statements to your service by adding the statements in the `iamRoleStatements` array in the `provider` object. As those statements will be merged into the CloudFormation template you can use Join, Ref or any other CloudFormation method or feature. Here's an example:
 
 ```yml
 # serverless.yml
@@ -129,7 +129,7 @@ provider:
       -  Effect: "Allow"
          Action:
            - "s3:ListBucket"
-         Resource: "arn:aws:s3:::someBucket/*"
+         Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket"} ] ] }
 ```
 
 On deployment, all these statements will be added to the IAM role that is assumed by your lambda functions.

--- a/docs/guide/custom-provider-resources.md
+++ b/docs/guide/custom-provider-resources.md
@@ -116,6 +116,28 @@ resources:
 The corresponding resources which are defined inside the `cloudformation-resources.json` file will be resolved and loaded
 into the `Resources` section.
 
+## Adding custom IAM role statements
+If you want to give permission to your functions to access certain resources on your AWS account, you can add custom IAM role statements to your service by adding the statements in the `iamRoleStatements` array in the `provider` object. Here's an example: 
+
+```yml
+# serverless.yml
+
+service: new-service
+provider:
+  name: aws
+  iamRoleStatements:
+    - "Effect": "Allow",
+       "Action": 
+          - "something:SomethingElse"
+       "Resource": "arn:aws:logs:xxx:*:*"
+    - "Effect": "Allow",
+       "Action": 
+          - "different:VeryDifferent"
+       "Resource": "arn:aws:logs:xxx:*:*"
+```
+
+On deployment, all these statements will be added to the IAM role that is assumed by your lambda functions.
+
 ## How custom provider resources are added
 
 On deployment Serverless will load the base stack template and merge the custom resources you've defined in the `resources`

--- a/lib/plugins/aws/deploy/lib/core-cf.json
+++ b/lib/plugins/aws/deploy/lib/core-cf.json
@@ -30,7 +30,7 @@
     "IamPolicyLambda": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
-        "PolicyName": "${stage}-${project}-lambda",
+        "PolicyName": "",
         "PolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -41,7 +41,7 @@
                 "logs:CreateLogStream",
                 "logs:PutLogEvents"
               ],
-              "Resource": "arn:aws:logs:${region}:*:*"
+              "Resource": ""
             }
           ]
         },

--- a/lib/plugins/aws/deploy/lib/initializeResources.js
+++ b/lib/plugins/aws/deploy/lib/initializeResources.js
@@ -30,6 +30,22 @@ module.exports = {
       .Statement[0]
       .Resource = `arn:aws:logs:${this.options.region}:*:*`;
 
+    // add custom iam role statements
+    if (this.serverless.service.provider.iamRoleStatements &&
+      this.serverless.service.provider.iamRoleStatements instanceof Array) {
+      coreCFTemplate
+        .Resources
+        .IamPolicyLambda
+        .Properties
+        .PolicyDocument
+        .Statement = coreCFTemplate
+        .Resources
+        .IamPolicyLambda
+        .Properties
+        .PolicyDocument
+        .Statement.concat(this.serverless.service.provider.iamRoleStatements);
+    }
+
     // check if the user has added some "custom Resources" (and merge them into coreCFTemplate)
     if (this.serverless.service.resources && this.serverless.service.resources.Resources) {
       forEach(this.serverless.service.resources.Resources, (value, key) => {

--- a/lib/plugins/aws/deploy/tests/initializeResources.js
+++ b/lib/plugins/aws/deploy/tests/initializeResources.js
@@ -33,4 +33,26 @@ describe('#initializeResources()', () => {
     expect(Object.keys(awsDeploy.serverless.service.resources
       .Resources).length).to.be.equal(4);
   });
+
+  it('should add custom IAM policy statements', () => {
+    awsDeploy.serverless.service.service = 'first-service';
+
+    awsDeploy.serverless.service.provider = {
+      name: 'aws',
+      iamRoleStatements: [
+        {
+          Effect: 'Allow',
+          Action: [
+            'something:SomethingElse',
+          ],
+          Resource: 'some:aws:arn:xxx:*:*',
+        }],
+    };
+
+    awsDeploy.initializeResources();
+
+    expect(awsDeploy.serverless.service.resources.Resources
+      .IamPolicyLambda.Properties.PolicyDocument.Statement[1])
+      .to.deep.equal(awsDeploy.serverless.service.provider.iamRoleStatements[0]);
+  });
 });


### PR DESCRIPTION
Added functionality to add custom IAM role statements to the IAM role assumed by the service functions. Resolves issue #1535.

I also removed outdated `${project}` `${stage}` & `${region}` variable references that are relics from version 0. The strings get replaced anyway in code