### PR TITLE
Add check (and test) that function.events is an array.

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -145,6 +145,10 @@ class Service {
           if (!functionObj.events) {
             that.functions[functionName].events = [];
           }
+          if (!_.isArray(functionObj.events)) {
+            throw new SError(`Events for "${functionName}" must be an array,` +
+                             ` not an ${typeof functionObj.events}`);
+          }
 
           if (!functionObj.name) {
             that.functions[functionName].name =

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -332,6 +332,33 @@ describe('Service', () => {
       });
     });
 
+    it("should throw error if a function's event is not an array", () => {
+      const SUtils = new Utils();
+      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const serverlessYml = {
+        service: 'service-name',
+        provider: 'aws',
+        functions: {
+          functionA: {
+            events: {},
+          },
+        },
+      };
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load().then(() => {
+        // if we reach this, then no error was thrown as expected
+        // so make assertion fail intentionally to let us know something is wrong
+        expect(1).to.equal(2);
+      }).catch(e => {
+        expect(e.name).to.be.equal('ServerlessError');
+      });
+    });
+
     it('should throw error if provider property is invalid', () => {
       const SUtils = new Utils();
       const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
@@ -420,6 +447,11 @@ describe('Service', () => {
       };
     });
 
+    it('should throw error if events is not an array', () => {
+      expect(() => {
+        serviceInstance.getEventInFunction('schedule');
+      }).to.throw(Error);
+    });
     it('should return an event object based on provided function', () => {
       expect(serviceInstance.getEventInFunction('schedule', 'create'))
         .to.be.equal('rate(5 minutes)');

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -447,11 +447,6 @@ describe('Service', () => {
       };
     });
 
-    it('should throw error if events is not an array', () => {
-      expect(() => {
-        serviceInstance.getEventInFunction('schedule');
-      }).to.throw(Error);
-    });
     it('should return an event object based on provided function', () => {
       expect(serviceInstance.getEventInFunction('schedule', 'create'))
         .to.be.equal('rate(5 minutes)');


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2027 

## How did you implement it:

At the same time as the code is checking for `functionName` and initialising `events` (if unspecified), I added a check that `events` is an array, and throw a `ServerlessError` if not.

## How can we verify it:

Specify an object of values for `events` (or anything other than an array) and run an `sls` command.

Here is a sample function definition (note `events` is an object):

```yml
functions:
  logging:
    handler: functions/logging.handler
    events:
      http:
        path: logging
        method: get
```

You will see the following error when you try to run `sls info`:

```bash
sls info

  Serverless Error ---------------------------------------

     Events for "logging" must be an array, not an object
```

## Todos:

- [x] Write tests
- ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

