### PR TITLE
Closes #2328 - Silence deprecation warnings

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -6,6 +6,7 @@ const BbPromise = require('bluebird');
 const logError = require('../lib/classes/Error').logError;
 
 process.on('unhandledRejection', (e) => logError(e));
+process.noDeprecation = true;
 
 (() => BbPromise.resolve().then(() => {
   // requiring here so that if anything went wrong,


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2328

Silences the tedious deprecation warnings.

## How did you implement it:

Disabled them globally with the help of `process`.

## How can we verify it:

Checkout this branch and run some commands where the `aws-sdk` will be used.

## Todos:

- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES