### PR TITLE
Ensure files uploaded to lambda are world-readable

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -46,7 +46,7 @@ module.exports = {
         include.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
 
       if (!shouldBeExcluded || shouldBeIncluded) {
-        const permissions = fs.statSync(filePath).mode;
+        const permissions = fs.statSync(filePath).mode | 0o444;
         zip.file(relativeFilePath, fs.readFileSync(filePath), { unixPermissions: permissions });
       }
     });


### PR DESCRIPTION
##### Status:

Ready

##### Description:
This fixes Linux issue described in #1835.
Seems like it was once fixed in v0.5 (#975) but the code for setting correct permissions is not present in v1.0 and master.
This is a restore of #975 to the current code base.