### PR TITLE
Windows contrib blockers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "serverless-run-python-handler": "./bin/serverless-run-python-handler"
   },
   "scripts": {
-    "test": "istanbul cover _mocha tests/all -- -R spec --recursive",
+    "test": "istanbul cover node_modules/mocha/bin/_mocha tests/all -- -R spec --recursive",
     "lint": "eslint .",
     "integration-test": "mocha tests/integration_test"
   },

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -767,7 +767,7 @@ describe('PluginManager', () => {
     const serverlessInstance = new Serverless();
     serverlessInstance.init();
 
-    // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows. Add 'node' to command.
+    // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
     const execPrefix = os.platform() === 'win32' ? 'node ' : '';
     const serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
             '..', 'bin', 'serverless');

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -765,8 +765,11 @@ describe('PluginManager', () => {
   describe('Plugin/CLI integration', () => {
     const serverlessInstance = new Serverless();
     serverlessInstance.init();
-    const serverlessExec = path.join(serverlessInstance.config.serverlessPath,
-      '..', 'bin', 'serverless');
+
+    // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows. Add 'node' to command.
+    const execPrefix = os.platform() === 'win32' ? 'node ' : null;
+    const serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
+            '..', 'bin', 'serverless');
     const tmpDir = testUtils.getTmpDirPath();
     fse.mkdirSync(tmpDir);
     const cwd = process.cwd();

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -10,6 +10,7 @@ const fse = require('fs-extra');
 const execSync = require('child_process').execSync;
 const mockRequire = require('mock-require');
 const testUtils = require('../../tests/utils');
+const os = require('os');
 
 describe('PluginManager', () => {
   let pluginManager;

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -768,7 +768,7 @@ describe('PluginManager', () => {
     serverlessInstance.init();
 
     // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows. Add 'node' to command.
-    const execPrefix = os.platform() === 'win32' ? 'node ' : null;
+    const execPrefix = os.platform() === 'win32' ? 'node ' : '';
     const serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
             '..', 'bin', 'serverless');
     const tmpDir = testUtils.getTmpDirPath();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** #2044 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

To enable running tests, provided a relative path to "_mocha" in the package.json.
Addressed the test invocation of the "serverless" JS script in Windows by adding "node" to the command used to invoke.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

Can verify that this works on Windows by running the 'npm test' command in the root directory. The unit tests should all run. There is currently *ONE* test failure which will need to be addressed.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation
