### PR TITLE
Enables service installation with a name

### DIFF
--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -20,6 +20,7 @@ serverless install --url https://github.com/some/service
 
 ## Options
 - `--url` or `-u` The services GitHub URL. **Required**.
+- `--name` or `-n` Name for the service.
 
 ## Provided lifecycle events
 - `install:install`
@@ -31,6 +32,16 @@ serverless install --url https://github.com/some/service
 ```bash
 serverless install --url https://github.com/pmuens/serverless-crud
 ```
+
+This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `authentication` in the current working directory and unzips the files in this directory.
+
+### Installing a service from a GitHub URL with a new service name
+
+```bash
+serverless install --url https://github.com/johndoe/authentication --name my-authentication
+```
+
+This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `my-authentication` in the current working directory, unzips the files in this directory and renames service to `my-authentication` if `serverless.yml` exists in the service root.
 
 This example will download the .zip file of the `serverless-crud` service from GitHub, create a new directory with the name `serverless-crud` in the current working directory and unzips the files in this directory.
 

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -33,17 +33,15 @@ serverless install --url https://github.com/some/service
 serverless install --url https://github.com/pmuens/serverless-crud
 ```
 
-This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `authentication` in the current working directory and unzips the files in this directory.
+This example will download the .zip file of the `serverless-crud` service from GitHub, create a new directory with the name `serverless-crud` in the current working directory and unzips the files in this directory.
 
 ### Installing a service from a GitHub URL with a new service name
 
 ```bash
-serverless install --url https://github.com/johndoe/authentication --name my-authentication
+serverless install --url https://github.com/pmuens/serverless-crud --name my-crud
 ```
 
-This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `my-authentication` in the current working directory, unzips the files in this directory and renames the service to `my-authentication` if `serverless.yml` exists in the service root.
-
-This example will download the .zip file of the `serverless-crud` service from GitHub, create a new directory with the name `serverless-crud` in the current working directory and unzips the files in this directory.
+This example will download the .zip file of the `serverless-crud` service from GitHub, create a new directory with the name `my-crud` in the current working directory and unzips the files in this directory and renames the service to `my-crud` if `serverless.yml` exists in the service root.
 
 ### Installing a service from a directory in a GitHub URL
 

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -41,7 +41,7 @@ This example will download the .zip file of the `authentication` service from Gi
 serverless install --url https://github.com/johndoe/authentication --name my-authentication
 ```
 
-This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `my-authentication` in the current working directory, unzips the files in this directory and renames service to `my-authentication` if `serverless.yml` exists in the service root.
+This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `my-authentication` in the current working directory, unzips the files in this directory and renames the service to `my-authentication` if `serverless.yml` exists in the service root.
 
 This example will download the .zip file of the `serverless-crud` service from GitHub, create a new directory with the name `serverless-crud` in the current working directory and unzips the files in this directory.
 

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -4,6 +4,11 @@ const BbPromise = require('bluebird');
 const path = require('path');
 const URL = require('url');
 const download = require('download');
+const fse = require('fs-extra');
+
+const readFile = BbPromise.promisify(fse.readFile);
+const writeFile = BbPromise.promisify(fse.writeFile);
+
 const os = require('os');
 const fse = require('fs-extra');
 const readFile = BbPromise.promisify(require('fs').readFile);

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -74,6 +74,7 @@ class Install {
     };
 
     const name = this.options.name || parsedGitHubUrl.repo;
+    const renamed = name !== parsedGitHubUrl.repo;
 
     // validate if given url is a valid GitHub url
     if (url.hostname !== 'github.com' || !parsedGitHubUrl.owner || !parsedGitHubUrl.repo) {
@@ -137,10 +138,9 @@ class Install {
     });
   }
 }
-
-// line 122
+//
 // ).then(() => {
-//   if (!name) {
+//   if (!renamed) {
 //     return '';
 //   }
 //   return this.renameService(name, servicePath);

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -49,7 +49,7 @@ class Install {
           .catch(reject);
       }
 
-      return resolve(` but couldn't rename the service because serverless.yml doesn't exists in "${servicePath}"`);
+      return resolve(` but failed to rename the service because "${serviceFile}" doesn't exists`);
     });
   }
 

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -38,18 +38,23 @@ class Install {
         .then(this.install),
     };
 
-    this.renameService = (name, servicePath) => new BbPromise((resolve, reject) => {
+    this.renameService = (name, servicePath) => new BbPromise((resolve) => {
       const serviceFile = path.join(servicePath, 'serverless.yml');
-
-      if (this.serverless.utils.fileExistsSync(serviceFile)) {
-        return this.serverless.utils.readFile(serviceFile)
+      const packageFile = path.join(servicePath, 'package.json');
+      BbPromise.all([
+        this.serverless.utils.readFile(serviceFile)
           .then(contents => Object.assign(contents, { service: name }))
-          .then(contents => this.serverless.utils.writeFile(serviceFile, contents))
-          .then(() => resolve(` as "${name}"`))
-          .catch(reject);
-      }
-
-      return resolve(` but failed to rename the service because "${serviceFile}" doesn't exists`);
+          .then(contents => this.serverless.utils.writeFile(serviceFile, contents)),
+        this.serverless.utils.readFile(packageFile)
+          .then(contents => Object.assign(contents, { name }))
+          .then(contents => this.serverless.utils.writeFile(packageFile, contents)),
+      ])
+        .then(() => resolve(` as "${name}"`))
+        .catch((error) => {
+          this.serverless.cli.log('An error occurred while renaming the service.')
+          this.serverless.cli.log(error);
+          resolve('');
+        });
     });
   }
 

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -51,7 +51,7 @@ class Install {
       ])
         .then(() => resolve(` as "${name}"`))
         .catch((error) => {
-          this.serverless.cli.log('An error occurred while renaming the service.')
+          this.serverless.cli.log('An error occurred while renaming the service.');
           this.serverless.cli.log(error);
           resolve('');
         });

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -28,7 +28,6 @@ class Install {
           },
           name: {
             usage: 'Name for the service',
-            required: false,
             shortcut: 'n',
           },
         },
@@ -43,7 +42,7 @@ class Install {
     this.renameService = (name, servicePath) => new BbPromise((resolve) => {
       const serviceFile = path.join(servicePath, 'serverless.yml');
       const packageFile = path.join(servicePath, 'package.json');
-      BbPromise.all([
+      const promises = [
         readFile(serviceFile, 'utf-8')
           .then(contents =>
             contents.replace(/service\s*:.+/gi, (match) => {
@@ -52,10 +51,17 @@ class Install {
               return fractions.join(' #');
             }))
           .then(contents => writeFile(serviceFile, contents)),
-        this.serverless.utils.readFile(packageFile)
-          .then(contents => Object.assign(contents, { name }))
-          .then(contents => this.serverless.utils.writeFile(packageFile, contents)),
-      ])
+      ];
+
+      if (this.serverless.utils.fileExistsSync(packageFile)) {
+        promises.push(
+          this.serverless.utils.readFile(packageFile)
+            .then(contents => Object.assign(contents, { name }))
+            .then(contents => this.serverless.utils.writeFile(packageFile, contents))
+        );
+      }
+
+      BbPromise.all(promises)
         .then(() => resolve(` as "${name}"`))
         .catch((error) => {
           this.serverless.cli.log('An error occurred while renaming the service.');

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -24,6 +24,11 @@ class Install {
             required: true,
             shortcut: 'u',
           },
+          name: {
+            usage: 'Name for the service',
+            required: false,
+            shortcut: 'n',
+          },
         },
       },
     };
@@ -32,6 +37,20 @@ class Install {
       'install:install': () => BbPromise.bind(this)
         .then(this.install),
     };
+
+    this.renameService = (name, servicePath) => new BbPromise((resolve, reject) => {
+      const serviceFile = path.join(servicePath, 'serverless.yml');
+
+      if (this.serverless.utils.fileExistsSync(serviceFile)) {
+        return this.serverless.utils.readFile(serviceFile)
+          .then(contents => Object.assign(contents, { service: name }))
+          .then(contents => this.serverless.utils.writeFile(serviceFile, contents))
+          .then(() => resolve(` as "${name}"`))
+          .catch(reject);
+      }
+
+      return resolve(` but couldn't rename the service because serverless.yml doesn't exists in "${servicePath}"`);
+    });
   }
 
   install() {
@@ -48,6 +67,9 @@ class Install {
       repo: parts[2],
       branch: parts[4] || 'master',
     };
+
+    const name = this.options.name || parsedGitHubUrl.repo;
+
     // validate if given url is a valid GitHub url
     if (url.hostname !== 'github.com' || !parsedGitHubUrl.owner || !parsedGitHubUrl.repo) {
       const errorMessage = [
@@ -96,7 +118,7 @@ class Install {
       servicePath,
       { timeout: 30000, extract: true, strip: 1, mode: '755' }
     ).then(() => {
-      // if it's a directory inside of git
+    // if it's a directory inside of git
       if (parts.length > 4) {
         let directory = servicePath;
         for (let i = 5; i <= endIndex; i++) {
@@ -110,5 +132,15 @@ class Install {
     });
   }
 }
+
+// line 122
+// ).then(() => {
+//   if (!name) {
+//     return '';
+//   }
+//   return this.renameService(name, servicePath);
+// }).then((extraInfo) => {
+//   that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}"${extraInfo}.`);
+// });
 
 module.exports = Install;

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -63,8 +63,6 @@ class Install {
         const json = this.serverless.utils.readFileSync(packageFile);
         this.serverless.utils.writeFile(packageFile, Object.assign(json, { name }));
       }
-
-      return ` as "${name}"`;
     };
   }
 
@@ -104,14 +102,17 @@ class Install {
 
     const endIndex = parts.length - 1;
     let dirName;
+    let serviceName;
     let downloadServicePath;
 
     // check if it's a directory or the whole repository
     if (parts.length > 4) {
+      serviceName = parts[endIndex];
       dirName = this.options.name || parts[endIndex];
       // download the repo into a temporary directory
       downloadServicePath = path.join(os.tmpdir(), parsedGitHubUrl.repo);
     } else {
+      serviceName = parsedGitHubUrl.repo;
       dirName = this.options.name || parsedGitHubUrl.repo;
       downloadServicePath = path.join(process.cwd(), dirName);
     }
@@ -124,7 +125,7 @@ class Install {
       throw new this.serverless.classes.Error(errorMessage);
     }
 
-    this.serverless.cli.log(`Downloading and installing "${dirName}"...`);
+    this.serverless.cli.log(`Downloading and installing "${serviceName}"...`);
 
     const that = this;
 
@@ -145,12 +146,14 @@ class Install {
         fse.removeSync(downloadServicePath);
       }
     }).then(() => {
-      if (!renamed) {
-        return '';
-      }
+      if (!renamed) return BbPromise.resolve();
+
       return this.renameService(dirName, servicePath);
-    }).then((extraInfo) => {
-      that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}"${extraInfo}.`);
+    }).then(() => {
+      let message = `Successfully installed "${serviceName}"`;
+      if (renamed) message = `${message} as "${dirName}"`;
+
+      that.serverless.cli.log(message);
     });
   }
 }

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -70,6 +70,8 @@ class Install {
         const json = this.serverless.utils.readFileSync(packageFile);
         this.serverless.utils.writeFile(packageFile, Object.assign(json, { name }));
       }
+
+      return ` as "${name}"`;
     };
   }
 

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -44,36 +44,33 @@ class Install {
         .then(this.install),
     };
 
-    this.renameService = (name, servicePath) => new BbPromise((resolve) => {
+    this.renameService = (name, servicePath) => {
       const serviceFile = path.join(servicePath, 'serverless.yml');
       const packageFile = path.join(servicePath, 'package.json');
-      const promises = [
-        readFile(serviceFile, 'utf-8')
-          .then(contents =>
-            contents.replace(/service\s*:.+/gi, (match) => {
-              const fractions = match.split('#');
-              fractions[0] = `service: ${name}`;
-              return fractions.join(' #');
-            }))
-          .then(contents => writeFile(serviceFile, contents)),
-      ];
 
-      if (this.serverless.utils.fileExistsSync(packageFile)) {
-        promises.push(
-          this.serverless.utils.readFile(packageFile)
-            .then(contents => Object.assign(contents, { name }))
-            .then(contents => this.serverless.utils.writeFile(packageFile, contents))
-        );
+      if (!this.serverless.utils.fileExistsSync(serviceFile)) {
+        const errorMessage = [
+          'serverless.yml not found in',
+          ` ${servicePath}`,
+        ].join('');
+        throw new this.serverless.classes.Error(errorMessage);
       }
 
-      BbPromise.all(promises)
-        .then(() => resolve(` as "${name}"`))
-        .catch((error) => {
-          this.serverless.cli.log('An error occurred while renaming the service.');
-          this.serverless.cli.log(error);
-          resolve('');
-        });
-    });
+      const serverlessYml =
+        fse.readFileSync(serviceFile, 'utf-8')
+          .replace(/service\s*:.+/gi, (match) => {
+            const fractions = match.split('#');
+            fractions[0] = `service: ${name}`;
+            return fractions.join(' #');
+          });
+
+      fse.writeFileSync(serviceFile, serverlessYml);
+
+      if (this.serverless.utils.fileExistsSync(packageFile)) {
+        const json = this.serverless.utils.readFileSync(packageFile);
+        this.serverless.utils.writeFile(packageFile, Object.assign(json, { name }));
+      }
+    };
   }
 
   install() {

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -5,14 +5,7 @@ const path = require('path');
 const URL = require('url');
 const download = require('download');
 const fse = require('fs-extra');
-
-const readFile = BbPromise.promisify(fse.readFile);
-const writeFile = BbPromise.promisify(fse.writeFile);
-
 const os = require('os');
-const fse = require('fs-extra');
-const readFile = BbPromise.promisify(require('fs').readFile);
-const writeFile = BbPromise.promisify(require('fs').writeFile);
 
 class Install {
   constructor(serverless, options) {
@@ -90,9 +83,6 @@ class Install {
       branch: parts[4] || 'master',
     };
 
-    const name = this.options.name || parsedGitHubUrl.repo;
-    const renamed = name !== parsedGitHubUrl.repo;
-
     // validate if given url is a valid GitHub url
     if (url.hostname !== 'github.com' || !parsedGitHubUrl.owner || !parsedGitHubUrl.repo) {
       const errorMessage = [
@@ -114,17 +104,20 @@ class Install {
 
     const endIndex = parts.length - 1;
     let dirName;
-    let servicePath;
+    let downloadServicePath;
 
     // check if it's a directory or the whole repository
     if (parts.length > 4) {
-      dirName = parts[endIndex];
+      dirName = this.options.name || parts[endIndex];
       // download the repo into a temporary directory
-      servicePath = path.join(os.tmpdir(), parsedGitHubUrl.repo);
+      downloadServicePath = path.join(os.tmpdir(), parsedGitHubUrl.repo);
     } else {
-      dirName = parsedGitHubUrl.repo;
-      servicePath = path.join(process.cwd(), dirName);
+      dirName = this.options.name || parsedGitHubUrl.repo;
+      downloadServicePath = path.join(process.cwd(), dirName);
     }
+
+    const servicePath = path.join(process.cwd(), dirName);
+    const renamed = dirName !== (parts.length > 4 ? parts[endIndex] : parsedGitHubUrl.repo);
 
     if (this.serverless.utils.dirExistsSync(path.join(process.cwd(), dirName))) {
       const errorMessage = `A folder named "${dirName}" already exists.`;
@@ -138,31 +131,28 @@ class Install {
     // download service
     return download(
       downloadUrl,
-      servicePath,
+      downloadServicePath,
       { timeout: 30000, extract: true, strip: 1, mode: '755' }
     ).then(() => {
     // if it's a directory inside of git
       if (parts.length > 4) {
-        let directory = servicePath;
+        let directory = downloadServicePath;
         for (let i = 5; i <= endIndex; i++) {
           directory = path.join(directory, parts[i]);
         }
         that.serverless.utils
-          .copyDirContentsSync(directory, path.join(process.cwd(), parts[endIndex]));
-        fse.removeSync(servicePath);
+          .copyDirContentsSync(directory, servicePath);
+        fse.removeSync(downloadServicePath);
       }
-      that.serverless.cli.log(`Successfully installed service "${dirName}".`);
+    }).then(() => {
+      if (!renamed) {
+        return '';
+      }
+      return this.renameService(dirName, servicePath);
+    }).then((extraInfo) => {
+      that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}"${extraInfo}.`);
     });
   }
 }
-//
-// ).then(() => {
-//   if (!renamed) {
-//     return '';
-//   }
-//   return this.renameService(name, servicePath);
-// }).then((extraInfo) => {
-//   that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}"${extraInfo}.`);
-// });
 
 module.exports = Install;

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -6,6 +6,8 @@ const URL = require('url');
 const download = require('download');
 const os = require('os');
 const fse = require('fs-extra');
+const readFile = BbPromise.promisify(require('fs').readFile);
+const writeFile = BbPromise.promisify(require('fs').writeFile);
 
 class Install {
   constructor(serverless, options) {
@@ -42,9 +44,14 @@ class Install {
       const serviceFile = path.join(servicePath, 'serverless.yml');
       const packageFile = path.join(servicePath, 'package.json');
       BbPromise.all([
-        this.serverless.utils.readFile(serviceFile)
-          .then(contents => Object.assign(contents, { service: name }))
-          .then(contents => this.serverless.utils.writeFile(serviceFile, contents)),
+        readFile(serviceFile, 'utf-8')
+          .then(contents =>
+            contents.replace(/service\s*:.+/gi, (match) => {
+              const fractions = match.split('#');
+              fractions[0] = `service: ${name}`;
+              return fractions.join(' #');
+            }))
+          .then(contents => writeFile(serviceFile, contents)),
         this.serverless.utils.readFile(packageFile)
           .then(contents => Object.assign(contents, { name }))
           .then(contents => this.serverless.utils.writeFile(packageFile, contents)),

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -108,6 +108,7 @@ describe('Install', () => {
       };
 
       return install.install().then(() => {
+        expect(downloadStub.calledOnce).to.equal(true);
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
       });
     });

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -109,6 +109,7 @@ describe('Install', () => {
 
       return install.install().then(() => {
         expect(downloadStub.calledOnce).to.equal(true);
+        expect(downloadStub.args[0][1]).to.contain(install.options.name);
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
       });
     });

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -43,7 +43,7 @@ describe('Install', () => {
   });
 
   describe('#install()', () => {
-    it('shold throw an error if the passed URL option is not a valid URL', () => {
+    it('should throw an error if the passed URL option is not a valid URL', () => {
       install.options = { url: 'invalidUrl' };
 
       expect(() => install.install()).to.throw(Error);
@@ -72,6 +72,18 @@ describe('Install', () => {
 
     it('should download the service based on the GitHub URL', () => {
       install.options = { url: 'https://github.com/johndoe/service-to-be-downloaded' };
+
+      return install.install().then(() => {
+        expect(downloadStub.calledOnce).to.equal(true);
+        expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
+      });
+    });
+
+    it('should download and rename the service based on the GitHub URL', () => {
+      install.options = {
+        url: 'https://github.com/johndoe/service-to-be-downloaded',
+        name: 'new-name-for-the-service',
+      };
 
       return install.install().then(() => {
         expect(downloadStub.calledOnce).to.equal(true);

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -21,13 +21,18 @@ describe('Install', () => {
   let defaultServicePath;
   let newServicePath;
 
-  fse.mkdirsSync('tmp');
-  process.chdir('tmp');
+  process.chdir(
+    fse.mkdirsSync(
+      testUtils.getTmpDirPath()
+    ));
 
   beforeEach(() => {
     servicePath = './';
     defaultServicePath = path.join(servicePath, 'service-to-be-downloaded');
     newServicePath = path.join(servicePath, servicePath, 'new-service-name');
+
+    fse.removeSync(defaultServicePath);
+    fse.removeSync(newServicePath);
 
     downloadStub = sinon.stub().returns(BbPromise.resolve());
     Install = proxyquire('./install.js', {
@@ -170,35 +175,6 @@ describe('Install', () => {
       });
     });
 
-    it('should download and rename the service based on the GitHub URL', () => {
-      install.options = {
-        url: 'https://github.com/johndoe/service-to-be-downloaded',
-        name: 'new-service-name',
-      };
-
-      fse.removeSync(defaultServicePath);
-      fse.removeSync(newServicePath);
-
-      downloadStub.returns(new BbPromise((resolve) => {
-        remove(newServicePath)
-          .then(() => serverless
-            .utils.writeFileSync(
-              path.join(
-                newServicePath,
-                'serverless.yml'),
-              'service: service-name'))
-          .then(resolve);
-      }));
-
-      return install.install().then(() => {
-        expect(downloadStub.calledOnce).to.equal(true);
-        expect(downloadStub.args[0][1]).to.contain(install.options.name);
-        expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
-        const yml = serverless.utils.readFileSync(path.join(newServicePath, 'serverless.yml'));
-        expect(yml.service).to.equal(install.options.name);
-      });
-    });
-
     it('should download the service based on directories in the GitHub URL', () => {
       install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
       sinon.stub(serverless.utils, 'copyDirContentsSync').returns(true);
@@ -226,6 +202,57 @@ describe('Install', () => {
 
       expect(() => install.install()).to.throw(Error);
       process.chdir(cwd);
+    });
+
+    it('should download and rename the service based on the GitHub URL', () => {
+      install.options = {
+        url: 'https://github.com/johndoe/service-to-be-downloaded',
+        name: 'new-service-name',
+      };
+
+      downloadStub.returns(
+        remove(newServicePath)
+          .then(() => {
+            const sp = downloadStub.args[0][1];
+            const slsYml = path.join(
+              sp,
+              'serverless.yml');
+            serverless
+              .utils.writeFileSync(slsYml, 'service: service-name');
+          }));
+
+      return install.install().then(() => {
+        expect(downloadStub.calledOnce).to.equal(true);
+        expect(downloadStub.args[0][1]).to.contain(install.options.name);
+        expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
+        const yml = serverless.utils.readFileSync(path.join(newServicePath, 'serverless.yml'));
+        expect(yml.service).to.equal(install.options.name);
+      });
+    });
+
+    it('should download and rename the service based directories in the GitHub URL', () => {
+      install.options = {
+        url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb',
+        name: 'new-service-name',
+      };
+
+      downloadStub.returns(
+        remove(newServicePath)
+          .then(() => {
+            const sp = downloadStub.args[0][1];
+            const slsYml = path.join(
+              sp,
+              'rest-api-with-dynamodb',
+              'serverless.yml');
+            serverless
+              .utils.writeFileSync(slsYml, 'service: service-name');
+          }));
+
+      return install.install().then(() => {
+        expect(downloadStub.calledOnce).to.equal(true);
+        const yml = serverless.utils.readFileSync(path.join(newServicePath, 'serverless.yml'));
+        expect(yml.service).to.equal(install.options.name);
+      });
     });
   });
 });

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -91,6 +91,25 @@ describe('Install', () => {
           expect(packageJson.name).to.equal(newServiceName);
         });
     });
+
+    it('should set new service in commented serverless.yml without existing package.json', () => {
+      const defaultServiceYml =
+        '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
+      const newServiceYml =
+        '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+
+      const servicePath = testUtils.getTmpDirPath();
+      const serviceFile = path.join(servicePath, 'serverless.yml');
+
+      serverless.utils.writeFileDir(serviceFile);
+      fs.writeFileSync(serviceFile, defaultServiceYml);
+
+      return install.renameService('new-service-name', servicePath)
+        .then(() => {
+          const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
+          expect(serviceYml).to.equal(newServiceYml);
+        });
+    });
   });
 
   describe('#install()', () => {

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -42,9 +42,11 @@ describe('Install', () => {
       });
     });
 
-    it('should set new service value in serverless.yml and name value in package.json', (done) => {
-      const defaultServiceYml = 'service: service-name\n\nprovider:\n  name: aws\n';
-      const newServiceYml = 'service: new-service-name\n\nprovider:\n  name: aws\n';
+    it('should set new service in serverless.yml and name in package.json', (done) => {
+      const defaultServiceYml =
+        'service: service-name\n\nprovider:\n  name: aws\n';
+      const newServiceYml =
+        'service: new-service-name\n\nprovider:\n  name: aws\n';
 
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';
@@ -67,9 +69,11 @@ describe('Install', () => {
         .catch(done);
     });
 
-    it('should set new service value in serverless.yml and name value in package.json with yaml comments', (done) => {
-      const defaultServiceYml = '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
-      const newServiceYml = '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+    it('should set new service in commented serverless.yml and name in package.json', (done) => {
+      const defaultServiceYml =
+        '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
+      const newServiceYml =
+        '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
 
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -8,6 +8,7 @@ const testUtils = require('../../../tests/utils');
 const fse = require('fs-extra');
 const path = require('path');
 const proxyquire = require('proxyquire');
+const fs = require('fs');
 
 describe('Install', () => {
   let install;
@@ -42,21 +43,49 @@ describe('Install', () => {
     });
 
     it('should set new service value in serverless.yml and name value in package.json', (done) => {
+      const defaultServiceYml = 'service: service-name\n\nprovider:\n  name: aws\n';
+      const newServiceYml = 'service: new-service-name\n\nprovider:\n  name: aws\n';
+
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';
 
       const servicePath = testUtils.getTmpDirPath();
-      const serviceFile = path.join(servicePath, 'serverless.yml');
       const packageFile = path.join(servicePath, 'package.json');
+      const serviceFile = path.join(servicePath, 'serverless.yml');
 
-      serverless.utils.writeFileSync(serviceFile, { service: defaultServiceName });
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+      fs.writeFileSync(serviceFile, defaultServiceYml);
 
       install.renameService(newServiceName, servicePath)
         .then(() => {
-          const serviceYml = serverless.utils.readFileSync(serviceFile);
+          const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
           const packageJson = serverless.utils.readFileSync(packageFile);
-          expect(serviceYml.service).to.equal(newServiceName);
+          expect(serviceYml).to.equal(newServiceYml);
+          expect(packageJson.name).to.equal(newServiceName);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should set new service value in serverless.yml and name value in package.json with yaml comments', (done) => {
+      const defaultServiceYml = '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
+      const newServiceYml = '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+
+      const defaultServiceName = 'service-name';
+      const newServiceName = 'new-service-name';
+
+      const servicePath = testUtils.getTmpDirPath();
+      const packageFile = path.join(servicePath, 'package.json');
+      const serviceFile = path.join(servicePath, 'serverless.yml');
+
+      serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+      fs.writeFileSync(serviceFile, defaultServiceYml);
+
+      install.renameService(newServiceName, servicePath)
+        .then(() => {
+          const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
+          const packageJson = serverless.utils.readFileSync(packageFile);
+          expect(serviceYml).to.equal(newServiceYml);
           expect(packageJson.name).to.equal(newServiceName);
           done();
         })

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -40,6 +40,28 @@ describe('Install', () => {
         install.install.restore();
       });
     });
+
+    it('should set new service value in serverless.yml and name value in package.json', (done) => {
+      const defaultServiceName = 'service-name';
+      const newServiceName = 'new-service-name';
+
+      const servicePath = testUtils.getTmpDirPath();
+      const serviceFile = path.join(servicePath, 'serverless.yml');
+      const packageFile = path.join(servicePath, 'package.json');
+
+      serverless.utils.writeFileSync(serviceFile, { service: defaultServiceName });
+      serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+
+      install.renameService(newServiceName, servicePath)
+        .then(() => {
+          const serviceYml = serverless.utils.readFileSync(serviceFile);
+          const packageJson = serverless.utils.readFileSync(packageFile);
+          expect(serviceYml.service).to.equal(newServiceName);
+          expect(packageJson.name).to.equal(newServiceName);
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('#install()', () => {

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -16,23 +16,20 @@ describe('Install', () => {
   let serverless;
   let downloadStub;
   let Install;
+  let cwd;
 
   let servicePath;
-  let defaultServicePath;
   let newServicePath;
 
-  process.chdir(
-    fse.mkdirsSync(
-      testUtils.getTmpDirPath()
-    ));
-
   beforeEach(() => {
-    servicePath = './';
-    defaultServicePath = path.join(servicePath, 'service-to-be-downloaded');
-    newServicePath = path.join(servicePath, servicePath, 'new-service-name');
+    const tmpDir = testUtils.getTmpDirPath();
+    cwd = process.cwd();
 
-    fse.removeSync(defaultServicePath);
-    fse.removeSync(newServicePath);
+    fse.mkdirsSync(tmpDir);
+    process.chdir(tmpDir);
+
+    servicePath = tmpDir;
+    newServicePath = path.join(servicePath, 'new-service-name');
 
     downloadStub = sinon.stub().returns(BbPromise.resolve());
     Install = proxyquire('./install.js', {
@@ -41,6 +38,11 @@ describe('Install', () => {
     serverless = new Serverless();
     install = new Install(serverless);
     serverless.init();
+  });
+
+  afterEach(() => {
+    // change back to the old cwd
+    process.chdir(cwd);
   });
 
   describe('#constructor()', () => {
@@ -68,14 +70,13 @@ describe('Install', () => {
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';
 
-      const tempPath = testUtils.getTmpDirPath();
-      const packageFile = path.join(tempPath, 'package.json');
-      const serviceFile = path.join(tempPath, 'serverless.yml');
+      const packageFile = path.join(servicePath, 'package.json');
+      const serviceFile = path.join(servicePath, 'serverless.yml');
 
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      install.renameService(newServiceName, tempPath);
+      install.renameService(newServiceName, servicePath);
       const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
       const packageJson = serverless.utils.readFileSync(packageFile);
       expect(serviceYml).to.equal(newServiceYml);
@@ -91,14 +92,13 @@ describe('Install', () => {
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';
 
-      const tempPath = testUtils.getTmpDirPath();
-      const packageFile = path.join(tempPath, 'package.json');
-      const serviceFile = path.join(tempPath, 'serverless.yml');
+      const packageFile = path.join(servicePath, 'package.json');
+      const serviceFile = path.join(servicePath, 'serverless.yml');
 
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      install.renameService(newServiceName, tempPath);
+      install.renameService(newServiceName, servicePath);
       const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
       const packageJson = serverless.utils.readFileSync(packageFile);
       expect(serviceYml).to.equal(newServiceYml);
@@ -111,13 +111,12 @@ describe('Install', () => {
       const newServiceYml =
         '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
 
-      const tempPath = testUtils.getTmpDirPath();
-      const serviceFile = path.join(tempPath, 'serverless.yml');
+      const serviceFile = path.join(servicePath, 'serverless.yml');
 
       serverless.utils.writeFileDir(serviceFile);
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      install.renameService('new-service-name', tempPath);
+      install.renameService('new-service-name', servicePath);
       const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
       expect(serviceYml).to.equal(newServiceYml);
     });
@@ -126,13 +125,12 @@ describe('Install', () => {
       const defaultServiceYml =
         '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
 
-      const tempPath = testUtils.getTmpDirPath();
-      const serviceFile = path.join(tempPath, 'serverledss.yml');
+      const serviceFile = path.join(servicePath, 'serverledss.yml');
 
       serverless.utils.writeFileDir(serviceFile);
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      expect(() => install.renameService('new-service-name', tempPath)).to.throw(Error);
+      expect(() => install.renameService('new-service-name', servicePath)).to.throw(Error);
     });
   });
 
@@ -152,23 +150,15 @@ describe('Install', () => {
     it('should throw an error if a directory with the same service name is already present', () => {
       install.options = { url: 'https://github.com/johndoe/existing-service' };
 
-      const tmpDir = testUtils.getTmpDirPath();
-      const serviceDirName = path.join(tmpDir, 'existing-service');
+      const serviceDirName = path.join(servicePath, 'existing-service');
       fse.mkdirsSync(serviceDirName);
 
-      const cwd = process.cwd();
-      process.chdir(tmpDir);
-
       expect(() => install.install()).to.throw(Error);
-
-      process.chdir(cwd);
     });
 
     it('should download the service based on the GitHub URL', () => {
       install.options = { url: 'https://github.com/johndoe/service-to-be-downloaded' };
 
-      fse.removeSync(defaultServicePath);
-      fse.removeSync(newServicePath);
       return install.install().then(() => {
         expect(downloadStub.calledOnce).to.equal(true);
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
@@ -193,15 +183,10 @@ describe('Install', () => {
 
     it('should throw an error if the same service name exists as directory in Github', () => {
       install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
-      const tmpDir = testUtils.getTmpDirPath();
-      const serviceDirName = path.join(tmpDir, 'rest-api-with-dynamodb');
+      const serviceDirName = path.join(servicePath, 'rest-api-with-dynamodb');
       fse.mkdirsSync(serviceDirName);
 
-      const cwd = process.cwd();
-      process.chdir(tmpDir);
-
       expect(() => install.install()).to.throw(Error);
-      process.chdir(cwd);
     });
 
     it('should download and rename the service based on the GitHub URL', () => {

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -8,7 +8,8 @@ const testUtils = require('../../../tests/utils');
 const fse = require('fs-extra');
 const path = require('path');
 const proxyquire = require('proxyquire');
-const fs = require('fs');
+
+const remove = BbPromise.promisify(fse.remove);
 
 describe('Install', () => {
   let install;
@@ -16,7 +17,17 @@ describe('Install', () => {
   let downloadStub;
   let Install;
 
+  let servicePath;
+  let defaultServicePath;
+  let newServicePath;
+
+  process.chdir('tmp');
+
   beforeEach(() => {
+    servicePath = './';
+    defaultServicePath = path.join(servicePath, 'service-to-be-downloaded');
+    newServicePath = path.join(servicePath, servicePath, 'new-service-name');
+
     downloadStub = sinon.stub().returns(BbPromise.resolve());
     Install = proxyquire('./install.js', {
       download: downloadStub,
@@ -51,16 +62,16 @@ describe('Install', () => {
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';
 
-      const servicePath = testUtils.getTmpDirPath();
-      const packageFile = path.join(servicePath, 'package.json');
-      const serviceFile = path.join(servicePath, 'serverless.yml');
+      const tempPath = testUtils.getTmpDirPath();
+      const packageFile = path.join(tempPath, 'package.json');
+      const serviceFile = path.join(tempPath, 'serverless.yml');
 
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
-      fs.writeFileSync(serviceFile, defaultServiceYml);
+      fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      return install.renameService(newServiceName, servicePath)
+      return install.renameService(newServiceName, tempPath)
         .then(() => {
-          const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
+          const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
           const packageJson = serverless.utils.readFileSync(packageFile);
           expect(serviceYml).to.equal(newServiceYml);
           expect(packageJson.name).to.equal(newServiceName);
@@ -76,16 +87,16 @@ describe('Install', () => {
       const defaultServiceName = 'service-name';
       const newServiceName = 'new-service-name';
 
-      const servicePath = testUtils.getTmpDirPath();
-      const packageFile = path.join(servicePath, 'package.json');
-      const serviceFile = path.join(servicePath, 'serverless.yml');
+      const tempPath = testUtils.getTmpDirPath();
+      const packageFile = path.join(tempPath, 'package.json');
+      const serviceFile = path.join(tempPath, 'serverless.yml');
 
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
-      fs.writeFileSync(serviceFile, defaultServiceYml);
+      fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      return install.renameService(newServiceName, servicePath)
+      return install.renameService(newServiceName, tempPath)
         .then(() => {
-          const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
+          const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
           const packageJson = serverless.utils.readFileSync(packageFile);
           expect(serviceYml).to.equal(newServiceYml);
           expect(packageJson.name).to.equal(newServiceName);
@@ -98,15 +109,15 @@ describe('Install', () => {
       const newServiceYml =
         '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
 
-      const servicePath = testUtils.getTmpDirPath();
-      const serviceFile = path.join(servicePath, 'serverless.yml');
+      const tempPath = testUtils.getTmpDirPath();
+      const serviceFile = path.join(tempPath, 'serverless.yml');
 
       serverless.utils.writeFileDir(serviceFile);
-      fs.writeFileSync(serviceFile, defaultServiceYml);
+      fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      return install.renameService('new-service-name', servicePath)
+      return install.renameService('new-service-name', tempPath)
         .then(() => {
-          const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
+          const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
           expect(serviceYml).to.equal(newServiceYml);
         });
     });
@@ -143,6 +154,8 @@ describe('Install', () => {
     it('should download the service based on the GitHub URL', () => {
       install.options = { url: 'https://github.com/johndoe/service-to-be-downloaded' };
 
+      fse.removeSync(defaultServicePath);
+      fse.removeSync(newServicePath);
       return install.install().then(() => {
         expect(downloadStub.calledOnce).to.equal(true);
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
@@ -152,13 +165,29 @@ describe('Install', () => {
     it('should download and rename the service based on the GitHub URL', () => {
       install.options = {
         url: 'https://github.com/johndoe/service-to-be-downloaded',
-        name: 'new-name-for-the-service',
+        name: 'new-service-name',
       };
+
+      fse.removeSync(defaultServicePath);
+      fse.removeSync(newServicePath);
+
+      downloadStub.returns(new BbPromise((resolve) => {
+        remove(newServicePath)
+          .then(() => serverless
+            .utils.writeFileSync(
+              path.join(
+                newServicePath,
+                'serverless.yml'),
+              'service: service-name'))
+          .then(resolve);
+      }));
 
       return install.install().then(() => {
         expect(downloadStub.calledOnce).to.equal(true);
         expect(downloadStub.args[0][1]).to.contain(install.options.name);
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
+        const yml = serverless.utils.readFileSync(path.join(newServicePath, 'serverless.yml'));
+        expect(yml.service).to.equal(install.options.name);
       });
     });
 

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -86,7 +86,6 @@ describe('Install', () => {
       };
 
       return install.install().then(() => {
-        expect(downloadStub.calledOnce).to.equal(true);
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
       });
     });

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -70,13 +70,11 @@ describe('Install', () => {
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      return install.renameService(newServiceName, tempPath)
-        .then(() => {
-          const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
-          const packageJson = serverless.utils.readFileSync(packageFile);
-          expect(serviceYml).to.equal(newServiceYml);
-          expect(packageJson.name).to.equal(newServiceName);
-        });
+      install.renameService(newServiceName, tempPath);
+      const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
+      const packageJson = serverless.utils.readFileSync(packageFile);
+      expect(serviceYml).to.equal(newServiceYml);
+      expect(packageJson.name).to.equal(newServiceName);
     });
 
     it('should set new service in commented serverless.yml and name in package.json', () => {
@@ -95,13 +93,11 @@ describe('Install', () => {
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      return install.renameService(newServiceName, tempPath)
-        .then(() => {
-          const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
-          const packageJson = serverless.utils.readFileSync(packageFile);
-          expect(serviceYml).to.equal(newServiceYml);
-          expect(packageJson.name).to.equal(newServiceName);
-        });
+      install.renameService(newServiceName, tempPath);
+      const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
+      const packageJson = serverless.utils.readFileSync(packageFile);
+      expect(serviceYml).to.equal(newServiceYml);
+      expect(packageJson.name).to.equal(newServiceName);
     });
 
     it('should set new service in commented serverless.yml without existing package.json', () => {
@@ -116,11 +112,22 @@ describe('Install', () => {
       serverless.utils.writeFileDir(serviceFile);
       fse.writeFileSync(serviceFile, defaultServiceYml);
 
-      return install.renameService('new-service-name', tempPath)
-        .then(() => {
-          const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
-          expect(serviceYml).to.equal(newServiceYml);
-        });
+      install.renameService('new-service-name', tempPath);
+      const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
+      expect(serviceYml).to.equal(newServiceYml);
+    });
+
+    it('should fail to set new service name in serverless.yml', () => {
+      const defaultServiceYml =
+        '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
+
+      const tempPath = testUtils.getTmpDirPath();
+      const serviceFile = path.join(tempPath, 'serverledss.yml');
+
+      serverless.utils.writeFileDir(serviceFile);
+      fse.writeFileSync(serviceFile, defaultServiceYml);
+
+      expect(() => install.renameService('new-service-name', tempPath)).to.throw(Error);
     });
   });
 

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -21,6 +21,7 @@ describe('Install', () => {
   let defaultServicePath;
   let newServicePath;
 
+  fse.mkdirsSync('tmp');
   process.chdir('tmp');
 
   beforeEach(() => {

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -42,7 +42,7 @@ describe('Install', () => {
       });
     });
 
-    it('should set new service in serverless.yml and name in package.json', (done) => {
+    it('should set new service in serverless.yml and name in package.json', () => {
       const defaultServiceYml =
         'service: service-name\n\nprovider:\n  name: aws\n';
       const newServiceYml =
@@ -58,18 +58,16 @@ describe('Install', () => {
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
       fs.writeFileSync(serviceFile, defaultServiceYml);
 
-      install.renameService(newServiceName, servicePath)
+      return install.renameService(newServiceName, servicePath)
         .then(() => {
           const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
           const packageJson = serverless.utils.readFileSync(packageFile);
           expect(serviceYml).to.equal(newServiceYml);
           expect(packageJson.name).to.equal(newServiceName);
-          done();
-        })
-        .catch(done);
+        });
     });
 
-    it('should set new service in commented serverless.yml and name in package.json', (done) => {
+    it('should set new service in commented serverless.yml and name in package.json', () => {
       const defaultServiceYml =
         '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
       const newServiceYml =
@@ -85,15 +83,13 @@ describe('Install', () => {
       serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
       fs.writeFileSync(serviceFile, defaultServiceYml);
 
-      install.renameService(newServiceName, servicePath)
+      return install.renameService(newServiceName, servicePath)
         .then(() => {
           const serviceYml = fs.readFileSync(serviceFile, 'utf-8');
           const packageJson = serverless.utils.readFileSync(packageFile);
           expect(serviceYml).to.equal(newServiceYml);
           expect(packageJson.name).to.equal(newServiceName);
-          done();
-        })
-        .catch(done);
+        });
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This PR enables to rename the service when installing from GitHub, for example `serverless install --name new-service-name --url https://github.com/SC5/serverless-messenger-boilerplate` will install `serverless-messenger-boilerplate` to folder `new-service-name` and change `service` value in `serverless.yml` to `new-service-name`.

Closes https://github.com/serverless/serverless/issues/2626

## How did you implement it:

Added new parameter `name` to install class and renameService helper function for renaming service in yaml file.

## How can we verify it:

`serverless install --name new-service-name --url https://github.com/SC5/serverless-messenger-boilerplate` should install service to `new-service-name` folder and change service name to `new-service-name`.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

