### PR TITLE
Allow integration tests longer timeouts

### DIFF
--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -291,7 +291,8 @@ describe('CLI', () => {
       process.chdir(this.cwd);
     });
 
-    it('prints general --help to stdout', (done) => {
+    it('prints general --help to stdout', function (done) {
+      this.timeout(10000);
       exec(`${this.serverlessExec} --help`, (err, stdout) => {
         if (err) {
           done(err);
@@ -303,7 +304,8 @@ describe('CLI', () => {
       });
     });
 
-    it('prints command --help to stdout', (done) => {
+    it('prints command --help to stdout', function (done) {
+      this.timeout(10000);
       exec(`${this.serverlessExec} deploy --help`, (err, stdout) => {
         if (err) {
           done(err);

--- a/tests/classes/CLI.js
+++ b/tests/classes/CLI.js
@@ -17,7 +17,7 @@ describe('CLI', () => {
   let cli;
   let serverless;
 
-  beforeEach(() => {
+  beforeEach(function () { // eslint-disable-line prefer-arrow-callback
     serverless = new Serverless({});
   });
 
@@ -269,7 +269,7 @@ describe('CLI', () => {
   });
 
   describe('integration tests', () => {
-    before(() => {
+    before(function () {
       const tmpDir = testUtils.getTmpDirPath();
 
       this.cwd = process.cwd();
@@ -287,7 +287,7 @@ describe('CLI', () => {
         '..', 'bin', 'serverless');
     });
 
-    after(() => {
+    after(function () { // eslint-disable-line prefer-arrow-callback
       process.chdir(this.cwd);
     });
 

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -763,7 +763,8 @@ describe('PluginManager', () => {
     });
   });
 
-  it('Plugin/CLI integration', () => {
+  it('Plugin/CLI integration', function () {
+    this.timeout(10000);
     const serverlessInstance = new Serverless();
     serverlessInstance.init();
 

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -188,7 +188,7 @@ describe('PluginManager', () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(function () { // eslint-disable-line prefer-arrow-callback
     serverless = new Serverless();
     pluginManager = new PluginManager(serverless);
   });
@@ -349,7 +349,7 @@ describe('PluginManager', () => {
   });
 
   describe('#loadAllPlugins()', () => {
-    beforeEach(() => {
+    beforeEach(function () { // eslint-disable-line prefer-arrow-callback
       mockRequire('ServicePluginMock1', ServicePluginMock1);
       mockRequire('ServicePluginMock2', ServicePluginMock2);
     });
@@ -396,7 +396,7 @@ describe('PluginManager', () => {
       expect(pluginManager.plugins[2]).to.be.instanceof(ServicePluginMock2);
     });
 
-    afterEach(() => {
+    afterEach(function () { // eslint-disable-line prefer-arrow-callback
       mockRequire.stop('ServicePluginMock1');
       mockRequire.stop('ServicePluginMock2');
     });
@@ -411,7 +411,7 @@ describe('PluginManager', () => {
   });
 
   describe('#loadServicePlugins()', () => {
-    beforeEach(() => {
+    beforeEach(function () { // eslint-disable-line prefer-arrow-callback
       mockRequire('ServicePluginMock1', ServicePluginMock1);
       mockRequire('ServicePluginMock2', ServicePluginMock2);
     });
@@ -427,7 +427,7 @@ describe('PluginManager', () => {
       expect(pluginManager.plugins).to.contain(servicePluginMock2);
     });
 
-    afterEach(() => {
+    afterEach(function () { // eslint-disable-line prefer-arrow-callback
       mockRequire.stop('ServicePluginMock1');
       mockRequire.stop('ServicePluginMock2');
     });
@@ -443,7 +443,7 @@ describe('PluginManager', () => {
   });
 
   describe('#getEvents()', () => {
-    beforeEach(() => {
+    beforeEach(function () { // eslint-disable-line prefer-arrow-callback
       const synchronousPluginMockInstance = new SynchronousPluginMock();
       pluginManager.loadCommands(synchronousPluginMockInstance);
     });
@@ -481,7 +481,7 @@ describe('PluginManager', () => {
   });
 
   describe('#getPlugins()', () => {
-    beforeEach(() => {
+    beforeEach(function () { // eslint-disable-line prefer-arrow-callback
       mockRequire('ServicePluginMock1', ServicePluginMock1);
       mockRequire('ServicePluginMock2', ServicePluginMock2);
     });
@@ -494,7 +494,7 @@ describe('PluginManager', () => {
       expect(pluginManager.getPlugins()[1]).to.be.instanceof(ServicePluginMock2);
     });
 
-    afterEach(() => {
+    afterEach(function () { // eslint-disable-line prefer-arrow-callback
       mockRequire.stop('ServicePluginMock1');
       mockRequire.stop('ServicePluginMock2');
     });
@@ -692,7 +692,7 @@ describe('PluginManager', () => {
     });
 
     describe('when using a synchronous hook function', () => {
-      beforeEach(() => {
+      beforeEach(function () { // eslint-disable-line prefer-arrow-callback
         pluginManager.addPlugin(SynchronousPluginMock);
       });
 
@@ -716,7 +716,7 @@ describe('PluginManager', () => {
     });
 
     describe('when using a promise based hook function', () => {
-      beforeEach(() => {
+      beforeEach(function () { // eslint-disable-line prefer-arrow-callback
         pluginManager.addPlugin(PromisePluginMock);
       });
 
@@ -740,7 +740,7 @@ describe('PluginManager', () => {
     });
 
     describe('when using provider specific plugins', () => {
-      beforeEach(() => {
+      beforeEach(function () { // eslint-disable-line prefer-arrow-callback
         pluginManager.setProvider('provider1');
 
         pluginManager.addPlugin(Provider1PluginMock);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it
-->

## What did you implement:

Sometimes tests fail because integration tests have too limited timeouts set, setting timeouts higher for those integrationt tests.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works, e.g. an example serverless.yml
or AWS CLI commands to trigger something.
-->


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Leave a comment that this is ready for review once you've finished the implementation

