### PR TITLE
add tracking-id to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ admin.env
 .env
 tmp
 .coveralls.yml
+tracking-id


### PR DESCRIPTION
Ignore tracking-id file which shows up in `git status` every time I work on serverless.

## How did you implement it:

I changed .gitignore.

## How can we verify it:

(before fix): Do something like `npm test` and observe the `tracking-id` file in lib under `git status`.
(after fix): Git does not care about the file

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

