### PR TITLE
add support for custom outputs as part of the custom resource

### DIFF
--- a/lib/plugins/aws/deploy/README.md
+++ b/lib/plugins/aws/deploy/README.md
@@ -31,3 +31,23 @@ Furthermore it updates the stack with all the Resources which are defined in `se
 The stack status is checked every 5 seconds with the help of the CloudFormation API. It will return a success message if
 the stack status is `CREATE_COMPLETE` or `UPDATE_COMPLETE` (depends if you deploy your service for the first time or
 redeploy it after making some changes).
+
+### Custom outputs
+
+```yml
+resources:
+  Resources:
+    ExampleBucket:
+      Type: AWS::S3::Bucket
+      Outputs:
+        ExampleBucketName:
+          Description: Name of the ExampleBucket
+          Value:
+            Ref: ExampleBucket
+        ExampleBucketEndpoint:
+          Description: Endpoint for the ExampleBucket
+          Value:
+            Fn::GetAtt:
+              - ExampleBucket
+              - DomainName
+```

--- a/lib/plugins/aws/deploy/lib/initializeResources.js
+++ b/lib/plugins/aws/deploy/lib/initializeResources.js
@@ -49,6 +49,18 @@ module.exports = {
     // check if the user has added some "custom Resources" (and merge them into coreCFTemplate)
     if (this.serverless.service.resources && this.serverless.service.resources.Resources) {
       forEach(this.serverless.service.resources.Resources, (value, key) => {
+        // check if the user has added some "custom Outputs"
+        if ('Outputs' in value) {
+          forEach(value.Outputs, (outputValue, outputKey) => {
+            const newOutputsObject = {
+              [outputKey]: outputValue,
+            };
+
+            merge(coreCFTemplate.Outputs, newOutputsObject);
+          });
+          delete value.Outputs; // eslint-disable-line no-param-reassign
+        }
+
         const newResourceObject = {
           [key]: value,
         };

--- a/lib/plugins/aws/deploy/tests/initializeResources.js
+++ b/lib/plugins/aws/deploy/tests/initializeResources.js
@@ -22,8 +22,8 @@ describe('#initializeResources()', () => {
 
     awsDeploy.serverless.service.resources = {
       Resources: {
-        fakeResource: {
-          fakeProp: 'fakeValue',
+        FakeResource: {
+          FakeProp: 'FakeValue',
         },
       },
     };
@@ -32,6 +32,48 @@ describe('#initializeResources()', () => {
 
     expect(Object.keys(awsDeploy.serverless.service.resources
       .Resources).length).to.be.equal(4);
+    expect(Object.keys(awsDeploy.serverless.service.resources
+      .Outputs).length).to.be.equal(1);
+    expect(awsDeploy.serverless.service.resources
+      .Resources.FakeResource.FakeProp).to.equal('FakeValue');
+  });
+
+  it('should add core resources and merge custom resources with outputs', () => {
+    awsDeploy.serverless.service.service = 'first-service';
+
+    awsDeploy.serverless.service.resources = {
+      Resources: {
+        FakeResource: {
+          Type: 'AWS::S3::Bucket',
+          Outputs: {
+            ExampleBucketName: {
+              Description: 'Name of ExampleBucket',
+              Value: {
+                Ref: 'ExampleBucket',
+              },
+            },
+            ExampleBucketEndpoint: {
+              Description: 'Endpoint for ExampleBucket',
+              Value: {
+                'Fn::GetAtt': [
+                  'ExampleBucket',
+                  'DomainName',
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    awsDeploy.initializeResources();
+
+    expect(Object.keys(awsDeploy.serverless.service.resources
+      .Outputs).length).to.be.equal(3);
+    expect(awsDeploy.serverless.service.resources.Outputs.ExampleBucketName)
+    .to.deep.equal(awsDeploy.serverless.service.resources.Outputs.ExampleBucketName);
+    expect(awsDeploy.serverless.service.resources.Outputs.ExampleBucketEndpoint)
+    .to.deep.equal(awsDeploy.serverless.service.resources.Outputs.ExampleBucketEndpoint);
   });
 
   it('should add custom IAM policy statements', () => {


### PR DESCRIPTION
##### Status:

Ready

##### Description:

Essential for variable support in the future #1707.

##### Todos:

- [x] Write tests
