### PR TITLE
fix failing tests exit code

### DIFF
--- a/lib/plugins/aws/invokeLocal/tests/index.js
+++ b/lib/plugins/aws/invokeLocal/tests/index.js
@@ -8,7 +8,6 @@ const AwsProvider = require('../../provider/awsProvider');
 const Serverless = require('../../../../Serverless');
 const BbPromise = require('bluebird');
 const testUtils = require('../../../../../tests/utils');
-const fse = require('fs-extra');
 
 describe('AwsInvokeLocal', () => {
   const serverless = new Serverless();
@@ -183,20 +182,6 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.options.functionObj.runtime = 'python';
       expect(() => awsInvokeLocal.invokeLocal()).to.throw(Error);
       delete awsInvokeLocal.options.functionObj.runtime;
-    });
-  });
-
-  describe('#invokeLocalNodeJs()', () => {
-    it('should log handler callback', () => {
-      serverless.cli = new serverless.classes.CLI(serverless);
-      const consoleLogStub = sinon.stub(serverless.cli, 'consoleLog');
-      serverless.config.servicePath = testUtils.getTmpDirPath();
-      fse.copySync(path.join(serverless.config.serverlessPath,
-        'plugins', 'create', 'templates', 'aws-nodejs'),
-        serverless.config.servicePath, { clobber: true, preserveTimestamps: true });
-      awsInvokeLocal.invokeLocalNodeJs('handler', 'hello', {});
-      expect(consoleLogStub.called).to.equal(true);
-      serverless.cli.consoleLog.restore();
     });
   });
 });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -184,7 +184,7 @@ describe('AwsProvider', () => {
       awsProvider.request('S3', 'error', {}, 'dev', 'us-east-1')
         .then(() => done('Should not succeed'))
         .catch((err) => {
-          expect(err.message).to.contain('https://git.io/viZAC');
+          expect(err.message).to.contain('https://git.io/vXsdd');
           done();
         })
         .catch(done);


### PR DESCRIPTION
Removed test causes that `npm test` has a wrong exit code (0) when some tests are failing.

Closes #2603.