### PR TITLE
Implement stack tags and policy #1956

### DIFF
--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -26,8 +26,19 @@ provider:
   stackTags: # Optional CF stack tags
    key: value
   stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except deleting/replacing EC2 instances (use with caution!)
-    - {Effect: Allow, Principal: "*", Action: "Update:*", Resource: "*"}
-    - {Effect: Deny, Principal: "*", Action: [Update:Replace, Update:Delete], Condition: {StringEquals: {ResourceType: [AWS::EC2::Instance]}}}
+    - Effect: Allow
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
+    - Effect: Deny
+      Principal: "*"
+      Action:
+        - Update:Replace
+        - Update:Delete
+      Condition:
+        StringEquals:
+          ResourceType:
+            - AWS::EC2::Instance
 ```
 
 ### Deployment S3Bucket

--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -25,11 +25,9 @@ provider:
   deploymentBucket: com.serverless.${self:provider.region}.deploys # Overwrite the default deployment bucket
   stackTags: # Optional CF stack tags
    key: value
-  stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except for the ProductionDatabase (use with caution!)
-    - Effect: Allow
-      Action: "Update:*"
-      Principal: "*"
-      NotResource" : LogicalResourceId/ProductionDatabase
+  stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except deleting/replacing EC2 instances (use with caution!)
+    - {Effect: Allow, Principal: "*", Action: "Update:*", Resource: "*"}
+    - {Effect: Deny, Principal: "*", Action: [Update:Replace, Update:Delete], Condition: {StringEquals: {ResourceType: [AWS::EC2::Instance]}}}
 ```
 
 ### Deployment S3Bucket

--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -23,6 +23,13 @@ provider:
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
   deploymentBucket: com.serverless.${self:provider.region}.deploys # Overwrite the default deployment bucket
+  stackTags: # Optional CF stack tags
+   key: value
+  stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except for the ProductionDatabase (use with caution!)
+    - Effect: Allow
+      Action: "Update:*"
+      Principal: "*"
+      NotResource" : LogicalResourceId/ProductionDatabase
 ```
 
 ### Deployment S3Bucket

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const path = require('path');
 const BbPromise = require('bluebird');
 
@@ -7,7 +8,12 @@ module.exports = {
   create() {
     this.serverless.cli.log('Creating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
-    const stackTags = this.serverless.service.provider.stackTags || {STAGE: this.options.stage};
+    let stackTags = { STAGE: this.options.stage };
+
+    // Merge additional stack tags
+    if (typeof this.serverless.service.provider.stackTags === 'object') {
+      stackTags = _.extend(stackTags, this.serverless.service.provider.stackTags);
+    }
 
     const params = {
       StackName: stackName,
@@ -18,7 +24,7 @@ module.exports = {
       Parameters: [],
       TemplateBody: JSON.stringify(this.serverless.service.provider
         .compiledCloudFormationTemplate),
-      Tags: Object.keys(stackTags).map((key) => {return {Key: key, Value: stackTags[key]}})
+      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
     return this.sdk.request('CloudFormation',

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -7,6 +7,7 @@ module.exports = {
   create() {
     this.serverless.cli.log('Creating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+    const stackTags = this.serverless.service.provider.stackTags || {STAGE: this.options.stage};
 
     const params = {
       StackName: stackName,
@@ -17,10 +18,7 @@ module.exports = {
       Parameters: [],
       TemplateBody: JSON.stringify(this.serverless.service.provider
         .compiledCloudFormationTemplate),
-      Tags: [{
-        Key: 'STAGE',
-        Value: this.options.stage,
-      }],
+      Tags: Object.keys(stackTags).map((key) => {return {Key: key, Value: stackTags[key]}})
     };
 
     return this.sdk.request('CloudFormation',

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const BbPromise = require('bluebird');
+const _ = require('lodash');
 const path = require('path');
+const BbPromise = require('bluebird');
 
 module.exports = {
   update() {
@@ -13,7 +14,13 @@ module.exports = {
 
     this.serverless.cli.log('Updating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
-    const stackTags = this.serverless.service.provider.stackTags || { STAGE: this.options.stage };
+    let stackTags = { STAGE: this.options.stage };
+
+    // Merge additional stack tags
+    if (typeof this.serverless.service.provider.stackTags === 'object') {
+      stackTags = _.extend(stackTags, this.serverless.service.provider.stackTags);
+    }
+
     const params = {
       StackName: stackName,
       Capabilities: [
@@ -24,7 +31,7 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    // Policy must have has at least one statement, otherwise no updates would be possible at all
+    // Policy must have at least one statement, otherwise no updates would be possible at all
     if (this.serverless.service.provider.stackPolicy &&
         this.serverless.service.provider.stackPolicy.length) {
       params.StackPolicyBody = JSON.stringify({

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -13,7 +13,7 @@ module.exports = {
 
     this.serverless.cli.log('Updating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
-    const stackTags = this.serverless.service.provider.stackTags || {STAGE: this.options.stage};
+    const stackTags = this.serverless.service.provider.stackTags || { STAGE: this.options.stage };
     const params = {
       StackName: stackName,
       Capabilities: [
@@ -21,13 +21,14 @@ module.exports = {
       ],
       Parameters: [],
       TemplateURL: templateUrl,
-      Tags: Object.keys(stackTags).map((key) => {return {Key: key, Value: stackTags[key]}})
+      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    // Only allow a policy that has at least one statement, otherwise no updates would be possible at all
-    if (this.serverless.service.provider.stackPolicy && this.serverless.service.provider.stackPolicy.length) {
+    // Policy must have has at least one statement, otherwise no updates would be possible at all
+    if (this.serverless.service.provider.stackPolicy &&
+        this.serverless.service.provider.stackPolicy.length) {
       params.StackPolicyBody = JSON.stringify({
-        Statement: this.serverless.service.provider.stackPolicy
+        Statement: this.serverless.service.provider.stackPolicy,
       });
     }
 

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -13,6 +13,7 @@ module.exports = {
 
     this.serverless.cli.log('Updating Stack...');
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+    const stackTags = this.serverless.service.provider.stackTags || {STAGE: this.options.stage};
     const params = {
       StackName: stackName,
       Capabilities: [
@@ -20,7 +21,15 @@ module.exports = {
       ],
       Parameters: [],
       TemplateURL: templateUrl,
+      Tags: Object.keys(stackTags).map((key) => {return {Key: key, Value: stackTags[key]}})
     };
+
+    // Only allow a policy that has at least one statement, otherwise no updates would be possible at all
+    if (this.serverless.service.provider.stackPolicy && this.serverless.service.provider.stackPolicy.length) {
+      params.StackPolicyBody = JSON.stringify({
+        Statement: this.serverless.service.provider.stackPolicy
+      });
+    }
 
     return this.sdk.request('CloudFormation',
       'updateStack',

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -64,6 +64,22 @@ describe('createStack', () => {
         expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
       });
     });
+
+    it('should include custom stack tags', () => {
+      awsDeploy.serverless.service.provider.stackTags = {'STAGE': 'overridden', 'tag1': 'value1'};
+
+      const createStackStub = sinon
+        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+
+      return awsDeploy.create().then(() => {
+        expect(createStackStub.args[0][2].Tags)
+          .to.deep.equal([
+            { Key: 'STAGE', Value: 'overridden' },
+            { Key: 'tag1', Value: 'value1' }
+          ]);
+        awsDeploy.sdk.request.restore();
+      });
+    });
   });
 
   describe('#createStack()', () => {

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -66,7 +66,7 @@ describe('createStack', () => {
     });
 
     it('should include custom stack tags', () => {
-      awsDeploy.serverless.service.provider.stackTags = {'STAGE': 'overridden', 'tag1': 'value1'};
+      awsDeploy.serverless.service.provider.stackTags = { STAGE: 'overridden', tag1: 'value1' };
 
       const createStackStub = sinon
         .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
@@ -75,7 +75,7 @@ describe('createStack', () => {
         expect(createStackStub.args[0][2].Tags)
           .to.deep.equal([
             { Key: 'STAGE', Value: 'overridden' },
-            { Key: 'tag1', Value: 'value1' }
+            { Key: 'tag1', Value: 'value1' },
           ]);
         awsDeploy.sdk.request.restore();
       });

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -47,11 +47,37 @@ describe('updateStack', () => {
         expect(updateStackStub.args[0][2].TemplateURL)
           .to.be.equal(`https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
           .service.package.artifactDirectoryName}/compiled-cloudformation-template.json`);
+        expect(updateStackStub.args[0][2].Tags)
+          .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(updateStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
 
         awsDeploy.sdk.request.restore();
       })
     );
+
+    it('should include custom stack tags and policy', () => {
+      awsDeploy.serverless.service.provider.stackTags = {
+        'STAGE': 'overridden',
+        'tag1': 'value1'
+      };
+      awsDeploy.serverless.service.provider.stackPolicy = [{
+        "Effect":"Allow",
+        "Principal":"*",
+        "Action":"Update:*",
+        "Resource":"*"
+      }];
+
+      return awsDeploy.update().then(() => {
+        expect(updateStackStub.args[0][2].Tags)
+          .to.deep.equal([
+          { Key: 'STAGE', Value: 'overridden' },
+          { Key: 'tag1', Value: 'value1' }
+        ]);
+        expect(updateStackStub.args[0][2].StackPolicyBody)
+          .to.equal('{"Statement":[{"Effect":"Allow","Principal":"*","Action":"Update:*","Resource":"*"}]}');
+        awsDeploy.sdk.request.restore();
+      });
+    });
   });
 
   describe('#updateStack()', () => {

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -56,25 +56,24 @@ describe('updateStack', () => {
     );
 
     it('should include custom stack tags and policy', () => {
-      awsDeploy.serverless.service.provider.stackTags = {
-        'STAGE': 'overridden',
-        'tag1': 'value1'
-      };
+      awsDeploy.serverless.service.provider.stackTags = { STAGE: 'overridden', tag1: 'value1' };
       awsDeploy.serverless.service.provider.stackPolicy = [{
-        "Effect":"Allow",
-        "Principal":"*",
-        "Action":"Update:*",
-        "Resource":"*"
+        Effect: 'Allow',
+        Principal: '*',
+        Action: 'Update:*',
+        Resource: '*',
       }];
 
       return awsDeploy.update().then(() => {
         expect(updateStackStub.args[0][2].Tags)
           .to.deep.equal([
-          { Key: 'STAGE', Value: 'overridden' },
-          { Key: 'tag1', Value: 'value1' }
-        ]);
+            { Key: 'STAGE', Value: 'overridden' },
+            { Key: 'tag1', Value: 'value1' },
+          ]);
         expect(updateStackStub.args[0][2].StackPolicyBody)
-          .to.equal('{"Statement":[{"Effect":"Allow","Principal":"*","Action":"Update:*","Resource":"*"}]}');
+          .to.equal(
+            '{"Statement":[{"Effect":"Allow","Principal":"*","Action":"Update:*","Resource":"*"}]}'
+          );
         awsDeploy.sdk.request.restore();
       });
     });


### PR DESCRIPTION
## What did you implement:

***Implement custom Stack Tags and Policy:*** #1956 

## How did you implement it:

Implemented by adding two optional serverless.yml parameters:
* provider.stackTags - a map of CF stack tags
* provider.stackPolicy - a list of CF stack policies

Tags are obvious and more details about stack policies can be found at:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html#stack-policy-reference

## How can we verify it:

Deploy the following config:

```yml
provider:
  name: aws
  runtime: nodejs4.3
  stackTags:
    key: value
  stackPolicy:
   - {Effect: Allow, Principal: "*", Action: "Update:*", Resource: "*"}
   - {Effect: Deny, Principal: "*", Action: [Update:Replace, Update:Delete], Condition: {StringEquals: {ResourceType: [AWS::EC2::Instance]}}}
```
In CloudFormation console verify that the tags and policy has been set.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
