### PR TITLE
Fix profile handling when other keys are present

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     volumes:
       - .:/app
       - ~/.aws/:/root/.aws
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_PROFILE
+      - AWS_SESSION_TOKEN
+      - AWS_SECURITY_TOKEN
   aws-nodejs:
     image: node:5.11.1
     volumes:

--- a/lib/plugins/aws/index.js
+++ b/lib/plugins/aws/index.js
@@ -33,7 +33,7 @@ class SDK {
 
   request(service, method, params, stage, region) {
     const that = this;
-    const credentials = that.getCredentials(stage, region);
+    const credentials = that.getCredentials(region);
     const persistentRequest = (f) => new BbPromise((resolve, reject) => {
       const doCall = () => {
         f()
@@ -78,21 +78,15 @@ class SDK {
     });
   }
 
-  getCredentials(stage, region) {
-    let prefix;
-    if (stage) {
-      prefix = `AWS_${stage.toUpperCase()}`;
-    } else {
-      prefix = 'AWS';
+  getCredentials(region) {
+    const credentials = { region };
+    const profile = this.serverless.service.provider.profile;
+
+    if (typeof profile !== 'undefined' && profile) {
+      credentials.credentials = new AWS.SharedIniFileCredentials({ profile });
     }
 
-    const profile = process.env[`${prefix}_PROFILE`] ||
-      this.serverless.service.provider.profile;
-
-    return {
-      credentials: new AWS.SharedIniFileCredentials({ profile }),
-      region,
-    };
+    return credentials;
   }
 
   getServerlessDeploymentBucketName(stage, region) {

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -85,22 +85,11 @@ describe('AWS SDK', () => {
   });
 
   describe('#getCredentials()', () => {
-    it('should get credentials', () => {
+    it('should set region for credentials', () => {
       const serverless = new Serverless();
-      process.env.AWS_PROFILE = 'default';
       const awsSdk = new AwsSdk(serverless);
-      const credentials = awsSdk.getCredentials();
-      expect(credentials.credentials.profile).to.equal('default');
-      delete process.env.AWS_PROFILE;
-    });
-
-    it('should get stage credentials', () => {
-      const serverless = new Serverless();
-      process.env.AWS_DEV_PROFILE = 'default';
-      const awsSdk = new AwsSdk(serverless);
-      const credentials = awsSdk.getCredentials('dev');
-      expect(credentials.credentials.profile).to.equal('default');
-      delete process.env.AWS_DEV_PROFILE;
+      const credentials = awsSdk.getCredentials('testregion');
+      expect(credentials.region).to.equal('testregion');
     });
 
     it('should get credentials from provider', () => {
@@ -109,6 +98,22 @@ describe('AWS SDK', () => {
       serverless.service.provider.profile = 'notDefault';
       const credentials = awsSdk.getCredentials();
       expect(credentials.credentials.profile).to.equal('notDefault');
+    });
+
+    it('should not set credentials if empty profile is set', () => {
+      const serverless = new Serverless();
+      const awsSdk = new AwsSdk(serverless);
+      serverless.service.provider.profile = '';
+      const credentials = awsSdk.getCredentials('testregion');
+      expect(credentials).to.eql({ region: 'testregion' });
+    });
+
+    it('should not set credentials if profile is not set', () => {
+      const serverless = new Serverless();
+      const awsSdk = new AwsSdk(serverless);
+      serverless.service.provider.profile = undefined;
+      const credentials = awsSdk.getCredentials('testregion');
+      expect(credentials).to.eql({ region: 'testregion' });
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR
-->

Profiles were always set in the credentials, thus if a user provided environment keys, but no profiles the build failed (as it did on master).

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Only set the profile credentials if a profile is actually configured. Additionally removed the AWS_$STAGE_PROFILE functionality as its not necessary any more and confusing.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

export environment variables for your AWS SDK account and remove the profile config from a serverless.yml file. The file should be correctly deployed. If you want to deploy a service to a different profile simply set up that profile and deploy there after configuring the profile config in the serverless.yml


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation

