### PR TITLE
Fix command name in docs cheat sheet example

### DIFF
--- a/docs/providers/aws/guide/workflow.md
+++ b/docs/providers/aws/guide/workflow.md
@@ -60,7 +60,7 @@ serverless deploy function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME]
 ##### Invoke Function
 Invokes an AWS Lambda Function on AWS and returns logs.
 ```
-serverless deploy function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME] -l
+serverless invoke function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME] -l
 ```
 
 ##### Streaming Logs


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Simple correction for incorrect serverless command name in docs cheat sheet example.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

Error is here: https://serverless.com/framework/docs/providers/aws/guide/workflow/

![image](https://cloud.githubusercontent.com/assets/28325/20029219/65b7bbfa-a396-11e6-9cb0-9c5da25d65e8.png)


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

