### PR TITLE
Allow services with no functions #2267

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -58,9 +58,6 @@ class Service {
         if (!serverlessFile.provider) {
           throw new SError('"provider" property is missing in serverless.yml');
         }
-        if (!serverlessFile.functions) {
-          throw new SError('"functions" property is missing in serverless.yml');
-        }
 
         if (typeof serverlessFile.provider !== 'object') {
           const providerName = serverlessFile.provider;
@@ -84,7 +81,7 @@ class Service {
         that.custom = serverlessFile.custom;
         that.plugins = serverlessFile.plugins;
         that.resources = serverlessFile.resources;
-        that.functions = serverlessFile.functions;
+        that.functions = serverlessFile.functions || {};
 
         if (serverlessFile.package) {
           that.package.individually = serverlessFile.package.individually;

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -334,7 +334,7 @@ describe('Service', () => {
       });
     });
 
-    it('should throw error if functions property is missing', () => {
+    it('should not throw error if functions property is missing', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'service-name',
@@ -347,11 +347,7 @@ describe('Service', () => {
       serviceInstance = new Service(serverless);
 
       return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
-      }).catch(e => {
-        expect(e.name).to.be.equal('ServerlessError');
+        expect(serverless.service.functions).to.deep.equal({});
       });
     });
 

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -6,6 +6,10 @@ const path = require('path');
 
 module.exports = {
   mergeIamTemplates() {
+    if (!this.serverless.service.getAllFunctions().length) {
+      return BbPromise.resolve();
+    }
+
     if (typeof this.serverless.service.provider.iamRoleARN !== 'string') {
       // merge in the iamRoleLambdaTemplate
       const iamRoleLambdaExecutionTemplate = this.serverless.utils.readFileSync(

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -32,6 +32,18 @@ describe('#mergeIamTemplates()', () => {
     };
   });
 
+  it('should not merge there are no functions', () => {
+    awsDeploy.serverless.service.functions = {};
+
+    return awsDeploy.mergeIamTemplates()
+      .then(() => {
+        const resources = awsDeploy.serverless.service.provider
+                            .compiledCloudFormationTemplate.Resources;
+
+        expect(resources.IamRoleLambdaExecution).to.equal(undefined);
+        expect(resources.IamPolicyLambdaExecution).to.equal(undefined);
+      });
+  });
 
   it('should merge the IamRoleLambdaExecution template into the CloudFormation template', () => {
     const IamRoleLambdaExecutionTemplate = awsDeploy.serverless.utils.readFileSync(


### PR DESCRIPTION
## What did you implement:
Closes #2267

Allows people to create services that do not contain functions.

## How did you implement it:
Simply removed the error and defaulted the functions property to an empty object.

## How can we verify it:
Create a project with a simple config and try a deployment.

```
service: test-sls-proj
provider:
  name: aws
  runtime: nodejs4.3
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

