### PR TITLE
add ability for functions to override runtime to have multi-language …

### DIFF
--- a/docs/02-providers/aws/README.md
+++ b/docs/02-providers/aws/README.md
@@ -19,7 +19,7 @@ Following are examples and descriptions of all available AWS specific provider c
 ```yaml
 provider:
   name: aws # Set the provider you want to use, in this case AWS
-  runtime: nodejs4.3 # Runtime used for all functions in this provider
+  runtime: nodejs4.3 # Default runtime for functions in this provider
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
   deploymentBucket: com.serverless.${self:provider.region}.deploys # Overwrite the default deployment bucket
@@ -52,6 +52,7 @@ functions:
     name: ${self:provider.stage}-lambdaName # Deployed Lambda name
     description: Description of what the lambda function does # Description to publish to AWS
     handler: handler.hello # handler set in AWS Lambda
+    runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, default is 1024
     timeout: 10 # optional, default is 6
 ```

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -56,7 +56,8 @@ class AwsCompileFunctions {
     const Timeout = Number(functionObject.timeout)
       || Number(this.serverless.service.provider.timeout)
       || 6;
-    const Runtime = this.serverless.service.provider.runtime
+    const Runtime = functionObject.runtime
+      || this.serverless.service.provider.runtime
       || 'nodejs4.3';
 
     newFunction.Properties.Handler = Handler;

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -219,6 +219,41 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compliedFunction);
     });
 
+    it('should allow functions to use a different runtime' +
+      ' than the service default runtime if specified', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          runtime: 'python2.7',
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
+              awsCompileFunctions.serverless.service.package.artifact}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'python2.7',
+          Timeout: 6,
+        },
+      };
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FuncLambdaFunction
+      ).to.deep.equal(compiledFunction);
+    });
+
     it('should default to the nodejs4.3 runtime when no provider runtime is given', () => {
       awsCompileFunctions.serverless.service.provider.runtime = null;
       awsCompileFunctions.serverless.service.functions = {


### PR DESCRIPTION
## What did you implement:

It was desired to have one service with functions written in multiple languages. (ie python at the top level and javascript in some function level). This appeared to just be a configuration change.

## How did you implement it:

Allow "runtime" inside of a function config:

```
functions:
  echo:
    handler: handler.echo
    runtime: nodejs4.3
```

## How can we verify it:

Set the top level runtime differently:

```
provider:
  name: aws
  runtime: python2.7

functions:
  echo:
    handler: handler.echo
    runtime: nodejs4.3
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

…services