### PR TITLE
refactor apiGateway deployment and restApi

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -5,42 +5,34 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileDeployment() {
-    const deploymentTemplate = `
-      {
-        "Type" : "AWS::ApiGateway::Deployment",
-        "Properties" : {
-          "RestApiId" : { "Ref": "ApiGatewayRestApi" },
-          "StageName" : "${this.options.stage}"
-        }
-      }
-    `;
-
     this.apiGatewayDeploymentLogicalId = `ApiGatewayDeployment${(new Date()).getTime().toString()}`;
-    const deploymentTemplateJson = JSON.parse(deploymentTemplate);
-    deploymentTemplateJson.DependsOn = this.methodDependencies;
 
-    const newDeploymentObject = {
-      [this.apiGatewayDeploymentLogicalId]: deploymentTemplateJson,
-    };
-
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-      newDeploymentObject);
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      [this.apiGatewayDeploymentLogicalId]: {
+        Type: 'AWS::ApiGateway::Deployment',
+        Properties: {
+          RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
+          StageName: this.options.stage,
+        },
+        DependsOn: this.methodDependencies,
+      },
+    });
 
     // create CLF Output for endpoint
-    const outputServiceEndpointTemplate = `
-    {
-      "Description": "URL of the service endpoint",
-      "Value": { "Fn::Join" : [ "", [ "https://", { "Ref": "ApiGatewayRestApi" },
-        ".execute-api.${this.options.region}.amazonaws.com/${this.options.stage}"] ] }
-    }`;
-
-    const newOutputEndpointObject = {
-      ServiceEndpoint: JSON.parse(outputServiceEndpointTemplate),
-    };
-
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
-      newOutputEndpointObject);
-
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+      ServiceEndpoint: {
+        Description: 'URL of the service endpoint',
+        Value: {
+          'Fn::Join': ['',
+            [
+              'https://',
+              { Ref: this.apiGatewayRestApiLogicalId },
+              `.execute-api.${this.options.region}.amazonaws.com/${this.options.stage}`,
+            ],
+          ],
+        },
+      },
+    });
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/apiKeys.js
@@ -19,20 +19,6 @@ describe('#compileApiKeys()', () => {
       Resources: {},
       Outputs: {},
     };
-    serverless.service.environment = {
-      stages: {
-        dev: {
-          regions: {
-            'us-east-1': {
-              vars: {
-                IamRoleLambdaExecution:
-                  'arn:aws:iam::12345678:role/service-dev-IamRoleLambdaExecution-FOO12345678',
-              },
-            },
-          },
-        },
-      },
-    };
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/deployment.js
@@ -8,34 +8,6 @@ describe('#compileDeployment()', () => {
   let serverless;
   let awsCompileApigEvents;
 
-  const serviceResourcesAwsResourcesObjectMock = {
-    Resources: {
-      DeploymentApigEvent: {
-        Type: 'AWS::ApiGateway::Deployment',
-        DependsOn: ['method-dependency1', 'method-dependency2'],
-        Properties: {
-          RestApiId: { Ref: 'ApiGatewayRestApi' },
-          StageName: 'dev',
-        },
-      },
-    },
-    Outputs: {
-      ServiceEndpoint: {
-        Description: 'URL of the service endpoint',
-        Value: {
-          'Fn::Join': [
-            '',
-            [
-              'https://',
-              { Ref: 'ApiGatewayRestApi' },
-              '.execute-api.us-east-1.amazonaws.com/dev',
-            ],
-          ],
-        },
-      },
-    },
-  };
-
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = {
@@ -47,6 +19,7 @@ describe('#compileDeployment()', () => {
       region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.methodDependencies = ['method-dependency1', 'method-dependency2'];
   });
 
@@ -59,20 +32,35 @@ describe('#compileDeployment()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[apiGatewayDeploymentLogicalId]
-      ).to.deep.equal(
-        serviceResourcesAwsResourcesObjectMock.Resources.DeploymentApigEvent
-      );
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::Deployment',
+        DependsOn: ['method-dependency1', 'method-dependency2'],
+        Properties: {
+          RestApiId: { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
+          StageName: 'dev',
+        },
+      });
     })
   );
 
-  it('should add service endpoint output', () => awsCompileApigEvents
-    .compileDeployment().then(() => {
+  it('should add service endpoint output', () =>
+    awsCompileApigEvents.compileDeployment().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Outputs.ServiceEndpoint
-      ).to.deep.equal(
-        serviceResourcesAwsResourcesObjectMock.Outputs.ServiceEndpoint
-      );
+      ).to.deep.equal({
+        Description: 'URL of the service endpoint',
+        Value: {
+          'Fn::Join': [
+            '',
+            [
+              'https://',
+              { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
+              '.execute-api.us-east-1.amazonaws.com/dev',
+            ],
+          ],
+        },
+      });
     })
   );
 });


### PR DESCRIPTION
Splitting up: https://github.com/serverless/serverless/pull/2262

## How did you implement it:

This is the refactoring of apiGateway/deployments. It also includes restApi, as a dependency. It's the same changes as https://github.com/serverless/serverless/pull/2491/files

## How can we verify it:

`npm test` passes, as to the `simple-api` integration tests.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

