### PR TITLE
Issue #1899 : Update sinon stubbed tests to always check for correct args

### DIFF
--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -50,9 +50,14 @@ describe('createStack', () => {
         .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.create().then(() => {
+        expect(createStackStub.args[0][0]).to.equal('CloudFormation');
         expect(createStackStub.args[0][1]).to.equal('createStack');
+        expect(createStackStub.args[0][2].StackName)
+          .to.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
         expect(JSON.parse(createStackStub.args[0][2].TemplateBody))
           .to.deep.equal(coreCloudFormationTemplate);
+        expect(createStackStub.args[0][2].Tags)
+          .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(createStackStub.calledOnce).to.be.equal(true);
         expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
         awsDeploy.sdk.request.restore();

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -148,8 +148,20 @@ describe('AwsInfo', () => {
       ],
     };
 
-    sinon.stub(awsInfo.sdk, 'request')
+    const describeStackStub = sinon.stub(awsInfo.sdk, 'request')
       .returns(BbPromise.resolve(describeStacksResponse));
+
+    it('should gather with correct params', () => awsInfo.gather()
+      .then(() => {
+        expect(describeStackStub.calledOnce).to.equal(true);
+        expect(describeStackStub.args[0][0]).to.equal('CloudFormation');
+        expect(describeStackStub.args[0][1]).to.equal('describeStacks');
+        expect(describeStackStub.args[0][2].StackName)
+          .to.equal(awsInfo.sdk.getStackName(awsInfo.options.stage));
+        expect(describeStackStub
+          .calledWith(awsInfo.options.stage, awsInfo.options.region));
+      })
+    );
 
     it('should get service name', () => {
       serverless.service.service = 'myservice';

--- a/lib/plugins/aws/remove/tests/bucket.js
+++ b/lib/plugins/aws/remove/tests/bucket.js
@@ -46,6 +46,8 @@ describe('emptyS3Bucket', () => {
         expect(listObjectsStub.args[0][0]).to.equal('S3');
         expect(listObjectsStub.args[0][1]).to.equal('listObjectsV2');
         expect(listObjectsStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
+        expect(listObjectsStub.args[0][2].Bucket)
+          .to.be.equal(awsRemove.bucketName);
         expect(awsRemove.objectsInBucket.length).to.equal(0);
         awsRemove.sdk.request.restore();
       });
@@ -65,6 +67,8 @@ describe('emptyS3Bucket', () => {
         expect(listObjectsStub.args[0][0]).to.equal('S3');
         expect(listObjectsStub.args[0][1]).to.equal('listObjectsV2');
         expect(listObjectsStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
+        expect(listObjectsStub.args[0][2].Bucket)
+          .to.be.equal(awsRemove.bucketName);
         expect(awsRemove.objectsInBucket[0]).to.deep.equal({ Key: 'object1' });
         expect(awsRemove.objectsInBucket[1]).to.deep.equal({ Key: 'object2' });
         awsRemove.sdk.request.restore();
@@ -82,6 +86,10 @@ describe('emptyS3Bucket', () => {
       return awsRemove.deleteObjects().then(() => {
         expect(deleteObjectsStub.calledOnce).to.be.equal(true);
         expect(deleteObjectsStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
+        expect(deleteObjectsStub.args[0][2].Bucket)
+          .to.be.equal(awsRemove.bucketName);
+        expect(deleteObjectsStub.args[0][2].Delete.Objects)
+          .to.be.equal(awsRemove.objectsInBucket);
         awsRemove.sdk.request.restore();
       });
     });

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -130,6 +130,8 @@ describe('AWS SDK', () => {
           expect(describeStackResourcesStub.calledWith(options.stage, options.region));
           expect(describeStackResourcesStub.args[0][0]).to.equal('CloudFormation');
           expect(describeStackResourcesStub.args[0][1]).to.equal('describeStackResources');
+          expect(describeStackResourcesStub.args[0][2].StackName)
+            .to.equal(`${awsSdk.serverless.service.service}-${options.stage}`);
 
           expect(bucketName).to.equal('serverlessDeploymentBucketName');
 

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -80,6 +80,8 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('create', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region
@@ -122,6 +124,8 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('update', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region
@@ -164,6 +168,8 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('removal', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region
@@ -198,6 +204,8 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('removal', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region
@@ -270,6 +278,8 @@ describe('monitorStack', () => {
         expect(e.name).to.be.equal('ServerlessError');
         expect(e.message).to.be.equal(errorMessage);
         expect(describeStackEventsStub.callCount).to.be.equal(4);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region
@@ -292,6 +302,8 @@ describe('monitorStack', () => {
       return awsPlugin.monitorStack('update', cfDataMock, 10).catch((e) => {
         expect(e.message).to.be.equal('Something went wrong.');
         expect(describeStackEventsStub.callCount).to.be.equal(1);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region
@@ -362,6 +374,8 @@ describe('monitorStack', () => {
         expect(e.name).to.be.equal('ServerlessError');
         expect(e.message).to.be.equal(errorMessage);
         expect(describeStackEventsStub.callCount).to.be.equal(4);
+        expect(describeStackEventsStub.args[0][2].StackName)
+          .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
           awsPlugin.options.stage,
           awsPlugin.options.region


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

Updates a few sinon stub tests that were missing argument checks.

[Issue #1899](https://github.com/serverless/serverless/issues/1899)

***Implementing Issue:*** #12345

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Looked through test implementations in all files, attempting to adhere to practices from other tests, and verified that tests with sinon stubs had argument checking (i.e., expect(sinonStub).args[*].to.be.('argument')).

Most sinon stub tests that were checking arguments ignored or skipped static argument types, in monitorStack.js, so I tried to check arguments that were dynamic, mainly StackNames.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:


Creates test cases to check for correct arugments from sinon stubs