### PR TITLE
Fixes --noDeploy without credentials or internet connection

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -53,28 +53,30 @@ module.exports = {
     return BbPromise.bind(this)
       // always write the template to disk, whether we are deploying or not
       .then(this.writeCreateTemplateToDisk)
-      .then(() => this.provider.request('CloudFormation',
+      .then(() => {
+        // no request to CloudFormation if not deploying
+        if (this.options.noDeploy) {
+          return BbPromise.resolve();
+        }
+        return this.provider.request('CloudFormation',
           'describeStackResources',
           { StackName: stackName },
           this.options.stage,
-          this.options.region)
-          .then(() => BbPromise.resolve('alreadyCreated'))
-          .catch(e => {
-            if (e.message.indexOf('does not exist') > -1) {
-              if (this.serverless.service.provider.deploymentBucket) {
-                this.createLater = true;
-              }
+          this.options.region);
+      })
+      .then(() => BbPromise.resolve('alreadyCreated'))
+      .catch((e) => {
+        if (e.message.indexOf('does not exist') > -1) {
+          if (this.serverless.service.provider.deploymentBucket) {
+            this.createLater = true;
+            return BbPromise.resolve();
+          }
+          return BbPromise.bind(this)
+            .then(this.create);
+        }
 
-              if (this.options.noDeploy || this.createLater) {
-                return BbPromise.resolve();
-              }
-              return BbPromise.bind(this)
-                .then(this.create);
-            }
-
-            throw new this.serverless.classes.Error(e);
-          })
-      );
+        throw new this.serverless.classes.Error(e);
+      });
   },
 
   // helper methods

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -54,9 +54,8 @@ module.exports = {
       // always write the template to disk, whether we are deploying or not
       .then(this.writeCreateTemplateToDisk)
       .then(() => {
-        // no request to CloudFormation if not deploying
         if (this.options.noDeploy) {
-          return BbPromise.resolve();
+          return 'noDeploy';
         }
         return this.provider.request('CloudFormation',
           'describeStackResources',
@@ -64,7 +63,7 @@ module.exports = {
           this.options.stage,
           this.options.region);
       })
-      .then(() => BbPromise.resolve('alreadyCreated'))
+      .then(response => BbPromise.resolve(response || 'alreadyCreated'))
       .catch((e) => {
         if (e.message.indexOf('does not exist') > -1) {
           if (this.serverless.service.provider.deploymentBucket) {

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -55,15 +55,15 @@ module.exports = {
       .then(this.writeCreateTemplateToDisk)
       .then(() => {
         if (this.options.noDeploy) {
-          return 'noDeploy';
+          return BbPromise.resolve();
         }
         return this.provider.request('CloudFormation',
           'describeStackResources',
           { StackName: stackName },
           this.options.stage,
-          this.options.region);
+          this.options.region)
+          .then(() => BbPromise.resolve('alreadyCreated'));
       })
-      .then(response => BbPromise.resolve(response || 'alreadyCreated'))
       .catch((e) => {
         if (e.message.indexOf('does not exist') > -1) {
           if (this.serverless.service.provider.deploymentBucket) {

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -138,8 +138,11 @@ describe('createStack', () => {
         .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
+      const awsRequestStub = sinon
+        .stub(awsDeploy.provider, 'request');
 
       return awsDeploy.createStack().then(() => {
+        expect(awsRequestStub.called).to.be.equal(false);
         expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
         expect(createStub.called).to.be.equal(false);
       });

--- a/lib/plugins/aws/deploy/tests/createStack.js
+++ b/lib/plugins/aws/deploy/tests/createStack.js
@@ -138,15 +138,8 @@ describe('createStack', () => {
         .stub(awsDeploy, 'writeCreateTemplateToDisk').returns(BbPromise.resolve());
       const createStub = sinon
         .stub(awsDeploy, 'create').returns(BbPromise.resolve());
-      const awsRequestStub = sinon
-        .stub(awsDeploy.provider, 'request')
-        .returns(BbPromise.reject({ message: 'does not exist' }));
 
       return awsDeploy.createStack().then(() => {
-        expect(awsRequestStub.args[0][0]).to.equal('CloudFormation');
-        expect(awsRequestStub.args[0][1]).to.equal('describeStackResources');
-        expect(awsRequestStub.args[0][2].StackName)
-          .to.equal(`${awsDeploy.serverless.service.service}-${awsDeploy.options.stage}`);
         expect(writeCreateTemplateToDiskStub.calledOnce).to.be.equal(true);
         expect(createStub.called).to.be.equal(false);
       });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless/serverless/issues/2648

**Before**
When deploying without internet connection `serverless deploy --noDeploy` throws following error 
```
  Error --------------------------------------------------

     ServerlessError: ServerlessError: Inaccessible host:
     `cloudformation.us-east-1.amazonaws.com'. This service
     may not be available in the `us-east-1' region.

     For debugging logs, run again after setting SLS_DEBUG env var.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues

     Please report this error. We think it might be a bug.

  Your Environment Information -----------------------------
     OS:                 darwin
     Node Version:       6.9.0
     Serverless Version: 1.1.0
```
And without valid AWS credential following error is thrown:
```
  Error --------------------------------------------------

     ServerlessError: ServerlessError: AWS provider credentials
     not found. You can find more info on how to set up provider
     credentials in our docs here: https://git.io/vXsdd

     For debugging logs, run again after setting SLS_DEBUG env var.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues

     Please report this error. We think it might be a bug.

  Your Environment Information -----------------------------
     OS:                 darwin
     Node Version:       6.9.0
     Serverless Version: 1.1.0
```

**After**
Running `serverless deploy --noDeploy` should only display following output
```
Serverless: Packaging service…
Serverless: Did not deploy due to --noDeploy
```


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

1. Run `serverless deploy --noDeploy` without internet connection.
2. Rename `~/.aws/crendentials` to `~/.aws/crendentials.bk` and run `serverless deploy --noDeploy`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation (N/A)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES
