### PR TITLE
Update outdated doc references

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -58,7 +58,7 @@ module.exports.logError = (e) => {
     }
 
     consoleLog(chalk.yellow('  Get Support --------------------------------------------'));
-    consoleLog(`${chalk.yellow('     Docs:          ')}${chalk.white('v1.docs.serverless.com')}`);
+    consoleLog(`${chalk.yellow('     Docs:          ')}${chalk.white('docs.serverless.com')}`);
     consoleLog(`${chalk.yellow('     Bugs:          ')}${chalk
       .white('github.com/serverless/serverless/issues')}`);
 

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -7,7 +7,7 @@
 # Just uncomment any of them to get that config option.
 #
 # For full config options, check the docs:
-#    v1.docs.serverless.com
+#    docs.serverless.com
 #
 # Happy Coding!
 

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -7,7 +7,7 @@
 # Just uncomment any of them to get that config option.
 #
 # For full config options, check the docs:
-#    v1.docs.serverless.com
+#    docs.serverless.com
 #
 # Happy Coding!
 

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -7,7 +7,7 @@
 # Just uncomment any of them to get that config option.
 #
 # For full config options, check the docs:
-#    v1.docs.serverless.com
+#    docs.serverless.com
 #
 # Happy Coding!
 

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -7,7 +7,7 @@
 # Just uncomment any of them to get that config option.
 #
 # For full config options, check the docs:
-#    v1.docs.serverless.com
+#    docs.serverless.com
 #
 # Happy Coding!
 


### PR DESCRIPTION
The docs are now available at docs.serverless.com (rather than v1.docs.serverless.com).