### PR TITLE
Fix failing deployment bug

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -45,23 +45,24 @@ module.exports = {
                 data.StackEvents.reverse().forEach((event) => {
                   const eventInRange = (monitoredSince < event.Timestamp);
                   const eventNotLogged = (loggedEvents.indexOf(event.EventId) === -1);
-                  let eventStatus = event.ResourceStatus;
+                  let eventStatus = event.ResourceStatus || null;
                   if (eventInRange && eventNotLogged) {
                     // Keep track of stack status
                     if (event.ResourceType === 'AWS::CloudFormation::Stack') {
                       stackStatus = eventStatus;
                     }
                     // Keep track of first failed event
-                    if (eventStatus.endsWith('FAILED') && stackLatestError === null) {
+                    if (eventStatus
+                      && eventStatus.endsWith('FAILED') && stackLatestError === null) {
                       stackLatestError = event;
                     }
                     // Log stack events
                     if (this.options.verbose) {
-                      if (eventStatus.endsWith('FAILED')) {
+                      if (eventStatus && eventStatus.endsWith('FAILED')) {
                         eventStatus = chalk.red(eventStatus);
-                      } else if (eventStatus.endsWith('PROGRESS')) {
+                      } else if (eventStatus && eventStatus.endsWith('PROGRESS')) {
                         eventStatus = chalk.yellow(eventStatus);
-                      } else if (eventStatus.endsWith('COMPLETE')) {
+                      } else if (eventStatus && eventStatus.endsWith('COMPLETE')) {
                         eventStatus = chalk.green(eventStatus);
                       }
                       let eventLog = `CloudFormation - ${eventStatus} - `;

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -77,7 +77,9 @@ module.exports = {
                 });
                 // Handle stack create/update/delete failures
                 if ((stackLatestError && !this.options.verbose)
-                || (stackStatus.endsWith('ROLLBACK_COMPLETE') && this.options.verbose)) {
+                || (stackStatus
+                    && stackStatus.endsWith('ROLLBACK_COMPLETE')
+                    && this.options.verbose)) {
                   this.serverless.cli.log('Deployment failed!');
                   let errorMessage = 'An error occurred while provisioning your stack: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;

--- a/lib/plugins/aws/tests/monitorStack.js
+++ b/lib/plugins/aws/tests/monitorStack.js
@@ -302,6 +302,63 @@ describe('monitorStack', () => {
       });
     });
 
+    it('should keep monitoring when 1st ResourceType is not "AWS::CloudFormation::Stack"', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const firstNoStackResourceTypeEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            LogicalResourceId: 'somebucket',
+            ResourceType: 'AWS::S3::Bucket',
+            Timestamp: new Date(),
+          },
+        ],
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            LogicalResourceId: 'mocha',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateComplete = {
+        StackEvents: [
+          {
+            EventId: '1m2n3o4p',
+            LogicalResourceId: 'mocha',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_COMPLETE',
+          },
+        ],
+      };
+      describeStackEventsStub.onCall(0).returns(BbPromise.resolve(firstNoStackResourceTypeEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateStartEvent));
+      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateComplete));
+
+      return awsPlugin.monitorStack('update', cfDataMock, 10).then(() => {
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        awsPlugin.provider.request.restore();
+      });
+    });
+
+
     it('should catch describeStackEvents error if stack was not in deleting state', () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {


### PR DESCRIPTION
## What did you implement:

Closes #2383 and #2395

Closes the issue where the deployment failed with the nasty `endsWith` error message.

## How did you implement it:

Added checks if variable is not null if `endsWith` is used.

Shoutouts to @bobby-brennan for providing the fix for it 🎉 

## How can we verify it:

Deploy the example listed in the issue for it (see above).

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES