### PR TITLE
refactor apiGateway index and validate

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const _ = require('lodash');
 
 const validate = require('./lib/validate');
 const compileRestApi = require('./lib/restApi');
@@ -32,19 +31,13 @@ class AwsCompileApigEvents {
 
     this.hooks = {
       'deploy:compileEvents': () => {
-        let noEndpoints = true;
-        _.forEach(this.serverless.service.functions, functionObj => {
-          if (functionObj.events) {
-            functionObj.events.forEach(event => {
-              // Allow events with empty http event to validate function
-              if ({}.hasOwnProperty.call(event, 'http')) noEndpoints = false;
-            });
-          }
-        });
-        if (noEndpoints) return BbPromise.resolve();
+        this.validated = this.validate();
+
+        if (this.validated.events.length === 0) {
+          return BbPromise.resolve();
+        }
 
         return BbPromise.bind(this)
-          .then(this.validate)
           .then(this.compileRestApi)
           .then(this.compileResources)
           .then(this.compileMethods)

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -1,14 +1,15 @@
 'use strict';
 
 const _ = require('lodash');
-const BbPromise = require('bluebird');
 
 module.exports = {
   validate() {
+    const httpEvents = [];
+
     // validate that path and method exists for each http event in service
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       functionObject.events.forEach(event => {
-        if ({}.hasOwnProperty.call(event, 'http')) {
+        if (_.has(event, 'http')) {
           let method;
           let path;
 
@@ -66,10 +67,17 @@ module.exports = {
             ].join('');
             throw new this.serverless.classes.Error(errorMessage);
           }
+
+          httpEvents.push({
+            functionName,
+            http: event,
+          });
         }
       });
     });
 
-    return BbPromise.resolve();
+    return {
+      events: httpEvents,
+    };
   },
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/index.js
@@ -8,44 +8,31 @@ const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 
 describe('AwsCompileApigEvents', () => {
-  const serverless = new Serverless();
-  serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-  serverless.service.provider.name = 'aws';
-  serverless.service.functions = {
-    first: {
-      events: [
-        {
-          http: {
-            path: 'users',
-            method: 'POST',
-          },
-        },
-      ],
-    },
-  };
-  serverless.service.environment = {
-    vars: {},
-    stages: {
-      dev: {
-        vars: {},
-        regions: {
-          'us-east-1': {
-            vars: {},
+  let awsCompileApigEvents;
+  beforeEach(() => {
+    const serverless = new Serverless();
+    serverless.service.environment = {
+      vars: {},
+      stages: {
+        dev: {
+          vars: {},
+          regions: {
+            'us-east-1': {
+              vars: {},
+            },
           },
         },
       },
-    },
-  };
-  const options = {
-    stage: 'dev',
-    region: 'us-east-1',
-  };
-  serverless.setProvider('aws', new AwsProvider(serverless));
-  const awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+  });
 
   describe('#constructor()', () => {
-    // note: order of test is important as we don't reset the instances in a beforeEach function
-
     it('should have hooks', () => expect(awsCompileApigEvents.hooks).to.be.not.empty);
 
     it('should set the provider variable to be an instanceof AwsProvider', () =>
@@ -53,7 +40,17 @@ describe('AwsCompileApigEvents', () => {
 
     it('should run promise chain in order', () => {
       const validateStub = sinon
-        .stub(awsCompileApigEvents, 'validate').returns(BbPromise.resolve());
+        .stub(awsCompileApigEvents, 'validate').returns({
+          events: [
+            {
+              functionName: 'first',
+              http: {
+                path: 'users',
+                method: 'POST',
+              },
+            },
+          ],
+        });
       const compileRestApiStub = sinon
         .stub(awsCompileApigEvents, 'compileRestApi').returns(BbPromise.resolve());
       const compileResourcesStub = sinon
@@ -82,12 +79,10 @@ describe('AwsCompileApigEvents', () => {
       });
     });
 
-    it('should resolve if no functions are given', (done) => {
+    it('should resolve if no functions are given', () => {
       awsCompileApigEvents.serverless.service.functions = {};
 
-      awsCompileApigEvents.hooks['deploy:compileEvents']().then(() => {
-        done();
-      });
+      return awsCompileApigEvents.hooks['deploy:compileEvents']();
     });
   });
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/validate.js
@@ -6,17 +6,10 @@ const Serverless = require('../../../../../../../Serverless');
 
 describe('#validate()', () => {
   let awsCompileApigEvents;
-  let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless);
-    awsCompileApigEvents.options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    awsCompileApigEvents.serverless.service.environment = {
+    const serverless = new Serverless();
+    serverless.service.environment = {
       vars: {},
       stages: {
         dev: {
@@ -25,9 +18,14 @@ describe('#validate()', () => {
         },
       },
     };
-    awsCompileApigEvents.serverless.service.environment.stages.dev.regions['us-east-1'] = {
+    serverless.service.environment.stages.dev.regions['us-east-1'] = {
       vars: {},
     };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
   });
 
   it('should reject an empty http event', () => {
@@ -95,7 +93,8 @@ describe('#validate()', () => {
       },
     };
 
-    expect(() => awsCompileApigEvents.validate()).to.not.throw(Error);
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events).to.be.an('Array').with.length(2);
   });
 
   it('should validate the http events string syntax method is case insensitive', () => {
@@ -112,7 +111,8 @@ describe('#validate()', () => {
       },
     };
 
-    expect(() => awsCompileApigEvents.validate()).to.not.throw(Error);
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events).to.be.an('Array').with.length(2);
   });
 
   it('should throw an error if the method is invalid', () => {


### PR DESCRIPTION
Splitting up: #2262


## What did you implement:

This refactors the validate and index parts of compile apiGateway events, which is needed before I can open all the other PRs for each function that actually processes events. So while this looks like a 'pointless' change, it's a precursor.

## How did you implement it:

validate returns an object now, which makes it simpler for each sub-function to enumerate http events (they don't have to loop through them all validating HTTP each time)

## How can we verify it:

`npm test` passes as do the `simple-api` integration tests for both integration types.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES 
