### PR TITLE
- ensure the Create/Update CloudFormation templates are always written to disk, even if the noDeploy option was not specified

### DIFF
--- a/docs/03-cli-reference/02-deploy.md
+++ b/docs/03-cli-reference/02-deploy.md
@@ -7,7 +7,7 @@ layout: Doc
 
 # Deploy
 
-Deploys your service.
+Deploys your service. You can access all created deployment artifacts in the `.serverless` folder.
 
 ```
 serverless deploy [function]

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -35,25 +35,28 @@ module.exports = {
     this.serverless.service.provider
       .compiledCloudFormationTemplate = this.loadCoreCloudFormationTemplate();
 
-    // just write the template to disk if a deployment should not be performed
-    if (this.options.noDeploy) {
-      return BbPromise.bind(this)
-        .then(this.writeCreateTemplateToDisk);
-    }
-
-    return this.sdk.request('CloudFormation',
-      'describeStackResources',
-      { StackName: stackName },
-      this.options.stage,
-      this.options.region)
-      .then(() => BbPromise.resolve('alreadyCreated'))
-      .catch(e => {
-        if (e.message.indexOf('does not exist') > -1) {
-          return BbPromise.bind(this)
-            .then(this.create);
+    return BbPromise.bind(this)
+      // always write the template to disk, whether we are deploying or not
+      .then(this.writeCreateTemplateToDisk)
+      .then(() => {
+        if (this.options.noDeploy) {
+          return BbPromise.resolve();
         }
 
-        throw new this.serverless.classes.Error(e);
+        return this.sdk.request('CloudFormation',
+          'describeStackResources',
+          { StackName: stackName },
+          this.options.stage,
+          this.options.region)
+          .then(() => BbPromise.resolve('alreadyCreated'))
+          .catch(e => {
+            if (e.message.indexOf('does not exist') > -1) {
+              return BbPromise.bind(this)
+                .then(this.create);
+            }
+
+            throw new this.serverless.classes.Error(e);
+          });
       });
   },
 

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -31,13 +31,15 @@ module.exports = {
 
   updateStack() {
     // just write the template to disk if a deployment should not be performed
-    if (this.options.noDeploy) {
-      return BbPromise.bind(this)
-        .then(this.writeUpdateTemplateToDisk);
-    }
-
     return BbPromise.bind(this)
-      .then(this.update);
+      .then(this.writeUpdateTemplateToDisk)
+      .then(() => {
+        if (this.options.noDeploy) {
+          return BbPromise.resolve();
+        }
+        return BbPromise.bind(this)
+          .then(this.update);
+      });
   },
 
   // helper methods

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -70,8 +70,11 @@ describe('createStack', () => {
       sinon.stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
 
       const coreCloudFormationTemplate = awsDeploy.loadCoreCloudFormationTemplate();
+      const writeCreateTemplateToDiskStub = sinon
+        .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
 
       return awsDeploy.createStack().then(() => {
+        expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate)
           .to.deep.equal(coreCloudFormationTemplate);
 
@@ -92,7 +95,7 @@ describe('createStack', () => {
       });
     });
 
-    it('should resolve if no deploy', () => {
+    it('should resolve if the noDeploy option is used', () => {
       awsDeploy.options.noDeploy = true;
 
       const writeCreateTemplateToDiskStub = sinon
@@ -104,7 +107,24 @@ describe('createStack', () => {
         expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
         expect(createStub.called).to.be.equal(false);
 
+        awsDeploy.writeCreateTemplateToDisk.restore();
         awsDeploy.create.restore();
+      });
+    });
+
+    it('should write the template to disk even if we do not specify the noDeploy option', () => {
+      awsDeploy.options.noDeploy = false;
+
+      const writeCreateTemplateToDiskStub = sinon
+        .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+
+      return awsDeploy.createStack().then(() => {
+        expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
+        expect(awsDeploy.sdk.request.called).to.be.equal(true);
+
+        awsDeploy.writeCreateTemplateToDisk.restore();
+        awsDeploy.sdk.request.restore();
       });
     });
 

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -67,6 +67,24 @@ describe('updateStack', () => {
         expect(writeUpdateTemplateStub.calledOnce).to.be.equal(true);
         expect(updateStub.called).to.be.equal(false);
 
+        awsDeploy.writeUpdateTemplateToDisk.restore();
+        awsDeploy.update.restore();
+      });
+    });
+
+    it('should write the template to disk even if the noDeploy option was not used', () => {
+      awsDeploy.options.noDeploy = false;
+
+      const writeUpdateTemplateStub = sinon
+        .stub(awsDeploy, 'writeUpdateTemplateToDisk').returns();
+      const updateStub = sinon
+        .stub(awsDeploy, 'update').returns(BbPromise.resolve());
+
+      return awsDeploy.updateStack().then(() => {
+        expect(writeUpdateTemplateStub.calledOnce).to.be.equal(true);
+        expect(updateStub.called).to.be.equal(true);
+
+        awsDeploy.writeUpdateTemplateToDisk.restore();
         awsDeploy.update.restore();
       });
     });


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2016 

## How did you implement it:

Basically made it so writeCreateTemplateToDisk() or writeUpdateTemplateToDisk() is always called on a create/update action, respectively, whether or not the -noDeploy option was used.

## How can we verify it:

deploy a function as per normal
`sls deploy`

you should now see cloudformation-template-(create|update)-stack.json files in .serverless/, in addition to the .zip file

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

