### PR TITLE
Add whitelisted options support for logStat

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -184,6 +184,20 @@ class Utils {
         userId = this.readFileSync(statsEnabledFilePath).toString();
       }
 
+      // filter out the whitelisted options
+      const options = serverless.processedInput.options;
+      const whitelistedOptionKeys = ['help', 'disable', 'enable'];
+      const optionKeys = Object.keys(options);
+
+      const filteredOptionKeys = optionKeys.filter((key) =>
+        whitelistedOptionKeys.indexOf(key) !== -1
+      );
+
+      const filteredOptions = {};
+      filteredOptionKeys.forEach((key) => {
+        filteredOptions[key] = options[key];
+      });
+
       // function related information retrieval
       const numberOfFunctions = _.size(serverless.service.functions);
 
@@ -270,6 +284,7 @@ class Utils {
           version: 2,
           command: {
             name: serverless.processedInput.commands.join(' '),
+            filteredOptions,
             isRunInService: (!!serverless.config.servicePath),
           },
           service: {

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -12,16 +12,17 @@ const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
 const serverlessVersion = require('../../package.json').version;
 
-const fetchStub = sinon.stub().returns(BbPromise.resolve());
-const Utils = proxyquire('../../lib/classes/Utils.js', {
-  'node-fetch': fetchStub,
-});
-
 describe('Utils', () => {
   let utils;
   let serverless;
+  let fetchStub;
+  let Utils;
 
   beforeEach(() => {
+    fetchStub = sinon.stub().returns(BbPromise.resolve());
+    Utils = proxyquire('../../lib/classes/Utils.js', {
+      'node-fetch': fetchStub,
+    });
     serverless = new Serverless();
     utils = new Utils(serverless);
     serverless.init();
@@ -293,6 +294,10 @@ describe('Utils', () => {
       process.env.USERPROFILE = tmpDirPath;
 
       serverlessDirPath = path.join(os.homedir(), '.serverless');
+
+      // set the properties for the processed inputs
+      serverless.processedInput.commands = [];
+      serverless.processedInput.options = {};
     });
 
     it('should resolve if a file called stats-disabled is present', () => {
@@ -325,6 +330,28 @@ describe('Utils', () => {
 
       return serverless.utils.logStat(serverless).then(() => {
         expect(fs.readFileSync(statsFilePath).toString()).to.be.equal(statsId);
+      });
+    });
+
+    it('should filter out whitelisted options', () => {
+      const options = {
+        help: true, // this should appear as it's whitelisted
+        confidential: 'some confidential input', // this should be dropped
+      };
+
+      // help is a whitelisted option
+      serverless.processedInput.options = options;
+
+      return utils.logStat(serverless).then(() => {
+        expect(fetchStub.calledOnce).to.equal(true);
+        expect(fetchStub.args[0][0]).to.equal('https://api.segment.io/v1/track');
+        expect(fetchStub.args[0][1].method).to.equal('POST');
+        expect(fetchStub.args[0][1].timeout).to.equal('1000');
+
+        const parsedBody = JSON.parse(fetchStub.args[0][1].body);
+
+        expect(parsedBody.properties.command.filteredOptions)
+          .to.deep.equal({ help: true });
       });
     });
 
@@ -385,8 +412,12 @@ describe('Utils', () => {
 
         expect(parsedBody.userId.length).to.be.at.least(1);
         // command property
+        expect(parsedBody.properties.command.name)
+          .to.equal('');
         expect(parsedBody.properties.command
           .isRunInService).to.equal(false); // false because CWD is not a service
+        expect(parsedBody.properties.command.filteredOptions)
+          .to.deep.equal({});
         // service property
         expect(parsedBody.properties.service.numberOfCustomPlugins).to.equal(0);
         expect(parsedBody.properties.service.hasCustomResourcesDefined).to.equal(true);


### PR DESCRIPTION
## What did you implement:

Closes #2610 

Adds a way to consider whitelisted options in the `logStat()` method.

## How did you implement it:

Add an array with whitelisted options and filter against it. Store the filtered options in the object for `logStat()`.

## How can we verify it:

Tests will cover that. Otherwise run e.g. `serverless deploy --help` and see that `help` appears in the `filteredOptions` object.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES