### PR TITLE
Rename lifecycle events of deploy plugin

### DIFF
--- a/docs/developing-plugins/building-provider-integrations.md
+++ b/docs/developing-plugins/building-provider-integrations.md
@@ -19,11 +19,11 @@ Let's take a look at the [core `deploy` plugin](/lib/plugins/deploy) and the dif
 
 The following lifecycle events are run in order once the user types `serverless deploy` and hits enter:
 
-- `deploy:initializeResources`
-- `deploy:createProviderStacks`
+- `deploy:initialize`
+- `deploy:setupProviderConfiguration`
 - `deploy:compileFunctions`
 - `deploy:compileEvents`
-- `deploy:createDeploymentPackage`
+- `deploy:createDeploymentArtifacts`
 - `deploy:deploy`
 
 You, as a plugin developer can hook into those lifecycles to compile and deploy functions and events on your providers
@@ -31,18 +31,18 @@ infrastructure.
 
 Let's take a closer look at each lifecycle event to understand what its purpose is and what it should be used for.
 
-#### `deploy:initializeResources`
+#### `deploy:initialize`
 
 This lifecycle should be used to load the basic resources the provider needs into memory (e.g. parse a basic resource
 template skeleton such as a CloudFormation template).
 
-#### `deploy:createProviderStacks`
+#### `deploy:setupProviderConfiguration`
 
-The purpose of the `deploy:createProviderStacks` lifecycle is to take the basic resource template which was created in
+The purpose of the `deploy:setupProviderConfiguration` lifecycle is to take the basic resource template which was created in
 the previous lifecycle and deploy the rough skeleton on the cloud providers infrastructure (without any functions
 or events) for the first time.
 
-#### `deploy:createDeploymentPackage`
+#### `deploy:createDeploymentArtifacts`
 
 The whole service get's zipped up into one .zip file.
 Serverless will automatically exclude the following files / folders to reduce the size of the .zip file:
@@ -79,13 +79,13 @@ Here are the steps the AWS plugins take to compile and deploy the service on the
 
 1. The [`serverless.yml`](../understanding-serverless/serverless-yml.md) and
 [`serverless.env.yml`](../understanding-serverless/serverless-env-yml.md) files are loaded into memory
-2. A default AWS CloudFormation template is loaded (`deploy:initializeResources`)
-3. The CloudFormation template is deployed to AWS (A S3 bucket for the service gets created) (`deploy:createProviderStacks`)
+2. A default AWS CloudFormation template is loaded (`deploy:initialize`)
+3. The CloudFormation template is deployed to AWS (A S3 bucket for the service gets created) (`deploy:setupProviderConfiguration`)
 4. The functions of the [`serverless.yml`](../understanding-serverless/serverless-yml.md) file are compiled to lambda
 resources and stored into memory (`deploy:compileFunctions`)
 5. Each functions events are compiled into CloudFormation resources and stored into memory (`deploy:compileEvents`)
 6. Old functions (if available) are removed from the S3 bucket (`deploy:deploy`)
-7. The service gets zipped up and is uploaded to S3 (`deploy:createDeploymentPackage` and `deploy:deploy`)
+7. The service gets zipped up and is uploaded to S3 (`deploy:createDeploymentArtifacts` and `deploy:deploy`)
 8. The compiled function and event resources are attached to the core CloudFormation template and the updated
 CloudFormation template gets redeployed (`deploy:deploy`)
 

--- a/lib/plugins/aws/deploy/README.md
+++ b/lib/plugins/aws/deploy/README.md
@@ -4,7 +4,7 @@ This plugin (re)deploys the service to AWS.
 
 ## How it works
 
-`Deploy` starts by hooking into the [`deploy:initializeResources`](/lib/plugins/deploy) lifecycle.
+`Deploy` starts by hooking into the [`deploy:initialize`](/lib/plugins/deploy) lifecycle.
 It fetches the basic CloudFormation template from `lib/templates` and replaces the necessary names and definitions
 with the one it gets from the `serverless.yml` file.
 
@@ -20,7 +20,7 @@ serverless.service.resources.Resources
 Other plugins (e.g. the `Compile Functions` plugin) use this `Resources` property to add the compiled resources by
 merging them in.
 
-Next up it hooks into the [`deploy:createProviderStacks`](/lib/plugins/deploy) lifecycle and deploys the
+Next up it hooks into the [`deploy:setupProviderConfiguration`](/lib/plugins/deploy) lifecycle and deploys the
 previously created CloudFormation template to AWS.
 
 In the end it hooks into [`deploy:deploy`](/lib/plugins/deploy) lifecycle. At first it removes old service .zip files

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -28,12 +28,12 @@ class AwsDeploy {
     );
 
     this.hooks = {
-      'before:deploy:initializeResources': () => BbPromise.bind(this)
+      'before:deploy:initialize': () => BbPromise.bind(this)
           .then(this.validate),
 
-      'deploy:initializeResources': () => BbPromise.bind(this).then(this.initializeResources),
+      'deploy:initialize': () => BbPromise.bind(this).then(this.initializeResources),
 
-      'deploy:createProviderStacks': () => BbPromise.bind(this).then(this.createStack),
+      'deploy:setupProviderConfiguration': () => BbPromise.bind(this).then(this.createStack),
 
       'deploy:deploy': () => BbPromise.bind(this)
         .then(this.uploadDeploymentPackage)

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -21,31 +21,31 @@ describe('AwsDeploy', () => {
     it('should set the provider variable to "aws"', () => expect(awsDeploy.provider)
       .to.equal('aws'));
 
-    it('should run "before:deploy:initializeResources" hook promise chain in order', () => {
+    it('should run "before:deploy:initialize" hook promise chain in order', () => {
       const validateStub = sinon
         .stub(awsDeploy, 'validate').returns(BbPromise.resolve());
 
-      return awsDeploy.hooks['before:deploy:initializeResources']().then(() => {
+      return awsDeploy.hooks['before:deploy:initialize']().then(() => {
         expect(validateStub.calledOnce).to.be.equal(true);
         awsDeploy.validate.restore();
       });
     });
 
-    it('should run "deploy:initializeResources" hook promise chain in order', () => {
+    it('should run "deploy:initialize" hook promise chain in order', () => {
       const initializeResourcesStub = sinon
         .stub(awsDeploy, 'initializeResources').returns(BbPromise.resolve());
 
-      return awsDeploy.hooks['deploy:initializeResources']().then(() => {
+      return awsDeploy.hooks['deploy:initialize']().then(() => {
         expect(initializeResourcesStub.calledOnce).to.be.equal(true);
         awsDeploy.initializeResources.restore();
       });
     });
 
-    it('should run "deploy:createProviderStacks" hook promise chain in order', () => {
+    it('should run "deploy:setupProviderConfiguration" hook promise chain in order', () => {
       const createStackStub = sinon
         .stub(awsDeploy, 'createStack').returns(BbPromise.resolve());
 
-      return awsDeploy.hooks['deploy:createProviderStacks']().then(() => {
+      return awsDeploy.hooks['deploy:setupProviderConfiguration']().then(() => {
         expect(createStackStub.calledOnce).to.be.equal(true);
         awsDeploy.createStack.restore();
       });

--- a/lib/plugins/deploy/README.md
+++ b/lib/plugins/deploy/README.md
@@ -13,9 +13,9 @@ Deploys your service.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 
 ## Provided lifecycle events
-- `deploy:initializeResources`
-- `deploy:createProviderStacks`
-- `deploy:createDeploymentPackage`
+- `deploy:initialize`
+- `deploy:setupProviderConfiguration`
+- `deploy:createDeploymentArtifacts`
 - `deploy:compileFunctions`
 - `deploy:compileEvents`
 - `deploy:deploy`

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -8,9 +8,9 @@ class Deploy {
       deploy: {
         usage: 'Deploy Service.',
         lifecycleEvents: [
-          'initializeResources',
-          'createProviderStacks',
-          'createDeploymentPackage',
+          'initialize',
+          'setupProviderConfiguration',
+          'createDeploymentArtifacts',
           'compileFunctions',
           'compileEvents',
           'deploy',

--- a/lib/plugins/package/README.md
+++ b/lib/plugins/package/README.md
@@ -4,7 +4,7 @@ This plugin creates a deployment package on a per service basis (it will zip up 
 
 ## How it works
 
-`Package` starts by hooking into the [`deploy:createDeploymentPackage`](/lib/plugins/deploy) lifecycle.
+`Package` starts by hooking into the [`deploy:createDeploymentArtifacts`](/lib/plugins/deploy) lifecycle.
 
 It will zip the whole service directory. The artifact will be stored in the `.serverless` directory which will be created
 upon zipping the service. The resulting path to the artifact will be appended to the `service.package.artifact` property.

--- a/lib/plugins/package/index.js
+++ b/lib/plugins/package/index.js
@@ -18,7 +18,7 @@ class Package {
     );
 
     this.hooks = {
-      'deploy:createDeploymentPackage': () => BbPromise.bind(this)
+      'deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.zipService),
 

--- a/lib/plugins/package/tests/index.js
+++ b/lib/plugins/package/tests/index.js
@@ -18,13 +18,13 @@ describe('#constructor()', () => {
 
   it('should have hooks', () => expect(packageService.hooks).to.be.not.empty);
 
-  it('should run promise chain in order for "deploy:createDeploymentPackage" hook', () => {
+  it('should run promise chain in order for "deploy:createDeploymentArtifacts" hook', () => {
     const validateStub = sinon
       .stub(packageService, 'validate').returns(BbPromise.resolve());
     const zipServiceStub = sinon
       .stub(packageService, 'zipService').returns(BbPromise.resolve());
 
-    return packageService.hooks['deploy:createDeploymentPackage']().then(() => {
+    return packageService.hooks['deploy:createDeploymentArtifacts']().then(() => {
       expect(validateStub.calledOnce).to.be.equal(true);
       expect(zipServiceStub.calledAfter(validateStub)).to.be.equal(true);
 


### PR DESCRIPTION
The renaming of the lifecycle events as discussed in https://github.com/serverless/serverless/issues/1577

@flomotlik @eahefnawy a question we have to answer before merging this is whether we want to introduce a deprecation warning here.

My feeling is that we don't have that much external plugins (if any) for now so we might want to skip the deprecation warning for now. What do you think?