### PR TITLE
Switch CloudFormation OnFailure behaviour to rollback instead of dele…

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -10,7 +10,7 @@ module.exports = {
     const coreCloudFormationTemplate = this.loadCoreCloudFormationTemplate();
     const params = {
       StackName: stackName,
-      OnFailure: 'DELETE',
+      OnFailure: 'ROLLBACK',
       Capabilities: [
         'CAPABILITY_IAM',
       ],


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2087 

## How did you implement it:

The existing behaviour of `DELETE` on CFN failure resulted in confusing outputs, that sometimes appeared as success. It also resulted in a race condition where a failure might not be seen at all due to CFN status polling (see my comment on #2087 for details).

Here's [the docs](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html) that correspond to the setting.

I specifically chose `ROLLBACK` over `DO_NOTHING` because in a vast majority of cases, rollback will work fine - the user will get the error message that caused the rollback, and they can investigate the root cause in the stack (which is no longer deleted). This will work best for the most common scenario - the user has tried to create a resource they don't have permission to create (again, see #2087).

In the unlikely event of a failure that leaves the stack in some other state, the stack will probably need to be deleted and recreated. This would be the case even if `DO_NOTHING` was specified.

## How can we verify it:

* Using a IAM User/Role that doesn't have S3 create permissions, launch a new stack

## Todos:

- ~~Write tests~~
- ~~Write documentation~~
- ~~Fix linting errors~~
- ~~Make sure code coverage hasn't dropped~~
- [ ] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation