### PR TITLE
Fix #2049: API Gateway integration to return 500 when Lambda functions time out

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -333,7 +333,8 @@ module.exports = {
             { StatusCode: 422, SelectionPattern: '.*\\[422\\].*' },
             { StatusCode: 500,
               SelectionPattern:
-                '.*(Process\\s?exited\\s?before\\s?completing\\s?request|Task\\s?timed\\s?out\\s?after\\s?|\\[500\\]).*' },
+                // eslint-disable-next-line max-len
+                '.*(Process\\s?exited\\s?before\\s?completing\\s?request|Task\\s?timed\\s?out\\s?|\\[500\\]).*' },
             { StatusCode: 502, SelectionPattern: '.*\\[502\\].*' },
             { StatusCode: 504, SelectionPattern: '.*\\[504\\].*' }
           );

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -333,7 +333,7 @@ module.exports = {
             { StatusCode: 422, SelectionPattern: '.*\\[422\\].*' },
             { StatusCode: 500,
               SelectionPattern:
-                '.*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\]).*' },
+                '.*(Process\\s?exited\\s?before\\s?completing\\s?request|Task\\s?timed\\s?out\\s?after\\s?|\\[500\\]).*' },
             { StatusCode: 502, SelectionPattern: '.*\\[502\\].*' },
             { StatusCode: 504, SelectionPattern: '.*\\[504\\].*' }
           );

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -665,7 +665,7 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[6]
       ).to.deep.equal({ StatusCode: 500,
-        SelectionPattern: '.*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\]).*' });
+        SelectionPattern: '.*(Process\\s?exited\\s?before\\s?completing\\s?request|Task\\s?timed\\s?out\\s?after\\s?|\\[500\\]).*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -665,7 +665,9 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[6]
       ).to.deep.equal({ StatusCode: 500,
-        SelectionPattern: '.*(Process\\s?exited\\s?before\\s?completing\\s?request|Task\\s?timed\\s?out\\s?after\\s?|\\[500\\]).*' });
+        SelectionPattern:
+          // eslint-disable-next-line max-len
+          '.*(Process\\s?exited\\s?before\\s?completing\\s?request|Task\\s?timed\\s?out\\s?|\\[500\\]).*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2049: API Gateway returns 200 when function times out

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Trivial change to add a match for "Task timed out after" in the response integration template

## How can we verify it:

Working example here (times out after 20 seconds and return a 500): https://stage-stealth-monitoring.domain.com.au/services/health/users-api-v1

## Todos:

- [X] Write tests
- [X] Write documentation (not applicable here)
- [x] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config/commands/resources
- [X] Leave a comment that this is ready for review once you've finished the implementation
