### PR TITLE
fixed the bug resultTtlInSeconds defaults to 300 when set to 0

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
@@ -51,7 +51,8 @@ module.exports = {
               throw new this.serverless.classes
                 .Error('Please provide either an authorizer name or ARN');
             }
-            resultTtlInSeconds = Number.parseInt(authorizer.resultTtlInSeconds, 10) || 300;
+            resultTtlInSeconds = Number.parseInt(authorizer.resultTtlInSeconds, 10);
+            resultTtlInSeconds = Number.isNaN(resultTtlInSeconds) ? 300 : resultTtlInSeconds;
             identitySource = authorizer.identitySource || 'method.request.header.Authorization';
           } else {
             const errorMessage = [

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/tests/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/tests/authorizers.js
@@ -108,7 +108,7 @@ describe('#compileAuthorizers()', () => {
   it('should create authorizer with the given config object', () => {
     awsCompileApigEvents.serverless.service.functions.first.events[0].http.authorizer = {
       name: 'authorizer',
-      resultTtlInSeconds: 400,
+      resultTtlInSeconds: 0,
       identitySource: 'method.request.header.Custom',
       identityValidationExpression: 'regex',
     };
@@ -117,7 +117,7 @@ describe('#compileAuthorizers()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.AuthorizerApiGatewayAuthorizer.Properties.AuthorizerResultTtlInSeconds
-      ).to.equal(400);
+      ).to.equal(0);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2587 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
It has returned `false` when set to 0, then fixed to reterun 0.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Please set 0 in `resultTtlInSeconds` statement and run `sls deploy`.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

