### PR TITLE
refactor PluginManager and CLI to better support command nesting, cleanup

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -62,9 +62,10 @@ class Serverless {
         // load all plugins
         this.pluginManager.loadAllPlugins(this.service.plugins);
 
-        // give the CLI the plugins so that it can print out plugin information
-        // such as options when the user enters --help
+        // give the CLI the plugins and commands so that it can print out
+        // information such as options when the user enters --help
         this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
+        this.cli.setLoadedCommands(this.pluginManager.getCommands());
 
         // populate variables after processing options
         return this.variables.populateService(this.pluginManager.cliOptions);

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -66,9 +66,6 @@ class Serverless {
         // information such as options when the user enters --help
         this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
         this.cli.setLoadedCommands(this.pluginManager.getCommands());
-
-        // populate variables after processing options
-        return this.variables.populateService(this.pluginManager.cliOptions);
       });
   }
 
@@ -79,12 +76,15 @@ class Serverless {
       this.utils.track(this);
     }
 
-    if (!this.cli.displayHelp(this.processedInput) && this.processedInput.commands.length) {
-      // trigger the plugin lifecycle when there's something which should be processed
-      return this.pluginManager.run(this.processedInput.commands);
+    if (this.cli.displayHelp(this.processedInput)) {
+      return BbPromise.resolve();
     }
 
-    return BbPromise.resolve();
+    // populate variables after --help, otherwise help may fail to print (https://github.com/serverless/serverless/issues/2041)
+    this.variables.populateService(this.pluginManager.cliOptions);
+
+    // trigger the plugin lifecycle when there's something which should be processed
+    return this.pluginManager.run(this.processedInput.commands);
   }
 
   getVersion() {

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -80,7 +80,11 @@ class Serverless {
       return BbPromise.resolve();
     }
 
-    // populate variables after --help, otherwise help may fail to print (https://github.com/serverless/serverless/issues/2041)
+    // make sure the command exists before doing anything else
+    this.pluginManager.validateCommand(this.processedInput.commands);
+
+    // populate variables after --help, otherwise help may fail to print
+    // (https://github.com/serverless/serverless/issues/2041)
     this.variables.populateService(this.pluginManager.cliOptions);
 
     // trigger the plugin lifecycle when there's something which should be processed

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -11,10 +11,15 @@ class CLI {
     this.serverless = serverless;
     this.inputArray = inputArray || null;
     this.loadedPlugins = [];
+    this.loadedCommands = {};
   }
 
   setLoadedPlugins(plugins) {
     this.loadedPlugins = plugins;
+  }
+
+  setLoadedCommands(commands) {
+    this.loadedCommands = commands;
   }
 
   processInput() {
@@ -63,6 +68,52 @@ class CLI {
     return false;
   }
 
+  displayCommandUsage(commandObject, command) {
+    const dotsLength = 30;
+
+    // check if command has lifecycleEvents (can be executed)
+    if (commandObject.lifecycleEvents) {
+      const usage = commandObject.usage;
+      const dots = _.repeat('.', dotsLength - command.length);
+      this.consoleLog(`${chalk.yellow(command)} ${chalk.dim(dots)} ${usage}`);
+    }
+
+    _.forEach(commandObject.commands, (subcommandObject, subcommand) => {
+      this.displayCommandUsage(subcommandObject, `${command} ${subcommand}`);
+    });
+  }
+
+  displayCommandOptions(commandObject) {
+    const dotsLength = 40;
+    _.forEach(commandObject.options, (optionsObject, option) => {
+      let optionsDots = _.repeat('.', dotsLength - option.length);
+      const optionsUsage = optionsObject.usage;
+
+      if (optionsObject.required) {
+        optionsDots = optionsDots.slice(0, optionsDots.length - 18);
+      } else {
+        optionsDots = optionsDots.slice(0, optionsDots.length - 7);
+      }
+      if (optionsObject.shortcut) {
+        optionsDots = optionsDots.slice(0, optionsDots.length - 5);
+      }
+
+      const optionInfo = `    --${option}`;
+      let shortcutInfo = '';
+      let requiredInfo = '';
+      if (optionsObject.shortcut) {
+        shortcutInfo = ` / -${optionsObject.shortcut}`;
+      }
+      if (optionsObject.required) {
+        requiredInfo = ' (required)';
+      }
+
+      const thingsToLog = `${optionInfo}${shortcutInfo}${requiredInfo} ${
+        chalk.dim(optionsDots)} ${optionsUsage}`;
+      this.consoleLog(chalk.yellow(thingsToLog));
+    });
+  }
+
   generateMainHelp() {
     this.consoleLog('');
 
@@ -73,153 +124,36 @@ class CLI {
 
     this.consoleLog('');
 
-    const sortedPlugins = _.sortBy(
-      this.loadedPlugins,
-      (plugin) => plugin.constructor.name
-    );
-
-    // TODO: implement recursive command exploration (now only 2 steps are possible)
-    const dotsLength = 25;
-    sortedPlugins.forEach((plugin) => {
-      _.forEach(plugin.commands,
-        (firstLevelCommandObject, firstLevelCommand) => {
-          // check if command has lifecycleEvents (can be execute)
-          if (firstLevelCommandObject.lifecycleEvents) {
-            const command = firstLevelCommand;
-            const usage = firstLevelCommandObject.usage;
-            const dots = _.repeat('.', dotsLength - command.length);
-            this.consoleLog(`${chalk
-              .yellow(command)} ${chalk
-              .dim(dots)} ${usage}`);
-          }
-          _.forEach(firstLevelCommandObject.commands,
-            (secondLevelCommandObject, secondLevelCommand) => {
-              // check if command has lifecycleEvents (can be executed)
-              if (secondLevelCommandObject.lifecycleEvents) {
-                const command = `${firstLevelCommand} ${secondLevelCommand}`;
-                const usage = secondLevelCommandObject.usage;
-                const dots = _.repeat('.', dotsLength - command.length);
-                this.consoleLog(`${chalk
-                  .yellow(command)} ${chalk
-                  .dim(dots)} ${usage}`);
-              }
-            });
-        });
+    _.forEach(this.loadedCommands, (details, command) => {
+      this.displayCommandUsage(details, command);
     });
 
     this.consoleLog('');
 
     // print all the installed plugins
     this.consoleLog(chalk.yellow.underline('Plugins'));
-    if (sortedPlugins.length) {
+
+    if (this.loadedPlugins.length) {
+      const sortedPlugins = _.sortBy(
+        this.loadedPlugins,
+        (plugin) => plugin.constructor.name
+      );
+
       this.consoleLog(sortedPlugins.map((plugin) => plugin.constructor.name).join(', '));
     } else {
       this.consoleLog('No plugins added yet');
     }
   }
 
-  generateCommandsHelp(commands) {
-    const dotsLength = 40;
+  generateCommandsHelp(commandsArray) {
+    const command = this.serverless.pluginManager.getCommand(commandsArray);
+    const commandName = commandsArray.join(' ');
 
-    // TODO: use lodash utility functions to reduce loop usage
-    // TODO: support more than 2 levels of nested commands
-    if (commands.length === 1) {
-      this.loadedPlugins.forEach((plugin) => {
-        _.forEach(plugin.commands, (commandObject, command) => {
-          if (command === commands[0]) {
-            if (commandObject.lifecycleEvents) {
-              // print the name of the plugin
-              this.consoleLog(chalk.yellow.underline(`Plugin: ${plugin.constructor.name}`));
-              // print the command with the corresponding usage
-              const commandsDots = _.repeat('.', dotsLength - command.length);
-              const commandsUsage = commandObject.usage;
-              this.consoleLog(`${chalk
-                .yellow(command)} ${chalk
-                .dim(commandsDots)} ${commandsUsage}`);
-              // print all options
-              _.forEach(commandObject.options, (optionsObject, option) => {
-                let optionsDots = _.repeat('.', dotsLength - option.length);
-                const optionsUsage = optionsObject.usage;
+    // print the name of the plugin
+    this.consoleLog(chalk.yellow.underline(`Plugin: ${command.pluginName}`));
 
-                if (optionsObject.required) {
-                  optionsDots = optionsDots.slice(0, optionsDots.length - 17);
-                } else {
-                  optionsDots = optionsDots.slice(0, optionsDots.length - 7);
-                }
-                if (optionsObject.shortcut) {
-                  optionsDots = optionsDots.slice(0, optionsDots.length - 5);
-                }
-
-                const optionInfo = `    --${option}`;
-                let shortcutInfo = '';
-                let requiredInfo = '';
-                if (optionsObject.shortcut) {
-                  shortcutInfo = ` / -${optionsObject.shortcut}`;
-                }
-                if (optionsObject.required) {
-                  requiredInfo = ' (required)';
-                }
-
-                const thingsToLog = `${optionInfo}${shortcutInfo}${requiredInfo} ${
-                  chalk.dim(optionsDots)} ${optionsUsage}`;
-                this.consoleLog(chalk.yellow(thingsToLog));
-              });
-            }
-          }
-        });
-      });
-    } else {
-      this.loadedPlugins.forEach((plugin) => {
-        _.forEach(plugin.commands,
-          (firstLevelCommandObject, firstLevelCommand) => {
-            if (firstLevelCommand === commands[0]) {
-              _.forEach(firstLevelCommandObject.commands,
-                (secondLevelCommandObject, secondLevelCommand) => {
-                  if (secondLevelCommand === commands[1]) {
-                    if (secondLevelCommandObject.lifecycleEvents) {
-                      // print the name of the plugin
-                      this.consoleLog(chalk.yellow.underline(`Plugin: ${plugin.constructor.name}`));
-                      // print the command with the corresponding usage
-                      const commandsDots = _.repeat('.', dotsLength - secondLevelCommand.length);
-                      const commandsUsage = secondLevelCommandObject.usage;
-                      this.consoleLog(`${chalk
-                        .yellow(secondLevelCommand)} ${chalk
-                        .dim(commandsDots)} ${commandsUsage}`);
-                      // print all options
-                      _.forEach(secondLevelCommandObject.options, (optionsObject, option) => {
-                        let optionsDots = _.repeat('.', dotsLength - option.length);
-                        const optionsUsage = optionsObject.usage;
-
-                        if (optionsObject.required) {
-                          optionsDots = optionsDots.slice(0, optionsDots.length - 17);
-                        } else {
-                          optionsDots = optionsDots.slice(0, optionsDots.length - 7);
-                        }
-                        if (optionsObject.shortcut) {
-                          optionsDots = optionsDots.slice(0, optionsDots.length - 5);
-                        }
-
-                        const optionInfo = `    --${option}`;
-                        let shortcutInfo = '';
-                        let requiredInfo = '';
-                        if (optionsObject.shortcut) {
-                          shortcutInfo = ` / -${optionsObject.shortcut}`;
-                        }
-                        if (optionsObject.required) {
-                          requiredInfo = ' (required)';
-                        }
-
-                        const thingsToLog = `${optionInfo}${shortcutInfo}${requiredInfo} ${
-                          chalk.dim(optionsDots)} ${optionsUsage}`;
-                        this.consoleLog(chalk.yellow(thingsToLog));
-                      });
-                    }
-                  }
-                });
-            }
-          });
-      });
-    }
+    this.displayCommandUsage(command, commandName);
+    this.displayCommandOptions(command);
 
     this.consoleLog('');
   }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -150,6 +150,10 @@ class PluginManager {
     return BbPromise.reduce(hooks, (__, hook) => hook(), null);
   }
 
+  validateCommand(commandsArray) {
+    this.getCommand(commandsArray);
+  }
+
   validateOptions(command) {
     _.forEach(command.options, (value, key) => {
       if (value.required && (this.cliOptions[key] === true || !(this.cliOptions[key]))) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -1,19 +1,20 @@
 'use strict';
 
 const path = require('path');
-const _ = require('lodash');
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 
 class PluginManager {
   constructor(serverless) {
     this.serverless = serverless;
     this.provider = null;
+
     this.cliOptions = {};
     this.cliCommands = [];
 
     this.plugins = [];
-    this.commandsList = [];
     this.commands = {};
+    this.hooks = {};
   }
 
   setProvider(provider) {
@@ -28,35 +29,132 @@ class PluginManager {
     this.cliCommands = commands;
   }
 
+  addPlugin(Plugin) {
+    const pluginInstance = new Plugin(this.serverless, this.cliOptions);
+
+    // ignore plugins that specify a different provider than the current one
+    if (pluginInstance.provider && (pluginInstance.provider !== this.provider)) {
+      return;
+    }
+
+    this.loadCommands(pluginInstance);
+    this.loadHooks(pluginInstance);
+
+    this.plugins.push(pluginInstance);
+  }
+
   loadAllPlugins(servicePlugins) {
     this.loadCorePlugins();
     this.loadServicePlugins(servicePlugins);
   }
 
-  validateCommands(commandsArray) {
-    // TODO: implement an option to get deeper than one level
-    if (!this.commands[commandsArray[0]]) {
-      const errorMessage = [
-        `command "${commandsArray[0]}" not found`,
-        ' Run "serverless help" for a list of all available commands.',
-      ].join();
-      throw new this.serverless.classes.Error(errorMessage);
+  loadPlugins(plugins) {
+    plugins.forEach((plugin) => {
+      const Plugin = require(plugin); // eslint-disable-line global-require
+
+      this.addPlugin(Plugin);
+    });
+  }
+
+  loadCorePlugins() {
+    const pluginsDirectoryPath = path.join(__dirname, '../plugins');
+
+    const corePlugins = this.serverless.utils
+      .readFileSync(path.join(pluginsDirectoryPath, 'Plugins.json')).plugins
+      .map((corePluginPath) => path.join(pluginsDirectoryPath, corePluginPath));
+
+    this.loadPlugins(corePlugins);
+  }
+
+  loadServicePlugins(servicePlugs) {
+    const servicePlugins = (typeof servicePlugs !== 'undefined' ? servicePlugs : []);
+
+    // we want to load plugins installed locally in the service
+    if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
+      module.paths.unshift(path.join(this.serverless.config.servicePath, 'node_modules'));
+    }
+
+    this.loadPlugins(servicePlugins);
+
+    // restore module paths
+    if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
+      module.paths.shift();
     }
   }
 
-  validateOptions(commandsArray) {
-    let options;
+  loadCommand(pluginName, details, key) {
+    const commands = _.mapValues(details.commands, (subDetails, subKey) =>
+      this.loadCommand(pluginName, subDetails, `${key}:${subKey}`)
+    );
+    return _.assign({}, details, { key, pluginName, commands });
+  }
 
-    // TODO: implement an option to get deeper than two levels
-    if (commandsArray.length === 1) {
-      options = this.commands[commandsArray[0]].options;
-    } else {
-      options = this.commands[commandsArray[0]].commands[commandsArray[1]].options;
+  loadCommands(pluginInstance) {
+    const pluginName = pluginInstance.constructor.name;
+    _.forEach(pluginInstance.commands, (details, key) => {
+      this.commands[key] = this.loadCommand(pluginName, details, key);
+    });
+  }
+
+  loadHooks(pluginInstance) {
+    _.forEach(pluginInstance.hooks, (hook, event) => {
+      this.hooks[event] = this.hooks[event] || [];
+      this.hooks[event].push(hook);
+    });
+  }
+
+  getCommands() {
+    return this.commands;
+  }
+
+  getCommand(commandsArray) {
+    return _.reduce(commandsArray, (current, name, index) => {
+      if (name in current.commands) {
+        return current.commands[name];
+      }
+      const commandName = commandsArray.slice(0, index + 1).join(' ');
+      const errorMessage = [
+        `Command "${commandName}" not found`,
+        ' Run "serverless help" for a list of all available commands.',
+      ].join();
+      throw new this.serverless.classes.Error(errorMessage);
+    }, { commands: this.commands });
+  }
+
+  getEvents(command) {
+    return _.flatMap(command.lifecycleEvents, (event) => [
+      `before:${command.key}:${event}`,
+      `${command.key}:${event}`,
+      `after:${command.key}:${event}`,
+    ]);
+  }
+
+  getPlugins() {
+    return this.plugins;
+  }
+
+  run(commandsArray) {
+    const command = this.getCommand(commandsArray);
+
+    this.convertShortcutsIntoOptions(command);
+    this.validateOptions(command);
+
+    const events = this.getEvents(command);
+    const hooks = _.flatMap(events, (event) => this.hooks[event] || []);
+
+    if (hooks.length === 0) {
+      const errorMessage = 'The command you entered did not catch on any hooks';
+      throw new this.serverless.classes.Error(errorMessage);
     }
 
-    _.forEach(options, (value, key) => {
+    return BbPromise.reduce(hooks, (__, hook) => hook(), null);
+  }
+
+  validateOptions(command) {
+    _.forEach(command.options, (value, key) => {
       if (value.required && (this.cliOptions[key] === true || !(this.cliOptions[key]))) {
         let requiredThings = `the --${key} option`;
+
         if (value.shortcut) {
           requiredThings += ` / -${value.shortcut} shortcut`;
         }
@@ -74,163 +172,19 @@ class PluginManager {
     });
   }
 
-  run(commandsArray) {
-    // check if the command the user has entered is provided through a plugin
-    this.validateCommands(commandsArray);
-
-    // check if all options are passed
-    this.validateOptions(commandsArray);
-
-    const events = this.getEvents(commandsArray, this.commands);
-    const hooks = events.reduce((memo, event) => {
-      this.plugins.forEach((pluginInstance) => {
-        // if a provider is given it should only add the hook when the plugins provider matches
-        // the services provider
-        if (!pluginInstance.provider || (pluginInstance.provider === this.provider)) {
-          _.forEach(pluginInstance.hooks, (hook, hookKey) => {
-            if (hookKey === event) {
-              memo.push(hook);
-            }
-          });
-        }
-      });
-      return memo;
-    }, []);
-
-    if (hooks.length === 0) {
-      const errorMessage = `The command you entered was not found.
-     Did you spell it correctly?`;
-      throw new this.serverless.classes.Error(errorMessage);
-    }
-
-    return BbPromise.reduce(hooks, (__, hook) => hook(), null);
-  }
-
-  convertShortcutsIntoOptions(cliOptions, commands) {
-    // TODO: implement an option to get deeper than two levels
-    // check if the command entered is the one in the commands object which holds all commands
-    // this is necessary so that shortcuts are not treated like global citizens but command
-    // bound properties
-    if (this.cliCommands.length === 1) {
-      _.forEach(commands, (firstCommand, firstCommandKey) => {
-        if (_.includes(this.cliCommands, firstCommandKey)) {
-          _.forEach(firstCommand.options, (optionObject, optionKey) => {
-            if (optionObject.shortcut && _.includes(Object.keys(cliOptions),
-                optionObject.shortcut)) {
-              Object.keys(cliOptions).forEach((option) => {
-                if (option === optionObject.shortcut) {
-                  this.cliOptions[optionKey] = this.cliOptions[option];
-                }
-              });
-            }
-          });
-        }
-      });
-    } else if (this.cliCommands.length === 2) {
-      _.forEach(commands, (firstCommand) => {
-        _.forEach(firstCommand.commands, (secondCommand, secondCommandKey) => {
-          if (_.includes(this.cliCommands, secondCommandKey)) {
-            _.forEach(secondCommand.options, (optionObject, optionKey) => {
-              if (optionObject.shortcut && _.includes(Object.keys(cliOptions),
-                  optionObject.shortcut)) {
-                Object.keys(cliOptions).forEach((option) => {
-                  if (option === optionObject.shortcut) {
-                    this.cliOptions[optionKey] = this.cliOptions[option];
-                  }
-                });
-              }
-            });
+  convertShortcutsIntoOptions(command) {
+    _.forEach(command.options, (optionObject, optionKey) => {
+      if (optionObject.shortcut && _.includes(Object.keys(this.cliOptions),
+          optionObject.shortcut)) {
+        Object.keys(this.cliOptions).forEach((option) => {
+          if (option === optionObject.shortcut) {
+            this.cliOptions[optionKey] = this.cliOptions[option];
           }
         });
-      });
-    }
-  }
-
-  addPlugin(Plugin) {
-    const pluginInstance = new Plugin(this.serverless, this.cliOptions);
-
-    this.loadCommands(pluginInstance);
-
-    // shortcuts should be converted into options so that the plugin
-    // author can use the option (instead of the shortcut)
-    this.convertShortcutsIntoOptions(this.cliOptions, this.commands);
-
-    this.plugins.push(pluginInstance);
-  }
-
-  loadCorePlugins() {
-    const pluginsDirectoryPath = path.join(__dirname, '../plugins');
-
-    const corePlugins = this.serverless.utils
-      .readFileSync(path.join(pluginsDirectoryPath, 'Plugins.json')).plugins;
-
-    corePlugins.forEach((corePlugin) => {
-      const Plugin = require(path // eslint-disable-line global-require
-        .join(pluginsDirectoryPath, corePlugin));
-
-      this.addPlugin(Plugin);
-    });
-  }
-
-  loadServicePlugins(servicePlugs) {
-    const servicePlugins = (typeof servicePlugs !== 'undefined' ? servicePlugs : []);
-
-    // we want to load plugins installed locally in the service
-    if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
-      module.paths.unshift(path.join(this.serverless.config.servicePath, 'node_modules'));
-    }
-
-    servicePlugins.forEach((servicePlugin) => {
-      const Plugin = require(servicePlugin); // eslint-disable-line global-require
-
-      this.addPlugin(Plugin);
-    });
-
-    // restore module paths
-    if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
-      module.paths.shift();
-    }
-  }
-
-  loadCommands(pluginInstance) {
-    this.commandsList.push(pluginInstance.commands);
-
-    // TODO: refactor ASAP as it slows down overall performance
-    // rebuild the commands
-    _.forEach(this.commandsList, (commands) => {
-      _.forEach(commands, (commandDetails, command) => {
-        this.commands[command] = commandDetails;
-      });
-    });
-  }
-
-  getEvents(commandsArray, availableCommands, pre) {
-    const prefix = (typeof pre !== 'undefined' ? pre : '');
-    const commandPart = commandsArray[0];
-
-    if (_.has(availableCommands, commandPart)) {
-      const commandDetails = availableCommands[commandPart];
-      if (commandsArray.length === 1) {
-        const events = [];
-        commandDetails.lifecycleEvents.forEach((event) => {
-          events.push(`before:${prefix}${commandPart}:${event}`);
-          events.push(`${prefix}${commandPart}:${event}`);
-          events.push(`after:${prefix}${commandPart}:${event}`);
-        });
-        return events;
       }
-      if (_.has(commandDetails, 'commands')) {
-        return this.getEvents(commandsArray.slice(1, commandsArray.length),
-          commandDetails.commands, `${commandPart}:`);
-      }
-    }
-
-    return [];
+    });
   }
 
-  getPlugins() {
-    return this.plugins;
-  }
 }
 
 module.exports = PluginManager;

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -92,7 +92,8 @@ class PluginManager {
   loadCommands(pluginInstance) {
     const pluginName = pluginInstance.constructor.name;
     _.forEach(pluginInstance.commands, (details, key) => {
-      this.commands[key] = this.loadCommand(pluginName, details, key);
+      const command = this.loadCommand(pluginName, details, key);
+      this.commands[key] = _.merge({}, this.commands[key], command);
     });
   }
 

--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -116,10 +116,11 @@ describe('CLI', () => {
           };
         }
       }
-      const pluginMock = new PluginMock();
-      const plugins = [pluginMock];
+      serverless.pluginManager.addPlugin(PluginMock);
 
-      cli.setLoadedPlugins(plugins);
+      cli.setLoadedPlugins(serverless.pluginManager.getPlugins());
+      cli.setLoadedCommands(serverless.pluginManager.getCommands());
+
       const processedInput = cli.processInput();
       const helpDisplayed = cli.displayHelp(processedInput);
 
@@ -180,10 +181,11 @@ describe('CLI', () => {
           };
         }
       }
-      const pluginMock = new PluginMock();
-      const plugins = [pluginMock];
+      serverless.pluginManager.addPlugin(PluginMock);
 
-      cli.setLoadedPlugins(plugins);
+      cli.setLoadedPlugins(serverless.pluginManager.getPlugins());
+      cli.setLoadedCommands(serverless.pluginManager.getCommands());
+
       const processedInput = cli.processInput();
       const helpDisplayed = cli.displayHelp(processedInput);
 
@@ -228,10 +230,11 @@ describe('CLI', () => {
           };
         }
       }
-      const pluginMock = new PluginMock();
-      const plugins = [pluginMock];
+      serverless.pluginManager.addPlugin(PluginMock);
 
-      cli.setLoadedPlugins(plugins);
+      cli.setLoadedPlugins(serverless.pluginManager.getPlugins());
+      cli.setLoadedCommands(serverless.pluginManager.getCommands());
+
       const processedInput = cli.processInput();
       const helpDisplayed = cli.displayHelp(processedInput);
 

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -388,6 +388,46 @@ describe('PluginManager', () => {
 
       expect(pluginManager.commands).to.have.property('deploy');
     });
+
+    it('should merge plugin commands', () => {
+      pluginManager.loadCommands({
+        commands: {
+          deploy: {
+            lifecycleEvents: [
+              'one',
+            ],
+            options: {
+              foo: {},
+            },
+          },
+        },
+      });
+
+      pluginManager.loadCommands({
+        commands: {
+          deploy: {
+            lifecycleEvents: [
+              'one',
+              'two',
+            ],
+            options: {
+              bar: {},
+            },
+            commands: {
+              fn: {
+              },
+            },
+          },
+        },
+      });
+
+      expect(pluginManager.commands.deploy).to.have.property('options')
+        .that.has.all.keys('foo', 'bar');
+      expect(pluginManager.commands.deploy).to.have.property('lifecycleEvents')
+        .that.is.an('array')
+        .that.deep.equals(['one', 'two']);
+      expect(pluginManager.commands.deploy.commands).to.have.property('fn');
+    });
   });
 
   describe('#getEvents()', () => {


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2084
***Implementing Issue:*** #2041
***Implementing Issue:*** #2037
***Implementing Issue:*** #1570
***Implementing Issue:*** #2041

I made PluginManager support arbitrarily nested commands by using loops/recursion instead of explicit checks (firstLevel -> secondLevel)

This made a bunch of stuff simpler and fixed a number of bugs. I also restricted plugin loading to just relevant ones (i.e match provider).

## How did you implement it:

One of the key changes was to make the pluginManager deal with the command object itself, vs. just an array of strings pointing to the command. (Exception: run and getCommand).

I think most PluginManager actions are now fairly straight forward, self-contained functions.

## How can we verify it:

N/A as it mostly just fixes up what people expected / what was documented already?
(integration tests pass)

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

