### PR TITLE
Add status code support for API Gateway

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -180,7 +180,7 @@ the `${file(templatefile)}` syntax.
 ### Status codes
 
 Serverless ships with default status codes you can use to e.g. signal that a resource could not be found (404) or that
-the user is not authorized to perform the action (401).
+the user is not authorized to perform the action (401). Those status codes are regex definitions that will be added to your API Gateway configuration.
 
 #### Overview of available status codes
 
@@ -207,6 +207,10 @@ module.exports.hello = (event, context, cb) => {
   cb(new Error('[404] Not found'));
 }
 ```
+
+### Catching exceptions in your Lambda function
+
+In case an exception is thrown in your lambda function AWS will send an error message with `Process exited before completing request`. This will be caught by the regular expression for the 500 HTTP status and the 500 status will be returned.
 
 ### Http setup with custom authorizer
 You can enable custom authorizers for your HTTP endpoint by setting the authorizer in your http event to another function

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -184,16 +184,16 @@ the user is not authorized to perform this action (401).
 
 #### Overview of available status codes
 
-|Status Code|Meaning|
-|-|-|
-|400|Bad Request|
-|401|Unauthorized|
-|403|Forbidden|
-|404|Not Found|
-|422|Unprocessable Entity|
-|500|Internal Server Error|
-|502|Bad Gateway|
-|504|Gateway Timeout|
+| Status Code | Meaning |
+| --- | --- |
+| 400 | Bad Request |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | Not Found |
+| 422 | Unprocessable Entity |
+| 500 | Internal Server Error |
+| 502 | Bad Gateway |
+| 504 | Gateway Timeout |
 
 #### Using status codes
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -177,6 +177,52 @@ functions:
 **Note:** The template is defined as plain text here. However you can also reference an external file with the help of
 the `${file(templatefile)}` syntax.
 
+### Status codes
+
+Serverless ships with default status codes you can use to e.g. signal that a resouce could not be found (404) or that
+the user is not authorized to perform this action (401).
+
+#### Overview of available status codes
+
+|Status Code|Meaning|
+|-|-|
+|400|Bad Request|
+|401|Unauthorized|
+|403|Forbidden|
+|404|Not Found|
+|422|Unprocessable Entity|
+|500|Internal Server Error|
+|502|Bad Gateway|
+|504|Gateway Timeout|
+
+#### Using status codes
+
+Here's an example which shows you how you can raise a 400 HTTP status from within your lambda function.
+
+```javascript
+module.exports.hello = (event, context, callback) => {
+  var response = {
+    status: 400,
+    errors: [
+      {
+        code: "1",
+        source: "/users/create",
+        message: "Invalid E-Mail",
+        detail: "The E-Mail address you've entered was invalid."
+      },
+      {
+        code: "2",
+        source: "/users/create",
+        message: "Invalid Password",
+        detail: "The provided password is too short."
+      },
+    ]
+  }
+
+  context.fail(JSON.stringify(response));
+};
+```
+
 ### Http setup with custom authorizer
 You can enable custom authorizers for your HTTP endpoint by setting the authorizer in your http event to another function
 in the same service, as shown in the following example

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -179,8 +179,8 @@ the `${file(templatefile)}` syntax.
 
 ### Status codes
 
-Serverless ships with default status codes you can use to e.g. signal that a resouce could not be found (404) or that
-the user is not authorized to perform this action (401).
+Serverless ships with default status codes you can use to e.g. signal that a resource could not be found (404) or that
+the user is not authorized to perform the action (401).
 
 #### Overview of available status codes
 
@@ -197,30 +197,15 @@ the user is not authorized to perform this action (401).
 
 #### Using status codes
 
-Here's an example which shows you how you can raise a 400 HTTP status from within your lambda function.
+To return a given status code you simply need to add square brackets with the status code of your choice to your
+returned message like this: `[401] You are not authorized to access this resource!`.
+
+Here's an example which shows you how you can raise a 404 HTTP status from within your lambda function.
 
 ```javascript
-module.exports.hello = (event, context, callback) => {
-  var response = {
-    status: 400,
-    errors: [
-      {
-        code: "1",
-        source: "/users/create",
-        message: "Invalid E-Mail",
-        detail: "The E-Mail address you've entered was invalid."
-      },
-      {
-        code: "2",
-        source: "/users/create",
-        message: "Invalid Password",
-        detail: "The provided password is too short."
-      },
-    ]
-  }
-
-  context.fail(JSON.stringify(response));
-};
+module.exports.hello = (event, context, cb) => {
+  cb(new Error('[404] Not found'));
+}
 ```
 
 ### Http setup with custom authorizer

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -99,19 +99,19 @@ module.exports = {
               "method": "$context.httpMethod",
               "principalId": "$context.authorizer.principalId",
               "stage": "$context.stage",
-              
+
               #set( $map = $input.params().header )
               "headers": $loop,
-              
+
               #set( $map = $input.params().querystring )
               "query": $loop,
-              
+
               #set( $map = $input.params().path )
               "path": $loop,
-              
+
               #set( $map = $context.identity )
               "identity": $loop,
-              
+
               #set( $map = $stageVariables )
               "stageVariables": $loop
             }
@@ -331,7 +331,9 @@ module.exports = {
             { StatusCode: 403, SelectionPattern: '.*\\[403\\].*' },
             { StatusCode: 404, SelectionPattern: '.*\\[404\\].*' },
             { StatusCode: 422, SelectionPattern: '.*\\[422\\].*' },
-            { StatusCode: 500, SelectionPattern: '.*\\[500\\].*' },
+            { StatusCode: 500,
+              SelectionPattern:
+                '.*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\]).*' },
             { StatusCode: 502, SelectionPattern: '.*\\[502\\].*' },
             { StatusCode: 504, SelectionPattern: '.*\\[504\\].*' }
           );

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -313,6 +313,77 @@ module.exports = {
             _.merge(integrationResponses[0].ResponseParameters, corsIntegrationResponseParameter);
           }
 
+          // add default status codes
+          methodResponses.push(
+            { StatusCode: 400 },
+            { StatusCode: 401 },
+            { StatusCode: 403 },
+            { StatusCode: 404 },
+            { StatusCode: 422 },
+            { StatusCode: 500 },
+            { StatusCode: 502 },
+            { StatusCode: 504 }
+          );
+
+          integrationResponses.push(
+            {
+              StatusCode: 400,
+              SelectionPattern: '.*"status":400.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 401,
+              SelectionPattern: '.*"status":401.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 403,
+              SelectionPattern: '.*"status":403.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 404,
+              SelectionPattern: '.*"status":404.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 422,
+              SelectionPattern: '.*"status":422.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 500,
+              SelectionPattern: '.*"status":500.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 502,
+              SelectionPattern: '.*"status":502.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            },
+            {
+              StatusCode: 504,
+              SelectionPattern: '.*"status":504.*',
+              ResponseTemplates: {
+                'application/json': "$input.path('$.errorMessage')",
+              },
+            }
+          );
+
           const normalizedFunctionName = functionName[0].toUpperCase()
             + functionName.substr(1);
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -326,62 +326,14 @@ module.exports = {
           );
 
           integrationResponses.push(
-            {
-              StatusCode: 400,
-              SelectionPattern: '.*"status":400.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 401,
-              SelectionPattern: '.*"status":401.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 403,
-              SelectionPattern: '.*"status":403.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 404,
-              SelectionPattern: '.*"status":404.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 422,
-              SelectionPattern: '.*"status":422.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 500,
-              SelectionPattern: '.*"status":500.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 502,
-              SelectionPattern: '.*"status":502.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            },
-            {
-              StatusCode: 504,
-              SelectionPattern: '.*"status":504.*',
-              ResponseTemplates: {
-                'application/json': "$input.path('$.errorMessage')",
-              },
-            }
+            { StatusCode: 400, SelectionPattern: '.*\\[400\\].*' },
+            { StatusCode: 401, SelectionPattern: '.*\\[401\\].*' },
+            { StatusCode: 403, SelectionPattern: '.*\\[403\\].*' },
+            { StatusCode: 404, SelectionPattern: '.*\\[404\\].*' },
+            { StatusCode: 422, SelectionPattern: '.*\\[422\\].*' },
+            { StatusCode: 500, SelectionPattern: '.*\\[500\\].*' },
+            { StatusCode: 502, SelectionPattern: '.*\\[502\\].*' },
+            { StatusCode: 504, SelectionPattern: '.*\\[504\\].*' }
           );
 
           const normalizedFunctionName = functionName[0].toUpperCase()

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -664,7 +664,8 @@ describe('#compileMethods()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[6]
-      ).to.deep.equal({ StatusCode: 500, SelectionPattern: '.*\\[500\\].*' });
+      ).to.deep.equal({ StatusCode: 500,
+        SelectionPattern: '.*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\]).*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -601,4 +601,142 @@ describe('#compileMethods()', () => {
       expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
     });
   });
+
+  it('should add method responses for different status codes', () =>
+    awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[1].StatusCode
+      ).to.equal(400);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[2].StatusCode
+      ).to.equal(401);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[3].StatusCode
+      ).to.equal(403);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[4].StatusCode
+      ).to.equal(404);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[5].StatusCode
+      ).to.equal(422);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[6].StatusCode
+      ).to.equal(500);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[7].StatusCode
+      ).to.equal(502);
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.MethodResponses[8].StatusCode
+      ).to.equal(504);
+    })
+  );
+
+  it('should add integration responses for different status codes', () =>
+    awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[1]
+      ).to.deep.equal(
+        {
+          StatusCode: 400,
+          SelectionPattern: '.*"status":400.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[2]
+      ).to.deep.equal(
+        {
+          StatusCode: 401,
+          SelectionPattern: '.*"status":401.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[3]
+      ).to.deep.equal(
+        {
+          StatusCode: 403,
+          SelectionPattern: '.*"status":403.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[4]
+      ).to.deep.equal(
+        {
+          StatusCode: 404,
+          SelectionPattern: '.*"status":404.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[5]
+      ).to.deep.equal(
+        {
+          StatusCode: 422,
+          SelectionPattern: '.*"status":422.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[6]
+      ).to.deep.equal(
+        {
+          StatusCode: 500,
+          SelectionPattern: '.*"status":500.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[7]
+      ).to.deep.equal(
+        {
+          StatusCode: 502,
+          SelectionPattern: '.*"status":502.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[8]
+      ).to.deep.equal(
+        {
+          StatusCode: 504,
+          SelectionPattern: '.*"status":504.*',
+          ResponseTemplates: {
+            'application/json': "$input.path('$.errorMessage')",
+          },
+        }
+      );
+    })
+  );
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -606,35 +606,35 @@ describe('#compileMethods()', () => {
     awsCompileApigEvents.compileMethods().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[1].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[1].StatusCode
       ).to.equal(400);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[2].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[2].StatusCode
       ).to.equal(401);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[3].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[3].StatusCode
       ).to.equal(403);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[4].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[4].StatusCode
       ).to.equal(404);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[5].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[5].StatusCode
       ).to.equal(422);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[6].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[6].StatusCode
       ).to.equal(500);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[7].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[7].StatusCode
       ).to.equal(502);
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.MethodResponses[8].StatusCode
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[8].StatusCode
       ).to.equal(504);
     })
   );
@@ -643,7 +643,7 @@ describe('#compileMethods()', () => {
     awsCompileApigEvents.compileMethods().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[1]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
       ).to.deep.equal(
         {
           StatusCode: 400,
@@ -655,7 +655,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[2]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[2]
       ).to.deep.equal(
         {
           StatusCode: 401,
@@ -667,7 +667,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[3]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[3]
       ).to.deep.equal(
         {
           StatusCode: 403,
@@ -679,7 +679,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[4]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[4]
       ).to.deep.equal(
         {
           StatusCode: 404,
@@ -691,7 +691,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[5]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[5]
       ).to.deep.equal(
         {
           StatusCode: 422,
@@ -703,7 +703,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[6]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[6]
       ).to.deep.equal(
         {
           StatusCode: 500,
@@ -715,7 +715,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[7]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]
       ).to.deep.equal(
         {
           StatusCode: 502,
@@ -727,7 +727,7 @@ describe('#compileMethods()', () => {
       );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.GetMethodApigEvent1.Properties.Integration.IntegrationResponses[8]
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[8]
       ).to.deep.equal(
         {
           StatusCode: 504,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -644,99 +644,35 @@ describe('#compileMethods()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
-      ).to.deep.equal(
-        {
-          StatusCode: 400,
-          SelectionPattern: '.*"status":400.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 400, SelectionPattern: '.*\\[400\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[2]
-      ).to.deep.equal(
-        {
-          StatusCode: 401,
-          SelectionPattern: '.*"status":401.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 401, SelectionPattern: '.*\\[401\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[3]
-      ).to.deep.equal(
-        {
-          StatusCode: 403,
-          SelectionPattern: '.*"status":403.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 403, SelectionPattern: '.*\\[403\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[4]
-      ).to.deep.equal(
-        {
-          StatusCode: 404,
-          SelectionPattern: '.*"status":404.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 404, SelectionPattern: '.*\\[404\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[5]
-      ).to.deep.equal(
-        {
-          StatusCode: 422,
-          SelectionPattern: '.*"status":422.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 422, SelectionPattern: '.*\\[422\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[6]
-      ).to.deep.equal(
-        {
-          StatusCode: 500,
-          SelectionPattern: '.*"status":500.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 500, SelectionPattern: '.*\\[500\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]
-      ).to.deep.equal(
-        {
-          StatusCode: 502,
-          SelectionPattern: '.*"status":502.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 502, SelectionPattern: '.*\\[502\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[8]
-      ).to.deep.equal(
-        {
-          StatusCode: 504,
-          SelectionPattern: '.*"status":504.*',
-          ResponseTemplates: {
-            'application/json': "$input.path('$.errorMessage')",
-          },
-        }
-      );
+      ).to.deep.equal({ StatusCode: 504, SelectionPattern: '.*\\[504\\].*' });
     })
   );
 });


### PR DESCRIPTION
***Implementing Issue:*** #608

## What did you implement:
Status code support for API Gateway (that you can e.g. return a 404 from within your lambda function).

## How did you implement it:
Added the `method responses` and `integration responses` to the `API Gateway compile method` method.

## How can we verify it:
Use this handler to raise a 404 error:

```
module.exports.hello = (event, context, cb) => {
  cb(new Error('[404] Not found'));
}
```

## Todos:
- [x] Write tests
- [x] Fix linting errors
- [x] Add docs
- [x] Provide verification config/commands/resources

## Notes / Things to be aware of:
- Uses the old resources logical Ids in test

/cc @eahefnawy @flomotlik 