### PR TITLE
Fix authorizer creation error when no TTL is supplied (fixes #1948)

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
@@ -26,7 +26,7 @@ module.exports = {
                 .length - 1].split('-');
               authorizerName = splittedLambdaName[splittedLambdaName.length - 1];
             }
-            resultTtlInSeconds = '300';
+            resultTtlInSeconds = 300;
             identitySource = 'method.request.header.Auth';
           } else if (typeof authorizer === 'object') {
             if (authorizer.arn) {
@@ -43,7 +43,7 @@ module.exports = {
               throw new this.serverless.classes
                 .Error('Please provide either an authorizer name or ARN');
             }
-            resultTtlInSeconds = String(authorizer.resultTtlInSeconds) || '300';
+            resultTtlInSeconds = Number.parseInt(authorizer.resultTtlInSeconds, 10) || 300;
             identitySource = authorizer.identitySource || 'method.request.header.Auth';
           } else {
             const errorMessage = [
@@ -60,7 +60,7 @@ module.exports = {
             {
               "Type" : "AWS::ApiGateway::Authorizer",
               "Properties" : {
-                "AuthorizerResultTtlInSeconds" : "${resultTtlInSeconds}",
+                "AuthorizerResultTtlInSeconds" : ${resultTtlInSeconds},
                 "AuthorizerUri" : {"Fn::Join" : ["", [
                   "arn:aws:apigateway:",
                   {"Ref" : "AWS::Region"},

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/authorizers.js
@@ -66,7 +66,7 @@ describe('#compileAuthorizers()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.authorizerAuthorizer.Properties.AuthorizerResultTtlInSeconds
-      ).to.equal('300');
+      ).to.equal(300);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -108,7 +108,7 @@ describe('#compileAuthorizers()', () => {
   it('should create authorizer with the given config object', () => {
     awsCompileApigEvents.serverless.service.functions.first.events[0].http.authorizer = {
       name: 'authorizer',
-      resultTtlInSeconds: '400',
+      resultTtlInSeconds: 400,
       identitySource: 'method.request.header.Custom',
       identityValidationExpression: 'regex',
     };
@@ -117,7 +117,7 @@ describe('#compileAuthorizers()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.authorizerAuthorizer.Properties.AuthorizerResultTtlInSeconds
-      ).to.equal('400');
+      ).to.equal(400);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -137,7 +137,7 @@ describe('#compileAuthorizers()', () => {
   it('should create authorizer with the given config object with ARN', () => {
     awsCompileApigEvents.serverless.service.functions.first.events[0].http.authorizer = {
       arn: 'sss:dev-authorizer',
-      resultTtlInSeconds: '400',
+      resultTtlInSeconds: 400,
       identitySource: 'method.request.header.Custom',
       identityValidationExpression: 'regex',
     };
@@ -146,7 +146,7 @@ describe('#compileAuthorizers()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.authorizerAuthorizer.Properties.AuthorizerResultTtlInSeconds
-      ).to.equal('400');
+      ).to.equal(400);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
##### Status:

Ready

##### Description:
See #1948
When using the object notation without providing a TTL, [`String(authorizer.resultTtlInSeconds)`](https://github.com/serverless/serverless/blob/85f4084e6b0fd4a6d763ace8cd0db82817bbc712/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js#L46) returns "undefined", which makes the creation of the authorizer fail.
