### PR TITLE
fix #1983 - rename default custom authorizer header to Authorization

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -85,7 +85,7 @@ functions:
           authorizer:
             name: authorizerFunc
             resultTtlInSeconds: 0
-            identitySource: method.request.header.Auth
+            identitySource: method.request.header.Authorization
             identityValidationExpression: someRegex
   authorizerFunc:
     handler: handlers.authorizerFunc
@@ -122,7 +122,7 @@ functions:
           authorizer:
             arn: xxx:xxx:Lambda-Name
             resultTtlInSeconds: 0
-            identitySource: method.request.header.Auth
+            identitySource: method.request.header.Authorization
             identityValidationExpression: someRegex
 ```
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
@@ -27,7 +27,7 @@ module.exports = {
               authorizerName = splittedLambdaName[splittedLambdaName.length - 1];
             }
             resultTtlInSeconds = 300;
-            identitySource = 'method.request.header.Auth';
+            identitySource = 'method.request.header.Authorization';
           } else if (typeof authorizer === 'object') {
             if (authorizer.arn) {
               authorizerArn = authorizer.arn;
@@ -44,7 +44,7 @@ module.exports = {
                 .Error('Please provide either an authorizer name or ARN');
             }
             resultTtlInSeconds = Number.parseInt(authorizer.resultTtlInSeconds, 10) || 300;
-            identitySource = authorizer.identitySource || 'method.request.header.Auth';
+            identitySource = authorizer.identitySource || 'method.request.header.Authorization';
           } else {
             const errorMessage = [
               `authorizer property in function ${functionName} is not an object nor a string.`,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/authorizers.js
@@ -71,7 +71,7 @@ describe('#compileAuthorizers()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.authorizerAuthorizer.Properties.IdentitySource
-      ).to.equal('method.request.header.Auth');
+      ).to.equal('method.request.header.Authorization');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
***Implementing Issue:*** #1983

## What did you implement:

Changed default API Gateway custom authorizer header from Auth to Authorization.
