### PR TITLE
Prettify AwsCompileFunctions error messages

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -26,7 +26,7 @@ class AwsCompileFunctions {
       this.serverless.service.package.artifact;
 
     if (!artifactFilePath) {
-      throw new Error(`No artifact path is set for function: ${functionName}`);
+      throw new Error(`No artifact path is set for function: "${functionName}"`);
     }
 
     if (this.serverless.service.package.deploymentBucket) {
@@ -39,7 +39,7 @@ class AwsCompileFunctions {
 
     if (!functionObject.handler) {
       const errorMessage = [
-        `Missing "handler" property in function ${functionName}`,
+        `Missing "handler" property in function ""${functionName}".`,
         ' Please make sure you point to the correct lambda handler.',
         ' For example: handler.hello.',
         ' Please check the docs for more info',


### PR DESCRIPTION
## What did you implement:

Prettifies the error message and fixes typos.

## How did you implement it:

Just updated the error message.

## How can we verify it:

Specify an invalid `functions` definition in `serverless.yml` and run `serverless deploy`.

## Todos:

- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES