### PR TITLE
Add newline on error message

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -67,9 +67,9 @@ module.exports.logError = (e) => {
     if (e.name !== 'ServerlessError') {
       consoleLog(' ');
       consoleLog(chalk.red('     Please report this error. We think it might be a bug.'));
-      consoleLog(' ');
     }
 
+    consoleLog(' ');
     consoleLog(chalk.yellow('  Your Environment Infomation -----------------------------'));
     consoleLog(chalk.yellow(`     OS:                 ${process.platform}`));
     consoleLog(chalk.yellow(`     Node Version:       ${process.version.replace(/^[v|V]/, '')}`));


### PR DESCRIPTION
## What did you implement:
<img width="723" alt="2016-10-09 13 23 03" src="https://cloud.githubusercontent.com/assets/1301012/19217920/4181799c-8e24-11e6-9be0-8424f3ffe997.png">

I fixed the bug that there is no line break on top of `Your Environment Infomation`.

## How did you implement it:
I added line break

## How can we verify it:
Please exec `$ serverless tracking e` in your serverless project. I fixed it as follow
<img width="698" alt="2016-10-09 13 39 07" src="https://cloud.githubusercontent.com/assets/1301012/19217968/cc8f71d2-8e25-11e6-9a8a-8ee85f18be8e.png">


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Change ready for review message below


