### PR TITLE
Add usage for command when missing options

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -60,7 +60,11 @@ class PluginManager {
         if (value.shortcut) {
           requiredThings += ` / -${value.shortcut} shortcut`;
         }
-        const errorMessage = `This command requires ${requiredThings}.`;
+        let errorMessage = `This command requires ${requiredThings}.`;
+
+        if (value.usage) {
+          errorMessage = `${errorMessage} Usage: ${value.usage}`;
+        }
 
         throw new this.serverless.classes.Error(errorMessage);
       }


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2155

## How did you implement it:

Add the usage message when it exists after the error about what is missing

## How can we verify it:

Run a command that requires an option that isn't specified and has a usage.


## Todos:

- [x] Write tests (Couldn't find any tests that test output from an Error in the PluginManager to copy)
- [x] Write documentation (N/A)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

