### PR TITLE
fix bug where variableSyntax is never set from config

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -11,7 +11,6 @@ class Variables {
     this.serverless = serverless;
     this.service = this.serverless.service;
 
-    this.variableSyntax = RegExp(this.service.defaults.variableSyntax, 'g');
     this.overwriteSyntax = RegExp(/,/g);
     this.fileRefSyntax = RegExp(/^file\(([a-zA-Z0-9._\-\/]+?)\)/g);
     this.envRefSyntax = RegExp(/^env:./g);
@@ -19,9 +18,16 @@ class Variables {
     this.selfRefSyntax = RegExp(/^self:./g);
   }
 
+  loadVariableSyntax() {
+    this.variableSyntax = RegExp(this.service.defaults.variableSyntax, 'g');
+  }
+
   populateService(processedOptions) {
     const that = this;
     this.options = processedOptions || {};
+
+    this.loadVariableSyntax();
+
     const variableSyntaxProperty = this.service.defaults.variableSyntax;
 
     // temporally remove variable syntax from service otherwise it'll match
@@ -183,4 +189,3 @@ class Variables {
 }
 
 module.exports = Variables;
-


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2143

## How did you implement it:
I moved assignment of `variableSyntax` in `Variables.js` from the `constructor` to a new method that is called in `populateService`. This ensures that the configuration is loaded from `serverless.yml` before `variableSyntax` is set.

## How can we verify it:
Add a custom variableSyntax to `serverless.yml`.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped

