### PR TITLE
Update to use describeStackResource

### DIFF
--- a/lib/plugins/aws/index.js
+++ b/lib/plugins/aws/index.js
@@ -4,7 +4,6 @@ const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
 const AWS = require('aws-sdk');
-const _ = require('lodash');
 
 class SDK {
   constructor(serverless) {
@@ -99,15 +98,16 @@ class SDK {
   getServerlessDeploymentBucketName(stage, region) {
     const stackName = `${this.serverless.service.service}-${stage}`;
     return this.request('CloudFormation',
-      'describeStackResources',
-      { StackName: stackName },
+      'describeStackResource',
+      {
+        StackName: stackName,
+        LogicalResourceId: 'ServerlessDeploymentBucket',
+      },
       stage,
       region
-    ).then((result) => {
-      const found = _.find(result.StackResources,
-        { LogicalResourceId: 'ServerlessDeploymentBucket' });
-      return found.PhysicalResourceId;
-    });
+    ).then((result) =>
+      result.StackResourceDetail.PhysicalResourceId
+    );
   }
 
   getStackName(stage) {

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -116,12 +116,9 @@ describe('AWS SDK', () => {
       const describeStackResourcesStub = sinon
         .stub(awsSdk, 'request')
         .returns(BbPromise.resolve({
-          StackResources: [
-            {
-              LogicalResourceId: 'ServerlessDeploymentBucket',
-              PhysicalResourceId: 'serverlessDeploymentBucketName',
-            },
-          ],
+          StackResourceDetail: {
+            PhysicalResourceId: 'serverlessDeploymentBucketName',
+          },
         }));
 
       return awsSdk.getServerlessDeploymentBucketName(options.stage, options.region)
@@ -129,7 +126,7 @@ describe('AWS SDK', () => {
           expect(describeStackResourcesStub.calledOnce).to.be.equal(true);
           expect(describeStackResourcesStub.calledWith(options.stage, options.region));
           expect(describeStackResourcesStub.args[0][0]).to.equal('CloudFormation');
-          expect(describeStackResourcesStub.args[0][1]).to.equal('describeStackResources');
+          expect(describeStackResourcesStub.args[0][1]).to.equal('describeStackResource');
           expect(describeStackResourcesStub.args[0][2].StackName)
             .to.equal(`${awsSdk.serverless.service.service}-${options.stage}`);
 


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2140 

## How did you implement it:

Get Serverless s3 bucket physical resource id by calling `describeStackResource` instead of iterating over `describeStackResources`.

## How can we verify it:

Deployment of any service will do.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

