### PR TITLE
Add AwsCompileDynamoDbEvents plugin

### DIFF
--- a/docs/02-providers/aws/04-resource-names-reference.md
+++ b/docs/02-providers/aws/04-resource-names-reference.md
@@ -25,7 +25,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |IAM::Role              | IamRoleLambdaExecution                                  | IamRoleLambdaExecution        |
 |IAM::Policy            | IamPolicyLambdaExecution                                | IamPolicyLambdaExecution      |
 |Lambda::Function       | {normalizedFunctionName}LambdaFunction                  | HelloLambdaFunction           |
-|Lambda::Permission     | <ul><li>**Schedule**: {normalizedFunctionName}LambdaPermissionEventsRuleSchedule{index} </li><li>**S3**: {normalizedFunctionName}LambdaPermissionS3</li><li>**APIG**: {normalizedFunctionName}LambdaPermissionApiGateway</li><li>**SNS**: {normalizedFunctionName}LambdaPermission{normalizedTopicName}</li> | <ul><li>**Schedule**: HelloLambdaPermissionEventsRuleSchedule1 </li><li>**S3**: HelloLambdaPermissionS3</li><li>**APIG**: HelloLambdaPermissionApiGateway</li><li>**SNS**: HelloLambdaPermissionSometopic</li> |
+|Lambda::Permission     | <ul><li>**Schedule**: {normalizedFunctionName}LambdaPermissionEventsRuleSchedule{index} </li><li>**S3**: {normalizedFunctionName}LambdaPermissionS3</li><li>**APIG**: {normalizedFunctionName}LambdaPermissionApiGateway</li><li>**SNS**: {normalizedFunctionName}LambdaPermission{normalizedTopicName}</li></ul> | <ul><li>**Schedule**: HelloLambdaPermissionEventsRuleSchedule1 </li><li>**S3**: HelloLambdaPermissionS3</li><li>**APIG**: HelloLambdaPermissionApiGateway</li><li>**SNS**: HelloLambdaPermissionSometopic</li></ul> |
 |Events::Rule           | {normalizedFuntionName}EventsRuleSchedule{SequentialID} | HelloEventsRuleSchedule1      |
 |ApiGateway::RestApi    | ApiGatewayRestApi                                       | ApiGatewayRestApi             |
 |ApiGateway::Resource   | ApiGatewayResource{normalizedPath}                      | <ul><li>ApiGatewayResourceUsers</li><li>ApiGatewayResourceUsers**Var** for paths containing a variable</li><li>ApiGatewayResource**Dash** if the path is just a `-`</li></ul>       |
@@ -34,3 +34,4 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |
+|AWS::Lambda::EventSourceMapping | <ul><li>**DynamoDB**: {normalizedFunctionName}EventSourceMappingDynamoDb{tableName} </li></ul> | <ul><li>**DynamoDB**: HelloLambdaEventSourceMappingDynamoDbUsers </li></ul> |

--- a/docs/02-providers/aws/events/06-dynamodb-streams.md
+++ b/docs/02-providers/aws/events/06-dynamodb-streams.md
@@ -18,7 +18,7 @@ functions:
 
 ## Setting the BatchSize and StartingPosition
 
-This configuration sets up a dynamodb event for the `preprocess` function which has a batch size of `100`. The staring position is
+This configuration sets up a disabled dynamodb event for the `preprocess` function which has a batch size of `100`. The staring position is
 `LATEST`.
 
 ```yml
@@ -30,4 +30,5 @@ functions:
           streamArn: some:dynamodb:stream:arn
           bathSize: 100
           startingPosition: LATEST
+          enabled: false
 ```

--- a/docs/02-providers/aws/events/06-dynamodb-streams.md
+++ b/docs/02-providers/aws/events/06-dynamodb-streams.md
@@ -6,25 +6,28 @@ layout: Doc
 
 # DynamoDB Streams
 
-Currently there's no native support for DynamoDB Streams ([we need your feedback](https://github.com/serverless/serverless/issues/1441))
-but you can use custom provider resources to setup the mapping.
-
-**Note:** You can also create the table in the `resources.Resources` section and use `Fn::GetAtt` to reference the `StreamArn`
-in the mappings `EventSourceArn` definition.
+This setup specifies that the `compute` function should be triggered whenever the corresponding dynamodb table is modified (e.g. a new entry is added).
 
 ```yml
-# serverless.yml
+functions:
+  compute:
+    handler: handler.compute
+    events:
+      - dynamodb: some:dynamodb:stream:arn
+```
 
-resources:
-  Resources:
-    mapping:
-      Type: AWS::Lambda::EventSourceMapping
-      Properties:
-        BatchSize: 10
-        EventSourceArn: "arn:aws:dynamodb:<region>:<aws-account-id>:table/<table-name>/stream/<stream-name>"
-        FunctionName:
-          Fn::GetAtt:
-            - "<function-name>"
-            - "Arn"
-        StartingPosition: "TRIM_HORIZON"
+## Setting the BatchSize and StartingPosition
+
+This configuration sets up a dynamodb event for the `preprocess` function which has a batch size of `100`. The staring position is
+`LATEST`.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - dynamodb:
+          streamArn: some:dynamodb:stream:arn
+          bathSize: 100
+          startingPosition: LATEST
 ```

--- a/lib/plugins/Plugins.json
+++ b/lib/plugins/Plugins.json
@@ -18,6 +18,7 @@
     "./aws/deploy/compile/events/s3/index.js",
     "./aws/deploy/compile/events/apiGateway/index.js",
     "./aws/deploy/compile/events/sns/index.js",
+    "./aws/deploy/compile/events/dynamodb/index.js",
     "./aws/deployFunction/index.js"
   ]
 }

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/README.md
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/README.md
@@ -39,7 +39,7 @@ functions:
 
 ### Dynamodb setup with extended event options
 
-This configuration sets up dynamodb event for the `preprocess` function which has a batch size of `100`. The staring position is
+This configuration sets up a disabled dynamodb event for the `preprocess` function which has a batch size of `100`. The staring position is
 `LATEST`.
 
 ```yml
@@ -52,4 +52,5 @@ functions:
           streamArn: some:dynamodb:stream:arn
           bathSize: 100
           startingPosition: LATEST
+          enabled: false
 ```

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
@@ -15,12 +15,10 @@ class AwsCompileDynamoDbEvents {
   compileDynamoDbEvents() {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionObj = this.serverless.service.getFunction(functionName);
-      let dynamoDbNumberInFunction = 0;
 
       if (functionObj.events) {
         functionObj.events.forEach(event => {
           if (event.dynamodb) {
-            dynamoDbNumberInFunction++;
             let EventSourceArn;
             let BatchSize = 10;
             let StartingPosition = 'TRIM_HORIZON';
@@ -99,9 +97,13 @@ class AwsCompileDynamoDbEvents {
               .PolicyDocument
               .Statement = statement.concat([dynamoDbStatement]);
 
+            let tableName = EventSourceArn.split('/')[1];
+            // normalize the tableName
+            tableName = tableName[0].toUpperCase() + tableName.substr(1);
+
             const newDynamoDbObject = {
-              [`${normalizedFunctionName}EventSourceMappingDynamoDb${
-                dynamoDbNumberInFunction}`]: JSON.parse(dynamoDbTemplate),
+              [`${normalizedFunctionName}EventSourceMappingDynamoDbTable${
+                tableName}`]: JSON.parse(dynamoDbTemplate),
             };
 
             _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const _ = require('lodash');
+
+class AwsCompileDynamoDbEvents {
+  constructor(serverless) {
+    this.serverless = serverless;
+    this.provider = 'aws';
+
+    this.hooks = {
+      'deploy:compileEvents': this.compileDynamoDbEvents.bind(this),
+    };
+  }
+
+  compileDynamoDbEvents() {
+    this.serverless.service.getAllFunctions().forEach((functionName) => {
+      const functionObj = this.serverless.service.getFunction(functionName);
+      let dynamoDbNumberInFunction = 0;
+
+      if (functionObj.events) {
+        functionObj.events.forEach(event => {
+          if (event.dynamodb) {
+            dynamoDbNumberInFunction++;
+            let EventSourceArn;
+            let BatchSize = 10;
+            let StartingPosition = 'TRIM_HORIZON';
+
+            // TODO validate streamArn syntax
+            if (typeof event.dynamodb === 'object') {
+              if (!event.dynamodb.streamArn) {
+                const errorMessage = [
+                  `Missing "streamArn" property for dynamodb event in function "${functionName}"`,
+                  ' The correct syntax is: dynamodb: <streamArn>',
+                  ' OR an object with "streamArn" property.',
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes
+                  .Error(errorMessage);
+              }
+              EventSourceArn = event.dynamodb.streamArn;
+              BatchSize = event.dynamodb.batchSize
+                || BatchSize;
+              StartingPosition = event.dynamodb.startingPosition
+                || StartingPosition;
+            } else if (typeof event.dynamodb === 'string') {
+              EventSourceArn = event.dynamodb;
+            } else {
+              const errorMessage = [
+                `DynamoDB event of function "${functionName}" is not an object nor a string`,
+                ' The correct syntax is: dynamodb: <streamArn>',
+                ' OR an object with "streamArn" property.',
+                ' Please check the docs for more info.',
+              ].join('');
+              throw new this.serverless.classes
+                .Error(errorMessage);
+            }
+
+            const normalizedFunctionName = functionName[0].toUpperCase() + functionName.substr(1);
+
+            const dynamoDbTemplate = `
+              {
+                "Type": "AWS::Lambda::EventSourceMapping",
+                "Properties": {
+                  "BatchSize": ${BatchSize},
+                  "EventSourceArn": "${EventSourceArn}",
+                  "FunctionName": {
+                    "Fn::GetAtt": [
+                      "${normalizedFunctionName}LambdaFunction",
+                      "Arn"
+                    ]
+                  },
+                  "StartingPosition": "${StartingPosition}"
+                }
+              }
+            `;
+
+            const dynamoDbStatement = {
+              Effect: 'Allow',
+              Action: [
+                'dynamodb:GetRecords',
+                'dynamodb:GetShardIterator',
+                'dynamodb:DescribeStream',
+                'dynamodb:ListStreams',
+              ],
+              Resource: EventSourceArn,
+            };
+
+            const statement = this.serverless.service.provider.compiledCloudFormationTemplate
+              .Resources
+              .IamPolicyLambdaExecution
+              .Properties
+              .PolicyDocument
+              .Statement;
+
+            this.serverless.service.provider.compiledCloudFormationTemplate
+              .Resources
+              .IamPolicyLambdaExecution
+              .Properties
+              .PolicyDocument
+              .Statement = statement.concat([dynamoDbStatement]);
+
+            const newDynamoDbObject = {
+              [`${normalizedFunctionName}EventSourceMappingDynamoDb${
+                dynamoDbNumberInFunction}`]: JSON.parse(dynamoDbTemplate),
+            };
+
+            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+              newDynamoDbObject);
+          }
+        });
+      }
+    });
+  }
+}
+
+module.exports = AwsCompileDynamoDbEvents;

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
@@ -58,6 +58,7 @@ class AwsCompileDynamoDbEvents {
             const dynamoDbTemplate = `
               {
                 "Type": "AWS::Lambda::EventSourceMapping",
+                "DependsOn": "IamPolicyLambdaExecution",
                 "Properties": {
                   "BatchSize": ${BatchSize},
                   "EventSourceArn": "${EventSourceArn}",

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
@@ -22,6 +22,7 @@ class AwsCompileDynamoDbEvents {
             let EventSourceArn;
             let BatchSize = 10;
             let StartingPosition = 'TRIM_HORIZON';
+            let Enabled = 'True';
 
             // TODO validate streamArn syntax
             if (typeof event.dynamodb === 'object') {
@@ -40,6 +41,9 @@ class AwsCompileDynamoDbEvents {
                 || BatchSize;
               StartingPosition = event.dynamodb.startingPosition
                 || StartingPosition;
+              if (typeof event.dynamodb.enabled !== 'undefined') {
+                Enabled = event.dynamodb.enabled ? 'True' : 'False';
+              }
             } else if (typeof event.dynamodb === 'string') {
               EventSourceArn = event.dynamodb;
             } else {
@@ -68,7 +72,8 @@ class AwsCompileDynamoDbEvents {
                       "Arn"
                     ]
                   },
-                  "StartingPosition": "${StartingPosition}"
+                  "StartingPosition": "${StartingPosition}",
+                  "Enabled": "${Enabled}"
                 }
               }
             `;

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/index.js
@@ -108,7 +108,7 @@ class AwsCompileDynamoDbEvents {
             tableName = tableName[0].toUpperCase() + tableName.substr(1);
 
             const newDynamoDbObject = {
-              [`${normalizedFunctionName}EventSourceMappingDynamoDbTable${
+              [`${normalizedFunctionName}EventSourceMappingDynamoDb${
                 tableName}`]: JSON.parse(dynamoDbTemplate),
             };
 

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
@@ -70,6 +70,7 @@ describe('AwsCompileDynamoDbEvents', () => {
                 streamArn: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
                 batchSize: 1,
                 startingPosition: 'STARTING_POSITION_ONE',
+                enabled: false,
               },
             },
             {
@@ -116,6 +117,10 @@ describe('AwsCompileDynamoDbEvents', () => {
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
         .dynamodb.startingPosition
       );
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .Properties.Enabled
+      ).to.equal('False');
 
       // event 2
       expect(awsCompileDynamoDbEvents.serverless.service
@@ -141,6 +146,10 @@ describe('AwsCompileDynamoDbEvents', () => {
         .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
         .Properties.StartingPosition
       ).to.equal('TRIM_HORIZON');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .Properties.Enabled
+      ).to.equal('True');
 
       // event 3
       expect(awsCompileDynamoDbEvents.serverless.service
@@ -166,6 +175,10 @@ describe('AwsCompileDynamoDbEvents', () => {
         .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Properties.StartingPosition
       ).to.equal('TRIM_HORIZON');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .Properties.Enabled
+      ).to.equal('True');
     });
 
     it('should add the necessary IAM role statements', () => {

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
@@ -89,94 +89,94 @@ describe('AwsCompileDynamoDbEvents', () => {
 
       // event 1
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbFoo
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbFoo
         .DependsOn
       ).to.equal('IamPolicyLambdaExecution');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbFoo
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
         .dynamodb.streamArn
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbFoo
         .Properties.BatchSize
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
         .dynamodb.batchSize
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbFoo
         .Properties.StartingPosition
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
         .dynamodb.startingPosition
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbFoo
         .Properties.Enabled
       ).to.equal('False');
 
       // event 2
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBar
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBar
         .DependsOn
       ).to.equal('IamPolicyLambdaExecution');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBar
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[1]
         .dynamodb.streamArn
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBar
         .Properties.BatchSize
       ).to.equal(10);
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBar
         .Properties.StartingPosition
       ).to.equal('TRIM_HORIZON');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBar
         .Properties.Enabled
       ).to.equal('True');
 
       // event 3
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBaz
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBaz
         .DependsOn
       ).to.equal('IamPolicyLambdaExecution');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBaz
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[2]
         .dynamodb
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBaz
         .Properties.BatchSize
       ).to.equal(10);
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBaz
         .Properties.StartingPosition
       ).to.equal('TRIM_HORIZON');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbBaz
         .Properties.Enabled
       ).to.equal('True');
     });

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
@@ -67,18 +67,18 @@ describe('AwsCompileDynamoDbEvents', () => {
           events: [
             {
               dynamodb: {
-                streamArn: 'stream:arn:one',
+                streamArn: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
                 batchSize: 1,
                 startingPosition: 'STARTING_POSITION_ONE',
               },
             },
             {
               dynamodb: {
-                streamArn: 'stream:arn:two',
+                streamArn: 'arn:aws:dynamodb:region:account:table/bar/stream/2',
               },
             },
             {
-              dynamodb: 'stream:arn:three',
+              dynamodb: 'arn:aws:dynamodb:region:account:table/baz/stream/3',
             },
           ],
         },
@@ -88,25 +88,25 @@ describe('AwsCompileDynamoDbEvents', () => {
 
       // event 1
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
         .dynamodb.streamArn
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
         .Properties.BatchSize
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
         .dynamodb.batchSize
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
         .Properties.StartingPosition
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
@@ -115,43 +115,43 @@ describe('AwsCompileDynamoDbEvents', () => {
 
       // event 2
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[1]
         .dynamodb.streamArn
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
         .Properties.BatchSize
       ).to.equal(10);
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
         .Properties.StartingPosition
       ).to.equal('TRIM_HORIZON');
 
       // event 3
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[2]
         .dynamodb
       );
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Properties.BatchSize
       ).to.equal(10);
       expect(awsCompileDynamoDbEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Properties.StartingPosition
       ).to.equal('TRIM_HORIZON');
     });
@@ -161,7 +161,7 @@ describe('AwsCompileDynamoDbEvents', () => {
         first: {
           events: [
             {
-              dynamodb: 'stream:arn:one',
+              dynamodb: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
             },
           ],
         },
@@ -176,7 +176,7 @@ describe('AwsCompileDynamoDbEvents', () => {
             'dynamodb:DescribeStream',
             'dynamodb:ListStreams',
           ],
-          Resource: 'stream:arn:one',
+          Resource: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
         },
       ];
 
@@ -203,11 +203,6 @@ describe('AwsCompileDynamoDbEvents', () => {
         Object.keys(awsCompileDynamoDbEvents.serverless.service.provider
           .compiledCloudFormationTemplate.Resources).length
       ).to.equal(1);
-
-      expect(
-        awsCompileDynamoDbEvents.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources
-      ).to.not.include.keys('FirstEventSourceMappingDynamoDb1');
     });
 
     it('should not add the IAM role statements when dynamodb events are not given', () => {

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
@@ -93,6 +93,10 @@ describe('AwsCompileDynamoDbEvents', () => {
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
+        .DependsOn
+      ).to.equal('IamPolicyLambdaExecution');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableFoo
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
@@ -120,6 +124,10 @@ describe('AwsCompileDynamoDbEvents', () => {
       ).to.equal('AWS::Lambda::EventSourceMapping');
       expect(awsCompileDynamoDbEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
+        .DependsOn
+      ).to.equal('IamPolicyLambdaExecution');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBar
         .Properties.EventSourceArn
       ).to.equal(
         awsCompileDynamoDbEvents.serverless.service.functions.first.events[1]
@@ -139,6 +147,10 @@ describe('AwsCompileDynamoDbEvents', () => {
         .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Type
       ).to.equal('AWS::Lambda::EventSourceMapping');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
+        .DependsOn
+      ).to.equal('IamPolicyLambdaExecution');
       expect(awsCompileDynamoDbEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDbTableBaz
         .Properties.EventSourceArn

--- a/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/dynamodb/tests/index.js
@@ -1,0 +1,230 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileDynamoDbEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+
+describe('AwsCompileDynamoDbEvents', () => {
+  let serverless;
+  let awsCompileDynamoDbEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {
+        IamPolicyLambdaExecution: {
+          Properties: {
+            PolicyDocument: {
+              Statement: [],
+            },
+          },
+        },
+      },
+    };
+    awsCompileDynamoDbEvents = new AwsCompileDynamoDbEvents(serverless);
+    awsCompileDynamoDbEvents.serverless.service.service = 'new-service';
+  });
+
+  describe('#constructor()', () => {
+    it('should set the provider variable to "aws"', () => expect(awsCompileDynamoDbEvents.provider)
+      .to.equal('aws'));
+  });
+
+  describe('#compileDynamoDbEvents()', () => {
+    it('should throw an error if dynamodb event type is not a string or an object', () => {
+      awsCompileDynamoDbEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              dynamodb: 42,
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileDynamoDbEvents.compileDynamoDbEvents()).to.throw(Error);
+    });
+
+    it('should throw an error if the "streamArn" property is not given', () => {
+      awsCompileDynamoDbEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              dynamodb: {
+                streamArn: null,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileDynamoDbEvents.compileDynamoDbEvents()).to.throw(Error);
+    });
+
+    it('should create event source mappings when dynamodb events are given', () => {
+      awsCompileDynamoDbEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              dynamodb: {
+                streamArn: 'stream:arn:one',
+                batchSize: 1,
+                startingPosition: 'STARTING_POSITION_ONE',
+              },
+            },
+            {
+              dynamodb: {
+                streamArn: 'stream:arn:two',
+              },
+            },
+            {
+              dynamodb: 'stream:arn:three',
+            },
+          ],
+        },
+      };
+
+      awsCompileDynamoDbEvents.compileDynamoDbEvents();
+
+      // event 1
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .Type
+      ).to.equal('AWS::Lambda::EventSourceMapping');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .Properties.EventSourceArn
+      ).to.equal(
+        awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
+        .dynamodb.streamArn
+      );
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .Properties.BatchSize
+      ).to.equal(
+        awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
+        .dynamodb.batchSize
+      );
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb1
+        .Properties.StartingPosition
+      ).to.equal(
+        awsCompileDynamoDbEvents.serverless.service.functions.first.events[0]
+        .dynamodb.startingPosition
+      );
+
+      // event 2
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .Type
+      ).to.equal('AWS::Lambda::EventSourceMapping');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .Properties.EventSourceArn
+      ).to.equal(
+        awsCompileDynamoDbEvents.serverless.service.functions.first.events[1]
+        .dynamodb.streamArn
+      );
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .Properties.BatchSize
+      ).to.equal(10);
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb2
+        .Properties.StartingPosition
+      ).to.equal('TRIM_HORIZON');
+
+      // event 3
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .Type
+      ).to.equal('AWS::Lambda::EventSourceMapping');
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .Properties.EventSourceArn
+      ).to.equal(
+        awsCompileDynamoDbEvents.serverless.service.functions.first.events[2]
+        .dynamodb
+      );
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .Properties.BatchSize
+      ).to.equal(10);
+      expect(awsCompileDynamoDbEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamoDb3
+        .Properties.StartingPosition
+      ).to.equal('TRIM_HORIZON');
+    });
+
+    it('should add the necessary IAM role statements', () => {
+      awsCompileDynamoDbEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              dynamodb: 'stream:arn:one',
+            },
+          ],
+        },
+      };
+
+      const iamRoleStatements = [
+        {
+          Effect: 'Allow',
+          Action: [
+            'dynamodb:GetRecords',
+            'dynamodb:GetShardIterator',
+            'dynamodb:DescribeStream',
+            'dynamodb:ListStreams',
+          ],
+          Resource: 'stream:arn:one',
+        },
+      ];
+
+      awsCompileDynamoDbEvents.compileDynamoDbEvents();
+
+      expect(awsCompileDynamoDbEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .IamPolicyLambdaExecution.Properties
+        .PolicyDocument.Statement
+      ).to.deep.equal(iamRoleStatements);
+    });
+
+    it('should not create event source mapping when dynamodb events are not given', () => {
+      awsCompileDynamoDbEvents.serverless.service.functions = {
+        first: {
+          events: [],
+        },
+      };
+
+      awsCompileDynamoDbEvents.compileDynamoDbEvents();
+
+      // should be 1 because we've mocked the IamPolicyLambdaExecution above
+      expect(
+        Object.keys(awsCompileDynamoDbEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources).length
+      ).to.equal(1);
+
+      expect(
+        awsCompileDynamoDbEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources
+      ).to.not.include.keys('FirstEventSourceMappingDynamoDb1');
+    });
+
+    it('should not add the IAM role statements when dynamodb events are not given', () => {
+      awsCompileDynamoDbEvents.serverless.service.functions = {
+        first: {
+          events: [],
+        },
+      };
+
+      awsCompileDynamoDbEvents.compileDynamoDbEvents();
+
+      expect(
+        awsCompileDynamoDbEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .IamPolicyLambdaExecution.Properties
+          .PolicyDocument.Statement.length
+      ).to.equal(0);
+    });
+  });
+});

--- a/tests/all.js
+++ b/tests/all.js
@@ -34,6 +34,7 @@ require('../lib/plugins/aws/deploy/compile/events/s3/tests');
 require('../lib/plugins/aws/deploy/compile/events/schedule/tests');
 require('../lib/plugins/aws/deploy/compile/events/apiGateway/tests/all');
 require('../lib/plugins/aws/deploy/compile/events/sns/tests');
+require('../lib/plugins/aws/deploy/compile/events/dynamodb/tests');
 require('../lib/plugins/aws/deployFunction/tests/index');
 
 // Other Tests


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #1441

Adds support for the `dynamodb` event definition. No need to set it up through custom resources anymore.

## How did you implement it:

Introduced a new plugin which will compile the corresponding EventSourceMappings for CloudFormation. Furthermore the `IamRoleStatements` are updated so that the DynamoDB table can make sure that the lambda function is triggered.

## How can we verify it:

First of all you need to create a new DynamoDB table and set up a new Stream for that table (In `Overview` --> `Stream details` --> `Manage Stream`. Copy and paste the ARN for the stream.

Next up use this `serverless.yml` file and paste the ARN you've just copied:

```yml
service: new-test-service

provider:
  name: aws
  runtime: nodejs4.3

functions:
  hello:
    handler: handler.hello
    events:
      - dynamodb: <the:stream:arn>
      - dynamodb:
          streamArn: <the:stream:arn>
          batchSize: 200
          startingPosition: LATEST
          enabled: false
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES