### PR TITLE
Move default stage and region comments to provider section in template

### DIFF
--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -16,6 +16,9 @@ service: aws-java-gradle # NOTE: update this with your service name
 provider:
   name: aws
   runtime: java8
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
 # you can add statements to the Lambda function's IAM Role here
 #  iamRoleStatements:
 #    - Effect: "Allow"
@@ -30,11 +33,6 @@ provider:
 #          - ""
 #          - - "arn:aws:s3:::"
 #            - "Ref" : "ServerlessDeploymentBucket"
-
-# you can overwrite defaults here
-#defaults:
-#  stage: dev
-#  region: us-east-1
 
 # you can add packaging information here
 package:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -16,6 +16,9 @@ service: aws-java-maven # NOTE: update this with your service name
 provider:
   name: aws
   runtime: java8
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
 # you can add statements to the Lambda function's IAM Role here
 #  iamRoleStatements:
 #    - Effect: "Allow"
@@ -30,11 +33,6 @@ provider:
 #          - ""
 #          - - "arn:aws:s3:::"
 #            - "Ref" : "ServerlessDeploymentBucket"
-
-# you can overwrite defaults here
-#defaults:
-#  stage: dev
-#  region: us-east-1
 
 # you can add packaging information here
 package:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -16,6 +16,9 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
 # you can add statements to the Lambda function's IAM Role here
 #  iamRoleStatements:
 #    - Effect: "Allow"
@@ -30,11 +33,6 @@ provider:
 #          - ""
 #          - - "arn:aws:s3:::"
 #            - "Ref" : "ServerlessDeploymentBucket"
-
-# you can overwrite defaults here
-#defaults:
-#  stage: dev
-#  region: us-east-1
 
 # you can add packaging information here
 #package:

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -16,6 +16,9 @@ service: aws-python # NOTE: update this with your service name
 provider:
   name: aws
   runtime: python2.7
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
 # you can add statements to the Lambda function's IAM Role here
 #  iamRoleStatements:
 #    - Effect: "Allow"
@@ -30,11 +33,6 @@ provider:
 #          - ""
 #          - - "arn:aws:s3:::"
 #            - "Ref" : "ServerlessDeploymentBucket"
-
-# you can overwrite defaults here
-#defaults:
-#  stage: dev
-#  region: us-east-1
 
 # you can add packaging information here
 #package:


### PR DESCRIPTION
## What did you implement:

Update `serverless.yml` template comments/examples to match recent variable-related changes; Move the default `region` and `stage` variables in to the `provider` section (and out of the deprecated `defaults` section).

## How did you implement it:

Copy & paste :smiley:

## How can we verify it:

Look at [the templates](/serverless/serverless/tree/master/lib/plugins/create/templates).

## Todos:

- ~~Write tests~~
- ~~Write documentation~~
- ~~Fix linting errors~~
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation