### PR TITLE
Add Var at the end of path variable CF name

### DIFF
--- a/docs/02-providers/aws/04-resource-names-reference.md
+++ b/docs/02-providers/aws/04-resource-names-reference.md
@@ -28,7 +28,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |Lambda::Permission     | <ul><li>**Schedule**: {normalizedFunctionName}LambdaPermissionEventsRuleSchedule{index} </li><li>**S3**: {normalizedFunctionName}LambdaPermissionS3</li><li>**APIG**: {normalizedFunctionName}LambdaPermissionApiGateway</li><li>**SNS**: {normalizedFunctionName}LambdaPermission{normalizedTopicName}</li> | <ul><li>**Schedule**: HelloLambdaPermissionEventsRuleSchedule1 </li><li>**S3**: HelloLambdaPermissionS3</li><li>**APIG**: HelloLambdaPermissionApiGateway</li><li>**SNS**: HelloLambdaPermissionSometopic</li> |
 |Events::Rule           | {normalizedFuntionName}EventsRuleSchedule{SequentialID} | HelloEventsRuleSchedule1      |
 |ApiGateway::RestApi    | ApiGatewayRestApi                                       | ApiGatewayRestApi             |
-|ApiGateway::Resource   | ApiGatewayResource{normalizedPath}                      | ApiGatewayResourceUsers       |
+|ApiGateway::Resource   | ApiGatewayResource{normalizedPath}                      | <ul><li>ApiGatewayResourceUsers</li><li>ApiGatewayResourceUsers**Var** for paths containing a variable</li><li>ApiGatewayResource**Dash** if the path is just a `-`</li></ul>       |
 |ApiGateway::Method     | ApiGatewayResource{normalizedPath}{normalizedMethod}    | ApiGatewayResourceUsersGet    |
 |ApiGateway::Authorizer | {normalizedFunctionName}ApiGatewayAuthorizer            | HelloApiGatewayAuthorizer     |
 |ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/resources.js
@@ -43,9 +43,10 @@ module.exports = {
       });
     });
 
-    const capitalizeAlphaNumericPath = (path) => _.capitalize(
-      path
+    const capitalizeAlphaNumericPath = (path) => _.upperFirst(
+      _.capitalize(path)
       .replace(/-/g, 'Dash')
+      .replace(/\{(.*)\}/g, '$1Var')
       .replace(/[^0-9A-Za-z]/g, '')
     );
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/resources.js
@@ -81,10 +81,10 @@ describe('#compileResources()', () => {
         'bar/-': 'ApiGatewayResourceBarDash',
         'foo/bar': 'ApiGatewayResourceFooBar',
         foo: 'ApiGatewayResourceFoo',
-        'bar/{id}/foobar': 'ApiGatewayResourceBarIdFoobar',
-        'bar/{id}': 'ApiGatewayResourceBarId',
-        'bar/{foo_id}/foobar': 'ApiGatewayResourceBarFooidFoobar',
-        'bar/{foo_id}': 'ApiGatewayResourceBarFooid',
+        'bar/{id}/foobar': 'ApiGatewayResourceBarIdVarFoobar',
+        'bar/{id}': 'ApiGatewayResourceBarIdVar',
+        'bar/{foo_id}/foobar': 'ApiGatewayResourceBarFooidVarFoobar',
+        'bar/{foo_id}': 'ApiGatewayResourceBarFooidVar',
         'bar/foo': 'ApiGatewayResourceBarFoo',
         bar: 'ApiGatewayResourceBar',
       };
@@ -107,14 +107,14 @@ describe('#compileResources()', () => {
         .Resources.ApiGatewayResourceBar.Properties.ParentId['Fn::GetAtt'][1])
         .to.equal('RootResourceId');
       expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.ApiGatewayResourceBarId.Properties.ParentId.Ref)
+        .Resources.ApiGatewayResourceBarIdVar.Properties.ParentId.Ref)
         .to.equal('ApiGatewayResourceBar');
       expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.ApiGatewayResourceBarFooid.Properties.ParentId.Ref)
+        .Resources.ApiGatewayResourceBarFooidVar.Properties.ParentId.Ref)
         .to.equal('ApiGatewayResourceBar');
       expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.ApiGatewayResourceBarFooidFoobar.Properties.ParentId.Ref)
-        .to.equal('ApiGatewayResourceBarFooid');
+        .Resources.ApiGatewayResourceBarFooidVarFoobar.Properties.ParentId.Ref)
+        .to.equal('ApiGatewayResourceBarFooidVar');
     })
   );
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR
-->

At the moment when you create a variable path in APIG the Cloudformation resource name does not say that its a variable path. This can be an issue when somebody calls a path by the same name as the variable, e.g.:

```
- http: get users/something
- http: get users/{something}
```

This PR adds `var` at the end of the APIG Resource CF name.

## How did you implement it:

Regex parsing of CF path variable.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

Copy the folliwing function config into your service and it should correctly set the names
```
functions:
  hello:
    handler: handler.hello
    timeout: 1
    events:
      - http: get users/{somevar}
      - http: get users/{secondsomevar+}
```


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [ ] Leave a comment that this is ready for review once you've finished the implementation
