### PR TITLE
add filename option to YAML.load

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -76,7 +76,7 @@ class Utils {
     if (filePath.endsWith('.json')) {
       contents = JSON.parse(contents);
     } else if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
-      contents = YAML.load(contents.toString());
+      contents = YAML.load(contents.toString(), { filename: filePath });
     } else {
       contents = contents.toString().trim();
     }

--- a/tests/classes/Utils.js
+++ b/tests/classes/Utils.js
@@ -5,13 +5,7 @@ const os = require('os');
 const expect = require('chai').expect;
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
-const BbPromise = require('bluebird');
-const fse = BbPromise.promisifyAll(require('fs-extra'));
 
-const writeFileSync = (filePath, contents) => {
-  fse.mkdirsSync(path.dirname(filePath));
-  return fse.writeFileSync(filePath, contents);
-};
 const serverless = new Serverless();
 
 describe('Utils', () => {
@@ -134,8 +128,9 @@ describe('Utils', () => {
 
     it('should throw YAMLException with filename if yml file is invalid format', () => {
       const tmpFilePath = testUtils.getTmpFilePath('invalid.yml');
-      const contents = ': a';
-      writeFileSync(tmpFilePath, contents);
+
+      serverless.utils.writeFileSync(tmpFilePath, ': a');
+
       expect(() => {
         serverless.utils.readFileSync(tmpFilePath);
       }).to.throw(new RegExp(`in "${tmpFilePath}"`));

--- a/tests/classes/Utils.js
+++ b/tests/classes/Utils.js
@@ -5,7 +5,13 @@ const os = require('os');
 const expect = require('chai').expect;
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
+const BbPromise = require('bluebird');
+const fse = BbPromise.promisifyAll(require('fs-extra'));
 
+const writeFileSync = (filePath, contents) => {
+  fse.mkdirsSync(path.dirname(filePath));
+  return fse.writeFileSync(filePath, contents);
+};
 const serverless = new Serverless();
 
 describe('Utils', () => {
@@ -106,6 +112,33 @@ describe('Utils', () => {
       const obj = serverless.utils.readFileSync(tmpFilePath);
 
       expect(obj.foo).to.equal('bar');
+    });
+
+    it('should read a filename extension .yml', () => {
+      const tmpFilePath = testUtils.getTmpFilePath('anything.yml');
+
+      serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
+      const obj = serverless.utils.readFileSync(tmpFilePath);
+
+      expect(obj.foo).to.equal('bar');
+    });
+
+    it('should read a filename extension .yaml', () => {
+      const tmpFilePath = testUtils.getTmpFilePath('anything.yaml');
+
+      serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
+      const obj = serverless.utils.readFileSync(tmpFilePath);
+
+      expect(obj.foo).to.equal('bar');
+    });
+
+    it('should throw YAMLException with filename if yml file is invalid format', () => {
+      const tmpFilePath = testUtils.getTmpFilePath('invalid.yml');
+      const contents = ': a';
+      writeFileSync(tmpFilePath, contents);
+      expect(() => {
+        serverless.utils.readFileSync(tmpFilePath);
+      }).to.throw(new RegExp(`in "${tmpFilePath}"`));
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

State: is ready
No issue.

Problem: I don't know whether an error has occurred in any "yml" file
<!--
Briefly describe the feature if no issue exists for this PR
-->

Before
![before](https://cloud.githubusercontent.com/assets/968151/18713491/729fc0d6-804d-11e6-8122-b60162dd0605.png)

After
![after](https://cloud.githubusercontent.com/assets/968151/18713511/86efaeca-804d-11e6-8ec0-5f807694301a.png)

## How did you implement it:

see the js-yaml README(https://github.com/nodeca/js-yaml)
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

serverless.yml(valid)
```yml
service: my-serverless-app
custom: ${file(./myCustomFile.yml)}
provider:
  name: aws
  runtime: python2.7

functions:
  hello:
    handler: handler.hello
```

myCustomFile.yml(Invalid)
```yml
: foo
```

```sh
$ sls help
```

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped