### PR TITLE
Update integration tests to auto remove log groups

### DIFF
--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/custom-resources/service/serverless.yml
+++ b/tests/integration/aws/general/custom-resources/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/nested-handlers/service/serverless.yml
+++ b/tests/integration/aws/general/nested-handlers/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/overwrite-resources/service/serverless.yml
+++ b/tests/integration/aws/general/overwrite-resources/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
@@ -1,6 +1,9 @@
 service: aws-nodejs
 
-provider: aws
+provider:
+  name: aws
+  runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
@@ -1,6 +1,9 @@
 service: aws-nodejs
 
-provider: aws
+provider:
+  name: aws
+  runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
@@ -1,6 +1,9 @@
 service: aws-nodejs
 
-provider: aws
+provider:
+  name: aws
+  runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
@@ -1,6 +1,9 @@
 service: aws-nodejs
 
-provider: aws
+provider:
+  name: aws
+  runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
@@ -1,6 +1,9 @@
 service: aws-nodejs
 
-provider: aws
+provider:
+  name: aws
+  runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/general/custom-plugins/service/serverless.yml
+++ b/tests/integration/general/custom-plugins/service/serverless.yml
@@ -3,6 +3,7 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
+  cfLogs: true
 
 functions:
   hello:


### PR DESCRIPTION
## What did you implement:

Add the `cfLogs: true` setting in the services of the integration tests so that the log groups will be removed automatically when the stack is removed.

## How did you implement it:

Just added the setting in the corresponding `serverless.yml` file.

## How can we verify it:

Run the complex integration test suite.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES