### PR TITLE
Print note about tracking

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -150,6 +150,14 @@ class Utils {
     // create a new file with a uuid as the tracking id if not yet present
     const trackingIdFilePath = path.join(serverless.config.serverlessPath, 'tracking-id');
     if (!this.fileExistsSync(trackingIdFilePath)) {
+      const trackingMessage = [
+        'Note: Serverless gathers anonymized usage information.',
+        ' You can always disable it by running "serverless tracking --disable".',
+        ' Please read the documentation to learn more about tracking and how it works.',
+      ].join('');
+
+      this.serverless.cli.log(trackingMessage);
+
       fs.writeFileSync(trackingIdFilePath, userId);
     } else {
       userId = fs.readFileSync(trackingIdFilePath).toString();

--- a/tests/classes/Utils.js
+++ b/tests/classes/Utils.js
@@ -289,11 +289,14 @@ describe('Utils', () => {
       serverless.config.serverlessPath = tmpDirPath;
     });
 
-    it('should create a new file with a tracking id if not found', () => {
+    it('should create a new file with a tracking id and inform the user if not found', () => {
       const trackingIdFilePath = path.join(serverlessPath, 'tracking-id');
+      const logStub = sinon.stub(serverless.cli, 'log');
 
       return serverless.utils.track(serverless).then(() => {
         expect(fs.readFileSync(trackingIdFilePath).toString().length).to.be.above(1);
+        expect(logStub.calledOnce).to.equal(true);
+        serverless.cli.log.restore();
       });
     });
 


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2278

Prints out a note when the tracking-id is created so that the user is aware of tracking.

## How did you implement it:

Added a `log` statement in the section of `track()` where the tracking id is generated.

## How can we verify it:

Run the tests with `npm test` or create a new service (without having a tracking-id in the Serverless directory).

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES