### PR TITLE
add support for description/input params of schedule event

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -43,8 +43,19 @@ class AwsCompileScheduledEvents {
               Description = typeof event.schedule.description === 'string' ?
                 event.schedule.description :
                 `Invoke lambda function '${functionName}' schedule at ${event.schedule.rate}`;
+
               Input = typeof event.schedule.input === 'object' ?
                 JSON.stringify(event.schedule.input) : '';
+              if (Input.length > 8192) {
+                const errorMessage = [
+                  'Validation error "input" property',
+                  ` for schedule event in function ${functionName}`,
+                  ' Length Constraints: Maximum length of 8192',
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes
+                  .Error(errorMessage);
+              }
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -23,6 +23,8 @@ class AwsCompileScheduledEvents {
             scheduleNumberInFunction++;
             let ScheduleExpression;
             let State;
+            let Description;
+            let Input;
 
             // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
@@ -38,9 +40,17 @@ class AwsCompileScheduledEvents {
               }
               ScheduleExpression = event.schedule.rate;
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
+              Description = typeof event.schedule.description === 'string' ?
+                event.schedule.description :
+                `Invoke lambda function '${functionName}' schedule at ${event.schedule.rate}`;
+              Input = typeof event.schedule.input === 'object' ?
+                JSON.stringify(event.schedule.input) : '';
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';
+              Description =
+                `Invoke lambda function '${functionName}' schedule at ${event.schedule}`;
+              Input = '';
             } else {
               const errorMessage = [
                 `Schedule event of function ${functionName} is not an object nor a string`,
@@ -54,42 +64,56 @@ class AwsCompileScheduledEvents {
 
             const normalizedFunctionName = functionName[0].toUpperCase() + functionName.substr(1);
 
-            const scheduleTemplate = `
-              {
-                "Type": "AWS::Events::Rule",
-                "Properties": {
-                  "ScheduleExpression": "${ScheduleExpression}",
-                  "State": "${State}",
-                  "Targets": [{
-                    "Arn": { "Fn::GetAtt": ["${normalizedFunctionName}LambdaFunction", "Arn"] },
-                    "Id": "${functionName}Schedule"
-                  }]
-                }
-              }
-            `;
+            const scheduleTemplate = {
+              Type: 'AWS::Events::Rule',
+              Properties: {
+                Description: `${Description}`,
+                ScheduleExpression: `${ScheduleExpression}`,
+                State: `${State}`,
+                Targets: [
+                  {
+                    Arn: {
+                      'Fn::GetAtt': [
+                        `${normalizedFunctionName}LambdaFunction`,
+                        'Arn',
+                      ],
+                    },
+                    Id: `${functionName}Schedule`,
+                    Input: `${Input}`,
+                    // TODO Support InputPath
+                  },
+                ],
+              },
+            };
 
-            const permissionTemplate = `
-              {
-                "Type": "AWS::Lambda::Permission",
-                "Properties": {
-                  "FunctionName": { "Fn::GetAtt": ["${
-              normalizedFunctionName}LambdaFunction", "Arn"] },
-                  "Action": "lambda:InvokeFunction",
-                  "Principal": "events.amazonaws.com",
-                  "SourceArn": { "Fn::GetAtt": ["${
-              normalizedFunctionName}EventsRuleSchedule${scheduleNumberInFunction}", "Arn"] }
-                }
-              }
-            `;
+            const permissionTemplate = {
+              Type: 'AWS::Lambda::Permission',
+              Properties: {
+                FunctionName: {
+                  'Fn::GetAtt': [
+                    `${normalizedFunctionName}LambdaFunction`,
+                    'Arn',
+                  ],
+                },
+                Action: 'lambda:InvokeFunction',
+                Principal: 'events.amazonaws.com',
+                SourceArn: {
+                  'Fn::GetAtt': [
+                    `${normalizedFunctionName}EventsRuleSchedule${scheduleNumberInFunction}`,
+                    'Arn',
+                  ],
+                },
+              },
+            };
 
             const newScheduleObject = {
               [`${normalizedFunctionName}EventsRuleSchedule${
-                scheduleNumberInFunction}`]: JSON.parse(scheduleTemplate),
+                scheduleNumberInFunction}`]: scheduleTemplate,
             };
 
             const newPermissionObject = {
               [`${normalizedFunctionName}LambdaPermissionEventsRuleSchedule${
-                scheduleNumberInFunction}`]: JSON.parse(permissionTemplate),
+                scheduleNumberInFunction}`]: permissionTemplate,
             };
 
             _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -194,10 +194,10 @@ describe('AwsCompileScheduledEvents', () => {
       expect(schedule1.Properties.Targets[0].Input).to.eq('');
     });
 
-    it('should throw a Error if input length 8192', () => {
-      const inputParams = {
-        a: 'b'.repeat('8185'),
-      };
+    it('should throw a Error if input length is 8193', () => {
+      const inputParams = [
+        'a'.repeat('8189'),
+      ];
 
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -193,5 +193,27 @@ describe('AwsCompileScheduledEvents', () => {
         .eq('Invoke lambda function \'first\' schedule at rate(20 minutes)');
       expect(schedule1.Properties.Targets[0].Input).to.eq('');
     });
+
+    it('should throw a Error if input length 8192', () => {
+      const inputParams = {
+        a: 'b'.repeat('8185'),
+      };
+
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                input: inputParams,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(JSON.stringify(inputParams).length).to.equal(8193);
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+    });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -113,5 +113,85 @@ describe('AwsCompileScheduledEvents', () => {
           .Resources
       ).to.deep.equal({});
     });
+
+    it('should populate description/input params', () => {
+      const inputParams = {
+        a: 'a',
+        b: [
+          1,
+          false,
+        ],
+      };
+
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(20 minutes)',
+                description: 'my description',
+                input: inputParams,
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      const schedule1 = awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1;
+
+      expect(schedule1.Type).to.eq('AWS::Events::Rule');
+      expect(schedule1.Properties.Description).to.eq('my description');
+      expect(schedule1.Properties.Targets[0].Input).to.eq(JSON.stringify(inputParams));
+    });
+
+    it('should not populate description/input params when event does contains that params',
+      () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(20 minutes)',
+                },
+              },
+            ],
+          },
+        };
+
+        awsCompileScheduledEvents.compileScheduledEvents();
+
+        const schedule1 = awsCompileScheduledEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1;
+
+        expect(schedule1.Type).to.eq('AWS::Events::Rule');
+        expect(schedule1.Properties.Description).to
+          .eq('Invoke lambda function \'first\' schedule at rate(20 minutes)');
+        expect(schedule1.Properties.Targets[0].Input).to.eq('');
+      });
+
+    it('should not populate description/input params when schedule event is string object', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: 'rate(20 minutes)',
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      const schedule1 = awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1;
+
+      expect(schedule1.Type).to.eq('AWS::Events::Rule');
+      expect(schedule1.Properties.Description).to
+        .eq('Invoke lambda function \'first\' schedule at rate(20 minutes)');
+      expect(schedule1.Properties.Targets[0].Input).to.eq('');
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** N/A

<!--
Briefly describe the feature if no issue exists for this PR
-->

Support for "description" and "input" params of schedule event

AWS => CloudWatch => Rules

<img width="600" alt="1" src="https://cloud.githubusercontent.com/assets/968151/18787301/43eebed6-81dd-11e6-866c-5d7a433685fa.png">

<img width="600" alt="2" src="https://cloud.githubusercontent.com/assets/968151/18787306/482bca48-81dd-11e6-9e81-2d72bc1268de.png">

### new yml format

```yml
# ...
functions:
  hello:
    handler: handler.hello
    events:
      -
        schedule:
          rate: rate(10 minutes)
          enabled: false
          description: 'my description' # <= here(optional)
          input: # <= here(optional)
            a: 'b'
            b:
              - 1
              - false
```

###  If description does not specify

Set default description `Invoke lambda function '[funcationName]' schedule at [rate]`

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

1. Add new two variables `Description` and `Input`.
2. Set that variables from `event.schedule` object
3. Populate to `const scheduleTemplate`

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

see https://github.com/kengos/sls-schedule-event-test

```sh
$ git clone git@github.com:kengos/sls-schedule-event-test.git
$ cd sls-schedule-event-test
$ npm install
$ ./node_modules/.bin/sls deploy
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation