### PR TITLE
Migrate integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - if [[ -z "$INTEGRATION_TEST" && -z "$DISABLE_TESTS" ]]; then npm test; fi
   - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" && -z "$INTEGRATION_TEST" ]]; then npm run lint; fi
   - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} && "$INTEGRATION_TEST_SUITE" == "simple" ]]; then npm run simple-integration-test; fi
-  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} && "$INTEGRATION_TEST_SUITE" == "complex" ]]; then npm run complex-integration-test; fi
+  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} && "$INTEGRATION_TEST_SUITE" == "complex" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then npm run complex-integration-test; fi
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ install:
 script:
   - if [[ -z "$INTEGRATION_TEST" && -z "$DISABLE_TESTS" ]]; then npm test; fi
   - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" && -z "$INTEGRATION_TEST" ]]; then npm run lint; fi
-  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run integration-test; fi
+  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run simple-integration-test; fi
+  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run complex-integration-test; fi
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ matrix:
     - node_js: '6.2'
       env:
         - INTEGRATION_TEST=true
+        - INTEGRATION_TEST_SUITE=simple
+        - secure: Ia2nYzOeYvTE6qOP7DBKX3BO7s/U7TXdsvB2nlc3kOPFi//IbTVD0/cLKCAE5XqTzrrliHINSVsFcJNSfjCwmDSRmgoIGrHj5CJkWpkI6FEPageo3mdqFQYEc8CZeAjsPBNaHe6Ewzg0Ev/sjTByLSJYVqokzDCF1QostSxx1Ss6SGt1zjxeP/Hp4yOJn52VAm9IHAKYn7Y62nMAFTaaTPUQHvW0mJj6m2Z8TWyPU+2Bx6mliO65gTPFGs+PdHGwHtmSF/4IcUO504x+HjDuwzW2itomLXZmIOFfGDcFYadKWzVMAfJzoRWOcVKF4jXdMoSCOviWpHGtK35E7K956MTXkroVoWCS7V0knQDovbRZj8c8td8mS4tdprUA+TzgZoHet2atWNtMuTh79rdmwoAO+IAWJegYj62Tdfy3ycESzY+KxSaV8kysG9sR3PRFoWjZerA7MhLZEzQMORXDGjJlgwLaZfYVqjlsGe5p5etFBUTd0WbFgSwOKLoA2U/fm7WzqItkjs3UWaHuvFVvwYixGxjEVmVczS6wa2cdGpHtVD9H7km4fPEzljHqQ26v0P5e8eylgqLF2IB6mL7UqGFrAtrMvAgN/M3gnq4dTs/wq1AJIOxEP7YW7kc0NAldk8vUz6t5GzCPNcuukxAku91Awnh0twxgUywatgJLZPY=
+        - secure: Dgaa5XIsA5Vbw/CYQLUAuVVsDX26C8+f1XYGwsbNmFQKbKvM8iy9lGrHlfrT3jftJkJH6re8tP1RjyZjjzLe25KPk4Tps7grNteCyiIIEDsC2aHhiXHD6zNHsItpxYusaFfyQinFWnK4CAYKWb9ZNIwHIDUIB4vq807QGAhYsnoj1Lg/ajWvtEKBwYjEzDz9OjB91lw7lpCnHtmKKw5A+TNIVGpDDZ/jRBqETsPaePtiXC9UTHZQyM3gFoeVXiJw9KSU/gjIx9REihCaWWPbnuQSeIONGGlVWY9V4DTZIsJr9/uwDcbioeXDD3G1ezGtNPPRSNTtq08QlUtE4mEtKea/+ObpllKZCeZGn6AJhMn+uqMIP95FFlqBB55YzRcLZY+Igi/qm/9LJ9RinAhxRVXiwzeQ+BdVA6jshAAzr+7wklux6lZAa0xGw9pgTv7MI4RP2LJ/LMP1ppFsnv9n/qt93Ax1VEwEu3xHZe3VTYL9tbXOPTZutf6fKjUrW7wSSuy637queESjYnnPKSb1vZcPxjSFlyh+GJvxu/3PurF9aqfiBdiorIBre+pQS4lakLtoft5nsbA+4iYUwrXR58qUPVUqQ7a0A0hedOWlp6g9ixLa6nugUP5aobJzR71T8l/IjqpnY2EEd/iINEb0XfUiZtB5zHaqFWejBtmWwCI=
+    - node_js: '6.2'
+      env:
+        - INTEGRATION_TEST=true
+        - INTEGRATION_TEST_SUITE=complex
         - secure: Ia2nYzOeYvTE6qOP7DBKX3BO7s/U7TXdsvB2nlc3kOPFi//IbTVD0/cLKCAE5XqTzrrliHINSVsFcJNSfjCwmDSRmgoIGrHj5CJkWpkI6FEPageo3mdqFQYEc8CZeAjsPBNaHe6Ewzg0Ev/sjTByLSJYVqokzDCF1QostSxx1Ss6SGt1zjxeP/Hp4yOJn52VAm9IHAKYn7Y62nMAFTaaTPUQHvW0mJj6m2Z8TWyPU+2Bx6mliO65gTPFGs+PdHGwHtmSF/4IcUO504x+HjDuwzW2itomLXZmIOFfGDcFYadKWzVMAfJzoRWOcVKF4jXdMoSCOviWpHGtK35E7K956MTXkroVoWCS7V0knQDovbRZj8c8td8mS4tdprUA+TzgZoHet2atWNtMuTh79rdmwoAO+IAWJegYj62Tdfy3ycESzY+KxSaV8kysG9sR3PRFoWjZerA7MhLZEzQMORXDGjJlgwLaZfYVqjlsGe5p5etFBUTd0WbFgSwOKLoA2U/fm7WzqItkjs3UWaHuvFVvwYixGxjEVmVczS6wa2cdGpHtVD9H7km4fPEzljHqQ26v0P5e8eylgqLF2IB6mL7UqGFrAtrMvAgN/M3gnq4dTs/wq1AJIOxEP7YW7kc0NAldk8vUz6t5GzCPNcuukxAku91Awnh0twxgUywatgJLZPY=
         - secure: Dgaa5XIsA5Vbw/CYQLUAuVVsDX26C8+f1XYGwsbNmFQKbKvM8iy9lGrHlfrT3jftJkJH6re8tP1RjyZjjzLe25KPk4Tps7grNteCyiIIEDsC2aHhiXHD6zNHsItpxYusaFfyQinFWnK4CAYKWb9ZNIwHIDUIB4vq807QGAhYsnoj1Lg/ajWvtEKBwYjEzDz9OjB91lw7lpCnHtmKKw5A+TNIVGpDDZ/jRBqETsPaePtiXC9UTHZQyM3gFoeVXiJw9KSU/gjIx9REihCaWWPbnuQSeIONGGlVWY9V4DTZIsJr9/uwDcbioeXDD3G1ezGtNPPRSNTtq08QlUtE4mEtKea/+ObpllKZCeZGn6AJhMn+uqMIP95FFlqBB55YzRcLZY+Igi/qm/9LJ9RinAhxRVXiwzeQ+BdVA6jshAAzr+7wklux6lZAa0xGw9pgTv7MI4RP2LJ/LMP1ppFsnv9n/qt93Ax1VEwEu3xHZe3VTYL9tbXOPTZutf6fKjUrW7wSSuy637queESjYnnPKSb1vZcPxjSFlyh+GJvxu/3PurF9aqfiBdiorIBre+pQS4lakLtoft5nsbA+4iYUwrXR58qUPVUqQ7a0A0hedOWlp6g9ixLa6nugUP5aobJzR71T8l/IjqpnY2EEd/iINEb0XfUiZtB5zHaqFWejBtmWwCI=
     - node_js: '6.2'
@@ -22,8 +29,8 @@ install:
 script:
   - if [[ -z "$INTEGRATION_TEST" && -z "$DISABLE_TESTS" ]]; then npm test; fi
   - if [[ ! -z "$DISABLE_TESTS" && ! -z "$LINTING" && -z "$INTEGRATION_TEST" ]]; then npm run lint; fi
-  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run simple-integration-test; fi
-  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} ]]; then npm run complex-integration-test; fi
+  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} && "$INTEGRATION_TEST_SUITE" == "simple" ]]; then npm run simple-integration-test; fi
+  - if [[ ! -z "$INTEGRATION_TEST" && ! -z ${AWS_ACCESS_KEY_ID+x} && "$INTEGRATION_TEST_SUITE" == "complex" ]]; then npm run complex-integration-test; fi
 
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "scripts": {
     "test": "istanbul cover node_modules/mocha/bin/_mocha tests/all -- -R spec --recursive",
     "lint": "eslint .",
-    "integration-test": "mocha tests/integration_test"
+    "simple-integration-test": "mocha tests/integration/simple-integration-test",
+    "complex-integration-test": "mocha tests/integration/all"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/tests/integration/all.js
+++ b/tests/integration/all.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// AWS
+// General
+require('./aws/general/nested-handlers/tests');
+require('./aws/general/custom-resources/tests');
+
+// API Gateway
+// Integration: Lambda
+require('./aws/api-gateway/integration-lambda/simple-api/tests');
+require('./aws/api-gateway/integration-lambda/custom-authorizers/tests');
+require('./aws/api-gateway/integration-lambda/cors/tests');
+require('./aws/api-gateway/integration-lambda/api-keys/tests');
+// Integration: Lambda Proxy
+require('./aws/api-gateway/integration-lambda-proxy/simple-api/tests');
+
+// Schedule
+require('./aws/schedule/multiple-schedules-multiple-functions/tests');
+
+// General
+require('./general/custom-plugins/tests');

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/handler.js
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/handler.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Hello from API Gateway!',
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
@@ -1,0 +1,18 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http: POST hello
+      - http: GET hello
+      - http:
+          method: PUT
+          path: hello
+      - http:
+          method: DELETE
+          path: hello

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/tests.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+const fetch = require('node-fetch');
+
+const Utils = require('../../../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+
+describe('AWS - API Gateway (Integration: Lambda Proxy): Simple API test', function () {
+  this.timeout(0);
+
+  let stackName;
+  let endpoint;
+
+  before(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should expose the endpoint(s) in the CloudFormation Outputs', () =>
+    CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'ServiceEndpoint' }).OutputValue)
+      .then((endpointOutput) => {
+        endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+        endpoint = `${endpoint}/hello`;
+      })
+  );
+
+  it('should expose an accessible POST HTTP endpoint', () =>
+    fetch(endpoint, { method: 'POST' })
+      .then(response => response.json())
+      .then((json) => {
+        expect(json.message).to.equal('Hello from API Gateway!');
+      })
+  );
+
+  it('should expose an accessible GET HTTP endpoint', () =>
+    fetch(endpoint)
+      .then(response => response.json())
+      .then((json) => {
+        expect(json.message).to.equal('Hello from API Gateway!');
+      })
+  );
+
+  it('should expose an accessible PUT HTTP endpoint', () =>
+    fetch(endpoint, { method: 'PUT' })
+      .then(response => response.json())
+      .then((json) => {
+        expect(json.message).to.equal('Hello from API Gateway!');
+      })
+  );
+
+  it('should expose an accessible DELETE HTTP endpoint', () =>
+    fetch(endpoint, { method: 'DELETE' })
+      .then(response => response.json())
+      .then((json) => {
+        expect(json.message).to.equal('Hello from API Gateway!');
+      })
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/handler.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/handler.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Hello from API Gateway!', event });
+};

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
@@ -1,0 +1,17 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+  apiKeys:
+    - myApiKey
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          path: hello
+          method: GET
+          integration: lambda
+          private: true

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/tests.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const execSync = require('child_process').execSync;
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+const fetch = require('node-fetch');
+
+const Utils = require('../../../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+const APIG = new AWS.APIGateway({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+BbPromise.promisifyAll(APIG, { suffix: 'Promised' });
+
+describe('AWS - API Gateway (Integration: Lambda): API keys test', () => {
+  let stackName;
+  let endpoint;
+  let apiKey;
+
+  before(function () {
+    this.timeout(0);
+
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should expose the endpoint(s) in the CloudFormation Outputs', function () {
+    this.timeout(0);
+
+    return CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'ServiceEndpoint' }).OutputValue)
+      .then((endpointOutput) => {
+        endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+        endpoint = `${endpoint}/hello`;
+      });
+  });
+
+  it('should expose the API key(s) with its values when running the info command', function () {
+    this.timeout(0);
+
+    const info = execSync(`${Utils.serverlessExec} info`);
+
+    const stringifiedOutput = (new Buffer(info, 'base64').toString());
+
+    // some regex magic to extract the first API key value from the info output
+    apiKey = stringifiedOutput.match(/(api keys:\n)(\s*)(.+):(\s*)(.+)/)[5];
+
+    expect(apiKey.length).to.be.above(0);
+  });
+
+  it('should reject a request with an invalid API Key', function () {
+    this.timeout(0);
+
+    return fetch(endpoint)
+      .then((response) => {
+        expect(response.status).to.equal(403);
+      });
+  });
+
+  it('should succeed if correct API key is given', function () {
+    this.timeout(0);
+
+    return fetch(endpoint, { headers: { 'x-api-key': apiKey } })
+      .then(response => response.json())
+      .then((json) => {
+        expect(json.message).to.equal('Hello from API Gateway!');
+        expect(json.event.identity.apiKey).to.equal(apiKey);
+        expect(json.event.headers['x-api-key']).to.equal(apiKey);
+      });
+  });
+
+  after(function () {
+    this.timeout(0);
+
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/handler.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/handler.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Hello from API Gateway!', event });
+};

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
@@ -1,0 +1,28 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          method: GET
+          path: simple-cors
+          integration: lambda
+          cors: true
+      - http:
+          method: GET
+          path: complex-cors
+          integration: lambda
+          cors:
+            origins:
+              - '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/tests.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+const fetch = require('node-fetch');
+
+const Utils = require('../../../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+
+describe('AWS - API Gateway (Integration: Lambda): CORS test', function () {
+  this.timeout(0);
+
+  let stackName;
+  let endpointBase;
+
+  before(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should expose the endpoint(s) in the CloudFormation Outputs', () =>
+    CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'ServiceEndpoint' }).OutputValue)
+      .then((endpointOutput) => {
+        endpointBase = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+      })
+  );
+
+  it('should setup CORS support with simple string config', () =>
+    fetch(`${endpointBase}/simple-cors`, { method: 'OPTIONS' })
+      .then((response) => {
+        const headers = response.headers;
+
+        expect(headers.get('access-control-allow-headers'))
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+        expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
+        expect(headers.get('access-control-allow-origin')).to.equal('*');
+      })
+  );
+
+  it('should setup CORS support with complex object config', () =>
+    fetch(`${endpointBase}/complex-cors`, { method: 'OPTIONS' })
+      .then((response) => {
+        const headers = response.headers;
+
+        expect(headers.get('access-control-allow-headers'))
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+        expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
+        expect(headers.get('access-control-allow-origin')).to.equal('*');
+      })
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/handler.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/handler.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const generatePolicy = (principalId, effect, resource) => {
+  const authResponse = {};
+  authResponse.principalId = principalId;
+
+  if (effect && resource) {
+    const policyDocument = {};
+    policyDocument.Version = '2012-10-17';
+    policyDocument.Statement = [];
+
+    const statementOne = {};
+    statementOne.Action = 'execute-api:Invoke';
+    statementOne.Effect = effect;
+    statementOne.Resource = resource;
+    policyDocument.Statement[0] = statementOne;
+    authResponse.policyDocument = policyDocument;
+  }
+
+  return authResponse;
+};
+
+// protected function
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Successfully authorized!', event });
+};
+
+// auth function
+module.exports.auth = (event, context) => {
+  const token = event.authorizationToken.split(' ');
+
+  if (token[0] === 'Bearer' && token[1] === 'ShouldBeAuthorized') {
+    context.succeed(generatePolicy('SomeRandomId', 'Allow', '*'));
+  }
+
+  context.fail('Unauthorized');
+};

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
@@ -1,0 +1,17 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          path: hello
+          method: GET
+          integration: lambda
+          authorizer: auth
+  auth:
+    handler: handler.auth

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/tests.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+const fetch = require('node-fetch');
+
+const Utils = require('../../../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+
+describe('AWS - API Gateway (Integration: Lambda): Custom authorizers test', function () {
+  this.timeout(0);
+
+  let stackName;
+  let endpoint;
+
+  before(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should expose the endpoint(s) in the CloudFormation Outputs', () =>
+    CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'ServiceEndpoint' }).OutputValue)
+      .then((endpointOutput) => {
+        endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+        endpoint = `${endpoint}/hello`;
+      })
+  );
+
+  it('should reject requests without authorization', () =>
+    fetch(endpoint)
+      .then((response) => {
+        expect(response.status).to.equal(401);
+      })
+  );
+
+  it('should reject requests with wrong authorization', () =>
+    fetch(endpoint, { headers: { Authorization: 'Bearer ShouldNotBeAuthorized' } })
+      .then((response) => {
+        expect(response.status).to.equal(401);
+      })
+  );
+
+  it('should authorize requests with correct authorization', () =>
+    fetch(endpoint, { headers: { Authorization: 'Bearer ShouldBeAuthorized' } })
+      .then(response => response.json())
+      .then((json) => {
+        expect(json.message).to.equal('Successfully authorized!');
+        expect(json.event.principalId).to.equal('SomeRandomId');
+        expect(json.event.headers.Authorization).to.equal('Bearer ShouldBeAuthorized');
+      })
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/handler.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/handler.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Hello from API Gateway!', event });
+};

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
@@ -1,0 +1,26 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          method: POST
+          path: hello
+          integration: lambda
+      - http:
+          method: GET
+          path: hello
+          integration: lambda
+      - http:
+          method: PUT
+          path: hello
+          integration: lambda
+      - http:
+          method: DELETE
+          path: hello
+          integration: lambda

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/tests.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+const fetch = require('node-fetch');
+
+const Utils = require('../../../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+
+describe('AWS - API Gateway (Integration: Lambda): Simple API test', function () {
+  this.timeout(0);
+
+  let stackName;
+  let endpoint;
+
+  before(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should expose the endpoint(s) in the CloudFormation Outputs', () =>
+    CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'ServiceEndpoint' }).OutputValue)
+      .then((endpointOutput) => {
+        endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+        endpoint = `${endpoint}/hello`;
+      })
+  );
+
+  it('should expose an accessible POST HTTP endpoint', () =>
+    fetch(endpoint, { method: 'POST' })
+      .then(response => response.json())
+      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
+  );
+
+  it('should expose an accessible GET HTTP endpoint', () =>
+    fetch(endpoint)
+      .then(response => response.json())
+      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
+  );
+
+  it('should expose an accessible PUT HTTP endpoint', () =>
+    fetch(endpoint, { method: 'PUT' })
+      .then(response => response.json())
+      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
+  );
+
+  it('should expose an accessible DELETE HTTP endpoint', () =>
+    fetch(endpoint, { method: 'DELETE' })
+      .then(response => response.json())
+      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/general/custom-resources/service/handler.js
+++ b/tests/integration/aws/general/custom-resources/service/handler.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/tests/integration/aws/general/custom-resources/service/serverless.yml
+++ b/tests/integration/aws/general/custom-resources/service/serverless.yml
@@ -1,0 +1,20 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+
+resources:
+  Resources:
+    MyCustomS3Bucket:
+      Type: 'AWS::S3::Bucket'
+      Properties:
+        BucketName: WillBeReplacedBeforeDeployment
+  Outputs:
+    MyCustomOutput:
+      Value: SomeValue
+      Description: Used to test custom outputs

--- a/tests/integration/aws/general/custom-resources/tests.js
+++ b/tests/integration/aws/general/custom-resources/tests.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const AWS = require('aws-sdk');
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+const fse = require('fs-extra');
+const crypto = require('crypto');
+
+const Utils = require('../../../../utils/index');
+
+const CF = new AWS.CloudFormation({ region: 'us-east-1' });
+const S3 = new AWS.S3({ region: 'us-east-1' });
+BbPromise.promisifyAll(CF, { suffix: 'Promised' });
+BbPromise.promisifyAll(S3, { suffix: 'Promised' });
+
+describe('AWS - General: Custom resources test', function () {
+  this.timeout(0);
+
+  let stackName;
+  let s3BucketName;
+
+  before(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+
+    // replace name of bucket which is created through custom resources with something unique
+    const serverlessYmlFilePath = path.join(process.cwd(), 'serverless.yml');
+    let serverlessYmlFileContent = fse.readFileSync(serverlessYmlFilePath).toString();
+
+    s3BucketName = crypto.randomBytes(8).toString('hex');
+
+    serverlessYmlFileContent = serverlessYmlFileContent
+      .replace(/WillBeReplacedBeforeDeployment/, s3BucketName);
+
+    fse.writeFileSync(serverlessYmlFilePath, serverlessYmlFileContent);
+
+    Utils.deployService();
+  });
+
+  it('should add the custom outputs to the Outputs section', () =>
+    CF.describeStacksPromised({ StackName: stackName })
+      .then((result) => _.find(result.Stacks[0].Outputs,
+        { OutputKey: 'MyCustomOutput' }).OutputValue)
+      .then((endpointOutput) => {
+        expect(endpointOutput).to.equal('SomeValue');
+      })
+  );
+
+  it('should create the custom resources (a S3 bucket)', () =>
+    S3.listBucketsPromised()
+      .then((result) => !!_.find(result.Buckets,
+        { Name: s3BucketName }))
+      .then((found) => expect(found).to.equal(true))
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/general/nested-handlers/service/deeply/nested/handler.js
+++ b/tests/integration/aws/general/nested-handlers/service/deeply/nested/handler.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Your first function handler
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/tests/integration/aws/general/nested-handlers/service/serverless.yml
+++ b/tests/integration/aws/general/nested-handlers/service/serverless.yml
@@ -1,0 +1,9 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: deeply/nested/handler.hello

--- a/tests/integration/aws/general/nested-handlers/tests.js
+++ b/tests/integration/aws/general/nested-handlers/tests.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const execSync = require('child_process').execSync;
+
+const Utils = require('../../../../utils/index');
+
+describe('AWS - General: Nested handlers test', function () {
+  this.timeout(0);
+
+  before(() => {
+    Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should invoke the nested handler function from AWS', () => {
+    const invoked = execSync(`${Utils.serverlessExec} invoke --function hello --noGreeting true`);
+
+    const result = JSON.parse(new Buffer(invoked, 'base64').toString());
+    expect(result.message).to.be.equal('Go Serverless v1.0! Your function executed successfully!');
+  });
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/handler.js
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/handler.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  process.stdout.write(event.source);
+  process.stdout.write(event['detail-type']);
+  callback(null, { message: 'Hello from Schedule!', event });
+};
+
+module.exports.world = (event, context, callback) => {
+  process.stdout.write(event.source);
+  process.stdout.write(event['detail-type']);
+  callback(null, { message: 'Hello from Schedule!', event });
+};

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
@@ -1,0 +1,13 @@
+service: aws-nodejs
+
+provider: aws
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - schedule: rate(1 minute)
+  world:
+    handler: handler.world
+    events:
+      - schedule: rate(1 minute)

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/tests.js
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/tests.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const Utils = require('../../../../utils/index');
+const BbPromise = require('bluebird');
+
+describe('AWS - Schedule: multiple schedules with multiple functions', function () {
+  this.timeout(0);
+
+  before(() => {
+    Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should trigger functions every minute', () => BbPromise.resolve()
+    .delay(100000)
+    .then(() => {
+      const helloLogs = Utils.getFunctionLogs('hello');
+      const worldLogs = Utils.getFunctionLogs('world');
+
+      expect(/Scheduled Event/g.test(helloLogs)).to.equal(true);
+      expect(/aws\.events/g.test(helloLogs)).to.equal(true);
+      expect(/Scheduled Event/g.test(worldLogs)).to.equal(true);
+      expect(/aws\.events/g.test(worldLogs)).to.equal(true);
+    })
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/tests.js
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/tests.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect;
 const Utils = require('../../../../utils/index');
 const BbPromise = require('bluebird');
 
-describe('AWS - Schedule: multiple schedules with multiple functions', function () {
+describe('AWS - Schedule: Multiple schedules with multiple functions', function () {
   this.timeout(0);
 
   before(() => {

--- a/tests/integration/general/custom-plugins/service/handler.js
+++ b/tests/integration/general/custom-plugins/service/handler.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Your first function handler
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/tests/integration/general/custom-plugins/service/package.json
+++ b/tests/integration/general/custom-plugins/service/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-service",
+  "version": "0.1.0",
+  "dependencies": {}
+}

--- a/tests/integration/general/custom-plugins/service/serverless-plugin-greeter/main.js
+++ b/tests/integration/general/custom-plugins/service/serverless-plugin-greeter/main.js
@@ -1,0 +1,26 @@
+'use strict';
+
+class Greeter {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.commands = {
+      greet: {
+        lifecycleEvents: [
+          'greet',
+        ],
+      },
+    };
+
+    this.hooks = {
+      'greet:greet': this.greet.bind(this),
+    };
+  }
+
+  greet() {
+    process.stdout.write('Hello from the greeter plugin!');
+  }
+}
+
+module.exports = Greeter;

--- a/tests/integration/general/custom-plugins/service/serverless-plugin-greeter/package.json
+++ b/tests/integration/general/custom-plugins/service/serverless-plugin-greeter/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "serverless-plugin-greeter",
+  "version": "0.1.0",
+  "main": "main.js"
+}

--- a/tests/integration/general/custom-plugins/service/serverless.yml
+++ b/tests/integration/general/custom-plugins/service/serverless.yml
@@ -1,0 +1,12 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+
+plugins:
+  - serverless-plugin-greeter

--- a/tests/integration/general/custom-plugins/tests.js
+++ b/tests/integration/general/custom-plugins/tests.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const execSync = require('child_process').execSync;
+
+const Utils = require('../../../utils/index');
+
+describe('General: Custom plugins test', function () {
+  this.timeout(0);
+
+  before(() => {
+    Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+
+    // cd into the plugins directory
+    execSync('cd serverless-plugin-greeter');
+
+    // link and install the npm package / plugin
+    execSync('npm link serverless-plugin-greeter && npm install --save serverless-plugin-greeter');
+
+    // cd back into the service directory
+    execSync('cd ..');
+  });
+
+  it('should successfully run the greet command of the custom plugin', () => {
+    const pluginExecution = execSync(`${Utils.serverlessExec} greet`);
+
+    // note: the result will return a newline at the end
+    const result = new Buffer(pluginExecution, 'base64').toString();
+
+    expect(result).to.equal('Hello from the greeter plugin!');
+  });
+
+  after(() => {
+    // unlink the npm package
+    execSync('npm r serverless-plugin-greeter -g');
+  });
+});

--- a/tests/integration/simple-integration-test.js
+++ b/tests/integration/simple-integration-test.js
@@ -5,9 +5,9 @@ const path = require('path');
 const fse = require('fs-extra');
 const BbPromise = require('bluebird');
 const execSync = require('child_process').execSync;
-const Serverless = require('../lib/Serverless');
+const Serverless = require('../../lib/Serverless');
 const AWS = require('aws-sdk');
-const testUtils = require('./utils');
+const testUtils = require('../utils/index');
 
 const serverless = new Serverless();
 serverless.init();

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -3,6 +3,15 @@
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
+const BbPromise = require('bluebird');
+const fse = require('fs-extra');
+const execSync = require('child_process').execSync;
+const AWS = require('aws-sdk');
+const Serverless = require('../../lib/Serverless');
+
+const serverless = new Serverless();
+serverless.init();
+const serverlessExec = path.join(serverless.config.serverlessPath, '..', 'bin', 'serverless');
 
 const getTmpDirPath = () => path.join(os.tmpdir(),
   'tmpdirs-serverless', 'serverless', crypto.randomBytes(8).toString('hex'));
@@ -10,6 +19,83 @@ const getTmpDirPath = () => path.join(os.tmpdir(),
 const getTmpFilePath = (fileName) => path.join(getTmpDirPath(), fileName);
 
 module.exports = {
+  serverlessExec,
   getTmpDirPath,
   getTmpFilePath,
+
+  createTestService: (templateName, testServiceDir) => {
+    const serviceName = `service-${(new Date()).getTime().toString()}`;
+    const tmpDir = path.join(os.tmpdir(),
+      'tmpdirs-serverless',
+      'integration-test-suite',
+      crypto.randomBytes(8).toString('hex'));
+
+    fse.mkdirsSync(tmpDir);
+    process.chdir(tmpDir);
+
+    // create a new Serverless service
+    execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
+
+    if (testServiceDir) {
+      fse.copySync(testServiceDir, tmpDir, { clobber: true, preserveTimestamps: true });
+    }
+
+    execSync(`sed -i.bak s/${templateName}/${serviceName}/g serverless.yml`);
+
+    process.env.TOPIC_1 = `${serviceName}-1`;
+    process.env.TOPIC_2 = `${serviceName}-1`;
+
+    // return the name of the CloudFormation stack
+    return `${serviceName}-dev`;
+  },
+
+  createAndRemoveInBucket(bucketName) {
+    const S3 = new AWS.S3({ region: 'us-east-1' });
+    BbPromise.promisifyAll(S3, { suffix: 'Promised' });
+
+    const params = {
+      Bucket: bucketName,
+      Key: 'object',
+      Body: 'hello world',
+    };
+
+    return S3.putObjectPromised(params)
+      .then(() => {
+        delete params.Body;
+        return S3.deleteObjectPromised(params);
+      });
+  },
+
+  publishSnsMessage(topicName, message) {
+    const SNS = new AWS.SNS({ region: 'us-east-1' });
+    BbPromise.promisifyAll(SNS, { suffix: 'Promised' });
+
+    return SNS.listTopicsPromised()
+      .then(data => {
+        const topicArn = data.Topics.find(topic => RegExp(topicName, 'g')
+          .test(topic.TopicArn)).TopicArn;
+
+        const params = {
+          Message: message,
+          TopicArn: topicArn,
+        };
+
+        return SNS.publishPromised(params);
+      });
+  },
+
+  getFunctionLogs(functionName) {
+    const logs = execSync(`${serverlessExec} logs --function ${functionName} --noGreeting true`);
+    const logsString = new Buffer(logs, 'base64').toString();
+    process.stdout.write(logsString);
+    return logsString;
+  },
+
+  deployService() {
+    execSync(`${serverlessExec} deploy`, { stdio: 'inherit' });
+  },
+
+  removeService() {
+    execSync(`${serverlessExec} remove`, { stdio: 'inherit' });
+  },
 };


### PR DESCRIPTION
## What did you implement:

***Implementing Issue:*** #2377 

Move integration tests from the integration-tests-suite repository to the main Serverless repository.

## How did you implement it:

Moved the files. Furthermore the integration test we had in the Serverless repository was renamed to `simple-integration-test` and is still run (deploy-invoke-updated-invoke-remove lifecycle).

The `.travis.yml` file is also updated.

## How can we verify it:

Run `npm run simple-integration-test` and `npm run complex-integration-test`

## Todos:

- [x] Write tests
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES