### PR TITLE
Allow Inclusion after Exclusion using ! Globs

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -16,9 +16,21 @@ Sometimes you might like to have more control over your function artifacts and h
 
 You can use the `package` and `exclude` configuration for more control over the packaging process.
 
-## Exclude
+## Exclude / include
 
-Exclude allows you to define globs that will be excluded from the resulting artifact.
+Exclude allows you to define globs that will be excluded from the resulting artifact. If you wish to
+include files you can use a glob pattern prefixed with `!` such as `!re-include-me/**`. Serverless will run the glob patterns in order.
+
+## Example
+
+Exclude all node_modules but then re-include a specific modules (in this case node-fetch)
+
+``` yaml
+package:
+  exclude:
+    - node_modules/**
+    - !node_modules/node-fetch/**
+```
 
 ```
 exclude:

--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -29,7 +29,7 @@ Exclude all node_modules but then re-include a specific modules (in this case no
 package:
   exclude:
     - node_modules/**
-    - !node_modules/node-fetch/**
+    - "!node_modules/node-fetch/**"
 ```
 
 ```

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -18,7 +18,7 @@ module.exports = {
     const packageExcludes = this.serverless.service.package.exclude || [];
 
     // add defaults for exclude
-    return _.union(exclude, packageExcludes, this.defaultExcludes);
+    return _.union(this.defaultExcludes, packageExcludes, exclude);
   },
 
   getServiceArtifactName() {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -38,6 +38,7 @@ module.exports = {
         cwd: servicePath,
         dot: true,
         silent: true,
+        follow: true,
       });
 
       files.forEach((filePath) => {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -4,11 +4,20 @@ const archiver = require('archiver');
 const BbPromise = require('bluebird');
 const path = require('path');
 const fs = require('fs');
-const glob = require('glob');
+const glob = require('glob-all');
 
 module.exports = {
   zipDirectory(servicePath, exclude, zipFileName) {
-    exclude.push('.serverless/**');
+    const patterns = ['**'];
+    exclude.forEach((pattern) => {
+      if (pattern.charAt(0) !== '!') {
+        patterns.push(`!${pattern}`);
+      } else {
+        patterns.push(pattern.substring(1));
+      }
+    });
+
+    patterns.push('!.serverless/**');
 
     const zip = archiver.create('zip');
 
@@ -25,9 +34,8 @@ module.exports = {
     output.on('open', () => {
       zip.pipe(output);
 
-      const files = glob.sync('**', {
+      const files = glob.sync(patterns, {
         cwd: servicePath,
-        ignore: exclude,
         dot: true,
         silent: true,
       });

--- a/lib/plugins/package/tests/packageService.js
+++ b/lib/plugins/package/tests/packageService.js
@@ -32,11 +32,10 @@ describe('#packageService()', () => {
 
       const exclude = packageService.getExcludedPaths();
       expect(exclude).to.deep.equal([
-        'dir', 'file.js',
         '.git', '.gitignore', '.DS_Store',
         'npm-debug.log',
         'serverless.yaml', 'serverless.yml',
-        '.serverless',
+        '.serverless', 'dir', 'file.js',
       ]);
     });
 
@@ -52,12 +51,11 @@ describe('#packageService()', () => {
 
       const exclude = packageService.getExcludedPaths(funcExclude);
       expect(exclude).to.deep.equal([
-        'lib', 'other.js',
-        'dir', 'file.js',
         '.git', '.gitignore', '.DS_Store',
         'npm-debug.log',
         'serverless.yaml', 'serverless.yml',
-        '.serverless',
+        '.serverless', 'dir', 'file.js',
+        'lib', 'other.js',
       ]);
     });
   });

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -177,8 +177,9 @@ describe('#zipService()', () => {
 
   it('should exclude globs', () => {
     const exclude = [
-      'exclude-me*/**',
       'node_modules/exclude-me/**',
+      'exclude-me/**',
+      'exclude-me.js',
     ];
 
     const zipFileName = getTestArtifactFileName('re-include');
@@ -214,6 +215,52 @@ describe('#zipService()', () => {
 
       expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
         .to.equal('node_modules/include-me/include-aswell');
+    });
+  });
+
+  it('should re-include files using ! glob pattern', () => {
+    const exclude = [
+      'node_modules/exclude-me/**',
+      'exclude-me/**',
+      '!exclude-me.js',
+    ];
+
+    const zipFileName = getTestArtifactFileName('re-include');
+
+    return packageService.zipDirectory(servicePath, exclude, zipFileName)
+    .then((artifact) => {
+      const data = fs.readFileSync(artifact);
+
+      return zip.loadAsync(data);
+    }).then(unzippedData => {
+      const unzippedFileData = unzippedData.files;
+
+      expect(Object.keys(unzippedFileData)
+             .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
+
+      expect(unzippedFileData['handler.js'].name)
+        .to.equal('handler.js');
+
+      expect(unzippedFileData['lib/function.js'].name)
+        .to.equal('lib/function.js');
+
+      expect(unzippedFileData['include-me.js'].name)
+        .to.equal('include-me.js');
+
+      expect(unzippedFileData['include-me/some-file'].name)
+        .to.equal('include-me/some-file');
+
+      expect(unzippedFileData['a-serverless-plugin.js'].name)
+        .to.equal('a-serverless-plugin.js');
+
+      expect(unzippedFileData['node_modules/include-me/include'].name)
+        .to.equal('node_modules/include-me/include');
+
+      expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
+        .to.equal('node_modules/include-me/include-aswell');
+
+      expect(unzippedFileData['exclude-me.js'].name)
+        .to.equal('exclude-me.js');
     });
   });
 });

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -222,7 +222,7 @@ describe('#zipService()', () => {
     const exclude = [
       'node_modules/exclude-me/**',
       'exclude-me/**',
-      '!exclude-me.js',
+      '!include-me.js',
     ];
 
     const zipFileName = getTestArtifactFileName('re-include');
@@ -259,8 +259,8 @@ describe('#zipService()', () => {
       expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
         .to.equal('node_modules/include-me/include-aswell');
 
-      expect(unzippedFileData['exclude-me.js'].name)
-        .to.equal('exclude-me.js');
+      expect(unzippedFileData['include-me.js'].name)
+        .to.equal('include-me.js');
     });
   });
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,9 +23,9 @@
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.1.0.tgz",
       "dependencies": {
         "async": {
-          "version": "2.0.1",
+          "version": "2.1.1",
           "from": "async@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.1.tgz"
         }
       }
     },
@@ -35,9 +35,9 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz"
     },
     "argparse": {
-      "version": "1.0.7",
+      "version": "1.0.9",
       "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
     },
     "async": {
       "version": "1.5.2",
@@ -45,21 +45,9 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "aws-sdk": {
-      "version": "2.6.7",
-      "from": "aws-sdk@2.6.7",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.7.tgz",
-      "dependencies": {
-        "base64-js": {
-          "version": "1.2.0",
-          "from": "base64-js@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
-        },
-        "buffer": {
-          "version": "4.9.1",
-          "from": "buffer@4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
-        }
-      }
+      "version": "2.6.8",
+      "from": "aws-sdk@>=2.3.17 <3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.8.tgz"
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -67,13 +55,13 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base64-js": {
-      "version": "0.0.8",
-      "from": "base64-js@0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+      "version": "1.2.0",
+      "from": "base64-js@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.1.2 <1.2.0",
+      "from": "bl@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "dependencies": {
         "readable-stream": {
@@ -85,7 +73,7 @@
     },
     "bluebird": {
       "version": "3.4.6",
-      "from": "bluebird@3.4.6",
+      "from": "bluebird@>=3.4.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
     },
     "brace-expansion": {
@@ -94,9 +82,9 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "buffer": {
-      "version": "3.6.0",
-      "from": "buffer@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
+      "version": "4.9.1",
+      "from": "buffer@4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
     },
     "buffer-crc32": {
       "version": "0.2.5",
@@ -120,7 +108,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.0 <2.0.0",
+      "from": "chalk@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "combined-stream": {
@@ -129,9 +117,9 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
-      "version": "2.9.0",
-      "from": "commander@>=2.9.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+      "version": "2.8.1",
+      "from": "commander@>=2.8.1 <2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -175,7 +163,7 @@
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <3.0.0",
+      "from": "debug@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decompress": {
@@ -231,7 +219,14 @@
     "end-of-stream": {
       "version": "1.1.0",
       "from": "end-of-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+        }
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -280,7 +275,7 @@
     },
     "fs-extra": {
       "version": "0.26.7",
-      "from": "fs-extra@>=0.26.4 <0.27.0",
+      "from": "fs-extra@>=0.26.7 <0.27.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
     },
     "fs.realpath": {
@@ -304,9 +299,14 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz"
     },
     "glob": {
-      "version": "7.1.0",
-      "from": "glob@7.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz"
+      "version": "7.1.1",
+      "from": "glob@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+    },
+    "glob-all": {
+      "version": "3.1.0",
+      "from": "glob-all@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz"
     },
     "got": {
       "version": "6.5.0",
@@ -314,9 +314,9 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.5.0.tgz"
     },
     "graceful-fs": {
-      "version": "4.1.6",
+      "version": "4.1.9",
       "from": "graceful-fs@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -339,19 +339,19 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
-      "version": "1.1.6",
+      "version": "1.1.8",
       "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "inflight": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
       "version": "1.3.4",
@@ -385,7 +385,7 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
+      "from": "is-stream@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "isarray": {
@@ -400,18 +400,25 @@
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@>=3.5.5 <4.0.0",
+      "from": "js-yaml@>=3.6.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
     },
     "json-refs": {
       "version": "2.1.6",
       "from": "json-refs@>=2.1.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.6.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+        }
+      }
     },
     "jsonfile": {
-      "version": "2.3.1",
+      "version": "2.4.0",
       "from": "jsonfile@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
     },
     "klaw": {
       "version": "1.3.0",
@@ -425,7 +432,7 @@
     },
     "lodash": {
       "version": "4.16.4",
-      "from": "lodash@4.16.4",
+      "from": "lodash@>=4.13.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz"
     },
     "lowercase-keys": {
@@ -444,14 +451,14 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
-      "version": "1.23.0",
-      "from": "mime-db@>=1.23.0 <1.24.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+      "version": "1.24.0",
+      "from": "mime-db@>=1.24.0 <1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.11",
+      "version": "2.1.12",
       "from": "mime-types@>=2.1.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
     },
     "minimatch": {
       "version": "3.0.3",
@@ -465,7 +472,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "from": "mkdirp@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
@@ -477,7 +484,7 @@
     },
     "moment": {
       "version": "2.15.1",
-      "from": "moment@2.15.1",
+      "from": "moment@>=2.13.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
     },
     "ms": {
@@ -492,13 +499,13 @@
     },
     "node-fetch": {
       "version": "1.6.3",
-      "from": "node-fetch@1.6.3",
+      "from": "node-fetch@>=1.5.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
     "node-status-codes": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "node-status-codes@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-2.0.1.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
@@ -511,14 +518,14 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "once": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "path-is-absolute": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-loader": {
       "version": "1.0.1",
@@ -532,7 +539,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "pify@>=2.3.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
@@ -603,14 +610,7 @@
     "seek-bzip": {
       "version": "1.0.5",
       "from": "seek-bzip@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "from": "commander@>=2.8.1 <2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
     },
     "semver": {
       "version": "5.0.3",
@@ -619,7 +619,7 @@
     },
     "semver-regex": {
       "version": "1.0.0",
-      "from": "semver-regex@latest",
+      "from": "semver-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
     },
     "shelljs": {
@@ -654,7 +654,7 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.1 <1.1.0",
+      "from": "strip-json-comments@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "strip-outer": {
@@ -716,13 +716,25 @@
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "from": "tunnel-agent@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "unbzip2-stream": {
       "version": "1.0.10",
       "from": "unbzip2-stream@>=1.0.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.10.tgz"
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.10.tgz",
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "from": "base64-js@0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+        },
+        "buffer": {
+          "version": "3.6.0",
+          "from": "buffer@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
+        }
+      }
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -751,7 +763,7 @@
     },
     "uuid": {
       "version": "2.0.3",
-      "from": "uuid@2.0.3",
+      "from": "uuid@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
     },
     "wrappy": {
@@ -780,6 +792,18 @@
       "version": "4.0.1",
       "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yargs": {
+      "version": "1.2.6",
+      "from": "yargs@>=1.2.6 <1.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.1.0",
+          "from": "minimist@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz"
+        }
+      }
     },
     "yauzl": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "chalk": "^1.1.1",
     "download": "^5.0.2",
     "fs-extra": "^0.26.7",
-    "glob": "^7.0.6",
+    "glob-all": "^3.1.0",
     "https-proxy-agent": "^1.0.0",
     "js-yaml": "^3.6.1",
     "json-refs": "^2.1.5",


### PR DESCRIPTION
## What did you implement:

**_Implementing Issue:**_ #2264 and #2472
## How did you implement it:
- Switched out glob to use glob-all that supports `!` patterns and arrays of patterns being passed for globbing.
## How can we verify it:
- Added spec demoing re-inclusion glob patterns

Example of re-including `node-fetch` module after excluding all `node_modules`

```
package:
  exclude:
    node_modules
    !node_modules/node-fetch
```
## Todos:
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

**_Is this ready for review?:**_ YES
