### PR TITLE
Correctly Escape Form URL Encoded Values

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -73,9 +73,9 @@ module.exports = {
                 #set( $keyVal = $token.split('=') )
                 #set( $keyValSize = $keyVal.size() )
                 #if( $keyValSize >= 1 )
-                  #set( $key = $util.urlDecode($keyVal[0]) )
+                  #set( $key = $util.escapeJavaScript($util.urlDecode($keyVal[0])) )
                   #if( $keyValSize >= 2 )
-                    #set( $val = $util.urlDecode($keyVal[1]) )
+                    #set( $val = $util.escapeJavaScript($util.urlDecode($keyVal[1])) )
                   #else
                     #set( $val = '' )
                   #end


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2270 

Escape characters in default API Gateway form url encoded body mapping template.

## How did you implement it:

Wrapped body keys and values in a `$util.escapeJavaScript()` call.

## How can we verify it:

Create a handler that does anything and add a POST http event:

```
functions:
  endpoint:
    handler: handlers.endpoint
    events:
      - http:
          path: endpoint
          method: post
          integration: lambda
```

* Create an HTML form with a `textarea` input.
* View the form in a browser, and **type in some text with newlines** in the text area.
* Submit the form

```
<form
  action="https://##########.execute-api.##-####-#.amazonaws.com/dev/endpoint"
  method="POST"
>
  <textarea name="message"></textarea>
  <button type="submit">Send</button>
</form>
```

## Todos:

- [ ] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES

Fixes #2270