### PR TITLE
Remove provider storage on PluginManager level

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -60,10 +60,6 @@ class Serverless {
 
     return this.service.load(this.processedInput.options)
       .then(() => {
-        // set the provider of the service (so that the PluginManager takes care to
-        // execute the correct provider specific plugins)
-        this.pluginManager.setProvider(this.service.provider.name);
-
         // load all plugins
         this.pluginManager.loadAllPlugins(this.service.plugins);
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -7,7 +7,6 @@ const _ = require('lodash');
 class PluginManager {
   constructor(serverless) {
     this.serverless = serverless;
-    this.provider = null;
 
     this.cliOptions = {};
     this.cliCommands = [];
@@ -15,10 +14,6 @@ class PluginManager {
     this.plugins = [];
     this.commands = {};
     this.hooks = {};
-  }
-
-  setProvider(provider) {
-    this.provider = provider;
   }
 
   setCliOptions(options) {
@@ -33,7 +28,8 @@ class PluginManager {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
 
     // ignore plugins that specify a different provider than the current one
-    if (pluginInstance.provider && (pluginInstance.provider !== this.provider)) {
+    if (pluginInstance.provider
+      && (pluginInstance.provider !== this.serverless.service.provider.name)) {
       return;
     }
 

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -198,10 +198,6 @@ describe('PluginManager', () => {
       expect(pluginManager.serverless).to.deep.equal(serverless);
     });
 
-    it('should create a nullified provider variable', () => {
-      expect(pluginManager.provider).to.equal(null);
-    });
-
     it('should create an empty cliOptions object', () => {
       expect(pluginManager.cliOptions).to.deep.equal({});
     });
@@ -216,15 +212,6 @@ describe('PluginManager', () => {
 
     it('should create an empty commands object', () => {
       expect(pluginManager.commands).to.deep.equal({});
-    });
-  });
-
-  describe('#setProvider()', () => {
-    it('should set the provider variable', () => {
-      const provider = 'provider1';
-      pluginManager.setProvider(provider);
-
-      expect(pluginManager.provider).to.equal(provider);
     });
   });
 
@@ -670,7 +657,7 @@ describe('PluginManager', () => {
 
     describe('when using provider specific plugins', () => {
       beforeEach(function () { // eslint-disable-line prefer-arrow-callback
-        pluginManager.setProvider('provider1');
+        pluginManager.serverless.service.provider.name = 'provider1';
 
         pluginManager.addPlugin(Provider1PluginMock);
         pluginManager.addPlugin(Provider2PluginMock);


### PR DESCRIPTION
## What did you implement:

The `PluginManager` class has no more responsibility to store the provider information (what provider the service should use).

## How did you implement it:

Removed the `setProvider` method and replaced the check for the provider with an access to `this.serverless.service.provider.name`

## How can we verify it:

Look at code / run tests.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** NO

