### PR TITLE
Add checklist item for change permissions to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ Examples:
 - [ ] Fix linting errors
 - [ ] Make sure code coverage hasn't dropped
 - [ ] Provide verification config/commands/resources
-- [ ] Enable "Allow edits from maintainers" for this PR
+- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
 - [ ] Change ready for review message below
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,7 @@ Examples:
 - [ ] Fix linting errors
 - [ ] Make sure code coverage hasn't dropped
 - [ ] Provide verification config/commands/resources
+- [ ] Enable "Allow edits from maintainers" for this PR
 - [ ] Change ready for review message below
 
 


### PR DESCRIPTION
## What did you implement:

Add a checkbox item which should notice the PR creator to enable edit permissions for Serverless maintainers. This will make the whole collaboration easier.

See: https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/ for more infos about this feature.

## How did you implement it:

Updated the `.md` file for the PR template.

## How can we verify it:

Just take a look at the PR template.

## Todos:

- [x] Write documentation
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES