### PR TITLE
refactor apiKeys and restApi

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/apiKeys.js
@@ -6,41 +6,33 @@ const BbPromise = require('bluebird');
 module.exports = {
   compileApiKeys() {
     if (this.serverless.service.provider.apiKeys) {
-      if (this.serverless.service.provider.apiKeys.constructor !== Array) {
+      if (!Array.isArray(this.serverless.service.provider.apiKeys)) {
         throw new this.serverless.classes.Error('apiKeys property must be an array');
       }
 
-      let apiKeyNumber = 0;
-      this.serverless.service.provider.apiKeys.forEach(apiKey => {
-        apiKeyNumber++;
+      _.forEach(this.serverless.service.provider.apiKeys, (apiKey, i) => {
+        const apiKeyNumber = i + 1;
+
         if (typeof apiKey !== 'string') {
           throw new this.serverless.classes.Error('API Keys must be strings');
         }
 
-        const apiKeysTemplate = `
-        {
-          "Type" : "AWS::ApiGateway::ApiKey",
-          "Properties" : {
-            "Enabled" : true,
-            "Name" : "${apiKey}",
-            "StageKeys" : [{
-              "RestApiId": { "Ref": "ApiGatewayRestApi" },
-              "StageName": "${this.options.stage}"
-            }]
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          [`ApiGatewayApiKey${apiKeyNumber}`]: {
+            Type: 'AWS::ApiGateway::ApiKey',
+            Properties: {
+              Enabled: true,
+              Name: apiKey,
+              StageKeys: [{
+                RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
+                StageName: this.options.stage,
+              }],
+            },
+            DependsOn: this.apiGatewayDeploymentLogicalId,
           },
-          "DependsOn": "${this.apiGateWayDeploymentLogicalId}"
-        }
-        `;
-
-        const newApiKeyObject = {
-          [`ApiGatewayApiKey${apiKeyNumber}`]: JSON.parse(apiKeysTemplate),
-        };
-
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-          newApiKeyObject);
+        });
       });
     }
-
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -15,12 +15,12 @@ module.exports = {
       }
     `;
 
-    this.apiGateWayDeploymentLogicalId = `ApiGatewayDeployment${(new Date()).getTime().toString()}`;
+    this.apiGatewayDeploymentLogicalId = `ApiGatewayDeployment${(new Date()).getTime().toString()}`;
     const deploymentTemplateJson = JSON.parse(deploymentTemplate);
     deploymentTemplateJson.DependsOn = this.methodDependencies;
 
     const newDeploymentObject = {
-      [this.apiGateWayDeploymentLogicalId]: deploymentTemplateJson,
+      [this.apiGatewayDeploymentLogicalId]: deploymentTemplateJson,
     };
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/restApi.js
@@ -5,21 +5,16 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileRestApi() {
-    const restApiTemplate = `
-      {
-        "Type" : "AWS::ApiGateway::RestApi",
-        "Properties" : {
-          "Name" : "${this.options.stage}-${this.serverless.service.service}"
-        }
-      }
-    `;
+    this.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
 
-    const newRestApiObject = {
-      ApiGatewayRestApi: JSON.parse(restApiTemplate),
-    };
-
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-      newRestApiObject);
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      [this.apiGatewayRestApiLogicalId]: {
+        Type: 'AWS::ApiGateway::RestApi',
+        Properties: {
+          Name: `${this.options.stage}-${this.serverless.service.service}`,
+        },
+      },
+    });
 
     return BbPromise.resolve();
   },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
@@ -38,23 +38,12 @@ describe('#compileApiKeys()', () => {
       region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
-    awsCompileApigEvents.serverless.service.functions = {
-      first: {
-        events: [
-          {
-            http: {
-              path: 'users/create',
-              method: 'POST',
-              private: true,
-            },
-          },
-        ],
-      },
-    };
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
   });
 
-  it('should compile api key resource', () => awsCompileApigEvents
-    .compileApiKeys().then(() => {
+  it('should compile api key resource', () =>
+    awsCompileApigEvents.compileApiKeys().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayApiKey1.Type
@@ -79,6 +68,11 @@ describe('#compileApiKeys()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayApiKey1.Properties.StageKeys[0].StageName
       ).to.equal('dev');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayApiKey1.DependsOn
+      ).to.equal('ApiGatewayDeploymentTest');
     })
   );
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
@@ -52,13 +52,13 @@ describe('#compileDeployment()', () => {
 
   it('should create a deployment resource', () => awsCompileApigEvents
     .compileDeployment().then(() => {
-      const deploymentLogicalId = Object
+      const apiGatewayDeploymentLogicalId = Object
         .keys(awsCompileApigEvents.serverless.service.provider
           .compiledCloudFormationTemplate.Resources)[0];
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources[deploymentLogicalId]
+          .Resources[apiGatewayDeploymentLogicalId]
       ).to.deep.equal(
         serviceResourcesAwsResourcesObjectMock.Resources.DeploymentApigEvent
       );


### PR DESCRIPTION
Breaking out https://github.com/serverless/serverless/pull/2262

## How did you implement it:

I moved the refactoring of apiKeys and restApi from that PR to this one.

## How can we verify it:

`npm test` passes, and the api-keys integration tests pass.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES