### PR TITLE
Remove automatic servicePath detection to prevent unintended behavior

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -120,36 +120,12 @@ class Utils {
   }
 
   findServicePath() {
-    const that = this;
-
-    // Helper function
-    const isServiceDir = (dir) => {
-      let serverlessYmlFileFound = false;
-
-      if (that.serverless.utils.fileExistsSync(path.join(dir, 'serverless.yml'))) {
-        serverlessYmlFileFound = true;
-      } else if (that.serverless.utils.fileExistsSync(path.join(dir, 'serverless.yaml'))) {
-        serverlessYmlFileFound = true;
-      }
-
-      return serverlessYmlFileFound;
-    };
-
-    // Check up to 10 parent levels
-    let previous = '.';
     let servicePath = null;
-    let i = 10;
 
-    while (i >= 0) {
-      const fullPath = path.resolve(process.cwd(), previous);
-
-      if (isServiceDir(fullPath)) {
-        servicePath = fullPath;
-        break;
-      }
-
-      previous = path.join(previous, '..');
-      i--;
+    if (this.serverless.utils.fileExistsSync(path.join(process.cwd(), 'serverless.yml'))) {
+      servicePath = process.cwd();
+    } else if (this.serverless.utils.fileExistsSync(path.join(process.cwd(), 'serverless.yaml'))) {
+      servicePath = process.cwd();
     }
 
     return servicePath;


### PR DESCRIPTION
This PR removes the automatic servicePath detection as it might introduce weird / unexpected behavior (`findServicePath` will now look into the current CWD instead of doing a directory traversal if the `serverless.yml` or `serverless.yaml` file is not found).

Corresponding issue is: https://github.com/serverless/serverless/issues/1192