### PR TITLE
Only include specific files into npm deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,15 @@
     "internet of things",
     "serverless.com"
   ],
+  "files": [
+    "bin",
+    "lib",
+    "package.json",
+    "npm-shrinkwrap.json",
+    "README.md",
+    "LICENSE.txt",
+    "CHANGELOG.md"
+  ],
   "main": "lib/Serverless.js",
   "bin": {
     "serverless": "./bin/serverless",


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Otherwise we've had way too many files pushed to NPM and to users.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Change ready for review message below


***Is this ready for review?:*** NO

