### PR TITLE
Support form requests for APIG in v1

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -129,6 +129,56 @@ module.exports = {
               "stageVariables": $loop
             }
           `;
+          const DEFAULT_FORM_REQUEST_TEMPLATE = `
+            #define( $body )
+              {
+              #foreach( $token in $input.path('$').split('&') )
+                #set( $keyVal = $token.split('=') )
+                #set( $keyValSize = $keyVal.size() )
+                #if( $keyValSize >= 1 )
+                  #set( $key = $util.urlDecode($keyVal[0]) )
+                  #if( $keyValSize >= 2 )
+                    #set( $val = $util.urlDecode($keyVal[1]) )
+                  #else
+                    #set( $val = '' )
+                  #end
+                  "$key": "$val"#if($foreach.hasNext),#end
+                #end
+              #end
+              }
+            #end
+
+            #define( $loop )
+              {
+              #foreach($key in $map.keySet())
+                  "$util.escapeJavaScript($key)":
+                    "$util.escapeJavaScript($map.get($key))"
+                    #if( $foreach.hasNext ) , #end
+              #end
+              }
+            #end
+            {
+              "body": $body,
+              "method": "$context.httpMethod",
+              "principalId": "$context.authorizer.principalId",
+              "stage": "$context.stage",
+
+              #set( $map = $input.params().header )
+              "headers": $loop,
+
+              #set( $map = $input.params().querystring )
+              "query": $loop,
+
+              #set( $map = $input.params().path )
+              "path": $loop,
+
+              #set( $map = $context.identity )
+              "identity": $loop,
+
+              #set( $map = $stageVariables )
+              "stageVariables": $loop
+            }
+          `;
 
           const allowOrigin = '"method.response.header.Access-Control-Allow-Origin"';
           const corsMethodResponseTemplate =
@@ -168,7 +218,8 @@ module.exports = {
                     ]
                   },
                   "RequestTemplates" : {
-                    "application/json" : ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)}
+                    "application/json" : ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)},
+                    "application/x-www-form-urlencoded" : ${JSON.stringify(DEFAULT_FORM_REQUEST_TEMPLATE)}
                   },
                   "IntegrationResponses" : [
                     {


### PR DESCRIPTION
##### Status:

In Development

##### Description:

Adds a default velocity template to handle application/www-form-urlencoded requests and transform in a very similar way as a JSON request. Comes from #1593 and #1685.

##### Todos:

- [X] Form template
- [ ] DRY code