### PR TITLE
Clean up S3 bucket after a successful deploy

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -52,10 +52,10 @@ class AwsDeploy {
 
       'deploy:deploy': () => BbPromise.bind(this)
         .then(this.setBucketName)
-        .then(this.cleanupS3Bucket)
         .then(this.uploadArtifacts)
         .then(this.updateStack)
         .then((cfData) => this.monitorStack('update', cfData))
+        .then(this.cleanupS3Bucket)
         .then(() => {
           if (this.options.noDeploy) this.serverless.cli.log('Did not deploy due to --noDeploy');
         }),

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
@@ -5,8 +5,7 @@ const _ = require('lodash');
 
 module.exports = {
   getObjectsToRemove() {
-    // 4 old ones + the one which will be uploaded after the cleanup = 5
-    const directoriesToKeepCount = 4;
+    const directoriesToKeepCount = 5;
     const serviceStage = `${this.serverless.service.service}/${this.options.stage}`;
 
     return this.sdk.request('S3',

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -84,13 +84,13 @@ describe('AwsDeploy', () => {
 
       return awsDeploy.hooks['deploy:deploy']().then(() => {
         expect(setBucketNameStub.calledOnce).to.be.equal(true);
-        expect(cleanupS3BucketStub.calledAfter(setBucketNameStub))
-          .to.be.equal(true);
-        expect(uploadArtifactsStub.calledAfter(cleanupS3BucketStub))
+        expect(uploadArtifactsStub.calledAfter(setBucketNameStub))
           .to.be.equal(true);
         expect(updateStackStub.calledAfter(uploadArtifactsStub))
           .to.be.equal(true);
         expect(monitorStackStub.calledAfter(updateStackStub))
+          .to.be.equal(true);
+        expect(cleanupS3BucketStub.calledAfter(monitorStackStub))
           .to.be.equal(true);
       });
     });


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2011 

## How did you implement it:
Updated code as per issue

## How can we verify it:
Cause a cloudformation error 5 times and it will fail to rollback. After this change it should rollback successfully.


## Todos:

- [x] Write tests (Should this have integration tests?)
- [x] Write documentation (Fix to match existing documentation)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES