### PR TITLE
point folder links to README files

### DIFF
--- a/docs/01-guide/05-event-sources.md
+++ b/docs/01-guide/05-event-sources.md
@@ -67,7 +67,7 @@ You've successfully executed the function through the HTTP endpoint!
 Serverless provides more than just a HTTP event source. You can find the full list of all available event sources with
 corresponding examples in the provider specific docs:
 
-* [AWS event documentation](../02-providers/aws/events).
+* [AWS event documentation](../02-providers/aws/events/README.md).
 
 ## Conclusion
 

--- a/docs/01-guide/07-removing-services.md
+++ b/docs/01-guide/07-removing-services.md
@@ -20,7 +20,7 @@ We've just removed the whole service from our provider with a simple `serverless
 
 ## What's next?
 
-You can either dive deeper into our [Advanced Guides](./#advanced-guides) or read through the provider specific documentation we provide:
+You can either dive deeper into our [Advanced Guides](./README.md#advanced-guides) or read through the provider specific documentation we provide:
 
 * [AWS Documentation](../02-providers/aws/README.md)
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

Removing links that pointed to folders and instead point to files now

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation

