### PR TITLE
Fix api key value displaying in info plugin

### DIFF
--- a/docs/03-cli-reference/05-info.md
+++ b/docs/03-cli-reference/05-info.md
@@ -24,7 +24,8 @@ serverless info
 
 ### AWS
 
-On AWS the info plugin uses the `Outputs` section of the CloudFormation stack. Outputs will include Lambda function ARN's, a `ServiceEndpoint` for the API Gateway endpoint and user provided custom Outputs.
+On AWS the info plugin uses the `Outputs` section of the CloudFormation stack and the AWS SDK to gather the necessary information.
+See the example below for an example output.
 
 **Example:**
 
@@ -35,6 +36,8 @@ Service Information
 service: my-serverless-service
 stage: dev
 region: us-east-1
+api keys:
+  myKey: some123valid456api789key1011for1213api1415gateway
 endpoints:
   GET - https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/users
 functions:

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -39,9 +39,9 @@ module.exports = {
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
           newApiKeyObject);
 
-        // Add API Key to Outputs section
+        // Add Id of API Key to Outputs section (Note: This is the Id, not the value!)
         const newOutput = {
-          Description: apiKey,
+          Description: `Id of API key "${apiKey}"`,
           Value: {
             Ref: `ApiGatewayApiKey${apiKeyNumber}`,
           },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -38,21 +38,6 @@ module.exports = {
 
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
           newApiKeyObject);
-
-        // Add Id of API Key to Outputs section (Note: This is the Id, not the value!)
-        const newOutput = {
-          Description: `Id of API key "${apiKey}"`,
-          Value: {
-            Ref: `ApiGatewayApiKey${apiKeyNumber}`,
-          },
-        };
-
-        const newOutputObject = {
-          [`ApiGatewayApiKey${apiKeyNumber}Value`]: newOutput,
-        };
-
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
-          newOutputObject);
       });
     }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
@@ -82,20 +82,6 @@ describe('#compileApiKeys()', () => {
     })
   );
 
-  it('should add api keys cf output template', () => awsCompileApigEvents
-    .compileApiKeys().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Outputs.ApiGatewayApiKey1Value.Description
-      ).to.equal('Id of API key "1234567890"');
-
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Outputs.ApiGatewayApiKey1Value.Value.Ref
-      ).to.equal('ApiGatewayApiKey1');
-    })
-  );
-
   it('throw error if apiKey property is not an array', () => {
     awsCompileApigEvents.serverless.service.provider.apiKeys = 2;
     expect(() => awsCompileApigEvents.compileApiKeys()).to.throw(Error);

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
@@ -87,7 +87,7 @@ describe('#compileApiKeys()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Outputs.ApiGatewayApiKey1Value.Description
-      ).to.equal('1234567890');
+      ).to.equal('Id of API key "1234567890"');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -106,30 +106,22 @@ class AwsInfo {
   }
 
   getApiKeyValues(gatheredData) {
-    const outputs = gatheredData.outputs;
     const info = gatheredData.info;
 
-    // check if there are API key outputs in the stacks Outputs section
-    let apiKeyOutputs;
-    if (outputs) {
-      apiKeyOutputs = outputs.filter((output) => output.OutputKey.match(/^ApiGatewayApiKey/));
-    }
+    // check if the user has set api keys
+    const apiKeyNames = this.serverless.service.provider.apiKeys || [];
 
-    if (apiKeyOutputs.length) {
+    if (apiKeyNames.length) {
       return this.sdk.request('APIGateway',
         'getApiKeys',
         { includeValues: true },
         this.options.stage,
         this.options.region
-      ).then((apiKeys) => {
-        const items = apiKeys.items;
+      ).then((allApiKeys) => {
+        const items = allApiKeys.items;
         if (items) {
-          // extract the ids from the API key object
-          const apiKeyIds = [];
-          apiKeyOutputs.forEach((apiKeyOutput) => apiKeyIds.push(apiKeyOutput.OutputValue));
-
           // filter out the API keys only created for this stack
-          const filteredItems = items.filter((item) => _.includes(apiKeyIds, item.id));
+          const filteredItems = items.filter((item) => _.includes(apiKeyNames, item.name));
 
           // iterate over all apiKeys and push the API key info and update the info object
           filteredItems.forEach((item) => {

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -51,12 +51,13 @@ class AwsInfo {
       this.options.stage,
       this.options.region)
     .then((result) => {
+      let outputs;
+
       if (result) {
-        const outputs = result.Stacks[0].Outputs;
+        outputs = result.Stacks[0].Outputs;
 
         // Functions
         info.functions = [];
-        info.apiKeys = [];
         outputs.filter(x => x.OutputKey.match(/LambdaFunctionArn$/))
           .forEach(x => {
             const functionInfo = {};
@@ -71,21 +72,23 @@ class AwsInfo {
             info.endpoint = x.OutputValue;
           });
 
-        // API Keys
-        outputs.filter(x => x.OutputKey.match(/^ApiGatewayApiKey/))
-          .forEach(x => {
-            const apiKeyInfo = {};
-            apiKeyInfo.name = x.Description;
-            apiKeyInfo.value = x.OutputValue;
-            info.apiKeys.push(apiKeyInfo);
-          });
-
         // Resources
         info.resources = [];
+
+        // API Keys
+        info.apiKeys = [];
       }
 
-      return BbPromise.resolve(info);
+      // create a gatheredData object which can be passed around ("[call] by reference")
+      const gatheredData = {
+        outputs,
+        info,
+      };
+
+      return BbPromise.resolve(gatheredData);
     })
+    .then((gatheredData) => this.getApiKeyValues(gatheredData))
+    .then((gatheredData) => BbPromise.resolve(gatheredData.info)) // resolve the info at the end
     .catch((e) => {
       let result;
 
@@ -100,6 +103,46 @@ class AwsInfo {
 
       return result;
     });
+  }
+
+  getApiKeyValues(gatheredData) {
+    const outputs = gatheredData.outputs;
+    const info = gatheredData.info;
+
+    // check if there are API key outputs in the stacks Outputs section
+    let apiKeyOutputs;
+    if (outputs) {
+      apiKeyOutputs = outputs.filter((output) => output.OutputKey.match(/^ApiGatewayApiKey/));
+    }
+
+    if (apiKeyOutputs) {
+      return this.sdk.request('APIGateway',
+        'getApiKeys',
+        { includeValues: true },
+        this.options.stage,
+        this.options.region
+      ).then((apiKeys) => {
+        const items = apiKeys.items;
+        if (items) {
+          // extract the ids from the API key object
+          const apiKeyIds = [];
+          apiKeyOutputs.forEach((apiKeyOutput) => apiKeyIds.push(apiKeyOutput.OutputValue));
+
+          // filter out the API keys only created for this stack
+          const filteredItems = items.filter((item) => _.includes(apiKeyIds, item.id));
+
+          // iterate over all apiKeys and push the API key info and update the info object
+          filteredItems.forEach((item) => {
+            const apiKeyInfo = {};
+            apiKeyInfo.name = item.name;
+            apiKeyInfo.value = item.value;
+            info.apiKeys.push(apiKeyInfo);
+          });
+        }
+        return BbPromise.resolve(gatheredData);
+      });
+    }
+    return BbPromise.resolve(gatheredData);
   }
 
   /**

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -115,7 +115,7 @@ class AwsInfo {
       apiKeyOutputs = outputs.filter((output) => output.OutputKey.match(/^ApiGatewayApiKey/));
     }
 
-    if (apiKeyOutputs) {
+    if (apiKeyOutputs.length) {
       return this.sdk.request('APIGateway',
         'getApiKeys',
         { includeValues: true },

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -255,19 +255,11 @@ describe('AwsInfo', () => {
       // TODO: implement a pattern for stub restoring to get rid of this
       awsInfo.sdk.request.restore();
 
+      // set the API Keys for the service
+      awsInfo.serverless.service.provider.apiKeys = ['foo', 'bar'];
+
       const gatheredData = {
-        outputs: [
-          {
-            OutputKey: 'ApiGatewayApiKey1Value',
-            OutputValue: '1234',
-            Description: 'Id for API key "foo"',
-          },
-          {
-            OutputKey: 'ApiGatewayApiKey2Value',
-            OutputValue: '5678',
-            Description: 'Id for API key "bar"',
-          },
-        ],
+        outputs: [],
         info: {
           apiKeys: [],
         },
@@ -315,6 +307,8 @@ describe('AwsInfo', () => {
     });
 
     it('should resolve with the passed-in data if no API key retrieval is necessary', () => {
+      awsInfo.serverless.service.provider.apiKeys = null;
+
       const gatheredData = {
         outputs: [],
         info: {

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -163,7 +163,7 @@ describe('AwsInfo', () => {
 
     it('should gather with correct params', () => awsInfo.gather()
       .then(() => {
-        expect(describeStackStub.calledOnce).to.equal(true);
+        expect(describeStackStub.called).to.equal(true);
         expect(describeStackStub.args[0][0]).to.equal('CloudFormation');
         expect(describeStackStub.args[0][1]).to.equal('describeStacks');
         expect(describeStackStub.args[0][2].StackName)
@@ -218,23 +218,6 @@ describe('AwsInfo', () => {
       });
     });
 
-    it('should get api keys', () => {
-      const expectedApiKeys = [
-        {
-          name: 'first',
-          value: 'xxx',
-        },
-        {
-          name: 'second',
-          value: 'yyy',
-        },
-      ];
-
-      return awsInfo.gather().then((info) => {
-        expect(info.apiKeys).to.deep.equal(expectedApiKeys);
-      });
-    });
-
     it("should provide only general info when stack doesn't exist (ValidationError)", () => {
       awsInfo.sdk.request.restore();
 
@@ -263,6 +246,91 @@ describe('AwsInfo', () => {
 
       return awsInfo.gather().catch((e) => {
         expect(e.name).to.equal('ServerlessError');
+      });
+    });
+  });
+
+  describe('#getApiKeyValues()', () => {
+    it('should return the api keys in the info object', () => {
+      // TODO: implement a pattern for stub restoring to get rid of this
+      awsInfo.sdk.request.restore();
+
+      const gatheredData = {
+        outputs: [
+          {
+            OutputKey: 'ApiGatewayApiKey1Value',
+            OutputValue: '1234',
+            Description: 'Id for API key "foo"',
+          },
+          {
+            OutputKey: 'ApiGatewayApiKey2Value',
+            OutputValue: '5678',
+            Description: 'Id for API key "bar"',
+          },
+        ],
+        info: {
+          apiKeys: [],
+        },
+      };
+
+      const apiKeyItems = {
+        items: [
+          {
+            id: '4711',
+            name: 'SomeRandomIdInUsersAccount',
+            value: 'ShouldNotBeConsidered',
+          },
+          {
+            id: '1234',
+            name: 'foo',
+            value: 'valueForKeyFoo',
+          },
+          {
+            id: '5678',
+            name: 'bar',
+            value: 'valueForKeyBar',
+          },
+        ],
+      };
+
+      const gatheredDataAfterKeyLookup = {
+        info: {
+          apiKeys: [
+            { name: 'foo', value: 'valueForKeyFoo' },
+            { name: 'bar', value: 'valueForKeyBar' },
+          ],
+        },
+      };
+
+      const getApiKeysStub = sinon
+        .stub(awsInfo.sdk, 'request')
+        .returns(BbPromise.resolve(apiKeyItems));
+
+      return awsInfo.getApiKeyValues(gatheredData).then((result) => {
+        expect(getApiKeysStub.calledOnce).to.equal(true);
+        expect(result.info.apiKeys).to.deep.equal(gatheredDataAfterKeyLookup.info.apiKeys);
+
+        awsInfo.sdk.request.restore();
+      });
+    });
+
+    it('should resolve with the passed-in data if no API key retrieval is necessary', () => {
+      const gatheredData = {
+        outputs: [],
+        info: {
+          apiKeys: [],
+        },
+      };
+
+      const getApiKeysStub = sinon
+        .stub(awsInfo.sdk, 'request')
+        .returns(BbPromise.resolve());
+
+      return awsInfo.getApiKeyValues(gatheredData).then((result) => {
+        expect(getApiKeysStub.calledOnce).to.equal(false);
+        expect(result).to.deep.equal(gatheredData);
+
+        awsInfo.sdk.request.restore();
       });
     });
   });


### PR DESCRIPTION
## What did you implement:

This PR fixes the problem that the `id` of the API Keys was displayed in the `info` plugin (rather than the actual values).

Corresponding issue / PR: https://github.com/serverless/serverless/pull/2079 and https://github.com/serverless/serverless/issues/2058

## How did you implement it:

Updated the `info` plugin so that it fetches the correct API key values via the AWS SDK when some are available for the service.

## How can we verify it:

Here's the `serverless.yml` config:

```yml
service: tinker

provider:
  name: aws
  apiKeys:
    - myKey

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: users/create
          method: get
          private: true
```

Next up run `serverless deploy` and copy the value of the corresponding API Key.
After that you can use the value to perform a GET request against the endpoint.

You might even want to add other API keys in the AWS APIG console to see that only the stacks API Keys are displayed.

Here are some screenshots which shows all the steps in detail:

<img width="1292" alt="bildschirmfoto 2016-09-21 um 13 30 38" src="https://cloud.githubusercontent.com/assets/1606004/18709426/6ae0674e-8000-11e6-9be0-05ea93f110df.png">

<img width="1292" alt="bildschirmfoto 2016-09-21 um 13 31 05" src="https://cloud.githubusercontent.com/assets/1606004/18709438/71920d54-8000-11e6-933b-74b63882f5b9.png">

<img width="1292" alt="bildschirmfoto 2016-09-21 um 13 32 04" src="https://cloud.githubusercontent.com/assets/1606004/18709444/781d6e70-8000-11e6-857d-7c34e6bdf489.png">

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

/cc @flomotlik @eahefnawy 