### PR TITLE
don't overwrite custom headers

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -58,8 +58,6 @@ module.exports = {
                 ].join('');
                 throw new this.serverless.classes
                 .Error(errorMessage);
-              } else {
-                cors.headers = headers;
               }
 
               if (!cors.methods.indexOf('OPTIONS') > -1) {


### PR DESCRIPTION

***Implementing Issue:*** #1984 

## What did you implement:
removed two lines that were overwriting custom cors headers with the defaults

## How can we verify it:
```yml
  cors:
    origins:
      - '*'
      - 'example.com'
    headers:
      - x-user-id
```
confirm that the header appear in your IntegrationResponse/HeaderMappings

## Todos:

- [ ] Write tests
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources

attempt to fix #1984