### PR TITLE
Fix and refactor noDeploy support and add tests

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -5,15 +5,6 @@ const BbPromise = require('bluebird');
 const async = require('async');
 
 module.exports = {
-  writeCreateTemplateToDisk() {
-    const cfTemplateFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless', `cf-template-create-${(new Date).getTime().toString()}.json`);
-
-    this.serverless.utils.writeFileSync(cfTemplateFilePath, this.serverless.service.resources);
-
-    return BbPromise.resolve();
-  },
-
   create() {
     this.serverless.cli.log('Creating Stack...');
 
@@ -100,6 +91,12 @@ module.exports = {
     this.serverless.service.provider
       .compiledCloudFormationTemplate = this.loadCoreCloudFormationTemplate();
 
+    // just write the template to disk if a deployment should not be performed
+    if (this.options.noDeploy) {
+      return this.writeCreateTemplateToDisk()
+        .then(BbPromise.resolve());
+    }
+
     return this.sdk.request('CloudFormation',
       'describeStackResources',
       { StackName: stackName },
@@ -108,14 +105,7 @@ module.exports = {
       .then(() => BbPromise.resolve())
       .catch(e => {
         if (e.message.indexOf('does not exist') > -1) {
-          const saveCfTemplate = BbPromise.bind(this)
-            .then(this.writeCreateTemplateToDisk);
-
-          if (this.options.noDeploy) {
-            return saveCfTemplate;
-          }
-
-          return saveCfTemplate
+          return BbPromise.bind(this)
             .then(this.create)
             .then(this.monitorCreate)
             .then(this.postCreate);
@@ -125,7 +115,7 @@ module.exports = {
       });
   },
 
-  // helper method to load the core CloudFormation template
+  // helper methods
   loadCoreCloudFormationTemplate() {
     return this.serverless.utils.readFileSync(
       path.join(this.serverless.config.serverlessPath,
@@ -135,5 +125,15 @@ module.exports = {
         'lib',
         'core-cloudformation-template.json')
     );
+  },
+
+  writeCreateTemplateToDisk() {
+    const cfTemplateFilePath = path.join(this.serverless.config.servicePath,
+      '.serverless', 'cloudformation-template-create-stack.json');
+
+    this.serverless.utils.writeFileSync(cfTemplateFilePath,
+      this.serverless.service.provider.compiledCloudFormationTemplate);
+
+    return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -5,14 +5,6 @@ const async = require('async');
 const path = require('path');
 
 module.exports = {
-  writeUpdateTemplateToDisk() {
-    const cfTemplateFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless', `cf-template-update-${(new Date).getTime().toString()}.json`);
-    this.serverless.utils.writeFileSync(cfTemplateFilePath, this.serverless.service.resources);
-
-    return BbPromise.resolve();
-  },
-
   update() {
     this.serverless.cli.log('Updating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
@@ -81,15 +73,26 @@ module.exports = {
   },
 
   updateStack() {
-    const saveCfTemplate = BbPromise.bind(this)
-      .then(this.writeUpdateTemplateToDisk);
-
+    // just write the template to disk if a deployment should not be performed
     if (this.options.noDeploy) {
-      return saveCfTemplate;
+      return BbPromise.bind(this)
+        .then(this.writeUpdateTemplateToDisk())
+        .then(BbPromise.resolve());
     }
 
-    return saveCfTemplate
+    return BbPromise.bind(this)
       .then(this.update)
       .then(this.monitorUpdate);
+  },
+
+  // helper methods
+  writeUpdateTemplateToDisk() {
+    const cfTemplateFilePath = path.join(this.serverless.config.servicePath,
+      '.serverless', 'cloudformation-template-update-stack.json');
+
+    this.serverless.utils.writeFileSync(cfTemplateFilePath,
+      this.serverless.service.provider.compiledCloudFormationTemplate);
+
+    return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -222,8 +222,6 @@ describe('createStack', () => {
 
       sinon.stub(awsDeploy.sdk, 'request').returns(BbPromise.reject(errorMock));
 
-      const writeCreateTemplateToDiskStub = sinon
-        .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
       const monitorStub = sinon
@@ -232,8 +230,7 @@ describe('createStack', () => {
         .stub(awsDeploy, 'postCreate').returns(BbPromise.resolve());
 
       return awsDeploy.createStack().then(() => {
-        expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
-        expect(createStub.calledAfter(writeCreateTemplateToDiskStub)).to.be.equal(true);
+        expect(createStub.calledOnce).to.be.equal(true);
         expect(monitorStub.calledAfter(createStub)).to.be.equal(true);
         expect(postCreateStub.calledAfter(monitorStub)).to.be.equal(true);
 
@@ -251,6 +248,21 @@ describe('createStack', () => {
 
       expect(template.Resources.ServerlessDeploymentBucket.Type)
         .to.equal('AWS::S3::Bucket');
+    });
+  });
+
+  describe('#writeCreateTemplateToDisk', () => {
+    it('should write the compiled CloudFormation template into the .serverless directory', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+
+      const templatePath = path.join(tmpDirPath,
+        '.serverless',
+        'cloudformation-template-create-stack.json');
+
+      return awsDeploy.writeCreateTemplateToDisk().then(() => {
+        expect(serverless.utils.fileExistsSync(templatePath)).to.equal(true);
+        expect(serverless.utils.readFileSync(templatePath)).to.deep.equal({ key: 'value' });
+      });
     });
   });
 });

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -149,20 +149,32 @@ describe('updateStack', () => {
     });
 
     it('should run promise chain in order', () => {
-      const writeUpdateTemplateStub = sinon
-        .stub(awsDeploy, 'writeUpdateTemplateToDisk').returns();
       const updateStub = sinon
         .stub(awsDeploy, 'update').returns(BbPromise.resolve());
       const monitorStub = sinon
         .stub(awsDeploy, 'monitorUpdate').returns(BbPromise.resolve());
 
       return awsDeploy.updateStack().then(() => {
-        expect(writeUpdateTemplateStub.calledOnce).to.be.equal(true);
-        expect(updateStub.calledAfter(writeUpdateTemplateStub)).to.be.equal(true);
+        expect(updateStub.calledOnce).to.be.equal(true);
         expect(monitorStub.calledAfter(updateStub)).to.be.equal(true);
 
         awsDeploy.update.restore();
         awsDeploy.monitorUpdate.restore();
+      });
+    });
+  });
+
+  describe('#writeUpdateTemplateToDisk', () => {
+    it('should write the compiled CloudFormation template into the .serverless directory', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+
+      const templatePath = path.join(tmpDirPath,
+        '.serverless',
+        'cloudformation-template-update-stack.json');
+
+      return awsDeploy.writeUpdateTemplateToDisk().then(() => {
+        expect(serverless.utils.fileExistsSync(templatePath)).to.equal(true);
+        expect(serverless.utils.readFileSync(templatePath)).to.deep.equal({ key: 'value' });
       });
     });
   });

--- a/lib/plugins/deploy/README.md
+++ b/lib/plugins/deploy/README.md
@@ -11,7 +11,7 @@ Deploys your service.
 `serverless deploy function`)
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
-- `--noDeploy` Skips the deployment steps and leaves artefacts in `.serverless`
+- `--noDeploy` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 
 ## Provided lifecycle events
 - `deploy:cleanup`

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -27,6 +27,7 @@ class Deploy {
           },
           noDeploy: {
             usage: 'Build artifacts without deploying',
+            shortcut: 'n',
           },
         },
         commands: {


### PR DESCRIPTION
This PR fixes the "wrong CloudFormation template" bug (https://github.com/serverless/serverless/issues/1880).

Furthermore a refactoring was done and test for the `writeTemplateToDisk` functions are added.