### PR TITLE
Allow invoke to accept absolute paths

### DIFF
--- a/docs/01-guide/README.md
+++ b/docs/01-guide/README.md
@@ -6,7 +6,7 @@ layout: Doc
 
 # Guide
 
-This guide will help you build your Serverless services. We'll start by giving you information on how to install Serverless. After that we create and deploy a service, invoke a services function and add additional event sources to our function.
+This guide will help you build your Serverless services. We'll start by giving you information on how to install Serverless. After that we create and deploy a service, invoke a service's function and add additional event sources to our function.
 
 At the end we'll add custom provider resources to our service and remove it.
 

--- a/docs/03-cli-reference/04-invoke.md
+++ b/docs/03-cli-reference/04-invoke.md
@@ -17,11 +17,11 @@ serverless invoke --function functionName
 - `--function` or `-f` The name of the function in your service that you want to invoke. **Required**.
 - `--stage` or `-s` The stage in your service you want to invoke your function in.
 - `--region` or `-r` The region in your stage that you want to invoke your function in.
-- `--path` or `-p` The path to a json file holding input data to be passed to the invoked function. This path is relative to the
-root directory of the service.
+- `--path` or `-p` The path to a json file holding input data to be passed to the invoked function. Either an absolute or
+ relative (to the root directory of your service) may be given.
 - `--type` or `-t` The type of invocation. Either `RequestResponse`, `Event` or `DryRun`. Default is `RequestResponse`.
 - `--log` or `-l` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation.
-Default is `false`.
+ Default is `false`.
 
 ## Provided lifecycle events
 - `invoke:invoke`
@@ -53,3 +53,9 @@ serverless invoke --function functionName --stage dev --region us-east-1 --path 
 
 This example will pass the json data in the `lib/data.json` file (relative to the root of the service) while invoking
 the specified/deployed function.
+
+```
+serverless invoke --function functionName --stage dev --region us-east-1 --path /tmp/data.json
+```
+
+This example will pass the json data in the `/tmp/data.json` file while invoking the specified/deployed function.

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -31,13 +31,13 @@ class AwsInvoke {
     this.options.functionObj = this.serverless.service.getFunction(this.options.function);
 
     if (this.options.path) {
-      if (!this.serverless.utils
-          .fileExistsSync(path.join(this.serverless.config.servicePath, this.options.path))) {
+      const absolutePath = path.isAbsolute(this.options.path) ?
+        this.options.path :
+        path.join(this.serverless.config.servicePath, this.options.path);
+      if (!this.serverless.utils.fileExistsSync(absolutePath)) {
         throw new this.serverless.classes.Error('The file you provided does not exist.');
       }
-
-      this.options.data = this.serverless.utils
-        .readFileSync(path.join(this.serverless.config.servicePath, this.options.path));
+      this.options.data = this.serverless.utils.readFileSync(absolutePath);
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -77,7 +77,7 @@ describe('AwsInvoke', () => {
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);
     });
 
-    it('it should parse file if file path is provided', () => {
+    it('it should parse file if relative file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {
         testProp: 'testValue',
@@ -85,6 +85,22 @@ describe('AwsInvoke', () => {
       serverless.utils.writeFileSync(path
         .join(serverless.config.servicePath, 'data.json'), JSON.stringify(data));
       awsInvoke.options.path = 'data.json';
+
+      return awsInvoke.extendedValidate().then(() => {
+        expect(awsInvoke.options.data).to.deep.equal(data);
+        awsInvoke.options.path = false;
+        serverless.config.servicePath = true;
+      });
+    });
+
+    it('it should parse file if absolute file path is provided', () => {
+      serverless.config.servicePath = testUtils.getTmpDirPath();
+      const data = {
+        testProp: 'testValue',
+      };
+      const dataFile = path.join(serverless.config.servicePath, 'data.json');
+      serverless.utils.writeFileSync(dataFile, JSON.stringify(data));
+      awsInvoke.options.path = dataFile;
 
       return awsInvoke.extendedValidate().then(() => {
         expect(awsInvoke.options.data).to.deep.equal(data);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

***Implementing Issue:*** #2442

<!--
Briefly describe the feature if no issue exists for this PR
-->
Allow for the given `path` parameter to be an absolute path.  Detect this case and do not prepend the service path in this case.
Update docs appropriately
Fix random missing apostrophe

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

run tests or use an absolute path with the `-p` flag

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES