### PR TITLE
Set default or custom function.name property

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -157,6 +157,7 @@ class Service {
         // Validate: Check region exists in stage
         this.getRegionInStage(options.stage, options.region);
 
+        // setup function.name property
         _.forEach(that.functions, (functionObj, functionName) => {
           if (!functionObj.name) {
             that.functions[functionName].name = `${that.service}-${options.stage}-${functionName}`;

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -157,6 +157,12 @@ class Service {
         // Validate: Check region exists in stage
         this.getRegionInStage(options.stage, options.region);
 
+        _.forEach(that.functions, (functionObj, functionName) => {
+          if (!functionObj.name) {
+            that.functions[functionName].name = `${that.service}-${options.stage}-${functionName}`;
+          }
+        });
+
         let varTemplateSyntax = /\${([\s\S]+?)}/g;
 
         if (this.variableSyntax) {

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -67,8 +67,7 @@ class AwsCompileFunctions {
       }
 
       const Handler = functionObject.handler;
-      const FunctionName = functionObject.name
-        || `${this.serverless.service.service}-${this.options.stage}-${functionLogicalName}`;
+      const FunctionName = functionObject.name;
       const MemorySize = Number(functionObject.memorySize)
         || Number(this.serverless.service.provider.memorySize)
         || 1024;

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -35,6 +35,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
+          name: 'new-service-dev-func',
         },
       };
       const compliedFunction = {
@@ -64,6 +65,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
+          name: 'new-service-dev-func',
           vpc: {
             securityGroupIds: ['xxx'],
             subnetIds: ['xxx'],
@@ -140,6 +142,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
+          name: 'new-service-dev-func',
         },
       };
       const compiledFunction = {
@@ -172,6 +175,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
+          name: 'new-service-dev-func',
         },
       };
       const compiledFunction = {

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -28,7 +28,7 @@ class AwsInvoke {
     this.validate();
 
     // validate function exists in service
-    this.serverless.service.getFunction(this.options.function);
+    this.options.functionObj = this.serverless.service.getFunction(this.options.function);
 
     if (this.options.path) {
       if (!this.serverless.utils
@@ -52,8 +52,7 @@ class AwsInvoke {
     }
 
     const params = {
-      FunctionName: `${this.serverless.service.service}-${
-        this.options.stage}-${this.options.function}`,
+      FunctionName: this.options.functionObj.name,
       InvocationType: invocationType,
       LogType: this.options.log,
       Payload: new Buffer(JSON.stringify(this.options.data || {})),

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -113,6 +113,9 @@ describe('AwsInvoke', () => {
       awsInvoke.options = {
         stage: 'dev',
         function: 'first',
+        functionObj: {
+          name: 'customName',
+        },
       };
     });
 
@@ -120,7 +123,7 @@ describe('AwsInvoke', () => {
       .then(() => {
         expect(invokeStub.calledOnce).to.be.equal(true);
         expect(invokeStub.calledWith(awsInvoke.options.stage, awsInvoke.options.region));
-        expect(invokeStub.args[0][2].FunctionName).to.be.equal('new-service-dev-first');
+        expect(invokeStub.args[0][2].FunctionName).to.be.equal('customName');
         expect(invokeStub.args[0][2].InvocationType).to.be.equal('RequestResponse');
         expect(invokeStub.args[0][2].LogType).to.be.equal('None');
         expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
@@ -134,7 +137,7 @@ describe('AwsInvoke', () => {
       return awsInvoke.invoke().then(() => {
         expect(invokeStub.calledOnce).to.be.equal(true);
         expect(invokeStub.calledWith(awsInvoke.options.stage, awsInvoke.options.region));
-        expect(invokeStub.args[0][2].FunctionName).to.be.equal('new-service-dev-first');
+        expect(invokeStub.args[0][2].FunctionName).to.be.equal('customName');
         expect(invokeStub.args[0][2].InvocationType).to.be.equal('RequestResponse');
         expect(invokeStub.args[0][2].LogType).to.be.equal('Tail');
         expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
@@ -148,7 +151,7 @@ describe('AwsInvoke', () => {
       return awsInvoke.invoke().then(() => {
         expect(invokeStub.calledOnce).to.be.equal(true);
         expect(invokeStub.calledWith(awsInvoke.options.stage, awsInvoke.options.region));
-        expect(invokeStub.args[0][2].FunctionName).to.be.equal('new-service-dev-first');
+        expect(invokeStub.args[0][2].FunctionName).to.be.equal('customName');
         expect(invokeStub.args[0][2].InvocationType).to.be.equal('OtherType');
         expect(invokeStub.args[0][2].LogType).to.be.equal('None');
         expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -29,13 +29,10 @@ class AwsLogs {
     this.validate();
 
     // validate function exists in service
-    this.serverless.service.getFunction(this.options.function);
+    const lambdaName = this.serverless.service.getFunction(this.options.function).name;
 
     this.options.interval = this.options.interval || 1000;
-    this.options.logGroupName = `/aws/lambda/${this.serverless.service
-      .service}-${this.options
-      .stage}-${this.options
-      .function}`;
+    this.options.logGroupName = `/aws/lambda/${lambdaName}`;
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -60,6 +60,7 @@ describe('AwsLogs', () => {
       serverless.service.functions = {
         first: {
           handler: true,
+          name: 'customName',
         },
       };
     });
@@ -74,7 +75,7 @@ describe('AwsLogs', () => {
       expect(awsLogs.options.region).to.deep.equal('us-east-1');
       expect(awsLogs.options.function).to.deep.equal('first');
       expect(awsLogs.options.interval).to.be.equal(1000);
-      expect(awsLogs.options.logGroupName).to.deep.equal('/aws/lambda/null-dev-first');
+      expect(awsLogs.options.logGroupName).to.deep.equal('/aws/lambda/customName');
     }));
   });
 

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -140,9 +140,15 @@ describe('Service', () => {
       serviceInstance = new Service(serverless);
 
       return serviceInstance.load().then((loadedService) => {
+        const expectedFunc = {
+          functionA: {
+            name: 'my-service-dev-functionA',
+            events: [],
+          },
+        };
         expect(loadedService.service).to.be.equal('my-service');
         expect(loadedService.provider).to.deep.equal({ name: 'aws' });
-        expect(loadedService.functions).to.deep.equal({ functionA: { events: [] } });
+        expect(loadedService.functions).to.deep.equal(expectedFunc);
         expect(serviceInstance.environment.stages.dev.regions['us-east-1'].vars)
           .to.deep.equal({});
       });
@@ -181,9 +187,15 @@ describe('Service', () => {
       serviceInstance = new Service(serverless);
 
       return serviceInstance.load().then((loadedService) => {
+        const expectedFunc = {
+          functionA: {
+            name: 'my-service-dev-functionA',
+            events: [],
+          },
+        };
         expect(loadedService.service).to.be.equal('my-service');
         expect(loadedService.provider).to.deep.equal({ name: 'aws' });
-        expect(loadedService.functions).to.deep.equal({ functionA: { events: [] } });
+        expect(loadedService.functions).to.deep.equal(expectedFunc);
         expect(serviceInstance.environment.stages.dev.regions['us-east-1'].vars)
           .to.deep.equal({});
       });
@@ -561,7 +573,7 @@ describe('Service', () => {
       });
     });
 
-    xit('should load custom function names if provided', () => {
+    it('should load custom function names if provided', () => {
       const SUtils = new Utils();
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
       const serverlessYml = {
@@ -632,7 +644,13 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
       return serviceInstance.load().then((loadedService) => {
-        expect(loadedService.functions).to.be.deep.equal({ functionA: { events: [] } });
+        const expectedFunc = {
+          functionA: {
+            name: 'testService-dev-functionA',
+            events: [],
+          },
+        };
+        expect(loadedService.functions).to.be.deep.equal(expectedFunc);
       });
     });
 

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -561,6 +561,44 @@ describe('Service', () => {
       });
     });
 
+    xit('should load custom function names if provided', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
+      const serverlessYml = {
+        service: 'testService',
+        provider: 'aws',
+        functions: {
+          functionA: {
+            name: 'customName',
+          },
+        },
+      };
+      const serverlessEnvYml = {
+        vars: {},
+        stages: {
+          dev: {
+            vars: {},
+            regions: {},
+          },
+        },
+      };
+
+      serverlessEnvYml.stages.dev.regions['us-east-1'] = {
+        vars: {},
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.env.yml'),
+        YAML.dump(serverlessEnvYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+      return serviceInstance.load().then((loadedService) => {
+        expect(loadedService.functions.functionA.name).to.equal('customName');
+      });
+    });
+
     it('should load and add events property if no events provided', () => {
       const SUtils = new Utils();
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());


### PR DESCRIPTION
This PR sets a default `name` property in the function object if it doesn't exist. This includes updating the logs and invoke plugins as they're using the function name. Resolves Issues #1718 & #1697

cc/ @flomotlik @pmuens 