### PR TITLE
fixed overwrite resources bug

### DIFF
--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -46,7 +46,7 @@ The bucket must exist beforehand and be in the same region as the Lambda functio
 
 * **From CloudFormation Bucket to Self Provided Bucket:** You need to manually empty the CloudFormation bucket. On the next deployment the bucket will be removed and we will use the self provided bucket. Without emptying the CloudFormation bucket your next deployment will fail.
 
-* **From Self Provided Bucket to CloudFormation Bucket:** You'll need to add the following custom resources template to `serverles.yml`:
+* **From Self Provided Bucket to CloudFormation Bucket:** You'll need to add the following custom resources template to `serverless.yml`:
 
 ```yml
 resources:

--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -42,11 +42,11 @@ provider:
 ```
 
 ### Deployment S3 Bucket
-The bucket must exist beforehand and be in the same region as the deploy. Due to the importance and hard dependency of the deployment bucket, if you want to switch between the core and custom bucket, you have to do the following:
+The bucket must exist beforehand and be in the same region as the Lambda functions you want to deploy. Due to the importance and hard dependency of the deployment bucket, if you want to switch between the core and custom bucket, you have to do the following:
 
-* **From Default Bucket to Custom Bucket:** You'll need to manually empty the default bucket so that it would be removed by CloudFormation and replaced with the custom bucket.
+* **From CloudFormation Bucket to Self Provided Bucket:** You need to manually empty the CloudFormation bucket. On the next deployment the bucket will be removed and we will use the self provided bucket. Without emptying the CloudFormation bucket your next deployment will fail.
 
-* **From Custom Bucket to Default Bucket:** You'll need to add the following custom resources template to `serverles.yml`:
+* **From Self Provided Bucket to CloudFormation Bucket:** You'll need to add the following custom resources template to `serverles.yml`:
 
 ```yml
 resources:
@@ -54,7 +54,7 @@ resources:
     ServerlessDeploymentBucket:
       Type: AWS::S3::Bucket
 ```
-then deploy your service to create that default bucket, then remove the `provider.deploymentBucket` property and deploy your service again. This syncs the framework back to the default bucket without conflict.
+then deploy your service to create the CloudFormation bucket, then remove the `provider.deploymentBucket` property and deploy your service again. This syncs the framework back to the CloudFormation Bucket without conflict. After that deployment you can remove the CloudFormation bucket from the resources section in `serverless.yml` as it will be automatically added from now on.
 
 ## Additional function configuration
 

--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -41,8 +41,20 @@ provider:
             - AWS::EC2::Instance
 ```
 
-### Deployment S3Bucket
-The bucket must exist beforehand and be in the same region as the deploy.
+### Deployment S3 Bucket
+The bucket must exist beforehand and be in the same region as the deploy. Due to the importance and hard dependency of the deployment bucket, if you want to switch between the core and custom bucket, you have to do the following:
+
+* **From Default Bucket to Custom Bucket:** You'll need to manually empty the default bucket so that it would be removed by CloudFormation and replaced with the custom bucket.
+
+* **From Custom Bucket to Default Bucket:** You'll need to add the following custom resources template to `serverles.yml`:
+
+```yml
+resources:
+  Resources:
+    ServerlessDeploymentBucket:
+      Type: AWS::S3::Bucket
+```
+then deploy your service to create that default bucket, then remove the `provider.deploymentBucket` property and deploy your service again. This syncs the framework back to the default bucket without conflict.
 
 ## Additional function configuration
 

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -42,8 +42,7 @@ class AwsDeploy {
         .then(this.configureStack),
 
       'deploy:setupProviderConfiguration': () => BbPromise.bind(this)
-        .then(this.createStack)
-        .then((cfData) => this.monitorStack('create', cfData)),
+        .then(this.createStack),
 
       'before:deploy:compileFunctions': () => BbPromise.bind(this)
         .then(this.generateArtifactDirectoryName),

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -11,6 +11,7 @@ const cleanupS3Bucket = require('./lib/cleanupS3Bucket');
 const uploadArtifacts = require('./lib/uploadArtifacts');
 const updateStack = require('./lib/updateStack');
 const configureStack = require('./lib/configureStack');
+const mergeIamTemplates = require('./lib/mergeIamTemplates');
 
 class AwsDeploy {
   constructor(serverless, options) {
@@ -29,7 +30,8 @@ class AwsDeploy {
       uploadArtifacts,
       updateStack,
       monitorStack,
-      configureStack
+      configureStack,
+      mergeIamTemplates
     );
 
     this.hooks = {
@@ -37,8 +39,7 @@ class AwsDeploy {
         .then(this.validate),
 
       'deploy:initialize': () => BbPromise.bind(this)
-        .then(this.configureStack)
-        .then(this.mergeCustomProviderResources),
+        .then(this.configureStack),
 
       'deploy:setupProviderConfiguration': () => BbPromise.bind(this)
         .then(this.createStack)
@@ -48,11 +49,12 @@ class AwsDeploy {
         .then(this.generateArtifactDirectoryName),
 
       'deploy:deploy': () => BbPromise.bind(this)
+        .then(this.mergeIamTemplates)
+        .then(this.mergeCustomProviderResources)
         .then(this.setBucketName)
         .then(this.cleanupS3Bucket)
         .then(this.uploadArtifacts)
         .then(this.updateStack)
-        .then((cfData) => this.monitorStack('update', cfData))
         .then(() => {
           if (this.options.noDeploy) this.serverless.cli.log('Did not deploy due to --noDeploy');
         }),

--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
 
@@ -15,65 +14,6 @@ module.exports = {
         'lib',
         'core-cloudformation-template.json')
     );
-
-    if (typeof this.serverless.service.provider.iamRoleARN !== 'string') {
-      // merge in the iamRoleLambdaTemplate
-      const iamRoleLambdaExecutionTemplate = this.serverless.utils.readFileSync(
-        path.join(this.serverless.config.serverlessPath,
-          'plugins',
-          'aws',
-          'deploy',
-          'lib',
-          'iam-role-lambda-execution-template.json')
-      );
-
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        iamRoleLambdaExecutionTemplate);
-
-      // merge in the iamPolicyLambdaTemplate
-      const iamPolicyLambdaExecutionTemplate = this.serverless.utils.readFileSync(
-        path.join(this.serverless.config.serverlessPath,
-          'plugins',
-          'aws',
-          'deploy',
-          'lib',
-          'iam-policy-lambda-execution-template.json')
-      );
-
-      // set the necessary variables for the IamPolicyLambda
-      iamPolicyLambdaExecutionTemplate
-        .IamPolicyLambdaExecution
-        .Properties
-        .PolicyName = `${this.options.stage}-${this.serverless.service.service}-lambda`;
-
-      iamPolicyLambdaExecutionTemplate
-        .IamPolicyLambdaExecution
-        .Properties
-        .PolicyDocument
-        .Statement[0]
-        .Resource = `arn:aws:logs:${this.options.region}:*:*`;
-
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        iamPolicyLambdaExecutionTemplate);
-
-
-      // add custom iam role statements
-      if (this.serverless.service.provider.iamRoleStatements &&
-        this.serverless.service.provider.iamRoleStatements instanceof Array) {
-        this.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-          .IamPolicyLambdaExecution
-          .Properties
-          .PolicyDocument
-          .Statement = this.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-          .IamPolicyLambdaExecution
-          .Properties
-          .PolicyDocument
-          .Statement.concat(this.serverless.service.provider.iamRoleStatements);
-      }
-    }
-
     const bucketName = this.serverless.service.provider.deploymentBucket;
 
     if (bucketName) {

--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -27,7 +27,9 @@ module.exports = {
           this.options.stage,
           this.options.region
         ))
-        .then(result => {
+        .then(resultParam => {
+          const result = resultParam;
+          if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
           if (result.LocationConstraint !== this.options.region) {
             throw new this.serverless.classes.Error(
               'Deployment bucket is not in the same region as the lambda function'

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -31,7 +31,8 @@ module.exports = {
       'createStack',
       params,
       this.options.stage,
-      this.options.region);
+      this.options.region)
+      .then((cfData) => this.monitorStack('create', cfData));
   },
 
   createStack() {
@@ -50,9 +51,7 @@ module.exports = {
     return BbPromise.bind(this)
       // always write the template to disk, whether we are deploying or not
       .then(this.writeCreateTemplateToDisk)
-      .then(() => {
-
-        return this.provider.request('CloudFormation',
+      .then(() => this.provider.request('CloudFormation',
           'describeStackResources',
           { StackName: stackName },
           this.options.stage,
@@ -72,12 +71,15 @@ module.exports = {
             }
 
             throw new this.serverless.classes.Error(e);
-          });
-      });
+          })
+      );
   },
 
   // helper methods
   writeCreateTemplateToDisk() {
+    if (this.serverless.service.provider.deploymentBucket) {
+      return BbPromise.resolve();
+    }
     const cfTemplateFilePath = path.join(this.serverless.config.servicePath,
       '.serverless', 'cloudformation-template-create-stack.json');
 

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -51,9 +51,6 @@ module.exports = {
       // always write the template to disk, whether we are deploying or not
       .then(this.writeCreateTemplateToDisk)
       .then(() => {
-        if (this.options.noDeploy) {
-          return BbPromise.resolve();
-        }
 
         return this.provider.request('CloudFormation',
           'describeStackResources',
@@ -63,6 +60,13 @@ module.exports = {
           .then(() => BbPromise.resolve('alreadyCreated'))
           .catch(e => {
             if (e.message.indexOf('does not exist') > -1) {
+              if (this.serverless.service.provider.deploymentBucket) {
+                this.createLater = true;
+              }
+
+              if (this.options.noDeploy || this.createLater) {
+                return BbPromise.resolve();
+              }
               return BbPromise.bind(this)
                 .then(this.create);
             }

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+const path = require('path');
+
+module.exports = {
+  mergeIamTemplates() {
+    if (typeof this.serverless.service.provider.iamRoleARN !== 'string') {
+      // merge in the iamRoleLambdaTemplate
+      const iamRoleLambdaExecutionTemplate = this.serverless.utils.readFileSync(
+        path.join(this.serverless.config.serverlessPath,
+          'plugins',
+          'aws',
+          'deploy',
+          'lib',
+          'iam-role-lambda-execution-template.json')
+      );
+
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+        iamRoleLambdaExecutionTemplate);
+
+      // merge in the iamPolicyLambdaTemplate
+      const iamPolicyLambdaExecutionTemplate = this.serverless.utils.readFileSync(
+        path.join(this.serverless.config.serverlessPath,
+          'plugins',
+          'aws',
+          'deploy',
+          'lib',
+          'iam-policy-lambda-execution-template.json')
+      );
+
+      // set the necessary variables for the IamPolicyLambda
+      iamPolicyLambdaExecutionTemplate
+        .IamPolicyLambdaExecution
+        .Properties
+        .PolicyName = `${this.options.stage}-${this.serverless.service.service}-lambda`;
+
+      iamPolicyLambdaExecutionTemplate
+        .IamPolicyLambdaExecution
+        .Properties
+        .PolicyDocument
+        .Statement[0]
+        .Resource = `arn:aws:logs:${this.options.region}:*:*`;
+
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+        iamPolicyLambdaExecutionTemplate);
+
+
+      // add custom iam role statements
+      if (this.serverless.service.provider.iamRoleStatements &&
+        this.serverless.service.provider.iamRoleStatements instanceof Array) {
+        this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamPolicyLambdaExecution
+          .Properties
+          .PolicyDocument
+          .Statement = this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamPolicyLambdaExecution
+          .Properties
+          .PolicyDocument
+          .Statement.concat(this.serverless.service.provider.iamRoleStatements);
+      }
+    }
+
+    return BbPromise.resolve();
+  },
+
+};

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -5,6 +5,38 @@ const path = require('path');
 const BbPromise = require('bluebird');
 
 module.exports = {
+  createFallback() {
+    this.createLater = false;
+    this.serverless.cli.log('Creating Stack...');
+
+    const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+    let stackTags = { STAGE: this.options.stage };
+
+    // Merge additional stack tags
+    if (typeof this.serverless.service.provider.stackTags === 'object') {
+      stackTags = _.extend(stackTags, this.serverless.service.provider.stackTags);
+    }
+
+    const params = {
+      StackName: stackName,
+      OnFailure: 'ROLLBACK',
+      Capabilities: [
+        'CAPABILITY_IAM',
+      ],
+      Parameters: [],
+      TemplateBody: JSON.stringify(this.serverless.service.provider
+        .compiledCloudFormationTemplate),
+      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
+    };
+
+    return this.sdk.request('CloudFormation',
+      'createStack',
+      params,
+      this.options.stage,
+      this.options.region)
+      .then((cfData) => this.monitorStack('create', cfData));
+  },
+
   update() {
     const templateUrl = `https://s3.amazonaws.com/${
         this.bucketName
@@ -43,7 +75,8 @@ module.exports = {
       'updateStack',
       params,
       this.options.stage,
-      this.options.region);
+      this.options.region)
+      .then((cfData) => this.monitorStack('update', cfData));
   },
 
   updateStack() {
@@ -53,6 +86,9 @@ module.exports = {
       .then(() => {
         if (this.options.noDeploy) {
           return BbPromise.resolve();
+        } else if (this.createLater) {
+          return BbPromise.bind(this)
+            .then(this.createFallback);
         }
         return BbPromise.bind(this)
           .then(this.update);
@@ -61,8 +97,9 @@ module.exports = {
 
   // helper methods
   writeUpdateTemplateToDisk() {
+    const updateOrCreate = this.createLater ? 'create' : 'update';
     const cfTemplateFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless', 'cloudformation-template-update-stack.json');
+      '.serverless', `cloudformation-template-${updateOrCreate}-stack.json`);
 
     this.serverless.utils.writeFileSync(cfTemplateFilePath,
       this.serverless.service.provider.compiledCloudFormationTemplate);

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -11,7 +11,11 @@ module.exports = {
 
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
     let stackTags = { STAGE: this.options.stage };
-
+    const templateUrl = `https://s3.amazonaws.com/${
+      this.bucketName
+      }/${
+      this.serverless.service.package.artifactDirectoryName
+      }/compiled-cloudformation-template.json`;
     // Merge additional stack tags
     if (typeof this.serverless.service.provider.stackTags === 'object') {
       stackTags = _.extend(stackTags, this.serverless.service.provider.stackTags);
@@ -24,8 +28,7 @@ module.exports = {
         'CAPABILITY_IAM',
       ],
       Parameters: [],
-      TemplateBody: JSON.stringify(this.serverless.service.provider
-        .compiledCloudFormationTemplate),
+      TemplateURL: templateUrl,
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -32,7 +32,7 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    return this.sdk.request('CloudFormation',
+    return this.provider.request('CloudFormation',
       'createStack',
       params,
       this.options.stage,

--- a/lib/plugins/aws/deploy/tests/all.js
+++ b/lib/plugins/aws/deploy/tests/all.js
@@ -9,3 +9,4 @@ require('./uploadArtifacts');
 require('./updateStack');
 require('./index');
 require('./configureStack');
+require('./mergeIamTemplates');

--- a/lib/plugins/aws/deploy/tests/configureStack.js
+++ b/lib/plugins/aws/deploy/tests/configureStack.js
@@ -10,6 +10,7 @@ const validate = require('../../lib/validate');
 const configureStack = require('../lib/configureStack');
 
 describe('#configureStack', () => {
+
   let serverless;
   const awsPlugin = {};
 
@@ -21,7 +22,6 @@ describe('#configureStack', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-
     Object.assign(awsPlugin, configureStack, validate);
   });
 
@@ -60,7 +60,6 @@ describe('#configureStack', () => {
       })
       .then(() => {});
   });
-
 
   it('should merge the IamRoleLambdaExecution template into the CloudFormation template', () => {
     const IamRoleLambdaExecutionTemplate = awsPlugin.serverless.utils.readFileSync(
@@ -157,7 +156,7 @@ describe('#configureStack', () => {
 
     sinon
       .stub(awsPlugin.provider, 'request')
-      .returns(BbPromise.resolve({ LocationConstraint: awsPlugin.options.region }));
+      .returns(BbPromise.resolve({ LocationConstraint: '' }));
 
     return awsPlugin.configureStack()
       .then(() => {
@@ -172,7 +171,6 @@ describe('#configureStack', () => {
         ).to.not.exist;
       });
   });
-
   it('should not add IamPolicyLambdaExecution', () => {
     awsPlugin.serverless.service.provider.iamRoleARN = 'some:aws:arn:xxx:*:*';
 

--- a/lib/plugins/aws/deploy/tests/configureStack.js
+++ b/lib/plugins/aws/deploy/tests/configureStack.js
@@ -10,7 +10,6 @@ const validate = require('../../lib/validate');
 const configureStack = require('../lib/configureStack');
 
 describe('#configureStack', () => {
-
   let serverless;
   const awsPlugin = {};
 
@@ -61,83 +60,6 @@ describe('#configureStack', () => {
       .then(() => {});
   });
 
-  it('should merge the IamRoleLambdaExecution template into the CloudFormation template', () => {
-    const IamRoleLambdaExecutionTemplate = awsPlugin.serverless.utils.readFileSync(
-      path.join(
-        __dirname,
-        '..',
-        'lib',
-        'iam-role-lambda-execution-template.json'
-      )
-    );
-
-    return awsPlugin.configureStack()
-      .then(() => {
-        expect(awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.IamRoleLambdaExecution
-        ).to.deep.equal(IamRoleLambdaExecutionTemplate.IamRoleLambdaExecution);
-      });
-  });
-
-  it('should merge IamPolicyLambdaExecution template into the CloudFormation template', () =>
-    awsPlugin.configureStack()
-      .then(() => {
-        // we check for the type here because a deep equality check will error out due to
-        // the updates which are made after the merge (they are tested in a separate test)
-        expect(awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.IamPolicyLambdaExecution.Type
-        ).to.deep.equal('AWS::IAM::Policy');
-      })
-  );
-
-  it('should update the necessary variables for the IamPolicyLambdaExecution', () =>
-    awsPlugin.configureStack()
-      .then(() => {
-        expect(awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-          .IamPolicyLambdaExecution
-          .Properties
-          .PolicyName
-        ).to.equal(
-          `${
-            awsPlugin.options.stage
-            }-${
-            awsPlugin.serverless.service.service
-            }-lambda`
-        );
-
-        expect(awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-          .IamPolicyLambdaExecution
-          .Properties
-          .PolicyDocument
-          .Statement[0]
-          .Resource
-        ).to.equal(`arn:aws:logs:${awsPlugin.options.region}:*:*`);
-      })
-  );
-
-  it('should add custom IAM policy statements', () => {
-    awsPlugin.serverless.service.provider.name = 'aws';
-    awsPlugin.serverless.service.provider.iamRoleStatements = [
-      {
-        Effect: 'Allow',
-        Action: [
-          'something:SomethingElse',
-        ],
-        Resource: 'some:aws:arn:xxx:*:*',
-      },
-    ];
-
-
-    return awsPlugin.configureStack()
-      .then(() => {
-        expect(awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.IamPolicyLambdaExecution.Properties.PolicyDocument.Statement[1]
-        ).to.deep.equal(awsPlugin.serverless.service.provider.iamRoleStatements[0]);
-      });
-  });
-
   it('should use a custom bucket if specified', () => {
     const bucketName = 'com.serverless.deploys';
 
@@ -170,25 +92,5 @@ describe('#configureStack', () => {
             .Resources.ServerlessDeploymentBucket
         ).to.not.exist;
       });
-  });
-  it('should not add IamPolicyLambdaExecution', () => {
-    awsPlugin.serverless.service.provider.iamRoleARN = 'some:aws:arn:xxx:*:*';
-
-    return awsPlugin.configureStack()
-      .then(() => expect(
-          awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.IamPolicyLambdaExecution
-        ).to.not.exist);
-  });
-
-
-  it('should not add IamRole', () => {
-    awsPlugin.serverless.service.provider.iamRoleARN = 'some:aws:arn:xxx:*:*';
-
-    return awsPlugin.configureStack()
-      .then(() => expect(
-          awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.IamRoleLambdaExecution
-        ).to.not.exist);
   });
 });

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -65,7 +65,7 @@ describe('createStack', () => {
           .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(createStackStub.calledOnce).to.be.equal(true);
         expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.sdk.request.restore();
+        awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();
       });
     });
@@ -132,7 +132,8 @@ describe('createStack', () => {
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
       const awsRequestStub = sinon
-        .stub(awsDeploy.sdk, 'request').returns(BbPromise.reject({ message: 'does not exist' }));
+        .stub(awsDeploy.provider, 'request')
+        .returns(BbPromise.reject({ message: 'does not exist' }));
 
       return awsDeploy.createStack().then(() => {
         expect(awsRequestStub.args[0][0]).to.equal('CloudFormation');
@@ -148,7 +149,8 @@ describe('createStack', () => {
       awsDeploy.serverless.service.provider.deploymentBucket = 'serverless';
 
       sinon.stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
-      sinon.stub(awsDeploy.sdk, 'request').returns(BbPromise.reject({ message: 'does not exist' }));
+      sinon.stub(awsDeploy.provider, 'request')
+        .returns(BbPromise.reject({ message: 'does not exist' }));
 
       return awsDeploy.createStack().then(() => {
         expect(awsDeploy.createLater).to.equal(true);

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -52,6 +52,7 @@ describe('createStack', () => {
 
       const createStackStub = sinon
         .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
 
       return awsDeploy.create().then(() => {
         expect(createStackStub.args[0][0]).to.equal('CloudFormation');
@@ -64,6 +65,8 @@ describe('createStack', () => {
           .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(createStackStub.calledOnce).to.be.equal(true);
         expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        awsDeploy.sdk.request.restore();
+        awsDeploy.monitorStack.restore();
       });
     });
 
@@ -72,6 +75,7 @@ describe('createStack', () => {
 
       const createStackStub = sinon
         .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
 
       return awsDeploy.create().then(() => {
         expect(createStackStub.args[0][2].Tags)
@@ -80,6 +84,7 @@ describe('createStack', () => {
             { Key: 'tag1', Value: 'value1' },
           ]);
         awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
       });
     });
   });
@@ -126,10 +131,27 @@ describe('createStack', () => {
         .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
+      const awsRequestStub = sinon
+        .stub(awsDeploy.sdk, 'request').returns(BbPromise.reject({ message: 'does not exist' }));
 
       return awsDeploy.createStack().then(() => {
+        expect(awsRequestStub.args[0][0]).to.equal('CloudFormation');
+        expect(awsRequestStub.args[0][1]).to.equal('describeStackResources');
+        expect(awsRequestStub.args[0][2].StackName)
+          .to.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
         expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
         expect(createStub.called).to.be.equal(false);
+      });
+    });
+
+    it('should set the createLater flag and resolve if deployment bucket is provided', () => {
+      awsDeploy.serverless.service.provider.deploymentBucket = 'serverless';
+
+      sinon.stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.sdk, 'request').returns(BbPromise.reject({ message: 'does not exist' }));
+
+      return awsDeploy.createStack().then(() => {
+        expect(awsDeploy.createLater).to.equal(true);
       });
     });
 
@@ -181,6 +203,15 @@ describe('createStack', () => {
   });
 
   describe('#writeCreateTemplateToDisk', () => {
+    it('should resolve if deployment bucket is provided', () => {
+      awsDeploy.serverless.service.provider.deploymentBucket = 'serverless';
+      const writeFileSyncStub = sinon.stub(awsDeploy.serverless.utils, 'writeFileSync');
+
+      return awsDeploy.writeCreateTemplateToDisk().then(() => {
+        expect(writeFileSyncStub.called).to.be.equal(false);
+        awsDeploy.serverless.utils.writeFileSync.restore();
+      });
+    });
     it('should write the compiled CloudFormation template into the .serverless directory', () => {
       awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
 

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -40,12 +40,8 @@ describe('AwsDeploy', () => {
     it('should run "deploy:setupProviderConfiguration" hook promise chain in order', () => {
       const createStackStub = sinon
         .stub(awsDeploy, 'createStack').returns(BbPromise.resolve());
-      const monitorStackStub = sinon
-        .stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
-
       return awsDeploy.hooks['deploy:setupProviderConfiguration']().then(() => {
         expect(createStackStub.calledOnce).to.be.equal(true);
-        expect(monitorStackStub.calledOnce).to.be.equal(true);
       });
     });
 
@@ -62,16 +58,16 @@ describe('AwsDeploy', () => {
       const configureStackStub = sinon
         .stub(awsDeploy, 'configureStack').returns(BbPromise.resolve());
 
-      const mergeCustomProviderResourcesStub = sinon
-        .stub(awsDeploy, 'mergeCustomProviderResources').returns(BbPromise.resolve());
-
       return awsDeploy.hooks['deploy:initialize']().then(() => {
         expect(configureStackStub.calledOnce).to.be.equal(true);
-        expect(mergeCustomProviderResourcesStub.calledOnce).to.be.equal(true);
       });
     });
 
     it('should run "deploy:deploy" promise chain in order', () => {
+      const mergeIamTemplatesStub = sinon
+        .stub(awsDeploy, 'mergeIamTemplates').returns(BbPromise.resolve());
+      const mergeCustomProviderResourcesStub = sinon
+        .stub(awsDeploy, 'mergeCustomProviderResources').returns(BbPromise.resolve());
       const setBucketNameStub = sinon
         .stub(awsDeploy, 'setBucketName').returns(BbPromise.resolve());
       const cleanupS3BucketStub = sinon
@@ -80,28 +76,29 @@ describe('AwsDeploy', () => {
         .stub(awsDeploy, 'uploadArtifacts').returns(BbPromise.resolve());
       const updateStackStub = sinon
         .stub(awsDeploy, 'updateStack').returns(BbPromise.resolve());
-      const monitorStackStub = sinon
-        .stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
 
       return awsDeploy.hooks['deploy:deploy']().then(() => {
-        expect(setBucketNameStub.calledOnce).to.be.equal(true);
+        expect(mergeIamTemplatesStub.calledOnce).to.be.equal(true);
+        expect(mergeCustomProviderResourcesStub.calledAfter(mergeIamTemplatesStub))
+          .to.be.equal(true);
+        expect(setBucketNameStub.calledAfter(mergeCustomProviderResourcesStub))
+          .to.be.equal(true);
         expect(cleanupS3BucketStub.calledAfter(setBucketNameStub))
           .to.be.equal(true);
         expect(uploadArtifactsStub.calledAfter(cleanupS3BucketStub))
           .to.be.equal(true);
         expect(updateStackStub.calledAfter(uploadArtifactsStub))
           .to.be.equal(true);
-        expect(monitorStackStub.calledAfter(updateStackStub))
-          .to.be.equal(true);
       });
     });
 
     it('should notify about noDeploy', () => {
+      sinon.stub(awsDeploy, 'mergeIamTemplates').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy, 'mergeCustomProviderResources').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'setBucketName').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'cleanupS3Bucket').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'uploadArtifacts').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'updateStack').returns(BbPromise.resolve());
-      sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
       sinon.stub(awsDeploy.serverless.cli, 'log').returns();
       awsDeploy.options.noDeploy = true;
 

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+
+const Serverless = require('../../../../Serverless');
+const AwsDeploy = require('../');
+
+describe('#mergeIamTemplates', () => {
+  let awsDeploy;
+  let serverless;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.serverless.cli = new serverless.classes.CLI();
+    awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+    };
+  });
+
+
+  it('should merge the IamRoleLambdaExecution template into the CloudFormation template', () => {
+    const IamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        'lib',
+        'iam-role-lambda-execution-template.json'
+      )
+    );
+
+    return awsDeploy.mergeIamTemplates()
+      .then(() => {
+        expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.IamRoleLambdaExecution
+        ).to.deep.equal(IamRoleLambdaExecutionTemplate.IamRoleLambdaExecution);
+      });
+  });
+
+  it('should merge IamPolicyLambdaExecution template into the CloudFormation template', () =>
+    awsDeploy.mergeIamTemplates()
+      .then(() => {
+        // we check for the type here because a deep equality check will error out due to
+        // the updates which are made after the merge (they are tested in a separate test)
+        expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.IamPolicyLambdaExecution.Type
+        ).to.deep.equal('AWS::IAM::Policy');
+      })
+  );
+
+  it('should update the necessary variables for the IamPolicyLambdaExecution', () =>
+    awsDeploy.mergeIamTemplates()
+      .then(() => {
+        expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamPolicyLambdaExecution
+          .Properties
+          .PolicyName
+        ).to.equal(
+          `${
+            awsDeploy.options.stage
+            }-${
+            awsDeploy.serverless.service.service
+            }-lambda`
+        );
+
+        expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamPolicyLambdaExecution
+          .Properties
+          .PolicyDocument
+          .Statement[0]
+          .Resource
+        ).to.equal(`arn:aws:logs:${awsDeploy.options.region}:*:*`);
+      })
+  );
+
+  it('should add custom IAM policy statements', () => {
+    awsDeploy.serverless.service.provider.name = 'aws';
+    awsDeploy.serverless.service.provider.iamRoleStatements = [
+      {
+        Effect: 'Allow',
+        Action: [
+          'something:SomethingElse',
+        ],
+        Resource: 'some:aws:arn:xxx:*:*',
+      },
+    ];
+
+
+    return awsDeploy.mergeIamTemplates()
+      .then(() => {
+        expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.IamPolicyLambdaExecution.Properties.PolicyDocument.Statement[1]
+        ).to.deep.equal(awsDeploy.serverless.service.provider.iamRoleStatements[0]);
+      });
+  });
+
+  it('should not add IamPolicyLambdaExecution if arn is provided', () => {
+    awsDeploy.serverless.service.provider.iamRoleARN = 'some:aws:arn:xxx:*:*';
+
+    return awsDeploy.mergeIamTemplates()
+      .then(() => expect(
+          awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.IamPolicyLambdaExecution
+        ).to.not.exist);
+  });
+
+
+  it('should not add IamRole if arn is provided', () => {
+    awsDeploy.serverless.service.provider.iamRoleARN = 'some:aws:arn:xxx:*:*';
+
+    return awsDeploy.configureStack()
+      .then(() => expect(
+          awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.IamRoleLambdaExecution
+        ).to.not.exist);
+  });
+});

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect;
 const Serverless = require('../../../../Serverless');
 const AwsDeploy = require('../');
 
-describe('#mergeIamTemplates', () => {
+describe('#mergeIamTemplates()', () => {
   let awsDeploy;
   let serverless;
 

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -31,12 +31,56 @@ describe('updateStack', () => {
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });
 
+  describe('#createFallback()', () => {
+    it('should create a stack with the CF template URL', () => {
+      const createStackStub = sinon
+        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
+
+      return awsDeploy.createFallback().then(() => {
+        expect(createStackStub.args[0][0]).to.equal('CloudFormation');
+        expect(createStackStub.args[0][1]).to.equal('createStack');
+        expect(createStackStub.args[0][2].StackName)
+          .to.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
+        expect(createStackStub.args[0][2].OnFailure).to.equal('ROLLBACK');
+        expect(createStackStub.args[0][2].TemplateURL)
+          .to.be.equal(`https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
+          .service.package.artifactDirectoryName}/compiled-cloudformation-template.json`);
+        expect(createStackStub.args[0][2].Tags)
+          .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
+        expect(createStackStub.calledOnce).to.be.equal(true);
+        expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        awsDeploy.sdk.request.restore();
+        awsDeploy.monitorStack.restore();
+      });
+    });
+
+    it('should include custom stack tags', () => {
+      awsDeploy.serverless.service.provider.stackTags = { STAGE: 'overridden', tag1: 'value1' };
+
+      const createStackStub = sinon
+        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
+
+      return awsDeploy.createFallback().then(() => {
+        expect(createStackStub.args[0][2].Tags)
+          .to.deep.equal([
+            { Key: 'STAGE', Value: 'overridden' },
+            { Key: 'tag1', Value: 'value1' },
+          ]);
+        awsDeploy.sdk.request.restore();
+        awsDeploy.monitorStack.restore();
+      });
+    });
+  });
+
   describe('#update()', () => {
     let updateStackStub;
 
     beforeEach(() => {
       updateStackStub = sinon
         .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
     });
 
     it('should update the stack', () => awsDeploy.update()
@@ -53,7 +97,9 @@ describe('updateStack', () => {
           .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(updateStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
 
+
         awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
       })
     );
 
@@ -76,7 +122,9 @@ describe('updateStack', () => {
           .to.equal(
             '{"Statement":[{"Effect":"Allow","Principal":"*","Action":"Update:*","Resource":"*"}]}'
           );
+
         awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
       });
     });
   });
@@ -92,6 +140,26 @@ describe('updateStack', () => {
 
       return awsDeploy.updateStack().then(() => {
         expect(writeUpdateTemplateStub.calledOnce).to.be.equal(true);
+        expect(updateStub.called).to.be.equal(false);
+
+        awsDeploy.writeUpdateTemplateToDisk.restore();
+        awsDeploy.update.restore();
+      });
+    });
+
+    it('should fallback to createStack if createLater flag exists', () => {
+      awsDeploy.createLater = true;
+
+      const writeUpdateTemplateStub = sinon
+        .stub(awsDeploy, 'writeUpdateTemplateToDisk').returns();
+      const createFallbackStub = sinon
+        .stub(awsDeploy, 'createFallback').returns(BbPromise.resolve());
+      const updateStub = sinon
+        .stub(awsDeploy, 'update').returns(BbPromise.resolve());
+
+      return awsDeploy.updateStack().then(() => {
+        expect(writeUpdateTemplateStub.calledOnce).to.be.equal(true);
+        expect(createFallbackStub.calledOnce).to.be.equal(true);
         expect(updateStub.called).to.be.equal(false);
 
         awsDeploy.writeUpdateTemplateToDisk.restore();

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -34,7 +34,7 @@ describe('updateStack', () => {
   describe('#createFallback()', () => {
     it('should create a stack with the CF template URL', () => {
       const createStackStub = sinon
-        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
 
       return awsDeploy.createFallback().then(() => {
@@ -50,7 +50,7 @@ describe('updateStack', () => {
           .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(createStackStub.calledOnce).to.be.equal(true);
         expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.sdk.request.restore();
+        awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();
       });
     });
@@ -59,7 +59,7 @@ describe('updateStack', () => {
       awsDeploy.serverless.service.provider.stackTags = { STAGE: 'overridden', tag1: 'value1' };
 
       const createStackStub = sinon
-        .stub(awsDeploy.sdk, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
 
       return awsDeploy.createFallback().then(() => {
@@ -68,7 +68,7 @@ describe('updateStack', () => {
             { Key: 'STAGE', Value: 'overridden' },
             { Key: 'tag1', Value: 'value1' },
           ]);
-        awsDeploy.sdk.request.restore();
+        awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();
       });
     });

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -8,6 +8,9 @@ module.exports = {
   monitorStack(action, cfData, frequency) {
     // Skip monitoring if a deployment should not be performed
     if (this.options.noDeploy) return BbPromise.bind(this).then(BbPromise.resolve());
+    if (this.createLater & action === 'create') {
+      return BbPromise.bind(this).then(BbPromise.resolve());
+    }
 
     // Skip monitoring if stack was already created
     if (cfData === 'alreadyCreated') return BbPromise.bind(this).then(BbPromise.resolve());

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -8,9 +8,6 @@ module.exports = {
   monitorStack(action, cfData, frequency) {
     // Skip monitoring if a deployment should not be performed
     if (this.options.noDeploy) return BbPromise.bind(this).then(BbPromise.resolve());
-    if (this.createLater & action === 'create') {
-      return BbPromise.bind(this).then(BbPromise.resolve());
-    }
 
     // Skip monitoring if stack was already created
     if (cfData === 'alreadyCreated') return BbPromise.bind(this).then(BbPromise.resolve());

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -177,14 +177,18 @@ class AwsProvider {
   getServerlessDeploymentBucketName(stage, region) {
     const stackName = `${this.serverless.service.service}-${stage}`;
     return this.request('CloudFormation',
-      'describeStackResource',
+      'describeStacks',
       {
         StackName: stackName,
-        LogicalResourceId: 'ServerlessDeploymentBucket',
       },
       stage,
       region
-    ).then((result) => result.StackResourceDetail.PhysicalResourceId);
+    ).then((result) => {
+      const outputs = result.Stacks[0].Outputs;
+      const deploymentBucket = outputs
+        .find(x => x.OutputKey.match(/ServerlessDeploymentBucketName/)).OutputValue;
+      return deploymentBucket;
+    });
   }
 
   getStackName(stage) {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -175,20 +175,19 @@ class AwsProvider {
   }
 
   getServerlessDeploymentBucketName(stage, region) {
+    if (this.serverless.service.provider.deploymentBucket) {
+      return BbPromise.resolve(this.serverless.service.provider.deploymentBucket);
+    }
     const stackName = `${this.serverless.service.service}-${stage}`;
     return this.request('CloudFormation',
-      'describeStacks',
+      'describeStackResource',
       {
         StackName: stackName,
+        LogicalResourceId: 'ServerlessDeploymentBucket',
       },
       stage,
       region
-    ).then((result) => {
-      const outputs = result.Stacks[0].Outputs;
-      const deploymentBucket = outputs
-        .find(x => x.OutputKey.match(/ServerlessDeploymentBucketName/)).OutputValue;
-      return deploymentBucket;
-    });
+    ).then((result) => result.StackResourceDetail.PhysicalResourceId);
   }
 
   getStackName(stage) {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -379,6 +379,29 @@ describe('AwsProvider', () => {
           awsProvider.request.restore();
         });
     });
+
+    it('should return the name of the custom deployment bucket', () => {
+      awsSdk.serverless.service.provider.deploymentBucket = 'custom-bucket';
+      const options = {
+        stage: 'dev',
+        region: 'us-east-1',
+      };
+
+      const describeStackResourcesStub = sinon
+        .stub(awsSdk, 'request')
+        .returns(BbPromise.resolve({
+          StackResourceDetail: {
+            PhysicalResourceId: 'serverlessDeploymentBucketName',
+          },
+        }));
+
+      return awsSdk.getServerlessDeploymentBucketName(options.stage, options.region)
+        .then((bucketName) => {
+          expect(describeStackResourcesStub.called).to.be.equal(false);
+          expect(bucketName).to.equal('custom-bucket');
+          awsSdk.request.restore();
+        });
+    });
   });
 
   describe('#getStackName', () => {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -381,25 +381,25 @@ describe('AwsProvider', () => {
     });
 
     it('should return the name of the custom deployment bucket', () => {
-      awsSdk.serverless.service.provider.deploymentBucket = 'custom-bucket';
+      awsProvider.serverless.service.provider.deploymentBucket = 'custom-bucket';
       const options = {
         stage: 'dev',
         region: 'us-east-1',
       };
 
       const describeStackResourcesStub = sinon
-        .stub(awsSdk, 'request')
+        .stub(awsProvider, 'request')
         .returns(BbPromise.resolve({
           StackResourceDetail: {
             PhysicalResourceId: 'serverlessDeploymentBucketName',
           },
         }));
 
-      return awsSdk.getServerlessDeploymentBucketName(options.stage, options.region)
+      return awsProvider.getServerlessDeploymentBucketName(options.stage, options.region)
         .then((bucketName) => {
           expect(describeStackResourcesStub.called).to.be.equal(false);
           expect(bucketName).to.equal('custom-bucket');
-          awsSdk.request.restore();
+          awsProvider.request.restore();
         });
     });
   });

--- a/tests/integration/all.js
+++ b/tests/integration/all.js
@@ -4,6 +4,7 @@
 // General
 require('./aws/general/nested-handlers/tests');
 require('./aws/general/custom-resources/tests');
+require('./aws/general/overwrite-resources/tests');
 
 // API Gateway
 // Integration: Lambda

--- a/tests/integration/aws/general/overwrite-resources/service/handler.js
+++ b/tests/integration/aws/general/overwrite-resources/service/handler.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};
+
+module.exports.world = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};
+

--- a/tests/integration/aws/general/overwrite-resources/service/serverless.yml
+++ b/tests/integration/aws/general/overwrite-resources/service/serverless.yml
@@ -1,0 +1,18 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+  world:
+    handler: handler.world
+
+resources:
+  Resources:
+    HelloLambdaFunction:
+      Type: "AWS::Lambda::Function"
+      Properties:
+        Timeout: 10

--- a/tests/integration/aws/general/overwrite-resources/tests.js
+++ b/tests/integration/aws/general/overwrite-resources/tests.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const AWS = require('aws-sdk');
+const BbPromise = require('bluebird');
+
+const Utils = require('../../../../utils/index');
+
+const Lambda = new AWS.Lambda({ region: 'us-east-1' });
+BbPromise.promisifyAll(Lambda, { suffix: 'Promised' });
+
+describe('AWS - General: Overwrite resources test', function () {
+  this.timeout(0);
+
+  let stackName;
+
+  before(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should overwrite timeout config for hello function', () => {
+    const helloFunctionName = `${stackName}-hello`;
+    return Lambda.getFunctionPromised({ FunctionName: helloFunctionName })
+      .then(data => {
+        const timeout = data.Configuration.Timeout;
+        expect(timeout).to.equal(10);
+      });
+  });
+
+  it('should NOT overwrite timeout config for world function', () => {
+    const worldFunctionName = `${stackName}-world`;
+    return Lambda.getFunctionPromised({ FunctionName: worldFunctionName })
+      .then(data => {
+        const timeout = data.Configuration.Timeout;
+        expect(timeout).to.equal(6);
+      });
+  });
+
+  after(() => {
+    Utils.removeService();
+  });
+});


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

***Implementing Issue:*** #2359 & #2404

* Fixes overwriting default resources using custom resources
* Fixes creating IAM templates in the update step rather than the create step
* Fixes bucket region validation for us-east-1

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
I've moved the process of merging custom resources **after** compiling functions/events, hence enabling overwriting.

I've moved IAM templates to the update step, which works fine if no custom bucket was provided. If custom bucket is provided, it gets a little complicated because the create step does not have any resources to create (no bucket to create).

So in that case I switch to a 1 step deployment process by creating **all** resources at the same time by falling back to a create method when trying to update everything. On second deployment, update works the same way.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->
Using this config:

```yml
service: serverless-deployment-bucket-bug-4

provider:
  name: aws
  runtime: nodejs4.3
  stage: prod
  region: us-west-2

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: hello/test
          method: get
          cors: true
          authorizer: auth
  auth:
    handler: handler.auth

resources:
  Resources:
    HelloLambdaFunction:
      Type: "AWS::Lambda::Function"
      Properties:
        Timeout: 10
```
### Verify Resource Overwriting
run `serverless deploy` and check the AWS console for the hello function. Make sure it's Timeout is set to 10 instead of the default 6

### Verifying IAM is created in the update step
run `serverless deploy --noDeploy` and make sure the IAM templates are in the update file not the create file

### Verifying deploying uses 1 step in case of custom bucket
rename the service to signal `create`, then add a `deploymentBucket` in the provider object, then run `serverless deploy`, you should notice that everything is packaged and uploaded to the custom bucket, then stack creation process is started without any update process. You can run deploy again and it'll update normally.

### Verifying custom bucket in us-east-1 works
add the following to `serverless.yml`

```yml
provider:
  region: us-east-1
  deploymentBucket: any-existing-us-east-1-bucket
```
You should see that it deploys correctly without giving the `bucket is not in the same region as lambda` error as reported in issue #2404 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES