### PR TITLE
Added topic_arn config to SNS events

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -141,6 +141,8 @@ functions:
       - sns: topic:arn:xxx
 ```
 
+Just make sure your topic is already subscribed to the function, as there's no way to add subscriptions to pre-existing topics in CF. The framework will just give permission to SNS to invoke the function.
+
 #### Extended event definition
 
 This event definition ensures that the `aggregator` function get's called every time a message is sent to the

--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -131,6 +131,15 @@ functions:
     events:
       - sns: dispatch
 ```
+Or if you have a pre-existing topic ARN, you can just provide the topic ARN instead:
+
+```yml
+functions:
+  dispatcher:
+    handler: dispatcher.dispatch
+    events:
+      - sns: topic:arn:xxx
+```
 
 #### Extended event definition
 

--- a/lib/plugins/aws/deploy/compile/events/sns/README.md
+++ b/lib/plugins/aws/deploy/compile/events/sns/README.md
@@ -78,4 +78,4 @@ functions:
       - sns: some:arn:xxx
 ```
 
-This framework will detect that you've provided an ARN and will hook this function to the topic arn you provided.
+The framework will detect that you've provided an ARN and will give permission to SNS to invoke that function. **You need to make sure you subscribe your function to that pre-existing topic manually**, as there's no way to add subscriptions to an existing topic ARN via CloudFormation.

--- a/lib/plugins/aws/deploy/compile/events/sns/README.md
+++ b/lib/plugins/aws/deploy/compile/events/sns/README.md
@@ -53,3 +53,29 @@ functions:
           topic_name: lambda-caller
           display_name: Used to chain lambda functions
 ```
+
+### SNS setup with pre-existing topic ARN
+If you already have a topic that you've created manually, you can simply just provide the topic arn instead of the topic name using the `topic_arn` property. Here's an example:
+
+```yml
+# serverless.yml
+functions:
+  run:
+    handler: event.run
+    events:
+      - sns:
+          topic_arn: some:arn:xxx
+```
+
+Or as a shortcut you can provide it as a string value to the `sns` key:
+
+```yml
+# serverless.yml
+functions:
+  run:
+    handler: event.run
+    events:
+      - sns: some:arn:xxx
+```
+
+This framework will detect that you've provided an ARN and will hook this function to the topic arn you provided.

--- a/lib/plugins/aws/deploy/compile/events/sns/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/index.js
@@ -27,9 +27,12 @@ class AwsCompileSNSEvents {
           if (event.sns) {
             let topicName;
             let displayName = '';
+            let topicArn;
 
             if (typeof event.sns === 'object') {
-              if (!event.sns.topic_name || !event.sns.display_name) {
+              if (event.sns.topic_arn) {
+                topicArn = event.sns.topic_arn;
+              } else if (!event.sns.topic_name || !event.sns.display_name) {
                 const errorMessage = [
                   `Missing "topic_name" property for sns event in function ${functionName}`,
                   ' The correct syntax is: sns: topic-name',
@@ -38,11 +41,16 @@ class AwsCompileSNSEvents {
                 ].join('');
                 throw new this.serverless.classes
                   .Error(errorMessage);
+              } else {
+                topicName = event.sns.topic_name;
+                displayName = event.sns.display_name;
               }
-              topicName = event.sns.topic_name;
-              displayName = event.sns.display_name;
             } else if (typeof event.sns === 'string') {
-              topicName = event.sns;
+              if (event.sns.indexOf(':') === -1) {
+                topicName = event.sns;
+              } else {
+                topicArn = event.sns;
+              }
             } else {
               const errorMessage = [
                 `SNS event of function ${functionName} is not an object nor a string`,
@@ -90,8 +98,16 @@ class AwsCompileSNSEvents {
               [`${functionName}SNSEventPermission${i}`]: JSON.parse(permissionTemplate),
             };
 
-            _.merge(this.serverless.service.resources.Resources,
-              newSNSObject, newPermissionObject);
+            // create new topic if no topic arn provided
+            if (!topicArn) {
+              _.merge(this.serverless.service.resources.Resources,
+                newSNSObject);
+            } else {
+              newPermissionObject[`${functionName}SNSEventPermission${i}`]
+                .Properties.SourceArn = topicArn;
+            }
+
+            _.merge(this.serverless.service.resources.Resources, newPermissionObject);
           }
         }
       }

--- a/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
@@ -58,6 +58,38 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should only create permission resource when topic_arn is given', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topic_arn: 'some:arn:xxx',
+              },
+            },
+            {
+              sns: 'some:other:arn:xxx',
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(typeof awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEvent0
+      ).to.equal('undefined');
+      expect(typeof awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEvent1
+      ).to.equal('undefined');
+      expect(awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEventPermission0.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEventPermission1.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
     it('should throw an error when the event an object and the display_name is not given', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
Added functionality for SNS events to accept a `topic_arn` configuration, which enables the function to hook to a pre-existing SNS topic. Resolves Issue #1607

cc/ @flomotlik @pmuens 