### PR TITLE
merge IAM resources after create and before compiling functions and e…

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -42,13 +42,13 @@ class AwsDeploy {
         .then(this.configureStack),
 
       'deploy:setupProviderConfiguration': () => BbPromise.bind(this)
-        .then(this.createStack),
+        .then(this.createStack)
+        .then(this.mergeIamTemplates),
 
       'before:deploy:compileFunctions': () => BbPromise.bind(this)
         .then(this.generateArtifactDirectoryName),
 
       'deploy:deploy': () => BbPromise.bind(this)
-        .then(this.mergeIamTemplates)
         .then(this.mergeCustomProviderResources)
         .then(this.setBucketName)
         .then(this.cleanupS3Bucket)

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -40,8 +40,11 @@ describe('AwsDeploy', () => {
     it('should run "deploy:setupProviderConfiguration" hook promise chain in order', () => {
       const createStackStub = sinon
         .stub(awsDeploy, 'createStack').returns(BbPromise.resolve());
+      const mergeIamTemplatesStub = sinon
+        .stub(awsDeploy, 'mergeIamTemplates').returns(BbPromise.resolve());
       return awsDeploy.hooks['deploy:setupProviderConfiguration']().then(() => {
         expect(createStackStub.calledOnce).to.be.equal(true);
+        expect(mergeIamTemplatesStub.calledAfter(createStackStub)).to.be.equal(true);
       });
     });
 
@@ -64,8 +67,6 @@ describe('AwsDeploy', () => {
     });
 
     it('should run "deploy:deploy" promise chain in order', () => {
-      const mergeIamTemplatesStub = sinon
-        .stub(awsDeploy, 'mergeIamTemplates').returns(BbPromise.resolve());
       const mergeCustomProviderResourcesStub = sinon
         .stub(awsDeploy, 'mergeCustomProviderResources').returns(BbPromise.resolve());
       const setBucketNameStub = sinon
@@ -78,8 +79,7 @@ describe('AwsDeploy', () => {
         .stub(awsDeploy, 'updateStack').returns(BbPromise.resolve());
 
       return awsDeploy.hooks['deploy:deploy']().then(() => {
-        expect(mergeIamTemplatesStub.calledOnce).to.be.equal(true);
-        expect(mergeCustomProviderResourcesStub.calledAfter(mergeIamTemplatesStub))
+        expect(mergeCustomProviderResourcesStub.calledOnce)
           .to.be.equal(true);
         expect(setBucketNameStub.calledAfter(mergeCustomProviderResourcesStub))
           .to.be.equal(true);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Changed the order of the deployment process where merging IAM resources happens before compiling functions/events and after stack creation. This is because compiling some events (ie. dynamo & kinesis) need to add IAM statements. So they have to be available beforehand

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
check the code
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

…vents