### PR TITLE
fix Glob for .git and .serverless directories

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -5,13 +5,13 @@ const _ = require('lodash');
 
 module.exports = {
   defaultExcludes: [
-    '.git',
+    '.git/**',
     '.gitignore',
     '.DS_Store',
     'npm-debug.log',
     'serverless.yaml',
     'serverless.yml',
-    '.serverless',
+    '.serverless/**',
   ],
 
   getExcludedPaths(exclude) {

--- a/lib/plugins/package/tests/packageService.js
+++ b/lib/plugins/package/tests/packageService.js
@@ -32,10 +32,10 @@ describe('#packageService()', () => {
 
       const exclude = packageService.getExcludedPaths();
       expect(exclude).to.deep.equal([
-        '.git', '.gitignore', '.DS_Store',
+        '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log',
         'serverless.yaml', 'serverless.yml',
-        '.serverless', 'dir', 'file.js',
+        '.serverless/**', 'dir', 'file.js',
       ]);
     });
 
@@ -51,10 +51,10 @@ describe('#packageService()', () => {
 
       const exclude = packageService.getExcludedPaths(funcExclude);
       expect(exclude).to.deep.equal([
-        '.git', '.gitignore', '.DS_Store',
+        '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log',
         'serverless.yaml', 'serverless.yml',
-        '.serverless', 'dir', 'file.js',
+        '.serverless/**', 'dir', 'file.js',
         'lib', 'other.js',
       ]);
     });


### PR DESCRIPTION
The exclude glob was not matching .git or .serverless, so these were being included in packages.

## How did you implement it:

I added `/**` to the end of the globs.

## How can we verify it:

`sls deploy --noDeploy` and then unzip the file.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

