### PR TITLE
[DOCS] Match endpoint path to example in "Setting up Events"

### DIFF
--- a/docs/01-guide/05-event-sources.md
+++ b/docs/01-guide/05-event-sources.md
@@ -53,13 +53,13 @@ After deploying your service you should see the URL for your http endpoint in th
 
 ```bash
 endpoints:
-  GET - https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/users
+  GET - https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/greet
 ```
 
 We can now simply call it:
 
 ```bash
-$ curl https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/users
+$ curl https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/greet
 {"message":"Go Serverless v1.0! Your function executed successfully!"}
 ```
 


### PR DESCRIPTION
## What did you implement:

Fixed the Quick Start Guide referencing the wrong endpoint for the given example in the "Setting up Events" section".

## How did you implement it:

Changed endpoint path to match given example

## How can we verify it:

Read the altered page.

## Todos:

None

