### PR TITLE
Fix very small bug with PluginManager tests.

### DIFF
--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -763,7 +763,7 @@ describe('PluginManager', () => {
     });
   });
 
-  describe('Plugin/CLI integration', () => {
+  it('Plugin/CLI integration', () => {
     const serverlessInstance = new Serverless();
     serverlessInstance.init();
 


### PR DESCRIPTION
## What did you implement:

A super small bugfix. The 'test' code actually always runs, since describe blocks are always executed, so for example if you did `mocha test -g "..."` even if it does not match this test, the test still runs. Mocha also doesn't treat it as a test failure but rather it interferes with the entire test run.

## How did you implement it:

I changed a single word.

## How can we verify it:

Run `npm test`. Still works :D


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

