### PR TITLE
Add Lambda proxy functionality for API Gateway

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -12,6 +12,7 @@ module.exports = {
           let method;
           let path;
           let requestPassThroughBehavior = 'NEVER';
+          let integrationType = 'AWS_PROXY';
 
           if (typeof event.http === 'object') {
             method = event.http.method;
@@ -342,6 +343,37 @@ module.exports = {
           const normalizedFunctionName = functionName[0].toUpperCase()
             + functionName.substr(1);
 
+          // check if LAMBDA or LAMBDA-PROXY was used for the integration type
+          if (typeof event.http === 'object') {
+            if (Boolean(event.http.integration) === true) {
+              // normalize the integration for further processing
+              const normalizedIntegration = event.http.integration.toUpperCase();
+              // check if the user has entered a non-valid integration
+              const allowedIntegrations = [
+                'LAMBDA', 'LAMBDA-PROXY',
+              ];
+              if (allowedIntegrations.indexOf(normalizedIntegration) === -1) {
+                const errorMessage = [
+                  `Invalid APIG integration "${event.http.integration}"`,
+                  ` in function "${functionName}".`,
+                  ' Supported integrations are: lambda, lambda-proxy.',
+                ].join('');
+                throw new this.serverless.classes.Error(errorMessage);
+              }
+              // map the Serverless integration to the corresponding CloudFormation types
+              // LAMBDA --> AWS
+              // LAMBDA-PROXY --> AWS_PROXY
+              if (normalizedIntegration === 'LAMBDA') {
+                integrationType = 'AWS';
+              } else if (normalizedIntegration === 'LAMBDA-PROXY') {
+                integrationType = 'AWS_PROXY';
+              } else {
+                // default to AWS_PROXY (just in case...)
+                integrationType = 'AWS_PROXY';
+              }
+            }
+          }
+
           const methodTemplate = `
             {
               "Type" : "AWS::ApiGateway::Method",
@@ -352,7 +384,7 @@ module.exports = {
                 "RequestParameters" : {},
                 "Integration" : {
                   "IntegrationHttpMethod" : "POST",
-                  "Type" : "AWS",
+                  "Type" : "${integrationType}",
                   "Uri" : {
                     "Fn::Join": [ "",
                       [

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -118,7 +118,7 @@ module.exports = {
             }
           `;
 
-          let integrationRequestTemplates = {
+          const integrationRequestTemplates = {
             'application/json': DEFAULT_JSON_REQUEST_TEMPLATE,
             'application/x-www-form-urlencoded': DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
           };
@@ -278,7 +278,7 @@ module.exports = {
             },
           ];
 
-          let integrationResponses = [
+          const integrationResponses = [
             {
               StatusCode: 200,
               ResponseParameters: {},
@@ -375,10 +375,15 @@ module.exports = {
           }
 
           // reset / remove irrelevant configuration if the AWS_PROXY (LAMBDA-PROXY) is used
-          if (integrationType === 'AWS_PROXY') {
-            integrationRequestTemplates = {};
-            integrationResponses = [];
-            requestPassThroughBehavior = '';
+          if (integrationType === 'AWS_PROXY' && (
+            (!!event.http.request) || (!!event.http.response)
+          )) {
+            const warningMessage = [
+              'Warning! You\'re using the LAMBDA-PROXY in combination with request / response',
+              ` configuration in your function "${functionName}".`,
+              ' This configuration will be ignored during deployment.',
+            ].join('');
+            this.serverless.cli.log(warningMessage);
           }
 
           const methodTemplate = `

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -118,7 +118,7 @@ module.exports = {
             }
           `;
 
-          const integrationRequestTemplates = {
+          let integrationRequestTemplates = {
             'application/json': DEFAULT_JSON_REQUEST_TEMPLATE,
             'application/x-www-form-urlencoded': DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
           };
@@ -278,7 +278,7 @@ module.exports = {
             },
           ];
 
-          const integrationResponses = [
+          let integrationResponses = [
             {
               StatusCode: 200,
               ResponseParameters: {},
@@ -372,6 +372,13 @@ module.exports = {
                 integrationType = 'AWS_PROXY';
               }
             }
+          }
+
+          // reset / remove irrelevant configuration if the AWS_PROXY (LAMBDA-PROXY) is used
+          if (integrationType === 'AWS_PROXY') {
+            integrationRequestTemplates = {};
+            integrationResponses = {};
+            requestPassThroughBehavior = '';
           }
 
           const methodTemplate = `

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -377,7 +377,7 @@ module.exports = {
           // reset / remove irrelevant configuration if the AWS_PROXY (LAMBDA-PROXY) is used
           if (integrationType === 'AWS_PROXY') {
             integrationRequestTemplates = {};
-            integrationResponses = {};
+            integrationResponses = [];
             requestPassThroughBehavior = '';
           }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -374,7 +374,7 @@ module.exports = {
             }
           }
 
-          // reset / remove irrelevant configuration if the AWS_PROXY (LAMBDA-PROXY) is used
+          // show a warning when request / response config is used with AWS_PROXY (LAMBDA-PROXY)
           if (integrationType === 'AWS_PROXY' && (
             (!!event.http.request) || (!!event.http.response)
           )) {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -678,4 +678,69 @@ describe('#compileMethods()', () => {
       ).to.deep.equal({ StatusCode: 504, SelectionPattern: '.*\\[504\\].*' });
     })
   );
+
+  it('should set "AWS_PROXY" as the default integration type', () =>
+    awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.Type
+      ).to.equal('AWS_PROXY');
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.Integration.Type
+      ).to.equal('AWS_PROXY');
+    })
+  );
+
+  it('should set users integration type if specified', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+            },
+          },
+          {
+            http: {
+              path: 'users/create',
+              method: 'POST',
+              integration: 'LAMBDA-PROXY', // this time use uppercase syntax
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.Type
+      ).to.equal('AWS');
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.Integration.Type
+      ).to.equal('AWS_PROXY');
+    });
+  });
+
+  it('should throw an error when an invalid integration type was provided', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'INVALID',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
+  });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
@@ -856,58 +857,39 @@ describe('#compileMethods()', () => {
     expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
   });
 
-  describe('when using the LAMBDA-PROXY integration type', () => {
-    beforeEach(() => {
-      awsCompileApigEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              http: {
-                method: 'get',
-                path: 'users/list',
-                integration: 'lambda-proxy', // can be removed as it defaults to this
-                request: {
-                  passThrough: 'NEVER',
-                  template: {
-                    'template/1': '{ "stage" : "$context.stage" }',
-                    'template/2': '{ "httpMethod" : "$context.httpMethod" }',
-                  },
-                },
-                response: {
-                  template: "$input.path('$.foo')",
+  it('should show a warning message when using request / response config with LAMBDA-PROXY', () => {
+    // initialize so we get the log method from the CLI in place
+    serverless.init();
+
+    const logStub = sinon.stub(serverless.cli, 'log');
+
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'get',
+              path: 'users/list',
+              integration: 'lambda-proxy', // can be removed as it defaults to this
+              request: {
+                passThrough: 'NEVER',
+                template: {
+                  'template/1': '{ "stage" : "$context.stage" }',
+                  'template/2': '{ "httpMethod" : "$context.httpMethod" }',
                 },
               },
+              response: {
+                template: "$input.path('$.foo')",
+              },
             },
-          ],
-        },
-      };
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(logStub.calledOnce).to.be.equal(true);
+      expect(logStub.args[0][0].length).to.be.at.least(1);
     });
-
-    it('should clear the RequestTemplates', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.RequestTemplates
-        ).to.deep.equal({});
-      })
-    );
-
-    it('should clear the IntegrationResponses', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses
-        ).to.deep.equal([]);
-      })
-    );
-
-    it('should clear the PassthroughBehavior', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.PassthroughBehavior
-        ).to.deep.equal('');
-      })
-    );
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -897,7 +897,7 @@ describe('#compileMethods()', () => {
         expect(
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses
-        ).to.deep.equal({});
+        ).to.deep.equal([]);
       })
     );
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -857,8 +857,31 @@ describe('#compileMethods()', () => {
   });
 
   describe('when using the LAMBDA-PROXY integration type', () => {
-    // we're relying on the http events defined at the top of the file
-    // which integration types will all default to LAMBDA-PROXY
+    beforeEach(() => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'get',
+                path: 'users/list',
+                integration: 'lambda-proxy', // can be removed as it defaults to this
+                request: {
+                  passThrough: 'NEVER',
+                  template: {
+                    'template/1': '{ "stage" : "$context.stage" }',
+                    'template/2': '{ "httpMethod" : "$context.httpMethod" }',
+                  },
+                },
+                response: {
+                  template: "$input.path('$.foo')",
+                },
+              },
+            },
+          ],
+        },
+      };
+    });
 
     it('should clear the RequestTemplates', () =>
       awsCompileApigEvents.compileMethods().then(() => {
@@ -882,7 +905,7 @@ describe('#compileMethods()', () => {
       awsCompileApigEvents.compileMethods().then(() => {
         expect(
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ApiGatewayMethodUsersCreatePost.Properties.Integration.PassthroughBehavior
+            .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.PassthroughBehavior
         ).to.deep.equal('');
       })
     );

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -385,7 +385,7 @@ describe('#compileMethods()', () => {
           .Resources.ApiGatewayMethodUsersListGet.Properties
           .Integration.RequestTemplates['application/json']
         ).to.have.length.above(0);
-      })
+      });
     });
 
     it('should setup a default "application/x-www-form-urlencoded" template', () => {
@@ -783,7 +783,7 @@ describe('#compileMethods()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]
-      ).to.deep.equal({ StatusCode: 502, SelectionPattern: '.*\\[502\\].*'} );
+      ).to.deep.equal({ StatusCode: 502, SelectionPattern: '.*\\[502\\].*' });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[8]

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -233,8 +233,40 @@ describe('#compileMethods()', () => {
     });
   });
 
-  it('should add CORS origins to method only when CORS is enabled', () => {
+  it('should add CORS origins to method only when CORS and LAMBDA integration are enabled', () => {
     const origin = '\'*\'';
+
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              path: 'users/create',
+              method: 'POST',
+              integration: 'lambda',
+              cors: true,
+            },
+          },
+          {
+            http: {
+              path: 'users/list',
+              method: 'GET',
+              integration: 'lambda',
+            },
+          },
+          {
+            http: {
+              path: 'users/update',
+              method: 'PUT',
+              integration: 'lambda',
+              cors: {
+                origins: ['*'],
+              },
+            },
+          },
+        ],
+      },
+    };
 
     return awsCompileApigEvents.compileMethods().then(() => {
       // Check origin.
@@ -333,31 +365,73 @@ describe('#compileMethods()', () => {
   });
 
   describe('when dealing with request configuration', () => {
-    it('should setup a default "application/json" template', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
+    it('should setup a default "application/json" template', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                integration: 'lambda',
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
         expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties
           .Integration.RequestTemplates['application/json']
         ).to.have.length.above(0);
       })
-    );
+    });
 
-    it('should setup a default "application/x-www-form-urlencoded" template', () =>
-      awsCompileApigEvents.compileMethods().then(() => {
+    it('should setup a default "application/x-www-form-urlencoded" template', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                integration: 'lambda',
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
         expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties
           .Integration.RequestTemplates['application/x-www-form-urlencoded']
         ).to.have.length.above(0);
-      })
-    );
+      });
+    });
 
-    it('should use the default request pass-through behavior when none specified', () =>
-       awsCompileApigEvents.compileMethods().then(() => {
-         expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.PassthroughBehavior
-         ).to.equal('NEVER');
-       })
-    );
+    it('should use the default request pass-through behavior when none specified', () => {
+      awsCompileApigEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'GET',
+                path: 'users/list',
+                integration: 'lambda',
+              },
+            },
+          ],
+        },
+      };
+
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.PassthroughBehavior
+        ).to.equal('NEVER');
+      });
+    });
 
     it('should use defined pass-through behavior', () => {
       awsCompileApigEvents.serverless.service.functions = {
@@ -367,6 +441,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 request: {
                   passThrough: 'WHEN_NO_TEMPLATES',
                 },
@@ -391,6 +466,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 request: {
                   passThrough: 'BOGUS',
                 },
@@ -411,6 +487,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 request: {
                   template: {
                     'template/1': '{ "stage" : "$context.stage" }',
@@ -444,6 +521,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 request: {
                   template: {
                     'application/json': 'overwritten-request-template-content',
@@ -471,6 +549,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 request: 'some string',
               },
             },
@@ -489,6 +568,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 request: {
                   template: 'some string',
                 },
@@ -511,6 +591,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 response: {
                   headers: {
                     'Content-Type': "'text/plain'",
@@ -545,6 +626,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 response: {
                   template: "$input.path('$.foo')",
                 },
@@ -571,6 +653,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 response: 'some string',
               },
             },
@@ -589,6 +672,7 @@ describe('#compileMethods()', () => {
               http: {
                 method: 'GET',
                 path: 'users/list',
+                integration: 'lambda',
                 response: {
                   headers: 'some string',
                 },
@@ -602,8 +686,22 @@ describe('#compileMethods()', () => {
     });
   });
 
-  it('should add method responses for different status codes', () =>
-    awsCompileApigEvents.compileMethods().then(() => {
+  it('should add method responses for different status codes', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[1].StatusCode
@@ -636,11 +734,25 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[8].StatusCode
       ).to.equal(504);
-    })
-  );
+    });
+  });
 
-  it('should add integration responses for different status codes', () =>
-    awsCompileApigEvents.compileMethods().then(() => {
+  it('should add integration responses for different status codes', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
@@ -671,13 +783,13 @@ describe('#compileMethods()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[7]
-      ).to.deep.equal({ StatusCode: 502, SelectionPattern: '.*\\[502\\].*' });
+      ).to.deep.equal({ StatusCode: 502, SelectionPattern: '.*\\[502\\].*'} );
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[8]
       ).to.deep.equal({ StatusCode: 504, SelectionPattern: '.*\\[504\\].*' });
-    })
-  );
+    });
+  });
 
   it('should set "AWS_PROXY" as the default integration type', () =>
     awsCompileApigEvents.compileMethods().then(() => {
@@ -742,5 +854,37 @@ describe('#compileMethods()', () => {
     };
 
     expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
+  });
+
+  describe('when using the LAMBDA-PROXY integration type', () => {
+    // we're relying on the http events defined at the top of the file
+    // which integration types will all default to LAMBDA-PROXY
+
+    it('should clear the RequestTemplates', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.RequestTemplates
+        ).to.deep.equal({});
+      })
+    );
+
+    it('should clear the IntegrationResponses', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses
+        ).to.deep.equal({});
+      })
+    );
+
+    it('should clear the PassthroughBehavior', () =>
+      awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.ApiGatewayMethodUsersCreatePost.Properties.Integration.PassthroughBehavior
+        ).to.deep.equal('');
+      })
+    );
   });
 });


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2174 

Adds the new `AWS_PROXY` feature (Lambda proxy) as a default for the method integrations in API Gateway. Furthermore users can set this integration to `AWS` --> `integration: lambda` in their `serverless.yml` file.

## How did you implement it:

Updated the `method.js` file in the API Gateway compilation step.

## How can we verify it:

Here's a `serverless.yml` file for validation:

```yml
service: tinker

provider:
  name: aws

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: users/create
          method: get
          integration: lambda
```

Furthermore you might run the tests with `npm test`.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

/cc @flomotlik @eahefnawy 