### PR TITLE
Automatically add IamPolicyLambda for VPC when using VPC config

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/iam-policy-lambda-vpc-template.json
+++ b/lib/plugins/aws/deploy/compile/functions/iam-policy-lambda-vpc-template.json
@@ -9,9 +9,6 @@
           {
             "Effect": "Allow",
             "Action": [
-              "logs:CreateLogGroup",
-              "logs:CreateLogStream",
-              "logs:PutLogEvents",
               "ec2:CreateNetworkInterface",
               "ec2:DescribeNetworkInterfaces",
               "ec2:DeleteNetworkInterface"

--- a/lib/plugins/aws/deploy/compile/functions/iam-policy-lambda-vpc-template.json
+++ b/lib/plugins/aws/deploy/compile/functions/iam-policy-lambda-vpc-template.json
@@ -1,0 +1,30 @@
+{
+  "IamPolicyLambdaVpc": {
+    "Type": "AWS::IAM::ManagedPolicy",
+    "Properties": {
+      "PolicyName": "",
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "ec2:CreateNetworkInterface",
+              "ec2:DescribeNetworkInterfaces",
+              "ec2:DeleteNetworkInterface"
+            ],
+            "Resource": "*"
+          }
+        ]
+      },
+      "Roles": [
+        {
+          "Ref": "IamRoleLambda"
+        }
+      ]
+    }
+  }
+}

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -154,6 +154,7 @@ class AwsCompileFunctions {
         newFunction.Properties.Role = { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] };
       }
 
+      // Check if a VPC should be used
       if (!functionObject.vpc) functionObject.vpc = {};
       if (!this.serverless.service.provider.vpc) this.serverless.service.provider.vpc = {};
 
@@ -168,8 +169,26 @@ class AwsCompileFunctions {
         delete newFunction.Properties.VpcConfig;
       }
 
+      // add the VPC permissions to the lambda execution role if a VPC config is given
+      if (newFunction.Properties.VpcConfig) {
+        // merge in the iamPolicyLambdaVPCTemplate
+        const iamPolicyLambdaVpcTemplate = this.serverless.utils.readFileSync(
+          path.join(this.serverless.config.serverlessPath,
+            'plugins',
+            'aws',
+            'deploy',
+            'compile',
+            'functions',
+            'iam-policy-lambda-vpc-template.json')
+        );
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+          iamPolicyLambdaVpcTemplate);
+      }
+
       const normalizedFunctionName = functionName[0].toUpperCase() + functionName.substr(1);
       const functionLogicalId = `${normalizedFunctionName}LambdaFunction`;
+
       const newFunctionObject = {
         [functionLogicalId]: newFunction,
       };

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -210,52 +210,6 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compliedFunction);
     });
 
-    it('should create a function resource with VPC config', () => {
-      awsCompileFunctions.serverless.service.functions = {
-        func: {
-          handler: 'func.function.handler',
-          name: 'new-service-dev-func',
-          vpc: {
-            securityGroupIds: ['xxx'],
-            subnetIds: ['xxx'],
-          },
-        },
-      };
-      const compliedFunction = {
-        Type: 'AWS::Lambda::Function',
-        Properties: {
-          Code: {
-            S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
-              awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 6,
-          VpcConfig: {
-            SecurityGroupIds: ['xxx'],
-            SubnetIds: ['xxx'],
-          },
-        },
-      };
-
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compliedFunction);
-
-      awsCompileFunctions.serverless.service.functions = {
-        func: {
-          handler: 'func.function.handler',
-        },
-      };
-    });
-
     it('should consider function based config when creating a function resource', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
@@ -403,6 +357,73 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(
         expectedOutputs
       );
+    });
+
+    describe('when using a VPC config', () => {
+      beforeEach(() => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            vpc: {
+              securityGroupIds: ['xxx'],
+              subnetIds: ['xxx'],
+            },
+          },
+        };
+      });
+
+      it('should create a function resource with VPC config', () => {
+        const compliedFunction = {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
+                awsCompileFunctions.serverless.service.package.artifact}`,
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            VpcConfig: {
+              SecurityGroupIds: ['xxx'],
+              SubnetIds: ['xxx'],
+            },
+          },
+        };
+
+        awsCompileFunctions.compileFunctions();
+
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compliedFunction);
+
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+          },
+        };
+      });
+
+      it('should merge the IamPolicyLambdaVpc template into the CloudFormation template', () => {
+        const iamPolicyLambdaVpcTemplate = awsCompileFunctions.serverless.utils.readFileSync(
+          path.join(
+            __dirname,
+            '..',
+            'iam-policy-lambda-vpc-template.json'
+          )
+        );
+
+        awsCompileFunctions.compileFunctions();
+
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.IamPolicyLambdaVpc
+        ).to.deep.equal(iamPolicyLambdaVpcTemplate.IamPolicyLambdaVpc);
+      });
     });
   });
 });


### PR DESCRIPTION
Adds the IamPolicy rule automatically when using a VPC.

Corresponding issue: https://github.com/serverless/serverless/issues/1786

**Todos:**
- [x] Update tests so that the new artifact deployment method is considered #1906
- [x] Rebase once #1951 is merged (use the new logical id for the template)
- [ ] Check if the new logical if for the IamPolicy is correct

/cc @eahefnawy @flomotlik 
