### PR TITLE
Issue #2026: implementing common logger

### DIFF
--- a/lib/classes/Logger.js
+++ b/lib/classes/Logger.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const chalk = require('chalk');
+const _ = require('lodash');
+
+/**
+ * The default mappings from our internal logger to underlying chalk methods.
+ * These can be overridden on a logger instance via constructor.
+ *
+ * These will get exposed on the logger as `logger.INFO`, `logger.WHITE`, `logger.HEADING`, etc.
+ */
+const styleMapping = {
+  // expose the 'no-style' style
+  default: 'reset',
+  // level mappings
+  log: 'black',
+  info: 'green',
+  debug: 'magenta',
+  warn: 'yellow',
+  error: 'red',
+  // color mappings
+  black: 'black',
+  red: 'red',
+  green: 'green',
+  yellow: 'yellow',
+  blue: ' blue',
+  magenta: 'magenta',
+  cyan: 'cyan',
+  white: 'white',
+  gray: 'gray',
+  grey: 'grey',
+  // style mappings
+  underline: 'underline',
+  bold: 'bold',
+  light: 'dim',
+  // composite chalk styles
+  heading: 'underline.bold',
+};
+
+/**
+ * Apply the styles to the given message
+ * @param message the message
+ * @param stylePath the style path expression
+ * @return {*} the styled message
+ */
+function applyStyle(message, stylePath) {
+  // if we have a style path expression present
+  if (stylePath && stylePath.length !== 0) {
+    // figure out which chalk function we're calling
+    const chalkFn = _.at(chalk, stylePath);
+
+    // if we found one, use it
+    if (chalkFn[0]) {
+      return chalkFn[0](message);
+    }
+  }
+
+  // otherwise, just return the message
+  return message;
+}
+
+/**
+ * Internal log method.  Will first apply any styles before logging.
+ * @param message The message to log
+ * @param stylePath the style path
+ */
+function logInternal(message, stylePath) {
+  console.log(applyStyle(message, stylePath)); // eslint-disable-line no-console
+}
+
+/**
+ * Convenience method that builds a logger function for a given level (info, debug, etc.)
+ * @param level The log level
+ * @returns {Function} the logging function
+ */
+function buildLogMethod(level) {
+  // the log method takes a message, and any extra styles to apply (e.g., underline, dim, etc.)
+  return function () {
+    const message = _.head(arguments);
+    const extraStyles = _.tail(arguments);
+    const styleArr = [this.styles[level]];
+
+    // if extra styles were passed in, we need to map them appropriately and add to the styleArr
+    if (Array.isArray(extraStyles) && extraStyles.length > 0) {
+      extraStyles.forEach((s) => {
+        if (this.styles[s]) {
+          styleArr.push(this.styles[s]);
+        } else {
+          styleArr.push(s);
+        }
+      });
+    }
+
+    // call internal logger fn
+    logInternal(message, styleArr.join('.'));
+
+    // return `this` for method chaining
+    return this;
+  };
+}
+
+/**
+ * Provides console logging functionality with common styling
+ */
+class Logger {
+
+  constructor(mappingOverride) {
+    this.styles = {};
+
+    // apply default style mapping, then override with passed in config (if present)
+    _.defaults(this.styles, mappingOverride || {}, styleMapping);
+  }
+
+  /**
+   * Get the style mapping currently in use
+   * @return {{}|*}
+   */
+  getStyles() {
+    return _.clone(this.styles);
+  }
+
+  /**
+   * Convenience method to get a single style mapping
+   * @param key the key
+   * @return {*} the style value
+   */
+  getStyle(key) {
+    return this.styles[key];
+  }
+
+  /**
+   * Apply styles to the given message
+   * @param message the message to style
+   * @param styles... the styles to use (e.g., BOLD, UNDERLINE, etc.)
+   * @return {String} the styled message
+   */
+  style() {
+    const message = _.head(arguments);
+    const extraStyles = _.tail(arguments);
+
+    if (Array.isArray(extraStyles) && extraStyles.length > 0) {
+      return applyStyle(message, extraStyles.join('.'));
+    }
+
+    return applyStyle(message);
+  }
+
+  /**
+   * Convenience method to log a newline on the console
+   */
+  newline() {
+    return this.log('');
+  }
+}
+
+/**
+ * Log message using default style
+ * @type {Function}
+ */
+Logger.prototype.log = buildLogMethod('log');
+
+/**
+ * Log message using 'info' style
+ * @type {Function}
+ */
+Logger.prototype.info = buildLogMethod('info');
+
+/**
+ * Log message using 'debug' style
+ * @type {Function}
+ */
+Logger.prototype.debug = buildLogMethod('debug');
+
+/**
+ * Log message using 'warn' style
+ * @type {Function}
+ */
+Logger.prototype.warn = buildLogMethod('warn');
+
+/**
+ * Log message using 'error' style
+ * @type {Function}
+ * @param {String} message The message to log
+ * @param {String...} styles The extra styles to apply
+ */
+Logger.prototype.error = buildLogMethod('error');
+
+
+// apply all style properties to the logger prototype as uppercase property names
+Object.defineProperties(Logger.prototype, (() => {
+  const p = {};
+
+  // apply all style properties
+  Object.keys(styleMapping).forEach((s) => {
+    p[s.toUpperCase()] = {
+      enumerable: true,
+      get() {
+        return this.styles[s];
+      },
+    };
+  });
+
+  return p;
+})());
+
+
+// export default Logger instance
+module.exports = new Logger();
+
+// export class for customizing
+module.exports.Logger = Logger;

--- a/tests/all.js
+++ b/tests/all.js
@@ -8,6 +8,7 @@ require('./classes/Config');
 require('./classes/Service');
 require('./classes/Variables');
 require('./classes/YamlParser');
+require('./classes/Logger');
 require('./classes/CLI');
 
 // Core Plugins Tests

--- a/tests/classes/Logger.js
+++ b/tests/classes/Logger.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * Test: Logger Class
+ */
+const expect = require('chai').expect;
+const logger = require('../../lib/classes/Logger');
+const Logger = require('../../lib/classes/Logger').Logger;
+const chalk = require('chalk');
+const sinon = require('sinon');
+
+describe('Logger', () => {
+  // alias for the console.log spy
+  let consoleSpy;
+
+  // spy console.log calls
+  beforeEach(() => {
+    consoleSpy = sinon.spy(console, 'log');
+  });
+
+  // restore console.log
+  afterEach(() => {
+    consoleSpy.restore();
+  });
+
+  describe('#constructor()', () => {
+    it('should allow customization of styles', () => {
+      const l = new Logger({
+        info: 'cyan',
+        debug: 'green',
+        error: 'magenta',
+      });
+
+      // verify prototype property
+      expect(l.ERROR).to.equal('magenta');
+
+      // verify getStyle method
+      expect(l.getStyle('error')).to.equal('magenta');
+
+      // verify method call uses overridden style
+      expect(l.info('Bar')).to.equal(l);
+
+      const expectedResult = chalk.cyan('Bar');
+      expect(consoleSpy.getCall(0).args[0]).to.equal(expectedResult);
+    });
+  });
+
+  // ensure each log method calls the console with the chalk-formatted message
+  ['log', 'info', 'debug', 'warn', 'error'].forEach((level) => {
+    describe(`#${level}()`, () => {
+      it(`should log a message with ${level} level styling`, () => {
+        const l = logger[level]('foo');
+
+        const expectedResult = chalk[logger.getStyle(level)]('foo');
+
+        // console.log should have been called with the formatted message as the only argument
+        expect(consoleSpy.getCall(0).args[0]).to.equal(expectedResult);
+
+        // it should return itself for chaining
+        expect(l).to.equal(logger);
+      });
+
+      it(`should log a message with ${level} and header styling`, () => {
+        const l = logger[level]('foo', logger.HEADING);
+
+        const expectedResult = chalk[logger.getStyle(level)].underline.bold('foo');
+
+        // console.log should have been called with the formatted message as the only argument
+        expect(consoleSpy.getCall(0).args[0]).to.equal(expectedResult);
+
+        // it should return itself for chaining
+        expect(l).to.equal(logger);
+      });
+    });
+  });
+
+  describe('#style()', () => {
+    it('should return a styled message', () => {
+      const msg = logger.style('foo', logger.BOLD, logger.UNDERLINE);
+      const exp = chalk.bold.underline('foo');
+
+      expect(msg).to.equal(exp);
+    });
+
+    it('should work even if input message is undefined', () => {
+      const msg = logger.style(undefined, logger.UNDERLINE, logger.BOLD);
+      const exp = chalk.underline.bold(undefined);
+
+      expect(msg).to.equal(exp);
+    });
+
+    it('should return no styling if a bad style is passed', () => {
+      const msg = logger.style('foo', logger.BOLD, 'badstyle');
+      expect(msg).to.equal('foo');
+    });
+
+    it('should be able to build styles independently', () => {
+      const under = logger.style('bar', logger.UNDERLINE, logger.RED);
+      const bold = logger.style('foo', logger.GREEN, logger.BOLD);
+
+      expect(under).to.equal(chalk.underline.red('bar'));
+      expect(bold).to.equal(chalk.green.bold('foo'));
+    });
+  });
+});


### PR DESCRIPTION
## What did you implement:
***Implementing Issue:*** #2026 

This is the **first pass** to address this request -- it does not replace the calls to `chalk` that are currently throughout the code.  It adds the new logging functionality (and corresponding test).  Once this is accepted and merged, I can go back through the code to replace logging appropriately.

## How did you implement it:
Added new file under classes/Logger.js.  This exposes common methods (log, info, debug, error, warn) and allow for adding additional pre-defined styles for each (e.g., logger.HEADING => underline + bold).

The current default setting is:

- info -> green
- debug -> magenta
- warn -> yellow
- error -> red

This scheme can be adjusted either by updating the code (to set defaults for all of serverless), or by passing a config object to the logger's constructor.

## How can we verify it:
There is a test present in tests/classes/Logger.js.  To use/test in the project, use something like:

```javascript
const logger = require('./Logger');

logger.info('Welcome to Serverless!');
logger.debug('This is a debug message');
logger.warn('This is a warning message', logger.UNDERLINE, logger.LIGHT);
logger.error('This is an error message', logger.HEADING);
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation