### PR TITLE
[Fix #2545] Added warnings when deploying cors with lambda-proxy

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -596,10 +596,10 @@ module.exports = {
 
           // show a warning when request / response config is used with AWS_PROXY (LAMBDA-PROXY)
           if (integrationType === 'AWS_PROXY' && (
-            (!!event.http.request) || (!!event.http.response)
+            (!!event.http.request) || (!!event.http.response) || (!!event.http.cors)
           )) {
             const warningMessage = [
-              'Warning! You\'re using the LAMBDA-PROXY in combination with request / response',
+              'Warning! You\'re using the LAMBDA-PROXY in combination with request / response / cors',
               ` configuration in your function "${functionName}".`,
               ' This configuration will be ignored during deployment.',
             ].join('');

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/methods.js
@@ -594,13 +594,14 @@ module.exports = {
             }
           }
 
-          // show a warning when request / response config is used with AWS_PROXY (LAMBDA-PROXY)
+          // show a warning when request / response / cors
+          // config is used with AWS_PROXY (LAMBDA-PROXY)
           if (integrationType === 'AWS_PROXY' && (
             (!!event.http.request) || (!!event.http.response) || (!!event.http.cors)
           )) {
             const warningMessage = [
-              'Warning! You\'re using the LAMBDA-PROXY in combination with request / response / cors',
-              ` configuration in your function "${functionName}".`,
+              'Warning! You\'re using the LAMBDA-PROXY in combination with request / response',
+              ` / cors configuration in your function "${functionName}".`,
               ' This configuration will be ignored during deployment.',
             ].join('');
             this.serverless.cli.log(warningMessage);

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/methods.js
@@ -11,6 +11,8 @@ describe('#compileMethods()', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
+    // Mock CLI in place so we get the log method
+    serverless.cli = { log: () => { } };
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.service.environment = {
@@ -39,7 +41,6 @@ describe('#compileMethods()', () => {
             http: {
               path: 'users/create',
               method: 'POST',
-              cors: true,
             },
           },
           {
@@ -49,19 +50,12 @@ describe('#compileMethods()', () => {
             http: {
               path: 'users/update',
               method: 'PUT',
-              cors: {
-                origins: ['*'],
-              },
             },
           },
           {
             http: {
               path: 'users/delete',
               method: 'DELETE',
-              cors: {
-                origins: ['*'],
-                headers: ['CustomHeaderA', 'CustomHeaderB'],
-              },
             },
           },
         ],
@@ -354,6 +348,42 @@ describe('#compileMethods()', () => {
   it('should create preflight method for CORS enabled resource', () => {
     const origin = '\'*\'';
     const headers = '\'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token\'';
+
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              path: 'users/create',
+              method: 'POST',
+              cors: true,
+            },
+          },
+          {
+            http: 'GET users/list',
+          },
+          {
+            http: {
+              path: 'users/update',
+              method: 'PUT',
+              cors: {
+                origins: ['*'],
+              },
+            },
+          },
+          {
+            http: {
+              path: 'users/delete',
+              method: 'DELETE',
+              cors: {
+                origins: ['*'],
+                headers: ['CustomHeaderA', 'CustomHeaderB'],
+              },
+            },
+          },
+        ],
+      },
+    };
 
     return awsCompileApigEvents.compileMethods().then(() => {
       expect(
@@ -1024,10 +1054,31 @@ describe('#compileMethods()', () => {
     expect(() => awsCompileApigEvents.compileMethods()).to.throw(Error);
   });
 
-  it('should show a warning message when using request / response config with LAMBDA-PROXY', () => {
-    // initialize so we get the log method from the CLI in place
-    serverless.init();
+  it('should show a warning message when using CORS config with LAMBDA-PROXY', () => {
+    const logStub = sinon.stub(serverless.cli, 'log');
 
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'get',
+              path: 'users/list',
+              integration: 'lambda-proxy', // can be removed as it defaults to this
+              cors: true,
+            },
+          },
+        ],
+      },
+    };
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(logStub.calledOnce).to.be.equal(true);
+      expect(logStub.args[0][0].length).to.be.at.least(1);
+    });
+  });
+
+  it('should show a warning message when using request / response config with LAMBDA-PROXY', () => {
     const logStub = sinon.stub(serverless.cli, 'log');
 
     awsCompileApigEvents.serverless.service.functions = {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2545

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Added warning to existing warnings regarding `request` and `response` configuration being ignored.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

With the following configuration you should see warnings printed to the console when using `serverless deploy`:

```yml
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: user/create
          method: get
          cors:
            origins:
              - '*'
```
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

