### PR TITLE
Stub AWS SDK for getCredentials() tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: node_js
 
-node_js:
-  - '4.4'
-  - '5.11'
-  - '6.2'
+matrix:
+  include:
+    - node_js: '4.4'
+    - node_js: '5.11'
+    - node_js: '6.2'
+    - node_js: '6.2'
+      env:
+        - INTEGRATION_TEST=true
+        - secure: Ia2nYzOeYvTE6qOP7DBKX3BO7s/U7TXdsvB2nlc3kOPFi//IbTVD0/cLKCAE5XqTzrrliHINSVsFcJNSfjCwmDSRmgoIGrHj5CJkWpkI6FEPageo3mdqFQYEc8CZeAjsPBNaHe6Ewzg0Ev/sjTByLSJYVqokzDCF1QostSxx1Ss6SGt1zjxeP/Hp4yOJn52VAm9IHAKYn7Y62nMAFTaaTPUQHvW0mJj6m2Z8TWyPU+2Bx6mliO65gTPFGs+PdHGwHtmSF/4IcUO504x+HjDuwzW2itomLXZmIOFfGDcFYadKWzVMAfJzoRWOcVKF4jXdMoSCOviWpHGtK35E7K956MTXkroVoWCS7V0knQDovbRZj8c8td8mS4tdprUA+TzgZoHet2atWNtMuTh79rdmwoAO+IAWJegYj62Tdfy3ycESzY+KxSaV8kysG9sR3PRFoWjZerA7MhLZEzQMORXDGjJlgwLaZfYVqjlsGe5p5etFBUTd0WbFgSwOKLoA2U/fm7WzqItkjs3UWaHuvFVvwYixGxjEVmVczS6wa2cdGpHtVD9H7km4fPEzljHqQ26v0P5e8eylgqLF2IB6mL7UqGFrAtrMvAgN/M3gnq4dTs/wq1AJIOxEP7YW7kc0NAldk8vUz6t5GzCPNcuukxAku91Awnh0twxgUywatgJLZPY=
+        - secure: Dgaa5XIsA5Vbw/CYQLUAuVVsDX26C8+f1XYGwsbNmFQKbKvM8iy9lGrHlfrT3jftJkJH6re8tP1RjyZjjzLe25KPk4Tps7grNteCyiIIEDsC2aHhiXHD6zNHsItpxYusaFfyQinFWnK4CAYKWb9ZNIwHIDUIB4vq807QGAhYsnoj1Lg/ajWvtEKBwYjEzDz9OjB91lw7lpCnHtmKKw5A+TNIVGpDDZ/jRBqETsPaePtiXC9UTHZQyM3gFoeVXiJw9KSU/gjIx9REihCaWWPbnuQSeIONGGlVWY9V4DTZIsJr9/uwDcbioeXDD3G1ezGtNPPRSNTtq08QlUtE4mEtKea/+ObpllKZCeZGn6AJhMn+uqMIP95FFlqBB55YzRcLZY+Igi/qm/9LJ9RinAhxRVXiwzeQ+BdVA6jshAAzr+7wklux6lZAa0xGw9pgTv7MI4RP2LJ/LMP1ppFsnv9n/qt93Ax1VEwEu3xHZe3VTYL9tbXOPTZutf6fKjUrW7wSSuy637queESjYnnPKSb1vZcPxjSFlyh+GJvxu/3PurF9aqfiBdiorIBre+pQS4lakLtoft5nsbA+4iYUwrXR58qUPVUqQ7a0A0hedOWlp6g9ixLa6nugUP5aobJzR71T8l/IjqpnY2EEd/iINEb0XfUiZtB5zHaqFWejBtmWwCI=
 
 sudo: false
 
@@ -11,15 +17,8 @@ install:
   - travis_retry npm install
 
 script:
-  - npm test
-  # Only Run Integration Tests and ESLINT for the first job in the whole build to make the build faster
-  # Only Run Integration Test when an AWS ACCESS KEY ID is available so the build doesn't fail for PR's from forks
-  - if [[ "$TRAVIS_JOB_NUMBER" =~ [0-9]+\.1 && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run integration-test; fi
-  - if [[ "$TRAVIS_JOB_NUMBER" =~ [0-9]+\.1 ]]; then npm run lint; fi
+  - if [[ -z "$INTEGRATION_TEST" ]]; then npm test && npm run lint; fi
+  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run integration-test; fi
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
-env:
-  global:
-  - secure: d/mNhZSYk4y2FcSr88NKic/6n+rhONDRNzt6qLMBQ1tQ8YZ0ktzd54X/j7YMLwIA2/yl4PquJF5kwGyVzIhSl6IjmH/YhSEsQzGPI/1YI/pBoG+O9nocqr1jPnUbNhph9+ICiCUtXzeT6LaSKtV0r70eI9/sdB4aKko1I9m+o6tfZPfBiKhDYnvihbOI+yg1rqaWOeDNfWuv7aatsSmqOjScpKYSOAg/aB0ireotc9nFLb3ju2b+fNyzkg3eunFKuZh5pdSm5Zt5QE3nJHKe7rBzx8YkddeJIjiUaaIdW2hIp1PcePc6wOqaZA/lxgfoyLPn8MrcB57ifPeV8M7OW+VhL76beZfgxPB/sVQwpanCl9gyBdge1elep0ZGHWm7X2Y2WhredISxBTkbvBxepKXC6ZyXNW8K3XVEPVp+zwixHDST5E6AHlC0Kzn6QadZEuFoBkSylz+pYedGEGMTakS4jYidcvG+/4TC2Z9ByiDNumA3ooKsjcZyfoPD40IaB/qzZxBDt9rETKvzby1vgGiMvw7stZ0QWwbmeNshAcHGL/Md/oQDQtTMae0rgLjVjc56FQRzfoEDQYlczl/aGk8CPOjFsq9CcS3CdhhlgjTvnGyPtRZBe4djR6pt980SD4H/R8ELxK9uzWWxQ1SvEZYyTCHCjgwZkNstUwH+LIM=
-  - secure: AjvCD8P7YbGeatnTrdUpPS5ckHquVLkkL8CFFHZvIJPpWDFrZL5srJZ7iRiUjfHxIf35BKqMjmM03zLD/hYYd0erslVmKwzo56ESvcEG30cgai4LIh6dO3XaqAK4oTdwSMbW6HTIbg1zr8sXdsGVTvA0UrHHbd2HYLPffxA40T6hcsYko+3qHeO1ZXlfB6IP7mi4nD0VA04GMEFNBC+LenvP6UbDSh3nWwMb4WSCstgy48fKRddsiAZLZr4+4alNTcfwHS3aPjbU/aYH7GcG4uy/T/Lcd8DWVdiUv/a/wXJZPdqULF3Gh7dnnQJFDfXheSSq+MjqRM1/by7WzoltuRwzXGrzj+qyVlxHIt0sb8WNscdeVga7jgddyXFf9awz09vOv8pxDQuPYRhSExJ0SIbmX3DpOTwiWF71VcH/Oqjn7a42D1ItqmUbj9GOycu7Izlnw0iPrRFJ5NyXwL4KegEJtTOXRSQ4f/jeQhNG/RUnUDmarku5LMN2XFcVb/Y2FAAc6NHfdUsOiJfYx060RPDQTVbZ8JfAhM7ZLUl9a0HL0Xa/aADysYQ3eN39E4CJaoxh0VkNkRjG1v6WKYEvjFCke7uHhRFfe/K7qCzbtExBj/wzokB+zGR9V0deXVD/dShN78HpVeq88mivml9KKtqzwQAj2IBQEb38M6Mdkg4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,18 @@ matrix:
         - INTEGRATION_TEST=true
         - secure: Ia2nYzOeYvTE6qOP7DBKX3BO7s/U7TXdsvB2nlc3kOPFi//IbTVD0/cLKCAE5XqTzrrliHINSVsFcJNSfjCwmDSRmgoIGrHj5CJkWpkI6FEPageo3mdqFQYEc8CZeAjsPBNaHe6Ewzg0Ev/sjTByLSJYVqokzDCF1QostSxx1Ss6SGt1zjxeP/Hp4yOJn52VAm9IHAKYn7Y62nMAFTaaTPUQHvW0mJj6m2Z8TWyPU+2Bx6mliO65gTPFGs+PdHGwHtmSF/4IcUO504x+HjDuwzW2itomLXZmIOFfGDcFYadKWzVMAfJzoRWOcVKF4jXdMoSCOviWpHGtK35E7K956MTXkroVoWCS7V0knQDovbRZj8c8td8mS4tdprUA+TzgZoHet2atWNtMuTh79rdmwoAO+IAWJegYj62Tdfy3ycESzY+KxSaV8kysG9sR3PRFoWjZerA7MhLZEzQMORXDGjJlgwLaZfYVqjlsGe5p5etFBUTd0WbFgSwOKLoA2U/fm7WzqItkjs3UWaHuvFVvwYixGxjEVmVczS6wa2cdGpHtVD9H7km4fPEzljHqQ26v0P5e8eylgqLF2IB6mL7UqGFrAtrMvAgN/M3gnq4dTs/wq1AJIOxEP7YW7kc0NAldk8vUz6t5GzCPNcuukxAku91Awnh0twxgUywatgJLZPY=
         - secure: Dgaa5XIsA5Vbw/CYQLUAuVVsDX26C8+f1XYGwsbNmFQKbKvM8iy9lGrHlfrT3jftJkJH6re8tP1RjyZjjzLe25KPk4Tps7grNteCyiIIEDsC2aHhiXHD6zNHsItpxYusaFfyQinFWnK4CAYKWb9ZNIwHIDUIB4vq807QGAhYsnoj1Lg/ajWvtEKBwYjEzDz9OjB91lw7lpCnHtmKKw5A+TNIVGpDDZ/jRBqETsPaePtiXC9UTHZQyM3gFoeVXiJw9KSU/gjIx9REihCaWWPbnuQSeIONGGlVWY9V4DTZIsJr9/uwDcbioeXDD3G1ezGtNPPRSNTtq08QlUtE4mEtKea/+ObpllKZCeZGn6AJhMn+uqMIP95FFlqBB55YzRcLZY+Igi/qm/9LJ9RinAhxRVXiwzeQ+BdVA6jshAAzr+7wklux6lZAa0xGw9pgTv7MI4RP2LJ/LMP1ppFsnv9n/qt93Ax1VEwEu3xHZe3VTYL9tbXOPTZutf6fKjUrW7wSSuy637queESjYnnPKSb1vZcPxjSFlyh+GJvxu/3PurF9aqfiBdiorIBre+pQS4lakLtoft5nsbA+4iYUwrXR58qUPVUqQ7a0A0hedOWlp6g9ixLa6nugUP5aobJzR71T8l/IjqpnY2EEd/iINEb0XfUiZtB5zHaqFWejBtmWwCI=
-
+    - node_js: '6.2'
+      env:
+        - DISABLE_TESTS=true
+        - LINTING=true
 sudo: false
 
 install:
   - travis_retry npm install
 
 script:
-  - if [[ -z "$INTEGRATION_TEST" ]]; then npm test && npm run lint; fi
+  - if [[ -z "$INTEGRATION_TEST" && -z "$DISABLE_TESTS" ]]; then npm test; fi
+  - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" && -z "$INTEGRATION_TEST" ]]; then npm run lint; fi
   - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run integration-test; fi
 
 after_success:

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -182,6 +182,11 @@ describe('AWS SDK', () => {
   });
 
   describe('#getCredentials()', () => {
+    const mockCreds = (configParam) => {
+      const config = configParam;
+      delete config.credentials;
+      return config;
+    };
     const awsStub = sinon.stub().returns();
     const AwsSdkProxyquired = proxyquire('../index.js', {
       'aws-sdk': awsStub,
@@ -206,13 +211,13 @@ describe('AWS SDK', () => {
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
+      const credentials = mockCreds(newAwsSdk.getCredentials('teststage', 'testregion'));
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if credentials is an empty object', () => {
       serverless.service.provider.credentials = {};
-      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
+      const credentials = mockCreds(newAwsSdk.getCredentials('teststage', 'testregion'));
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -222,7 +227,7 @@ describe('AWS SDK', () => {
         secretAccessKey: undefined,
         sessionToken: undefined,
       };
-      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
+      const credentials = mockCreds(newAwsSdk.getCredentials('teststage', 'testregion'));
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -232,11 +237,19 @@ describe('AWS SDK', () => {
         secretAccessKey: '',
         sessionToken: '',
       };
-      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
+      const credentials = mockCreds(newAwsSdk.getCredentials('teststage', 'testregion'));
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should get credentials from provider declared credentials', () => {
+      const tmpAccessKeyID = process.env.AWS_ACCESS_KEY_ID;
+      const tmpAccessKeySecret = process.env.AWS_SECRET_ACCESS_KEY;
+      const tmpSessionToken = process.env.AWS_SESSION_TOKEN;
+
+      delete process.env.AWS_ACCESS_KEY_ID;
+      delete process.env.AWS_SECRET_ACCESS_KEY;
+      delete process.env.AWS_SESSION_TOKEN;
+
       serverless.service.provider.credentials = {
         accessKeyId: 'accessKeyId',
         secretAccessKey: 'secretAccessKey',
@@ -244,6 +257,10 @@ describe('AWS SDK', () => {
       };
       const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials.credentials).to.deep.eql(serverless.service.provider.credentials);
+
+      process.env.AWS_ACCESS_KEY_ID = tmpAccessKeyID;
+      process.env.AWS_SECRET_ACCESS_KEY = tmpAccessKeySecret;
+      process.env.AWS_SESSION_TOKEN = tmpSessionToken;
     });
 
     it('should get credentials from environment declared for-all-stages credentials', () => {
@@ -290,13 +307,13 @@ describe('AWS SDK', () => {
 
     it('should not set credentials if profile is not set', () => {
       serverless.service.provider.profile = undefined;
-      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
+      const credentials = mockCreds(newAwsSdk.getCredentials('teststage', 'testregion'));
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
+      const credentials = mockCreds(newAwsSdk.getCredentials('teststage', 'testregion'));
       expect(credentials).to.eql({ region: 'testregion' });
     });
 

--- a/lib/plugins/aws/tests/index.js
+++ b/lib/plugins/aws/tests/index.js
@@ -5,6 +5,7 @@ const BbPromise = require('bluebird');
 const expect = require('chai').expect;
 const Serverless = require('../../../Serverless');
 const AwsSdk = require('../');
+const proxyquire = require('proxyquire');
 
 describe('AWS SDK', () => {
   let awsSdk;
@@ -181,26 +182,37 @@ describe('AWS SDK', () => {
   });
 
   describe('#getCredentials()', () => {
+    const awsStub = sinon.stub().returns();
+    const AwsSdkProxyquired = proxyquire('../index.js', {
+      'aws-sdk': awsStub,
+    });
+
+    let newAwsSdk;
+
+    beforeEach(() => {
+      newAwsSdk = new AwsSdkProxyquired(serverless);
+    });
+
     it('should set region for credentials', () => {
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials.region).to.equal('testregion');
     });
 
     it('should get credentials from provider', () => {
       serverless.service.provider.profile = 'notDefault';
-      const credentials = awsSdk.getCredentials();
+      const credentials = newAwsSdk.getCredentials();
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if credentials is an empty object', () => {
       serverless.service.provider.credentials = {};
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -210,7 +222,7 @@ describe('AWS SDK', () => {
         secretAccessKey: undefined,
         sessionToken: undefined,
       };
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -220,7 +232,7 @@ describe('AWS SDK', () => {
         secretAccessKey: '',
         sessionToken: '',
       };
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -230,7 +242,7 @@ describe('AWS SDK', () => {
         secretAccessKey: 'secretAccessKey',
         sessionToken: 'sessionToken',
       };
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials.credentials).to.deep.eql(serverless.service.provider.credentials);
     });
 
@@ -248,7 +260,7 @@ describe('AWS SDK', () => {
       process.env.AWS_ACCESS_KEY_ID = testVal.accessKeyId;
       process.env.AWS_SECRET_ACCESS_KEY = testVal.secretAccessKey;
       process.env.AWS_SESSION_TOKEN = testVal.sessionToken;
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       process.env.AWS_ACCESS_KEY_ID = prevVal.accessKeyId;
       process.env.AWS_SECRET_ACCESS_KEY = prevVal.secretAccessKey;
       process.env.AWS_SESSION_TOKEN = prevVal.sessionToken;
@@ -269,7 +281,7 @@ describe('AWS SDK', () => {
       process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = testVal.accessKeyId;
       process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = testVal.secretAccessKey;
       process.env.AWS_TESTSTAGE_SESSION_TOKEN = testVal.sessionToken;
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = prevVal.accessKeyId;
       process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = prevVal.secretAccessKey;
       process.env.AWS_TESTSTAGE_SESSION_TOKEN = prevVal.sessionToken;
@@ -278,26 +290,26 @@ describe('AWS SDK', () => {
 
     it('should not set credentials if profile is not set', () => {
       serverless.service.provider.profile = undefined;
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should get credentials from provider declared profile', () => {
       serverless.service.provider.profile = 'notDefault';
-      const credentials = awsSdk.getCredentials();
+      const credentials = newAwsSdk.getCredentials();
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
 
     it('should get credentials from environment declared for-all-stages profile', () => {
       const prevVal = process.env.AWS_PROFILE;
       process.env.AWS_PROFILE = 'notDefault';
-      const credentials = awsSdk.getCredentials();
+      const credentials = newAwsSdk.getCredentials();
       process.env.AWS_PROFILE = prevVal;
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
@@ -305,7 +317,7 @@ describe('AWS SDK', () => {
     it('should get credentials from environment declared stage-specific profile', () => {
       const prevVal = process.env.AWS_TESTSTAGE_PROFILE;
       process.env.AWS_TESTSTAGE_PROFILE = 'notDefault';
-      const credentials = awsSdk.getCredentials('teststage', 'testregion');
+      const credentials = newAwsSdk.getCredentials('teststage', 'testregion');
       process.env.AWS_TESTSTAGE_PROFILE = prevVal;
       expect(credentials.credentials.profile).to.equal('notDefault');
     });

--- a/tests/integration_test.js
+++ b/tests/integration_test.js
@@ -14,7 +14,7 @@ serverless.init();
 const serverlessExec = path.join(serverless.config.serverlessPath, '..', 'bin', 'serverless');
 
 const tmpDir = testUtils.getTmpDirPath();
-fse.mkdirSync(tmpDir);
+fse.mkdirsSync(tmpDir);
 process.chdir(tmpDir);
 
 const templateName = 'aws-nodejs';


### PR DESCRIPTION
## What did you implement:

Stubbed out the AWS SDK for the `getCredentials()` so that keys are not exposed in failing tests.

## How did you implement it:

Added a proxyquire and a corresponding stub and replaced the `awsSdk` usage with the proxyquired one.

## How can we verify it:

Run `npm test` to see that all tests are still passing despite the fact that the source code is changed to use the proxyquire with the stub.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES