### PR TITLE
Don’t show log message if service name exists

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -102,7 +102,7 @@ class Create {
     this.serverless.cli
       .log(`Successfully created service with template: "${this.options.template}"`);
 
-    if (!servicePath) {
+    if (!(servicePath || serviceName)) {
       this.serverless.cli
         .log('NOTE: Please update the "service" property in serverless.yml with your service name');
     }


### PR DESCRIPTION
***Implementing Issue:*** #2428 

If service name exists, skip the update service message