### PR TITLE
Add serverless-wsgi to list of plugins in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Use these plugins to overwrite or extend the Framework's functionality...
 * [serverless-scriptable](https://github.com/wei-xu-myob/serverless-scriptable-plugin)
 * [serverless-plugin-stage-variables](https://github.com/svdgraaf/serverless-plugin-stage-variables)
 * [serverless-dynamodb-local](https://github.com/99xt/serverless-dynamodb-local/tree/v1)
+* [serverless-wsgi](https://github.com/logandk/serverless-wsgi) - Deploy Python WSGI applications (Flask/Django etc.)
 
 ## <a name="v1-projects"></a>Example Projects (V1.0)
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I've added the `serverless-wsgi` plugin for serving Python web applications to the list of v1.0 supported plugins, as I believe it will be useful to other developers.

## How did you implement it:

This is simply a README.md change.

## How can we verify it:

Read that `serverless-wsgi` appears below the *Plugins (V1.0)* header.

## Todos:

- [ ] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [X] Change ready for review message below


***Is this ready for review?:*** YES
