### PR TITLE
Add any to list of allowed http methods

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -43,11 +43,13 @@ module.exports = {
             throw new this.serverless.classes
               .Error(errorMessage);
           }
-
-          if (['get', 'post', 'put', 'patch', 'options', 'head', 'delete'].indexOf(method) === -1) {
+          const allowedMethods = [
+            'get', 'post', 'put', 'patch', 'options', 'head', 'delete', 'any',
+          ];
+          if (allowedMethods.indexOf(method) === -1) {
             const errorMessage = [
               `Invalid APIG method "${method}" in function "${functionName}".`,
-              ' AWS supported methods are: get, post, put, patch, options, head, delete.',
+              ' AWS supported methods are: get, post, put, patch, options, head, delete, any.',
             ].join('');
             throw new this.serverless.classes.Error(errorMessage);
           }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

AWS now supports the ANY method for catching any http request, this adds support for it.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

Here is a serverless.yml that configures the any keyword.
```
service: aws-any-test

provider: aws

functions:
  hello:
    handler: handler.hello
    events:
      - http: any users
```

After deployment you can run curl against an endpoint:

```
curl ENDPOINT_URL -v # for GET reqeust
curl -X POST ENDPOINT_URL -v
```

## Todos:

- [ ] Write tests # Validation is currently not tested, don't think this needs to be)
- [ ] Write documentation (no additional docs necessary)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
