### PR TITLE
Add getTmpDir util method and refactor tests

### DIFF
--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -2,17 +2,17 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const os = require('os');
 const path = require('path');
 const BbPromise = require('bluebird');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+const testUtils = require('../../../../../tests/utils');
 
 describe('createStack', () => {
   let serverless;
   let awsDeploy;
 
-  const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+  const tmpDirPath = testUtils.getTmpDirPath();
   const serverlessEnvYmlPath = path.join(tmpDirPath, 'serverless.env.yml');
   const serverlessYmlPath = path.join(tmpDirPath, 'serverless.yml');
   const serverlessYml = {

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -2,17 +2,17 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const os = require('os');
 const path = require('path');
 const BbPromise = require('bluebird');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+const testUtils = require('../../../../../tests/utils');
 
 describe('updateStack', () => {
   let serverless;
   let awsDeploy;
 
-  const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+  const tmpDirPath = testUtils.getTmpDirPath();
   const serverlessEnvYmlPath = path.join(tmpDirPath, 'serverless.env.yml');
   const serverlessEnvYml = {
     vars: {},

--- a/lib/plugins/aws/deploy/tests/uploadDeploymentPackage.js
+++ b/lib/plugins/aws/deploy/tests/uploadDeploymentPackage.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const sinon = require('sinon');
-const os = require('os');
 const path = require('path');
 const BbPromise = require('bluebird');
 const expect = require('chai').expect;
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+const testUtils = require('../../../../../tests/utils');
 
 describe('uploadDeploymentPackage', () => {
   let serverless;
@@ -182,7 +182,7 @@ describe('uploadDeploymentPackage', () => {
 
   describe('#uploadZipFileToS3Bucket()', () => {
     it('should upload the zip file to the S3 bucket', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -4,11 +4,11 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const Package = require('../../../package');
 const AwsDeployFunction = require('../');
 const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
+const testUtils = require('../../../../../tests/utils');
 
 describe('AwsDeployFunction', () => {
   let serverless;
@@ -135,7 +135,7 @@ describe('AwsDeployFunction', () => {
   describe('#deployFunction()', () => {
     it('should deploy the function', () => {
       // write a file to disc to simulate that the deployment artifact exists
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -3,10 +3,10 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const path = require('path');
-const os = require('os');
 const AwsInvoke = require('../');
 const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
+const testUtils = require('../../../../../tests/utils');
 
 describe('AwsInvoke', () => {
   const serverless = new Serverless();
@@ -78,7 +78,7 @@ describe('AwsInvoke', () => {
     });
 
     it('it should parse file if file path is provided', () => {
-      serverless.config.servicePath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {
         testProp: 'testValue',
       };
@@ -100,7 +100,7 @@ describe('AwsInvoke', () => {
     });
 
     it('it should throw error if file path does not exist', () => {
-      serverless.config.servicePath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      serverless.config.servicePath = testUtils.getTmpDirPath();
       awsInvoke.options.path = 'some/path';
 
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);

--- a/lib/plugins/create/tests/create.js
+++ b/lib/plugins/create/tests/create.js
@@ -37,13 +37,18 @@ describe('Create', () => {
   });
 
   describe('#create()', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      tmpDir = testUtils.getTmpDirPath();
+    });
+
     it('should throw error if user passed unsupported template', () => {
       create.options.template = 'invalid-template';
       expect(() => create.create()).to.throw(Error);
     });
 
     it('should set servicePath based on cwd', () => {
-      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -61,7 +66,6 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-nodejs" template', () => {
-      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -80,7 +84,6 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-python" template', () => {
-      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -99,7 +102,6 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-java-maven" template', () => {
-      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -132,7 +134,6 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-java-gradle" template', () => {
-      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);

--- a/lib/plugins/create/tests/create.js
+++ b/lib/plugins/create/tests/create.js
@@ -2,12 +2,12 @@
 
 const expect = require('chai').expect;
 const path = require('path');
-const os = require('os');
 const fse = require('fs-extra');
 const BbPromise = require('bluebird');
 const Create = require('../create');
 const Serverless = require('../../../Serverless');
 const sinon = require('sinon');
+const testUtils = require('../../../../tests/utils');
 
 describe('Create', () => {
   let create;
@@ -43,7 +43,7 @@ describe('Create', () => {
     });
 
     it('should set servicePath based on cwd', () => {
-      const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -61,7 +61,7 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-nodejs" template', () => {
-      const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -80,7 +80,7 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-python" template', () => {
-      const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -99,7 +99,7 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-java-maven" template', () => {
-      const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);
@@ -132,7 +132,7 @@ describe('Create', () => {
     });
 
     it('should generate scaffolding for "aws-java-gradle" template', () => {
-      const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDir = testUtils.getTmpDirPath();
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);
       process.chdir(tmpDir);

--- a/lib/plugins/package/tests/cleanup.js
+++ b/lib/plugins/package/tests/cleanup.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const expect = require('chai').expect;
-const os = require('os');
 const path = require('path');
 const Package = require('../index');
 const Serverless = require('../../../../lib/Serverless');
+const testUtils = require('../../../../tests/utils');
 
 describe('#cleanup()', () => {
   let serverless;
@@ -14,7 +14,7 @@ describe('#cleanup()', () => {
     serverless = new Serverless();
     packageService = new Package(serverless);
 
-    serverless.config.servicePath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+    serverless.config.servicePath = testUtils.getTmpDirPath();
   });
 
   it('should remove .serverless in the service directory', () => {

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -3,10 +3,10 @@
 const expect = require('chai').expect;
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 const JsZip = require('jszip');
 const Package = require('../index');
 const Serverless = require('../../../../lib/Serverless');
+const testUtils = require('../../../../tests/utils');
 
 describe('#zipService()', () => {
   let serverless;
@@ -20,7 +20,7 @@ describe('#zipService()', () => {
     packageService.serverless.cli = new serverless.classes.CLI();
 
     // create a mock service in a temporary directory
-    const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+    const tmpDirPath = testUtils.getTmpDirPath();
     const handlerPath = path.join(tmpDirPath, 'handler.js');
     serverless.utils.writeFileSync(handlerPath, 'handler.js file content');
     const nestedFunctionPath = path.join(tmpDirPath, 'lib', 'function.js');
@@ -131,7 +131,7 @@ describe('#zipService()', () => {
 
   it('should resolve if the user has specified his own artifact', (done) => {
     // create an artifact in a temp directory
-    const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+    const tmpDirPath = testUtils.getTmpDirPath();
     const handlerPath = path.join(tmpDirPath, 'handler.js');
     serverless.utils.writeFileSync(handlerPath, 'handler.js file content');
     packageService.serverless.utils.walkDirSync(tmpDirPath).forEach((filePath) => {

--- a/lib/plugins/tracking/tests/tracking.js
+++ b/lib/plugins/tracking/tests/tracking.js
@@ -4,8 +4,8 @@ const expect = require('chai').expect;
 const Tracking = require('../tracking');
 const Serverless = require('../../../Serverless');
 const path = require('path');
-const os = require('os');
 const fse = require('fs-extra');
+const testUtils = require('../../../../tests/utils');
 
 describe('Tracking', () => {
   let tracking;
@@ -29,7 +29,7 @@ describe('Tracking', () => {
 
   describe('#tracking()', () => {
     beforeEach(() => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       fse.mkdirsSync(tmpDirPath);
 
       serverless.config.serverlessPath = tmpDirPath;

--- a/tests/all.js
+++ b/tests/all.js
@@ -33,3 +33,6 @@ require('../lib/plugins/aws/deploy/compile/events/schedule/tests');
 require('../lib/plugins/aws/deploy/compile/events/apiGateway/tests/all');
 require('../lib/plugins/aws/deploy/compile/events/sns/tests');
 require('../lib/plugins/aws/deployFunction/tests/index');
+
+// Other Tests
+require('./utils/tests');

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -6,10 +6,10 @@ const Serverless = require('../../lib/Serverless');
 const Create = require('../../lib/plugins/create/create');
 
 const path = require('path');
-const os = require('os');
 const fse = require('fs-extra');
 const execSync = require('child_process').execSync;
 const mockRequire = require('mock-require');
+const testUtils = require('../../tests/utils');
 
 describe('PluginManager', () => {
   let pluginManager;
@@ -679,7 +679,7 @@ describe('PluginManager', () => {
     serverlessInstance.init();
     const serverlessExec = path.join(serverlessInstance.config.serverlessPath,
       '..', 'bin', 'serverless');
-    const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+    const tmpDir = testUtils.getTmpDirPath();
     fse.mkdirSync(tmpDir);
     const cwd = process.cwd();
     process.chdir(tmpDir);

--- a/tests/classes/Serverless.js
+++ b/tests/classes/Serverless.js
@@ -6,7 +6,6 @@ const semverRegex = require('semver-regex');
 const fs = require('fs');
 const fse = require('fs-extra');
 const path = require('path');
-const os = require('os');
 
 const YamlParser = require('../../lib/classes/YamlParser');
 const PluginManager = require('../../lib/classes/PluginManager');
@@ -14,6 +13,7 @@ const Utils = require('../../lib/classes/Utils');
 const Service = require('../../lib/classes/Service');
 const CLI = require('../../lib/classes/CLI');
 const Error = require('../../lib/classes/Error').SError;
+const testUtils = require('../../tests/utils');
 
 describe('Serverless', () => {
   let serverless;
@@ -129,7 +129,7 @@ describe('Serverless', () => {
     });
 
     it('should track if tracking is enabled', (done) => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       fse.mkdirsSync(tmpDirPath);
 
       serverless.config.serverlessPath = tmpDirPath;
@@ -138,7 +138,7 @@ describe('Serverless', () => {
     });
 
     it('should not track if tracking is disabled', (done) => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       fse.mkdirsSync(tmpDirPath);
       fs.writeFileSync(path.join(tmpDirPath, 'do-not-track'), 'some-content');
 

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -103,6 +103,11 @@ describe('Service', () => {
 
   describe('#load()', () => {
     let serviceInstance;
+    let tmpDirPath;
+
+    beforeEach(() => {
+      tmpDirPath = testUtils.getTmpDirPath();
+    });
 
     it('should resolve if no servicePath is found', (done) => {
       const serverless = new Serverless();
@@ -113,7 +118,6 @@ describe('Service', () => {
 
     it('should support Serverless files with a .yaml extension', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYaml = {
         service: 'my-service',
         provider: 'aws',
@@ -160,7 +164,6 @@ describe('Service', () => {
 
     it('should support Serverless files with a .yml extension', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'my-service',
         provider: 'aws',
@@ -207,7 +210,6 @@ describe('Service', () => {
 
     it('should load and populate from filesystem', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -287,7 +289,6 @@ describe('Service', () => {
 
     it('should load and populate stage vars', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -325,7 +326,6 @@ describe('Service', () => {
 
     it('should load and populate region vars', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -367,7 +367,6 @@ describe('Service', () => {
 
     it('should load and populate region vars when region is provided as shortcut', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -415,7 +414,6 @@ describe('Service', () => {
 
     it('should load and populate non string variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -456,7 +454,6 @@ describe('Service', () => {
 
     it('should load and populate object variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -499,7 +496,6 @@ describe('Service', () => {
 
     it('should load and populate boolean and 0 variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -543,7 +539,6 @@ describe('Service', () => {
 
     it('should load and populate object variables deep sub properties', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -588,7 +583,6 @@ describe('Service', () => {
 
     it('should load and populate substring variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -632,7 +626,6 @@ describe('Service', () => {
 
     it('should load and populate with custom variable syntax', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${{testVar}}',
         defaults: {
@@ -673,7 +666,6 @@ describe('Service', () => {
 
     it('should load custom function names if provided', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'testService',
         provider: 'aws',
@@ -711,7 +703,6 @@ describe('Service', () => {
 
     it('should load and add events property if no events provided', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'testService',
         provider: 'aws',
@@ -754,7 +745,6 @@ describe('Service', () => {
 
     it('should throw error if service property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         provider: 'aws',
         functions: {},
@@ -792,7 +782,6 @@ describe('Service', () => {
 
     it('should throw error if provider property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         functions: {},
@@ -830,7 +819,6 @@ describe('Service', () => {
 
     it('should throw error if provider property is invalid', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'invalid',
@@ -869,7 +857,6 @@ describe('Service', () => {
 
     it('should throw error if functions property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -905,7 +892,6 @@ describe('Service', () => {
 
     it('should throw error if variable does not exist', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -947,7 +933,6 @@ describe('Service', () => {
 
     it('should throw error if we try to access sub property of string variable', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -991,7 +976,6 @@ describe('Service', () => {
 
     it('should throw error if we try to access sub property of non-object variable', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -1035,7 +1019,6 @@ describe('Service', () => {
 
     it('should throw error if sub property does not exist in object at any level', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -1081,7 +1064,6 @@ describe('Service', () => {
 
     it('should throw error if trying to populate non string vars into string', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -1125,7 +1107,6 @@ describe('Service', () => {
 
     it('should throw error if trying to populate non string deep vars into string', () => {
       const SUtils = new Utils();
-      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const path = require('path');
-const os = require('os');
 const YAML = require('js-yaml');
 const expect = require('chai').expect;
 const Service = require('../../lib/classes/Service');
 const Utils = require('../../lib/classes/Utils');
 const Serverless = require('../../lib/Serverless');
+const testUtils = require('../../tests/utils');
 
 describe('Service', () => {
   describe('#constructor()', () => {
@@ -113,7 +113,7 @@ describe('Service', () => {
 
     it('should support Serverless files with a .yaml extension', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYaml = {
         service: 'my-service',
         provider: 'aws',
@@ -160,7 +160,7 @@ describe('Service', () => {
 
     it('should support Serverless files with a .yml extension', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'my-service',
         provider: 'aws',
@@ -207,7 +207,7 @@ describe('Service', () => {
 
     it('should load and populate from filesystem', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -287,7 +287,7 @@ describe('Service', () => {
 
     it('should load and populate stage vars', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -325,7 +325,7 @@ describe('Service', () => {
 
     it('should load and populate region vars', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -367,7 +367,7 @@ describe('Service', () => {
 
     it('should load and populate region vars when region is provided as shortcut', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${testVar}',
         provider: 'aws',
@@ -415,7 +415,7 @@ describe('Service', () => {
 
     it('should load and populate non string variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -456,7 +456,7 @@ describe('Service', () => {
 
     it('should load and populate object variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -499,7 +499,7 @@ describe('Service', () => {
 
     it('should load and populate boolean and 0 variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -543,7 +543,7 @@ describe('Service', () => {
 
     it('should load and populate object variables deep sub properties', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -588,7 +588,7 @@ describe('Service', () => {
 
     it('should load and populate substring variables', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -632,7 +632,7 @@ describe('Service', () => {
 
     it('should load and populate with custom variable syntax', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: '${{testVar}}',
         defaults: {
@@ -673,7 +673,7 @@ describe('Service', () => {
 
     it('should load custom function names if provided', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'testService',
         provider: 'aws',
@@ -711,7 +711,7 @@ describe('Service', () => {
 
     it('should load and add events property if no events provided', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'testService',
         provider: 'aws',
@@ -754,7 +754,7 @@ describe('Service', () => {
 
     it('should throw error if service property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         provider: 'aws',
         functions: {},
@@ -792,7 +792,7 @@ describe('Service', () => {
 
     it('should throw error if provider property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         functions: {},
@@ -830,7 +830,7 @@ describe('Service', () => {
 
     it('should throw error if provider property is invalid', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'invalid',
@@ -869,7 +869,7 @@ describe('Service', () => {
 
     it('should throw error if functions property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -905,7 +905,7 @@ describe('Service', () => {
 
     it('should throw error if variable does not exist', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -947,7 +947,7 @@ describe('Service', () => {
 
     it('should throw error if we try to access sub property of string variable', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -991,7 +991,7 @@ describe('Service', () => {
 
     it('should throw error if we try to access sub property of non-object variable', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -1035,7 +1035,7 @@ describe('Service', () => {
 
     it('should throw error if sub property does not exist in object at any level', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -1081,7 +1081,7 @@ describe('Service', () => {
 
     it('should throw error if trying to populate non string vars into string', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -1125,7 +1125,7 @@ describe('Service', () => {
 
     it('should throw error if trying to populate non string deep vars into string', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',

--- a/tests/classes/Utils.js
+++ b/tests/classes/Utils.js
@@ -39,7 +39,7 @@ describe('Utils', () => {
 
   describe('#writeFileSync()', () => {
     it('should write a .json file synchronously', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
+      const tmpFilePath = testUtils.getTmpFilePath('anything.json');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
       const obj = serverless.utils.readFileSync(tmpFilePath);
@@ -48,7 +48,7 @@ describe('Utils', () => {
     });
 
     it('should write a .yml file synchronously', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.yml');
+      const tmpFilePath = testUtils.getTmpFilePath('anything.yml');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
@@ -58,7 +58,7 @@ describe('Utils', () => {
     });
 
     it('should write a .yaml file synchronously', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.yaml');
+      const tmpFilePath = testUtils.getTmpFilePath('anything.yaml');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
@@ -74,7 +74,7 @@ describe('Utils', () => {
 
   describe('#writeFile()', () => {
     it('should write a file asynchronously', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
+      const tmpFilePath = testUtils.getTmpFilePath('anything.json');
 
       // note: use return when testing promises otherwise you'll have unhandled rejection errors
       return serverless.utils.writeFile(tmpFilePath, { foo: 'bar' }).then(() => {
@@ -87,7 +87,7 @@ describe('Utils', () => {
 
   describe('#readFileSync()', () => {
     it('should read a file synchronously', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
+      const tmpFilePath = testUtils.getTmpFilePath('anything.json');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
       const obj = serverless.utils.readFileSync(tmpFilePath);
@@ -98,7 +98,7 @@ describe('Utils', () => {
 
   describe('#readFile()', () => {
     it('should read a file asynchronously', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
+      const tmpFilePath = testUtils.getTmpFilePath('anything.json');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 

--- a/tests/classes/Utils.js
+++ b/tests/classes/Utils.js
@@ -4,6 +4,7 @@ const path = require('path');
 const os = require('os');
 const expect = require('chai').expect;
 const Serverless = require('../../lib/Serverless');
+const testUtils = require('../../tests/utils');
 
 const serverless = new Serverless();
 
@@ -38,11 +39,7 @@ describe('Utils', () => {
 
   describe('#writeFileSync()', () => {
     it('should write a .json file synchronously', () => {
-      const tmpFilePath = path.join(
-        os.tmpdir(),
-        (new Date()).getTime().toString(),
-        'anything.json'
-      );
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
       const obj = serverless.utils.readFileSync(tmpFilePath);
@@ -51,11 +48,7 @@ describe('Utils', () => {
     });
 
     it('should write a .yml file synchronously', () => {
-      const tmpFilePath = path.join(
-        os.tmpdir(),
-        (new Date()).getTime().toString(),
-        'anything.yml'
-      );
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.yml');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
@@ -65,11 +58,7 @@ describe('Utils', () => {
     });
 
     it('should write a .yaml file synchronously', () => {
-      const tmpFilePath = path.join(
-        os.tmpdir(),
-        (new Date()).getTime().toString(),
-        'anything.yaml'
-      );
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.yaml');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
@@ -85,11 +74,7 @@ describe('Utils', () => {
 
   describe('#writeFile()', () => {
     it('should write a file asynchronously', () => {
-      const tmpFilePath = path.join(
-        os.tmpdir(),
-        (new Date()).getTime().toString(),
-        'anything.json'
-      );
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
 
       // note: use return when testing promises otherwise you'll have unhandled rejection errors
       return serverless.utils.writeFile(tmpFilePath, { foo: 'bar' }).then(() => {
@@ -102,11 +87,7 @@ describe('Utils', () => {
 
   describe('#readFileSync()', () => {
     it('should read a file synchronously', () => {
-      const tmpFilePath = path.join(
-        os.tmpdir(),
-        (new Date()).getTime().toString(),
-        'anything.json'
-      );
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
       const obj = serverless.utils.readFileSync(tmpFilePath);
@@ -117,11 +98,7 @@ describe('Utils', () => {
 
   describe('#readFile()', () => {
     it('should read a file asynchronously', () => {
-      const tmpFilePath = path.join(
-        os.tmpdir(),
-        (new Date()).getTime().toString(),
-        'anything.json'
-      );
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'anything.json');
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
@@ -134,7 +111,7 @@ describe('Utils', () => {
 
   describe('#walkDirSync()', () => {
     it('should return an array with corresponding paths to the found files', () => {
-      const tmpDirPath = path.join(os.tmpDir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
 
       const nestedDir1 = path.join(tmpDirPath, 'foo');
       const nestedDir2 = path.join(tmpDirPath, 'foo', 'bar');
@@ -197,7 +174,7 @@ describe('Utils', () => {
     const testDir = process.cwd();
 
     it('should detect if the CWD is a service directory when using Serverless .yaml files', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const tmpFilePath = path.join(tmpDirPath, 'serverless.yaml');
 
       serverless.utils.writeFileSync(tmpFilePath, 'foo');
@@ -209,7 +186,7 @@ describe('Utils', () => {
     });
 
     it('should detect if the CWD is a service directory when using Serverless .yml files', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const tmpFilePath = path.join(tmpDirPath, 'serverless.yml');
 
       serverless.utils.writeFileSync(tmpFilePath, 'foo');

--- a/tests/classes/YamlParser.js
+++ b/tests/classes/YamlParser.js
@@ -15,7 +15,7 @@ const serverless = new Serverless();
 describe('YamlParser', () => {
   describe('#parse()', () => {
     it('should parse a simple .yaml file', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'simple.yaml');
+      const tmpFilePath = testUtils.getTmpFilePath('simple.yaml');
 
       serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
 
@@ -25,7 +25,7 @@ describe('YamlParser', () => {
     });
 
     it('should parse a simple .yml file', () => {
-      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'simple.yml');
+      const tmpFilePath = testUtils.getTmpFilePath('simple.yml');
 
       serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
 

--- a/tests/classes/YamlParser.js
+++ b/tests/classes/YamlParser.js
@@ -7,15 +7,15 @@
 const expect = require('chai').expect;
 const YAML = require('js-yaml');
 const path = require('path');
-const os = require('os');
 const Serverless = require('../../lib/Serverless');
+const testUtils = require('../../tests/utils');
 
 const serverless = new Serverless();
 
 describe('YamlParser', () => {
   describe('#parse()', () => {
     it('should parse a simple .yaml file', () => {
-      const tmpFilePath = path.join(os.tmpdir(), (new Date()).getTime().toString(), 'simple.yaml');
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'simple.yaml');
 
       serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
 
@@ -25,7 +25,7 @@ describe('YamlParser', () => {
     });
 
     it('should parse a simple .yml file', () => {
-      const tmpFilePath = path.join(os.tmpdir(), (new Date()).getTime().toString(), 'simple.yml');
+      const tmpFilePath = path.join(testUtils.getTmpDirPath(), 'simple.yml');
 
       serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
 
@@ -35,7 +35,7 @@ describe('YamlParser', () => {
     });
 
     it('should parse a .yml file with JSON-REF to YAML', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
 
       serverless.utils.writeFileSync(path.join(tmpDirPath, 'ref.yml'), { foo: 'bar' });
 
@@ -53,7 +53,7 @@ describe('YamlParser', () => {
     });
 
     it('should parse a .yml file with JSON-REF to JSON', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
 
       serverless.utils.writeFileSync(path.join(tmpDirPath, 'ref.json'), { foo: 'bar' });
 
@@ -71,7 +71,7 @@ describe('YamlParser', () => {
     });
 
     it('should parse a .yml file with recursive JSON-REF', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
 
       serverless.utils.writeFileSync(path.join(tmpDirPath, 'three.yml'), { foo: 'bar' });
 

--- a/tests/integration_test.js
+++ b/tests/integration_test.js
@@ -2,18 +2,18 @@
 
 const expect = require('chai').expect;
 const path = require('path');
-const os = require('os');
 const fse = require('fs-extra');
 const BbPromise = require('bluebird');
 const execSync = require('child_process').execSync;
 const Serverless = require('../lib/Serverless');
 const AWS = require('aws-sdk');
+const testUtils = require('./utils');
 
 const serverless = new Serverless();
 serverless.init();
 const serverlessExec = path.join(serverless.config.serverlessPath, '..', 'bin', 'serverless');
 
-const tmpDir = path.join(os.tmpdir(), (new Date()).getTime().toString());
+const tmpDir = testUtils.getTmpDirPath();
 fse.mkdirSync(tmpDir);
 process.chdir(tmpDir);
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+module.exports = {
+  getTmpDirPath: () => path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex')),
+};

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -4,6 +4,11 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 
+const getTmpDirPath = () => path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+
+const getTmpFilePath = (fileName) => path.join(getTmpDirPath(), fileName);
+
 module.exports = {
-  getTmpDirPath: () => path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex')),
+  getTmpDirPath,
+  getTmpFilePath,
 };

--- a/tests/utils/tests/index.js
+++ b/tests/utils/tests/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const expect = require('chai').expect;
+const testUtils = require('../index');
+
+describe('Test utils', () => {
+  describe('#getTmpDirPath()', () => {
+    it('should return a valid tmpDir path', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+
+      expect(tmpDirPath).to.match(/.+.{16}/);
+    });
+  });
+});

--- a/tests/utils/tests/index.js
+++ b/tests/utils/tests/index.js
@@ -11,4 +11,13 @@ describe('Test utils', () => {
       expect(tmpDirPath).to.match(/.+.{16}/);
     });
   });
+
+  describe('#getTmpFilePath()', () => {
+    it('should return a valid tmpFile path', () => {
+      const fileName = 'foo.bar';
+      const tmpFilePath = testUtils.getTmpFilePath(fileName);
+
+      expect(tmpFilePath).to.match(/.+.{16}.{1}foo\.bar/);
+    });
+  });
 });


### PR DESCRIPTION
Adds a testing util method so that tmpDirs are always unique and don't depend on the time.

Corresponding issue: https://github.com/serverless/serverless/issues/1887

/cc @flomotlik @eahefnawy 