### PR TITLE
Add integration tests for slashes in API Gateway paths

### DIFF
--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
@@ -9,11 +9,30 @@ functions:
   hello:
     handler: handler.hello
     events:
-      - http: POST hello
-      - http: GET hello
+      # paths without a slash
+      - http: POST without-slash
+      - http: GET without-slash
       - http:
           method: PUT
-          path: hello
+          path: without-slash
       - http:
           method: DELETE
-          path: hello
+          path: without-slash
+      # paths with a slash
+      - http: POST /with-slash
+      - http: GET /with-slash
+      - http:
+          method: PUT
+          path: /with-slash
+      - http:
+          method: DELETE
+          path: /with-slash
+      # root only paths
+      - http: POST /
+      - http: GET /
+      - http:
+          method: PUT
+          path: /
+      - http:
+          method: DELETE
+          path: /

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/tests.js
@@ -29,41 +29,111 @@ describe('AWS - API Gateway (Integration: Lambda Proxy): Simple API test', funct
         { OutputKey: 'ServiceEndpoint' }).OutputValue)
       .then((endpointOutput) => {
         endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
-        endpoint = `${endpoint}/hello`;
+        endpoint = `${endpoint}`;
       })
   );
 
-  it('should expose an accessible POST HTTP endpoint', () =>
-    fetch(endpoint, { method: 'POST' })
-      .then(response => response.json())
-      .then((json) => {
-        expect(json.message).to.equal('Hello from API Gateway!');
-      })
-  );
+  describe('when having a "without-slash" path setup', () => {
+    it('should expose an accessible POST HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
 
-  it('should expose an accessible GET HTTP endpoint', () =>
-    fetch(endpoint)
-      .then(response => response.json())
-      .then((json) => {
-        expect(json.message).to.equal('Hello from API Gateway!');
-      })
-  );
+      return fetch(testEndpoint, { method: 'POST' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
 
-  it('should expose an accessible PUT HTTP endpoint', () =>
-    fetch(endpoint, { method: 'PUT' })
-      .then(response => response.json())
-      .then((json) => {
-        expect(json.message).to.equal('Hello from API Gateway!');
-      })
-  );
+    it('should expose an accessible GET HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
 
-  it('should expose an accessible DELETE HTTP endpoint', () =>
-    fetch(endpoint, { method: 'DELETE' })
-      .then(response => response.json())
-      .then((json) => {
-        expect(json.message).to.equal('Hello from API Gateway!');
-      })
-  );
+      return fetch(testEndpoint)
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible PUT HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
+
+      return fetch(testEndpoint, { method: 'PUT' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible DELETE HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
+
+      return fetch(testEndpoint, { method: 'DELETE' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+  });
+
+  describe('when having a "/with-slash" path setup', () => {
+    it('should expose an accessible POST HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint, { method: 'POST' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible GET HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint)
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible PUT HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint, { method: 'PUT' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible DELETE HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint, { method: 'DELETE' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+  });
+
+  describe('when having a "/" path setup', () => {
+    it('should expose an accessible POST HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint, { method: 'POST' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible GET HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint)
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible PUT HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint, { method: 'PUT' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible DELETE HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint, { method: 'DELETE' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+  });
 
   after(() => {
     Utils.removeService();

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
@@ -9,19 +9,54 @@ functions:
   hello:
     handler: handler.hello
     events:
+      # paths without a slash
       - http:
           method: POST
-          path: hello
+          path: without-slash
           integration: lambda
       - http:
           method: GET
-          path: hello
+          path: without-slash
           integration: lambda
       - http:
           method: PUT
-          path: hello
+          path: without-slash
           integration: lambda
       - http:
           method: DELETE
-          path: hello
+          path: without-slash
+          integration: lambda
+      # paths with a slash
+      - http:
+          method: POST
+          path: /with-slash
+          integration: lambda
+      - http:
+          method: GET
+          path: /with-slash
+          integration: lambda
+      - http:
+          method: PUT
+          path: /with-slash
+          integration: lambda
+      - http:
+          method: DELETE
+          path: /with-slash
+          integration: lambda
+      # root only paths
+      - http:
+          method: POST
+          path: /
+          integration: lambda
+      - http:
+          method: GET
+          path: /
+          integration: lambda
+      - http:
+          method: PUT
+          path: /
+          integration: lambda
+      - http:
+          method: DELETE
+          path: /
           integration: lambda

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/tests.js
@@ -29,33 +29,111 @@ describe('AWS - API Gateway (Integration: Lambda): Simple API test', function ()
         { OutputKey: 'ServiceEndpoint' }).OutputValue)
       .then((endpointOutput) => {
         endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
-        endpoint = `${endpoint}/hello`;
+        endpoint = `${endpoint}`;
       })
   );
 
-  it('should expose an accessible POST HTTP endpoint', () =>
-    fetch(endpoint, { method: 'POST' })
-      .then(response => response.json())
-      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
-  );
+  describe('when having a "without-slash" path setup', () => {
+    it('should expose an accessible POST HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
 
-  it('should expose an accessible GET HTTP endpoint', () =>
-    fetch(endpoint)
-      .then(response => response.json())
-      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
-  );
+      return fetch(testEndpoint, { method: 'POST' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
 
-  it('should expose an accessible PUT HTTP endpoint', () =>
-    fetch(endpoint, { method: 'PUT' })
-      .then(response => response.json())
-      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
-  );
+    it('should expose an accessible GET HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
 
-  it('should expose an accessible DELETE HTTP endpoint', () =>
-    fetch(endpoint, { method: 'DELETE' })
-      .then(response => response.json())
-      .then((json) => expect(json.message).to.equal('Hello from API Gateway!'))
-  );
+      return fetch(testEndpoint)
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible PUT HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
+
+      return fetch(testEndpoint, { method: 'PUT' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible DELETE HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/without-slash`;
+
+      return fetch(testEndpoint, { method: 'DELETE' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+  });
+
+  describe('when having a "/with-slash" path setup', () => {
+    it('should expose an accessible POST HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint, { method: 'POST' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible GET HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint)
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible PUT HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint, { method: 'PUT' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible DELETE HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}/with-slash`;
+
+      return fetch(testEndpoint, { method: 'DELETE' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+  });
+
+  describe('when having a "/" path setup', () => {
+    it('should expose an accessible POST HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint, { method: 'POST' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible GET HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint)
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible PUT HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint, { method: 'PUT' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+
+    it('should expose an accessible DELETE HTTP endpoint', () => {
+      const testEndpoint = `${endpoint}`;
+
+      return fetch(testEndpoint, { method: 'DELETE' })
+        .then(response => response.json())
+        .then((json) => expect(json.message).to.equal('Hello from API Gateway!'));
+    });
+  });
 
   after(() => {
     Utils.removeService();


### PR DESCRIPTION
## What did you implement:

Add the integration tests for the recently merged refactoring PR #2666 which cover the usage of slashes in path configuration (including root paths).

## How did you implement it:

Update the `simple-api` tests in the complex integration test suite.

## How can we verify it:

Run `npm run complex-integration-test`

## Todos:

- [x] Write tests
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES