### PR TITLE
s3 events docs typo

### DIFF
--- a/docs/02-providers/aws/events/02-s3.md
+++ b/docs/02-providers/aws/events/02-s3.md
@@ -13,7 +13,7 @@ This will create a `photos` bucket which fires the `resize` function when an obj
 ```yml
 functions:
   resize:
-    handler: resize
+    handler: resize.handler
     events:
       - s3: photos
 ```


### PR DESCRIPTION
Missing `handler` in the handler path