### PR TITLE
Added friendly error for missing AWS credentials

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -12,6 +12,8 @@ module.exports.SError = class ServerlessError extends Error {
 
 module.exports.logError = (e) => {
   try {
+    const words = e.message.split(' ');
+
     const consoleLog = (message) => {
       console.log(message); // eslint-disable-line no-console
     };
@@ -26,8 +28,7 @@ module.exports.logError = (e) => {
     consoleLog(chalk.yellow(` ${errorType} ${line}`));
     consoleLog(' ');
 
-    // format error message to fit neatly
-    const words = e.message.split(' ');
+
     let logLine = [];
     words.forEach(word => {
       logLine.push(word);

--- a/lib/plugins/aws/index.js
+++ b/lib/plugins/aws/index.js
@@ -59,9 +59,19 @@ class SDK {
       // req.on('send', function (r) {console.log(r)});
 
       return new BbPromise((resolve, reject) => {
-        req.send((err, data) => {
+        req.send((errParam, data) => {
+          const err = errParam;
           if (err) {
-            reject(err);
+            if (err.message === 'Missing credentials in config') {
+              const errorMessage = [
+                '"default" profile was not found in ~/.aws/credentials.',
+                ' Please make sure you add a "default" profile',
+                ' with valid API Key & Secret, or set the API Key & Secret',
+                ' as env vars. For more info, check our docs.',
+              ].join('');
+              err.message = errorMessage;
+            }
+            reject(new this.serverless.classes.Error(err.message));
           } else {
             resolve(data);
           }

--- a/lib/plugins/aws/index.js
+++ b/lib/plugins/aws/index.js
@@ -64,10 +64,9 @@ class SDK {
           if (err) {
             if (err.message === 'Missing credentials in config') {
               const errorMessage = [
-                '"default" profile was not found in ~/.aws/credentials.',
-                ' Please make sure you add a "default" profile',
-                ' with valid API Key & Secret, or set the API Key & Secret',
-                ' as env vars. For more info, check our docs.',
+                'AWS provider credentials not found.',
+                ' You can find more info on how to set up provider',
+                ' credentials in our docs here: https://git.io/v64aN',
               ].join('');
               err.message = errorMessage;
             }


### PR DESCRIPTION
This PR adds a friendly error message for when a `default` profile is not set in the user computer as discussed in Issue #1520.

cc/ @pmuens @flomotlik 