### PR TITLE
[Fix #1719] single function deployment extends package

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -8,25 +8,23 @@ const validate = require('../lib/validate');
 // The Package plugin which is used to zip the service
 const Package = require('../../package');
 
-class AwsDeployFunction {
+
+class AwsDeployFunction extends Package {
   constructor(serverless, options) {
-    this.serverless = serverless;
-    this.options = options || {};
+    super(serverless, options || {} );
+
     this.provider = 'aws';
     this.sdk = new SDK(serverless);
 
-    this.pkg = new Package(this.serverless, this.options);
-
-    Object.assign(this, validate);
-
-    this.hooks = {
+    Object.assign(this.hooks, {
       'deploy:function:deploy': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.checkIfFunctionExists)
         .then(this.zipFunction)
         .then(this.deployFunction)
         .then(this.cleanup),
-    };
+    });
+
   }
 
   checkIfFunctionExists() {
@@ -58,7 +56,7 @@ class AwsDeployFunction {
   }
 
   zipFunction() {
-    return this.pkg.packageFunction(this.options.function);
+    return this.packageFunction(this.options.function);
   }
 
   deployFunction() {
@@ -79,9 +77,6 @@ class AwsDeployFunction {
     });
   }
 
-  cleanup() {
-    return this.pkg.cleanup();
-  }
 }
 
 module.exports = AwsDeployFunction;

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -55,11 +55,12 @@ describe('AwsDeployFunction', () => {
 
     it('should set an empty options object if no options are given', () => {
       const awsDeployFunctionWithEmptyOptions = new AwsDeployFunction(serverless);
-
       expect(awsDeployFunctionWithEmptyOptions.options).to.deep.equal({});
     });
 
     it('should run promise chain in order', () => {
+      const validateStub = sinon
+        .stub(awsDeployFunction, 'validate').returns(BbPromise.resolve());
       const checkIfFunctionExistsStub = sinon
         .stub(awsDeployFunction, 'checkIfFunctionExists').returns(BbPromise.resolve());
       const zipFunctionStub = sinon
@@ -70,7 +71,9 @@ describe('AwsDeployFunction', () => {
         .stub(awsDeployFunction, 'cleanup').returns(BbPromise.resolve());
 
       return awsDeployFunction.hooks['deploy:function:deploy']().then(() => {
-        expect(checkIfFunctionExistsStub.calledOnce).to.be.equal(true);
+        expect(validateStub.calledOnce).to.be.equal(true);
+        expect(checkIfFunctionExistsStub.calledAfter(validateStub))
+          .to.be.equal(true);
         expect(zipFunctionStub.calledAfter(checkIfFunctionExistsStub))
           .to.be.equal(true);
         expect(deployFunctionStub.calledAfter(zipFunctionStub))
@@ -78,6 +81,7 @@ describe('AwsDeployFunction', () => {
         expect(cleanupStub.calledAfter(deployFunctionStub))
           .to.be.equal(true);
 
+        awsDeployFunction.validate.restore();
         awsDeployFunction.checkIfFunctionExists.restore();
         awsDeployFunction.zipFunction.restore();
         awsDeployFunction.deployFunction.restore();
@@ -120,16 +124,14 @@ describe('AwsDeployFunction', () => {
     it('should zip the function', () => {
       const pkg = new Package();
 
-      awsDeployFunction.pkg = pkg;
-
       const packageFunctionStub = sinon
-        .stub(pkg, 'packageFunction').returns(BbPromise.resolve());
+        .stub(awsDeployFunction, 'packageFunction').returns(BbPromise.resolve());
 
       return awsDeployFunction.zipFunction().then(() => {
         expect(packageFunctionStub.calledOnce).to.be.equal(true);
         expect(packageFunctionStub.args[0][0]).to.be.equal(awsDeployFunction.options.function);
 
-        awsDeployFunction.pkg.packageFunction.restore();
+        awsDeployFunction.packageFunction.restore();
       });
     });
   });
@@ -159,22 +161,6 @@ describe('AwsDeployFunction', () => {
         expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
         expect(updateFunctionCodeStub.args[0][2].ZipFile).to.deep.equal(data);
         awsDeployFunction.sdk.request.restore();
-      });
-    });
-  });
-
-  describe('#cleanup()', () => {
-    it('should remove the temporary .serverless directory', () => {
-      const pkg = new Package();
-
-      awsDeployFunction.pkg = pkg;
-
-      const cleanupStub = sinon
-        .stub(pkg, 'cleanup').returns(BbPromise.resolve());
-
-      return awsDeployFunction.cleanup().then(() => {
-        expect(cleanupStub.calledOnce).to.be.equal(true);
-        awsDeployFunction.pkg.cleanup.restore();
       });
     });
   });


### PR DESCRIPTION
## What did you implement:

**_Implementing Issue:**_ #1719 

`AwsDeployFunction` now `extends Package`. 

Methods previously called on an internal package instance are now handled by the instance.
