### PR TITLE
Remove unnecessary checks in API Gateway validate method

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -10,17 +10,6 @@ module.exports = {
         'This plugin needs access to Resources section of the AWS CloudFormation template');
     }
 
-    this.options.stage = this.options.stage
-      || (this.serverless.service.defaults && this.serverless.service.defaults.stage)
-      || 'dev';
-    this.options.region = this.options.region
-      || (this.serverless.service.defaults && this.serverless.service.defaults.region)
-      || 'us-east-1';
-
-    // validate stage / region exists in service
-    this.serverless.service.getStage(this.options.stage);
-    this.serverless.service.getRegionInStage(this.options.stage, this.options.region);
-
     // validate that path and method exists for each http event in service
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       functionObject.events.forEach(event => {


### PR DESCRIPTION
This checks are already done in the main `awsDeploy` plugin which uses the `compileAPIGEvents` plugin.

Issue: https://github.com/serverless/serverless/issues/1774