### PR TITLE
Support Dash Character for API Gateway Resource Path

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -43,7 +43,11 @@ module.exports = {
       });
     });
 
-    const capitalizeAlphaNumericPath = (path) => _.capitalize(path.replace(/[^0-9A-Za-z]/g, ''));
+    const capitalizeAlphaNumericPath = (path) => _.capitalize(
+      path
+      .replace(/-/g, 'Dash')
+      .replace(/[^0-9A-Za-z]/g, '')
+    );
 
     // ['users', 'users/create', 'users/create/something']
     this.resourcePaths.forEach(path => {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
@@ -22,6 +22,9 @@ describe('#compileResources()', () => {
             },
           },
           {
+            http: 'GET bar/-',
+          },
+          {
             http: 'GET bar/foo',
           },
           {
@@ -57,8 +60,17 @@ describe('#compileResources()', () => {
 
   it('should construct the correct resourcePaths array', () => awsCompileApigEvents
     .compileResources().then(() => {
-      const expectedResourcePaths = ['foo/bar', 'foo', 'bar/foo', 'bar', 'bar/{id}',
-        'bar/{id}/foobar', 'bar/{foo_id}', 'bar/{foo_id}/foobar'];
+      const expectedResourcePaths = [
+        'foo/bar',
+        'foo',
+        'bar/-',
+        'bar',
+        'bar/foo',
+        'bar/{id}',
+        'bar/{id}/foobar',
+        'bar/{foo_id}',
+        'bar/{foo_id}/foobar',
+      ];
       expect(awsCompileApigEvents.resourcePaths).to.deep.equal(expectedResourcePaths);
     })
   );
@@ -66,6 +78,7 @@ describe('#compileResources()', () => {
   it('should construct the correct resourceLogicalIds object', () => awsCompileApigEvents
     .compileResources().then(() => {
       const expectedResourceLogicalIds = {
+        'bar/-': 'ApiGatewayResourceBarDash',
         'foo/bar': 'ApiGatewayResourceFooBar',
         foo: 'ApiGatewayResourceFoo',
         'bar/{id}/foobar': 'ApiGatewayResourceBarIdFoobar',


### PR DESCRIPTION
## What did you implement:

Required an AWS API resource path part to be a single `-` character,  currently ParentId for a `AWS::ApiGateway::Resource` has to be alphanumeric so Cloud Formation errors as it is removed when normalized. This pull request translates the `-` character into the word `Dash` to allow the resource to be created in AWS API Gateway.

## How did you implement it:

Simple regex replace of `-` to `Dash`

## How can we verify it:

Specs below, additionally using my fork currently on a project to allow me to continue with work, so it is well tested.

## Todos:

- [x] Write tests
- [x] Write documentation (Not Applicable?)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

I do have a different version that used short SHA's of the strings for the path names but presumed you wanted to keep this format as it would have other implications for RegEx matching in methods.

Thought I would keep it simple, hopefully this will suffice. 💃 

