### PR TITLE
Custom response status code

### DIFF
--- a/docs/02-providers/aws/events/01-apigateway.md
+++ b/docs/02-providers/aws/events/01-apigateway.md
@@ -250,6 +250,24 @@ functions:
 **Note:** The template is defined as plain text here. However you can also reference an external file with the help of
 the `${file(templatefile)}` syntax.
 
+### Using a custom response status code
+
+The default response status code (200) can be overidden by specifying one of your own.
+
+```yml
+functions:
+  create:
+    handler: posts.redirect
+    events:
+      - http:
+          method: get
+          path: whatever
+          response:
+            statusCode: 301
+            headers:
+              Location: "integration.response.body.url"
+```
+
 ### Status codes
 
 Serverless ships with default status codes you can use to e.g. signal that a resource could not be found (404) or that

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -229,6 +229,9 @@ module.exports = {
             method.substr(1).toLowerCase();
           const extractedResourceId = resourceLogicalId.match(/ApiGatewayResource(.*)/)[1];
 
+          // default response status code
+          let statusCode = 200;
+
           // default response configuration
           const methodResponseHeaders = [];
           const integrationResponseHeaders = [];
@@ -260,6 +263,12 @@ module.exports = {
                 }
               }
               integrationResponseTemplate = event.http.response.template;
+
+              // override status code if defined
+              if (event.http.response.statusCode &&
+                    Number.isInteger(event.http.response.statusCode)) {
+                statusCode = event.http.response.statusCode;
+              }
             } else {
               const errorMessage = [
                 'Response config must be provided as an object.',
@@ -272,15 +281,15 @@ module.exports = {
           // scaffolds for method responses
           const methodResponses = [
             {
-              ResponseModels: {},
+              StatusCode: statusCode,
               ResponseParameters: {},
-              StatusCode: 200,
+              ResponseModels: {},
             },
           ];
 
           const integrationResponses = [
             {
-              StatusCode: 200,
+              StatusCode: statusCode,
               ResponseParameters: {},
               ResponseTemplates: {},
             },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -792,6 +792,106 @@ describe('#compileMethods()', () => {
     });
   });
 
+  it('should set the default method response status code', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[0].StatusCode
+      ).to.equal(200);
+    });
+  });
+
+  it('should set the default integration response status code', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration
+          .IntegrationResponses[0].StatusCode
+      ).to.equal(200);
+    });
+  });
+
+  it('should set a custom status code', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+              response: {
+                statusCode: 999,
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.MethodResponses[0].StatusCode
+      ).to.equal(999);
+    });
+  });
+
+  it('should set a custom integration response status code', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+              response: {
+                statusCode: 999,
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersListGet.Properties.Integration
+          .IntegrationResponses[0].StatusCode
+      ).to.equal(999);
+    });
+  });
+
   it('should set "AWS_PROXY" as the default integration type', () =>
     awsCompileApigEvents.compileMethods().then(() => {
       expect(


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

***Implementing Issue:*** #2281

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

This PR makes the default 200 response as a variable that can be overridden by specifying a value in `event.http.response.statusCode` it will update the default response code with this setting.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

When setting a custom response code such as 
```yml
    events:
      - http:
          integration: lambda
          path: download/{document}
          method: get
          response:
            statusCode: 302
            headers:
              Location: "integration.response.body.url"
```
A get request to `/download/whatevs`  should return a 302 HTTP code with the appropriate response value in the *Location* header

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES
