### PR TITLE
check that stackStatus is not null

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -77,7 +77,9 @@ module.exports = {
                 });
                 // Handle stack create/update/delete failures
                 if ((stackLatestError && !this.options.verbose)
-                || (stackStatus.endsWith('ROLLBACK_COMPLETE') && this.options.verbose)) {
+                || (stackStatus
+                    && stackStatus.endsWith('ROLLBACK_COMPLETE')
+                    && this.options.verbose)) {
                   this.serverless.cli.log('Deployment failed!');
                   let errorMessage = 'An error occurred while provisioning your stack: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->
## What did you implement:

**_Implementing Issue:**_ #2383 

<!--
Briefly describe the feature if no issue exists for this PR
-->

`serverStatus` is null in some circumstances, so the check for `serverStatus.endsWith('...')` causes a crash.
## How did you implement it:

One-line check to make sure the value is set before calling `.endsWith`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
## How can we verify it:

Run `serverless deploy` on Ubuntu 14.04

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->
## Todos:
- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Change ready for review message below

**_Is this ready for review?:**_ Yes
