### PR TITLE
Fix not thrown error after failed ResourceStatus bug

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -18,13 +18,6 @@ module.exports = {
       'UPDATE_COMPLETE',
       'DELETE_COMPLETE',
     ];
-    const invalidStatuses = [
-      'CREATE_FAILED',
-      'DELETE_FAILED',
-      'ROLLBACK_FAILED',
-      'UPDATE_ROLLBACK_COMPLETE',
-      'UPDATE_ROLLBACK_FAILED',
-    ];
     const loggedEvents = [];
     const monitoredSince = new Date();
     monitoredSince.setSeconds(monitoredSince.getSeconds() - 5);
@@ -83,7 +76,7 @@ module.exports = {
                   }
                 });
                 // Handle stack create/update/delete failures
-                if (invalidStatuses.indexOf(stackStatus) >= 0 && stackLatestError !== null) {
+                if (stackLatestError) {
                   this.serverless.cli.log('Deployment failed!');
                   let errorMessage = 'An error occurred while provisioning your stack: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -76,7 +76,8 @@ module.exports = {
                   }
                 });
                 // Handle stack create/update/delete failures
-                if (stackLatestError) {
+                if ((stackLatestError && !this.options.verbose)
+                || (stackStatus.endsWith('ROLLBACK_COMPLETE') && this.options.verbose)) {
                   this.serverless.cli.log('Deployment failed!');
                   let errorMessage = 'An error occurred while provisioning your stack: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -232,52 +232,22 @@ describe('monitorStack', () => {
           },
         ],
       };
-      const updateFailedEvent = {
+      const updateFinishedEvent = {
         StackEvents: [
           {
             EventId: '1e2f3g4h',
-            LogicalResourceId: 'mochaS3',
-            ResourceType: 'S3::Bucket',
-            Timestamp: new Date(),
-            ResourceStatus: 'CREATE_FAILED',
-            ResourceStatusReason: 'Bucket already exists',
-          },
-        ],
-      };
-      const updateRollbackEvent = {
-        StackEvents: [
-          {
-            EventId: '1i2j3k4l',
             LogicalResourceId: 'mocha',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
-            ResourceStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
+            ResourceStatus: 'UPDATE_COMPLETE',
           },
         ],
       };
-      const updateRollbackFailedEvent = {
-        StackEvents: [
-          {
-            EventId: '1m2n3o4p',
-            LogicalResourceId: 'mocha',
-            ResourceType: 'AWS::CloudFormation::Stack',
-            Timestamp: new Date(),
-            ResourceStatus: 'UPDATE_ROLLBACK_COMPLETE',
-          },
-        ],
-      };
-
       describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
-      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFailedEvent));
-      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateRollbackEvent));
-      describeStackEventsStub.onCall(3).returns(BbPromise.resolve(updateRollbackFailedEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
 
-      return awsPlugin.monitorStack('update', cfDataMock, 10).catch((e) => {
-        let errorMessage = 'An error occurred while provisioning your stack: ';
-        errorMessage += 'mochaS3 - Bucket already exists.';
-        expect(e.name).to.be.equal('ServerlessError');
-        expect(e.message).to.be.equal(errorMessage);
-        expect(describeStackEventsStub.callCount).to.be.equal(4);
+      return awsPlugin.monitorStack('update', cfDataMock, 10).then(() => {
+        expect(describeStackEventsStub.callCount).to.be.equal(2);
         expect(describeStackEventsStub.args[0][2].StackName)
           .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
@@ -312,7 +282,7 @@ describe('monitorStack', () => {
       });
     });
 
-    it('should throw an error if CloudFormation returned unusual stack status', () => {
+    it('should throw an error and exits if CloudFormation returned *_FALIED stack status', () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.sdk, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
@@ -373,7 +343,8 @@ describe('monitorStack', () => {
         errorMessage += 'mochaS3 - Bucket already exists.';
         expect(e.name).to.be.equal('ServerlessError');
         expect(e.message).to.be.equal(errorMessage);
-        expect(describeStackEventsStub.callCount).to.be.equal(4);
+        // callCount is 2 because Serverless will immediately exits and shows the error
+        expect(describeStackEventsStub.callCount).to.be.equal(2);
         expect(describeStackEventsStub.args[0][2].StackName)
           .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -232,22 +232,51 @@ describe('monitorStack', () => {
           },
         ],
       };
-      const updateFinishedEvent = {
+      const updateFailedEvent = {
         StackEvents: [
           {
             EventId: '1e2f3g4h',
+            LogicalResourceId: 'mochaS3',
+            ResourceType: 'S3::Bucket',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_FAILED',
+            ResourceStatusReason: 'Bucket already exists',
+          },
+        ],
+      };
+      const updateRollbackEvent = {
+        StackEvents: [
+          {
+            EventId: '1i2j3k4l',
             LogicalResourceId: 'mocha',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
-            ResourceStatus: 'UPDATE_COMPLETE',
+            ResourceStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateRollbackComplete = {
+        StackEvents: [
+          {
+            EventId: '1m2n3o4p',
+            LogicalResourceId: 'mocha',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'ROLLBACK_COMPLETE',
           },
         ],
       };
       describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
-      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFailedEvent));
+      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateRollbackEvent));
+      describeStackEventsStub.onCall(3).returns(BbPromise.resolve(updateRollbackComplete));
 
-      return awsPlugin.monitorStack('update', cfDataMock, 10).then(() => {
-        expect(describeStackEventsStub.callCount).to.be.equal(2);
+      return awsPlugin.monitorStack('update', cfDataMock, 10).catch((e) => {
+        let errorMessage = 'An error occurred while provisioning your stack: ';
+        errorMessage += 'mochaS3 - Bucket already exists.';
+        expect(e.name).to.be.equal('ServerlessError');
+        expect(e.message).to.be.equal(errorMessage);
+        expect(describeStackEventsStub.callCount).to.be.equal(4);
         expect(describeStackEventsStub.args[0][2].StackName)
           .to.be.equal(cfDataMock.StackId);
         expect(describeStackEventsStub.calledWith(
@@ -282,7 +311,7 @@ describe('monitorStack', () => {
       });
     });
 
-    it('should throw an error and exits if CloudFormation returned *_FALIED stack status', () => {
+    it('should throw an error and exit immediataley if statck status is *_FAILED', () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.sdk, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',


### PR DESCRIPTION
## What did you implement:

Fixes a bug where error messages were not thrown / shown during stack monitoring process (e.g. during stack creation process).

## How did you implement it:

Updated the `monitorStack` method so that it immediately throws an error when a `*_FAILED` ResourceStatus is reported.

## How can we verify it:

1. Install https://github.com/pmuens/serverless-crud
2. Deploy it
3. Remove it
4. Re-Deploy it

You should see the error that the DynamoDB table `users` is still there (this error was previously not shown).

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES