### PR TITLE
add Support file parsing in variables

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -103,6 +103,8 @@ functions:
 
 In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `schedule` property. It's completely recursive and you can go as deep as you want.
 
+Files with the extension `.json`, `.yml`, or `.yaml` will be parsed automatically. If your file does not have one of these extensions you can use `${file:json(path)}` or `${file:yaml(path)}` to explicitly have it parsed in your config.
+
 ## Multiple Configuration Files
 
 Adding many custom resources to your `serverless.yml` file could bloat the whole file, so you can use the Serverless Variable syntax to split this up.

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -73,16 +73,25 @@ class Utils {
     });
   }
 
-  readFileSync(filePath) {
+  readFileSync(filePath, fileTypeParam) {
     let contents;
+    let fileType = fileTypeParam;
+
+    if (typeof fileType === 'undefined') {
+      if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
+        fileType = 'yaml';
+      } else if (filePath.endsWith('.json')) {
+        fileType = 'json';
+      }
+    }
 
     // Read file
     contents = fse.readFileSync(filePath);
 
-    // Auto-parse JSON
-    if (filePath.endsWith('.json')) {
+    // Auto-parse JSON and YAML
+    if (fileType === 'json') {
       contents = JSON.parse(contents);
-    } else if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
+    } else if (fileType === 'yaml') {
       contents = YAML.load(contents.toString(), { filename: filePath });
     } else {
       contents = contents.toString().trim();

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -153,6 +153,15 @@ describe('Utils', () => {
         serverless.utils.readFileSync(tmpFilePath);
       }).to.throw(new RegExp('YAMLException:.*invalid.yml'));
     });
+
+    it('should respect fileType parameter', () => {
+      const tmpFilePath = testUtils.getTmpFilePath('this-is-yaml');
+
+      serverless.utils.writeFileSync(tmpFilePath, 'foo: bar');
+      const obj = serverless.utils.readFileSync(tmpFilePath, 'yaml');
+
+      expect(obj.foo).to.equal('bar');
+    });
   });
 
   describe('#readFile()', () => {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -12,7 +12,7 @@ class Variables {
     this.service = this.serverless.service;
 
     this.overwriteSyntax = RegExp(/,/g);
-    this.fileRefSyntax = RegExp(/^file\(([a-zA-Z0-9._\-/]+?)\)/g);
+    this.fileRefSyntax = RegExp(/^file:?(json|yaml)?\(([a-zA-Z0-9._\-/]+?)\)/g);
     this.envRefSyntax = RegExp(/^env:./g);
     this.optRefSyntax = RegExp(/^opt:./g);
     this.selfRefSyntax = RegExp(/^self:./g);
@@ -150,7 +150,11 @@ class Variables {
   }
 
   getValueFromFile(variableString) {
-    const matchedFileRefString = variableString.match(this.fileRefSyntax)[0];
+    const regex = new RegExp(this.fileRefSyntax);
+    const captureGroups = regex.exec(variableString);
+    const matchedPart = captureGroups[0];
+    const matchedFileType = captureGroups[1];
+    const matchedFileRefString = captureGroups[2];
     const referencedFileRelativePath = matchedFileRefString
       .replace(this.fileRefSyntax, (match, varName) => varName.trim());
     const referencedFileFullPath = path.join(this.serverless.config.servicePath,
@@ -160,10 +164,13 @@ class Variables {
       return undefined;
     }
 
-    let valueToPopulate = this.serverless.utils.readFileSync(referencedFileFullPath);
-    if (matchedFileRefString !== variableString) {
-      let deepProperties = variableString
-        .replace(matchedFileRefString, '');
+    let valueToPopulate = this.serverless.utils.readFileSync(
+      referencedFileFullPath,
+      matchedFileType
+    );
+
+    if (matchedPart !== variableString) {
+      let deepProperties = variableString.replace(matchedPart, '');
       if (deepProperties.substring(0, 1) !== ':') {
         const errorMessage = [
           'Invalid variable syntax when referencing',

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -409,6 +409,22 @@ describe('Variables', () => {
       expect(valueToPopulate).to.equal('hello world');
     });
 
+    it('should parse files with type specified', () => {
+      const serverless = new Serverless();
+      const SUtils = new Utils();
+      const tmpDirPath = testUtils.getTmpDirPath();
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'someFile'),
+        '{ "foo": "bar" }');
+
+      serverless.config.update({ servicePath: tmpDirPath });
+
+      const valueToPopulate = serverless.variables.getValueFromFile('file:json(./someFile)');
+      expect(valueToPopulate).to.deep.equal({
+        foo: 'bar',
+      });
+    });
+
     it('should trim trailing whitespace and new line character', () => {
       const serverless = new Serverless();
       const SUtils = new Utils();


### PR DESCRIPTION
## What did you implement:

`file()` variable references work as is, but users can optionally use `file:json()` or `file:yaml()` in order to explicitly parse the contents of the file. This is useful in certain applications where files have a structure but their extension does not match - for example, a terraform `.tfstate` file, is actually JSON.

## How did you implement it:

I mostly piggybacked on existing variables ref/syntax parsing.

## How can we verify it:

`npm test` works, `npm run simple-integration-test` works.

Creating a serverless.yml that has

```
custom:
  foo: ${file:json(./some-file').foo}`
```

where some-file contains `{ "foo": "bar" }` should set custom.foo to "bar".

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

