### PR TITLE
Fix #1823 - S3 event compile creates an extra bucket with the event configuration

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -39,12 +39,12 @@ class AwsCompileS3Events {
                 throw new this.serverless.classes
                   .Error(errorMessage);
               }
-              BucketName = event.s3.bucket + i;
+              BucketName = event.s3.bucket;
               if (event.s3.event) {
                 Event = event.s3.event;
               }
             } else if (typeof event.s3 === 'string') {
-              BucketName = event.s3 + i;
+              BucketName = event.s3;
             } else {
               const errorMessage = [
                 `S3 event of function ${functionName} is not an object nor a string.`,
@@ -54,24 +54,28 @@ class AwsCompileS3Events {
               throw new this.serverless.classes
                 .Error(errorMessage);
             }
+
+            const notificationTemplate = `
+              "NotificationConfiguration": {
+                "LambdaConfigurations": [
+                  {
+                    "Event": "${Event}",
+                    "Function": {
+                      "Fn::GetAtt": [
+                        "${functionName}",
+                        "Arn"
+                      ]
+                    }
+                  }
+                ]
+              }`;
+
             const bucketTemplate = `
               {
                 "Type": "AWS::S3::Bucket",
                 "Properties": {
                   "BucketName": "${BucketName}",
-                  "NotificationConfiguration": {
-                    "LambdaConfigurations": [
-                      {
-                        "Event": "${Event}",
-                        "Function": {
-                          "Fn::GetAtt": [
-                            "${functionName}",
-                            "Arn"
-                          ]
-                        }
-                      }
-                    ]
-                  }
+                  ${notificationTemplate}
                 }
               }
             `;
@@ -88,22 +92,38 @@ class AwsCompileS3Events {
                   },
                   "Action": "lambda:InvokeFunction",
                   "Principal": "s3.amazonaws.com"
-                } 
+                }
               }
             `;
 
-            const bucketResourceKey = BucketName.replace(/-/g, '');
+            const bucketResourceKey = BucketName.replace(/-/g, '') + i;
 
-            const newBucketObject = {
-              [`${bucketResourceKey}S3Event`]: JSON.parse(bucketTemplate),
-            };
+            // check if bucket already appears in resources
+            // (currently supports only 1 event per bucket)
+            const existingBucket = _.find(this.serverless.service.resources.Resources, {
+              Type: 'AWS::S3::Bucket',
+              Properties: { BucketName },
+            });
 
+            if (existingBucket) {
+              // bucket already exists in the resources, so only add the notification
+              _.merge(existingBucket.Properties, JSON.parse(`{${notificationTemplate}}`));
+            } else {
+              // create the bucket resource object
+              const newBucketObject = {
+                [`${bucketResourceKey}S3Event`]: JSON.parse(bucketTemplate),
+              };
+
+              _.merge(this.serverless.service.resources.Resources, newBucketObject);
+            }
+
+            // add permission object
             const newPermissionObject = {
               [`${bucketResourceKey}S3EventPermission`]: JSON.parse(permissionTemplate),
             };
 
             _.merge(this.serverless.service.resources.Resources,
-              newBucketObject, newPermissionObject);
+              newPermissionObject);
           }
         }
       }

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -57,20 +57,82 @@ describe('AwsCompileS3Events', () => {
       expect(awsCompileS3Events.serverless.service.resources.Resources
         .firstfunctionbuckettwo1S3EventPermission.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbucketone0S3Event.Properties.BucketName
+      ).to.equal('first-function-bucket-one');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbuckettwo1S3Event.Properties.BucketName
+      ).to.equal('first-function-bucket-two');
     });
 
-    it('should not create corresponding resources when S3 events are not given', () => {
-      awsCompileS3Events.serverless.service.functions = {
-        first: {
-          events: [],
-        },
-      };
+    describe('#compileS3Events()', () => {
+      it('should throw an error if the resource section is not available', () => {
+        awsCompileS3Events.serverless.service.resources.Resources = false;
+        expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+      });
 
-      awsCompileS3Events.compileS3Events();
+      it('should create corresponding resources when S3 events & ' +
+         'custom S3 bucket resource are given ', () => {
+        awsCompileS3Events.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                s3: 'first-function-bucket-one',
+              },
+              {
+                s3: {
+                  bucket: 'first-function-bucket-two',
+                  event: 's3:ObjectCreated:Put',
+                },
+              },
+            ],
+          },
+        };
 
-      expect(
-        awsCompileS3Events.serverless.service.resources.Resources
-      ).to.deep.equal({});
+        awsCompileS3Events.serverless.service.resources.Resources = {
+          newResource: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'first-function-bucket-one',
+            },
+          },
+        };
+
+        awsCompileS3Events.compileS3Events();
+
+        expect(awsCompileS3Events.serverless.service.resources.Resources
+          .newResource.Type
+        ).to.equal('AWS::S3::Bucket');
+        expect(awsCompileS3Events.serverless.service.resources.Resources
+          .firstfunctionbuckettwo1S3Event.Type
+        ).to.equal('AWS::S3::Bucket');
+        expect(awsCompileS3Events.serverless.service.resources.Resources
+          .firstfunctionbucketone0S3EventPermission.Type
+        ).to.equal('AWS::Lambda::Permission');
+        expect(awsCompileS3Events.serverless.service.resources.Resources
+          .firstfunctionbuckettwo1S3EventPermission.Type
+        ).to.equal('AWS::Lambda::Permission');
+        expect(awsCompileS3Events.serverless.service.resources.Resources
+          .newResource.Properties.BucketName
+        ).to.equal('first-function-bucket-one');
+        expect(awsCompileS3Events.serverless.service.resources.Resources
+          .firstfunctionbuckettwo1S3Event.Properties.BucketName
+        ).to.equal('first-function-bucket-two');
+      });
+
+      it('should not create corresponding resources when S3 events are not given', () => {
+        awsCompileS3Events.serverless.service.functions = {
+          first: {
+            events: [],
+          },
+        };
+
+        awsCompileS3Events.compileS3Events();
+
+        expect(
+          awsCompileS3Events.serverless.service.resources.Resources
+        ).to.deep.equal({});
+      });
     });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -65,74 +65,67 @@ describe('AwsCompileS3Events', () => {
       ).to.equal('first-function-bucket-two');
     });
 
-    describe('#compileS3Events()', () => {
-      it('should throw an error if the resource section is not available', () => {
-        awsCompileS3Events.serverless.service.resources.Resources = false;
-        expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
-      });
-
-      it('should create corresponding resources when S3 events & ' +
-         'custom S3 bucket resource are given ', () => {
-        awsCompileS3Events.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                s3: 'first-function-bucket-one',
-              },
-              {
-                s3: {
-                  bucket: 'first-function-bucket-two',
-                  event: 's3:ObjectCreated:Put',
-                },
-              },
-            ],
-          },
-        };
-
-        awsCompileS3Events.serverless.service.resources.Resources = {
-          newResource: {
-            Type: 'AWS::S3::Bucket',
-            Properties: {
-              BucketName: 'first-function-bucket-one',
+    it('should create corresponding resources when S3 events & ' +
+       'custom S3 bucket resource are given ', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: 'first-function-bucket-one',
             },
+            {
+              s3: {
+                bucket: 'first-function-bucket-two',
+                event: 's3:ObjectCreated:Put',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileS3Events.serverless.service.resources.Resources = {
+        newResource: {
+          Type: 'AWS::S3::Bucket',
+          Properties: {
+            BucketName: 'first-function-bucket-one',
           },
-        };
+        },
+      };
 
-        awsCompileS3Events.compileS3Events();
+      awsCompileS3Events.compileS3Events();
 
-        expect(awsCompileS3Events.serverless.service.resources.Resources
-          .newResource.Type
-        ).to.equal('AWS::S3::Bucket');
-        expect(awsCompileS3Events.serverless.service.resources.Resources
-          .firstfunctionbuckettwo1S3Event.Type
-        ).to.equal('AWS::S3::Bucket');
-        expect(awsCompileS3Events.serverless.service.resources.Resources
-          .firstfunctionbucketone0S3EventPermission.Type
-        ).to.equal('AWS::Lambda::Permission');
-        expect(awsCompileS3Events.serverless.service.resources.Resources
-          .firstfunctionbuckettwo1S3EventPermission.Type
-        ).to.equal('AWS::Lambda::Permission');
-        expect(awsCompileS3Events.serverless.service.resources.Resources
-          .newResource.Properties.BucketName
-        ).to.equal('first-function-bucket-one');
-        expect(awsCompileS3Events.serverless.service.resources.Resources
-          .firstfunctionbuckettwo1S3Event.Properties.BucketName
-        ).to.equal('first-function-bucket-two');
-      });
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .newResource.Type
+      ).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbuckettwo1S3Event.Type
+      ).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbucketone0S3EventPermission.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbuckettwo1S3EventPermission.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .newResource.Properties.BucketName
+      ).to.equal('first-function-bucket-one');
+      expect(awsCompileS3Events.serverless.service.resources.Resources
+        .firstfunctionbuckettwo1S3Event.Properties.BucketName
+      ).to.equal('first-function-bucket-two');
+    });
 
-      it('should not create corresponding resources when S3 events are not given', () => {
-        awsCompileS3Events.serverless.service.functions = {
-          first: {
-            events: [],
-          },
-        };
+    it('should not create corresponding resources when S3 events are not given', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [],
+        },
+      };
 
-        awsCompileS3Events.compileS3Events();
+      awsCompileS3Events.compileS3Events();
 
-        expect(
-          awsCompileS3Events.serverless.service.resources.Resources
-        ).to.deep.equal({});
-      });
+      expect(
+        awsCompileS3Events.serverless.service.resources.Resources
+      ).to.deep.equal({});
     });
   });
 });


### PR DESCRIPTION
Pull Request Template ------------------------
* Check out our Pull Request Guidelines here: https://github.com/serverless/serverless/blob/v1.0/CONTRIBUTING.md

##### Status:

Ready

##### Description:
Fixing issue #1823:
1. Not creating additional buckets 
2. Verifying whether bucket already exists as a custom resource. In this case, the s3 event (`NotificationConfiguration`) will be added to that bucket.

Notice that even after this PR, we still don't support multiple events per bucket.

##### Todos:

- [x] Write tests
