### PR TITLE
Add verbose mode to deploy and remove docs

### DIFF
--- a/docs/01-guide/03-deploying-services.md
+++ b/docs/01-guide/03-deploying-services.md
@@ -7,7 +7,7 @@ layout: Doc
 
 Make sure that you're still in the service directory that we've created the service in before.
 
-Run `serverless deploy` to start the deployment process (make sure that the credentials for your provider are properly configured).
+Run `serverless deploy -v` to start the deployment process (make sure that the credentials for your provider are properly configured). This command will also print the progress during the deployment as we've configured the `verbose` mode.
 
 Serverless will now deploy the whole service to the configured provider. It will use the default `dev` stage and `us-east-1` region.
 
@@ -23,7 +23,7 @@ provider:
   region: us-west-2
 ```
 
-After running `serverless deploy` you should see the progress of the deployment process in your terminal.
+After running `serverless deploy -v` you should see the progress of the deployment process in your terminal.
 A success message will tell you once everything is deployed and ready to use!
 
 ## Deploying to a different stage and region

--- a/docs/01-guide/07-removing-services.md
+++ b/docs/01-guide/07-removing-services.md
@@ -8,10 +8,9 @@ layout: Doc
 
 The last step we want to introduce in this guide is how to remove the service.
 
-Removal is done with the help of the `remove` command. Just run `serverless remove` to trigger the removal process.
+Removal is done with the help of the `remove` command. Just run `serverless remove -v` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
 
-Serverless will start the removal and informs you about it's process on the console.
-A success message is printed once the whole service is removed.
+Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole service is removed.
 
 **Note:** The removal process will only remove the service on your providers infrastructure. The service directory will still remain on your local machine so you can still modify and (re)deploy it to another stage, region or provider later on.
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** 

Added verbose mode to deploy and remove docs so users now right away that the verbose mode is available.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:
