### PR TITLE
Update API Gateway API keys integration test

### DIFF
--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
@@ -4,7 +4,7 @@ provider:
   name: aws
   runtime: nodejs4.3
   apiKeys:
-    - myApiKey
+    - WillBeReplacedBeforeDeployment
 
 functions:
   hello:


### PR DESCRIPTION
## What did you implement:

API keys should be unique on a per-test basis.

## How did you implement it:

Add code which parses the `serverless.yml` file and replaces the key before the deployment with a unique name.

## How can we verify it:

Run the corresponding integration tests.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES