### PR TITLE
Fix typo in environment error message

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -70,7 +70,7 @@ module.exports.logError = (e) => {
     }
 
     consoleLog(' ');
-    consoleLog(chalk.yellow('  Your Environment Infomation -----------------------------'));
+    consoleLog(chalk.yellow('  Your Environment Information -----------------------------'));
     consoleLog(chalk.yellow(`     OS:                 ${process.platform}`));
     consoleLog(chalk.yellow(`     Node Version:       ${process.version.replace(/^[v|V]/, '')}`));
     consoleLog(chalk.yellow(`     Serverless Version: ${version}`));


### PR DESCRIPTION
## What did you implement:

Fixes a minor typo in the environment info of the error message.

## How did you implement it:

Fixed typo.

## How can we verify it:

Run `serverless deploy wasd`

## Todos:

- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES