### PR TITLE
Updated example for only including a specific file in output

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -32,6 +32,14 @@ package:
     - "!node_modules/node-fetch/**"
 ```
 
+Exclude all files but `handler.js`
+
+``` yaml
+package:
+  exclude:
+    - "!src/function/handler.js"
+```
+
 ```
 exclude:
   - tmp/**


### PR DESCRIPTION
## What did you implement:

Small docs change to add an example for including a single file when packaging

Based on the discussion in #2529 , may update depending on my question with the `node_modules` example that doesn't seem to work for me

***Is this ready for review?:*** YES

