### PR TITLE
Update provider properties in plugins

### DIFF
--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -110,7 +110,7 @@ describe('Serverless', () => {
   describe('#init()', () => {
     it('should create a new CLI instance', () => {
       serverless.init();
-      expect(serverless.cli).to.be.instanceOf(CLI);
+      expect(serverless.cli).to.be.instanceof(CLI);
     });
 
     // note: we just test that the processedInput variable is set (not the content of it)

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
@@ -16,7 +16,7 @@ class AwsCompileApigEvents {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = 'aws';
+    this.provider = this.serverless.getProvider('aws');
 
     Object.assign(
       this,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
@@ -3,6 +3,7 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
+const AwsProvider = require('../../../../../../awsProvider/awsProvider');
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
@@ -39,7 +40,7 @@ describe('AwsCompileApigEvents', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
-
+  serverless.setProvider('aws', new AwsProvider(serverless));
   const awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
 
   describe('#constructor()', () => {
@@ -47,8 +48,8 @@ describe('AwsCompileApigEvents', () => {
 
     it('should have hooks', () => expect(awsCompileApigEvents.hooks).to.be.not.empty);
 
-    it('should set the provider variable to "aws"', () => expect(awsCompileApigEvents.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to be an instanceof AwsProvider', () =>
+      expect(awsCompileApigEvents.provider).to.be.instanceof(AwsProvider));
 
     it('should run promise chain in order', () => {
       const validateStub = sinon

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 class AwsCompileS3Events {
   constructor(serverless) {
     this.serverless = serverless;
-    this.provider = 'aws';
+    this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
       'deploy:compileEvents': this.compileS3Events.bind(this),

--- a/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/tests/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const AwsProvider = require('../../../../../../awsProvider/awsProvider');
 const AwsCompileS3Events = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
@@ -11,13 +12,14 @@ describe('AwsCompileS3Events', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileS3Events = new AwsCompileS3Events(serverless);
     awsCompileS3Events.serverless.service.service = 'new-service';
   });
 
   describe('#constructor()', () => {
-    it('should set the provider variable to "aws"', () => expect(awsCompileS3Events.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsCompileS3Events.provider).to.be.instanceof(AwsProvider));
   });
 
   describe('#compileS3Events()', () => {

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 class AwsCompileScheduledEvents {
   constructor(serverless) {
     this.serverless = serverless;
-    this.provider = 'aws';
+    this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
       'deploy:compileEvents': this.compileScheduledEvents.bind(this),

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const AwsProvider = require('../../../../../../awsProvider/awsProvider');
 const AwsCompileScheduledEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
@@ -11,13 +12,14 @@ describe('AwsCompileScheduledEvents', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileScheduledEvents = new AwsCompileScheduledEvents(serverless);
     awsCompileScheduledEvents.serverless.service.service = 'new-service';
   });
 
   describe('#constructor()', () => {
-    it('should set the provider variable to "aws"', () => expect(awsCompileScheduledEvents.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsCompileScheduledEvents.provider).to.be.instanceof(AwsProvider));
   });
 
   describe('#compileScheduledEvents()', () => {

--- a/lib/plugins/aws/deploy/compile/events/sns/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 class AwsCompileSNSEvents {
   constructor(serverless) {
     this.serverless = serverless;
-    this.provider = 'aws';
+    this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
       'deploy:compileEvents': this.compileSNSEvents.bind(this),

--- a/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/tests/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const AwsProvider = require('../../../../../../awsProvider/awsProvider');
 const AwsCompileSNSEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
@@ -11,12 +12,13 @@ describe('AwsCompileSNSEvents', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileSNSEvents = new AwsCompileSNSEvents(serverless);
   });
 
   describe('#constructor()', () => {
-    it('should set the provider variable to "aws"', () => expect(awsCompileSNSEvents.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsCompileSNSEvents.provider).to.be.instanceof(AwsProvider));
   });
 
   describe('#compileSNSEvents()', () => {

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 class AwsCompileStreamEvents {
   constructor(serverless) {
     this.serverless = serverless;
-    this.provider = 'aws';
+    this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
       'deploy:compileEvents': this.compileStreamEvents.bind(this),

--- a/lib/plugins/aws/deploy/compile/events/stream/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/tests/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const AwsProvider = require('../../../../../../awsProvider/awsProvider');
 const AwsCompileStreamEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
@@ -21,13 +22,14 @@ describe('AwsCompileStreamEvents', () => {
         },
       },
     };
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileStreamEvents = new AwsCompileStreamEvents(serverless);
     awsCompileStreamEvents.serverless.service.service = 'new-service';
   });
 
   describe('#constructor()', () => {
-    it('should set the provider variable to "aws"', () => expect(awsCompileStreamEvents.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to be an instance of AwsProvider', () =>
+      expect(awsCompileStreamEvents.provider).to.be.instanceof(AwsProvider));
   });
 
   describe('#compileStreamEvents()', () => {

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -7,7 +7,7 @@ class AwsCompileFunctions {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = 'aws';
+    this.provider = this.serverless.getProvider('aws');
 
     this.compileFunctions = this.compileFunctions.bind(this);
     this.compileFunction = this.compileFunction.bind(this);

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const expect = require('chai').expect;
+const AwsProvider = require('../../../../../awsProvider/awsProvider');
 const AwsCompileFunctions = require('../index');
 const Serverless = require('../../../../../../Serverless');
 
@@ -17,6 +18,7 @@ describe('AwsCompileFunctions', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileFunctions = new AwsCompileFunctions(serverless, options);
     awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
@@ -34,8 +36,8 @@ describe('AwsCompileFunctions', () => {
   });
 
   describe('#constructor()', () => {
-    it('should set the provider variable to "aws"', () => expect(awsCompileFunctions.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsCompileFunctions.provider).to.be.instanceof(AwsProvider));
   });
 
   describe('#compileFunctions()', () => {

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -16,8 +16,7 @@ class AwsDeploy {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = 'aws';
-    this.aws = this.serverless.getProvider(this.provider);
+    this.provider = this.serverless.getProvider('aws');
 
     Object.assign(
       this,

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
@@ -9,7 +9,7 @@ module.exports = {
     const directoriesToKeepCount = 4;
     const serviceStage = `${this.serverless.service.service}/${this.options.stage}`;
 
-    return this.aws.request('S3',
+    return this.provider.request('S3',
       'listObjectsV2',
       {
         Bucket: this.bucketName,
@@ -62,7 +62,7 @@ module.exports = {
     if (objectsToRemove && objectsToRemove.length) {
       this.serverless.cli.log('Removing old service versions...');
 
-      return this.aws.request('S3',
+      return this.provider.request('S3',
         'deleteObjects',
         {
           Bucket: this.bucketName,

--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -79,7 +79,7 @@ module.exports = {
     if (bucketName) {
       return BbPromise.bind(this)
         .then(() => this.validateS3BucketName(bucketName))
-        .then(() => this.aws.request('S3',
+        .then(() => this.provider.request('S3',
           'getBucketLocation',
           {
             Bucket: bucketName,

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -27,7 +27,7 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    return this.aws.request('CloudFormation',
+    return this.provider.request('CloudFormation',
       'createStack',
       params,
       this.options.stage,
@@ -55,7 +55,7 @@ module.exports = {
           return BbPromise.resolve();
         }
 
-        return this.aws.request('CloudFormation',
+        return this.provider.request('CloudFormation',
           'describeStackResources',
           { StackName: stackName },
           this.options.stage,

--- a/lib/plugins/aws/deploy/lib/setBucketName.js
+++ b/lib/plugins/aws/deploy/lib/setBucketName.js
@@ -12,7 +12,7 @@ module.exports = {
       return BbPromise.resolve();
     }
 
-    return this.aws.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
+    return this.provider.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
       .then((bucketName) => {
         this.bucketName = bucketName;
       });

--- a/lib/plugins/aws/deploy/lib/updateStack.js
+++ b/lib/plugins/aws/deploy/lib/updateStack.js
@@ -39,7 +39,7 @@ module.exports = {
       });
     }
 
-    return this.aws.request('CloudFormation',
+    return this.provider.request('CloudFormation',
       'updateStack',
       params,
       this.options.stage,

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -19,7 +19,7 @@ module.exports = {
       ContentType: 'application/json',
     };
 
-    return this.aws.request('S3',
+    return this.provider.request('S3',
       'putObject',
       params,
       this.options.stage,
@@ -42,7 +42,7 @@ module.exports = {
       ContentType: 'application/zip',
     };
 
-    return this.aws.request('S3',
+    return this.provider.request('S3',
       'putObject',
       params,
       this.options.stage,

--- a/lib/plugins/aws/deploy/tests/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/tests/cleanupS3Bucket.js
@@ -33,7 +33,7 @@ describe('cleanupS3Bucket', () => {
       };
 
       const listObjectsStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve(serviceObjects));
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve(serviceObjects));
 
       return awsDeploy.getObjectsToRemove().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
@@ -42,7 +42,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
 
@@ -65,7 +65,7 @@ describe('cleanupS3Bucket', () => {
       };
 
       const listObjectsStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve(serviceObjects));
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve(serviceObjects));
 
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
         expect(objectsToRemove).to.not
@@ -106,7 +106,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
 
@@ -123,7 +123,7 @@ describe('cleanupS3Bucket', () => {
       };
 
       const listObjectsStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve(serviceObjects));
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve(serviceObjects));
 
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
         expect(objectsToRemove.length).to.equal(0);
@@ -133,7 +133,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
 
@@ -152,7 +152,7 @@ describe('cleanupS3Bucket', () => {
       };
 
       const listObjectsStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve(serviceObjects));
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve(serviceObjects));
 
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
         expect(objectsToRemove.length).to.equal(0);
@@ -162,7 +162,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
         expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
   });
@@ -172,13 +172,13 @@ describe('cleanupS3Bucket', () => {
 
     beforeEach(() => {
       deleteObjectsStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
     });
 
     it('should resolve if no service objects are found in the S3 bucket', () => awsDeploy
       .removeObjects().then(() => {
         expect(deleteObjectsStub.calledOnce).to.be.equal(false);
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       })
     );
 
@@ -197,7 +197,7 @@ describe('cleanupS3Bucket', () => {
         expect(deleteObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
         expect(deleteObjectsStub.args[0][2].Delete.Objects).to.be.equal(objectsToRemove);
         expect(deleteObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/deploy/tests/configureStack.js
+++ b/lib/plugins/aws/deploy/tests/configureStack.js
@@ -16,7 +16,7 @@ describe('#configureStack', () => {
   beforeEach(() => {
     serverless = new Serverless();
     awsPlugin.serverless = serverless;
-    awsPlugin.aws = new AwsProvider(serverless);
+    awsPlugin.provider = new AwsProvider(serverless);
     awsPlugin.options = {
       stage: 'dev',
       region: 'us-east-1',
@@ -29,7 +29,7 @@ describe('#configureStack', () => {
     const bucketName = 'com.serverless.deploys';
 
     const getBucketLocationStub = sinon
-      .stub(awsPlugin.aws, 'request').returns(
+      .stub(awsPlugin.provider, 'request').returns(
         BbPromise.resolve({ LocationConstraint: awsPlugin.options.region })
       );
 
@@ -46,7 +46,7 @@ describe('#configureStack', () => {
     const bucketName = 'com.serverless.deploys';
 
     const createStackStub = sinon
-      .stub(awsPlugin.aws, 'request').returns(
+      .stub(awsPlugin.provider, 'request').returns(
         BbPromise.resolve({ LocationConstraint: 'us-west-1' })
       );
 
@@ -156,7 +156,7 @@ describe('#configureStack', () => {
       .compiledCloudFormationTemplate = coreCloudFormationTemplate;
 
     sinon
-      .stub(awsPlugin.aws, 'request')
+      .stub(awsPlugin.provider, 'request')
       .returns(BbPromise.resolve({ LocationConstraint: awsPlugin.options.region }));
 
     return awsPlugin.configureStack()

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -51,7 +51,7 @@ describe('createStack', () => {
         .compiledCloudFormationTemplate = coreCloudFormationTemplate;
 
       const createStackStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.create().then(() => {
         expect(createStackStub.args[0][0]).to.equal('CloudFormation');
@@ -71,7 +71,7 @@ describe('createStack', () => {
       awsDeploy.serverless.service.provider.stackTags = { STAGE: 'overridden', tag1: 'value1' };
 
       const createStackStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.create().then(() => {
         expect(createStackStub.args[0][2].Tags)
@@ -79,14 +79,14 @@ describe('createStack', () => {
             { Key: 'STAGE', Value: 'overridden' },
             { Key: 'tag1', Value: 'value1' },
           ]);
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
   });
 
   describe('#createStack()', () => {
     it('should store the core CloudFormation template in the provider object', () => {
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       const coreCloudFormationTemplate = awsDeploy.serverless.utils.readFileSync(
         path.join(__dirname,
@@ -112,7 +112,7 @@ describe('createStack', () => {
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
 
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.createStack().then(() => {
         expect(createStub.called).to.be.equal(false);
@@ -138,11 +138,11 @@ describe('createStack', () => {
 
       const writeCreateTemplateToDiskStub = sinon
         .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.createStack().then((res) => {
         expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
-        expect(awsDeploy.aws.request.called).to.be.equal(true);
+        expect(awsDeploy.provider.request.called).to.be.equal(true);
         expect(res).to.equal('alreadyCreated');
       });
     });
@@ -152,7 +152,7 @@ describe('createStack', () => {
         message: 'Something went wrong.',
       };
 
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.reject(errorMock));
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.reject(errorMock));
 
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
@@ -169,7 +169,7 @@ describe('createStack', () => {
         message: 'does not exist',
       };
 
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.reject(errorMock));
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.reject(errorMock));
 
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const AwsProvider = require('../../../awsProvider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 const expect = require('chai').expect;
@@ -14,7 +15,7 @@ describe('AwsDeploy', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });
@@ -22,8 +23,8 @@ describe('AwsDeploy', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsDeploy.hooks).to.be.not.empty);
 
-    it('should set the provider variable to "aws"', () => expect(awsDeploy.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsDeploy.provider).to.be.instanceof(AwsProvider));
   });
 
   describe('hooks', () => {

--- a/lib/plugins/aws/deploy/tests/setBucketName.js
+++ b/lib/plugins/aws/deploy/tests/setBucketName.js
@@ -22,7 +22,7 @@ describe('#setBucketName()', () => {
     awsDeploy = new AwsDeploy(serverless, options);
 
     getServerlessDeploymentBucketNameStub = sinon
-      .stub(awsDeploy.aws, 'getServerlessDeploymentBucketName')
+      .stub(awsDeploy.provider, 'getServerlessDeploymentBucketName')
       .returns(BbPromise.resolve('bucket-name'));
   });
 
@@ -32,7 +32,7 @@ describe('#setBucketName()', () => {
       expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
       expect(getServerlessDeploymentBucketNameStub
         .calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-      awsDeploy.aws.getServerlessDeploymentBucketName.restore();
+      awsDeploy.provider.getServerlessDeploymentBucketName.restore();
     })
   );
 
@@ -41,7 +41,7 @@ describe('#setBucketName()', () => {
 
     return awsDeploy.setBucketName().then(() => {
       expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(false);
-      awsDeploy.aws.getServerlessDeploymentBucketName.restore();
+      awsDeploy.provider.getServerlessDeploymentBucketName.restore();
     });
   });
 

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -36,7 +36,7 @@ describe('updateStack', () => {
 
     beforeEach(() => {
       updateStackStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
     });
 
     it('should update the stack', () => awsDeploy.update()
@@ -53,7 +53,7 @@ describe('updateStack', () => {
           .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(updateStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
 
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       })
     );
 
@@ -76,7 +76,7 @@ describe('updateStack', () => {
           .to.equal(
             '{"Statement":[{"Effect":"Allow","Principal":"*","Action":"Update:*","Resource":"*"}]}'
           );
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/deploy/tests/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/tests/uploadArtifacts.js
@@ -31,7 +31,7 @@ describe('uploadArtifacts', () => {
       awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
 
       const putObjectStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
@@ -46,19 +46,19 @@ describe('uploadArtifacts', () => {
           .provider.compiledCloudFormationTemplate));
         expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
 
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
   });
 
   describe('#uploadZipFile()', () => {
     it('should throw for null artifact paths', () => {
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
       expect(() => awsDeploy.uploadZipFile(null)).to.throw(Error);
     });
 
     it('should throw for empty artifact paths', () => {
-      sinon.stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
       expect(() => awsDeploy.uploadZipFile('')).to.throw(Error);
     });
 
@@ -70,7 +70,7 @@ describe('uploadArtifacts', () => {
       const artifactFileBuffer = serverless.utils.readFileSync(artifactFilePath);
 
       const putObjectStub = sinon
-        .stub(awsDeploy.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
@@ -84,7 +84,7 @@ describe('uploadArtifacts', () => {
           .to.be.equal(artifactFileBuffer.toString());
         expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
 
-        awsDeploy.aws.request.restore();
+        awsDeploy.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -11,8 +11,7 @@ class AwsDeployFunction {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = 'aws';
-    this.aws = this.serverless.getProvider(this.provider);
+    this.provider = this.serverless.getProvider('aws');
 
     this.pkg = new Package(this.serverless, this.options);
 
@@ -37,7 +36,7 @@ class AwsDeployFunction {
       FunctionName: this.options.functionObj.name,
     };
 
-    this.aws.request(
+    this.provider.request(
       'Lambda',
       'getFunction',
       params,
@@ -68,7 +67,7 @@ class AwsDeployFunction {
       ZipFile: data,
     };
 
-    return this.aws.request(
+    return this.provider.request(
       'Lambda',
       'updateFunctionCode',
       params,

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -52,8 +52,8 @@ describe('AwsDeployFunction', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsDeployFunction.hooks).to.be.not.empty);
 
-    it('should set the provider variable to "aws"', () => expect(awsDeployFunction.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsDeployFunction.provider).to.be.instanceof(AwsProvider));
 
     it('should set an empty options object if no options are given', () => {
       const awsDeployFunctionWithEmptyOptions = new AwsDeployFunction(serverless);
@@ -100,7 +100,7 @@ describe('AwsDeployFunction', () => {
 
     it('should check if the function is deployed', () => {
       const getFunctionStub = sinon
-        .stub(awsDeployFunction.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeployFunction.provider, 'request').returns(BbPromise.resolve());
 
       awsDeployFunction.serverless.service.functions = {
         first: {
@@ -117,7 +117,7 @@ describe('AwsDeployFunction', () => {
         expect(getFunctionStub.args[0][0]).to.be.equal('Lambda');
         expect(getFunctionStub.args[0][1]).to.be.equal('getFunction');
         expect(getFunctionStub.args[0][2].FunctionName).to.be.equal('first');
-        awsDeployFunction.aws.request.restore();
+        awsDeployFunction.provider.request.restore();
       });
     });
   });
@@ -151,7 +151,7 @@ describe('AwsDeployFunction', () => {
       awsDeployFunction.options.functionObj.artifact = artifactFilePath;
 
       const updateFunctionCodeStub = sinon
-        .stub(awsDeployFunction.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsDeployFunction.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeployFunction.deployFunction().then(() => {
         const data = fs.readFileSync(artifactFilePath);
@@ -164,7 +164,7 @@ describe('AwsDeployFunction', () => {
         expect(updateFunctionCodeStub.args[0][1]).to.be.equal('updateFunctionCode');
         expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
         expect(updateFunctionCodeStub.args[0][2].ZipFile).to.deep.equal(data);
-        awsDeployFunction.aws.request.restore();
+        awsDeployFunction.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -8,8 +8,7 @@ const _ = require('lodash');
 class AwsInfo {
   constructor(serverless, options) {
     this.serverless = serverless;
-    this.provider = 'aws';
-    this.aws = this.serverless.getProvider(this.provider);
+    this.provider = this.serverless.getProvider('aws');
     this.options = options || {};
     Object.assign(this, validate);
 
@@ -36,7 +35,7 @@ class AwsInfo {
    * Gather information about the service
    */
   gather() {
-    const stackName = this.aws.getStackName(this.options.stage);
+    const stackName = this.provider.getStackName(this.options.stage);
     const info = {
       service: this.serverless.service.service,
       stage: this.options.stage,
@@ -44,7 +43,7 @@ class AwsInfo {
     };
 
     // Get info from CloudFormation Outputs
-    return this.aws.request('CloudFormation',
+    return this.provider.request('CloudFormation',
       'describeStacks',
       { StackName: stackName },
       this.options.stage,
@@ -112,7 +111,7 @@ class AwsInfo {
     const apiKeyNames = this.serverless.service.provider.apiKeys || [];
 
     if (apiKeyNames.length) {
-      return this.aws.request('APIGateway',
+      return this.provider.request('APIGateway',
         'getApiKeys',
         { includeValues: true },
         this.options.stage,

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -43,8 +43,8 @@ describe('AwsInfo', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsInfo.hooks).to.be.not.empty);
 
-    it('should set the provider variable to "aws"', () => expect(awsInfo.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to the AwsProvider instance', () =>
+      expect(awsInfo.provider).to.be.instanceof(AwsProvider));
 
     it('should set an empty options object if no options are given', () => {
       const awsInfoWithEmptyOptions = new AwsInfo(serverless);
@@ -160,7 +160,7 @@ describe('AwsInfo', () => {
       ],
     };
 
-    const describeStackStub = sinon.stub(awsInfo.aws, 'request')
+    const describeStackStub = sinon.stub(awsInfo.provider, 'request')
       .returns(BbPromise.resolve(describeStacksResponse));
 
     it('should gather with correct params', () => awsInfo.gather()
@@ -169,7 +169,7 @@ describe('AwsInfo', () => {
         expect(describeStackStub.args[0][0]).to.equal('CloudFormation');
         expect(describeStackStub.args[0][1]).to.equal('describeStacks');
         expect(describeStackStub.args[0][2].StackName)
-          .to.equal(awsInfo.aws.getStackName(awsInfo.options.stage));
+          .to.equal(awsInfo.provider.getStackName(awsInfo.options.stage));
         expect(describeStackStub
           .calledWith(awsInfo.options.stage, awsInfo.options.region));
       })
@@ -221,7 +221,7 @@ describe('AwsInfo', () => {
     });
 
     it("should provide only general info when stack doesn't exist (ValidationError)", () => {
-      awsInfo.aws.request.restore();
+      awsInfo.provider.request.restore();
 
       serverless.service.service = 'my-first';
       const validationError = {
@@ -229,7 +229,7 @@ describe('AwsInfo', () => {
         message: 'Stack with id not-created-service does not exist',
       };
 
-      sinon.stub(awsInfo.aws, 'request').returns(BbPromise.reject(validationError));
+      sinon.stub(awsInfo.provider, 'request').returns(BbPromise.reject(validationError));
 
       const expectedInfo = {
         service: 'my-first',
@@ -243,8 +243,8 @@ describe('AwsInfo', () => {
     });
 
     it('should throw a ServerlessError when AWS sdk throws an error', () => {
-      awsInfo.aws.request.restore();
-      sinon.stub(awsInfo.aws, 'request').returns(BbPromise.reject(Error));
+      awsInfo.provider.request.restore();
+      sinon.stub(awsInfo.provider, 'request').returns(BbPromise.reject(Error));
 
       return awsInfo.gather().catch((e) => {
         expect(e.name).to.equal('ServerlessError');
@@ -255,7 +255,7 @@ describe('AwsInfo', () => {
   describe('#getApiKeyValues()', () => {
     it('should return the api keys in the info object', () => {
       // TODO: implement a pattern for stub restoring to get rid of this
-      awsInfo.aws.request.restore();
+      awsInfo.provider.request.restore();
 
       // set the API Keys for the service
       awsInfo.serverless.service.provider.apiKeys = ['foo', 'bar'];
@@ -297,14 +297,14 @@ describe('AwsInfo', () => {
       };
 
       const getApiKeysStub = sinon
-        .stub(awsInfo.aws, 'request')
+        .stub(awsInfo.provider, 'request')
         .returns(BbPromise.resolve(apiKeyItems));
 
       return awsInfo.getApiKeyValues(gatheredData).then((result) => {
         expect(getApiKeysStub.calledOnce).to.equal(true);
         expect(result.info.apiKeys).to.deep.equal(gatheredDataAfterKeyLookup.info.apiKeys);
 
-        awsInfo.aws.request.restore();
+        awsInfo.provider.request.restore();
       });
     });
 
@@ -319,14 +319,14 @@ describe('AwsInfo', () => {
       };
 
       const getApiKeysStub = sinon
-        .stub(awsInfo.aws, 'request')
+        .stub(awsInfo.provider, 'request')
         .returns(BbPromise.resolve());
 
       return awsInfo.getApiKeyValues(gatheredData).then((result) => {
         expect(getApiKeysStub.calledOnce).to.equal(false);
         expect(result).to.deep.equal(gatheredData);
 
-        awsInfo.aws.request.restore();
+        awsInfo.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -10,8 +10,7 @@ class AwsInvoke {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = 'aws';
-    this.aws = this.serverless.getProvider(this.provider);
+    this.provider = this.serverless.getProvider('aws');
 
     Object.assign(this, validate);
 
@@ -57,7 +56,8 @@ class AwsInvoke {
       Payload: new Buffer(JSON.stringify(this.options.data || {})),
     };
 
-    return this.aws.request('Lambda', 'invoke', params, this.options.stage, this.options.region);
+    return this.provider
+      .request('Lambda', 'invoke', params, this.options.stage, this.options.region);
   }
 
   log(invocationReply) {

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -22,8 +22,8 @@ describe('AwsInvoke', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsInvoke.hooks).to.be.not.empty);
 
-    it('should set the provider variable to "aws"', () => expect(awsInvoke.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsInvoke.provider).to.be.instanceof(AwsProvider));
 
     it('should run promise chain in order', () => {
       const validateStub = sinon
@@ -138,7 +138,7 @@ describe('AwsInvoke', () => {
   describe('#invoke()', () => {
     let invokeStub;
     beforeEach(() => {
-      invokeStub = sinon.stub(awsInvoke.aws, 'request').returns(BbPromise.resolve());
+      invokeStub = sinon.stub(awsInvoke.provider, 'request').returns(BbPromise.resolve());
       awsInvoke.serverless.service.service = 'new-service';
       awsInvoke.options = {
         stage: 'dev',
@@ -157,7 +157,7 @@ describe('AwsInvoke', () => {
         expect(invokeStub.args[0][2].InvocationType).to.be.equal('RequestResponse');
         expect(invokeStub.args[0][2].LogType).to.be.equal('None');
         expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
-        awsInvoke.aws.request.restore();
+        awsInvoke.provider.request.restore();
       })
     );
 
@@ -171,7 +171,7 @@ describe('AwsInvoke', () => {
         expect(invokeStub.args[0][2].InvocationType).to.be.equal('RequestResponse');
         expect(invokeStub.args[0][2].LogType).to.be.equal('Tail');
         expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
-        awsInvoke.aws.request.restore();
+        awsInvoke.provider.request.restore();
       });
     });
 
@@ -185,7 +185,7 @@ describe('AwsInvoke', () => {
         expect(invokeStub.args[0][2].InvocationType).to.be.equal('OtherType');
         expect(invokeStub.args[0][2].LogType).to.be.equal('None');
         expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
-        awsInvoke.aws.request.restore();
+        awsInvoke.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -35,7 +35,7 @@ module.exports = {
             const params = {
               StackName: cfData.StackId,
             };
-            return this.aws.request('CloudFormation',
+            return this.provider.request('CloudFormation',
               'describeStackEvents',
               params,
               this.options.stage,

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -11,8 +11,7 @@ class AwsLogs {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = 'aws';
-    this.aws = this.serverless.getProvider(this.provider);
+    this.provider = this.serverless.getProvider('aws');
 
     Object.assign(this, validate);
 
@@ -44,7 +43,7 @@ class AwsLogs {
       orderBy: 'LastEventTime',
     };
 
-    return this.aws
+    return this.provider
       .request('CloudWatchLogs',
         'describeLogStreams',
         params,
@@ -119,7 +118,7 @@ class AwsLogs {
       }
     }
 
-    return this.aws
+    return this.provider
       .request('CloudWatchLogs',
         'filterLogEvents',
         params,

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -31,8 +31,8 @@ describe('AwsLogs', () => {
       expect(awsLogsWithEmptyOptions.options).to.deep.equal({});
     });
 
-    it('should set the provider variable to "aws"', () => expect(awsLogs.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsLogs.provider).to.be.instanceof(AwsProvider));
 
     it('should run promise chain in order', () => {
       const validateStub = sinon
@@ -116,7 +116,7 @@ describe('AwsLogs', () => {
           },
         ],
       };
-      const getLogStreamsStub = sinon.stub(awsLogs.aws, 'request').returns(
+      const getLogStreamsStub = sinon.stub(awsLogs.provider, 'request').returns(
         BbPromise.resolve(replyMock)
       );
 
@@ -139,20 +139,20 @@ describe('AwsLogs', () => {
           expect(logStreamNames[1])
             .to.be.equal('2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba');
 
-          awsLogs.aws.request.restore();
+          awsLogs.provider.request.restore();
         });
     });
 
     it('should throw error if no log streams found', () => {
-      sinon.stub(awsLogs.aws, 'request').returns(BbPromise.resolve());
+      sinon.stub(awsLogs.provider, 'request').returns(BbPromise.resolve());
 
       return awsLogs.getLogStreams()
         .then(() => {
           expect(1).to.equal(2);
-          awsLogs.aws.request.restore();
+          awsLogs.provider.request.restore();
         }).catch(e => {
           expect(e.name).to.be.equal('ServerlessError');
-          awsLogs.aws.request.restore();
+          awsLogs.provider.request.restore();
         });
     });
   });
@@ -177,7 +177,7 @@ describe('AwsLogs', () => {
         '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
         '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
       ];
-      const filterLogEventsStub = sinon.stub(awsLogs.aws, 'request').returns(
+      const filterLogEventsStub = sinon.stub(awsLogs.provider, 'request').returns(
         BbPromise.resolve(replyMock)
       );
       awsLogs.serverless.service.service = 'new-service';
@@ -203,7 +203,7 @@ describe('AwsLogs', () => {
           expect(filterLogEventsStub.args[0][2].logStreamNames).to.deep.equal(logStreamNamesMock);
           expect(filterLogEventsStub.args[0][2].filterPattern).to.be.equal('error');
           expect(typeof filterLogEventsStub.args[0][2].startTime).to.be.equal('number');
-          awsLogs.aws.request.restore();
+          awsLogs.provider.request.restore();
         });
     });
 
@@ -226,7 +226,7 @@ describe('AwsLogs', () => {
         '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
         '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
       ];
-      const filterLogEventsStub = sinon.stub(awsLogs.aws, 'request').returns(
+      const filterLogEventsStub = sinon.stub(awsLogs.provider, 'request').returns(
         BbPromise.resolve(replyMock)
       );
       awsLogs.serverless.service.service = 'new-service';
@@ -252,7 +252,7 @@ describe('AwsLogs', () => {
           expect(filterLogEventsStub.args[0][2].logStreamNames).to.deep.equal(logStreamNamesMock);
           expect(filterLogEventsStub.args[0][2].filterPattern).to.be.equal('error');
           expect(typeof filterLogEventsStub.args[0][2].startTime).to.be.equal('number');
-          awsLogs.aws.request.restore();
+          awsLogs.provider.request.restore();
         });
     });
   });

--- a/lib/plugins/aws/remove/index.js
+++ b/lib/plugins/aws/remove/index.js
@@ -10,8 +10,7 @@ class AwsRemove {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = 'aws';
-    this.aws = this.serverless.getProvider(this.provider);
+    this.provider = this.serverless.getProvider('aws');
 
     Object.assign(this, validate, emptyS3Bucket, removeStack, monitorStack);
 

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -4,7 +4,7 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   setServerlessDeploymentBucketName() {
-    return this.aws.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
+    return this.provider.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
       .then((bucketName) => {
         this.bucketName = bucketName;
       });
@@ -15,7 +15,7 @@ module.exports = {
 
     this.serverless.cli.log('Getting all objects in S3 bucket...');
     const serviceStage = `${this.serverless.service.service}/${this.options.stage}`;
-    return this.aws.request('S3', 'listObjectsV2', {
+    return this.provider.request('S3', 'listObjectsV2', {
       Bucket: this.bucketName,
       Prefix: `serverless/${serviceStage}`,
     }, this.options.stage, this.options.region).then((result) => {
@@ -33,7 +33,7 @@ module.exports = {
   deleteObjects() {
     this.serverless.cli.log('Removing objects in S3 bucket...');
     if (this.objectsInBucket.length) {
-      return this.aws.request('S3', 'deleteObjects', {
+      return this.provider.request('S3', 'deleteObjects', {
         Bucket: this.bucketName,
         Delete: {
           Objects: this.objectsInBucket,

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -13,7 +13,7 @@ module.exports = {
       StackId: stackName,
     };
 
-    return this.aws.request('CloudFormation',
+    return this.provider.request('CloudFormation',
       'deleteStack',
       params,
       this.options.stage,

--- a/lib/plugins/aws/remove/tests/bucket.js
+++ b/lib/plugins/aws/remove/tests/bucket.js
@@ -25,7 +25,7 @@ describe('emptyS3Bucket', () => {
   describe('#setServerlessDeploymentBucketName()', () => {
     it('should store the name of the Serverless deployment bucket in the "this" variable', () => {
       const getServerlessDeploymentBucketNameStub = sinon
-        .stub(awsRemove.aws, 'getServerlessDeploymentBucketName')
+        .stub(awsRemove.provider, 'getServerlessDeploymentBucketName')
         .returns(BbPromise.resolve('new-service-dev-us-east-1-12345678'));
 
       return awsRemove.setServerlessDeploymentBucketName().then(() => {
@@ -33,14 +33,14 @@ describe('emptyS3Bucket', () => {
         expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
         expect(getServerlessDeploymentBucketNameStub
           .calledWith(awsRemove.options.stage, awsRemove.options.region));
-        awsRemove.aws.getServerlessDeploymentBucketName.restore();
+        awsRemove.provider.getServerlessDeploymentBucketName.restore();
       });
     });
   });
 
   describe('#listObjects()', () => {
     it('should resolve if no objects are present', () => {
-      const listObjectsStub = sinon.stub(awsRemove.aws, 'request')
+      const listObjectsStub = sinon.stub(awsRemove.provider, 'request')
         .returns(BbPromise.resolve());
 
       return awsRemove.listObjects().then(() => {
@@ -51,12 +51,12 @@ describe('emptyS3Bucket', () => {
         expect(listObjectsStub.args[0][2].Bucket)
           .to.be.equal(awsRemove.bucketName);
         expect(awsRemove.objectsInBucket.length).to.equal(0);
-        awsRemove.aws.request.restore();
+        awsRemove.provider.request.restore();
       });
     });
 
     it('should push objects to the array if present', () => {
-      const listObjectsStub = sinon.stub(awsRemove.aws, 'request')
+      const listObjectsStub = sinon.stub(awsRemove.provider, 'request')
         .returns(BbPromise.resolve({
           Contents: [
             { Key: 'object1' },
@@ -73,7 +73,7 @@ describe('emptyS3Bucket', () => {
           .to.be.equal(awsRemove.bucketName);
         expect(awsRemove.objectsInBucket[0]).to.deep.equal({ Key: 'object1' });
         expect(awsRemove.objectsInBucket[1]).to.deep.equal({ Key: 'object2' });
-        awsRemove.aws.request.restore();
+        awsRemove.provider.request.restore();
       });
     });
   });
@@ -82,7 +82,7 @@ describe('emptyS3Bucket', () => {
     it('should delete all objects in the S3 bucket', () => {
       awsRemove.objectsInBucket = [{ Key: 'foo' }];
 
-      const deleteObjectsStub = sinon.stub(awsRemove.aws, 'request')
+      const deleteObjectsStub = sinon.stub(awsRemove.provider, 'request')
         .returns(BbPromise.resolve());
 
       return awsRemove.deleteObjects().then(() => {
@@ -92,7 +92,7 @@ describe('emptyS3Bucket', () => {
           .to.be.equal(awsRemove.bucketName);
         expect(deleteObjectsStub.args[0][2].Delete.Objects)
           .to.be.equal(awsRemove.objectsInBucket);
-        awsRemove.aws.request.restore();
+        awsRemove.provider.request.restore();
       });
     });
 

--- a/lib/plugins/aws/remove/tests/index.js
+++ b/lib/plugins/aws/remove/tests/index.js
@@ -3,7 +3,8 @@
 const expect = require('chai').expect;
 const BbPromise = require('bluebird');
 const sinon = require('sinon');
-const AwsRemove = require('../');
+const AwsProvider = require('../../../awsProvider/awsProvider');
+const AwsRemove = require('../index');
 const Serverless = require('../../../../Serverless');
 
 describe('AwsRemove', () => {
@@ -12,14 +13,15 @@ describe('AwsRemove', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
+  serverless.setProvider('aws', new AwsProvider(serverless));
   const awsRemove = new AwsRemove(serverless, options);
   awsRemove.serverless.cli = new serverless.classes.CLI();
 
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsRemove.hooks).to.be.not.empty);
 
-    it('should set the provider variable to "aws"', () => expect(awsRemove.provider)
-      .to.equal('aws'));
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsRemove.provider).to.be.instanceof(AwsProvider));
 
     it('should have access to the serverless instance', () => {
       expect(awsRemove.serverless).to.deep.equal(serverless);

--- a/lib/plugins/aws/remove/tests/stack.js
+++ b/lib/plugins/aws/remove/tests/stack.js
@@ -25,12 +25,12 @@ describe('removeStack', () => {
   describe('#remove()', () => {
     it('should remove a stack', () => {
       const removeStackStub = sinon
-        .stub(awsRemove.aws, 'request').returns(BbPromise.resolve());
+        .stub(awsRemove.provider, 'request').returns(BbPromise.resolve());
 
       return awsRemove.remove().then(() => {
         expect(removeStackStub.calledOnce).to.be.equal(true);
         expect(removeStackStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
-        awsRemove.aws.request.restore();
+        awsRemove.provider.request.restore();
       });
     });
   });

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -14,7 +14,7 @@ describe('monitorStack', () => {
 
   beforeEach(() => {
     awsPlugin.serverless = serverless;
-    awsPlugin.aws = new AwsProvider(serverless);
+    awsPlugin.provider = new AwsProvider(serverless);
     awsPlugin.serverless.cli = new CLI(serverless);
     awsPlugin.options = {
       stage: 'dev',
@@ -27,28 +27,28 @@ describe('monitorStack', () => {
   describe('#monitorStack()', () => {
     it('should skip monitoring if the --noDeploy option is specified', () => {
       awsPlugin.options.noDeploy = true;
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
 
       return awsPlugin.monitorStack('update', cfDataMock, 10).then(() => {
         expect(describeStackEventsStub.callCount).to.be.equal(0);
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should skip monitoring if the stack was already created', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
 
       return awsPlugin.monitorStack('update', 'alreadyCreated', 10).then(() => {
         expect(describeStackEventsStub.callCount).to.be.equal(0);
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should keep monitoring until CREATE_COMPLETE stack status', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -87,12 +87,12 @@ describe('monitorStack', () => {
           awsPlugin.options.region
         ));
         expect(stackStatus).to.be.equal('CREATE_COMPLETE');
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should keep monitoring until UPDATE_COMPLETE stack status', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -131,12 +131,12 @@ describe('monitorStack', () => {
           awsPlugin.options.region
         ));
         expect(stackStatus).to.be.equal('UPDATE_COMPLETE');
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should keep monitoring until DELETE_COMPLETE stack status', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -175,12 +175,12 @@ describe('monitorStack', () => {
           awsPlugin.options.region
         ));
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should keep monitoring until DELETE_COMPLETE or stack not found catch', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -211,13 +211,13 @@ describe('monitorStack', () => {
           awsPlugin.options.region
         ));
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should output all stack events information with the --verbose option', () => {
       awsPlugin.options.verbose = true;
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -283,12 +283,12 @@ describe('monitorStack', () => {
           awsPlugin.options.stage,
           awsPlugin.options.region
         ));
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should catch describeStackEvents error if stack was not in deleting state', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -307,12 +307,12 @@ describe('monitorStack', () => {
           awsPlugin.options.stage,
           awsPlugin.options.region
         ));
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
 
     it('should throw an error and exit immediataley if statck status is *_FAILED', () => {
-      const describeStackEventsStub = sinon.stub(awsPlugin.aws, 'request');
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
       };
@@ -380,7 +380,7 @@ describe('monitorStack', () => {
           awsPlugin.options.stage,
           awsPlugin.options.region
         ));
-        awsPlugin.aws.request.restore();
+        awsPlugin.provider.request.restore();
       });
     });
   });

--- a/tests/classes/PluginManager.js
+++ b/tests/classes/PluginManager.js
@@ -273,7 +273,7 @@ describe('PluginManager', () => {
     it('should add a plugin instance to the plugins array', () => {
       pluginManager.addPlugin(SynchronousPluginMock);
 
-      expect(pluginManager.plugins[0]).to.be.an.instanceof(SynchronousPluginMock);
+      expect(pluginManager.plugins[0]).to.be.instanceof(SynchronousPluginMock);
     });
 
     it('should load the plugin commands', () => {


### PR DESCRIPTION
## What did you implement:

The plugins `provider` properties are now instances of the `AwsProvider` class.

## How did you implement it:

Updated all the existing plugins and tests

## How can we verify it:

See code / tests.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES