### PR TITLE
Fix noDeploy errors when stack is not created

### DIFF
--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -16,14 +16,20 @@ class AwsInfo {
 
     this.hooks = {
       'info:info': () => BbPromise.bind(this)
-          .then(this.validate)
-          .then(this.gather)
-          .then(this.display),
+        .then(this.validate)
+        .then(this.gather)
+        .then(this.display),
 
       'deploy:deploy': () => BbPromise.bind(this)
-          .then(this.validate)
-          .then(this.gather)
-          .then(this.display),
+        .then(() => {
+          if (this.options.noDeploy) {
+            return BbPromise.resolve();
+          }
+          return BbPromise.bind(this)
+            .then(this.validate)
+            .then(this.gather)
+            .then(this.display);
+        }),
     };
   }
 
@@ -38,8 +44,7 @@ class AwsInfo {
       region: this.options.region,
     };
 
-		// Get info from CLF Outputs
-
+    // Get info from CloudFormation Outputs
     return this.sdk.request('CloudFormation',
       'describeStacks',
       { StackName: stackName },

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -69,22 +69,45 @@ describe('AwsInfo', () => {
       });
     });
 
-    it('should run promise chain in order for deploy hook', () => {
-      const validateStub = sinon
-        .stub(awsInfo, 'validate').returns(BbPromise.resolve());
-      const gatherStub = sinon
-        .stub(awsInfo, 'gather').returns(BbPromise.resolve());
-      const displayStub = sinon
-        .stub(awsInfo, 'display').returns(BbPromise.resolve());
+    describe('when running "deploy:deploy" hook', () => {
+      it('should run promise chain in order if no deploy is not set', () => {
+        const validateStub = sinon
+          .stub(awsInfo, 'validate').returns(BbPromise.resolve());
+        const gatherStub = sinon
+          .stub(awsInfo, 'gather').returns(BbPromise.resolve());
+        const displayStub = sinon
+          .stub(awsInfo, 'display').returns(BbPromise.resolve());
 
-      return awsInfo.hooks['deploy:deploy']().then(() => {
-        expect(validateStub.calledOnce).to.be.equal(true);
-        expect(gatherStub.calledAfter(validateStub)).to.be.equal(true);
-        expect(displayStub.calledAfter(gatherStub)).to.be.equal(true);
+        return awsInfo.hooks['deploy:deploy']().then(() => {
+          expect(validateStub.calledOnce).to.be.equal(true);
+          expect(gatherStub.calledAfter(validateStub)).to.be.equal(true);
+          expect(displayStub.calledAfter(gatherStub)).to.be.equal(true);
 
-        awsInfo.validate.restore();
-        awsInfo.gather.restore();
-        awsInfo.display.restore();
+          awsInfo.validate.restore();
+          awsInfo.gather.restore();
+          awsInfo.display.restore();
+        });
+      });
+
+      it('should resolve if no deploy', () => {
+        awsInfo.options.noDeploy = true;
+
+        const validateStub = sinon
+          .stub(awsInfo, 'validate').returns(BbPromise.resolve());
+        const gatherStub = sinon
+          .stub(awsInfo, 'gather').returns(BbPromise.resolve());
+        const displayStub = sinon
+          .stub(awsInfo, 'display').returns(BbPromise.resolve());
+
+        return awsInfo.hooks['deploy:deploy']().then(() => {
+          expect(validateStub.calledOnce).to.be.equal(false);
+          expect(gatherStub.calledOnce).to.be.equal(false);
+          expect(displayStub.calledOnce).to.be.equal(false);
+
+          awsInfo.validate.restore();
+          awsInfo.gather.restore();
+          awsInfo.display.restore();
+        });
       });
     });
   });


### PR DESCRIPTION
This adds a check to the `awsInfo` plugin which checks for the `noDeploy` option and causes the `deploy:deploy` hook to be ignored so that the error about the missing stack is not show.

Corresponding issue: https://github.com/serverless/serverless/issues/1878