### PR TITLE
fix loading of asynchronous credentials.

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -59,6 +59,8 @@ const impl = {
       const profileCredentials = new AWS.SharedIniFileCredentials({ profile });
       if (Object.keys(profileCredentials).length) {
         credentials.profile = profile; // eslint-disable-line no-param-reassign
+        // eslint-disable-next-line no-param-reassign
+        credentials.profileCredentials = profileCredentials;
       }
       impl.addCredentials(credentials, profileCredentials);
     }
@@ -176,7 +178,13 @@ class AwsProvider {
     impl.addEnvironmentCredentials(credentials, `AWS_${stageUpper}`); // stage specific creds
     impl.addEnvironmentProfile(credentials, `AWS_${stageUpper}`);
 
-    if (Object.keys(credentials).length) {
+    if (credentials.profileCredentials != null && credentials.accessKeyId == null) {
+      // A profile was specified, but there is no access key present. This
+      // typically means that that temporary credentials are generated on demand.
+      // In this case just use the original AWS.SharedIniFileCredentials object,
+      // and let the AWS library handle the details.
+      returnValue.credentials = credentials.profileCredentials;
+    } else if (Object.keys(credentials).length) {
       returnValue.credentials = credentials;
     }
     return returnValue;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -201,6 +201,19 @@ describe('AwsProvider', () => {
       'aws-sdk': awsStub,
     });
 
+    function restoreEnv(values) {
+      for (const key of Object.keys(values)) {
+        const value = values[key];
+        if (typeof value === 'undefined') {
+          // `process.env.<KEY> = undefined` sets it to a string value 'undefined'
+          // delete it instead.
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+
     let newAwsProvider;
     const newOptions = {
       stage: 'teststage',
@@ -278,9 +291,9 @@ describe('AwsProvider', () => {
 
     it('should get credentials from environment declared for-all-stages credentials', () => {
       const prevVal = {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
+        AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+        AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+        AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
       };
       const testVal = {
         accessKeyId: 'accessKeyId',
@@ -291,17 +304,15 @@ describe('AwsProvider', () => {
       process.env.AWS_SECRET_ACCESS_KEY = testVal.secretAccessKey;
       process.env.AWS_SESSION_TOKEN = testVal.sessionToken;
       const credentials = newAwsProvider.getCredentials();
-      process.env.AWS_ACCESS_KEY_ID = prevVal.accessKeyId;
-      process.env.AWS_SECRET_ACCESS_KEY = prevVal.secretAccessKey;
-      process.env.AWS_SESSION_TOKEN = prevVal.sessionToken;
+      restoreEnv(prevVal);
       expect(credentials.credentials).to.deep.eql(testVal);
     });
 
     it('should get credentials from environment declared stage specific credentials', () => {
       const prevVal = {
-        accessKeyId: process.env.AWS_TESTSTAGE_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_TESTSTAGE_SESSION_TOKEN,
+        AWS_TESTSTAGE_ACCESS_KEY_ID: process.env.AWS_TESTSTAGE_ACCESS_KEY_ID,
+        AWS_TESTSTAGE_SECRET_ACCESS_KEY: process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY,
+        AWS_TESTSTAGE_SESSION_TOKEN: process.env.AWS_TESTSTAGE_SESSION_TOKEN,
       };
       const testVal = {
         accessKeyId: 'accessKeyId',
@@ -312,9 +323,7 @@ describe('AwsProvider', () => {
       process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = testVal.secretAccessKey;
       process.env.AWS_TESTSTAGE_SESSION_TOKEN = testVal.sessionToken;
       const credentials = newAwsProvider.getCredentials();
-      process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = prevVal.accessKeyId;
-      process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = prevVal.secretAccessKey;
-      process.env.AWS_TESTSTAGE_SESSION_TOKEN = prevVal.sessionToken;
+      restoreEnv(prevVal);
       expect(credentials.credentials).to.deep.eql(testVal);
     });
 
@@ -340,7 +349,7 @@ describe('AwsProvider', () => {
       const prevVal = process.env.AWS_PROFILE;
       process.env.AWS_PROFILE = 'notDefault';
       const credentials = newAwsProvider.getCredentials();
-      process.env.AWS_PROFILE = prevVal;
+      restoreEnv({ AWS_PROFILE: prevVal });
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
 
@@ -348,7 +357,7 @@ describe('AwsProvider', () => {
       const prevVal = process.env.AWS_TESTSTAGE_PROFILE;
       process.env.AWS_TESTSTAGE_PROFILE = 'notDefault';
       const credentials = newAwsProvider.getCredentials();
-      process.env.AWS_TESTSTAGE_PROFILE = prevVal;
+      restoreEnv({ AWS_TESTSTAGE_PROFILE: prevVal });
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
   });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
+const AWS = require('aws-sdk');
 
 const AwsProvider = require('./awsProvider');
 const Serverless = require('../../../Serverless');
@@ -351,6 +352,7 @@ describe('AwsProvider', () => {
       const credentials = newAwsProvider.getCredentials();
       restoreEnv({ AWS_PROFILE: prevVal });
       expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials.credentials).to.instanceof(AWS.SharedIniFileCredentials);
     });
 
     it('should get credentials from environment declared stage-specific profile', () => {
@@ -359,6 +361,14 @@ describe('AwsProvider', () => {
       const credentials = newAwsProvider.getCredentials();
       restoreEnv({ AWS_TESTSTAGE_PROFILE: prevVal });
       expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials.credentials).to.instanceof(AWS.SharedIniFileCredentials);
+    });
+
+    it('should get credentials from provider declared profile', () => {
+      serverless.service.provider.profile = 'notDefault';
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials.credentials).to.instanceof(AWS.SharedIniFileCredentials);
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->
## What did you implement:

**_Implementing Issue:**_ #2355 

The issue is that if a `role_arn` is defined in the profile, the actual `accessKeyId`, `secretAccessKey` and  `sessionToken` are load asynchronously. By the time these are copied into the `credentials` object, these haven't been loaded yet.
## How did you implement it:

There are two main solutions to this:
1. Call `refresh()` on the `SharedIniFileCredentials` object, and only copy the credentials after it has loaded.
2. Keep it as a `SharedIniFileCredentials` object, and let the AWS SDK handle the details. It's unlikely that you'll want to override any of the details if you're using a profile anyway.

I went with option 2.
## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

You need an account with roles setup: http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html

Then a `~/.aws/credentials` file with something like this:

``` ini
[main]
aws_access_key_id = ...
aws_secret_access_key = ...

[subaccount]
role_arn = arn:aws:iam::<my-account>:role/Admin
source_profile = main
```

Then test with `AWS_PROFILE=subaccount serverless info`, or by specifying `profile: subaccount` in `serverless.yml`.
## Todos:
- [x] Properly design the implementation
- [x] Write tests
- [x] Write documentation - N/A
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources - N/A
- [x] Change ready for review message below

**_Is this ready for review?:**_ YES
