### PR TITLE
Fix for users being misinformed of success when create fails do to pe…

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -83,8 +83,17 @@ class Create {
 
     // copy template files recursively to cwd
     // while keeping template file tree
-    this.serverless.utils.copyDirContentsSync(path.join(this.serverless.config.serverlessPath,
-      'plugins', 'create', 'templates', this.options.template), process.cwd());
+    try {
+      this.serverless.utils.copyDirContentsSync(path.join(this.serverless.config.serverlessPath,
+       'plugins', 'create', 'templates', this.options.template), process.cwd());
+    } catch (err) {
+      const errorMessage = [
+        'Error unable to create a service in this directory. ',
+        'Please check that you have the required permissions to write to the directory',
+      ].join('');
+
+      throw new this.serverless.classes.Error(errorMessage);
+    }
 
     // rename the service if the user has provided a path via options and is creating a service
     if ((boilerplatePath || serviceName) && notPlugin) {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #1965 

**Note**: The original issue found in 1.0-beta had a much less friendly behavior of informing the user everything succeeded. As of 1.1 it fails earlier. All this PR now does is really add a user friendly message. Not sure if "user friendly" is needed.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Simple try/catch handler around the outer code using copyDirContentsSync.

**Note:** This catches any error and treats it as a permission error. I think this is OK since there is no other error handling we are adding at this time AND that should be the bulk if not all errors that can happen.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->
**Before (as of 1.1)**
<img width="489" alt="screen shot 2016-11-04 at 3 24 16 pm" src="https://cloud.githubusercontent.com/assets/144618/20024329/358e03d8-a2a3-11e6-9401-62422006cf56.png">

**After**
<img width="452" alt="screen shot 2016-11-04 at 3 18 46 pm" src="https://cloud.githubusercontent.com/assets/144618/20024217/81020cac-a2a2-11e6-85ec-497d5aaf8938.png">

No tests were written but happy to provide them. Looked at the current tests and unsure how to simulate a permission error without making the tests unreadable for this edge case.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config/commands/resources
- [X] Change ready for review message below


***Is this ready for review?:*** YES