### PR TITLE
fix: #1973 deploy fails with unhelpful error message

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -32,7 +32,7 @@ module.exports = {
   createStack() {
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
 
-    if (/^[a-zA-Z-]+/.test(stackName) || stackName.length > 128){
+    if (/^[a-zA-Z1-9-]+/.test(stackName) || stackName.length > 128){
       const errorMessage = [
                 'The stack name "' + stackName + '" is not quallify. ',
                 'A stack name can contain only alphanumeric',

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -32,6 +32,16 @@ module.exports = {
   createStack() {
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
 
+    if (/^[a-zA-Z-]+/.test(stackName) || stackName.length > 128){
+      const errorMessage = [
+                'The stack name "' + stackName + '" is not quallify. ',
+                'A stack name can contain only alphanumeric',
+                ' (case sensitive) and hyphens. It must characters',
+                ' start with an alphabetic character and cannot',
+                ' be longer than 128 characters.'
+              ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
     this.serverless.service.provider
       .compiledCloudFormationTemplate = this.loadCoreCloudFormationTemplate();
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** #1973

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Add logic in lib/plugins/aws/deploy/lib/createStack.js createStack() function to test the invalid stack name and throw the correct and meaningful error message.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Just to deploy a invalid AWS CF stack name and the error message will appear.
![image](https://cloud.githubusercontent.com/assets/1528417/18790888/2eabac9a-81e3-11e6-9a15-cd43c03e4115.png)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation
