### PR TITLE
add AWS_DEFAULT_REGION environment variable support

### DIFF
--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -13,6 +13,7 @@ module.exports = {
       || (this.serverless.service.defaults && this.serverless.service.defaults.stage)
       || 'dev';
     this.options.region = this.options.region
+      || process.env.AWS_DEFAULT_REGION
       || (this.serverless.service.defaults && this.serverless.service.defaults.region)
       || 'us-east-1';
 

--- a/lib/plugins/aws/tests/validate.js
+++ b/lib/plugins/aws/tests/validate.js
@@ -49,6 +49,17 @@ describe('#validate()', () => {
     });
   });
 
+  it('should default to AWS_DEFAULT_REGION region if region is not provided ', () => {
+    awsPlugin.options.region = false;
+    process.env.AWS_DEFAULT_REGION = 'us-west-2';
+    return awsPlugin.validate().then(() => {
+      expect(awsPlugin.options.region).to.equal('us-west-2');
+    })
+    .finally(() => {
+      delete process.env.AWS_DEFAULT_REGION;
+    });
+  });
+
   it('should default to "us-east-1" region if region is not provided', () => {
     awsPlugin.options.region = false;
     return awsPlugin.validate().then(() => {


### PR DESCRIPTION
Implementing Issue: #2078

I added the ability to use the AWS_DEFAULT_REGION environment variable to change which region various AWS commands are going to.

How did you implement it:

It feels weird that the 'validate' function manipulates the config but it was already doing it with service.defaults and the actual hard coded default value, so I added it to the same spot. The test is a bit ugly (and didn't increase coverage at all) but it's there.

How can we verify it:

From some test project, just call AWS_DEFAULT_REGION={someOtherRegion} sls deploy I tested this with my own AWS account.

Todos:

Not sure if you want any documentation for it.