### PR TITLE
Print a . while loading

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -259,6 +259,10 @@ class CLI {
     this.consoleLog('');
   }
 
+  printDot() {
+    process.stdout.write(chalk.yellow('.'));
+  }
+
   log(message) {
     this.consoleLog(`Serverless: ${chalk.yellow(`${message}`)}`);
   }

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -40,6 +40,8 @@ module.exports = {
       let stackStatus = null;
       let stackData = null;
 
+      this.serverless.cli.log('Checking stack creation progress...');
+
       async.whilst(
         () => (stackStatus !== 'CREATE_COMPLETE'),
         (callback) => {
@@ -56,7 +58,7 @@ module.exports = {
                 stackData = data;
                 stackStatus = stackData.Stacks[0].StackStatus;
 
-                this.serverless.cli.log('Checking stack creation progress...');
+                this.serverless.cli.printDot();
 
                 if (!stackStatus || validStatuses.indexOf(stackStatus) === -1) {
                   return reject(new this.serverless.classes
@@ -67,7 +69,11 @@ module.exports = {
               });
           }, frequency || 5000);
         },
-        () => resolve(stackData.Stacks[0]));
+        () => {
+          // empty console.log a prettier output
+          this.serverless.cli.consoleLog('');
+          resolve(stackData.Stacks[0]);
+        });
     });
   },
 

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -70,7 +70,7 @@ module.exports = {
           }, frequency || 5000);
         },
         () => {
-          // empty console.log a prettier output
+          // empty console.log for a prettier output
           this.serverless.cli.consoleLog('');
           resolve(stackData.Stacks[0]);
         });

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -64,7 +64,7 @@ module.exports = {
           }, frequency || 5000);
         },
         () => {
-          // empty console.log a prettier output
+          // empty console.log for a prettier output
           this.serverless.cli.consoleLog('');
           resolve(stackData.Stacks[0]);
         });

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -34,6 +34,8 @@ module.exports = {
       let stackStatus = null;
       let stackData = null;
 
+      this.serverless.cli.log('Checking stack update progress...');
+
       async.whilst(
         () => (stackStatus !== 'UPDATE_COMPLETE'),
         (callback) => {
@@ -50,7 +52,7 @@ module.exports = {
                 stackData = data;
                 stackStatus = stackData.Stacks[0].StackStatus;
 
-                this.serverless.cli.log('Checking stack update progress...');
+                this.serverless.cli.printDot();
 
                 if (!stackStatus || validStatuses.indexOf(stackStatus) === -1) {
                   return reject(new this.serverless.classes
@@ -61,7 +63,11 @@ module.exports = {
               });
           }, frequency || 5000);
         },
-        () => resolve(stackData.Stacks[0]));
+        () => {
+          // empty console.log a prettier output
+          this.serverless.cli.consoleLog('');
+          resolve(stackData.Stacks[0]);
+        });
     });
   },
 

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -79,7 +79,7 @@ module.exports = {
           }, frequency || 5000);
         },
         () => {
-          // empty console.log a prettier output
+          // empty console.log for a prettier output
           this.serverless.cli.consoleLog('');
           resolve(stackSummaries[0]);
         });

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -37,6 +37,8 @@ module.exports = {
       let stackStatus = null;
       let stackSummaries = null;
 
+      this.serverless.cli.log('Checking stack removal progress...');
+
       async.whilst(
         () => (stackStatus !== 'DELETE_COMPLETE'),
         (callback) => {
@@ -65,7 +67,7 @@ module.exports = {
                 );
                 stackStatus = stack.StackStatus;
 
-                this.serverless.cli.log('Checking stack removal progress...');
+                this.serverless.cli.printDot();
 
                 if (!stackStatus || validStatuses.indexOf(stackStatus) === -1) {
                   return reject(new this.serverless.classes
@@ -76,7 +78,11 @@ module.exports = {
               });
           }, frequency || 5000);
         },
-        () => resolve(stackSummaries[0]));
+        () => {
+          // empty console.log a prettier output
+          this.serverless.cli.consoleLog('');
+          resolve(stackSummaries[0]);
+        });
     });
   },
 


### PR DESCRIPTION
Corresponding issue: https://github.com/serverless/serverless/issues/1446

This PR implements a . printing while loading (e.g. checking if the stack is created).
This will reduce the used terminal real estate dramatically.

/cc @eahefnawy @flomotlik 