### PR TITLE
Fixing #1168 - adding ability to specify APIG pass through behavior

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/README.md
@@ -96,6 +96,39 @@ functions:
 **Note:** The templates are defined as plain text here. However you can also reference an external file with the help of
 the `${file(templatefile)}` syntax.
 
+
+#### Pass Through Behavior
+API Gateway provides multiple ways to handle requests where the Content-Type header does not match any of the specified mapping templates.  When this happens, the request payload will either be passed through the integration request *without transformation* or rejected with a `415 - Unsupported Media Type`, depending on the configuration.
+
+You can define this behavior as follows (if not specified, a value of **NEVER** will be used):
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          method: get
+          path: whatever
+          request:
+            passThrough: NEVER
+```
+
+There are 3 available options:
+
+|Value             | Passed Through When                           | Rejected When                                                           |
+|----------------- | --------------------------------------------- | ----------------------------------------------------------------------- |
+|NEVER             |  Never                                        | No templates defined or Content-Type does not match a defined template  |
+|WHEN_NO_MATCH     |  Content-Type does not match defined template | Never                                                                   |
+|WHEN_NO_TEMPLATES |  No templates were defined                    | One or more templates defined, but Content-Type does not match          |
+
+See the [api gateway documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#integration-passthrough-behaviors) for detailed descriptions of these options.
+
+**Notes:**
+
+- A missing/empty request Content-Type is considered to be the API Gateway default (`application/json`)
+- API Gateway docs refer to "WHEN_NO_TEMPLATE" (singular), but this will fail during creation as the actual value should be "WHEN_NO_TEMPLATES" (plural)
+
 ### Responses
 
 Serverless lets you setup custom headers and a response template for your `http` event.

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -11,6 +11,7 @@ module.exports = {
         if (event.http) {
           let method;
           let path;
+          let requestPassThroughBehavior = 'NEVER';
 
           if (typeof event.http === 'object') {
             method = event.http.method;
@@ -121,6 +122,10 @@ module.exports = {
             'application/x-www-form-urlencoded': DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
           };
 
+          const requestPassThroughBehaviors = [
+            'NEVER', 'WHEN_NO_MATCH', 'WHEN_NO_TEMPLATES',
+          ];
+
           // check if custom request configuration should be used
           if (Boolean(event.http.request) === true) {
             if (typeof event.http.request === 'object') {
@@ -146,6 +151,21 @@ module.exports = {
                 ' Please check the docs for more info.',
               ].join('');
               throw new this.serverless.classes.Error(errorMessage);
+            }
+
+            if (Boolean(event.http.request.passThrough) === true) {
+              if (requestPassThroughBehaviors.indexOf(event.http.request.passThrough) === -1) {
+                const errorMessage = [
+                  'Request passThrough "',
+                  event.http.request.passThrough,
+                  '" is not one of ',
+                  requestPassThroughBehaviors.join(', '),
+                ].join('');
+
+                throw new this.serverless.classes.Error(errorMessage);
+              }
+
+              requestPassThroughBehavior = event.http.request.passThrough;
             }
           }
 
@@ -319,6 +339,7 @@ module.exports = {
                     ]
                   },
                   "RequestTemplates" : ${JSON.stringify(integrationRequestTemplates)},
+                  "PassthroughBehavior": "${requestPassThroughBehavior}",
                   "IntegrationResponses" : ${JSON.stringify(integrationResponses)}
                 },
                 "ResourceId" : { "Ref": "${resourceLogicalId}" },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -351,6 +351,58 @@ describe('#compileMethods()', () => {
       })
     );
 
+    it('should use the default request pass-through behavior when none specified', () =>
+       awsCompileApigEvents.compileMethods().then(() => {
+         expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.PassthroughBehavior
+         ).to.equal('NEVER');
+       })
+    );
+
+    it('should use defined pass-through behavior', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                request: {
+                  passThrough: 'WHEN_NO_TEMPLATES',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.PassthroughBehavior
+        ).to.equal('WHEN_NO_TEMPLATES');
+      });
+    });
+
+    it('should throw an error if an invalid pass-through value is provided', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                request: {
+                  passThrough: 'BOGUS',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
+    });
+
     it('should set custom request templates', () => {
       awsCompileApigEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
***Implementing Issue:*** #1168 

## What did you implement:
Added ability to specify a pass-through behavior for API Gateway requests.  It requires that you select one of the valid methods (NEVER, WHEN_NO_MATCH, WHEN_NO_TEMPLATES), and uses NEVER as the default value if none was specified.

## How did you implement it:
I updated the apiGateway events method processing to include a check for the "passThrough" configuration.  If none specified, it will use the default value.  If an invalid value is passed, an error will be thrown.

## How can we verify it:
Update your function config under events.http.request to include a "passThrough" value.

```yml
functions:
  create:
    handler: posts.create
    events:
      - http:
          method: get
          path: whatever
          request:
            passThrough: WHEN_NO_TEMPLATES
```

You can verify that the resulting CloudFormation template under Integration -> PassthroughBehavior has the correct value.
 
Once deployed, you can confirm in the API Gateway dashboard under that method -> Integration Request -> Body Mapping Templates.

## Todos:

- [x] Write tests
- [x] Write docs
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

…API Gateway