### PR TITLE
Add subdirectory for tmpDirs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage
 node_modules
 tmp
+tmpdirs-serverless

--- a/.gitignore
+++ b/.gitignore
@@ -27,16 +27,17 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 
-#IDE Stuff
+# IDE stuff
 **/.idea
 
-#OS STUFF
+# OS stuff
 .DS_Store
 .tmp
 
-#SERVERLESS STUFF
+# Serverless stuff
 admin.env
 .env
 tmp
 .coveralls.yml
 tracking-id
+tmpdirs-serverless

--- a/lib/plugins/aws/deploy/tests/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/tests/uploadArtifacts.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const sinon = require('sinon');
-const os = require('os');
 const path = require('path');
 const BbPromise = require('bluebird');
 const expect = require('chai').expect;

--- a/lib/plugins/aws/deploy/tests/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/tests/uploadArtifacts.js
@@ -7,6 +7,7 @@ const BbPromise = require('bluebird');
 const expect = require('chai').expect;
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+const testUtils = require('../../../../../tests/utils');
 
 describe('uploadArtifacts', () => {
   let serverless;
@@ -61,7 +62,7 @@ describe('uploadArtifacts', () => {
     });
 
     it('should upload the .zip file to the S3 bucket', () => {
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
+      const tmpDirPath = testUtils.getTmpDirPath();
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -7,6 +7,7 @@ const expect = require('chai').expect;
 const Service = require('../../lib/classes/Service');
 const Utils = require('../../lib/classes/Utils');
 const Serverless = require('../../lib/Serverless');
+const testUtils = require('../../tests/utils');
 
 describe('Service', () => {
   describe('#constructor()', () => {
@@ -101,6 +102,11 @@ describe('Service', () => {
 
   describe('#load()', () => {
     let serviceInstance;
+    let tmpDirPath;
+
+    beforeEach(() => {
+      tmpDirPath = testUtils.getTmpDirPath();
+    });
 
     it('should resolve if no servicePath is found', () => {
       const serverless = new Serverless();
@@ -111,7 +117,6 @@ describe('Service', () => {
 
     it('should load from filesystem', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'new-service',
         provider: 'aws',
@@ -164,7 +169,6 @@ describe('Service', () => {
 
     it('should make sure function name contains the default stage', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'new-service',
         provider: 'aws',
@@ -206,7 +210,6 @@ describe('Service', () => {
 
     it('should support Serverless file with a .yaml extension', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYaml = {
         service: 'my-service',
         provider: 'aws',
@@ -238,7 +241,6 @@ describe('Service', () => {
 
     it('should support Serverless file with a .yml extension', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'my-service',
         provider: 'aws',
@@ -268,7 +270,6 @@ describe('Service', () => {
 
     it('should throw error if service property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         provider: 'aws',
         functions: {},
@@ -290,7 +291,6 @@ describe('Service', () => {
 
     it('should throw error if provider property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'service-name',
         functions: {},
@@ -312,7 +312,6 @@ describe('Service', () => {
 
     it('should throw error if functions property is missing', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -334,7 +333,6 @@ describe('Service', () => {
 
     it("should throw error if a function's event is not an array", () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'service-name',
         provider: 'aws',
@@ -361,7 +359,6 @@ describe('Service', () => {
 
     it('should throw error if provider property is invalid', () => {
       const SUtils = new Utils();
-      const tmpDirPath = path.join(os.tmpdir(), (new Date()).getTime().toString());
       const serverlessYml = {
         service: 'service-name',
         provider: 'invalid',

--- a/tests/classes/Service.js
+++ b/tests/classes/Service.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const os = require('os');
 const YAML = require('js-yaml');
 const expect = require('chai').expect;
 const Service = require('../../lib/classes/Service');

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -4,7 +4,8 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 
-const getTmpDirPath = () => path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+const getTmpDirPath = () => path.join(os.tmpdir(),
+  'tmpdirs-serverless', 'serverless', crypto.randomBytes(8).toString('hex'));
 
 const getTmpFilePath = (fileName) => path.join(getTmpDirPath(), fileName);
 


### PR DESCRIPTION
## What did you implement:

Add a subdirectory so that all directories which are generated for the tests are stored there.
Furthermore old tests are updated so that they use the tmpDir name generated by the test
utils functionality. This makes working with Docker way better as the tmpDirs are not created
It the root directory.

**Note:** This PR play nicely together with e.g. this one https://github.com/serverless/integration-test-suite/pull/25 as it uses the same nesting (tmpDirs created by both will be stored in the `tmpdirs-serverless` directory).

## How did you implement it:

Added subdirectories to the path the `getTmpDirPath` test utils method generates.

## How can we verify it:

Just run `npm test`. You won't see any differences (as long as you are not using Docker).

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

/cc @flomotlik 