### PR TITLE
Move variableSyntax into defaults and update docs

### DIFF
--- a/docs/understanding-serverless/serverless-yml.md
+++ b/docs/understanding-serverless/serverless-yml.md
@@ -19,6 +19,7 @@ plugins:
 defaults: # overwrite defaults
   stage: dev
   region: us-east-1
+  variableSyntax: '\${{([\s\S]+?)}}' # change variable syntax to ${{foo}}
 
 package:
   # only the following paths will be included in the resulting artifact which will be uploaded. Without specific include everything in the current folder will be included

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -18,8 +18,8 @@ class Service {
     this.defaults = {
       stage: 'dev',
       region: 'us-east-1',
+      variableSyntax: null,
     };
-    this.variableSyntax = null;
     this.custom = {};
     this.plugins = [];
     this.functions = {};
@@ -88,7 +88,6 @@ class Service {
 
         that.service = serverlessYml.service;
         that.provider = serverlessYml.provider;
-        that.variableSyntax = serverlessYml.variableSyntax;
         that.custom = serverlessYml.custom;
         that.plugins = serverlessYml.plugins;
         that.resources = serverlessYml.resources;
@@ -115,6 +114,9 @@ class Service {
         }
         if (serverlessYml.defaults && serverlessYml.defaults.region) {
           this.defaults.region = serverlessYml.defaults.region;
+        }
+        if (serverlessYml.defaults && serverlessYml.defaults.variableSyntax) {
+          this.defaults.variableSyntax = serverlessYml.defaults.variableSyntax;
         }
       })
       .then(() => that.serverless.yamlParser
@@ -159,11 +161,11 @@ class Service {
 
         let varTemplateSyntax = /\${([\s\S]+?)}/g;
 
-        if (this.variableSyntax) {
-          varTemplateSyntax = RegExp(this.variableSyntax, 'g');
+        if (this.defaults && this.defaults.variableSyntax) {
+          varTemplateSyntax = RegExp(this.defaults.variableSyntax, 'g');
 
           // temporally remove variable syntax from service otherwise it'll match
-          this.variableSyntax = true;
+          this.defaults.variableSyntax = true;
         }
 
         const commonVars = this.getVariables();
@@ -303,7 +305,9 @@ class Service {
         this.environment = environment;
 
         // put back variable syntax if we removed it for processing
-        if (this.variableSyntax) this.variableSyntax = varTemplateSyntax;
+        if (this.defaults && this.defaults.variableSyntax) {
+          this.defaults.variableSyntax = varTemplateSyntax;
+        }
 
         return this;
       });

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -22,7 +22,11 @@ describe('Service', () => {
 
       expect(serviceInstance.service).to.be.equal(null);
       expect(serviceInstance.provider).to.deep.equal({});
-      expect(serviceInstance.variableSyntax).to.be.equal(null);
+      expect(serviceInstance.defaults).to.deep.equal({
+        stage: 'dev',
+        region: 'us-east-1',
+        variableSyntax: null,
+      });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);
       expect(serviceInstance.functions).to.deep.equal({});
@@ -527,7 +531,9 @@ describe('Service', () => {
       const tmpDirPath = path.join(os.tmpdir(), (new Date).getTime().toString());
       const serverlessYml = {
         service: '${{testVar}}',
-        variableSyntax: '\\${{([\\s\\S]+?)}}',
+        defaults: {
+          variableSyntax: '\\${{([\\s\\S]+?)}}',
+        },
         provider: 'aws',
         functions: {},
       };
@@ -557,7 +563,7 @@ describe('Service', () => {
 
       return serviceInstance.load().then((loadedService) => {
         expect(loadedService.service).to.be.equal('commonVar');
-        delete serviceInstance.variableSyntax;
+        delete serviceInstance.defaults.variableSyntax;
       });
     });
 


### PR DESCRIPTION
PR for issue #1728

##### Status:
Ready

##### Description:
Moves `variableVariable` syntax to the `defaults` object in `serverless.yaml`. Add the `variableSyntax` property to  `docs/understanding-serverless/serverless-yml.md` with a brief explanation explanation.

I was a little unsure about what to add in the docs. I've kept it minimal but if more explanation is required let me know.

##### Todos:
 - [x] Move variableSyntax property into defaults object
 - [x]  Add docs for variableSyntax

