### PR TITLE
update aws-lambda-java-events to 1.3.0

### DIFF
--- a/lib/plugins/create/templates/aws-java-gradle/build.gradle
+++ b/lib/plugins/create/templates/aws-java-gradle/build.gradle
@@ -7,7 +7,7 @@ repositories {
 dependencies {
     compile (
         'com.amazonaws:aws-lambda-java-core:1.1.0',
-        'com.amazonaws:aws-lambda-java-events:1.1.0'
+        'com.amazonaws:aws-lambda-java-events:1.3.0'
     )
 }
 

--- a/lib/plugins/create/templates/aws-java-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-java-maven/pom.xml
@@ -8,13 +8,16 @@
   <name>hello</name>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-lambda-java-core -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-core</artifactId>
       <version>1.1.0</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-events</artifactId>
+      <version>1.3.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Update aws-lambda-java-events to 1.3.0 in both `aws-java-gradle` and `aws-java-maven` template.
`aws-java-gradle` use old version 1.1.0 before and `aws-java-maven` didn't have this dependency.

This library includes all aws lambda trigger events like s3 events, dynamodb events etc. so it's better to include it in template. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How can we verify it:

Create a new project with those two templates then you should able to see aws-lambda-java-events dependency with version 1.3.0

***Is this ready for review?:*** YES

