### PR TITLE
On every deploy, publish a new Lambda function version

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -69,6 +69,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |IAM::Role              | IamRoleLambdaExecution                                  | IamRoleLambdaExecution        |
 |IAM::Policy            | IamPolicyLambdaExecution                                | IamPolicyLambdaExecution      |
 |Lambda::Function       | {normalizedFunctionName}LambdaFunction                  | HelloLambdaFunction           |
+|Lambda::Version        | {functionName}Version{sha256}                           | helloVersionr3pgoTvv1xT4E4NiCL6JG02fl6vIyi7OS1aW0FwAI |
 |Logs::LogGroup         | {normalizedFunctionName}LogGroup                        | HelloLogGroup                 |
 |Lambda::Permission     | <ul><li>**Schedule**: {normalizedFunctionName}LambdaPermissionEventsRuleSchedule{index} </li><li>**S3**: {normalizedFunctionName}LambdaPermission{normalizedBucketName}S3</li><li>**APIG**: {normalizedFunctionName}LambdaPermissionApiGateway</li><li>**SNS**: {normalizedFunctionName}LambdaPermission{normalizedTopicName}SNS</li> | <ul><li>**Schedule**: HelloLambdaPermissionEventsRuleSchedule1 </li><li>**S3**: HelloLambdaPermissionBucketS3</li><li>**APIG**: HelloLambdaPermissionApiGateway</li><li>**SNS**: HelloLambdaPermissionTopicSNS</li> |
 |Events::Rule           | {normalizedFuntionName}EventsRuleSchedule{SequentialID} | HelloEventsRuleSchedule1      |

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -144,11 +144,10 @@ class AwsCompileFunctions {
     newVersion.Properties.CodeSha256 = hash.read();
     newVersion.Properties.FunctionName = { Ref: functionLogicalId };
 
-    const normalSha = newVersion.Properties.CodeSha256.replace(/[^0-9a-z]/gi, '');
-
     // use the SHA in the logical resource ID of the version because
     // AWS::Lambda::Version resource will not support updates
-    const versionLogicalId = `${functionLogicalId}Version${normalSha}`;
+    const versionLogicalId = this.provider.naming.getLambdaVersionLogicalId(
+            functionName, newVersion.Properties.CodeSha256);
     const newVersionObject = {
       [versionLogicalId]: newVersion,
     };
@@ -167,11 +166,14 @@ class AwsCompileFunctions {
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
       newOutputObject);
 
+    const functionVersionOutputLogicalId = this.provider.naming
+      .getLambdaVersionOutputLogicalId(functionName);
     const newVersionOutput = this.cfOutputLatestVersionTemplate();
+
     newVersionOutput.Value = { Ref: versionLogicalId };
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-      [`${functionLogicalId}QualifiedArn`]: newVersionOutput,
+      [functionVersionOutputLogicalId]: newVersionOutput,
     });
   }
 

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 
@@ -131,6 +133,29 @@ class AwsCompileFunctions {
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
       newFunctionObject);
 
+    const newVersion = this.cfLambdaVersionTemplate();
+
+    const content = fs.readFileSync(artifactFilePath);
+    const hash = crypto.createHash('sha256');
+    hash.setEncoding('base64');
+    hash.write(content);
+    hash.end();
+
+    newVersion.Properties.CodeSha256 = hash.read();
+    newVersion.Properties.FunctionName = { 'Ref': functionLogicalId };
+
+    const normalSha = newVersion.Properties.CodeSha256.replace(/[^0-9a-z]/gi, '');
+
+    // use the SHA in the logical resource ID of the version because
+    // AWS::Lambda::Version resource will not support updates
+    const versionLogicalId = `${normalizedFunctionName}Version${normalSha}`;
+    const newVersionObject = {
+      [versionLogicalId]: newVersion,
+    };
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+      newVersionObject);
+
     // Add function to Outputs section
     const newOutput = this.cfOutputDescriptionTemplate();
     newOutput.Value = { 'Fn::GetAtt': [functionLogicalId, 'Arn'] };
@@ -141,6 +166,13 @@ class AwsCompileFunctions {
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
       newOutputObject);
+
+    const newVersionOutput = this.cfOutputLatestVersionTemplate();
+    newVersionOutput.Value = { 'Ref': versionLogicalId };
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+      [`${functionLogicalId}QualifiedArn`]: newVersionOutput,
+    });
   }
 
   compileFunctions() {
@@ -170,9 +202,30 @@ class AwsCompileFunctions {
     };
   }
 
+  cfLambdaVersionTemplate() {
+    return {
+      Type: 'AWS::Lambda::Version',
+      // Retain old versions even though they will not be in future
+      // CloudFormation stacks. On stack delete, these will be removed when
+      // their associated function is removed.
+      DeletionPolicy: 'Retain',
+      Properties: {
+        FunctionName: 'FunctionName',
+        CodeSha256: 'CodeSha256',
+      },
+    };
+  }
+
   cfOutputDescriptionTemplate() {
     return {
       Description: 'Lambda function info',
+      Value: 'Value',
+    };
+  }
+
+  cfOutputLatestVersionTemplate() {
+    return {
+      Description: 'Current Lambda function version',
       Value: 'Value',
     };
   }

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -148,7 +148,7 @@ class AwsCompileFunctions {
 
     // use the SHA in the logical resource ID of the version because
     // AWS::Lambda::Version resource will not support updates
-    const versionLogicalId = `${normalizedFunctionName}Version${normalSha}`;
+    const versionLogicalId = `${functionLogicalId}Version${normalSha}`;
     const newVersionObject = {
       [versionLogicalId]: newVersion,
     };

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -142,7 +142,7 @@ class AwsCompileFunctions {
     hash.end();
 
     newVersion.Properties.CodeSha256 = hash.read();
-    newVersion.Properties.FunctionName = { 'Ref': functionLogicalId };
+    newVersion.Properties.FunctionName = { Ref: functionLogicalId };
 
     const normalSha = newVersion.Properties.CodeSha256.replace(/[^0-9a-z]/gi, '');
 
@@ -168,7 +168,7 @@ class AwsCompileFunctions {
       newOutputObject);
 
     const newVersionOutput = this.cfOutputLatestVersionTemplate();
-    newVersionOutput.Value = { 'Ref': versionLogicalId };
+    newVersionOutput.Value = { Ref: versionLogicalId };
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
       [`${functionLogicalId}QualifiedArn`]: newVersionOutput,

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -24,13 +24,20 @@ describe('AwsCompileFunctions', () => {
       Resources: {},
       Outputs: {},
     };
+
+    const serviceArtifact = 'artifact.zip'
+    const individualArtifact = 'test.zip'
+    // The contents of the test artifacts need to be predictable so the hashes stay the same
+    serverless.utils.writeFileSync(serviceArtifact, 'foobar');
+    serverless.utils.writeFileSync(individualArtifact, 'barbaz');
+
     awsCompileFunctions.serverless.service.service = 'new-service';
     awsCompileFunctions.serverless.service.package.artifactDirectoryName = 'somedir';
-    awsCompileFunctions.serverless.service.package.artifact = 'artifact.zip';
+    awsCompileFunctions.serverless.service.package.artifact = serviceArtifact;
     awsCompileFunctions.serverless.service.functions = {};
     awsCompileFunctions.serverless.service.functions[functionName] = {
       name: 'test',
-      artifact: 'test.zip',
+      artifact: individualArtifact,
       handler: 'handler.hello',
     };
   });

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -25,8 +25,8 @@ describe('AwsCompileFunctions', () => {
       Outputs: {},
     };
 
-    const serviceArtifact = 'artifact.zip'
-    const individualArtifact = 'test.zip'
+    const serviceArtifact = 'artifact.zip';
+    const individualArtifact = 'test.zip';
     // The contents of the test artifacts need to be predictable so the hashes stay the same
     serverless.utils.writeFileSync(serviceArtifact, 'foobar');
     serverless.utils.writeFileSync(individualArtifact, 'barbaz');
@@ -798,9 +798,19 @@ describe('AwsCompileFunctions', () => {
           Description: 'Lambda function info',
           Value: { 'Fn::GetAtt': ['FuncLambdaFunction', 'Arn'] },
         },
+        FuncLambdaFunctionQualifiedArn: {
+          Description: 'Current Lambda function version',
+          Value: { Ref: 'FuncLambdaFunctionVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
+        },
         AnotherFuncLambdaFunctionArn: {
           Description: 'Lambda function info',
           Value: { 'Fn::GetAtt': ['AnotherFuncLambdaFunction', 'Arn'] },
+        },
+        AnotherFuncLambdaFunctionQualifiedArn: {
+          Description: 'Current Lambda function version',
+          Value: {
+            Ref: 'AnotherFuncLambdaFunctionVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
+          },
         },
       };
 

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -800,7 +800,7 @@ describe('AwsCompileFunctions', () => {
         },
         FuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
-          Value: { Ref: 'FuncLambdaFunctionVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
+          Value: { Ref: 'funcVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
         },
         AnotherFuncLambdaFunctionArn: {
           Description: 'Lambda function info',
@@ -809,7 +809,7 @@ describe('AwsCompileFunctions', () => {
         AnotherFuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
           Value: {
-            Ref: 'AnotherFuncLambdaFunctionVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
+            Ref: 'anotherFuncVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
           },
         },
       };

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -61,6 +61,12 @@ module.exports = {
   getLambdaOutputLogicalIdRegex() {
     return /LambdaFunctionArn$/;
   },
+  getLambdaVersionLogicalId(functionName, sha) {
+    return `${functionName}Version${sha.replace(/[^0-9a-z]/gi, '')}`;
+  },
+  getLambdaVersionOutputLogicalId(functionName) {
+    return `${this.getLambdaLogicalId(functionName)}QualifiedArn`;
+  },
 
   // API Gateway
   generateApiGatewayDeploymentLogicalId() {


### PR DESCRIPTION
## What did you implement:

This change publishes a Lambda version for each deploy. Now Lambda deploys count as distinct function versions, which is really helpful for logging & monitoring.

## How did you implement it:

This change adds:
- Calculation of SHA256 sums of artifacts
- An `AWS::Lambda::Alias` resource based on that SHA
- A dependency between each deployed function to its alias
- A stack output for each function `LogicalIdQualifiedArn` which is the
  function ARN with the version appended.

## How can we verify it:

In any serverless project, apply this patch and do a deploy. After the deploy, check in the console for the new function alias. Alternatively, use the CLI command `aws lambda list-versions-by-function --function-name yourservice-stage-functionName` and note that in addition to `$LATEST` there's also a pinned version. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES