### PR TITLE
[DOCS] Fix AWS::ApiGateway::Method format

### DIFF
--- a/docs/02-providers/aws/events/01-apigateway.md
+++ b/docs/02-providers/aws/events/01-apigateway.md
@@ -380,12 +380,12 @@ resources:
         RestApiId:
           Ref: ApiGatewayRestApi
     ProxyMethod:
-      ResourceId:
-        Ref: ProxyResource
-      RestApiId:
-        Ref: ApiGatewayRestApi
       Type: AWS::ApiGateway::Method
       Properties:
+        ResourceId:
+          Ref: ProxyResource
+        RestApiId:
+          Ref: ApiGatewayRestApi
         HttpMethod: GET # the method of your proxy. Is it GET or POST or ... ?
         MethodResponses:
           - StatusCode: 200


### PR DESCRIPTION
## What did you implement:

Fixed the AWS::ApiGateway::Method referenced in the docs. According to [the AWS docs][docs] `ResourceId` and `RestApiId` should be members of `Properties`.

[docs]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#aws-resource-apigateway-method-syntax.yaml

## How did you implement it:

I changed the code example to match the AWS docs.

## How can we verify it:

Compare Amazon's [YAML example][docs] to my alteration.

***Is this ready for review?:*** YES