### PR TITLE
Add string and instance powered provider check

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -27,9 +27,19 @@ class PluginManager {
   addPlugin(Plugin) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
 
+    let pluginProvider = null;
+    // check if plugin is provider agnostic
+    if (pluginInstance.provider) {
+      if (typeof pluginInstance.provider === 'string') {
+        pluginProvider = pluginInstance.provider;
+      } else if (typeof pluginInstance.provider === 'object') {
+        pluginProvider = pluginInstance.provider.constructor.getProviderName();
+      }
+    }
+
     // ignore plugins that specify a different provider than the current one
-    if (pluginInstance.provider
-      && (pluginInstance.provider !== this.serverless.service.provider.name)) {
+    if (pluginProvider
+      && (pluginProvider !== this.serverless.service.provider.name)) {
       return;
     }
 

--- a/lib/plugins/awsProvider/awsProvider.js
+++ b/lib/plugins/awsProvider/awsProvider.js
@@ -71,10 +71,14 @@ const impl = {
 };
 
 class AwsProvider {
+  static getProviderName() {
+    return 'aws';
+  }
+
   constructor(serverless) {
     this.serverless = serverless;
     this.sdk = AWS;
-
+    this.provider = this; // only load plugin in an AWS service context
     this.serverless.setProvider('aws', this);
 
     // Use HTTPS Proxy (Optional)

--- a/lib/plugins/awsProvider/awsProvider.test.js
+++ b/lib/plugins/awsProvider/awsProvider.test.js
@@ -21,13 +21,23 @@ describe('AwsProvider', () => {
     awsProvider.serverless.cli = new serverless.classes.CLI();
   });
 
+  describe('#getProviderName()', () => {
+    it('should return the provider name', () => {
+      expect(AwsProvider.getProviderName()).to.equal('aws');
+    });
+  });
+
   describe('#constructor()', () => {
+    it('should set Serverless instance', () => {
+      expect(typeof awsProvider.serverless).to.not.equal('undefined');
+    });
+
     it('should set AWS instance', () => {
       expect(typeof awsProvider.sdk).to.not.equal('undefined');
     });
 
-    it('should set Serverless instance', () => {
-      expect(typeof awsProvider.serverless).to.not.equal('undefined');
+    it('should set the provider property', () => {
+      expect(awsProvider.provider).to.equal(awsProvider);
     });
 
     it('should set AWS proxy', () => {

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -281,6 +281,51 @@ describe('PluginManager', () => {
 
       expect(pluginManager.commands).to.have.property('deploy');
     });
+
+    it('should skip service related plugins which not match the services provider', () => {
+      pluginManager.serverless.service.provider.name = 'someProvider';
+      class Plugin {
+        constructor() {
+          this.provider = 'someOtherProvider';
+        }
+      }
+
+      pluginManager.addPlugin(Plugin);
+
+      expect(pluginManager.plugins.length).to.equal(0);
+    });
+
+    it('should add service related plugins when provider property is the providers name', () => {
+      pluginManager.serverless.service.provider.name = 'someProvider';
+      class Plugin {
+        constructor() {
+          this.provider = 'someProvider';
+        }
+      }
+
+      pluginManager.addPlugin(Plugin);
+
+      expect(pluginManager.plugins[0]).to.be.an.instanceOf(Plugin);
+    });
+
+    it('should add service related plugins when provider propery is provider plugin', () => {
+      pluginManager.serverless.service.provider.name = 'someProvider';
+      class ProviderPlugin {
+        static getProviderName() {
+          return 'someProvider';
+        }
+      }
+      const providerPlugin = new ProviderPlugin();
+      class Plugin {
+        constructor() {
+          this.provider = providerPlugin;
+        }
+      }
+
+      pluginManager.addPlugin(Plugin);
+
+      expect(pluginManager.plugins[0]).to.be.an.instanceOf(Plugin);
+    });
   });
 
   describe('#loadAllPlugins()', () => {


### PR DESCRIPTION
## What did you implement:

The provider property in a plugin can be a string or the ProviderPlugin instance.
This introduces more beautiful code patterns when building plugins.

## How did you implement it:

Extended the `PluginManager` to support both types of provider properties.

## How can we verify it:

See tests.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES