### PR TITLE
add input, inputPath variable, resolves #2543

### DIFF
--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -36,9 +36,13 @@ functions:
       - schedule:
           rate: rate(10 minutes)
           enabled: false
-          input: '{"key": "value"}'
+          input:
+            key1: value1
+            key2: value2
+            stageParams:
+              stage: dev
       - schedule:
           rate: cron(0 12 * * ? *)
           enabled: false
-          inputPath: ''
+          inputPath: '$.stageVariables'
 ```

--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -36,7 +36,9 @@ functions:
       - schedule:
           rate: rate(10 minutes)
           enabled: false
+          input: '{"key": "value"}'
       - schedule:
           rate: cron(0 12 * * ? *)
           enabled: false
+          inputPath: ''
 ```

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -58,7 +58,7 @@ class AwsCompileScheduledEvents {
               }
               if (Input && typeof Input === 'string') {
                 // escape quotes to favor JSON.parse
-                Input = Input.replace(/\"/g,'\\"'); // eslint-disable-line
+                Input = Input.replace(/\"/g, '\\"'); // eslint-disable-line
               }
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
@@ -76,28 +76,21 @@ class AwsCompileScheduledEvents {
 
             const normalizedFunctionName = functionName[0].toUpperCase() + functionName.substr(1);
 
-            let scheduleTemplate = [`
+            const scheduleTemplate = `
               {
                 "Type": "AWS::Events::Rule",
                 "Properties": {
                   "ScheduleExpression": "${ScheduleExpression}",
                   "State": "${State}",
                   "Targets": [{
+                    ${Input ? `"Input": "${Input}",` : ``}
+                    ${InputPath ? `"InputPath": "${InputPath}",` : ``}
                     "Arn": { "Fn::GetAtt": ["${normalizedFunctionName}LambdaFunction", "Arn"] },
-                    "Id": "${functionName}Schedule"`,
-            ];
-            if (Input) {
-              scheduleTemplate.push(`,"Input": "${Input}"`);
-            }
-            if (InputPath) {
-              scheduleTemplate.push(`,"InputPath": "${InputPath}"`);
-            }
-            scheduleTemplate.push(`
+                    "Id": "${functionName}Schedule"
                   }]
                 }
               }
-            `);
-            scheduleTemplate = scheduleTemplate.join('');
+            `;
 
             const permissionTemplate = `
               {

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -45,8 +45,9 @@ class AwsCompileScheduledEvents {
 
               if (Input && InputPath) {
                 const errorMessage = [
-                  `Both Input and InputPath are provided for target ${functionName}`,
-                  ' Please check the docs for more info.',
+                  'You can\'t set both input & inputPath properties at the',
+                  'same time for schedule events.',
+                  'Please check the AWS docs for more info',
                 ].join('');
                 throw new this.serverless.classes
                   .Error(errorMessage);

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -42,6 +42,12 @@ class AwsCompileScheduledEvents {
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
               Input = event.schedule.input || '';
               InputPath = event.schedule.inputPath || '';
+
+              if (Input && typeof Input === 'object') {
+                Input = JSON.stringify(Input);
+              }
+              // escape quotes to favor JSON.parse
+              Input = Input.replace(/\"/g,'\\"'); // eslint-disable-line
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -23,6 +23,8 @@ class AwsCompileScheduledEvents {
             scheduleNumberInFunction++;
             let ScheduleExpression;
             let State;
+            let Input;
+            let InputPath;
 
             // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
@@ -38,9 +40,13 @@ class AwsCompileScheduledEvents {
               }
               ScheduleExpression = event.schedule.rate;
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
+              Input = event.schedule.input || '';
+              InputPath = event.schedule.inputPath || '';
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';
+              Input = '';
+              InputPath = '';
             } else {
               const errorMessage = [
                 `Schedule event of function ${functionName} is not an object nor a string`,
@@ -62,7 +68,9 @@ class AwsCompileScheduledEvents {
                   "State": "${State}",
                   "Targets": [{
                     "Arn": { "Fn::GetAtt": ["${normalizedFunctionName}LambdaFunction", "Arn"] },
-                    "Id": "${functionName}Schedule"
+                    "Id": "${functionName}Schedule",
+                    "Input" : "${Input}",
+                    "InputPath" : "${InputPath}"
                   }]
                 }
               }

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -40,19 +40,28 @@ class AwsCompileScheduledEvents {
               }
               ScheduleExpression = event.schedule.rate;
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
-              Input = event.schedule.input || '';
-              InputPath = event.schedule.inputPath || '';
+              Input = event.schedule.input;
+              InputPath = event.schedule.inputPath;
+
+              if (Input && InputPath) {
+                const errorMessage = [
+                  `Both Input and InputPath are provided for target ${functionName}`,
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes
+                  .Error(errorMessage);
+              }
 
               if (Input && typeof Input === 'object') {
                 Input = JSON.stringify(Input);
               }
-              // escape quotes to favor JSON.parse
-              Input = Input.replace(/\"/g,'\\"'); // eslint-disable-line
+              if (Input && typeof Input === 'string') {
+                // escape quotes to favor JSON.parse
+                Input = Input.replace(/\"/g,'\\"'); // eslint-disable-line
+              }
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';
-              Input = '';
-              InputPath = '';
             } else {
               const errorMessage = [
                 `Schedule event of function ${functionName} is not an object nor a string`,
@@ -66,7 +75,7 @@ class AwsCompileScheduledEvents {
 
             const normalizedFunctionName = functionName[0].toUpperCase() + functionName.substr(1);
 
-            const scheduleTemplate = `
+            let scheduleTemplate = [`
               {
                 "Type": "AWS::Events::Rule",
                 "Properties": {
@@ -74,13 +83,20 @@ class AwsCompileScheduledEvents {
                   "State": "${State}",
                   "Targets": [{
                     "Arn": { "Fn::GetAtt": ["${normalizedFunctionName}LambdaFunction", "Arn"] },
-                    "Id": "${functionName}Schedule",
-                    "Input" : "${Input}",
-                    "InputPath" : "${InputPath}"
+                    "Id": "${functionName}Schedule"`,
+            ];
+            if (Input) {
+              scheduleTemplate.push(`,"Input": "${Input}"`);
+            }
+            if (InputPath) {
+              scheduleTemplate.push(`,"InputPath": "${InputPath}"`);
+            }
+            scheduleTemplate.push(`
                   }]
                 }
               }
-            `;
+            `);
+            scheduleTemplate = scheduleTemplate.join('');
 
             const permissionTemplate = `
               {

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -101,7 +101,30 @@ describe('AwsCompileScheduledEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should respect input and inputPath variables', () => {
+    it('should respect inputPath variable', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                inputPath: '$.stageVariables',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Targets[0].InputPath
+      ).to.equal('$.stageVariables');
+    });
+
+    it('should respect input variable', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
           events: [
@@ -110,7 +133,6 @@ describe('AwsCompileScheduledEvents', () => {
                 rate: 'rate(10 minutes)',
                 enabled: false,
                 input: '{"key":"value"}',
-                inputPath: '$.stageVariables',
               },
             },
           ],
@@ -123,13 +145,34 @@ describe('AwsCompileScheduledEvents', () => {
         .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
         .Properties.Targets[0].Input
       ).to.equal('{"key":"value"}');
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
-        .Properties.Targets[0].InputPath
-      ).to.equal('$.stageVariables');
     });
 
     it('should respect input variable as an object', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                input: {
+                  key: 'value',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Targets[0].Input
+      ).to.equal('{"key":"value"}');
+    });
+
+    it('should throw an error when both Input and InputPath are set', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
           events: [
@@ -147,12 +190,7 @@ describe('AwsCompileScheduledEvents', () => {
         },
       };
 
-      awsCompileScheduledEvents.compileScheduledEvents();
-
-      expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
-        .Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
     });
 
     it('should not create corresponding resources when scheduled events are not given', () => {

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -101,6 +101,31 @@ describe('AwsCompileScheduledEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should respect input and inputPath variables', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                input: '{}'
+              },
+            }
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1.Properties.Targets[0].Input
+      ).to.equal('{}');
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1.Properties.Targets[0].InputPath
+      ).to.equal('');
+    });
+
     it('should not create corresponding resources when scheduled events are not given', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -109,9 +109,9 @@ describe('AwsCompileScheduledEvents', () => {
               schedule: {
                 rate: 'rate(10 minutes)',
                 enabled: false,
-                input: '{}'
+                input: '{}',
               },
-            }
+            },
           ],
         },
       };
@@ -119,10 +119,12 @@ describe('AwsCompileScheduledEvents', () => {
       awsCompileScheduledEvents.compileScheduledEvents();
 
       expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1.Properties.Targets[0].Input
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Targets[0].Input
       ).to.equal('{}');
       expect(awsCompileScheduledEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1.Properties.Targets[0].InputPath
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Targets[0].InputPath
       ).to.equal('');
     });
 

--- a/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/tests/index.js
@@ -109,7 +109,8 @@ describe('AwsCompileScheduledEvents', () => {
               schedule: {
                 rate: 'rate(10 minutes)',
                 enabled: false,
-                input: '{}',
+                input: '{"key":"value"}',
+                inputPath: '$.stageVariables',
               },
             },
           ],
@@ -121,11 +122,37 @@ describe('AwsCompileScheduledEvents', () => {
       expect(awsCompileScheduledEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
         .Properties.Targets[0].Input
-      ).to.equal('{}');
+      ).to.equal('{"key":"value"}');
       expect(awsCompileScheduledEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
         .Properties.Targets[0].InputPath
-      ).to.equal('');
+      ).to.equal('$.stageVariables');
+    });
+
+    it('should respect input variable as an object', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                input: {
+                  key: 'value',
+                },
+                inputPath: '$.stageVariables',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Targets[0].Input
+      ).to.equal('{"key":"value"}');
     });
 
     it('should not create corresponding resources when scheduled events are not given', () => {


### PR DESCRIPTION
## What did you implement:

I have added support for parsing Input and InputPath variables when defining a Schedule event.

An attempt to close #2543.
## How did you implement it:
## How can we verify it:

```
- schedule:
  rate: rate(10 minutes)
  enabled: false
  input: '{"key": "value"}'
- schedule:
  rate: rate(10 minutes)
  enabled: false
  input: 
    key: 'value'
- schedule:
  rate: cron(0 12 * * ? *)
  enabled: false
  inputPath: ''
```

**_Is this ready for review?:**_ YES
