### PR TITLE
Fix #1940: Load AWS profile from vars

### DIFF
--- a/docs/guide/provider-account-setup.md
+++ b/docs/guide/provider-account-setup.md
@@ -36,6 +36,7 @@ If you created a new AWS account make sure that a credit card is set up for the 
 To start using Serverless and access the AWS API you need to set the AWS API Access Key & Secret. 
 
 #### Quick Setup
+
 As a quick setup to get started you can export them as environment variables so they would be accessible to Serverless and the AWS SDK in your shell:
 
 ```
@@ -43,6 +44,7 @@ export AWS_ACCESS_KEY_ID=<key>
 export AWS_SECRET_ACCESS_KEY=<secret>
 serverless deploy
 ```
+
 #### Advanced & Longer Term Setup
 
 For a more permanent solution you can also set up credentials through the `aws-cli`, or by configuring the credentials file of the `aws-cli` directly. To set them up through the `aws-cli` [install it first](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) then run `aws configure` [to configure the aws-cli and credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html). Serverless will automatically use those credentials. You can even set up a different profiles for different accounts, which can be used by Serverless as well.
@@ -56,6 +58,22 @@ Default output format [None]: ENTER
 ```
 
 You can also edit the credentials file which is located in `~/.aws/credentials` directly. Read more about that file in the [AWS documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files)
+
+#### Profiles Per Stage
+
+To use a different AWS profile (already configured in your `~/.aws/credentials` file) for each stage you can specify a `profile` variable in stage variables (in your `serverless.env.yml`):
+
+```yaml
+stages:
+  dev:
+    vars:
+      profile: my-dev-profile
+  prod:
+    vars:
+      profile: my-prod-profile
+```
+
+Note that if you set your environment `AWS_PROFILE` value, it will override your file-base settings.
 
 ## Conclusion
 

--- a/lib/plugins/aws/index.js
+++ b/lib/plugins/aws/index.js
@@ -80,8 +80,6 @@ class SDK {
   }
 
   getCredentials(stage, region) {
-    const credentials = { region };
-
     let prefix;
     if (stage) {
       prefix = `AWS_${stage.toUpperCase()}`;
@@ -92,9 +90,10 @@ class SDK {
     const profile = process.env[`${prefix}_PROFILE`]
       || this.serverless.service.getVariables(stage).profile;
 
-    credentials.profile = profile;
-
-    return credentials;
+    return {
+      credentials: new AWS.SharedIniFileCredentials({ profile }),
+      region,
+    };
   }
 
   getServerlessDeploymentBucketName(stage, region) {

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -104,7 +104,7 @@ describe('AWS SDK', () => {
       };
       const awsSdk = new AwsSdk(serverless);
       const credentials = awsSdk.getCredentials();
-      expect(credentials.profile).to.equal('default');
+      expect(credentials.credentials.profile).to.equal('default');
     });
 
     it('should get stage credentials', () => {
@@ -126,7 +126,7 @@ describe('AWS SDK', () => {
       };
       const awsSdk = new AwsSdk(serverless);
       const credentials = awsSdk.getCredentials('dev');
-      expect(credentials.profile).to.deep.equal('default');
+      expect(credentials.credentials.profile).to.deep.equal('default');
     });
   });
 


### PR DESCRIPTION
Status: Ready

Description:

While trying to understand the problem I described in #1940 I looked at the internals related to setting and using the right AWS profile depending on the stage variables. While there was a test checking that the `profile` value in the `credentials` object was being set to the stage's variable, that is not how the profile needs to be set for the AWS Node.js SDK.

See the Node.js section in [this AWS blog post](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) for the proper way to set credentials with a profile name (i.e. load them from the credentials INI file in to a `credentials` property). As discussed in #1787 I could see the profile name being recognised by Serverless, but my AWS API calls were failing (because the profile wasn't being loaded by the SDK).

With this change I can run `sls deploy` *without* setting an `AWS_PROFILE` environment variable and the profile name will be extracted from my `serverless.env.yml` file. If I set an `AWS_PROFILE` environment variable it overrides my file-based settings.

- [x] Write tests
- [x] Update docs