### PR TITLE
Fix for #1994. Adds test to verify that YAML may be used for event.

### DIFF
--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -102,7 +102,9 @@ describe('AwsInvoke', () => {
       awsInvoke.options.path = 'data.yml';
 
       return awsInvoke.extendedValidate().then(() => {
-        expect(awsInvoke.options.data).to.deep.equal(data);
+        expect(awsInvoke.options.data).to.deep.equal({
+          testProp: 'testValue',
+        });
         awsInvoke.options.path = false;
         serverless.config.servicePath = true;
       });

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -95,7 +95,7 @@ describe('AwsInvoke', () => {
 
     it('it should parse a yaml file if file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
-      const yamlContent = "testProp: testValue";
+      const yamlContent = 'testProp: testValue';
 
       serverless.utils.writeFileSync(path
           .join(serverless.config.servicePath, 'data.yml'), yamlContent);

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -93,6 +93,21 @@ describe('AwsInvoke', () => {
       });
     });
 
+    it('it should parse a yaml file if file path is provided', () => {
+      serverless.config.servicePath = testUtils.getTmpDirPath();
+      const yamlContent = "testProp: testValue";
+
+      serverless.utils.writeFileSync(path
+          .join(serverless.config.servicePath, 'data.yml'), yamlContent);
+      awsInvoke.options.path = 'data.yml';
+
+      return awsInvoke.extendedValidate().then(() => {
+        expect(awsInvoke.options.data).to.deep.equal(data);
+        awsInvoke.options.path = false;
+        serverless.config.servicePath = true;
+      });
+    });
+
     it('it should throw error if service path is not set', () => {
       serverless.config.servicePath = false;
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

Added test case for verifying that YAML is properly parsed when used as the event input.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Modified the JSON version of the same test.

## How can we verify it:

Replace any event.json with the equivalent event.yml, invoke the lambda with that event.yml and all results should be the same. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
