### PR TITLE
Create CloudFormation::WaitCondition that depends on Deployment

### DIFF
--- a/docs/02-providers/aws/04-resource-names-reference.md
+++ b/docs/02-providers/aws/04-resource-names-reference.md
@@ -31,6 +31,6 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |ApiGateway::Resource   | ApiGatewayResource{normalizedPath}                      | <ul><li>ApiGatewayResourceUsers</li><li>ApiGatewayResourceUsers**Var** for paths containing a variable</li><li>ApiGatewayResource**Dash** if the path is just a `-`</li></ul>       |
 |ApiGateway::Method     | ApiGatewayResource{normalizedPath}{normalizedMethod}    | ApiGatewayResourceUsersGet    |
 |ApiGateway::Authorizer | {normalizedFunctionName}ApiGatewayAuthorizer            | HelloApiGatewayAuthorizer     |
-|ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
+|ApiGateway::Deployment | ApiGatewayDeployment                                    | ApiGatewayDeployment          |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |

--- a/docs/02-providers/aws/04-resource-names-reference.md
+++ b/docs/02-providers/aws/04-resource-names-reference.md
@@ -31,6 +31,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |ApiGateway::Resource   | ApiGatewayResource{normalizedPath}                      | <ul><li>ApiGatewayResourceUsers</li><li>ApiGatewayResourceUsers**Var** for paths containing a variable</li><li>ApiGatewayResource**Dash** if the path is just a `-`</li></ul>       |
 |ApiGateway::Method     | ApiGatewayResource{normalizedPath}{normalizedMethod}    | ApiGatewayResourceUsersGet    |
 |ApiGateway::Authorizer | {normalizedFunctionName}ApiGatewayAuthorizer            | HelloApiGatewayAuthorizer     |
-|ApiGateway::Deployment | ApiGatewayDeployment                                    | ApiGatewayDeployment          |
+|ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |
+|CloudFormation::WaitCondition | ApiGatewayDeploymentWait                         | ApiGatewayDeploymentWait - Used to Depend on the ApiGateway::Deployment |
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -28,7 +28,7 @@ module.exports = {
               "StageName": "${this.options.stage}"
             }]
           },
-          "DependsOn": "${this.apiGateWayDeploymentLogicalId}"
+          "DependsOn": "ApiGatewayDeployment"
         }
         `;
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -28,7 +28,7 @@ module.exports = {
               "StageName": "${this.options.stage}"
             }]
           },
-          "DependsOn": "ApiGatewayDeployment"
+          "DependsOn": "ApiGatewayDeploymentWait"
         }
         `;
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -9,22 +9,60 @@ module.exports = {
       {
         "Type" : "AWS::ApiGateway::Deployment",
         "Properties" : {
-          "Description": "${(new Date()).getTime().toString()}",
           "RestApiId" : { "Ref": "ApiGatewayRestApi" },
           "StageName" : "${this.options.stage}"
         }
       }
     `;
 
+    const deploymentLogicalName = `ApiGatewayDeployment${(new Date()).getTime().toString()}`;
     const deploymentTemplateJson = JSON.parse(deploymentTemplate);
     deploymentTemplateJson.DependsOn = this.methodDependencies;
 
     const newDeploymentObject = {
-      ApiGatewayDeployment: deploymentTemplateJson,
+      [deploymentLogicalName]: deploymentTemplateJson,
     };
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
       newDeploymentObject);
+
+    const waitConditionHandleTemplate = `
+      {
+        "Type": "AWS::CloudFormation::WaitConditionHandle",
+        "Properties": { }
+      }
+    `;
+
+    const apiGatewayDeploymentWaitHandleLogicalName = 'ApiGatewayDeploymentWaitHandle';
+    const waitConditionHandleTemplateJson = JSON.parse(waitConditionHandleTemplate);
+
+    const newWaitHandleObject = {
+      [apiGatewayDeploymentWaitHandleLogicalName]: waitConditionHandleTemplateJson,
+    };
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+      newWaitHandleObject);
+
+    const waitConditionTemplate = `
+      {
+        "Type": "AWS::CloudFormation::WaitCondition",
+        "DependsOn": "${deploymentLogicalName}",
+        "Properties": {
+          "Count" : "0",
+          "Handle" : { "Ref" : "${apiGatewayDeploymentWaitHandleLogicalName}" },
+          "Timeout" : "1"
+        }
+      }
+    `;
+
+    const waitConditionTemplateJson = JSON.parse(waitConditionTemplate);
+
+    const newWaitObject = {
+      ApiGatewayDeploymentWait: waitConditionTemplateJson,
+    };
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+      newWaitObject);
 
     // create CLF Output for endpoint
     const outputServiceEndpointTemplate = `

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -9,18 +9,18 @@ module.exports = {
       {
         "Type" : "AWS::ApiGateway::Deployment",
         "Properties" : {
+          "Description": "${(new Date()).getTime().toString()}",
           "RestApiId" : { "Ref": "ApiGatewayRestApi" },
           "StageName" : "${this.options.stage}"
         }
       }
     `;
 
-    this.apiGateWayDeploymentLogicalId = `ApiGatewayDeployment${(new Date()).getTime().toString()}`;
     const deploymentTemplateJson = JSON.parse(deploymentTemplate);
     deploymentTemplateJson.DependsOn = this.methodDependencies;
 
     const newDeploymentObject = {
-      [this.apiGateWayDeploymentLogicalId]: deploymentTemplateJson,
+      ApiGatewayDeployment: deploymentTemplateJson,
     };
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
@@ -14,9 +14,20 @@ describe('#compileDeployment()', () => {
         Type: 'AWS::ApiGateway::Deployment',
         DependsOn: ['method-dependency1', 'method-dependency2'],
         Properties: {
-          Description: '//This is replaced//',
           RestApiId: { Ref: 'ApiGatewayRestApi' },
           StageName: 'dev',
+        },
+      },
+      ApiGatewayDeploymentWaitHandle: {
+        Type: 'AWS::CloudFormation::WaitConditionHandle',
+        Properties: { },
+      },
+      ApiGatewayDeploymentWait: {
+        Type: 'AWS::CloudFormation::WaitCondition',
+        Properties: {
+          Count: '0',
+          Handle: { Ref: 'ApiGatewayDeploymentWaitHandle' },
+          Timeout: '1',
         },
       },
     },
@@ -53,26 +64,16 @@ describe('#compileDeployment()', () => {
 
   it('should create a deployment resource', () => awsCompileApigEvents
     .compileDeployment().then(() => {
-      // Replace the mock description with the actual auto generated value to allow deep equals
-      serviceResourcesAwsResourcesObjectMock.Resources.DeploymentApigEvent.Properties.Description =
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ApiGatewayDeployment.Properties.Description;
+      const deploymentLogicalId = Object
+        .keys(awsCompileApigEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources)[0];
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ApiGatewayDeployment
+          .Resources[deploymentLogicalId]
       ).to.deep.equal(
         serviceResourcesAwsResourcesObjectMock.Resources.DeploymentApigEvent
       );
-    })
-  );
-
-  it('should create a description that is a number', () => awsCompileApigEvents
-    .compileDeployment().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ApiGatewayDeployment.Properties.Description
-      ).to.be.above(0);
     })
   );
 
@@ -83,6 +84,35 @@ describe('#compileDeployment()', () => {
           .Outputs.ServiceEndpoint
       ).to.deep.equal(
         serviceResourcesAwsResourcesObjectMock.Outputs.ServiceEndpoint
+      );
+    })
+  );
+
+  it('should create a wait condition handle resource', () => awsCompileApigEvents
+    .compileDeployment().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayDeploymentWaitHandle
+      ).to.deep.equal(
+        serviceResourcesAwsResourcesObjectMock.Resources.ApiGatewayDeploymentWaitHandle
+      );
+    })
+  );
+
+  it('should create a wait condition resource', () => awsCompileApigEvents
+    .compileDeployment().then(() => {
+      const deploymentLogicalId = Object
+        .keys(awsCompileApigEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources)[0];
+
+      serviceResourcesAwsResourcesObjectMock.Resources
+        .ApiGatewayDeploymentWait.DependsOn = deploymentLogicalId;
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayDeploymentWait
+      ).to.deep.equal(
+        serviceResourcesAwsResourcesObjectMock.Resources.ApiGatewayDeploymentWait
       );
     })
   );

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
@@ -14,6 +14,7 @@ describe('#compileDeployment()', () => {
         Type: 'AWS::ApiGateway::Deployment',
         DependsOn: ['method-dependency1', 'method-dependency2'],
         Properties: {
+          Description: '//This is replaced//',
           RestApiId: { Ref: 'ApiGatewayRestApi' },
           StageName: 'dev',
         },
@@ -52,16 +53,26 @@ describe('#compileDeployment()', () => {
 
   it('should create a deployment resource', () => awsCompileApigEvents
     .compileDeployment().then(() => {
-      const deploymentLogicalId = Object
-        .keys(awsCompileApigEvents.serverless.service.provider
-          .compiledCloudFormationTemplate.Resources)[0];
+      // Replace the mock description with the actual auto generated value to allow deep equals
+      serviceResourcesAwsResourcesObjectMock.Resources.DeploymentApigEvent.Properties.Description =
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayDeployment.Properties.Description;
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources[deploymentLogicalId]
+          .Resources.ApiGatewayDeployment
       ).to.deep.equal(
         serviceResourcesAwsResourcesObjectMock.Resources.DeploymentApigEvent
       );
+    })
+  );
+
+  it('should create a description that is a number', () => awsCompileApigEvents
+    .compileDeployment().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayDeployment.Properties.Description
+      ).to.be.above(0);
     })
   );
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->
## What did you implement:

Fixes issue: https://github.com/serverless/serverless/issues/2233

<!--
Briefly describe the feature if no issue exists for this PR
-->
## How did you implement it:

I have created a CloudFormation::WaitCondition that depends on the uniquely named ApiGateway::Deployment. It is called `ApiGatewayDeploymentWait` and it is then possible to depend on this in for example ApiGateway::BasePathMapping resources.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
## How can we verify it:

Create a resource that depends on `ApiGatewayDeploymentWait` and see that they are updated after the ApiGateway::Deployment in CloudFormation.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->
## Todos:
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

**_Is this ready for review?:**_ YES
