### PR TITLE
Fixed platform detection for generating zip

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -51,13 +51,10 @@ module.exports = {
       }
     });
 
-    const platformName = ['UNIX', 'DOS'].indexOf(process.platform) !== -1 ? process.platform :
-      'UNIX';
-
     return zip.generateAsync({
       type: 'nodebuffer',
       compression: 'DEFLATE',
-      platform: platformName,
+      platform: process.platform,
     }).then(data => {
       const artifactFilePath = path.join(servicePath,
         '.serverless', zipFileName);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.0.0-beta.1.1",
+  "version": "1.0.0-beta.2",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -495,23 +495,6 @@
       "version": "1.3.1",
       "from": "file-entry-cache@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz"
-    },
-    "fileset": {
-      "version": "0.2.1",
-      "from": "fileset@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        }
-      }
     },
     "find-up": {
       "version": "1.1.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -853,9 +853,9 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.1.tgz"
     },
     "jszip": {
-      "version": "3.1.1",
-      "from": "jszip@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.1.tgz",
+      "version": "3.1.2",
+      "from": "jszip@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.2.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "https-proxy-agent": "^1.0.0",
     "js-yaml": "^3.6.1",
     "json-refs": "^2.1.5",
-    "jszip": "^3.1.0",
+    "jszip": "^3.1.2",
     "lodash": "^4.13.1",
     "minimist": "^1.2.0",
     "moment": "^2.13.0",


### PR DESCRIPTION
##### Status:

Ready

##### Description:

On Windows, ```process.platform``` equals ```win32```, therefore ```platformName``` was ```UNIX``` instead of ```DOS```.
This leaded into a strange behavior of resulting zip on UNIX platforms.
According to [jszip docs](http://stuk.github.io/jszip/documentation/api_jszip/generate_async.html), ```platform``` option also accepts ```process.platform``` values.
I simplified the code by passing ```process.platform``` directly.
It fixes the deploy bug on Windows described in #1835.