### PR TITLE
Fix hitting CloudFormation TemplateBody limit

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const validate = require('../lib/validate');
 const createStack = require('./lib/createStack');
 const mergeCustomProviderResources = require('./lib/mergeCustomProviderResources');
+const uploadCloudFormationTemplate = require('./lib/uploadCloudFormationTemplate');
 const uploadDeploymentPackage = require('./lib/uploadDeploymentPackage');
 const deployFunctions = require('./lib/deployFunctions');
 const updateStack = require('./lib/updateStack');
@@ -22,6 +23,7 @@ class AwsDeploy {
       validate,
       createStack,
       mergeCustomProviderResources,
+      uploadCloudFormationTemplate,
       uploadDeploymentPackage,
       deployFunctions,
       updateStack
@@ -36,6 +38,13 @@ class AwsDeploy {
       'before:deploy:deploy': () => BbPromise.bind(this).then(this.mergeCustomProviderResources),
 
       'deploy:deploy': () => BbPromise.bind(this)
+        .then(() => this.sdk
+          .getServerlessDeploymentBucketName(this.options.stage, this.options.region)
+            .then((bucketName) => {
+              this.bucketName = bucketName;
+            })
+        )
+        .then(this.uploadCloudFormationTemplate)
         .then(this.uploadDeploymentPackage)
         .then(this.deployFunctions)
         .then(this.updateStack)

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -6,6 +6,8 @@ const path = require('path');
 
 module.exports = {
   update() {
+    const templateUrl = `https://s3.amazonaws.com/${this.bucketName}/compiled-cloudformation-template.json`;
+
     this.serverless.cli.log('Updating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
     const params = {
@@ -14,7 +16,7 @@ module.exports = {
         'CAPABILITY_IAM',
       ],
       Parameters: [],
-      TemplateBody: JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate),
+      TemplateURL: templateUrl,
     };
 
     return this.sdk.request('CloudFormation',

--- a/lib/plugins/aws/deploy/lib/uploadCloudFormationTemplate.js
+++ b/lib/plugins/aws/deploy/lib/uploadCloudFormationTemplate.js
@@ -3,7 +3,11 @@
 const BbPromise = require('bluebird');
 
 module.exports = {
-  uploadCloudFormationTemplateToS3Bucket() {
+  uploadCloudFormationTemplate() {
+    if (this.options.noDeploy) {
+      return BbPromise.resolve();
+    }
+
     this.serverless.cli.log('Uploading CloudFormation file to S3...');
 
     const body = JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate);
@@ -19,14 +23,5 @@ module.exports = {
       params,
       this.options.stage,
       this.options.region);
-  },
-
-  uploadCloudFormationTemplate() {
-    if (this.options.noDeploy) {
-      return BbPromise.resolve();
-    }
-
-    return BbPromise.bind(this)
-      .then(this.uploadCloudFormationTemplateToS3Bucket);
   },
 };

--- a/lib/plugins/aws/deploy/lib/uploadCloudFormationTemplate.js
+++ b/lib/plugins/aws/deploy/lib/uploadCloudFormationTemplate.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+
+module.exports = {
+  uploadCloudFormationTemplateToS3Bucket() {
+    this.serverless.cli.log('Uploading CloudFormation file to S3...');
+
+    const body = JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate);
+
+    const params = {
+      Bucket: this.bucketName,
+      Key: 'compiled-cloudformation-template.json',
+      Body: body,
+    };
+
+    return this.sdk.request('S3',
+      'putObject',
+      params,
+      this.options.stage,
+      this.options.region);
+  },
+
+  uploadCloudFormationTemplate() {
+    if (this.options.noDeploy) {
+      return BbPromise.resolve();
+    }
+
+    return BbPromise.bind(this)
+      .then(this.uploadCloudFormationTemplateToS3Bucket);
+  },
+};

--- a/lib/plugins/aws/deploy/lib/uploadDeploymentPackage.js
+++ b/lib/plugins/aws/deploy/lib/uploadDeploymentPackage.js
@@ -6,13 +6,6 @@ const BbPromise = require('bluebird');
 const _ = require('lodash');
 
 module.exports = {
-  setServerlessDeploymentBucketName() {
-    return this.sdk.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
-      .then((bucketName) => {
-        this.bucketName = bucketName;
-      });
-  },
-
   getServiceObjectsFromS3Bucket() {
     // 4 old ones + the one which will be uploaded after the cleanup = 5
     const objectsToKeepCount = 4;
@@ -86,7 +79,6 @@ module.exports = {
     }
 
     return BbPromise.bind(this)
-      .then(this.setServerlessDeploymentBucketName)
       .then(this.getServiceObjectsFromS3Bucket)
       .then(this.cleanupS3Bucket)
       .then(this.uploadZipFileToS3Bucket);

--- a/lib/plugins/aws/deploy/tests/all.js
+++ b/lib/plugins/aws/deploy/tests/all.js
@@ -2,6 +2,7 @@
 
 require('./createStack');
 require('./mergeCustomProviderResources');
+require('./uploadCloudFormationTemplate');
 require('./uploadDeploymentPackage');
 require('./deployFunctions');
 require('./updateStack');

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -52,7 +52,11 @@ describe('AwsDeploy', () => {
     });
 
     it('should run "deploy:deploy" promise chain in order', () => {
-      const uploadDeploymentPackage = sinon
+      const getServerlessDeploymentBucketNameStub = sinon
+        .stub(awsDeploy.sdk, 'getServerlessDeploymentBucketName').returns(BbPromise.resolve());
+      const uploadCloudFormationTemplateStub = sinon
+        .stub(awsDeploy, 'uploadCloudFormationTemplate').returns(BbPromise.resolve());
+      const uploadDeploymentPackageStub = sinon
         .stub(awsDeploy, 'uploadDeploymentPackage').returns(BbPromise.resolve());
       const deployFunctionsStub = sinon
         .stub(awsDeploy, 'deployFunctions').returns(BbPromise.resolve());
@@ -60,10 +64,16 @@ describe('AwsDeploy', () => {
         .stub(awsDeploy, 'updateStack').returns(BbPromise.resolve());
 
       return awsDeploy.hooks['deploy:deploy']().then(() => {
-        expect(uploadDeploymentPackage.calledOnce).to.be.equal(true);
-        expect(deployFunctionsStub.calledAfter(uploadDeploymentPackage)).to.be.equal(true);
+        expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
+        expect(uploadCloudFormationTemplateStub.calledAfter(getServerlessDeploymentBucketNameStub))
+          .to.be.equal(true);
+        expect(uploadDeploymentPackageStub.calledAfter(uploadCloudFormationTemplateStub))
+          .to.be.equal(true);
+        expect(deployFunctionsStub.calledAfter(uploadDeploymentPackageStub)).to.be.equal(true);
         expect(updateStackStub.calledAfter(deployFunctionsStub)).to.be.equal(true);
 
+        awsDeploy.sdk.getServerlessDeploymentBucketName.restore();
+        awsDeploy.uploadCloudFormationTemplate.restore();
         awsDeploy.uploadDeploymentPackage.restore();
         awsDeploy.deployFunctions.restore();
         awsDeploy.updateStack.restore();

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -37,6 +37,7 @@ describe('updateStack', () => {
     awsDeploy = new AwsDeploy(serverless, options);
 
     awsDeploy.deployedFunctions = [{ name: 'first', zipFileKey: 'zipFileOfFirstFunction' }];
+    awsDeploy.bucketName = 'deployment-bucket';
     serverless.service.service = `service-${(new Date()).getTime().toString()}`;
     serverless.config.servicePath = tmpDirPath;
     serverless.utils.writeFileSync(serverlessEnvYmlPath, serverlessEnvYml);
@@ -54,6 +55,12 @@ describe('updateStack', () => {
     it('should update the stack', () => awsDeploy.update()
       .then(() => {
         expect(updateStackStub.calledOnce).to.be.equal(true);
+        expect(updateStackStub.args[0][0]).to.be.equal('CloudFormation');
+        expect(updateStackStub.args[0][1]).to.be.equal('updateStack');
+        expect(updateStackStub.args[0][2].StackName)
+          .to.be.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
+        expect(updateStackStub.args[0][2].TemplateURL)
+          .to.be.equal(`https://s3.amazonaws.com/${awsDeploy.bucketName}/compiled-cloudformation-template.json`);
         expect(updateStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
 
         awsDeploy.sdk.request.restore();

--- a/lib/plugins/aws/deploy/tests/uploadCloudFormationTemplate.js
+++ b/lib/plugins/aws/deploy/tests/uploadCloudFormationTemplate.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const sinon = require('sinon');
+const BbPromise = require('bluebird');
+const expect = require('chai').expect;
+const AwsDeploy = require('../index');
+const Serverless = require('../../../../Serverless');
+
+describe('uploadCloudFormationTemplate', () => {
+  let serverless;
+  let awsDeploy;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.bucketName = 'deployment-bucket';
+    awsDeploy.serverless.cli = new serverless.classes.CLI();
+  });
+
+  describe('#uploadCloudFormationTemplateToS3Bucket()', () => {
+    it('should upload the CloudFormation template file to the S3 bucket', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+
+      const putObjectStub = sinon
+        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+
+      return awsDeploy.uploadCloudFormationTemplateToS3Bucket().then(() => {
+        expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(putObjectStub.args[0][0]).to.be.equal('S3');
+        expect(putObjectStub.args[0][1]).to.be.equal('putObject');
+        expect(putObjectStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
+        expect(putObjectStub.args[0][2].Key).to.be.equal('compiled-cloudformation-template.json');
+        expect(putObjectStub.args[0][2].Body)
+          .to.be.equal(JSON.stringify(awsDeploy.serverless.service
+            .provider.compiledCloudFormationTemplate));
+
+        expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        awsDeploy.sdk.request.restore();
+      });
+    });
+  });
+
+  describe('#uploadCloudFormationTemplate()', () => {
+    it('should resolve if no deploy', () => {
+      awsDeploy.options.noDeploy = true;
+
+      const uploadCloudFormationTemplateToS3BucketStub = sinon
+        .stub(awsDeploy, 'uploadCloudFormationTemplateToS3Bucket').returns(BbPromise.resolve());
+
+      return awsDeploy.uploadCloudFormationTemplate().then(() => {
+        expect(uploadCloudFormationTemplateToS3BucketStub.called).to.be.equal(false);
+
+        awsDeploy.uploadCloudFormationTemplateToS3Bucket.restore();
+      });
+    });
+
+    it('should run promise chain in order', () => {
+      const uploadCloudFormationTemplateToS3BucketStub = sinon
+        .stub(awsDeploy, 'uploadCloudFormationTemplateToS3Bucket').returns(BbPromise.resolve());
+
+      return awsDeploy.uploadCloudFormationTemplate().then(() => {
+        expect(uploadCloudFormationTemplateToS3BucketStub.calledOnce).to.be.equal(true);
+
+        awsDeploy.uploadCloudFormationTemplateToS3Bucket.restore();
+      });
+    });
+  });
+});

--- a/lib/plugins/aws/deploy/tests/uploadCloudFormationTemplate.js
+++ b/lib/plugins/aws/deploy/tests/uploadCloudFormationTemplate.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect;
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 
-describe('uploadCloudFormationTemplate', () => {
+describe('#uploadCloudFormationTemplate()', () => {
   let serverless;
   let awsDeploy;
 
@@ -21,52 +21,37 @@ describe('uploadCloudFormationTemplate', () => {
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });
 
-  describe('#uploadCloudFormationTemplateToS3Bucket()', () => {
-    it('should upload the CloudFormation template file to the S3 bucket', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+  it('should upload the CloudFormation template file to the S3 bucket', () => {
+    awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
 
-      const putObjectStub = sinon
-        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+    const putObjectStub = sinon
+      .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
 
-      return awsDeploy.uploadCloudFormationTemplateToS3Bucket().then(() => {
-        expect(putObjectStub.calledOnce).to.be.equal(true);
-        expect(putObjectStub.args[0][0]).to.be.equal('S3');
-        expect(putObjectStub.args[0][1]).to.be.equal('putObject');
-        expect(putObjectStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(putObjectStub.args[0][2].Key).to.be.equal('compiled-cloudformation-template.json');
-        expect(putObjectStub.args[0][2].Body)
-          .to.be.equal(JSON.stringify(awsDeploy.serverless.service
-            .provider.compiledCloudFormationTemplate));
+    return awsDeploy.uploadCloudFormationTemplate().then(() => {
+      expect(putObjectStub.calledOnce).to.be.equal(true);
+      expect(putObjectStub.args[0][0]).to.be.equal('S3');
+      expect(putObjectStub.args[0][1]).to.be.equal('putObject');
+      expect(putObjectStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
+      expect(putObjectStub.args[0][2].Key).to.be.equal('compiled-cloudformation-template.json');
+      expect(putObjectStub.args[0][2].Body)
+        .to.be.equal(JSON.stringify(awsDeploy.serverless.service
+          .provider.compiledCloudFormationTemplate));
 
-        expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.sdk.request.restore();
-      });
+      expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+      awsDeploy.sdk.request.restore();
     });
   });
 
-  describe('#uploadCloudFormationTemplate()', () => {
-    it('should resolve if no deploy', () => {
-      awsDeploy.options.noDeploy = true;
+  it('should resolve if no deploy', () => {
+    awsDeploy.options.noDeploy = true;
 
-      const uploadCloudFormationTemplateToS3BucketStub = sinon
-        .stub(awsDeploy, 'uploadCloudFormationTemplateToS3Bucket').returns(BbPromise.resolve());
+    const putObjectStub = sinon
+      .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
 
-      return awsDeploy.uploadCloudFormationTemplate().then(() => {
-        expect(uploadCloudFormationTemplateToS3BucketStub.called).to.be.equal(false);
+    return awsDeploy.uploadCloudFormationTemplate().then(() => {
+      expect(putObjectStub.called).to.be.equal(false);
 
-        awsDeploy.uploadCloudFormationTemplateToS3Bucket.restore();
-      });
-    });
-
-    it('should run promise chain in order', () => {
-      const uploadCloudFormationTemplateToS3BucketStub = sinon
-        .stub(awsDeploy, 'uploadCloudFormationTemplateToS3Bucket').returns(BbPromise.resolve());
-
-      return awsDeploy.uploadCloudFormationTemplate().then(() => {
-        expect(uploadCloudFormationTemplateToS3BucketStub.calledOnce).to.be.equal(true);
-
-        awsDeploy.uploadCloudFormationTemplateToS3Bucket.restore();
-      });
+      awsDeploy.sdk.request.restore();
     });
   });
 });

--- a/lib/plugins/aws/deploy/tests/uploadDeploymentPackage.js
+++ b/lib/plugins/aws/deploy/tests/uploadDeploymentPackage.js
@@ -19,23 +19,8 @@ describe('uploadDeploymentPackage', () => {
       region: 'us-east-1',
     };
     awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.bucketName = 'deployment-bucket';
     awsDeploy.serverless.cli = new serverless.classes.CLI();
-  });
-
-  describe('#setServerlessDeploymentBucketName()', () => {
-    it('should store the name of the Serverless deployment bucket in the "this" variable', () => {
-      const getServerlessDeploymentBucketNameStub = sinon
-        .stub(awsDeploy.sdk, 'getServerlessDeploymentBucketName')
-        .returns(BbPromise.resolve('new-service-dev-us-east-1-12345678'));
-
-      return awsDeploy.setServerlessDeploymentBucketName().then(() => {
-        expect(awsDeploy.bucketName).to.equal('new-service-dev-us-east-1-12345678');
-        expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getServerlessDeploymentBucketNameStub
-          .calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.sdk.getServerlessDeploymentBucketName.restore();
-      });
-    });
   });
 
   describe('#getServiceObjectsFromS3Bucket()', () => {
@@ -49,6 +34,9 @@ describe('uploadDeploymentPackage', () => {
 
       return awsDeploy.getServiceObjectsFromS3Bucket().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
+        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
+        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
+        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();
       });
@@ -93,6 +81,9 @@ describe('uploadDeploymentPackage', () => {
         expect(objectsToRemove).to.not.include({ Key: 'first-service-7.zip' });
         expect(objectsToRemove).to.not.include({ Key: 'first-service-8.zip' });
         expect(listObjectsStub.calledOnce).to.be.equal(true);
+        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
+        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
+        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();
       });
@@ -119,6 +110,9 @@ describe('uploadDeploymentPackage', () => {
       return awsDeploy.getServiceObjectsFromS3Bucket().then((objectsToRemove) => {
         expect(objectsToRemove).to.equal(undefined);
         expect(listObjectsStub.calledOnce).to.be.equal(true);
+        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
+        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
+        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();
       });
@@ -148,6 +142,9 @@ describe('uploadDeploymentPackage', () => {
       return awsDeploy.getServiceObjectsFromS3Bucket().then((objectsToRemove) => {
         expect(objectsToRemove).to.equal(undefined);
         expect(listObjectsStub.calledOnce).to.be.equal(true);
+        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
+        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
+        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();
       });
@@ -174,6 +171,9 @@ describe('uploadDeploymentPackage', () => {
 
       return awsDeploy.cleanupS3Bucket(serviceObjects).then(() => {
         expect(deleteObjectsStub.calledOnce).to.be.equal(true);
+        expect(deleteObjectsStub.args[0][0]).to.be.equal('S3');
+        expect(deleteObjectsStub.args[0][1]).to.be.equal('deleteObjects');
+        expect(deleteObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(deleteObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();
       });
@@ -193,6 +193,9 @@ describe('uploadDeploymentPackage', () => {
 
       return awsDeploy.uploadZipFileToS3Bucket().then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(putObjectStub.args[0][0]).to.be.equal('S3');
+        expect(putObjectStub.args[0][1]).to.be.equal('putObject');
+        expect(putObjectStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();
       });
@@ -203,8 +206,6 @@ describe('uploadDeploymentPackage', () => {
     it('should resolve if no deploy', () => {
       awsDeploy.options.noDeploy = true;
 
-      const setServerlessDeploymentBucketNameStub = sinon
-        .stub(awsDeploy, 'setServerlessDeploymentBucketName').returns(BbPromise.resolve());
       const getServiceObjectsFromS3BucketStub = sinon
         .stub(awsDeploy, 'getServiceObjectsFromS3Bucket').returns(BbPromise.resolve());
       const cleanupS3BucketStub = sinon
@@ -213,12 +214,10 @@ describe('uploadDeploymentPackage', () => {
         .stub(awsDeploy, 'uploadZipFileToS3Bucket').returns(BbPromise.resolve());
 
       return awsDeploy.uploadDeploymentPackage().then(() => {
-        expect(setServerlessDeploymentBucketNameStub.called).to.be.equal(false);
         expect(getServiceObjectsFromS3BucketStub.called).to.be.equal(false);
         expect(cleanupS3BucketStub.called).to.be.equal(false);
         expect(uploadZipFileToS3BucketStub.called).to.be.equal(false);
 
-        awsDeploy.setServerlessDeploymentBucketName.restore();
         awsDeploy.getServiceObjectsFromS3Bucket.restore();
         awsDeploy.cleanupS3Bucket.restore();
         awsDeploy.uploadZipFileToS3Bucket.restore();
@@ -226,8 +225,6 @@ describe('uploadDeploymentPackage', () => {
     });
 
     it('should run promise chain in order', () => {
-      const setServerlessDeploymentBucketNameStub = sinon
-        .stub(awsDeploy, 'setServerlessDeploymentBucketName').returns(BbPromise.resolve());
       const getServiceObjectsFromS3BucketStub = sinon
         .stub(awsDeploy, 'getServiceObjectsFromS3Bucket').returns(BbPromise.resolve());
       const cleanupS3BucketStub = sinon
@@ -236,14 +233,11 @@ describe('uploadDeploymentPackage', () => {
         .stub(awsDeploy, 'uploadZipFileToS3Bucket').returns(BbPromise.resolve());
 
       return awsDeploy.uploadDeploymentPackage().then(() => {
-        expect(setServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getServiceObjectsFromS3BucketStub.calledAfter(setServerlessDeploymentBucketNameStub))
-          .to.be.equal(true);
+        expect(getServiceObjectsFromS3BucketStub.calledOnce).to.be.equal(true);
         expect(cleanupS3BucketStub.calledAfter(getServiceObjectsFromS3BucketStub))
           .to.be.equal(true);
         expect(uploadZipFileToS3BucketStub.calledAfter(cleanupS3BucketStub)).to.be.equal(true);
 
-        awsDeploy.setServerlessDeploymentBucketName.restore();
         awsDeploy.getServiceObjectsFromS3Bucket.restore();
         awsDeploy.cleanupS3Bucket.restore();
         awsDeploy.uploadZipFileToS3Bucket.restore();


### PR DESCRIPTION
The CloudFormation template will now be uploaded to S3 and referenced from there
in the updateStack method.

Corresponding issue is https://github.com/serverless/serverless/issues/1740

/cc @flomotlik @eahefnawy 