### PR TITLE
DRY out setProvider() usage

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -79,7 +79,7 @@ class AwsProvider {
     this.serverless = serverless;
     this.sdk = AWS;
     this.provider = this; // only load plugin in an AWS service context
-    this.serverless.setProvider('aws', this);
+    this.serverless.setProvider(this.constructor.getProviderName(), this);
 
     // Use HTTPS Proxy (Optional)
     const proxy = process.env.proxy


### PR DESCRIPTION
## What did you implement:

Remove the repetitive provider name in the `setProvider()` call.

## How did you implement it:

Just replaced the string with a call of the `getProviderName()` static method.

## How can we verify it:

See that tests pass.

## Todos:

- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES