### PR TITLE
[DOCS] Fix docs example code in YML: strings should be quoted

### DIFF
--- a/docs/02-providers/aws/events/01-apigateway.md
+++ b/docs/02-providers/aws/events/01-apigateway.md
@@ -71,11 +71,33 @@ functions:
           path: whatever
           request:
             template:
-              text/xhtml: { "stage" : "$context.stage" }
-              application/json: { "httpMethod" : "$context.httpMethod" }
+              text/xhtml: '{ "stage" : "$context.stage" }'
+              application/json: '{ "httpMethod" : "$context.httpMethod" }'
 ```
 
 **Note:** The templates are defined as plain text here. However you can also reference an external file with the help of the `${file(templatefile)}` syntax.
+
+**Note 2:** In .yml, strings containing `:`, `{`, `}`, `[`, `]`, `,`, `&`, `*`, `#`, `?`, `|`, `-`, `<`, `>`, `=`, `!`, `%`, `@`, `` ` `` must be quoted.
+
+If you want to map querystrings to the event object, you can use the `$input.params('hub.challenge')` syntax from API Gateway, as follows:
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          method: get
+          path: whatever
+          request:
+            template:
+              application/json: '{ "foo" : "$input.params(''bar'')" }'
+```
+
+**Note:** Notice when using single-quoted strings, any single quote `'` inside its contents must be doubled (`''`) to escape it.
+You can then access the query string `https://example.com/dev/whatever?bar=123` by `event.foo` in the lambda function.
+If you want to spread a string into multiple lines, you can use the `>` or `|` syntax, but the following strings have to be all indented with the same amount, [read more about `>` syntax](http://stackoverflow.com/questions/3790454/in-yaml-how-do-i-break-a-string-over-multiple-lines).
+
 
 ### Pass Through Behavior
 API Gateway provides multiple ways to handle requests where the Content-Type header does not match any of the specified mapping templates.  When this happens, the request payload will either be passed through the integration request *without transformation* or rejected with a `415 - Unsupported Media Type`, depending on the configuration.


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** #1968 (related)

<!--
Briefly describe the feature if no issue exists for this PR
-->

In file **`docs/02-providers/aws/events/01-apigateway.md`**, example code in section **Using custom request templates**:

```yml
request:
  template:
    text/xhtml: { "stage" : "$context.stage" }                  # <--- should be quoted!
    application/json: { "httpMethod" : "$context.httpMethod" }  # <--- should be quoted!
```

Strings containing `:`, `{`, `}`, `[`, `]`, `,`, `&`, `*`, `#`, `?`, `|`, `-`, `<`, `>`, `=`, `!`, `%`, `@`, `` ` `` must be quoted.

so the example should be like this:

```yml
request:
  template:
    text/xhtml: '{ "stage" : "$context.stage" }'
    application/json: '{ "httpMethod" : "$context.httpMethod" }'
```

Without the quotes, deployments will fail at `AWS::ApiGateway::Method` step.

I've been trying to use the custom request template after upgrading to v1.0, and finally found the correct syntax, lol.

Let me know if any correction is needed, and if more/less examples are preferred.


## How did you implement it:

Fix the example code by adding single quotes around the strings. added some notes and an example showing how to use `$input.params(''hub.verify_token'')` to map API Gateway query strings to custom request templates

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
