### PR TITLE
Added support for using existing SNS resources with function events

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/sns/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/index.js
@@ -12,6 +12,17 @@ class AwsCompileSNSEvents {
     };
   }
 
+  existingTopic(topicName) {
+    const resources = this.serverless.service.resources.Resources;
+
+    const resourceName = Object.keys(resources).find((name) => (
+      resources[name].Type === 'AWS::SNS::Topic' &&
+        resources[name].Properties.TopicName === topicName
+    ));
+
+    return resourceName;
+  }
+
   compileSNSEvents() {
     if (!this.serverless.service.resources.Resources) {
       throw new this.serverless.classes
@@ -90,21 +101,42 @@ class AwsCompileSNSEvents {
               }
             `;
 
-            const newSNSObject = {
-              [`${functionName}SNSEvent${i}`]: JSON.parse(snsTemplate),
-            };
-
             const newPermissionObject = {
               [`${functionName}SNSEventPermission${i}`]: JSON.parse(permissionTemplate),
             };
 
-            // create new topic if no topic arn provided
-            if (!topicArn) {
-              _.merge(this.serverless.service.resources.Resources,
-                newSNSObject);
-            } else {
+            const existingResourceName = this.existingTopic(topicName);
+            // Modify existing topic resource if one already exists
+            if (existingResourceName) {
+              const newSNSSubscription = JSON.parse(`{
+                    "Endpoint": { "Fn::GetAtt": ["${functionName}", "Arn"] },
+                    "Protocol": "lambda"}`);
+
+              if (!this.serverless.service.resources.Resources[existingResourceName].Properties
+                .hasOwnProperty('Subscription')) {
+                // Set subscription to empty array if the property does not exist
+                this.serverless.service.resources.Resources[existingResourceName].Properties
+                  .Subscription = [];
+              }
+              this.serverless.service.resources.Resources[existingResourceName].Properties
+                .Subscription.push(newSNSSubscription);
+
+              // Reference existing SNS Topic Resource if found
               newPermissionObject[`${functionName}SNSEventPermission${i}`]
-                .Properties.SourceArn = topicArn;
+                  .Properties.SourceArn = { Ref: existingResourceName };
+            } else {
+              const newSNSObject = {
+                [`${functionName}SNSEvent${i}`]: JSON.parse(snsTemplate),
+              };
+
+              // create new topic if no topic arn provided
+              if (!topicArn) {
+                _.merge(this.serverless.service.resources.Resources,
+                  newSNSObject);
+              } else {
+                newPermissionObject[`${functionName}SNSEventPermission${i}`]
+                  .Properties.SourceArn = topicArn;
+              }
             }
 
             _.merge(this.serverless.service.resources.Resources, newPermissionObject);

--- a/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
@@ -19,6 +19,21 @@ describe('AwsCompileSNSEvents', () => {
       .to.equal('aws'));
   });
 
+  describe('#existingTopic()', () => {
+    it('should return nothing if existing resource does not exist', () => expect(awsCompileSNSEvents
+      .existingTopic('SampleSNSTopic')).to.equal(undefined));
+
+    it('should return topic resource name if one exists', () => {
+      awsCompileSNSEvents.serverless.service.resources.Resources.sampleSNSTopic = {
+        Type: 'AWS::SNS::Topic',
+        Properties: {
+          TopicName: 'SampleSNSTopic',
+        },
+      };
+      expect(awsCompileSNSEvents.existingTopic('SampleSNSTopic')).to.equal('sampleSNSTopic');
+    });
+  });
+
   describe('#compileSNSEvents()', () => {
     it('should throw an error if the resource section is not available', () => {
       awsCompileSNSEvents.serverless.service.resources.Resources = false;
@@ -132,6 +147,60 @@ describe('AwsCompileSNSEvents', () => {
       expect(
         awsCompileSNSEvents.serverless.service.resources.Resources
       ).to.deep.equal({});
+    });
+
+    it('should update existing resource if one is present', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'existingTopic',
+                displayName: 'existingTopic',
+              },
+            },
+            {
+              sns: 'anotherExistingTopic',
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.serverless.service
+        .resources.Resources.existingTopic = {
+          Type: 'AWS::SNS::Topic',
+          Properties: {
+            TopicName: 'existingTopic',
+          },
+        };
+      awsCompileSNSEvents.serverless.service
+        .resources.Resources.anotherExistingTopic = {
+          Type: 'AWS::SNS::Topic',
+          Properties: {
+            TopicName: 'anotherExistingTopic',
+          },
+        };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(typeof awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEvent0
+      ).to.equal('undefined');
+      expect(typeof awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEvent1
+      ).to.equal('undefined');
+      expect(awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEventPermission0.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .resources.Resources.firstSNSEventPermission1.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .resources.Resources.existingTopic
+        .Properties.hasOwnProperty('Subscriptions'));
+      expect(awsCompileSNSEvents.serverless.service
+        .resources.Resources.anotherExistingTopic
+        .Properties.hasOwnProperty('Subscriptions'));
     });
   });
 });


### PR DESCRIPTION
##### Status:
Ready

##### Description:
This allows a function event to reference an SNS topic declared in the
resources section of the yaml file. Instead of creating a new resource
it will append to the subscriptions property of the existing topic and
add the corresponding function permission.