### PR TITLE
Bug fix for referencing sub properties of reference variables

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -133,12 +133,8 @@ class Variables {
 
   getValueFromSelf(variableString) {
     let valueToPopulate = _.cloneDeep(this.service);
-    const selfSubProperties = variableString.split(':')[1].split('.');
-    selfSubProperties.forEach(selfSubProperty => {
-      if (typeof valueToPopulate === 'undefined') valueToPopulate = {};
-      valueToPopulate = valueToPopulate[selfSubProperty];
-    });
-
+    const deepProperties = variableString.split(':')[1].split('.');
+    valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
     return valueToPopulate;
   }
 
@@ -162,14 +158,26 @@ class Variables {
         throw new this.serverless.classes
           .Error(errorMessage);
       }
-      deepProperties = deepProperties.slice(1);
-      const selfSubProperties = deepProperties.split('.');
-      selfSubProperties.forEach(selfSubProperty => {
-        if (typeof valueToPopulate === 'undefined') valueToPopulate = {};
-        valueToPopulate = valueToPopulate[selfSubProperty];
-      });
+      deepProperties = deepProperties.slice(1).split('.');
+      valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
     }
 
+    return valueToPopulate;
+  }
+
+  getDeepValue(deepProperties, valueToPopulateParam) {
+    let valueToPopulate = valueToPopulateParam;
+    deepProperties.forEach(subProperty => {
+      if (typeof valueToPopulate === 'undefined') {
+        valueToPopulate = {};
+      } else {
+        valueToPopulate = valueToPopulate[subProperty];
+      }
+
+      if (typeof valueToPopulate === 'string' && valueToPopulate.match(this.variableSyntax)) {
+        valueToPopulate = this.populateProperty(valueToPopulate);
+      }
+    });
     return valueToPopulate;
   }
 }


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2054

Fixed a bug with the variable system where referencing sub properties of files/self that are referencing other variables/properties are not populated.

## How did you implement it:

I added a new `getDeepValue()` method in the `Variables` class that takes care of populating deep references. This method is used by `getValuefromSelf` and `getValueFromFile` methods. After it populates the references property, it makes sure we populate any other referenced variables by calling the `populateProperty()` method again.

## How can we verify it:
using the following config:

```yml
service: serverless-complex-vars

custom:
  testA: ${self:custom.testB.testD}
  testB: ${self:custom.testC}
  testC:
    testD:
      BucketName: hello-world

provider: aws

functions:
  hello:
    handler: handler.hello

resources:
  Resources:
    testBucket:
      Type: AWS::S3::Bucket
      Properties: ${self:custom.testA}
```

run `serverless deploy --noDeploy` and check the generated bucket resource.

**With Master:** you'll see this:
```json
    "testBucket": {
      "Type": "AWS::S3::Bucket"
    }
```
**With PR:** you'll see this:
```json
    "testBucket": {
      "Type": "AWS::S3::Bucket",
      "Properties": {
          "BucketName": "hello-world"
      }
    }
```
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
