### PR TITLE
rework error logging

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -1,6 +1,6 @@
 'use strict';
-const chalk = require('chalk');
 const version = require('./../../package.json').version;
+const logger = require('./Logger');
 
 module.exports.SError = class ServerlessError extends Error {
   constructor(message, statusCode) {
@@ -14,67 +14,21 @@ module.exports.SError = class ServerlessError extends Error {
 
 module.exports.logError = (e) => {
   try {
-    const words = e.message.split(' ');
-
-    const consoleLog = (message) => {
-      console.log(message); // eslint-disable-line no-console
-    };
-
-    const errorType = e.name.replace(/([A-Z])/g, ' $1');
-    let line = '';
-    while (line.length < 56 - errorType.length) {
-      line = `${line}-`;
-    }
-
-    consoleLog(' ');
-    consoleLog(chalk.yellow(` ${errorType} ${line}`));
-    consoleLog(' ');
-
-
-    let logLine = [];
-    words.forEach(word => {
-      logLine.push(word);
-      const logLineString = logLine.join(' ');
-      if (logLineString.length > 50) {
-        consoleLog(chalk.yellow(`     ${logLineString}`));
-        logLine = [];
-      }
-    });
-
-    if (logLine.length !== 0) {
-      consoleLog(chalk.yellow(`     ${logLine.join(' ')}`));
-    }
-
-    consoleLog(' ');
-
-    if (e.name !== 'ServerlessError') {
-      consoleLog(chalk.red('     For debugging logs, run again after setting SLS_DEBUG env var.'));
-      consoleLog(' ');
-    }
-
+    logger.error(`${e.name}: ${e.message}`);
     if (process.env.SLS_DEBUG) {
-      consoleLog(chalk.yellow('  Stack Trace --------------------------------------------'));
-      consoleLog(' ');
-      consoleLog(e.stack);
-      consoleLog(' ');
+      logger.info(`\nStack Trace: ${e.stack}`);
     }
-
-    consoleLog(chalk.yellow('  Get Support --------------------------------------------'));
-    consoleLog(`${chalk.yellow('     Docs:          ')}${chalk.white('docs.serverless.com')}`);
-    consoleLog(`${chalk.yellow('     Bugs:          ')}${chalk
-      .white('github.com/serverless/serverless/issues')}`);
 
     if (e.name !== 'ServerlessError') {
-      consoleLog(' ');
-      consoleLog(chalk.red('     Please report this error. We think it might be a bug.'));
+      logger.error('\nWe think it might be a bug. ' +
+        'Please report this error including following information: ' +
+        `OS: ${process.platform}, ` +
+        `Node Version: ${process.version.replace(/^[v|V]/, '')}, ` +
+        `Serverless Version: ${version}.`);
     }
 
-    consoleLog(' ');
-    consoleLog(chalk.yellow('  Your Environment Infomation -----------------------------'));
-    consoleLog(chalk.yellow(`     OS:                 ${process.platform}`));
-    consoleLog(chalk.yellow(`     Node Version:       ${process.version.replace(/^[v|V]/, '')}`));
-    consoleLog(chalk.yellow(`     Serverless Version: ${version}`));
-    consoleLog(' ');
+    logger.info('\nGet support from official docs (http://docs.serverless.com) ' +
+      'or submit issue on GitHub (https://github.com/serverless/serverless/issues).');
 
     // Failure exit
     process.exit(1);

--- a/lib/classes/Logger.js
+++ b/lib/classes/Logger.js
@@ -1,0 +1,14 @@
+/* eslint no-console: off */
+'use strict';
+
+const chalk = require('chalk');
+
+module.exports = {
+  error(msg) {
+    console.error(chalk.red(msg));
+  },
+
+  info(msg) {
+    console.log(msg);
+  },
+};


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** https://github.com/serverless/serverless/issues/2026#issuecomment-252867528

## How did you implement it:

Rework of how logged error looks like.

## ServerlessError

Before:

<img width="618" alt="screenshot 2016-10-13 17 30 58" src="https://cloud.githubusercontent.com/assets/455261/19355516/f3ffaf00-916a-11e6-824a-8cf0a0388893.png">

After:

<img width="703" alt="screenshot 2016-10-13 17 31 39" src="https://cloud.githubusercontent.com/assets/455261/19355524/f8364cb4-916a-11e6-9ada-2b1c5ed43667.png">

With stack trace:

<img width="710" alt="screenshot 2016-10-13 17 33 01" src="https://cloud.githubusercontent.com/assets/455261/19355579/23581238-916b-11e6-983f-26177bfa40a4.png">

## Non ServerlessError

<img width="710" alt="screenshot 2016-10-13 17 34 46" src="https://cloud.githubusercontent.com/assets/455261/19355642/5ee1ed4c-916b-11e6-89f9-f188ccb76d67.png">

***Is this ready for review?:*** YES

