### PR TITLE
Fix timezone retrieval bug

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -262,7 +262,7 @@ class Utils {
         userId,
         event: 'framework_stat',
         properties: {
-          version: 1,
+          version: 2,
           command: {
             name: serverless.processedInput.commands.join(' '),
             isRunInService: (!!serverless.config.servicePath),
@@ -291,7 +291,7 @@ class Utils {
           general: {
             userId,
             timestamp: (new Date()).getTime(),
-            timezone: (new Date()).toString().match(/([A-Z]+[\+-][0-9]+.*)/)[1],
+            timezone: (new Date()).toString().match(/([A-Z]+[\+-][0-9]+)/)[1],
             operatingSystem: process.platform,
             serverlessVersion: serverless.version,
             nodeJsVersion: process.version,


### PR DESCRIPTION
## What did you implement:

This is a simple fix which removes the name of the timezone as this information varies based on the language of the OS (which in return makes it impossible to group by timezone as some of the timezones have a different name although they are basically the same).

`GMT+0200 (CEST)` --> `GMT+0200`

## How did you implement it:

Updates the regex which extracts the timezone. Furthermore the Version of the Schema was updated from `1` to `2` as this might introduce a breaking change in reports (/cc @worldsoup).

## How can we verify it:

Use a regex tool and test the regex or `console.log` out the data which is gathered.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES