### PR TITLE
Automatically include policy to enable Lambda to access VPC when using VPC config

### DIFF
--- a/lib/plugins/aws/deploy/lib/iam-policy-lambda-vpc-template.json
+++ b/lib/plugins/aws/deploy/lib/iam-policy-lambda-vpc-template.json
@@ -1,0 +1,17 @@
+{
+    "PolicyName": "IamPolicyLambdaVpc",
+    "PolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface"
+        ],
+        "Resource": "*"
+        }
+    ]
+    }
+}

--- a/lib/plugins/aws/deploy/lib/iam-policy-lambda-vpc-template.json
+++ b/lib/plugins/aws/deploy/lib/iam-policy-lambda-vpc-template.json
@@ -1,17 +1,17 @@
 {
-    "PolicyName": "IamPolicyLambdaVpc",
-    "PolicyDocument": {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-        "Effect": "Allow",
-        "Action": [
-            "ec2:CreateNetworkInterface",
-            "ec2:DescribeNetworkInterfaces",
-            "ec2:DeleteNetworkInterface"
-        ],
-        "Resource": "*"
-        }
-    ]
+  "PolicyName": "IamPolicyLambdaVpc",
+  "PolicyDocument": {
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+    "Effect": "Allow",
+    "Action": [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface"
+    ],
+    "Resource": "*"
     }
+  ]
+  }
 }

--- a/lib/plugins/aws/deploy/lib/iam-policy-lambda-vpc-template.json
+++ b/lib/plugins/aws/deploy/lib/iam-policy-lambda-vpc-template.json
@@ -1,17 +1,17 @@
 {
   "PolicyName": "IamPolicyLambdaVpc",
   "PolicyDocument": {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-    "Effect": "Allow",
-    "Action": [
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DeleteNetworkInterface"
-    ],
-    "Resource": "*"
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface"
+        ],
+        "Resource": "*"
+      }
+    ]
   }
 }

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -111,6 +111,45 @@ module.exports = {
         });
       }
 
+      const requiresVPCPermissions =
+        this.serverless.service.getAllFunctions().some((functionName) => {
+          const functionObject = this.serverless.service.getFunction(functionName);
+
+          if (!functionObject.vpc) functionObject.vpc = {};
+          if (!this.serverless.service.provider.vpc) this.serverless.service.provider.vpc = {};
+
+          const securityGroups = functionObject.vpc.securityGroupIds ||
+            this.serverless.service.provider.vpc.securityGroupIds;
+          const subnetIds = functionObject.vpc.subnetIds ||
+            this.serverless.service.provider.vpc.subnetIds;
+          return !(!securityGroups || !subnetIds);
+        });
+
+      // add the VPC permissions to the lambda execution role if a VPC config is given
+      if (requiresVPCPermissions) {
+        // merge in the iamPolicyLambdaVPCTemplate
+        const iamPolicyLambdaVpcTemplate = this.serverless.utils.readFileSync(
+          path.join(this.serverless.config.serverlessPath,
+            'plugins',
+            'aws',
+            'deploy',
+            'lib',
+            'iam-policy-lambda-vpc-template.json')
+        );
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamRoleLambdaExecution
+          .Properties
+          .Policies,
+          this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamRoleLambdaExecution
+          .Properties
+          .Policies
+          .concat(iamPolicyLambdaVpcTemplate));
+      }
+
       // add custom iam role statements
       if (this.serverless.service.provider.iamRoleStatements &&
         this.serverless.service.provider.iamRoleStatements instanceof Array) {

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -137,6 +137,18 @@ module.exports = {
             'iam-policy-lambda-vpc-template.json')
         );
 
+        if (!this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamRoleLambdaExecution
+          .Properties
+          .Policies) {
+          this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources
+            .IamRoleLambdaExecution
+            .Properties
+            .Policies = [];
+        }
+
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate
           .Resources
           .IamRoleLambdaExecution

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -46,7 +46,7 @@ describe('#mergeIamTemplates()', () => {
   });
 
   it('should merge the IamRoleLambdaExecution template into the CloudFormation template', () => {
-    const IamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(
+    const iamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(
       path.join(
         __dirname,
         '..',
@@ -59,7 +59,7 @@ describe('#mergeIamTemplates()', () => {
       .then(() => {
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.IamRoleLambdaExecution
-        ).to.deep.equal(IamRoleLambdaExecutionTemplate.IamRoleLambdaExecution);
+        ).to.deep.equal(iamRoleLambdaExecutionTemplate.IamRoleLambdaExecution);
       });
   });
 

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -81,7 +81,7 @@ describe('#mergeIamTemplates()', () => {
         subnetIds: ['TestSubnet'],
       };
 
-      const IamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(
+      const iamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(
         path.join(
           __dirname,
           '..',
@@ -97,7 +97,7 @@ describe('#mergeIamTemplates()', () => {
             .IamRoleLambdaExecution
             .Properties
             .Policies[0]
-          ).to.deep.equal(IamRoleLambdaExecutionTemplate);
+          ).to.deep.equal(iamRoleLambdaExecutionTemplate);
         });
     }
   );

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -74,6 +74,34 @@ describe('#mergeIamTemplates()', () => {
       })
   );
 
+  it('should merge the IamVPCPolicyLambda template into the CloudFormation template',
+    () => {
+      awsDeploy.serverless.service.functions[functionName].vpc = {
+        securityGroupIds: ['TestSecurityGroup'],
+        subnetIds: ['TestSubnet'],
+      };
+
+      const IamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(
+        path.join(
+          __dirname,
+          '..',
+          'lib',
+          'iam-policy-lambda-vpc-template.json'
+        )
+      );
+
+      return awsDeploy.mergeIamTemplates()
+        .then(() => {
+          expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources
+            .IamRoleLambdaExecution
+            .Properties
+            .Policies[0]
+          ).to.deep.equal(IamRoleLambdaExecutionTemplate);
+        });
+    }
+  );
+
   it('should update the necessary variables for the IamPolicyLambdaExecution',
     () => awsDeploy.mergeIamTemplates()
       .then(() => {


### PR DESCRIPTION
## What did you implement:

**Closes:** #1934 and #1786 

## How did you implement it:

I have included moved the policies from separate Cloudformation objects to be included in the role. This ensures that the role has been created before the functions start to create removing the error "Your access has been denied by EC2, please make sure your function execution role have permission to CreateNetworkInterface. EC2 Error Code: UnauthorizedOperation. EC2 Error Message: You are not authorized to perform this operation." from #1981. It will allow the functions to be deployed successfully
## How can we verify it:

Deploy a service with a vpc config with no custom iamRoleStatements and it will fail currently.
## Todos:
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
