### PR TITLE
add Node version and Serverless version in CLI errors

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -70,6 +70,7 @@ module.exports.logError = (e) => {
     }
 
     consoleLog(chalk.yellow('  Your Enviroment Infomation -----------------------------'));
+    consoleLog(chalk.yellow(`     OS:                 ${process.platform}`));
     consoleLog(chalk.yellow(`     Node Version:       ${process.version.replace(/^[v|V]/, '')}`));
     consoleLog(chalk.yellow(`     Serverless Version: ${version}`));
     consoleLog(' ');

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -1,5 +1,6 @@
 'use strict';
 const chalk = require('chalk');
+const version = require('./../../package.json').version;
 
 module.exports.SError = class ServerlessError extends Error {
   constructor(message) {
@@ -65,8 +66,12 @@ module.exports.logError = (e) => {
     if (e.name !== 'ServerlessError') {
       consoleLog(' ');
       consoleLog(chalk.red('     Please report this error. We think it might be a bug.'));
+      consoleLog(' ');
     }
 
+    consoleLog(chalk.yellow('  Your Enviroment Infomation -----------------------------'));
+    consoleLog(chalk.yellow(`     Node Version:       ${process.version.replace(/^[v|V]/, '')}`));
+    consoleLog(chalk.yellow(`     Serverless Version: ${version}`));
     consoleLog(' ');
 
     // Failure exit

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -69,7 +69,7 @@ module.exports.logError = (e) => {
       consoleLog(' ');
     }
 
-    consoleLog(chalk.yellow('  Your Enviroment Infomation -----------------------------'));
+    consoleLog(chalk.yellow('  Your Environment Infomation -----------------------------'));
     consoleLog(chalk.yellow(`     OS:                 ${process.platform}`));
     consoleLog(chalk.yellow(`     Node Version:       ${process.version.replace(/^[v|V]/, '')}`));
     consoleLog(chalk.yellow(`     Serverless Version: ${version}`));


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2109

## How did you implement it:
I added Node version and Serverless version in `lib/Error.js`
## How can we verify it:
Please exec `$ serverless tracking e` in your serverless project, and show messege below

<img width="686" alt="errors" src="https://cloud.githubusercontent.com/assets/1301012/18494609/115756a0-7a52-11e6-8022-64a8863bd179.png">


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

