### PR TITLE
Fix wrong statusCode in API Gateway README

### DIFF
--- a/docs/02-providers/aws/events/01-apigateway.md
+++ b/docs/02-providers/aws/events/01-apigateway.md
@@ -122,7 +122,7 @@ exports.handler = function(event, context) {
     };
 
     const response = {
-      statusCode: responseCode,
+      statusCode: 200,
       headers: {
         "x-custom-header" : "My Header Value"
       },


### PR DESCRIPTION
## What did you implement:

Fixes a misleading `statusCode` usage introduced due to copy and paste.

## How did you implement it:

Just updated the `statusCode`.

## How can we verify it:

Take a look at the API Gateway README.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES