### PR TITLE
fix AWS event stream deploy fails if name contains underscore

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -85,7 +85,7 @@ class AwsCompileStreamEvents {
             // get the name of the stream (and remove any non-alphanumerics in it)
             const streamName = EventSourceArn.split('/')[1];
             const normalizedStreamName = streamName[0].toUpperCase()
-              + streamName.substr(1).replace(/\W/g, '');
+              + streamName.substr(1).replace(/[^A-Za-z0-9]/g, '');
 
             // create type specific PolicyDocument statements
             let streamStatement = {};


### PR DESCRIPTION
## What did you implement:

Bug fix for #2474.

## How did you implement it:

Updated regular expression to remove `_` characters from`normalizedStreamName`.

## How can we verify it:

Create a DynamoDB table with a name that contains an underscore, activate streams on the table, and then try to deploy a Serverless function with an event source mapping pointing to this stream. Previously you would get an error as described in #2474.

***Is this ready for review?:*** YES
