### PR TITLE
Add custom validation for plugin options

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -64,6 +64,13 @@ class PluginManager {
 
         throw new this.serverless.classes.Error(errorMessage);
       }
+
+      if (_.isPlainObject(value.customValidation) &&
+        value.customValidation.regularExpression instanceof RegExp &&
+        typeof value.customValidation.errorMessage === 'string' &&
+        !value.customValidation.regularExpression.test(this.cliOptions[key])) {
+        throw new this.serverless.classes.Error(value.customValidation.errorMessage);
+      }
     });
   }
 

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -544,6 +544,50 @@ describe('PluginManager', () => {
 
       expect(() => { pluginManager.validateOptions(commandsArray); }).to.throw(Error);
     });
+
+    it('should throw an error if a customValidation is not set in a plain commands object', () => {
+      pluginManager.setCliOptions({ bar: 'dev' });
+
+      pluginManager.commands = {
+        foo: {
+          options: {
+            bar: {
+              customValidation: {
+                regularExpression: /^[0-9]+$/,
+                errorMessage: 'Custom Error Message',
+              },
+            },
+          },
+        },
+      };
+      const commandsArray = ['foo'];
+
+      expect(() => { pluginManager.validateOptions(commandsArray); }).to.throw(Error);
+    });
+
+    it('should throw an error if a customValidation is not set in a nested commands object', () => {
+      pluginManager.setCliOptions({ baz: 100 });
+
+      pluginManager.commands = {
+        foo: {
+          commands: {
+            bar: {
+              options: {
+                baz: {
+                  customValidation: {
+                    regularExpression: /^[a-zA-z¥s]+$/,
+                    errorMessage: 'Custom Error Message',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const commandsArray = ['foo', 'bar'];
+
+      expect(() => { pluginManager.validateOptions(commandsArray); }).to.throw(Error);
+    });
   });
 
   describe('#run()', () => {

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -588,6 +588,50 @@ describe('PluginManager', () => {
 
       expect(() => { pluginManager.validateOptions(commandsArray); }).to.throw(Error);
     });
+
+    it('should succeeds if a custom regex matches in a plain commands object', () => {
+      pluginManager.setCliOptions({ bar: 100 });
+
+      pluginManager.commands = {
+        foo: {
+          options: {
+            bar: {
+              customValidation: {
+                regularExpression: /^[0-9]+$/,
+                errorMessage: 'Custom Error Message',
+              },
+            },
+          },
+        },
+      };
+      const commandsArray = ['foo'];
+
+      expect(() => { pluginManager.validateOptions(commandsArray); }).to.not.throw(Error);
+    });
+
+    it('should succeeds if a custom regex matches in a nested commands object', () => {
+      pluginManager.setCliOptions({ baz: 'dev' });
+
+      pluginManager.commands = {
+        foo: {
+          commands: {
+            bar: {
+              options: {
+                baz: {
+                  customValidation: {
+                    regularExpression: /^[a-zA-z¥s]+$/,
+                    errorMessage: 'Custom Error Message',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const commandsArray = ['foo', 'bar'];
+
+      expect(() => { pluginManager.validateOptions(commandsArray); }).to.not.throw(Error);
+    });
   });
 
   describe('#run()', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Please follow the template, otherwise we'll have to ask you to update it
-->

***Implementing Issue:*** #1271

## What did you implement:
I implemented #1271
<!--
Briefly describe the feature
-->

## How did you implement it:
I implemented that the PluginManager can check against a regular expression.
If the check fail, the errorMessage is displayed.
```
foo: {
  options: {
    bar: {
      customValidation: {
        regularExpression: /^[0-9]+$/,
        errorMessage: 'Custom Error Message',
      },
    },
  },
}
```
<!--
If this is a nontrivial change please briefly describe your implementation.
-->

## How can we verify it:
Please set customValidation option in a plugin.

```
options: {
  stage: {
    usage: 'Stage of the service',
    shortcut: 's',
  },
  region: {
    usage: 'Region of the service',
    shortcut: 'r',
    customValidation: {
      regularExpression: /^[0-9]+$/,
      errorMessage: 'Custom Error Message',
    },
  },
}
```

If the check fail, the errorMessage is displayed.
<img width="832" alt="2016-08-30 5 45 08" src="https://cloud.githubusercontent.com/assets/1301012/18066833/10c72c62-6e75-11e6-89e7-b435ff829a3e.png">

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

