### PR TITLE
Fix tests

### DIFF
--- a/docs/03-cli-reference/05-logs.md
+++ b/docs/03-cli-reference/05-logs.md
@@ -18,7 +18,7 @@ serverless logs -f hello
 - `--function` or `-f` The function you want to fetch the logs for. **Required**
 - `--stage` or `-s` The stage you want to view the function logs for. If not provided, the plugin will use the default stage listed in `serverless.yml`. If that doesn't exist either it'll just fetch the logs from the `dev` stage.
 - `--region` or `-r` The region you want to view the function logs for. If not provided, the plugin will use the default region listed in `serverless.yml`. If that doesn't exist either it'll just fetch the logs from the `us-east-1` region.
-- `--startTime` A specific unit in time to start fetching logs from (ie: `2010-10-20` or `1469705761`). Here's a list of the supported string formats:
+- `--startTime` A specific unit in time to start fetching logs from (ie: `2010-10-20` or `1469705761`). All absolute dates/datetimes .e.g `2010-10-20` are parsed as UTC. Here's a list of the supported string formats:
 
 ```
 30m                   # since 30 minutes ago

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -27,12 +27,13 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    return this.provider.request('CloudFormation',
+    return this.provider.request(
+      'CloudFormation',
       'createStack',
       params,
       this.options.stage,
-      this.options.region)
-      .then((cfData) => this.monitorStack('create', cfData));
+      this.options.region
+    ).then((cfData) => this.monitorStack('create', cfData));
   },
 
   createStack() {

--- a/lib/plugins/aws/deploy/tests/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/tests/cleanupS3Bucket.js
@@ -37,11 +37,16 @@ describe('cleanupS3Bucket', () => {
 
       return awsDeploy.getObjectsToRemove().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
-        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
-        expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });
@@ -93,11 +98,16 @@ describe('cleanupS3Bucket', () => {
           .include(
             { Key: `${s3Key}${s3Key}/903940390431-2016-08-18T23:42:08/cloudformation.json` });
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
-        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
-        expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });
@@ -120,11 +130,16 @@ describe('cleanupS3Bucket', () => {
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
         expect(objectsToRemove.length).to.equal(0);
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
-        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
-        expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });
@@ -149,11 +164,16 @@ describe('cleanupS3Bucket', () => {
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
         expect(objectsToRemove.length).to.equal(0);
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
-        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
-        expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });
@@ -184,11 +204,18 @@ describe('cleanupS3Bucket', () => {
 
       return awsDeploy.removeObjects(objectsToRemove).then(() => {
         expect(deleteObjectsStub.calledOnce).to.be.equal(true);
-        expect(deleteObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(deleteObjectsStub.args[0][1]).to.be.equal('deleteObjects');
-        expect(deleteObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(deleteObjectsStub.args[0][2].Delete.Objects).to.be.equal(objectsToRemove);
-        expect(deleteObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(deleteObjectsStub.calledWithExactly(
+          'S3',
+          'deleteObjects',
+          {
+            Bucket: awsDeploy.bucketName,
+            Delete: {
+              Objects: objectsToRemove,
+            },
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -53,18 +53,22 @@ describe('createStack', () => {
       const createStackStub = sinon
         .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
       sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
-
       return awsDeploy.create().then(() => {
-        expect(createStackStub.args[0][0]).to.equal('CloudFormation');
-        expect(createStackStub.args[0][1]).to.equal('createStack');
-        expect(createStackStub.args[0][2].StackName)
-          .to.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
-        expect(JSON.parse(createStackStub.args[0][2].TemplateBody))
-          .to.deep.equal(coreCloudFormationTemplate);
-        expect(createStackStub.args[0][2].Tags)
-          .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(createStackStub.calledOnce).to.be.equal(true);
-        expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(createStackStub.calledWithExactly(
+          'CloudFormation',
+          'createStack',
+          {
+            StackName: `${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`,
+            OnFailure: 'ROLLBACK',
+            Capabilities: ['CAPABILITY_IAM'],
+            Parameters: [],
+            TemplateBody: JSON.stringify(coreCloudFormationTemplate),
+            Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();
       });

--- a/lib/plugins/aws/deploy/tests/updateStack.js
+++ b/lib/plugins/aws/deploy/tests/updateStack.js
@@ -38,18 +38,24 @@ describe('updateStack', () => {
       sinon.stub(awsDeploy, 'monitorStack').returns(BbPromise.resolve());
 
       return awsDeploy.createFallback().then(() => {
-        expect(createStackStub.args[0][0]).to.equal('CloudFormation');
-        expect(createStackStub.args[0][1]).to.equal('createStack');
-        expect(createStackStub.args[0][2].StackName)
-          .to.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
-        expect(createStackStub.args[0][2].OnFailure).to.equal('ROLLBACK');
-        expect(createStackStub.args[0][2].TemplateURL)
-          .to.be.equal(`https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
-          .service.package.artifactDirectoryName}/compiled-cloudformation-template.json`);
-        expect(createStackStub.args[0][2].Tags)
-          .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
         expect(createStackStub.calledOnce).to.be.equal(true);
-        expect(createStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(createStackStub.calledWithExactly(
+          'CloudFormation',
+          'createStack',
+          {
+            StackName: `${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`,
+            OnFailure: 'ROLLBACK',
+            Capabilities: [
+              'CAPABILITY_IAM',
+            ],
+            Parameters: [],
+            TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
+              .service.package.artifactDirectoryName}/compiled-cloudformation-template.json`,
+            Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();
       });
@@ -86,17 +92,22 @@ describe('updateStack', () => {
     it('should update the stack', () => awsDeploy.update()
       .then(() => {
         expect(updateStackStub.calledOnce).to.be.equal(true);
-        expect(updateStackStub.args[0][0]).to.be.equal('CloudFormation');
-        expect(updateStackStub.args[0][1]).to.be.equal('updateStack');
-        expect(updateStackStub.args[0][2].StackName)
-          .to.be.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
-        expect(updateStackStub.args[0][2].TemplateURL)
-          .to.be.equal(`https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
-          .service.package.artifactDirectoryName}/compiled-cloudformation-template.json`);
-        expect(updateStackStub.args[0][2].Tags)
-          .to.deep.equal([{ Key: 'STAGE', Value: awsDeploy.options.stage }]);
-        expect(updateStackStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-
+        expect(updateStackStub.calledWithExactly(
+          'CloudFormation',
+          'updateStack',
+          {
+            StackName: `${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`,
+            Capabilities: [
+              'CAPABILITY_IAM',
+            ],
+            Parameters: [],
+            TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
+              .service.package.artifactDirectoryName}/compiled-cloudformation-template.json`,
+            Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
 
         awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();

--- a/lib/plugins/aws/deploy/tests/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/tests/uploadArtifacts.js
@@ -35,17 +35,20 @@ describe('uploadArtifacts', () => {
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
-        expect(putObjectStub.args[0][0]).to.be.equal('S3');
-        expect(putObjectStub.args[0][1]).to.be.equal('putObject');
-        expect(putObjectStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(putObjectStub.args[0][2].Key)
-          .to.be.equal(`${awsDeploy.serverless.service.package
-          .artifactDirectoryName}/compiled-cloudformation-template.json`);
-        expect(putObjectStub.args[0][2].Body)
-          .to.be.equal(JSON.stringify(awsDeploy.serverless.service
-          .provider.compiledCloudFormationTemplate));
-        expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-
+        expect(putObjectStub.calledWithExactly(
+          'S3',
+          'putObject',
+          {
+            Bucket: awsDeploy.bucketName,
+            Key: `${awsDeploy.serverless.service.package
+              .artifactDirectoryName}/compiled-cloudformation-template.json`,
+            Body: JSON.stringify(awsDeploy.serverless.service.provider
+              .compiledCloudFormationTemplate),
+            ContentType: 'application/json',
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });
@@ -67,23 +70,27 @@ describe('uploadArtifacts', () => {
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
-      const artifactFileBuffer = serverless.utils.readFileSync(artifactFilePath);
+      const artifactFileBuffer = new Buffer(
+        serverless.utils.readFileSync(artifactFilePath), 'binary'
+      );
 
       const putObjectStub = sinon
         .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
-        expect(putObjectStub.args[0][0]).to.be.equal('S3');
-        expect(putObjectStub.args[0][1]).to.be.equal('putObject');
-        expect(putObjectStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(putObjectStub.args[0][2].Key)
-          .to.be.equal(`${awsDeploy.serverless.service.package
-          .artifactDirectoryName}/artifact.zip`);
-        expect(putObjectStub.args[0][2].Body.toString())
-          .to.be.equal(artifactFileBuffer.toString());
-        expect(putObjectStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
-
+        expect(putObjectStub.calledWithExactly(
+          'S3',
+          'putObject',
+          {
+            Bucket: awsDeploy.bucketName,
+            Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/artifact.zip`,
+            Body: artifactFileBuffer,
+            ContentType: 'application/zip',
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         awsDeploy.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -11,7 +11,7 @@ const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
 const testUtils = require('../../../../../tests/utils');
 
-describe('AwsDeployFunction', () => {
+describe.only('AwsDeployFunction', () => {
   let serverless;
   let awsDeployFunction;
 
@@ -111,12 +111,15 @@ describe('AwsDeployFunction', () => {
 
       return awsDeployFunction.checkIfFunctionExists().then(() => {
         expect(getFunctionStub.calledOnce).to.be.equal(true);
-        expect(getFunctionStub.calledWith(
-          awsDeployFunction.options.stage, awsDeployFunction.options.region)
-        );
-        expect(getFunctionStub.args[0][0]).to.be.equal('Lambda');
-        expect(getFunctionStub.args[0][1]).to.be.equal('getFunction');
-        expect(getFunctionStub.args[0][2].FunctionName).to.be.equal('first');
+        expect(getFunctionStub.calledWithExactly(
+          'Lambda',
+          'getFunction',
+          {
+            FunctionName: 'first',
+          },
+          awsDeployFunction.options.stage,
+          awsDeployFunction.options.region
+        )).to.be.equal(true);
         awsDeployFunction.provider.request.restore();
       });
     });
@@ -157,13 +160,16 @@ describe('AwsDeployFunction', () => {
         const data = fs.readFileSync(artifactFilePath);
 
         expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
-        expect(updateFunctionCodeStub.calledWith(
-          awsDeployFunction.options.stage, awsDeployFunction.options.region)
-        );
-        expect(updateFunctionCodeStub.args[0][0]).to.be.equal('Lambda');
-        expect(updateFunctionCodeStub.args[0][1]).to.be.equal('updateFunctionCode');
-        expect(updateFunctionCodeStub.args[0][2].FunctionName).to.be.equal('first');
-        expect(updateFunctionCodeStub.args[0][2].ZipFile).to.deep.equal(data);
+        expect(updateFunctionCodeStub.calledWithExactly(
+          'Lambda',
+          'updateFunctionCode',
+          {
+            FunctionName: 'first',
+            ZipFile: data,
+          },
+          awsDeployFunction.options.stage,
+          awsDeployFunction.options.region
+        )).to.be.equal(true);
         awsDeployFunction.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/deployFunction/tests/index.js
+++ b/lib/plugins/aws/deployFunction/tests/index.js
@@ -11,7 +11,7 @@ const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
 const testUtils = require('../../../../../tests/utils');
 
-describe.only('AwsDeployFunction', () => {
+describe('AwsDeployFunction', () => {
   let serverless;
   let awsDeployFunction;
 

--- a/lib/plugins/aws/deployList/tests/index.js
+++ b/lib/plugins/aws/deployList/tests/index.js
@@ -7,7 +7,7 @@ const AwsDeployList = require('../index');
 const AwsProvider = require('../../provider/awsProvider');
 const Serverless = require('../../../../Serverless');
 
-describe('AwsDeployList', () => {
+describe.only('AwsDeployList', () => {
   let serverless;
   let awsDeploy;
   let s3Key;
@@ -38,11 +38,16 @@ describe('AwsDeployList', () => {
 
       return awsDeploy.listDeployments().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
-        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
-        expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         const infoText = 'Couldn\'t find any existing deployments.';
         expect(awsDeploy.serverless.cli.log.calledWithExactly(infoText)).to.be.equal(true);
         const verifyText = 'Please verify that stage and region are correct.';
@@ -66,11 +71,16 @@ describe('AwsDeployList', () => {
 
       return awsDeploy.listDeployments().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.be.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.be.equal('listObjectsV2');
-        expect(listObjectsStub.args[0][2].Bucket).to.be.equal(awsDeploy.bucketName);
-        expect(listObjectsStub.args[0][2].Prefix).to.be.equal(`${s3Key}`);
-        expect(listObjectsStub.calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        )).to.be.equal(true);
         const infoText = 'Listing deployments:';
         expect(awsDeploy.serverless.cli.log.calledWithExactly(infoText)).to.be.equal(true);
         const timestampOne = 'Timestamp: 113304333331';

--- a/lib/plugins/aws/deployList/tests/index.js
+++ b/lib/plugins/aws/deployList/tests/index.js
@@ -7,7 +7,7 @@ const AwsDeployList = require('../index');
 const AwsProvider = require('../../provider/awsProvider');
 const Serverless = require('../../../../Serverless');
 
-describe.only('AwsDeployList', () => {
+describe('AwsDeployList', () => {
   let serverless;
   let awsDeploy;
   let s3Key;

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -165,13 +165,16 @@ describe('AwsInfo', () => {
 
     it('should gather with correct params', () => awsInfo.gather()
       .then(() => {
-        expect(describeStackStub.called).to.equal(true);
-        expect(describeStackStub.args[0][0]).to.equal('CloudFormation');
-        expect(describeStackStub.args[0][1]).to.equal('describeStacks');
-        expect(describeStackStub.args[0][2].StackName)
-          .to.equal(awsInfo.provider.getStackName(awsInfo.options.stage));
-        expect(describeStackStub
-          .calledWith(awsInfo.options.stage, awsInfo.options.region));
+        expect(describeStackStub.calledOnce).to.equal(true);
+        expect(describeStackStub.calledWithExactly(
+          'CloudFormation',
+          'describeStacks',
+          {
+            StackName: awsInfo.provider.getStackName(awsInfo.options.stage),
+          },
+          awsInfo.options.stage,
+          awsInfo.options.region
+        )).to.be.equal(true);
       })
     );
 

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -9,7 +9,7 @@ const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
 const testUtils = require('../../../../../tests/utils');
 
-describe.only('AwsInvoke', () => {
+describe('AwsInvoke', () => {
   const serverless = new Serverless();
   serverless.setProvider('aws', new AwsProvider(serverless));
   const options = {

--- a/lib/plugins/aws/invoke/tests/index.js
+++ b/lib/plugins/aws/invoke/tests/index.js
@@ -9,7 +9,7 @@ const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
 const testUtils = require('../../../../../tests/utils');
 
-describe('AwsInvoke', () => {
+describe.only('AwsInvoke', () => {
   const serverless = new Serverless();
   serverless.setProvider('aws', new AwsProvider(serverless));
   const options = {
@@ -168,11 +168,18 @@ describe('AwsInvoke', () => {
     it('should invoke with correct params', () => awsInvoke.invoke()
       .then(() => {
         expect(invokeStub.calledOnce).to.be.equal(true);
-        expect(invokeStub.calledWith(awsInvoke.options.stage, awsInvoke.options.region));
-        expect(invokeStub.args[0][2].FunctionName).to.be.equal('customName');
-        expect(invokeStub.args[0][2].InvocationType).to.be.equal('RequestResponse');
-        expect(invokeStub.args[0][2].LogType).to.be.equal('None');
-        expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
+        expect(invokeStub.calledWithExactly(
+          'Lambda',
+          'invoke',
+          {
+            FunctionName: 'customName',
+            InvocationType: 'RequestResponse',
+            LogType: 'None',
+            Payload: new Buffer(JSON.stringify({})),
+          },
+          awsInvoke.options.stage,
+          awsInvoke.options.region
+        )).to.be.equal(true);
         awsInvoke.provider.request.restore();
       })
     );
@@ -182,11 +189,18 @@ describe('AwsInvoke', () => {
 
       return awsInvoke.invoke().then(() => {
         expect(invokeStub.calledOnce).to.be.equal(true);
-        expect(invokeStub.calledWith(awsInvoke.options.stage, awsInvoke.options.region));
-        expect(invokeStub.args[0][2].FunctionName).to.be.equal('customName');
-        expect(invokeStub.args[0][2].InvocationType).to.be.equal('RequestResponse');
-        expect(invokeStub.args[0][2].LogType).to.be.equal('Tail');
-        expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
+        expect(invokeStub.calledWithExactly(
+          'Lambda',
+          'invoke',
+          {
+            FunctionName: 'customName',
+            InvocationType: 'RequestResponse',
+            LogType: 'Tail',
+            Payload: new Buffer(JSON.stringify({})),
+          },
+          awsInvoke.options.stage,
+          awsInvoke.options.region
+        )).to.be.equal(true);
         awsInvoke.provider.request.restore();
       });
     });
@@ -196,11 +210,18 @@ describe('AwsInvoke', () => {
 
       return awsInvoke.invoke().then(() => {
         expect(invokeStub.calledOnce).to.be.equal(true);
-        expect(invokeStub.calledWith(awsInvoke.options.stage, awsInvoke.options.region));
-        expect(invokeStub.args[0][2].FunctionName).to.be.equal('customName');
-        expect(invokeStub.args[0][2].InvocationType).to.be.equal('OtherType');
-        expect(invokeStub.args[0][2].LogType).to.be.equal('None');
-        expect(typeof invokeStub.args[0][2].Payload).to.not.be.equal('undefined');
+        expect(invokeStub.calledWithExactly(
+          'Lambda',
+          'invoke',
+          {
+            FunctionName: 'customName',
+            InvocationType: 'OtherType',
+            LogType: 'None',
+            Payload: new Buffer(JSON.stringify({})),
+          },
+          awsInvoke.options.stage,
+          awsInvoke.options.region
+        )).to.be.equal(true);
         awsInvoke.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -114,7 +114,7 @@ class AwsLogs {
           .startTime.replace(/\D/g, ''), this.options
           .startTime.replace(/\d/g, '')).valueOf();
       } else {
-        params.startTime = moment(this.options.startTime).valueOf();
+        params.startTime = moment.utc(this.options.startTime).valueOf();
       }
     }
 

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -118,6 +118,8 @@ class AwsLogs {
       }
     }
 
+    console.log('params.startTime', params.startTime);
+
     return this.provider
       .request('CloudWatchLogs',
         'filterLogEvents',

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -118,8 +118,6 @@ class AwsLogs {
       }
     }
 
-    console.log('params.startTime', params.startTime);
-
     return this.provider
       .request('CloudWatchLogs',
         'filterLogEvents',

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -220,6 +220,8 @@ describe('AwsLogs', () => {
             awsLogs.options.stage,
             awsLogs.options.region
           )).to.be.equal(true);
+
+          console.log('startTime', 1475262000000);
           awsLogs.provider.request.restore();
         });
     });
@@ -272,6 +274,8 @@ describe('AwsLogs', () => {
             awsLogs.options.stage,
             awsLogs.options.region
           )).to.be.equal(true);
+
+          console.log('startTime', 1287525600000);
           awsLogs.provider.request.restore();
         });
     });

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -164,7 +164,7 @@ describe('AwsLogs', () => {
 
     beforeEach(() => {
       // new Date() => return the fake Date 'Sat Sep 01 2016 00:00:00'
-      clock = sinon.useFakeTimers(new Date(2016, 9, 1).getTime());
+      clock = sinon.useFakeTimers(new Date(Date.UTC(2016, 9, 1)).getTime());
     });
 
     afterEach(() => {
@@ -215,13 +215,11 @@ describe('AwsLogs', () => {
               interleaved: true,
               logStreamNames: logStreamNamesMock,
               filterPattern: 'error',
-              startTime: 1475262000000,
+              startTime: 1475269200000,
             },
             awsLogs.options.stage,
             awsLogs.options.region
           )).to.be.equal(true);
-
-          console.log('startTime', 1475262000000);
           awsLogs.provider.request.restore();
         });
     });
@@ -268,14 +266,13 @@ describe('AwsLogs', () => {
               logGroupName: '/aws/lambda/new-service-dev-first',
               interleaved: true,
               logStreamNames: logStreamNamesMock,
-              startTime: 1287525600000, // '2010-10-20'
+              startTime: 1287532800000, // '2010-10-20'
               filterPattern: 'error',
             },
             awsLogs.options.stage,
             awsLogs.options.region
           )).to.be.equal(true);
 
-          console.log('startTime', 1287525600000);
           awsLogs.provider.request.restore();
         });
     });

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -123,16 +123,18 @@ describe('AwsLogs', () => {
       return awsLogs.getLogStreams()
         .then(logStreamNames => {
           expect(getLogStreamsStub.calledOnce).to.be.equal(true);
-          expect(getLogStreamsStub.calledWith('CloudWatchLogs',
+          expect(getLogStreamsStub.calledWithExactly(
+            'CloudWatchLogs',
             'describeLogStreams',
+            {
+              logGroupName: '/aws/lambda/new-service-dev-first',
+              descending: true,
+              limit: 50,
+              orderBy: 'LastEventTime',
+            },
             awsLogs.options.stage,
-            awsLogs.options.region));
-          expect(getLogStreamsStub.args[0][2].logGroupName)
-            .to.be.equal('/aws/lambda/new-service-dev-first');
-          expect(getLogStreamsStub.args[0][2].descending)
-            .to.be.equal(true);
-          expect(getLogStreamsStub.args[0][2].limit).to.be.equal(50);
-          expect(getLogStreamsStub.args[0][2].orderBy).to.be.equal('LastEventTime');
+            awsLogs.options.region
+          )).to.be.equal(true);
 
           expect(logStreamNames[0])
             .to.be.equal('2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba');
@@ -158,7 +160,19 @@ describe('AwsLogs', () => {
   });
 
   describe('#showLogs()', () => {
-    it('should call filterLogEvents API with correct params', () => {
+    let clock;
+
+    beforeEach(() => {
+      // new Date() => return the fake Date 'Sat Sep 01 2016 00:00:00'
+      clock = sinon.useFakeTimers(new Date(2016, 9, 1).getTime());
+    });
+
+    afterEach(() => {
+      // new Date() => will return the real time again (now)
+      clock.restore();
+    });
+
+    it.only('should call filterLogEvents API with correct params', () => {
       const replyMock = {
         events: [
           {
@@ -193,16 +207,19 @@ describe('AwsLogs', () => {
       return awsLogs.showLogs(logStreamNamesMock)
         .then(() => {
           expect(filterLogEventsStub.calledOnce).to.be.equal(true);
-          expect(filterLogEventsStub.calledWith('CloudWatchLogs',
+          expect(filterLogEventsStub.calledWithExactly(
+            'CloudWatchLogs',
             'filterLogEvents',
+            {
+              logGroupName: '/aws/lambda/new-service-dev-first',
+              interleaved: true,
+              logStreamNames: logStreamNamesMock,
+              filterPattern: 'error',
+              startTime: 1475262000000,
+            },
             awsLogs.options.stage,
-            awsLogs.options.region));
-          expect(filterLogEventsStub.args[0][2].logGroupName)
-            .to.be.equal('/aws/lambda/new-service-dev-first');
-          expect(filterLogEventsStub.args[0][2].interleaved).to.be.equal(true);
-          expect(filterLogEventsStub.args[0][2].logStreamNames).to.deep.equal(logStreamNamesMock);
-          expect(filterLogEventsStub.args[0][2].filterPattern).to.be.equal('error');
-          expect(typeof filterLogEventsStub.args[0][2].startTime).to.be.equal('number');
+            awsLogs.options.region
+          )).to.be.equal(true);
           awsLogs.provider.request.restore();
         });
     });
@@ -242,16 +259,19 @@ describe('AwsLogs', () => {
       return awsLogs.showLogs(logStreamNamesMock)
         .then(() => {
           expect(filterLogEventsStub.calledOnce).to.be.equal(true);
-          expect(filterLogEventsStub.calledWith('CloudWatchLogs',
+          expect(filterLogEventsStub.calledWithExactly(
+            'CloudWatchLogs',
             'filterLogEvents',
+            {
+              logGroupName: '/aws/lambda/new-service-dev-first',
+              interleaved: true,
+              logStreamNames: logStreamNamesMock,
+              startTime: 1287525600000, // '2010-10-20'
+              filterPattern: 'error',
+            },
             awsLogs.options.stage,
-            awsLogs.options.region));
-          expect(filterLogEventsStub.args[0][2].logGroupName)
-            .to.be.equal('/aws/lambda/new-service-dev-first');
-          expect(filterLogEventsStub.args[0][2].interleaved).to.be.equal(true);
-          expect(filterLogEventsStub.args[0][2].logStreamNames).to.deep.equal(logStreamNamesMock);
-          expect(filterLogEventsStub.args[0][2].filterPattern).to.be.equal('error');
-          expect(typeof filterLogEventsStub.args[0][2].startTime).to.be.equal('number');
+            awsLogs.options.region
+          )).to.be.equal(true);
           awsLogs.provider.request.restore();
         });
     });

--- a/lib/plugins/aws/logs/tests/index.js
+++ b/lib/plugins/aws/logs/tests/index.js
@@ -172,7 +172,7 @@ describe('AwsLogs', () => {
       clock.restore();
     });
 
-    it.only('should call filterLogEvents API with correct params', () => {
+    it('should call filterLogEvents API with correct params', () => {
       const replyMock = {
         events: [
           {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -367,15 +367,18 @@ describe('AwsProvider', () => {
 
       return awsProvider.getServerlessDeploymentBucketName(options.stage, options.region)
         .then((bucketName) => {
-          expect(describeStackResourcesStub.calledOnce).to.be.equal(true);
-          expect(describeStackResourcesStub.calledWith(options.stage, options.region));
-          expect(describeStackResourcesStub.args[0][0]).to.equal('CloudFormation');
-          expect(describeStackResourcesStub.args[0][1]).to.equal('describeStackResource');
-          expect(describeStackResourcesStub.args[0][2].StackName)
-            .to.equal(`${awsProvider.serverless.service.service}-${options.stage}`);
-
           expect(bucketName).to.equal('serverlessDeploymentBucketName');
-
+          expect(describeStackResourcesStub.calledOnce).to.be.equal(true);
+          expect(describeStackResourcesStub.calledWithExactly(
+            'CloudFormation',
+            'describeStackResource',
+            {
+              StackName: `${awsProvider.serverless.service.service}-${options.stage}`,
+              LogicalResourceId: 'ServerlessDeploymentBucket',
+            },
+            options.stage,
+            options.region
+          )).to.be.equal(true);
           awsProvider.request.restore();
         });
     });

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -15,6 +15,7 @@ module.exports = {
 
     this.serverless.cli.log('Getting all objects in S3 bucket…');
     const serviceStage = `${this.serverless.service.service}/${this.options.stage}`;
+
     return this.provider.request('S3', 'listObjectsV2', {
       Bucket: this.bucketName,
       Prefix: `serverless/${serviceStage}`,

--- a/lib/plugins/aws/remove/tests/bucket.js
+++ b/lib/plugins/aws/remove/tests/bucket.js
@@ -32,7 +32,7 @@ describe('emptyS3Bucket', () => {
       return awsRemove.setServerlessDeploymentBucketName().then(() => {
         expect(awsRemove.bucketName).to.equal('new-service-dev-us-east-1-12345678');
         expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getServerlessDeploymentBucketNameStub.calledWith(
+        expect(getServerlessDeploymentBucketNameStub.calledWithExactly(
           awsRemove.options.stage,
           awsRemove.options.region
         )).to.be.equal(true);

--- a/lib/plugins/aws/remove/tests/bucket.js
+++ b/lib/plugins/aws/remove/tests/bucket.js
@@ -9,6 +9,7 @@ const BbPromise = require('bluebird');
 
 describe('emptyS3Bucket', () => {
   const serverless = new Serverless();
+  serverless.service.service = 'emptyS3Bucket';
   serverless.setProvider('aws', new AwsProvider(serverless));
 
   let awsRemove;
@@ -31,8 +32,10 @@ describe('emptyS3Bucket', () => {
       return awsRemove.setServerlessDeploymentBucketName().then(() => {
         expect(awsRemove.bucketName).to.equal('new-service-dev-us-east-1-12345678');
         expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getServerlessDeploymentBucketNameStub
-          .calledWith(awsRemove.options.stage, awsRemove.options.region));
+        expect(getServerlessDeploymentBucketNameStub.calledWith(
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
         awsRemove.provider.getServerlessDeploymentBucketName.restore();
       });
     });
@@ -45,11 +48,16 @@ describe('emptyS3Bucket', () => {
 
       return awsRemove.listObjects().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.equal('listObjectsV2');
-        expect(listObjectsStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
-        expect(listObjectsStub.args[0][2].Bucket)
-          .to.be.equal(awsRemove.bucketName);
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsRemove.bucketName,
+            Prefix: `serverless/${serverless.service.service}/${awsRemove.options.stage}`,
+          },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
         expect(awsRemove.objectsInBucket.length).to.equal(0);
         awsRemove.provider.request.restore();
       });
@@ -66,11 +74,16 @@ describe('emptyS3Bucket', () => {
 
       return awsRemove.listObjects().then(() => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.args[0][0]).to.equal('S3');
-        expect(listObjectsStub.args[0][1]).to.equal('listObjectsV2');
-        expect(listObjectsStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
-        expect(listObjectsStub.args[0][2].Bucket)
-          .to.be.equal(awsRemove.bucketName);
+        expect(listObjectsStub.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsRemove.bucketName,
+            Prefix: `serverless/${serverless.service.service}/${awsRemove.options.stage}`,
+          },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
         expect(awsRemove.objectsInBucket[0]).to.deep.equal({ Key: 'object1' });
         expect(awsRemove.objectsInBucket[1]).to.deep.equal({ Key: 'object2' });
         awsRemove.provider.request.restore();
@@ -87,11 +100,18 @@ describe('emptyS3Bucket', () => {
 
       return awsRemove.deleteObjects().then(() => {
         expect(deleteObjectsStub.calledOnce).to.be.equal(true);
-        expect(deleteObjectsStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
-        expect(deleteObjectsStub.args[0][2].Bucket)
-          .to.be.equal(awsRemove.bucketName);
-        expect(deleteObjectsStub.args[0][2].Delete.Objects)
-          .to.be.equal(awsRemove.objectsInBucket);
+        expect(deleteObjectsStub.calledWithExactly(
+          'S3',
+          'deleteObjects',
+          {
+            Bucket: awsRemove.bucketName,
+            Delete: {
+              Objects: awsRemove.objectsInBucket,
+            },
+          },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
         awsRemove.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/remove/tests/stack.js
+++ b/lib/plugins/aws/remove/tests/stack.js
@@ -9,6 +9,7 @@ const BbPromise = require('bluebird');
 
 describe('removeStack', () => {
   const serverless = new Serverless();
+  serverless.service.service = 'removeStack';
   serverless.setProvider('aws', new AwsProvider(serverless));
 
   let awsRemove;
@@ -29,7 +30,15 @@ describe('removeStack', () => {
 
       return awsRemove.remove().then(() => {
         expect(removeStackStub.calledOnce).to.be.equal(true);
-        expect(removeStackStub.calledWith(awsRemove.options.stage, awsRemove.options.region));
+        expect(removeStackStub.calledWithExactly(
+          'CloudFormation',
+          'deleteStack',
+          {
+            StackName: `${serverless.service.service}-${awsRemove.options.stage}`,
+          },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
         awsRemove.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -8,7 +8,7 @@ const AwsProvider = require('../provider/awsProvider');
 const CLI = require('../../../classes/CLI');
 const monitorStack = require('../lib/monitorStack');
 
-describe('monitorStack', () => {
+describe.only('monitorStack', () => {
   const serverless = new Serverless();
   const awsPlugin = {};
 
@@ -80,12 +80,15 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('create', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         expect(stackStatus).to.be.equal('CREATE_COMPLETE');
         awsPlugin.provider.request.restore();
       });
@@ -124,12 +127,15 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('update', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         expect(stackStatus).to.be.equal('UPDATE_COMPLETE');
         awsPlugin.provider.request.restore();
       });
@@ -168,12 +174,15 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('removal', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
         awsPlugin.provider.request.restore();
       });
@@ -204,12 +213,15 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('removal', cfDataMock, 10).then((stackStatus) => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
         awsPlugin.provider.request.restore();
       });
@@ -277,12 +289,15 @@ describe('monitorStack', () => {
         expect(e.name).to.be.equal('ServerlessError');
         expect(e.message).to.be.equal(errorMessage);
         expect(describeStackEventsStub.callCount).to.be.equal(4);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
     });
@@ -301,12 +316,15 @@ describe('monitorStack', () => {
       return awsPlugin.monitorStack('update', cfDataMock, 10).catch((e) => {
         expect(e.message).to.be.equal('Something went wrong.');
         expect(describeStackEventsStub.callCount).to.be.equal(1);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
     });
@@ -374,12 +392,15 @@ describe('monitorStack', () => {
         expect(e.message).to.be.equal(errorMessage);
         // callCount is 2 because Serverless will immediately exits and shows the error
         expect(describeStackEventsStub.callCount).to.be.equal(2);
-        expect(describeStackEventsStub.args[0][2].StackName)
-          .to.be.equal(cfDataMock.StackId);
-        expect(describeStackEventsStub.calledWith(
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
           awsPlugin.options.stage,
           awsPlugin.options.region
-        ));
+        )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -8,7 +8,7 @@ const AwsProvider = require('../provider/awsProvider');
 const CLI = require('../../../classes/CLI');
 const monitorStack = require('../lib/monitorStack');
 
-describe.only('monitorStack', () => {
+describe('monitorStack', () => {
   const serverless = new Serverless();
   const awsPlugin = {};
 

--- a/lib/plugins/aws/tests/setBucketName.js
+++ b/lib/plugins/aws/tests/setBucketName.js
@@ -30,8 +30,10 @@ describe('#setBucketName()', () => {
     .setBucketName().then(() => {
       expect(awsDeploy.bucketName).to.equal('bucket-name');
       expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-      expect(getServerlessDeploymentBucketNameStub
-        .calledWith(awsDeploy.options.stage, awsDeploy.options.region));
+      expect(getServerlessDeploymentBucketNameStub.calledWithExactly(
+        awsDeploy.options.stage,
+        awsDeploy.options.region
+      )).to.be.equal(true);
       awsDeploy.provider.getServerlessDeploymentBucketName.restore();
     })
   );


### PR DESCRIPTION
## What did you implement:

Closes #2454
Closes #2493 

## How did you implement it:

I figured out that `calledWith` was not verified and learned about `calledWithExactly`. I had a brief call with Philipp and Eslam and both mentioned using `calledWithExactly` makes the code way more readable to them. In order use this everywhere I had to check for some additional parameters in some places as well as make sure the datetime generation is stubbed. 

## How can we verify it:

Run all the tests.

***Is this ready for review?:*** YES
