### PR TITLE
support description and input params for schedule event

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -23,6 +23,8 @@ class AwsCompileScheduledEvents {
             scheduleNumberInFunction++;
             let ScheduleExpression;
             let State;
+            let Description;
+            let Input = '';
 
             // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
@@ -38,9 +40,27 @@ class AwsCompileScheduledEvents {
               }
               ScheduleExpression = event.schedule.rate;
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
+              Description = typeof event.schedule.description === 'string' ?
+                event.schedule.description :
+                `Invoke lambda function '${functionName}' schedule at ${event.schedule.rate}`;
+              if (typeof event.schedule.input === 'object') {
+                Input = JSON.stringify(event.schedule.input);
+                if (Input.length > 8192) {
+                  const errorMessage = [
+                    'Validation error "input" property',
+                    ` for schedule event in function ${functionName}`,
+                    ' Length Constraints: Maximum length of 8192',
+                    ' Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes
+                    .Error(errorMessage);
+                }
+              }
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';
+              Description =
+                `Invoke lambda function '${functionName}' schedule at ${event.schedule}`;
             } else {
               const errorMessage = [
                 `Schedule event of function ${functionName} is not an object nor a string`,
@@ -54,42 +74,55 @@ class AwsCompileScheduledEvents {
 
             const normalizedFunctionName = functionName[0].toUpperCase() + functionName.substr(1);
 
-            const scheduleTemplate = `
-              {
-                "Type": "AWS::Events::Rule",
-                "Properties": {
-                  "ScheduleExpression": "${ScheduleExpression}",
-                  "State": "${State}",
-                  "Targets": [{
-                    "Arn": { "Fn::GetAtt": ["${normalizedFunctionName}LambdaFunction", "Arn"] },
-                    "Id": "${functionName}Schedule"
-                  }]
-                }
-              }
-            `;
+            const scheduleTemplate = {
+              Type: 'AWS::Events::Rule',
+              Properties: {
+                Description: `${Description}`,
+                ScheduleExpression: `${ScheduleExpression}`,
+                State: `${State}`,
+                Targets: [
+                  {
+                    Arn: {
+                      'Fn::GetAtt': [
+                        `${normalizedFunctionName}LambdaFunction`,
+                        'Arn',
+                      ],
+                    },
+                    Id: `${functionName}Schedule`,
+                    Input: `${Input}`,
+                  },
+                ],
+              },
+            };
 
-            const permissionTemplate = `
-              {
-                "Type": "AWS::Lambda::Permission",
-                "Properties": {
-                  "FunctionName": { "Fn::GetAtt": ["${
-              normalizedFunctionName}LambdaFunction", "Arn"] },
-                  "Action": "lambda:InvokeFunction",
-                  "Principal": "events.amazonaws.com",
-                  "SourceArn": { "Fn::GetAtt": ["${
-              normalizedFunctionName}EventsRuleSchedule${scheduleNumberInFunction}", "Arn"] }
-                }
-              }
-            `;
+            const permissionTemplate = {
+              Type: 'AWS::Lambda::Permission',
+              Properties: {
+                FunctionName: {
+                  'Fn::GetAtt': [
+                    `${normalizedFunctionName}LambdaFunction`,
+                    'Arn',
+                  ],
+                },
+                Action: 'lambda:InvokeFunction',
+                Principal: 'events.amazonaws.com',
+                SourceArn: {
+                  'Fn::GetAtt': [
+                    `${normalizedFunctionName}EventsRuleSchedule${scheduleNumberInFunction}`,
+                    'Arn',
+                  ],
+                },
+              },
+            };
 
             const newScheduleObject = {
               [`${normalizedFunctionName}EventsRuleSchedule${
-                scheduleNumberInFunction}`]: JSON.parse(scheduleTemplate),
+                scheduleNumberInFunction}`]: scheduleTemplate,
             };
 
             const newPermissionObject = {
               [`${normalizedFunctionName}LambdaPermissionEventsRuleSchedule${
-                scheduleNumberInFunction}`]: JSON.parse(permissionTemplate),
+                scheduleNumberInFunction}`]: permissionTemplate,
             };
 
             _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -52,6 +52,14 @@ describe('AwsCompileScheduledEvents', () => {
     });
 
     it('should create corresponding resources when schedule events are given', () => {
+      const inputParams = {
+        a: 'a',
+        b: [
+          0,
+          false,
+        ],
+      };
+
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
           events: [
@@ -59,16 +67,18 @@ describe('AwsCompileScheduledEvents', () => {
               schedule: {
                 rate: 'rate(10 minutes)',
                 enabled: false,
+                description: 'my description',
+                input: inputParams,
               },
             },
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: 'rate(20 minutes)',
                 enabled: true,
               },
             },
             {
-              schedule: 'rate(10 minutes)',
+              schedule: 'rate(30 minutes)',
             },
           ],
         },
@@ -76,27 +86,43 @@ describe('AwsCompileScheduledEvents', () => {
 
       awsCompileScheduledEvents.compileScheduledEvents();
 
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1.Type
-      ).to.equal('AWS::Events::Rule');
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule2.Type
-      ).to.equal('AWS::Events::Rule');
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule3.Type
-      ).to.equal('AWS::Events::Rule');
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionEventsRuleSchedule1.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionEventsRuleSchedule2.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionEventsRuleSchedule3.Type
-      ).to.equal('AWS::Lambda::Permission');
+      const resources = awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources;
+
+      const schedule1 = resources.FirstEventsRuleSchedule1;
+      expect(schedule1.Type).to.equal('AWS::Events::Rule');
+      expect(schedule1.Properties.State).to.equal('DISABLED');
+      expect(schedule1.Properties.ScheduleExpression).to
+        .equal('rate(10 minutes)');
+      expect(schedule1.Properties.Description).to
+        .equal('my description');
+      expect(schedule1.Properties.Targets[0].Input).to
+        .equal(JSON.stringify(inputParams));
+
+      const schedule2 = resources.FirstEventsRuleSchedule2;
+      expect(schedule2.Type).to.equal('AWS::Events::Rule');
+      expect(schedule2.Properties.State).to.equal('ENABLED');
+      expect(schedule2.Properties.Description).to
+        .equal('Invoke lambda function \'first\' schedule at rate(20 minutes)');
+      expect(schedule2.Properties.ScheduleExpression).to
+        .equal('rate(20 minutes)');
+      expect(schedule2.Properties.Targets[0].Input).to.equal('');
+
+      const schedule3 = resources.FirstEventsRuleSchedule3;
+      expect(schedule3.Type).to.equal('AWS::Events::Rule');
+      expect(schedule3.Properties.State).to.equal('ENABLED');
+      expect(schedule3.Properties.Description).to
+        .equal('Invoke lambda function \'first\' schedule at rate(30 minutes)');
+      expect(schedule3.Properties.ScheduleExpression)
+        .to.equal('rate(30 minutes)');
+      expect(schedule3.Properties.Targets[0].Input).to.equal('');
+
+      expect(resources.FirstLambdaPermissionEventsRuleSchedule1.Type)
+        .to.equal('AWS::Lambda::Permission');
+      expect(resources.FirstLambdaPermissionEventsRuleSchedule2.Type)
+        .to.equal('AWS::Lambda::Permission');
+      expect(resources.FirstLambdaPermissionEventsRuleSchedule3.Type)
+        .to.equal('AWS::Lambda::Permission');
     });
 
     it('should not create corresponding resources when scheduled events are not given', () => {
@@ -112,6 +138,28 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources
       ).to.deep.equal({});
+    });
+
+    it('should throw a Error if "input" length is 8193', () => {
+      const inputParams = [
+        'a'.repeat('8189'),
+      ];
+
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                input: inputParams,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(JSON.stringify(inputParams).length).to.equal(8193);
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
     });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

***Implementing Issue:*** N/A

<!--
Briefly describe the feature if no issue exists for this PR
-->
Support "description" and "input" params for schedule event.

AWS => CloudWatch => Rules

**description param**
<img width="600" alt="1" src="https://cloud.githubusercontent.com/assets/968151/18787301/43eebed6-81dd-11e6-866c-5d7a433685fa.png">

**input param**
<img width="600" alt="2" src="https://cloud.githubusercontent.com/assets/968151/18787306/482bca48-81dd-11e6-9e81-2d72bc1268de.png">

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Update `lib/plugins/aws/deploy/compile/events/schedule/index.js`
and add new two variables("Description", "Input")

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->

your serverless.yml
```yml
#...
functions:
  hello:
    handler: handler.hello
    events:
      -
        schedule:
          rate: rate(10 minutes)
          enabled: false
          description: 'my description'
          input:
            a: 'b'
            b:
              - 0
              - false
```

```sh
$ sls deploy
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

