### PR TITLE
Update api-gateway.md docs to include note about parsing JSON event body

### DIFF
--- a/docs/02-providers/aws/events/01-apigateway.md
+++ b/docs/02-providers/aws/events/01-apigateway.md
@@ -133,6 +133,11 @@ exports.handler = function(event, context, callback) {
 };
 ```
 
+**Note:** When the body is a JSON-Document, you must parse it yourself:
+```
+JSON.parse(event.body);
+```
+
 **Note:** If you want to use CORS with the lambda-proxy integration, remember to include `Access-Control-Allow-Origin` in your returned headers object.
 
 Take a look at the [AWS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html)


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Simple text addition to api-gateway docs to note that `event.body` needs to be `JSON.parse()`'d when using `lambda-proxy`

***Is this ready for review?:*** YES