### PR TITLE
Fix #1923: Include commented-out IAM statements in templates' serverless.yml.

### DIFF
--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -16,6 +16,16 @@ service: aws-java-gradle # NOTE: update this with your service name
 provider:
   name: aws
   runtime: java8
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -20,6 +20,10 @@ provider:
 #  iamRoleStatements:
 #    - Effect: "Allow"
 #      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
 #        - "s3:PutObject"
 #      Resource:
 #        Fn::Join:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -20,6 +20,10 @@ provider:
 #  iamRoleStatements:
 #    - Effect: "Allow"
 #      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
 #        - "s3:PutObject"
 #      Resource:
 #        Fn::Join:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -16,6 +16,16 @@ service: aws-java-maven # NOTE: update this with your service name
 provider:
   name: aws
   runtime: java8
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -20,6 +20,10 @@ provider:
 #  iamRoleStatements:
 #    - Effect: "Allow"
 #      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
 #        - "s3:PutObject"
 #      Resource:
 #        Fn::Join:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -16,6 +16,16 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -16,6 +16,16 @@ service: aws-python # NOTE: update this with your service name
 provider:
   name: aws
   runtime: python2.7
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
 
 # you can overwrite defaults here
 #defaults:

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -20,6 +20,10 @@ provider:
 #  iamRoleStatements:
 #    - Effect: "Allow"
 #      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
 #        - "s3:PutObject"
 #      Resource:
 #        Fn::Join:


### PR DESCRIPTION
##### Status:

Ready

##### Description:

Include an `iamRoleStatements` snippet (commented-out) in the default `serverless.yml` generated as part of a service template (fixes #1923).