### PR TITLE
Refactor functionName retrieval for deployFunction plugin

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -15,9 +15,6 @@ class AwsDeployFunction {
     this.provider = 'aws';
     this.sdk = new SDK(serverless);
 
-    this.functionName =
-      `${this.serverless.service.service}-${this.options.stage}-${this.options.function}`;
-
     this.pkg = new Package(this.serverless, this.options);
 
     Object.assign(this, validate);
@@ -34,11 +31,11 @@ class AwsDeployFunction {
 
   checkIfFunctionExists() {
     // check if the function exists in the service
-    this.serverless.service.getFunction(this.options.function);
+    this.options.functionObj = this.serverless.service.getFunction(this.options.function);
 
     // check if function exists on AWS
     const params = {
-      FunctionName: this.functionName,
+      FunctionName: this.options.functionObj.name,
     };
 
     this.sdk.request(
@@ -68,7 +65,7 @@ class AwsDeployFunction {
     const data = fs.readFileSync(this.serverless.service.package.artifact);
 
     const params = {
-      FunctionName: this.functionName,
+      FunctionName: this.options.functionObj.name,
       ZipFile: data,
     };
 

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -39,6 +39,9 @@ describe('AwsDeployFunction', () => {
       stage: 'dev',
       region: 'us-east-1',
       function: 'first',
+      functionObj: {
+        name: 'first',
+      },
     };
     serverless.init();
     awsDeployFunction = new AwsDeployFunction(serverless, options);
@@ -87,9 +90,9 @@ describe('AwsDeployFunction', () => {
       const getFunctionStub = sinon
         .stub(awsDeployFunction.sdk, 'request').returns(BbPromise.resolve());
 
-      awsDeployFunction.functionName = 'first';
       awsDeployFunction.serverless.service.functions = {
         first: {
+          name: 'first',
           handler: 'handler.first',
         },
       };
@@ -134,8 +137,6 @@ describe('AwsDeployFunction', () => {
 
       const updateFunctionCodeStub = sinon
         .stub(awsDeployFunction.sdk, 'request').returns(BbPromise.resolve());
-
-      awsDeployFunction.functionName = 'first';
 
       return awsDeployFunction.deployFunction().then(() => {
         const data = fs.readFileSync(artifactFilePath);


### PR DESCRIPTION
The `functionName` is now determined by the function object instead of creating it with the stage and region parameters.

Issue: https://github.com/serverless/serverless/issues/1773