### PR TITLE
Self should return undefined to enable correct fallback

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -169,7 +169,7 @@ class Variables {
     let valueToPopulate = valueToPopulateParam;
     deepProperties.forEach(subProperty => {
       if (typeof valueToPopulate === 'undefined') {
-        valueToPopulate = {};
+        valueToPopulate = undefined;
       } else {
         valueToPopulate = valueToPopulate[subProperty];
       }

--- a/tests/classes/Variables.js
+++ b/tests/classes/Variables.js
@@ -430,7 +430,7 @@ describe('Variables', () => {
       };
       const valueToPopulate = serverless.variables
         .getDeepValue(['custom', 'subProperty', 'deep', 'deeper'], valueToPopulateMock);
-      expect(valueToPopulate).to.deep.equal({});
+      expect(valueToPopulate).to.deep.equal(undefined);
     });
 
     it('should get deep values with variable references', () => {

--- a/tests/classes/Variables.js
+++ b/tests/classes/Variables.js
@@ -53,6 +53,25 @@ describe('Variables', () => {
       serverless.variables.populateVariable.restore();
     });
 
+    it('should call overwrite if overwrite syntax provided and first option is self', () => {
+      const serverless = new Serverless();
+      const property = 'my stage is ${self:nonExistingVariable, self:provider.stage}';
+
+      const overwriteStub = sinon
+        .stub(serverless.variables, 'overwrite').returns('dev');
+      const populateVariableStub = sinon
+        .stub(serverless.variables, 'populateVariable').returns('my stage is dev');
+
+      const newProperty = serverless.variables
+        .populateProperty(property);
+      expect(overwriteStub.called).to.equal(true);
+      expect(populateVariableStub.called).to.equal(true);
+      expect(newProperty).to.equal('my stage is dev');
+
+      serverless.variables.overwrite.restore();
+      serverless.variables.populateVariable.restore();
+    });
+
     it('should call getValueFromSource if no overwrite syntax provided', () => {
       const serverless = new Serverless();
       const property = 'my stage is ${opt:stage}';

--- a/tests/classes/Variables.js
+++ b/tests/classes/Variables.js
@@ -53,23 +53,22 @@ describe('Variables', () => {
       serverless.variables.populateVariable.restore();
     });
 
-    it('should call overwrite if overwrite syntax provided and first option is self', () => {
+    it('should fallback to default when a variable is first part of override', () => {
       const serverless = new Serverless();
-      const property = 'my stage is ${self:nonExistingVariable, self:provider.stage}';
+      const property =
+        'my stage is ${self:custom.stages.${self:provider.stage}.variable, self:provider.stage}';
 
-      const overwriteStub = sinon
-        .stub(serverless.variables, 'overwrite').returns('dev');
-      const populateVariableStub = sinon
-        .stub(serverless.variables, 'populateVariable').returns('my stage is dev');
+      const getValueFromSource = sinon
+        .stub(serverless.variables, 'getValueFromSource');
+      getValueFromSource.withArgs('self:provider.stage').returns('dev');
+      getValueFromSource.returns(undefined);
 
       const newProperty = serverless.variables
         .populateProperty(property);
-      expect(overwriteStub.called).to.equal(true);
-      expect(populateVariableStub.called).to.equal(true);
+
       expect(newProperty).to.equal('my stage is dev');
 
-      serverless.variables.overwrite.restore();
-      serverless.variables.populateVariable.restore();
+      serverless.variables.getValueFromSource.restore();
     });
 
     it('should call getValueFromSource if no overwrite syntax provided', () => {


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2081
## How did you implement it:

Return `undefined` when a variable doesn't exist to allow overwrite function to work as expected.

## How can we verify it:

Example test included


## Todos:

- [x] Write tests
- ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

