### PR TITLE
Fixing links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ Serverless is an MIT open-source project, actively maintained by a full-time, ve
 
 ## Links
 
-* [Guide to Serverless](./docs/01-guide/README.md)
-* [Features](#features)
-* [Documentation v.1](./docs/README.md) / [v.0](http://serverless.readme.io)
-* [Road Map](https://github.com/serverless/serverless/milestones)
-* [Contributing](#contributing)
-* [Community](#community)
-* [Changelog](https://github.com/serverless/serverless/releases)
+[Guide to Serverless](./docs/01-guide/README.md)
+
+[Features](#features)
+
+[Documentation v.1](./docs/README.md) / [v.0](http://serverless.readme.io)
+
+[Road Map](https://github.com/serverless/serverless/milestones)
+
+[Contributing](#contributing)
+
+[Community](#community)
+
+[Changelog](https://github.com/serverless/serverless/releases)
 
 ## <a name="quick-start"></a>Quick Start
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 The Framework uses new event-driven compute services, like AWS Lambda, Google CloudFunctions, and more.  It's a command line tool, providing scaffolding, workflow automation and best practices for developing and deploying your serverless architecture. It's also completely extensible via plugins.
 
-Serverless is an MIT open-source project, actively maintained by a full-time, venture-backed team.  Get started quickly by following the [Quickstart commands](#quick-start) or reading our [Guide to Serverless](docs/01-guide)
+Serverless is an MIT open-source project, actively maintained by a full-time, venture-backed team.  Get started quickly by following the [Quickstart commands](#quick-start) or reading our [Guide to Serverless](./docs/01-guide/README.md)
 
 ## Links
 
-* [Guide to Serverless](docs/01-guide)
+* [Guide to Serverless](./docs/01-guide/README.md)
 * [Features](#features)
-* [Documentation v.1](docs) / [v.0](http://serverless.readme.io)
+* [Documentation v.1](./docs/README.md) / [v.0](http://serverless.readme.io)
 * [Road Map](https://github.com/serverless/serverless/milestones)
 * [Contributing](#contributing)
 * [Community](#community)
@@ -20,14 +20,14 @@ Serverless is an MIT open-source project, actively maintained by a full-time, ve
 
 ## <a name="quick-start"></a>Quick Start
 
-Below is a quick list of commands to set up a new project. For a more in-depth look at Serverless check out the [Guide in our docs](docs/01-guide).
+Below is a quick list of commands to set up a new project. For a more in-depth look at Serverless check out the [Guide in our docs](./docs/01-guide/README.md).
 
 [Watch the video guide here](https://youtu.be/weOsx5rLWX0) or follow the steps below to create and deploy your first serverless microservice in minutes.
 
 | **Step** | **Command** |**Description**|
 |---|-------|------|
 |  1.  | `npm install -g serverless` | Install Serverless CLI  |
-|  3.  | [Set up your Provider credentials](/docs/02-providers/aws/01-setup.md) | Connect Serverless with your provider |
+|  3.  | [Set up your Provider credentials](./docs/02-providers/aws/01-setup.md) | Connect Serverless with your provider |
 |  4.  | `serverless create --template aws-nodejs --path my-service` | Create an AWS Lamdba function in Node.js |
 |  5.  | `cd my-service` | Change into your service directory  |
 |  6.  | `serverless deploy` | Deploy to your AWS account  |
@@ -35,7 +35,7 @@ Below is a quick list of commands to set up a new project. For a more in-depth l
 
 Run `serverless remove` to clean up this function from your account.
 
-Check out our in-depth [Guide to Serverless](docs/01-guide) for more information.
+Check out our in-depth [Guide to Serverless](./docs/01-guide/README.md) for more information.
 
 ## <a name="features"></a>Features
 
@@ -114,7 +114,7 @@ These consultants use the Serverless Framework and can help you build your serve
 
 # Previous Serverless Version 0.5.x
 
-Below are projects and plugins relating to version 0.5 and below. Note that these are not compatible with v1.0 but we are working diligently on updating them. [Guide on building v1.0 plugins](docs/developing-plugins)
+Below are projects and plugins relating to version 0.5 and below. Note that these are not compatible with v1.0 but we are working diligently on updating them. [Guide on building v1.0 plugins](./docs/04-extending-serverless/01-creating-plugins.md)
 
 You can read the v0.5.x documentation at [readme.io](https://serverless.readme.io/v0.5.0/docs).
 

--- a/docs/01-guide/04-invoking-functions.md
+++ b/docs/01-guide/04-invoking-functions.md
@@ -47,4 +47,4 @@ A service with functions alone is just the beginning. Event sources provide a re
 
 Let's take a closer look at how we can use different event sources and attach them to our function.
 
-[Next step > Event sources](05-event-sources.md)
+[Next step > Event sources](./05-event-sources.md)

--- a/docs/01-guide/05-event-sources.md
+++ b/docs/01-guide/05-event-sources.md
@@ -78,4 +78,4 @@ But what if you want to add custom provider specific resources to your service w
 
 Let's take a look at this now.
 
-[Next step > Managing custom provider resources](06-custom-provider-resources.md)
+[Next step > Managing custom provider resources](./06-custom-provider-resources.md)

--- a/docs/01-guide/06-custom-provider-resources.md
+++ b/docs/01-guide/06-custom-provider-resources.md
@@ -62,4 +62,4 @@ It gives you access to the whole feature set your provider offers and makes Serv
 
 The last thing we need to learn is how we can remove our service. Let's take a look at this now.
 
-[Next step > Removing your service](07-removing-services.md)
+[Next step > Removing your service](./07-removing-services.md)

--- a/docs/01-guide/07-removing-services.md
+++ b/docs/01-guide/07-removing-services.md
@@ -22,6 +22,6 @@ We've just removed the whole service from our provider with a simple `serverless
 
 You can either dive deeper into our [Advanced Guides](./#advanced-guides) or read through the provider specific documentation we provide:
 
-* [AWS Documentation](../02-providers/aws)
+* [AWS Documentation](../02-providers/aws/README.md)
 
 Have fun with building your Serverless services and if you have feedback on the please let us know in [our Forum](forum.serverless.com) or [open an Issue in our Github repository](https://github.com/serverless/serverless/issues/new) for any bugs you might encounter or if you have an idea for a new feature.

--- a/docs/01-guide/README.md
+++ b/docs/01-guide/README.md
@@ -13,15 +13,15 @@ We always try to make our documentation better, so if you have feedback on the G
 
 ## Getting started
 
-- [Installing Serverless](01-installing-serverless.md)
-- [Creating a service](02-creating-services.md)
-- [Deploying a service](03-deploying-services.md)
-- [Invoking a function](04-invoking-functions.md)
-- [Event sources](05-event-sources.md)
-- [Custom provider resources](06-custom-provider-resources.md)
-- [Removing a service](07-removing-services.md)
+- [Installing Serverless](./01-installing-serverless.md)
+- [Creating a service](./02-creating-services.md)
+- [Deploying a service](./03-deploying-services.md)
+- [Invoking a function](./04-invoking-functions.md)
+- [Event sources](./05-event-sources.md)
+- [Custom provider resources](./06-custom-provider-resources.md)
+- [Removing a service](./07-removing-services.md)
 
 ## Advanced Guides
-- [Serverless Variables](08-serverless-variables.md)
-- [Installing plugins](09-installing-plugins.md)
+- [Serverless Variables](./08-serverless-variables.md)
+- [Installing plugins](./09-installing-plugins.md)
 - [Including/Excluding files for deployment](./10-packaging.md)

--- a/docs/03-cli-reference/07-tracking.md
+++ b/docs/03-cli-reference/07-tracking.md
@@ -6,7 +6,7 @@ layout: Doc
 
 # Tracking
 
-This plugin implements a way to toggle the [framework usage tracking](/docs/usage-tracking) functionality.
+This plugin implements a way to toggle the [framework usage tracking](../usage-tracking.md) functionality.
 
 ```
 serverless tracking --enable

--- a/docs/04-extending-serverless/02-creating-provider-plugins.md
+++ b/docs/04-extending-serverless/02-creating-provider-plugins.md
@@ -6,7 +6,7 @@ layout: Doc
 # Building provider integrations
 
 Integrating different infrastructure providers happens through the standard plugin system.
-Take a look at the ["building plugins"](./building-plugins.md) documentation to understand how the plugin system works.
+Take a look at the ["building plugins"](./01-creating-plugins.md) documentation to understand how the plugin system works.
 
 ## Provider specific plugins
 
@@ -18,7 +18,7 @@ Infrastructure provider plugins should bind to specific lifecycle events of the 
 
 ### Deployment lifecycle
 
-Let's take a look at the [core `deploy` plugin](/lib/plugins/deploy) and the different lifecycle hooks it provides.
+Let's take a look at the [core `deploy` plugin](../../lib/plugins/deploy) and the different lifecycle hooks it provides.
 
 The following lifecycle events are run in order once the user types `serverless deploy` and hits enter:
 
@@ -92,4 +92,4 @@ Here are the steps the AWS plugins take to compile and deploy the service on the
 
 You may also take a closer look at the corresponding plugin code to get a deeper knowledge about what's going on behind the scenes.
 
-The full AWS integration can be found in [`lib/plugins/aws`](/lib/plugins/aws).
+The full AWS integration can be found in [`lib/plugins/aws`](../../lib/plugins/aws).

--- a/docs/04-extending-serverless/README.md
+++ b/docs/04-extending-serverless/README.md
@@ -11,5 +11,5 @@ to integrate your own provider into the Serverless framework.
 
 ## Table of contents
 
-- [Building plugins](01-creating-plugins.md)
-- [Building provider integrations](02-creating-provider-plugins.md)
+- [Building plugins](./01-creating-plugins.md)
+- [Building provider integrations](./02-creating-provider-plugins.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,15 +7,15 @@ layout: Doc
 
 Welcome to the Serverless documentation.
 
-- [Quick Start Guide](01-guide)
+- [Quick Start Guide](./01-guide/README.md)
 - [Core Concepts](#concepts)
-- [CLI Reference](03-cli-reference)
+- [CLI Reference](./03-cli-reference/README.md)
 - [Providers](#providers)
-- [Extending Serverless](04-extending-serverless)
+- [Extending Serverless](./04-extending-serverless/README.md)
 - [Contributing to Serverless](#contributing)
 
 ## Providers
-- [AWS Integration Docs](./02-providers/aws/)
+- [AWS Integration Docs](./02-providers/aws/README.md)
 
 ## Concepts
 
@@ -37,7 +37,7 @@ Serverless is used to build event driven architecture. Basically everything whic
 
 Events could be HTTP requests, events fired from a cloud storage (like a S3 bucket), scheduled events, etc.
 
-- [AWS Events](./02-providers/aws/events)
+- [AWS Events](./02-providers/aws/events/README.md)
 
 ### Resources
 
@@ -51,12 +51,12 @@ A *Serverless service* is a group of one or multiple functions and any resources
 
 Here you can read how to develop your own Serverless plugins. We'll get into details on how to write custom plugins to extend the functionality of Serverless. Furthermore we'll look into the way how you can use your plugin knowledge to integrate your own provider into the Serverless framework.
 
-- [Building plugins](./04-extending-serverless)
+- [Building plugins](./04-extending-serverless/README.md)
 
 Connect with the community on [gitter](https://gitter.im/serverless/serverless) or in the [Forum](http://forum.serverless.com)
 
 ## Contributing
-We love our contributors! Please read our [Contributing Document](CONTRIBUTING.md) to learn how you can start working on the Framework yourself.
+We love our contributors! Please read our [Contributing Document](../CONTRIBUTING.md) to learn how you can start working on the Framework yourself.
 
 Check out our [help-wanted](https://github.com/serverless/serverless/labels/help-wanted) or [help-wanted-easy](https://github.com/serverless/serverless/labels/help-wanted-easy) labels to find issues we want to move forward on with your help.
 

--- a/docs/usage-tracking.md
+++ b/docs/usage-tracking.md
@@ -30,8 +30,8 @@ We encourage you to look into the source to see more details about the actual im
 
 The tracking implementation consists of two parts:
 
-1. The [tracking plugin](/lib/plugins/tracking)
-2. The `track` method you can find in the [Utils class](/lib/classes/Utils.js)
+1. The [tracking plugin](../lib/plugins/tracking)
+2. The `track` method you can find in the [Utils class](../lib/classes/Utils.js)
 
 ## How to disable it
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** README.md links not working #2095

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
* Change links to `docs` folders to the `README.md` in that folder
* Include `./` for relative links that didn't have it
* Change links that started with `/` to appropriate relative path e.g. `../../lib/<whatever>`
* Update links to files that seem to have been renamed.

## How can we verify it:

Click through the links as though you were following the `README.md` that is displayed when you visit https://github.com/nurous/serverless/

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

## Note:
There were some broken links that were not clear what I should update them to in the source files they are:
```
../using-plugins/core-plugins.md
../understanding-serverless/serverless-env-yml.md
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation
