### PR TITLE
Add docs for DynamoDB and Kinesis stream setup

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -140,3 +140,15 @@ functions:
           topic_name: aggregate
           display_name: Data aggregation pipeline
 ```
+
+### Kinesis Streams
+
+We [need your feedback](https://github.com/serverless/serverless/issues/1608) for the exact implementation. In the
+meantime you should take a look at the [plugin README](/lib/plugins/aws/deploy/compile/events/kinesis) to see how you
+can easily setup this feature by hand.
+
+### DynamoDB Streams
+
+We [need your feedback](https://github.com/serverless/serverless/issues/1441) for the exact implementation. In the
+meantime you should take a look at the [plugin README](/lib/plugins/aws/deploy/compile/events/dynamodb) to see how you
+can easily setup this feature by hand.

--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -7,6 +7,13 @@ Just open up an [issue](https://github.com/serverless/serverless/issues) if you 
 
 The examples will show you how you can use the different event definitions.
 
+- [S3](#s3)
+- [Schedule](#schedule)
+- [HTTP endpoint](#http-endpoint)
+- [SNS](#sns)
+- [Kinesis Streams](#kinesis-streams)
+- [DynamoDB Streams](#dynamodb-streams)
+
 ## Amazon Web Services (AWS)
 
 ### S3
@@ -143,12 +150,44 @@ functions:
 
 ### Kinesis Streams
 
-We [need your feedback](https://github.com/serverless/serverless/issues/1608) for the exact implementation. In the
-meantime you should take a look at the [plugin README](/lib/plugins/aws/deploy/compile/events/kinesis) to see how you
-can easily setup this feature by hand.
+Currently there's no native support for Kinesis Streams ([we need your feedback](https://github.com/serverless/serverless/issues/1608))
+but you can use custom provider resources to setup the mapping:
+
+```yml
+# serverless.yml
+
+resources
+  Resources:
+    mapping:
+      Type: AWS::Lambda::EventSourceMapping
+      Properties:
+        BatchSize: 10
+        EventSourceArn: "arn:aws:kinesis:<region>:<aws-account-id>:stream/<stream-name>"
+        FunctionName:
+          Fn::GetAtt:
+            - "<function-name>"
+            - "Arn"
+        StartingPosition: "TRIM_HORIZON"
+```
 
 ### DynamoDB Streams
 
-We [need your feedback](https://github.com/serverless/serverless/issues/1441) for the exact implementation. In the
-meantime you should take a look at the [plugin README](/lib/plugins/aws/deploy/compile/events/dynamodb) to see how you
-can easily setup this feature by hand.
+Currently there's no native support for DynamoDB Streams ([we need your feedback](https://github.com/serverless/serverless/issues/1441))
+but you can use custom provider resources to setup the mapping:
+
+```yml
+# serverless.yml
+
+resources
+  Resources:
+    mapping:
+      Type: AWS::Lambda::EventSourceMapping
+      Properties:
+        BatchSize: 10
+        EventSourceArn: "arn:aws:dynamodb:<region>:<aws-account-id>:table/<table-name>/stream/<stream-name>"
+        FunctionName:
+          Fn::GetAtt:
+            - "<function-name>"
+            - "Arn"
+        StartingPosition: "TRIM_HORIZON"
+```

--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -151,7 +151,10 @@ functions:
 ### Kinesis Streams
 
 Currently there's no native support for Kinesis Streams ([we need your feedback](https://github.com/serverless/serverless/issues/1608))
-but you can use custom provider resources to setup the mapping:
+but you can use custom provider resources to setup the mapping.
+
+**Note:** You can also create the stream in the `resources.Resources` section and use `Fn::GetAtt` to reference the `Arn`
+in the mappings `EventSourceArn` definition.
 
 ```yml
 # serverless.yml
@@ -173,7 +176,10 @@ resources
 ### DynamoDB Streams
 
 Currently there's no native support for DynamoDB Streams ([we need your feedback](https://github.com/serverless/serverless/issues/1441))
-but you can use custom provider resources to setup the mapping:
+but you can use custom provider resources to setup the mapping.
+
+**Note:** You can also create the table in the `resources.Resources` section and use `Fn::GetAtt` to reference the `StreamArn`
+in the mappings `EventSourceArn` definition.
 
 ```yml
 # serverless.yml

--- a/docs/using-plugins/core-plugins.md
+++ b/docs/using-plugins/core-plugins.md
@@ -16,6 +16,8 @@ see the corresponding source code.
   - [Compile Scheduled Events](/lib/plugins/aws/deploy/compile/events/schedule)
   - [Compile Api Gateway Events](/lib/plugins/aws/deploy/compile/events/apiGateway)
   - [Compile SNS Events](/lib/plugins/aws/deploy/compile/events/sns)
+  - [Compile DynamoDB Stream Events](/lib/plugins/aws/deploy/compile/events/dynamodb)
+  - [Compile Kinesis Stream Events](/lib/plugins/aws/deploy/compile/events/kinesis)
   - [Deploy](/lib/plugins/aws/deploy)
   - [Invoke](/lib/plugins/aws/invoke)
   - [Remove](/lib/plugins/aws/remove)

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/README.md
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/README.md
@@ -15,6 +15,9 @@ section in your [`serverless.yml`](/docs/understanding-serverless/serverless-yml
 Add the following code to your [`serverless.yml`](/docs/understanding-serverless/serverless-yml.md) file to setup
 DynamoDB Stream support.
 
+**Note:** You can also create the table in the `resources.Resources` section and use `Fn::GetAtt` to reference the `StreamArn`
+in the mappings `EventSourceArn` definition.
+
 ```yml
 # serverless.yml
 

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/README.md
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/README.md
@@ -1,0 +1,33 @@
+# Compile DynamoDB Stream Events
+
+We're currently gathering feedback regarding the exact implementation of this plugin in the following GitHub issue:
+
+[Issue #1441](https://github.com/serverless/serverless/issues/1441)
+
+It would be great if you can chime in on this and give us feedback on your specific use case and how you think the plugin
+should work.
+
+In the meantime you can simply add the code below to the [custom provider resources](/docs/guide/custom-provider-resources.md)
+section in your [`serverless.yml`](/docs/understanding-serverless/serverless-yml.md) file.
+
+## Template code for DynamoDB Stream support
+
+Add the following code to your [`serverless.yml`](/docs/understanding-serverless/serverless-yml.md) file to setup
+DynamoDB Stream support.
+
+```yml
+# serverless.yml
+
+resources
+  Resources:
+    mapping:
+      Type: AWS::Lambda::EventSourceMapping
+      Properties:
+        BatchSize: 10
+        EventSourceArn: "arn:aws:dynamodb:<region>:<aws-account-id>:table/<table-name>/stream/<stream-name>"
+        FunctionName:
+          Fn::GetAtt:
+            - "<function-name>"
+            - "Arn"
+        StartingPosition: "TRIM_HORIZON"
+```

--- a/lib/plugins/aws/deploy/compile/events/kinesis/README.md
+++ b/lib/plugins/aws/deploy/compile/events/kinesis/README.md
@@ -1,0 +1,33 @@
+# Compile Kinesis Stream Events
+
+We're currently gathering feedback regarding the exact implementation of this plugin in the following GitHub issue:
+
+[Issue #1608](https://github.com/serverless/serverless/issues/1608)
+
+It would be great if you can chime in on this and give us feedback on your specific use case and how you think the plugin
+should work.
+
+In the meantime you can simply add the code below to the [custom provider resources](/docs/guide/custom-provider-resources.md)
+section in your [`serverless.yml`](/docs/understanding-serverless/serverless-yml.md) file.
+
+## Template code for Kinesis Stream support
+
+Add the following code to your [`serverless.yml`](/docs/understanding-serverless/serverless-yml.md) file to setup
+Kinesis Stream support.
+
+```yml
+# serverless.yml
+
+resources
+  Resources:
+    mapping:
+      Type: AWS::Lambda::EventSourceMapping
+      Properties:
+        BatchSize: 10
+        EventSourceArn: "arn:aws:kinesis:<region>:<aws-account-id>:stream/<stream-name>"
+        FunctionName:
+          Fn::GetAtt:
+            - "<function-name>"
+            - "Arn"
+        StartingPosition: "TRIM_HORIZON"
+```

--- a/lib/plugins/aws/deploy/compile/events/kinesis/README.md
+++ b/lib/plugins/aws/deploy/compile/events/kinesis/README.md
@@ -15,6 +15,9 @@ section in your [`serverless.yml`](/docs/understanding-serverless/serverless-yml
 Add the following code to your [`serverless.yml`](/docs/understanding-serverless/serverless-yml.md) file to setup
 Kinesis Stream support.
 
+**Note:** You can also create the stream in the `resources.Resources` section and use `Fn::GetAtt` to reference the `Arn`
+in the mappings `EventSourceArn` definition.
+
 ```yml
 # serverless.yml
 


### PR DESCRIPTION
Add "mock plugin directory" (where we can later on easily start the implementation in when we have enough feedback) and docs how to setup stream support for Kinesis and DynamoDB.

Furthermore links to the corresponding GitHub issues are added.

@mthenw can you take a look if the stream syntax is correct? Thanks!

Corresponding issues are:
[DynamoDB](https://github.com/serverless/serverless/issues/1441) and [Kinesis](https://github.com/serverless/serverless/issues/1608)

/cc @eahefnawy @flomotlik 