### PR TITLE
API Gateway request / response templates support

### DIFF
--- a/docs/guide/overview-of-event-sources.md
+++ b/docs/guide/overview-of-event-sources.md
@@ -103,20 +103,7 @@ functions:
           method: POST
 ```
 
-**Note:** Serverless supports a built in, universal velocity request template which makes the following parameters available
-in the `event` object:
-
-- body
-- method
-- principalId
-- stage
-- headers
-- query
-- path
-- identity
-- stageVariables
-
-To e.g. access the `body` parameter you can simply write `event.body`.
+See more in-depth configuration for the HTTP event [here](/lib/plugins/aws/deploy/compile/events/apiGateway/README.md).
 
 ### SNS
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -89,8 +89,8 @@ functions:
           path: whatever
           request:
             template:
-              text/xhtml: ./template-1.vm
-              application/json: ./template-2.vm
+              text/xhtml: { "stage" : "$context.stage" }
+              application/json: { "httpMethod" : "$context.httpMethod" }
 ```
 
 ### Responses

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -53,6 +53,86 @@ functions:
           method: post
 ```
 
+### Request templates
+
+#### Default request templates
+
+Serverless ships with the following default request templates you can use out of the box:
+
+1. `application/json`
+2. `application/x-www-form-urlencoded`
+
+Both templates give you access to the following properties you can access with the help of the `event` object:
+
+- body
+- method
+- principalId
+- stage
+- headers
+- query
+- path
+- identity
+- stageVariables
+
+#### Using custom request templates
+
+However you can define and use your own request templates as follows (you can even overwrite the default request templates
+by defining a new request template for an existing content type):
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          method: get
+          path: whatever
+          request:
+            template:
+              text/xhtml: ./template-1.vm
+              application/json: ./template-2.vm
+```
+
+### Responses
+
+Serverless enables you a way to set custom headers and a response template for your `http` event.
+
+#### Using custom response headers
+
+Here's an example which shows you how you can setup a custom response header:
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          method: get
+          path: whatever
+          response:
+            headers:
+              Content-Type: "'text/html'"
+```
+
+#### Using a custom response template
+
+Sometimes you'll want to define a custom response template API Gateway should use to transform your lambdas output.
+Here's an example which will transform the return value of your lambda so that the browser renders it as HTML:
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          method: get
+          path: whatever
+          response:
+            headers:
+              Content-Type: "'text/html'"
+            template: $input.path('$')
+```
+
 ### Http setup with custom authorizer
 You can enable custom authorizers for your HTTP endpoint by setting the authorizer in your http event to another function
 in the same service, as shown in the following example

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -93,9 +93,12 @@ functions:
               application/json: { "httpMethod" : "$context.httpMethod" }
 ```
 
+**Note:** The templates are defined as plain text here. However you can also reference an external file with the help of
+the `${file(templatefile)}` syntax.
+
 ### Responses
 
-Serverless enables you a way to set custom headers and a response template for your `http` event.
+Serverless lets you setup custom headers and a response template for your `http` event.
 
 #### Using custom response headers
 
@@ -111,8 +114,13 @@ functions:
           path: whatever
           response:
             headers:
-              Content-Type: "'text/html'"
+              Content-Type: integration.response.header.Content-Type
+              Cache-Control: "'max-age=120'"
 ```
+
+**Note:** You're able to use the [integration response variables](http://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html#mapping-response-parameters)
+for your header values. Headers are passed to API Gateway exactly like you define them. Passing the `Cache-Control` header
+as `"'max-age=120'"` means API Gateway will receive the value as `'max-age=120'` (enclosed with single quotes).
 
 #### Using a custom response template
 
@@ -132,6 +140,9 @@ functions:
               Content-Type: "'text/html'"
             template: $input.path('$')
 ```
+
+**Note:** The template is defined as plain text here. However you can also reference an external file with the help of
+the `${file(templatefile)}` syntax.
 
 ### Http setup with custom authorizer
 You can enable custom authorizers for your HTTP endpoint by setting the authorizer in your http event to another function

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -30,14 +30,6 @@ module.exports = {
           }
 
           // add the default request and response templates to the CloudFormation "Mappings" section
-
-          // request template
-          // provides
-          // {
-          //   body, method, principalId, stage, headers,
-          //   query, path, identity, stageVariables
-          // } = event
-          // as js objects
           const DEFAULT_JSON_REQUEST_TEMPLATE = `
             #define( $loop )
               {
@@ -48,6 +40,7 @@ module.exports = {
               #end
               }
             #end
+
             {
               "body": $input.json("$"),
               "method": "$context.httpMethod",
@@ -71,11 +64,64 @@ module.exports = {
             }
           `;
 
+          const DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE = `
+            #define( $body )
+              {
+              #foreach( $token in $input.path('$').split('&') )
+                #set( $keyVal = $token.split('=') )
+                #set( $keyValSize = $keyVal.size() )
+                #if( $keyValSize >= 1 )
+                  #set( $key = $util.urlDecode($keyVal[0]) )
+                  #if( $keyValSize >= 2 )
+                    #set( $val = $util.urlDecode($keyVal[1]) )
+                  #else
+                    #set( $val = '' )
+                  #end
+                  "$key": "$val"#if($foreach.hasNext),#end
+                #end
+              #end
+              }
+            #end
+
+            #define( $loop )
+              {
+              #foreach($key in $map.keySet())
+                  "$util.escapeJavaScript($key)":
+                    "$util.escapeJavaScript($map.get($key))"
+                    #if( $foreach.hasNext ) , #end
+              #end
+              }
+            #end
+
+            {
+              "body": $body,
+              "method": "$context.httpMethod",
+              "principalId": "$context.authorizer.principalId",
+              "stage": "$context.stage",
+              
+              #set( $map = $input.params().header )
+              "headers": $loop,
+              
+              #set( $map = $input.params().querystring )
+              "query": $loop,
+              
+              #set( $map = $input.params().path )
+              "path": $loop,
+              
+              #set( $map = $context.identity )
+              "identity": $loop,
+              
+              #set( $map = $stageVariables )
+              "stageVariables": $loop
+            }
+          `;
+
           const apiGatewayMappings = `
             {
               "ApiGateway": {
-                "RequestTemplate": {
-                  "Value": ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)}
+                "RequestTemplates": {
+                  "Json": ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)},
+                  "FormUrlEncoded": ${JSON.stringify(DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE)}
                 }
               }
             }
@@ -179,7 +225,10 @@ module.exports = {
                   },
                   "RequestTemplates" : {
                     "application/json" : {
-                      "Fn::FindInMap": [ "ApiGateway", "RequestTemplate", "Value" ]
+                      "Fn::FindInMap": [ "ApiGateway", "RequestTemplates", "Json" ]
+                    },
+                    "application/x-www-form-urlencoded" : {
+                      "Fn::FindInMap": [ "ApiGateway", "RequestTemplates", "FormUrlEncoded" ]
                     }
                   },
                   "IntegrationResponses" : [

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -29,6 +29,61 @@ module.exports = {
               .Error(errorMessage);
           }
 
+          // add the default request and response templates to the CloudFormation "Mappings" section
+
+          // request template
+          // provides
+          // {
+          //   body, method, principalId, stage, headers,
+          //   query, path, identity, stageVariables
+          // } = event
+          // as js objects
+          const DEFAULT_JSON_REQUEST_TEMPLATE = `
+            #define( $loop )
+              {
+              #foreach($key in $map.keySet())
+                  "$util.escapeJavaScript($key)":
+                    "$util.escapeJavaScript($map.get($key))"
+                    #if( $foreach.hasNext ) , #end
+              #end
+              }
+            #end
+            {
+              "body": $input.json("$"),
+              "method": "$context.httpMethod",
+              "principalId": "$context.authorizer.principalId",
+              "stage": "$context.stage",
+
+              #set( $map = $input.params().header )
+              "headers": $loop,
+
+              #set( $map = $input.params().querystring )
+              "query": $loop,
+
+              #set( $map = $input.params().path )
+              "path": $loop,
+
+              #set( $map = $context.identity )
+              "identity": $loop,
+
+              #set( $map = $stageVariables )
+              "stageVariables": $loop
+            }
+          `;
+
+          const apiGatewayMappings = `
+            {
+              "ApiGateway": {
+                "RequestTemplate": {
+                  "Value": ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)}
+                }
+              }
+            }
+          `;
+
+          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Mappings,
+            JSON.parse(apiGatewayMappings));
+
           // setup CORS
           let cors;
           let corsEnabled = false;
@@ -85,51 +140,6 @@ module.exports = {
             method.substr(1).toLowerCase();
           const extractedResourceId = resourceLogicalId.match(/ResourceApigEvent(.*)/)[1];
 
-          // universal velocity template
-          // provides
-          // `{ body,
-          //    method,
-          //    principalId,
-          //    stage,
-          //    headers,
-          //    query,
-          //    path,
-          //    identity,
-          //    stageVariables} = event`
-          // as js objects
-          const DEFAULT_JSON_REQUEST_TEMPLATE = `
-            #define( $loop )
-              {
-              #foreach($key in $map.keySet())
-                  "$util.escapeJavaScript($key)":
-                    "$util.escapeJavaScript($map.get($key))"
-                    #if( $foreach.hasNext ) , #end
-              #end
-              }
-            #end
-            {
-              "body": $input.json("$"),
-              "method": "$context.httpMethod",
-              "principalId": "$context.authorizer.principalId",
-              "stage": "$context.stage",
-
-              #set( $map = $input.params().header )
-              "headers": $loop,
-
-              #set( $map = $input.params().querystring )
-              "query": $loop,
-
-              #set( $map = $input.params().path )
-              "path": $loop,
-
-              #set( $map = $context.identity )
-              "identity": $loop,
-
-              #set( $map = $stageVariables )
-              "stageVariables": $loop
-            }
-          `;
-
           const allowOrigin = '"method.response.header.Access-Control-Allow-Origin"';
           const corsMethodResponseTemplate =
           corsEnabled ? `${allowOrigin} : ${allowOrigin}` : '';
@@ -168,7 +178,9 @@ module.exports = {
                     ]
                   },
                   "RequestTemplates" : {
-                    "application/json" : ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)}
+                    "application/json" : {
+                      "Fn::FindInMap": [ "ApiGateway", "RequestTemplate", "Value" ]
+                    }
                   },
                   "IntegrationResponses" : [
                     {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -121,6 +121,28 @@ module.exports = {
             'application/x-www-form-urlencoded': DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
           };
 
+          // check if custom request configuration should be used
+          if (Boolean(event.http.request) === true) {
+            if (typeof event.http.request === 'object') {
+              // merge custom request templates if provided
+              if (event.http.request.template) {
+                _.forEach(event.http.request.template, (value, key) => {
+                  const requestTemplate = {};
+
+                  requestTemplate[key] = this.serverless.utils.readFileSync(value).toString();
+
+                  _.merge(integrationRequestTemplates, requestTemplate);
+                });
+              }
+            } else {
+              const errorMessage = [
+                'Request config must be provided as an object.',
+                ' Please check the docs for more info.',
+              ].join('');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
+          }
+
           // setup CORS
           let cors;
           let corsEnabled = false;

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -187,22 +187,28 @@ module.exports = {
           const extractedResourceId = resourceLogicalId.match(/ResourceApigEvent(.*)/)[1];
 
           // default response configuration
-          let responseContentType = 'application/json';
-          let integrationResponseTemplate = "$input.path('$')";
+          const methodResponseHeaders = [];
+          const integrationResponseHeaders = [];
+          let integrationResponseTemplate = null;
 
           // check if custom response configuration should be used
           if (Boolean(event.http.response) === true) {
             if (typeof event.http.response === 'object') {
-              if (event.http.response.headers['Content-Type'] && event.http.response.template) {
-                responseContentType = event.http.response.headers['Content-Type'];
-                integrationResponseTemplate = event.http.response.template;
-              } else {
-                const errorMessage = [
-                  'Response config must set values for the Content-Type header and the template.',
-                  ' Please check the docs for more info.',
-                ].join('');
-                throw new this.serverless.classes.Error(errorMessage);
+              // prepare the headers if set
+              if (event.http.response.headers) {
+                _.forEach(event.http.response.headers, (value, key) => {
+                  const methodResponseHeader = {};
+                  methodResponseHeader[`method.response.header.${key}`] =
+                    `method.response.header.${value.toString()}`;
+                  methodResponseHeaders.push(methodResponseHeader);
+
+                  const integrationResponseHeader = {};
+                  integrationResponseHeader[`method.response.header.${key}`] =
+                    `'${value}'`;
+                  integrationResponseHeaders.push(integrationResponseHeader);
+                });
               }
+              integrationResponseTemplate = event.http.response.template;
             } else {
               const errorMessage = [
                 'Response config must be provided as an object.',
@@ -230,15 +236,17 @@ module.exports = {
           ];
 
           // merge the response configuration
-          _.merge(methodResponses[0].ResponseParameters, {
-            'method.response.header.Content-Type': 'method.response.header.Content-Type',
+          methodResponseHeaders.forEach((header) => {
+            _.merge(methodResponses[0].ResponseParameters, header);
           });
-          _.merge(integrationResponses[0].ResponseParameters, {
-            'method.response.header.Content-Type': `'${responseContentType}'`,
+          integrationResponseHeaders.forEach((header) => {
+            _.merge(integrationResponses[0].ResponseParameters, header);
           });
-          _.merge(integrationResponses[0].ResponseTemplates, {
-            'application/json': integrationResponseTemplate,
-          });
+          if (integrationResponseTemplate) {
+            _.merge(integrationResponses[0].ResponseTemplates, {
+              'application/json': integrationResponseTemplate,
+            });
+          }
 
           if (corsEnabled) {
             const corsMethodResponseParameter = {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -128,9 +128,7 @@ module.exports = {
               if (event.http.request.template) {
                 _.forEach(event.http.request.template, (value, key) => {
                   const requestTemplate = {};
-
-                  requestTemplate[key] = this.serverless.utils.readFileSync(value).toString();
-
+                  requestTemplate[key] = value;
                   _.merge(integrationRequestTemplates, requestTemplate);
                 });
               }

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -186,12 +186,43 @@ module.exports = {
             method.substr(1).toLowerCase();
           const extractedResourceId = resourceLogicalId.match(/ResourceApigEvent(.*)/)[1];
 
-          const allowOrigin = '"method.response.header.Access-Control-Allow-Origin"';
-          const corsMethodResponseTemplate =
-          corsEnabled ? `${allowOrigin} : ${allowOrigin}` : '';
+          // prepare the method responses
+          const methodResponses = [
+            {
+              ResponseModels: {},
+              ResponseParameters: {
+                'method.response.header.Content-Type': 'method.response.header.Content-Type',
+              },
+              StatusCode: 200,
+            },
+          ];
 
-          const corsMethodIntegrationTemplate =
-          corsEnabled ? `${allowOrigin}: "'${cors.origins.join(',')}'"` : '';
+          const integrationResponses = [
+            {
+              StatusCode: 200,
+              ResponseParameters: {
+                'method.response.header.Content-Type': "'text/html'",
+              },
+              ResponseTemplates: {
+                'text/html': "$input.path('$')",
+              },
+            },
+          ];
+
+          if (corsEnabled) {
+            const corsMethodResponseParameter = {
+              'method.response.header.Access-Control-Allow-Origin':
+                'method.response.header.Access-Control-Allow-Origin',
+            };
+
+            const corsIntegrationResponseParameter = {
+              'method.response.header.Access-Control-Allow-Origin':
+              `'${cors.origins.join('\',\'')}'`,
+            };
+
+            _.merge(methodResponses[0].ResponseParameters, corsMethodResponseParameter);
+            _.merge(integrationResponses[0].ResponseParameters, corsIntegrationResponseParameter);
+          }
 
           const methodTemplate = `
             {
@@ -199,15 +230,7 @@ module.exports = {
               "Properties" : {
                 "AuthorizationType" : "NONE",
                 "HttpMethod" : "${method.toUpperCase()}",
-                "MethodResponses" : [
-                  {
-                    "ResponseModels" : {},
-                    "ResponseParameters" : {
-                      ${corsMethodResponseTemplate}
-                    },
-                    "StatusCode" : "200"
-                  }
-                ],
+                "MethodResponses" : ${JSON.stringify(methodResponses)},
                 "RequestParameters" : {},
                 "Integration" : {
                   "IntegrationHttpMethod" : "POST",
@@ -231,17 +254,7 @@ module.exports = {
                       "Fn::FindInMap": [ "ApiGateway", "RequestTemplates", "FormUrlEncoded" ]
                     }
                   },
-                  "IntegrationResponses" : [
-                    {
-                      "StatusCode" : "200",
-                      "ResponseParameters" : {
-                        ${corsMethodIntegrationTemplate}
-                      },
-                      "ResponseTemplates" : {
-                        "application/json": ""
-                      }
-                    }
-                  ]
+                  "IntegrationResponses" : ${JSON.stringify(integrationResponses)}
                 },
                 "ResourceId" : { "Ref": "${resourceLogicalId}" },
                 "RestApiId" : { "Ref": "RestApiApigEvent" }

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -29,7 +29,7 @@ module.exports = {
               .Error(errorMessage);
           }
 
-          // add the default request and response templates to the CloudFormation "Mappings" section
+          // add default request templates
           const DEFAULT_JSON_REQUEST_TEMPLATE = `
             #define( $loop )
               {
@@ -116,19 +116,10 @@ module.exports = {
             }
           `;
 
-          const apiGatewayMappings = `
-            {
-              "ApiGateway": {
-                "RequestTemplates": {
-                  "Json": ${JSON.stringify(DEFAULT_JSON_REQUEST_TEMPLATE)},
-                  "FormUrlEncoded": ${JSON.stringify(DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE)}
-                }
-              }
-            }
-          `;
-
-          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Mappings,
-            JSON.parse(apiGatewayMappings));
+          const integrationRequestTemplates = {
+            'application/json': DEFAULT_JSON_REQUEST_TEMPLATE,
+            'application/x-www-form-urlencoded': DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
+          };
 
           // setup CORS
           let cors;
@@ -285,14 +276,7 @@ module.exports = {
                       ]
                     ]
                   },
-                  "RequestTemplates" : {
-                    "application/json" : {
-                      "Fn::FindInMap": [ "ApiGateway", "RequestTemplates", "Json" ]
-                    },
-                    "application/x-www-form-urlencoded" : {
-                      "Fn::FindInMap": [ "ApiGateway", "RequestTemplates", "FormUrlEncoded" ]
-                    }
-                  },
+                  "RequestTemplates" : ${JSON.stringify(integrationRequestTemplates)},
                   "IntegrationResponses" : ${JSON.stringify(integrationResponses)}
                 },
                 "ResourceId" : { "Ref": "${resourceLogicalId}" },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -186,13 +186,37 @@ module.exports = {
             method.substr(1).toLowerCase();
           const extractedResourceId = resourceLogicalId.match(/ResourceApigEvent(.*)/)[1];
 
-          // prepare the method responses
+          // default response configuration
+          let responseContentType = 'application/json';
+          let integrationResponseTemplate = "$input.path('$')";
+
+          // check if custom response configuration should be used
+          if (Boolean(event.http.response) === true) {
+            if (typeof event.http.response === 'object') {
+              if (event.http.response.headers['Content-Type'] && event.http.response.template) {
+                responseContentType = event.http.response.headers['Content-Type'];
+                integrationResponseTemplate = event.http.response.template;
+              } else {
+                const errorMessage = [
+                  'Response config must set values for the Content-Type header and the template.',
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes.Error(errorMessage);
+              }
+            } else {
+              const errorMessage = [
+                'Response config must be provided as an object.',
+                ' Please check the docs for more info.',
+              ].join('');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
+          }
+
+          // scaffolds for method responses
           const methodResponses = [
             {
               ResponseModels: {},
-              ResponseParameters: {
-                'method.response.header.Content-Type': 'method.response.header.Content-Type',
-              },
+              ResponseParameters: {},
               StatusCode: 200,
             },
           ];
@@ -200,14 +224,21 @@ module.exports = {
           const integrationResponses = [
             {
               StatusCode: 200,
-              ResponseParameters: {
-                'method.response.header.Content-Type': "'text/html'",
-              },
-              ResponseTemplates: {
-                'text/html': "$input.path('$')",
-              },
+              ResponseParameters: {},
+              ResponseTemplates: {},
             },
           ];
+
+          // merge the response configuration
+          _.merge(methodResponses[0].ResponseParameters, {
+            'method.response.header.Content-Type': 'method.response.header.Content-Type',
+          });
+          _.merge(integrationResponses[0].ResponseParameters, {
+            'method.response.header.Content-Type': `'${responseContentType}'`,
+          });
+          _.merge(integrationResponses[0].ResponseTemplates, {
+            'application/json': integrationResponseTemplate,
+          });
 
           if (corsEnabled) {
             const corsMethodResponseParameter = {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -217,7 +217,7 @@ module.exports = {
 
                   const integrationResponseHeader = {};
                   integrationResponseHeader[`method.response.header.${key}`] =
-                    `'${value}'`;
+                    `${value}`;
                   integrationResponseHeaders.push(integrationResponseHeader);
                 });
               }

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -125,12 +125,20 @@ module.exports = {
           if (Boolean(event.http.request) === true) {
             if (typeof event.http.request === 'object') {
               // merge custom request templates if provided
-              if (event.http.request.template) {
-                _.forEach(event.http.request.template, (value, key) => {
-                  const requestTemplate = {};
-                  requestTemplate[key] = value;
-                  _.merge(integrationRequestTemplates, requestTemplate);
-                });
+              if (Boolean(event.http.request.template) === true) {
+                if (typeof event.http.request.template === 'object') {
+                  _.forEach(event.http.request.template, (value, key) => {
+                    const requestTemplate = {};
+                    requestTemplate[key] = value;
+                    _.merge(integrationRequestTemplates, requestTemplate);
+                  });
+                } else {
+                  const errorMessage = [
+                    'Template config must be provided as an object.',
+                    ' Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes.Error(errorMessage);
+                }
               }
             } else {
               const errorMessage = [
@@ -206,18 +214,26 @@ module.exports = {
           if (Boolean(event.http.response) === true) {
             if (typeof event.http.response === 'object') {
               // prepare the headers if set
-              if (event.http.response.headers) {
-                _.forEach(event.http.response.headers, (value, key) => {
-                  const methodResponseHeader = {};
-                  methodResponseHeader[`method.response.header.${key}`] =
-                    `method.response.header.${value.toString()}`;
-                  methodResponseHeaders.push(methodResponseHeader);
+              if (Boolean(event.http.response.headers) === true) {
+                if (typeof event.http.response.headers === 'object') {
+                  _.forEach(event.http.response.headers, (value, key) => {
+                    const methodResponseHeader = {};
+                    methodResponseHeader[`method.response.header.${key}`] =
+                      `method.response.header.${value.toString()}`;
+                    methodResponseHeaders.push(methodResponseHeader);
 
-                  const integrationResponseHeader = {};
-                  integrationResponseHeader[`method.response.header.${key}`] =
-                    `${value}`;
-                  integrationResponseHeaders.push(integrationResponseHeader);
-                });
+                    const integrationResponseHeader = {};
+                    integrationResponseHeader[`method.response.header.${key}`] =
+                      `${value}`;
+                    integrationResponseHeaders.push(integrationResponseHeader);
+                  });
+                } else {
+                  const errorMessage = [
+                    'Response headers must be provided as an object.',
+                    ' Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes.Error(errorMessage);
+                }
               }
               integrationResponseTemplate = event.http.response.template;
             } else {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -11,7 +11,7 @@ describe('#compileMethods()', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.service = 'first-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {}, Mappings: {} };
     serverless.service.environment = {
       stages: {
         dev: {
@@ -292,6 +292,34 @@ describe('#compileMethods()', () => {
           .Resources.PreflightMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Methods']
       ).to.equal('\'OPTIONS,PUT\'');
+    });
+  });
+
+  it('should merge the request template into the "Mappings" section', () => awsCompileApigEvents
+    .compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Mappings.ApiGateway.RequestTemplate.Value
+      ).to.not.equal(undefined);
+    })
+  );
+
+  it('should reference the request template for the different content types', () => {
+    const findInMap = {
+      'Fn::FindInMap': [
+        'ApiGateway',
+        'RequestTemplate',
+        'Value',
+      ],
+    };
+
+    awsCompileApigEvents.compileMethods().then(() => {
+      // application/json
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.PostMethodApigEvent0.Properties.Integration
+          .RequestTemplates['application/json']
+      ).to.equal(JSON.stringify(findInMap));
     });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -299,17 +299,17 @@ describe('#compileMethods()', () => {
     .compileMethods().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Mappings.ApiGateway.RequestTemplate.Value
-      ).to.not.equal(undefined);
+          .Mappings.ApiGateway.RequestTemplates
+      ).to.not.deep.equal({});
     })
   );
 
-  it('should reference the request template for the different content types', () => {
-    const findInMap = {
+  it('should reference the request templates for the different content types', () => {
+    const findInMapForJson = {
       'Fn::FindInMap': [
         'ApiGateway',
-        'RequestTemplate',
-        'Value',
+        'RequestTemplates',
+        'Json',
       ],
     };
 
@@ -319,7 +319,22 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.PostMethodApigEvent0.Properties.Integration
           .RequestTemplates['application/json']
-      ).to.equal(JSON.stringify(findInMap));
+      ).to.deep.equal(findInMapForJson);
+
+      const findInMapForFormUrlEncoded = {
+        'Fn::FindInMap': [
+          'ApiGateway',
+          'RequestTemplates',
+          'FormUrlEncoded',
+        ],
+      };
+
+      // application/x-www-form-urlencoded
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.PostMethodApigEvent0.Properties.Integration
+          .RequestTemplates['application/x-www-form-urlencoded']
+      ).to.deep.equal(findInMapForFormUrlEncoded);
     });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -337,4 +337,34 @@ describe('#compileMethods()', () => {
       ).to.deep.equal(findInMapForFormUrlEncoded);
     });
   });
+
+  it('should have a Content-Type header response parameter defined in the method response', () => {
+    awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.PostMethodApigEvent0.Properties.MethodResponses[0]
+        .ResponseParameters['method.response.header.Content-Type']
+      ).to.equal('method.response.header.Content-Type');
+    });
+  });
+
+  it('should have a text/html response parameter defined in the integration response', () => {
+    awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.PostMethodApigEvent0.Properties.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Content-Type']
+      ).to.equal("'text/html'");
+    });
+  });
+
+  it('should have a text/html response template defined in the integration response', () => {
+    awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.PostMethodApigEvent0.Properties.IntegrationResponses[0]
+          .ResponseTemplates['text/html']
+      ).to.equal("$input.path('$')");
+    });
+  });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const path = require('path');
 const expect = require('chai').expect;
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
-const testUtils = require('../../../../../../../../tests/utils');
 
 describe('#compileMethods()', () => {
   let serverless;
@@ -317,13 +315,6 @@ describe('#compileMethods()', () => {
     );
 
     it('should set custom request templates', () => {
-      const tmpDirPath = testUtils.getTmpDirPath();
-      const requestTemplate1 = path.join(tmpDirPath, 'template-1.vm');
-      const requestTemplate2 = path.join(tmpDirPath, 'template-2.vm');
-
-      serverless.utils.writeFileSync(requestTemplate1, 'content-of-template-1');
-      serverless.utils.writeFileSync(requestTemplate2, 'content-of-template-2');
-
       awsCompileApigEvents.serverless.service.functions = {
         first: {
           events: [
@@ -333,8 +324,8 @@ describe('#compileMethods()', () => {
                 path: 'users/list',
                 request: {
                   template: {
-                    'template/1': requestTemplate1,
-                    'template/2': requestTemplate2,
+                    'template/1': '{ "stage" : "$context.stage" }',
+                    'template/2': '{ "httpMethod" : "$context.httpMethod" }',
                   },
                 },
               },
@@ -347,21 +338,16 @@ describe('#compileMethods()', () => {
         expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.GetMethodApigEvent1.Properties
           .Integration.RequestTemplates['template/1']
-        ).to.equal('content-of-template-1');
+        ).to.equal('{ "stage" : "$context.stage" }');
 
         expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.GetMethodApigEvent1.Properties
           .Integration.RequestTemplates['template/2']
-        ).to.equal('content-of-template-2');
+        ).to.equal('{ "httpMethod" : "$context.httpMethod" }');
       });
     });
 
     it('should be possible to overwrite default request templates', () => {
-      const tmpDirPath = testUtils.getTmpDirPath();
-      const requestTemplate = path.join(tmpDirPath, 'template.vm');
-
-      serverless.utils.writeFileSync(requestTemplate, 'overwritten-request-template-content');
-
       awsCompileApigEvents.serverless.service.functions = {
         first: {
           events: [
@@ -371,7 +357,7 @@ describe('#compileMethods()', () => {
                 path: 'users/list',
                 request: {
                   template: {
-                    'application/json': requestTemplate,
+                    'application/json': 'overwritten-request-template-content',
                   },
                 },
               },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -11,7 +11,7 @@ describe('#compileMethods()', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.service = 'first-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {}, Mappings: {} };
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.service.environment = {
       stages: {
         dev: {
@@ -295,47 +295,24 @@ describe('#compileMethods()', () => {
     });
   });
 
-  it('should merge the request template into the "Mappings" section', () => awsCompileApigEvents
-    .compileMethods().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Mappings.ApiGateway.RequestTemplates
-      ).to.not.deep.equal({});
-    })
-  );
+  describe('when dealing with request configuration', () => {
+    it('should setup a default "application/json" template', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties
+          .Integration.RequestTemplates['application/json']
+        ).to.have.length.above(0);
+      })
+    );
 
-  it('should reference the request templates for the different content types', () => {
-    const findInMapForJson = {
-      'Fn::FindInMap': [
-        'ApiGateway',
-        'RequestTemplates',
-        'Json',
-      ],
-    };
-
-    awsCompileApigEvents.compileMethods().then(() => {
-      // application/json
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.PostMethodApigEvent0.Properties.Integration
-          .RequestTemplates['application/json']
-      ).to.deep.equal(findInMapForJson);
-
-      const findInMapForFormUrlEncoded = {
-        'Fn::FindInMap': [
-          'ApiGateway',
-          'RequestTemplates',
-          'FormUrlEncoded',
-        ],
-      };
-
-      // application/x-www-form-urlencoded
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.PostMethodApigEvent0.Properties.Integration
-          .RequestTemplates['application/x-www-form-urlencoded']
-      ).to.deep.equal(findInMapForFormUrlEncoded);
-    });
+    it('should setup a default "application/x-www-form-urlencoded" template', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties
+          .Integration.RequestTemplates['application/x-www-form-urlencoded']
+        ).to.have.length.above(0);
+      })
+    );
   });
 
   describe('when dealing with response configuration', () => {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const path = require('path');
 const expect = require('chai').expect;
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
+const testUtils = require('../../../../../../../../tests/utils');
 
 describe('#compileMethods()', () => {
   let serverless;
@@ -313,6 +315,78 @@ describe('#compileMethods()', () => {
         ).to.have.length.above(0);
       })
     );
+
+    it('should set custom request templates', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const requestTemplate1 = path.join(tmpDirPath, 'template-1.vm');
+      const requestTemplate2 = path.join(tmpDirPath, 'template-2.vm');
+
+      serverless.utils.writeFileSync(requestTemplate1, 'content-of-template-1');
+      serverless.utils.writeFileSync(requestTemplate2, 'content-of-template-2');
+
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                request: {
+                  template: {
+                    'template/1': requestTemplate1,
+                    'template/2': requestTemplate2,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties
+          .Integration.RequestTemplates['template/1']
+        ).to.equal('content-of-template-1');
+
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties
+          .Integration.RequestTemplates['template/2']
+        ).to.equal('content-of-template-2');
+      });
+    });
+
+    it('should be possible to overwrite default request templates', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const requestTemplate = path.join(tmpDirPath, 'template.vm');
+
+      serverless.utils.writeFileSync(requestTemplate, 'overwritten-request-template-content');
+
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                request: {
+                  template: {
+                    'application/json': requestTemplate,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties
+          .Integration.RequestTemplates['application/json']
+        ).to.equal('overwritten-request-template-content');
+      });
+    });
   });
 
   describe('when dealing with response configuration', () => {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -338,33 +338,93 @@ describe('#compileMethods()', () => {
     });
   });
 
-  it('should have a Content-Type header response parameter defined in the method response', () => {
-    awsCompileApigEvents.compileMethods().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.PostMethodApigEvent0.Properties.MethodResponses[0]
-        .ResponseParameters['method.response.header.Content-Type']
-      ).to.equal('method.response.header.Content-Type');
-    });
-  });
+  describe('when dealing with response configuration', () => {
+    it('should have a Content-Type header defined in the method response', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.GetMethodApigEvent1.Properties.MethodResponses[0]
+            .ResponseParameters['method.response.header.Content-Type']
+        ).to.equal('method.response.header.Content-Type');
+      })
+    );
 
-  it('should have a text/html response parameter defined in the integration response', () => {
-    awsCompileApigEvents.compileMethods().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.PostMethodApigEvent0.Properties.IntegrationResponses[0]
-          .ResponseParameters['method.response.header.Content-Type']
-      ).to.equal("'text/html'");
-    });
-  });
+    it('should default to the application/json content type in the integration response', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+            .ResponseParameters['method.response.header.Content-Type']
+        ).to.equal("'application/json'");
+      })
+    );
 
-  it('should have a text/html response template defined in the integration response', () => {
-    awsCompileApigEvents.compileMethods().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.PostMethodApigEvent0.Properties.IntegrationResponses[0]
-          .ResponseTemplates['text/html']
-      ).to.equal("$input.path('$')");
+    it('should have a default response template defined in the integration response', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+            .ResponseTemplates['application/json']
+        ).to.equal("$input.path('$')");
+      })
+    );
+
+    it('should set the custom Content-Type header', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                response: {
+                  headers: {
+                    'Content-Type': 'text/plain',
+                  },
+                  template: "$input.path('$')",
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+            .ResponseParameters['method.response.header.Content-Type']
+        ).to.equal("'text/plain'");
+      });
+    });
+
+    it('should set the custom template', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                response: {
+                  headers: {
+                    'Content-Type': 'text/plain',
+                  },
+                  template: "$input.path('$.foo')",
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+            .ResponseTemplates['application/json']
+        ).to.equal("$input.path('$.foo')");
+      });
     });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -339,37 +339,7 @@ describe('#compileMethods()', () => {
   });
 
   describe('when dealing with response configuration', () => {
-    it('should have a Content-Type header defined in the method response', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.GetMethodApigEvent1.Properties.MethodResponses[0]
-            .ResponseParameters['method.response.header.Content-Type']
-        ).to.equal('method.response.header.Content-Type');
-      })
-    );
-
-    it('should default to the application/json content type in the integration response', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
-            .ResponseParameters['method.response.header.Content-Type']
-        ).to.equal("'application/json'");
-      })
-    );
-
-    it('should have a default response template defined in the integration response', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
-            .ResponseTemplates['application/json']
-        ).to.equal("$input.path('$')");
-      })
-    );
-
-    it('should set the custom Content-Type header', () => {
+    it('should set the custom headers', () => {
       awsCompileApigEvents.serverless.service.functions = {
         first: {
           events: [
@@ -380,8 +350,8 @@ describe('#compileMethods()', () => {
                 response: {
                   headers: {
                     'Content-Type': 'text/plain',
+                    'My-Custom-Header': 'my/custom/header',
                   },
-                  template: "$input.path('$')",
                 },
               },
             },
@@ -395,6 +365,11 @@ describe('#compileMethods()', () => {
             .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
             .ResponseParameters['method.response.header.Content-Type']
         ).to.equal("'text/plain'");
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
+            .ResponseParameters['method.response.header.My-Custom-Header']
+        ).to.equal("'my/custom/header'");
       });
     });
 
@@ -407,9 +382,6 @@ describe('#compileMethods()', () => {
                 method: 'GET',
                 path: 'users/list',
                 response: {
-                  headers: {
-                    'Content-Type': 'text/plain',
-                  },
                   template: "$input.path('$.foo')",
                 },
               },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -400,7 +400,7 @@ describe('#compileMethods()', () => {
                 path: 'users/list',
                 response: {
                   headers: {
-                    'Content-Type': 'text/plain',
+                    'Content-Type': "'text/plain'",
                     'My-Custom-Header': 'my/custom/header',
                   },
                 },
@@ -420,7 +420,7 @@ describe('#compileMethods()', () => {
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[0]
             .ResponseParameters['method.response.header.My-Custom-Header']
-        ).to.equal("'my/custom/header'");
+        ).to.equal('my/custom/header');
       });
     });
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -373,6 +373,44 @@ describe('#compileMethods()', () => {
         ).to.equal('overwritten-request-template-content');
       });
     });
+
+    it('should throw an error if the provided config is not an object', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                request: 'some string',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
+    });
+
+    it('should throw an error if the template config is not an object', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                request: {
+                  template: 'some string',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
+    });
   });
 
   describe('when dealing with response configuration', () => {
@@ -434,6 +472,44 @@ describe('#compileMethods()', () => {
             .ResponseTemplates['application/json']
         ).to.equal("$input.path('$.foo')");
       });
+    });
+
+    it('should throw an error if the provided config is not an object', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                response: 'some string',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
+    });
+
+    it('should throw an error if the headers are not objects', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                response: {
+                  headers: 'some string',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
     });
   });
 });

--- a/lib/plugins/aws/deploy/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/deploy/lib/core-cloudformation-template.json
@@ -12,5 +12,6 @@
         "Ref": "ServerlessDeploymentBucket"
       }
     }
-  }
+  },
+  "Mappings": {}
 }

--- a/lib/plugins/aws/deploy/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/deploy/lib/core-cloudformation-template.json
@@ -12,6 +12,5 @@
         "Ref": "ServerlessDeploymentBucket"
       }
     }
-  },
-  "Mappings": {}
+  }
 }


### PR DESCRIPTION
This PR updates the default request / response templates support but also adds support for custom request / response templates.

The corresponding issue is: https://github.com/serverless/serverless/issues/1593

/cc @flomotlik @eahefnawy 

---

**Todos:**
- [x] Default request template for multiple content types (see: https://github.com/serverless/serverless/pull/1920)
- [x] Support for custom request templates
- [x] Support for custom response templates
- [x] Docs

---

Functionality can be validated with this `functions` definition:

```
http:
  method: get
  path: whatever
  request:
    template:
      text/xhtml: { "stage" : "$context.stage" }
      text/plain: { "httpMethod" : "$context.httpMethod" }
  response:
    headers:
      Content-Type: "'text/html'"
    template: $input.path('$')
```