### PR TITLE
fix #1828 - removed lambda function name from Apig resources logica…

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -51,10 +51,8 @@ module.exports = {
       // resource name is the last element in the endpoint. It's not unique.
       const resourceName = path.split('/')[path.split('/').length - 1];
       const resourcePath = path;
-      const resourceIndex = this.resourcePaths.indexOf(resourcePath);
-      const resourceFunction = _.capitalize(this.resourceFunctions[resourceIndex]) +
-        resourcesArray.map(capitalizeAlphaNumericPath).join('');
-      const resourceLogicalId = `ResourceApigEvent${resourceFunction}`;
+      const resourceId = _.capitalize(resourcesArray.map(capitalizeAlphaNumericPath).join(''));
+      const resourceLogicalId = `ResourceApigEvent${resourceId}`;
       this.resourceLogicalIds[resourcePath] = resourceLogicalId;
       resourcesArray.pop();
 
@@ -62,10 +60,7 @@ module.exports = {
       if (resourcesArray.length === 0) {
         resourceParentId = '{ "Fn::GetAtt": ["RestApiApigEvent", "RootResourceId"] }';
       } else {
-        const resourceParentPath = resourcesArray.join('/');
-        const resourceParentIndex = this.resourcePaths.indexOf(resourceParentPath);
-        const resourceParentFunction = _.capitalize(this.resourceFunctions[resourceParentIndex]) +
-          resourcesArray.map(capitalizeAlphaNumericPath).join('');
+        const resourceParentFunction = _.capitalize(resourcesArray.map(capitalizeAlphaNumericPath).join(''));
         resourceParentId = `{ "Ref" : "ResourceApigEvent${resourceParentFunction}" }`;
       }
 


### PR DESCRIPTION
##### Status:

Ready

##### Description:

IMHO lambda function name should not be stored in Apig Logical id because when you change the lambda function name the logical id becomes inconsistent , like renaming function from `Hellothere` to `Hellothere2` -> `ResourceApigEventHellothereUserscreate` to `ResourceApigEventHellothere2Userscreate`  and cloud formation will throw an error. The Logical ids are already unique because of the PATHs  essence . I fixed that by removing lambda function name from the Apig logical id