### PR TITLE
Refactor YAML convention for SNS event definitions

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -155,8 +155,8 @@ functions:
     handler: aggregator.handler
     events:
       - sns:
-          topic_name: aggregate
-          display_name: Data aggregation pipeline
+          topicName: aggregate
+          displayName: Data aggregation pipeline
 ```
 
 ### Kinesis Streams

--- a/lib/plugins/aws/deploy/compile/events/sns/README.md
+++ b/lib/plugins/aws/deploy/compile/events/sns/README.md
@@ -50,12 +50,12 @@ functions:
     handler: event.run
     events:
       - sns:
-          topic_name: lambda-caller
-          display_name: Used to chain lambda functions
+          topicName: lambda-caller
+          displayName: Used to chain lambda functions
 ```
 
 ### SNS setup with pre-existing topic ARN
-If you already have a topic that you've created manually, you can simply just provide the topic arn instead of the topic name using the `topic_arn` property. Here's an example:
+If you already have a topic that you've created manually, you can simply just provide the topic arn instead of the topic name using the `topicArn` property. Here's an example:
 
 ```yml
 # serverless.yml
@@ -64,7 +64,7 @@ functions:
     handler: event.run
     events:
       - sns:
-          topic_arn: some:arn:xxx
+          topicArn: some:arn:xxx
 ```
 
 Or as a shortcut you can provide it as a string value to the `sns` key:

--- a/lib/plugins/aws/deploy/compile/events/sns/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/index.js
@@ -30,20 +30,20 @@ class AwsCompileSNSEvents {
             let topicArn;
 
             if (typeof event.sns === 'object') {
-              if (event.sns.topic_arn) {
-                topicArn = event.sns.topic_arn;
-              } else if (!event.sns.topic_name || !event.sns.display_name) {
+              if (event.sns.topicArn) {
+                topicArn = event.sns.topicArn;
+              } else if (!event.sns.topicName || !event.sns.displayName) {
                 const errorMessage = [
-                  `Missing "topic_name" property for sns event in function ${functionName}`,
+                  `Missing "topicName" property for sns event in function ${functionName}`,
                   ' The correct syntax is: sns: topic-name',
-                  ' OR an object with "topic_name" AND "display_name" properties.',
+                  ' OR an object with "topicName" AND "displayName" properties.',
                   ' Please check the docs for more info.',
                 ].join('');
                 throw new this.serverless.classes
                   .Error(errorMessage);
               } else {
-                topicName = event.sns.topic_name;
-                displayName = event.sns.display_name;
+                topicName = event.sns.topicName;
+                displayName = event.sns.displayName;
               }
             } else if (typeof event.sns === 'string') {
               if (event.sns.indexOf(':') === -1) {
@@ -55,7 +55,7 @@ class AwsCompileSNSEvents {
               const errorMessage = [
                 `SNS event of function ${functionName} is not an object nor a string`,
                 ' The correct syntax is: sns: topic-name',
-                ' OR an object with "topic_name" AND "display_name" properties.',
+                ' OR an object with "topicName" AND "displayName" properties.',
                 ' Please check the docs for more info.',
               ].join('');
               throw new this.serverless.classes

--- a/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
@@ -45,8 +45,8 @@ describe('AwsCompileSNSEvents', () => {
           events: [
             {
               sns: {
-                topic_name: 'Topic 1',
-                display_name: 'Display name for topic 1',
+                topicName: 'Topic 1',
+                displayName: 'Display name for topic 1',
               },
             },
             {
@@ -72,13 +72,13 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should only create permission resource when topic_arn is given', () => {
+    it('should only create permission resource when topicArn is given', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
             {
               sns: {
-                topic_arn: 'some:arn:xxx',
+                topicArn: 'some:arn:xxx',
               },
             },
             {
@@ -104,13 +104,13 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should throw an error when the event an object and the display_name is not given', () => {
+    it('should throw an error when the event an object and the displayName is not given', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
             {
               sns: {
-                display_name: 'Display name for topic 1',
+                displayName: 'Display name for topic 1',
               },
             },
           ],


### PR DESCRIPTION
A simple refactor to update the naming for the event definition so that camelCase is used (as described in #1804).