### PR TITLE
Fix Promise chain in deployFunction plugin

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -69,16 +69,14 @@ class AwsDeployFunction {
       ZipFile: data,
     };
 
-    this.sdk.request(
+    return this.sdk.request(
       'Lambda',
       'updateFunctionCode',
       params,
       this.options.stage, this.options.region
-    );
-
-    this.serverless.cli.log(`Successfully deployed function "${this.options.function}"`);
-
-    return BbPromise.resolve();
+    ).then(() => {
+      this.serverless.cli.log(`Successfully deployed function "${this.options.function}"`);
+    });
   }
 
   cleanup() {


### PR DESCRIPTION
## What did you implement:

Add a fix so that the Promise chain in the `deployFunction` plugin resolves correctly.

## How did you implement it:

Return the whole Promise and put the success message which is printed by the console into a separate `then`.

## How can we verify it:

Just run `serverless deploy function -f <function-name>` and see that the console message is shown when the function is deployed (and not earlier like before).

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** Yes

