### PR TITLE
S3 event rules

### DIFF
--- a/docs/02-providers/aws/events/02-s3.md
+++ b/docs/02-providers/aws/events/02-s3.md
@@ -31,6 +31,23 @@ functions:
           event: s3:ObjectRemoved:*
 ```
 
+## Setting filter rules
+
+This will create a bucket `photos`. The `users` function is called whenever an image with `.jpg` extension is uploaded to folder `uploads` in the bucket. Check out the [AWS documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-filtering) to learn more about all the different filter types that can be configured.
+
+```yml
+functions:
+  users:
+    handler: users.handler
+    rules:
+      - s3:
+          bucket: photos
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: uploads/
+            - suffix: .jpg
+```
+
 ## Triggering separate functions from the same bucket
 
 You're able to repeat the S3 event configuration in the same or separate functions so one bucket can call these functions. One caveat though is that you can't repeat the same configuration in both functions, e.g. the event type has to be different.

--- a/lib/plugins/aws/deploy/compile/events/s3/README.md
+++ b/lib/plugins/aws/deploy/compile/events/s3/README.md
@@ -17,7 +17,7 @@ the bucket name you've defined and an additional lambda notification configurati
 function and the `s3:objectCreated:*` events.
 
 The second possibility is to configure your S3 event more granular (like the bucket name or the event which this bucket
-should listen to) with the help of key value pairs.
+should listen to and or the filters rules) with the help of key value pairs.
 
 Take a look at the [Event syntax examples](#event-syntax-examples) below to see how you can setup S3 bucket events.
 
@@ -57,4 +57,20 @@ functions:
       - s3:
           bucket: confidential-information
           event: s3:ObjectRemoved:*
+```
+
+We can also specify filter rules.
+
+```yml
+# serverless.yml
+functions:
+  mail:
+    handler: mail.removal
+    events:
+      - s3:
+          bucket: confidential-information
+          event: s3:ObjectRemoved:*
+          rules:
+            - prefix: inbox/
+            - suffix: .eml
 ```

--- a/lib/plugins/aws/deploy/compile/events/s3/README.md
+++ b/lib/plugins/aws/deploy/compile/events/s3/README.md
@@ -17,7 +17,7 @@ the bucket name you've defined and an additional lambda notification configurati
 function and the `s3:objectCreated:*` events.
 
 The second possibility is to configure your S3 event more granular (like the bucket name or the event which this bucket
-should listen to and or the filters rules) with the help of key value pairs.
+should listen to) with the help of key value pairs.
 
 Take a look at the [Event syntax examples](#event-syntax-examples) below to see how you can setup S3 bucket events.
 

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -40,16 +40,6 @@ class AwsCompileS3Events {
                 notificationEvent = event.s3.event;
               }
               if (event.s3.rules) {
-                if (!event.s3.event) {
-                  const errorMessage = [
-                    `S3 filter rules of function ${functionName} requires "event" property`,
-                    ' The correct syntax is: s3: bucketName OR an object with',
-                    ' "bucket", "rules", and "event" property.',
-                    ' Please check the docs for more info.',
-                  ].join('');
-                  throw new this.serverless.classes
-                    .Error(errorMessage);
-                }
                 if (!_.isArray(event.s3.rules)) {
                   const errorMessage = [
                     `S3 filter rules of function ${functionName} is not an array`,

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -39,27 +39,18 @@ class AwsCompileS3Events {
               if (event.s3.event) {
                 notificationEvent = event.s3.event;
               }
-              notificationEvent = event.s3.event;
               if (event.s3.rules) {
-                if (_.isArray(event.s3.rules)) {
-                  const rules = [];
-                  event.s3.rules.forEach(rule => {
-                    if (_.isPlainObject(rule)) {
-                      const name = Object.keys(rule)[0];
-                      const value = rule[name];
-                      rules.push({ Name: name, Value: value });
-                    } else {
-                      const errorMessage = [
-                        `S3 filter rule ${rule} of function ${functionName} is not an object`,
-                        ' The correct syntax is: { Name: Value }',
-                        ' Please check the docs for more info.',
-                      ].join('');
-                      throw new this.serverless.classes
-                        .Error(errorMessage);
-                    }
-                  });
-                  filter = { Filter: { S3Key: { Rules: rules } } };
-                } else {
+                if (!event.s3.event) {
+                  const errorMessage = [
+                    `S3 filter rules of function ${functionName} requires "event" property`,
+                    ' The correct syntax is: s3: bucketName OR an object with',
+                    ' "bucket", "rules", and "event" property.',
+                    ' Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes
+                    .Error(errorMessage);
+                }
+                if (!_.isArray(event.s3.rules)) {
                   const errorMessage = [
                     `S3 filter rules of function ${functionName} is not an array`,
                     ' The correct syntax is: rules: [{ Name: Value }]',
@@ -68,6 +59,22 @@ class AwsCompileS3Events {
                   throw new this.serverless.classes
                     .Error(errorMessage);
                 }
+                const rules = [];
+                event.s3.rules.forEach(rule => {
+                  if (!_.isPlainObject(rule)) {
+                    const errorMessage = [
+                      `S3 filter rule ${rule} of function ${functionName} is not an object`,
+                      ' The correct syntax is: { Name: Value }',
+                      ' Please check the docs for more info.',
+                    ].join('');
+                    throw new this.serverless.classes
+                      .Error(errorMessage);
+                  }
+                  const name = Object.keys(rule)[0];
+                  const value = rule[name];
+                  rules.push({ Name: name, Value: value });
+                });
+                filter = { Filter: { S3Key: { Rules: rules } } };
               }
             } else if (typeof event.s3 === 'string') {
               bucketName = event.s3;

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -23,6 +23,7 @@ class AwsCompileS3Events {
           if (event.s3) {
             let bucketName;
             let notificationEvent = 's3:ObjectCreated:*';
+            let filter = {};
 
             if (typeof event.s3 === 'object') {
               if (!event.s3.bucket) {
@@ -37,6 +38,36 @@ class AwsCompileS3Events {
               bucketName = event.s3.bucket;
               if (event.s3.event) {
                 notificationEvent = event.s3.event;
+              }
+              notificationEvent = event.s3.event;
+              if (event.s3.rules) {
+                if (_.isArray(event.s3.rules)) {
+                  const rules = [];
+                  event.s3.rules.forEach(rule => {
+                    if (_.isPlainObject(rule)) {
+                      const name = Object.keys(rule)[0];
+                      const value = rule[name];
+                      rules.push({ Name: name, Value: value });
+                    } else {
+                      const errorMessage = [
+                        `S3 filter rule ${rule} of function ${functionName} is not an object`,
+                        ' The correct syntax is: { Name: Value }',
+                        ' Please check the docs for more info.',
+                      ].join('');
+                      throw new this.serverless.classes
+                        .Error(errorMessage);
+                    }
+                  });
+                  filter = { Filter: { S3Key: { Rules: rules } } };
+                } else {
+                  const errorMessage = [
+                    `S3 filter rules of function ${functionName} is not an array`,
+                    ' The correct syntax is: rules: [{ Name: Value }]',
+                    ' Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes
+                    .Error(errorMessage);
+                }
               }
             } else if (typeof event.s3 === 'string') {
               bucketName = event.s3;
@@ -56,7 +87,7 @@ class AwsCompileS3Events {
             // check if the bucket already defined
             // in another S3 event in the service
             if (bucketsLambdaConfigurations[bucketName]) {
-              const newLambdaConfiguration = {
+              let newLambdaConfiguration = {
                 Event: notificationEvent,
                 Function: {
                   'Fn::GetAtt': [
@@ -66,6 +97,11 @@ class AwsCompileS3Events {
                 },
               };
 
+              // Assign 'filter' if not empty
+              newLambdaConfiguration = _.assign(
+                newLambdaConfiguration,
+                filter
+              );
               bucketsLambdaConfigurations[bucketName]
                 .push(newLambdaConfiguration);
             } else {
@@ -80,6 +116,11 @@ class AwsCompileS3Events {
                   },
                 },
               ];
+              // Assign 'filter' if not empty
+              bucketsLambdaConfigurations[bucketName][0] = _.assign(
+                bucketsLambdaConfigurations[bucketName][0],
+                filter
+              );
             }
             s3EnabledFunctions.push(functionName);
           }

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -51,6 +51,40 @@ describe('AwsCompileS3Events', () => {
       expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
     });
 
+    it('should throw an error if the "rules" property is not an array', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: {
+                bucket: 'first-function-bucket',
+                rules: {},
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+    });
+
+    it('should throw an error if the "rules" property is invalid', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: {
+                bucket: 'first-function-bucket',
+                rules: [[]],
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+    });
+
     it('should create corresponding resources when S3 events are given', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {
@@ -62,6 +96,9 @@ describe('AwsCompileS3Events', () => {
               s3: {
                 bucket: 'first-function-bucket-two',
                 event: 's3:ObjectCreated:Put',
+                rules: [
+                  { prefix: 'subfolder/' },
+                ],
               },
             },
           ],
@@ -92,6 +129,9 @@ describe('AwsCompileS3Events', () => {
               s3: {
                 bucket: 'first-function-bucket-one',
                 event: 's3:ObjectCreated:Put',
+                rules: [
+                  { prefix: 'subfolder/' },
+                ],
               },
             },
           ],

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -87,25 +87,6 @@ describe('AwsCompileS3Events', () => {
       expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
     });
 
-    it('should throw an error if the "rules" is defined while the "event" is not', () => {
-      awsCompileS3Events.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              s3: {
-                bucket: 'first-function-bucket',
-                rules: [
-                  { prefix: 'subfolder/' },
-                ],
-              },
-            },
-          ],
-        },
-      };
-
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
-    });
-
     it('should create corresponding resources when S3 events are given', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -58,6 +58,7 @@ describe('AwsCompileS3Events', () => {
             {
               s3: {
                 bucket: 'first-function-bucket',
+                event: 's3:ObjectCreated:Put',
                 rules: {},
               },
             },
@@ -75,7 +76,27 @@ describe('AwsCompileS3Events', () => {
             {
               s3: {
                 bucket: 'first-function-bucket',
+                event: 's3:ObjectCreated:Put',
                 rules: [[]],
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+    });
+
+    it('should throw an error if the "rules" is defined while the "event" is not', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: {
+                bucket: 'first-function-bucket',
+                rules: [
+                  { prefix: 'subfolder/' },
+                ],
               },
             },
           ],
@@ -116,6 +137,11 @@ describe('AwsCompileS3Events', () => {
       expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FirstLambdaPermissionS3.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.S3BucketFirstfunctionbuckettwo.Properties.NotificationConfiguration
+        .LambdaConfigurations[0].Filter).to.deep.equal({
+          S3Key: { Rules: [{ Name: 'prefix', Value: 'subfolder/' }] },
+        });
     });
 
     it('should create single bucket resource when the same bucket referenced repeatedly', () => {


### PR DESCRIPTION
***Implementing Issue:*** #1873

Add support for filter rules in s3 events configuration

--
The rules can be implemented in an array of objects, each containing a single key/value with the key being the rule name (suffix, prefix)

```ynl

functions:
  resize:
    handler: resize.hello
    name: image-resize
    events:
      - s3:
          bucket: upload
          event: s3:ObjectCreated:*
          rules:
            -  prefix: images/
            -  suffix: .jpg

```
There can only be one rule per type, this is related to aws api, Check this [issue](https://github.com/aws/aws-cli/issues/1465)

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
