### PR TITLE
Use Globs to Exclude Files

### DIFF
--- a/docs/01-guide/10-packaging.md
+++ b/docs/01-guide/10-packaging.md
@@ -1,45 +1,38 @@
 <!--
-title: Including/Excluding files from packaging
+title: Excluding files from packaging
 menuText: Packaging Services
 layout: Doc
 -->
 
-# Including/Excluding files from packaging
+# Excluding files from packaging
 
 Sometimes you might like to have more control over your function artifacts and how they are packaged.
 
-You can use the `package` and `include/exclude` configuration for more control over the packaging process.
-
-## Include
-The `include` config allows you to selectively include files into the created package. Only the configured paths will be included in the package. If both include and exclude are defined exclude is applied first, then include so files are guaranteed to be included.
+You can use the `package` and `exclude` configuration for more control over the packaging process.
 
 ## Exclude
 
-Exclude allows you to define paths that will be excluded from the resulting artifact.
+Exclude allows you to define globs that will be excluded from the resulting artifact.
 
 ## Artifact
-For complete control over the packaging process you can specify your own zip file for your service. Serverless won't zip your service if this is configured so `include` and `exclude` will be ignored.
+For complete control over the packaging process you can specify your own zip file for your service. Serverless won't zip your service if this is configured so `exclude` will be ignored.
 
 ## Example
 
 ```yaml
 service: my-service
 package:
-  include:
-    - lib
-    - functions
   exclude:
-    - tmp
+    - tmp/**
     - .git
   artifact: path/to/my-artifact.zip
 ```
-
 
 ## Packaging functions separately
 
 If you want even more controls over your functions for deployment you can configure them to be packaged independently. This allows you more control for optimizing your deployment. To enable individual packaging set `individually` to true in the service wide packaging settings.
 
-Then for every function you can use the same `include/exclude/artifact` config options as you can service wide. The `include/exclude` options will be merged with the service wide options to create one `include/exclude` config per function during packaging.
+Then for every function you can use the same `exclude/artifact` config options as you can service wide. The `exclude` option will be merged with the service wide options to create one `exclude` config per function during packaging.
 
 ```yaml
 service: my-service
@@ -51,9 +44,9 @@ functions:
   hello:
     handler: handler.hello
     package:
-      include:
-        # We're including this file so it will be in the final package of this function only
-        - excluded-by-default.json
+      exclude:
+        # We're excluding this file so it will not be in the final package of this function only
+        - included-by-default.json
   world:
     handler: handler.hello
     package:

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -89,7 +89,6 @@ class Service {
           that.package.individually = serverlessFile.package.individually;
           that.package.artifact = serverlessFile.package.artifact;
           that.package.exclude = serverlessFile.package.exclude;
-          that.package.include = serverlessFile.package.include;
         }
 
         if (serverlessFile.defaults && serverlessFile.defaults.stage) {

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -38,8 +38,6 @@ provider:
 
 # you can add packaging information here
 package:
-#  include:
-#    - include-me.java
 #  exclude:
 #    - exclude-me.java
   artifact: build/distributions/hello.zip

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -38,8 +38,6 @@ provider:
 
 # you can add packaging information here
 package:
-#  include:
-#    - include-me.java
 #  exclude:
 #    - exclude-me.java
   artifact: target/hello-dev.jar

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -38,8 +38,6 @@ provider:
 
 # you can add packaging information here
 #package:
-#  include:
-#    - include-me.js
 #  exclude:
 #    - exclude-me.js
 #  artifact: my-service-code.zip

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -38,8 +38,6 @@ provider:
 
 # you can add packaging information here
 #package:
-#  include:
-#    - include-me.js
 #  exclude:
 #    - exclude-me.js
 #  artifact: my-service-code.zip

--- a/lib/plugins/package/README.md
+++ b/lib/plugins/package/README.md
@@ -9,8 +9,17 @@ This plugin creates a deployment package on a per service basis (it will zip up 
 It will zip the whole service directory. The artifact will be stored in the `.serverless` directory which will be created
 upon zipping the service. The resulting path to the artifact will be appended to the `service.package.artifact` property.
 
-The services `include` and `exclude` arrays are considered during zipping. At first the `exclude` will be applied. After
-that the `include` will be applied to ensure that previously excluded files and folders can be included again.
+Services can use `exclude` as an array. The array should be a series of
+globs to be considered for exclusion.
+
+For example in serverless.yaml:
+
+``` yaml
+package:
+  exclude:
+    - "test/**"
+    - "**/spec.js"
+```
 
 Serverless will automatically exclude `.git`, `.gitignore`, `serverless.yml`, and `.DS_Store`.
 

--- a/lib/plugins/package/README.md
+++ b/lib/plugins/package/README.md
@@ -12,7 +12,7 @@ upon zipping the service. The resulting path to the artifact will be appended to
 Services can use `exclude` as an array. The array should be a series of
 globs to be considered for exclusion.
 
-For example in serverless.yaml:
+For example in serverless.yml:
 
 ``` yaml
 package:

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -21,11 +21,6 @@ module.exports = {
     return _.union(exclude, packageExcludes, this.defaultExcludes);
   },
 
-  getIncludedPaths(include) {
-    const packageIncludes = this.serverless.service.package.include || [];
-    return _.union(include, packageIncludes);
-  },
-
   getServiceArtifactName() {
     return `${this.serverless.service.service}.zip`;
   },
@@ -57,10 +52,9 @@ module.exports = {
     const servicePath = this.serverless.config.servicePath;
 
     const exclude = this.getExcludedPaths();
-    const include = this.getIncludedPaths();
     const zipFileName = this.getServiceArtifactName();
 
-    return this.zipDirectory(servicePath, exclude, include, zipFileName).then(filePath => {
+    return this.zipDirectory(servicePath, exclude, zipFileName).then(filePath => {
       this.serverless.service.package.artifact = filePath;
       return filePath;
     });
@@ -80,10 +74,9 @@ module.exports = {
     const servicePath = this.serverless.config.servicePath;
 
     const exclude = this.getExcludedPaths(funcPackageConfig.exclude);
-    const include = this.getIncludedPaths(funcPackageConfig.include);
     const zipFileName = this.getFunctionArtifactName(functionObject);
 
-    return this.zipDirectory(servicePath, exclude, include, zipFileName).then((artifactPath) => {
+    return this.zipDirectory(servicePath, exclude, zipFileName).then((artifactPath) => {
       functionObject.artifact = artifactPath;
       return artifactPath;
     });

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -30,6 +30,10 @@ module.exports = {
         ignore: exclude,
         dot: true,
       }, (err, files) => {
+        if (err) {
+          throw err;
+        }
+
         files.forEach((filePath) => {
           const fullPath = path.resolve(
             servicePath,

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -53,5 +53,5 @@ module.exports = {
       output.on('close', () => resolve(artifactFilePath));
       zip.on('error', (err) => reject(err));
     });
-  }
-}
+  },
+};

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -8,7 +8,7 @@ const glob = require('glob');
 
 module.exports = {
   zipDirectory(servicePath, exclude, zipFileName) {
-    exclude.push('.serverless');
+    exclude.push('.serverless/**');
 
     const zip = archiver.create('zip');
 
@@ -28,6 +28,7 @@ module.exports = {
       glob('**', {
         cwd: servicePath,
         ignore: exclude,
+        dot: true,
       }, (err, files) => {
         files.forEach((filePath) => {
           const fullPath = path.resolve(

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -25,33 +25,30 @@ module.exports = {
     output.on('open', () => {
       zip.pipe(output);
 
-      glob('**', {
+      const files = glob.sync('**', {
         cwd: servicePath,
         ignore: exclude,
         dot: true,
-      }, (err, files) => {
-        if (err) {
-          throw err;
-        }
-
-        files.forEach((filePath) => {
-          const fullPath = path.resolve(
-            servicePath,
-            filePath
-          );
-
-          const stats = fs.statSync(fullPath);
-
-          if (!stats.isDirectory(fullPath)) {
-            zip.append(fs.readFileSync(fullPath), {
-              name: filePath,
-              mode: stats.mode,
-            });
-          }
-        });
-
-        zip.finalize();
+        silent: true,
       });
+
+      files.forEach((filePath) => {
+        const fullPath = path.resolve(
+          servicePath,
+          filePath
+        );
+
+        const stats = fs.statSync(fullPath);
+
+        if (!stats.isDirectory(fullPath)) {
+          zip.append(fs.readFileSync(fullPath), {
+            name: filePath,
+            mode: stats.mode,
+          });
+        }
+      });
+
+      zip.finalize();
     });
 
     return new BbPromise((resolve, reject) => {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -4,13 +4,19 @@ const archiver = require('archiver');
 const BbPromise = require('bluebird');
 const path = require('path');
 const fs = require('fs');
+const glob = require('glob');
 
 module.exports = {
-  zipDirectory(servicePath, exclude, include, zipFileName) {
+  zipDirectory(servicePath, exclude, zipFileName) {
+    exclude.push('.serverless');
+
     const zip = archiver.create('zip');
 
-    const artifactFilePath = path.join(servicePath,
-      '.serverless', zipFileName);
+    const artifactFilePath = path.join(
+      servicePath,
+      '.serverless',
+      zipFileName
+    );
 
     this.serverless.utils.writeFileDir(artifactFilePath);
 
@@ -19,31 +25,33 @@ module.exports = {
     output.on('open', () => {
       zip.pipe(output);
 
-      this.serverless.utils.walkDirSync(servicePath).forEach((filePath) => {
-        const relativeFilePath = path.relative(servicePath, filePath);
+      glob('**', {
+        cwd: servicePath,
+        ignore: exclude,
+      }, (err, files) => {
+        files.forEach((filePath) => {
+          const fullPath = path.resolve(
+            servicePath,
+            filePath
+          );
 
-        // ensure we don't include the new zip file in our zip
-        if (relativeFilePath.startsWith('.serverless')) return;
+          const stats = fs.statSync(fullPath);
 
-        const shouldBeExcluded =
-          exclude.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
+          if (!stats.isDirectory(fullPath)) {
+            zip.append(fs.readFileSync(fullPath), {
+              name: filePath,
+              mode: stats.mode,
+            });
+          }
+        });
 
-        const shouldBeIncluded =
-          include.some(value => relativeFilePath.toLowerCase().indexOf(value.toLowerCase()) > -1);
-
-        if (!shouldBeExcluded || shouldBeIncluded) {
-          const permissions = fs.statSync(filePath).mode;
-
-          zip.append(fs.readFileSync(filePath), { name: relativeFilePath, mode: permissions });
-        }
+        zip.finalize();
       });
-
-      zip.finalize();
     });
 
     return new BbPromise((resolve, reject) => {
       output.on('close', () => resolve(artifactFilePath));
       zip.on('error', (err) => reject(err));
     });
-  },
-};
+  }
+}

--- a/lib/plugins/package/tests/packageService.js
+++ b/lib/plugins/package/tests/packageService.js
@@ -62,24 +62,6 @@ describe('#packageService()', () => {
     });
   });
 
-  describe('#getIncludedPaths()', () => {
-    it('should include defaults', () => {
-      const include = packageService.getIncludedPaths();
-      expect(include).to.deep.equal([]);
-    });
-
-    it('should return package includes', () => {
-      const packageIncludes = [
-        'dir', 'file.js',
-      ];
-
-      serverless.service.package.include = packageIncludes;
-
-      const exclude = packageService.getIncludedPaths();
-      expect(exclude).to.deep.equal(packageIncludes);
-    });
-  });
-
   describe('#getServiceArtifactName()', () => {
     it('should create name with time', () => {
       const name = packageService.getServiceArtifactName();
@@ -149,7 +131,6 @@ describe('#packageService()', () => {
     it('should call zipService with settings', () => {
       const servicePath = 'test';
       const exclude = ['test-exclude'];
-      const include = ['test-include'];
       const artifactName = 'test-artifact.zip';
       const artifactFilePath = '/some/fake/path/test-artifact.zip';
 
@@ -157,8 +138,6 @@ describe('#packageService()', () => {
 
       const getExcludedPathsStub = sinon
         .stub(packageService, 'getExcludedPaths').returns(exclude);
-      const getIncludedPathsStub = sinon
-        .stub(packageService, 'getIncludedPaths').returns(include);
       const getServiceArtifactNameStub = sinon
         .stub(packageService, 'getServiceArtifactName').returns(artifactName);
 
@@ -167,14 +146,12 @@ describe('#packageService()', () => {
 
       return packageService.packageAll().then(() => {
         expect(getExcludedPathsStub.calledOnce).to.be.equal(true);
-        expect(getIncludedPathsStub.calledOnce).to.be.equal(true);
         expect(getServiceArtifactNameStub.calledOnce).to.be.equal(true);
 
         expect(zipDirectoryStub.calledOnce).to.be.equal(true);
         expect(zipDirectoryStub.args[0][0]).to.be.equal(servicePath);
         expect(zipDirectoryStub.args[0][1]).to.be.equal(exclude);
-        expect(zipDirectoryStub.args[0][2]).to.be.equal(include);
-        expect(zipDirectoryStub.args[0][3]).to.be.equal(artifactName);
+        expect(zipDirectoryStub.args[0][2]).to.be.equal(artifactName);
 
         expect(serverless.service.package.artifact).to.be.equal(artifactFilePath);
       });
@@ -187,7 +164,6 @@ describe('#packageService()', () => {
       const funcName = 'test-func';
 
       const exclude = ['test-exclude'];
-      const include = ['test-include'];
       const artifactName = 'test-artifact.zip';
       const artifactFilePath = '/some/fake/path/test-artifact.zip';
 
@@ -197,8 +173,6 @@ describe('#packageService()', () => {
 
       const getExcludedPathsStub = sinon
         .stub(packageService, 'getExcludedPaths').returns(exclude);
-      const getIncludedPathsStub = sinon
-        .stub(packageService, 'getIncludedPaths').returns(include);
       const getFunctionArtifactNameStub = sinon
         .stub(packageService, 'getFunctionArtifactName').returns(artifactName);
 
@@ -207,14 +181,12 @@ describe('#packageService()', () => {
 
       return packageService.packageFunction(funcName).then((filePath) => {
         expect(getExcludedPathsStub.calledOnce).to.be.equal(true);
-        expect(getIncludedPathsStub.calledOnce).to.be.equal(true);
         expect(getFunctionArtifactNameStub.calledOnce).to.be.equal(true);
 
         expect(zipDirectoryStub.calledOnce).to.be.equal(true);
         expect(zipDirectoryStub.args[0][0]).to.be.equal(servicePath);
         expect(zipDirectoryStub.args[0][1]).to.be.equal(exclude);
-        expect(zipDirectoryStub.args[0][2]).to.be.equal(include);
-        expect(zipDirectoryStub.args[0][3]).to.be.equal(artifactName);
+        expect(zipDirectoryStub.args[0][2]).to.be.equal(artifactName);
 
         expect(filePath).to.be.equal(artifactFilePath);
       });

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -32,6 +32,14 @@ describe('#zipService()', () => {
         permissions: 444,
       },
     },
+    'node_modules/include-me': {
+      'include': 'some-file-content',
+      'include-aswell': 'some-file content',
+    },
+    'node_modules/exclude-me': {
+      'exclude': 'some-file-content',
+      'exclude-aswell': 'some-file content',
+    },
     'exclude-me': {
       'some-file': 'some-file content',
     },
@@ -85,11 +93,10 @@ describe('#zipService()', () => {
 
   it('should zip a whole service', () => {
     const exclude = [];
-    const include = [];
     const zipFileName = getTestArtifactFileName('whole-service');
 
     return packageService
-      .zipDirectory(servicePath, exclude, include, zipFileName).then((artifact) => {
+      .zipDirectory(servicePath, exclude, zipFileName).then((artifact) => {
         const data = fs.readFileSync(artifact);
 
         return zip.loadAsync(data);
@@ -97,7 +104,7 @@ describe('#zipService()', () => {
         const unzippedFileData = unzippedData.files;
 
         expect(Object.keys(unzippedFileData)
-               .filter(file => !unzippedFileData[file].dir).length).to.equal(9);
+               .filter(file => !unzippedFileData[file].dir).length).to.equal(13);
 
         expect(unzippedFileData['handler.js'].name)
           .to.equal('handler.js');
@@ -125,15 +132,26 @@ describe('#zipService()', () => {
 
         expect(unzippedFileData['a-serverless-plugin.js'].name)
           .to.equal('a-serverless-plugin.js');
+
+        expect(unzippedFileData['node_modules/include-me/include'].name)
+          .to.equal('node_modules/include-me/include');
+
+        expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
+          .to.equal('node_modules/include-me/include-aswell');
+
+        expect(unzippedFileData['node_modules/exclude-me/exclude'].name)
+          .to.equal('node_modules/exclude-me/exclude');
+
+        expect(unzippedFileData['node_modules/exclude-me/exclude-aswell'].name)
+          .to.equal('node_modules/exclude-me/exclude-aswell');
       });
   });
 
   it('should keep file permissions', () => {
     const exclude = [];
-    const include = [];
     const zipFileName = getTestArtifactFileName('file-permissions');
 
-    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
+    return packageService.zipDirectory(servicePath, exclude, zipFileName)
       .then((artifact) => {
         const data = fs.readFileSync(artifact);
         return zip.loadAsync(data);
@@ -150,45 +168,15 @@ describe('#zipService()', () => {
       });
   });
 
-  it('should exclude defined files and folders', () => {
-    const exclude = ['exclude-me.js', 'exclude-me'];
-    const include = [];
-    const zipFileName = getTestArtifactFileName('exclude');
+  it('should exclude globs', () => {
+    const exclude = [
+      'exclude-me*/**',
+      'node_modules/exclude-me/**'
+    ];
 
-    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
-    .then((artifact) => {
-      const data = fs.readFileSync(artifact);
-
-      return zip.loadAsync(data);
-    }).then(unzippedData => {
-      const unzippedFileData = unzippedData.files;
-
-      expect(Object.keys(unzippedFileData)
-             .filter(file => !unzippedFileData[file].dir).length).to.equal(7);
-
-      expect(unzippedFileData['handler.js'].name)
-        .to.equal('handler.js');
-
-      expect(unzippedFileData['lib/function.js'].name)
-        .to.equal('lib/function.js');
-
-      expect(unzippedFileData['include-me.js'].name)
-        .to.equal('include-me.js');
-
-      expect(unzippedFileData['include-me/some-file'].name)
-        .to.equal('include-me/some-file');
-
-      expect(unzippedFileData['a-serverless-plugin.js'].name)
-        .to.equal('a-serverless-plugin.js');
-    });
-  });
-
-  it('should include a previously excluded file', () => {
-    const exclude = ['exclude-me.js', 'exclude-me'];
-    const include = ['exclude-me.js', 'exclude-me'];
     const zipFileName = getTestArtifactFileName('re-include');
 
-    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
+    return packageService.zipDirectory(servicePath, exclude, zipFileName)
     .then((artifact) => {
       const data = fs.readFileSync(artifact);
 
@@ -211,14 +199,15 @@ describe('#zipService()', () => {
       expect(unzippedFileData['include-me/some-file'].name)
         .to.equal('include-me/some-file');
 
-      expect(unzippedFileData['exclude-me.js'].name)
-        .to.equal('exclude-me.js');
-
-      expect(unzippedFileData['exclude-me/some-file'].name)
-        .to.equal('exclude-me/some-file');
-
       expect(unzippedFileData['a-serverless-plugin.js'].name)
         .to.equal('a-serverless-plugin.js');
+
+      expect(unzippedFileData['node_modules/include-me/include'].name)
+        .to.equal('node_modules/include-me/include');
+
+      expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
+        .to.equal('node_modules/include-me/include-aswell');
+
     });
   });
 });

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -33,11 +33,11 @@ describe('#zipService()', () => {
       },
     },
     'node_modules/include-me': {
-      'include': 'some-file-content',
+      include: 'some-file-content',
       'include-aswell': 'some-file content',
     },
     'node_modules/exclude-me': {
-      'exclude': 'some-file-content',
+      exclude: 'some-file-content',
       'exclude-aswell': 'some-file content',
     },
     'exclude-me': {
@@ -171,7 +171,7 @@ describe('#zipService()', () => {
   it('should exclude globs', () => {
     const exclude = [
       'exclude-me*/**',
-      'node_modules/exclude-me/**'
+      'node_modules/exclude-me/**',
     ];
 
     const zipFileName = getTestArtifactFileName('re-include');
@@ -207,7 +207,6 @@ describe('#zipService()', () => {
 
       expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
         .to.equal('node_modules/include-me/include-aswell');
-
     });
   });
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -114,11 +114,6 @@
       "from": "async@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-    },
     "aws-sdk": {
       "version": "2.5.3",
       "from": "aws-sdk@>=2.3.17 <3.0.0",
@@ -141,7 +136,7 @@
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.1.2 <1.2.0",
+      "from": "bl@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "dependencies": {
         "readable-stream": {
@@ -183,7 +178,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@>=1.1.1 <2.0.0",
+      "from": "builtin-modules@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "caller-id": {
@@ -218,7 +213,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.0 <2.0.0",
+      "from": "chalk@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "circular-json": {
@@ -332,12 +327,12 @@
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <3.0.0",
+      "from": "debug@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
+      "from": "decamelize@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-eql": {
@@ -563,7 +558,7 @@
     },
     "fs-extra": {
       "version": "0.26.7",
-      "from": "fs-extra@>=0.26.4 <0.27.0",
+      "from": "fs-extra@>=0.26.7 <0.27.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
     },
     "fs.realpath": {
@@ -642,7 +637,7 @@
     },
     "har-validator": {
       "version": "2.0.6",
-      "from": "har-validator@>=2.0.2 <2.1.0",
+      "from": "har-validator@>=2.0.6 <2.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has-ansi": {
@@ -657,7 +652,7 @@
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@>=3.1.0 <3.2.0",
+      "from": "hawk@>=3.1.3 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
@@ -812,7 +807,7 @@
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@>=3.5.5 <4.0.0",
+      "from": "js-yaml@>=3.6.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
     },
     "jsbn": {
@@ -894,6 +889,11 @@
       "version": "1.0.0",
       "from": "lcid@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+    },
+    "lcov-parse": {
+      "version": "0.0.6",
+      "from": "lcov-parse@0.0.6",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
     },
     "levn": {
       "version": "0.3.0",
@@ -985,6 +985,11 @@
       "from": "lodash.keys@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
+    "log-driver": {
+      "version": "1.2.4",
+      "from": "log-driver@1.2.4",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz"
+    },
     "lolex": {
       "version": "1.3.2",
       "from": "lolex@1.3.2",
@@ -1069,7 +1074,7 @@
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@>=1.4.2 <2.0.0",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "nopt": {
@@ -1094,12 +1099,12 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.0 <0.9.0",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.0.1 <5.0.0",
+      "from": "object-assign@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "once": {
@@ -1348,7 +1353,7 @@
     },
     "semver-regex": {
       "version": "1.0.0",
-      "from": "semver-regex@latest",
+      "from": "semver-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
     },
     "set-blocking": {
@@ -1420,7 +1425,7 @@
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "stack-trace@>=0.0.0 <0.1.0",
+      "from": "stack-trace@>=0.0.7 <0.1.0",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "string_decoder": {
@@ -1587,6 +1592,16 @@
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
+    "underscore": {
+      "version": "1.7.0",
+      "from": "underscore@>=1.7.0 <1.8.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+    },
+    "underscore.string": {
+      "version": "2.4.0",
+      "from": "underscore.string@>=2.4.0 <2.5.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+    },
     "uri-js": {
       "version": "2.1.1",
       "from": "uri-js@>=2.1.1 <3.0.0",
@@ -1608,9 +1623,9 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "uuid": {
-      "version": "2.0.2",
-      "from": "uuid@latest",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
+      "version": "2.0.3",
+      "from": "uuid@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -1639,7 +1654,7 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=0.0.2",
+      "from": "wordwrap@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "bluebird": "^3.4.0",
     "chalk": "^1.1.1",
     "fs-extra": "^0.26.7",
+    "glob": "^7.0.6",
     "https-proxy-agent": "^1.0.0",
     "js-yaml": "^3.6.1",
     "json-refs": "^2.1.5",

--- a/tests/classes/Serverless.js
+++ b/tests/classes/Serverless.js
@@ -151,7 +151,6 @@ describe('Serverless', () => {
           google: {},
         },
         package: {
-          include: ['include-me.js'],
           exclude: ['exclude-me.js'],
           artifact: 'some/path/foo.zip',
         },

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -53,7 +53,6 @@ describe('Service', () => {
           google: {},
         },
         package: {
-          include: ['include-me.js'],
           exclude: ['exclude-me.js'],
           artifact: 'some/path/foo.zip',
         },
@@ -69,7 +68,6 @@ describe('Service', () => {
       expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
       expect(serviceInstance.resources.azure).to.deep.equal({});
       expect(serviceInstance.resources.google).to.deep.equal({});
-      expect(serviceInstance.package.include[0]).to.equal('include-me.js');
       expect(serviceInstance.package.exclude[0]).to.equal('exclude-me.js');
       expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
     });
@@ -132,7 +130,6 @@ describe('Service', () => {
           google: {},
         },
         package: {
-          include: ['include-me.js'],
           exclude: ['exclude-me.js'],
           artifact: 'some/path/foo.zip',
         },
@@ -154,8 +151,6 @@ describe('Service', () => {
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
         expect(serviceInstance.resources.google).to.deep.equal({});
-        expect(serviceInstance.package.include.length).to.equal(1);
-        expect(serviceInstance.package.include[0]).to.equal('include-me.js');
         expect(serviceInstance.package.exclude.length).to.equal(1);
         expect(serviceInstance.package.exclude[0]).to.equal('exclude-me.js');
         expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
@@ -185,7 +180,6 @@ describe('Service', () => {
           google: {},
         },
         package: {
-          include: ['include-me.js'],
           exclude: ['exclude-me.js'],
           artifact: 'some/path/foo.zip',
         },


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2071

## How did you implement it:

* Added globs as a dependency of project
* Updated to use globs for `exclude`
* Update specs to test relevant changes

## How can we verify it:
Add folder src to a project then use example config to verify they are not included.  Other glob patterns can be tested.

Example config:
```
package:
  exclude:
    - "src/**"
    - "test/**"
    - "**/spec.js"
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation
