### PR TITLE
Fix regex linting errors

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -291,7 +291,7 @@ class Utils {
           general: {
             userId,
             timestamp: (new Date()).getTime(),
-            timezone: (new Date()).toString().match(/([A-Z]+[\+-][0-9]+)/)[1],
+            timezone: (new Date()).toString().match(/([A-Z]+[+-][0-9]+)/)[1],
             operatingSystem: process.platform,
             serverlessVersion: serverless.version,
             nodeJsVersion: process.version,

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -12,7 +12,7 @@ class Variables {
     this.service = this.serverless.service;
 
     this.overwriteSyntax = RegExp(/,/g);
-    this.fileRefSyntax = RegExp(/^file\(([a-zA-Z0-9._\-\/]+?)\)/g);
+    this.fileRefSyntax = RegExp(/^file\(([a-zA-Z0-9._\-/]+?)\)/g);
     this.envRefSyntax = RegExp(/^env:./g);
     this.optRefSyntax = RegExp(/^opt:./g);
     this.selfRefSyntax = RegExp(/^self:./g);

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -38,7 +38,7 @@ module.exports = {
 
   createStack() {
     const stackName = `${this.serverless.service.service}-${this.options.stage}`;
-    if (/^[^a-zA-Z].+|.*[^a-zA-Z0-9\-].*/.test(stackName) || stackName.length > 128) {
+    if (/^[^a-zA-Z].+|.*[^a-zA-Z0-9-].*/.test(stackName) || stackName.length > 128) {
       const errorMessage = [
         `The stack service name "${stackName}" is not valid. `,
         'A service name should only contain alphanumeric',

--- a/lib/plugins/aws/deploy/tests/generateArtifactDirectoryName.js
+++ b/lib/plugins/aws/deploy/tests/generateArtifactDirectoryName.js
@@ -20,7 +20,7 @@ describe('#generateArtifactDirectoryName()', () => {
 
   it('should generate a name for the artifact directory based on the current time', () => awsDeploy
     .generateArtifactDirectoryName().then(() => {
-      expect(awsDeploy.serverless.service.package.artifactDirectoryName).to.match(/[0-9]+\-.+/);
+      expect(awsDeploy.serverless.service.package.artifactDirectoryName).to.match(/[0-9]+-.+/);
     })
   );
 });


### PR DESCRIPTION
## What did you implement:

Fixes the recently introduced linting errors.

## How did you implement it:

Update regexes.

## How can we verify it:

Run `npm run lint`

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES