### PR TITLE
Bring back include configuration for an easier packaging control

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -18,27 +18,35 @@ You can use the `package` and `exclude` configuration for more control over the 
 
 ## Exclude / include
 
-Exclude allows you to define globs that will be excluded from the resulting artifact. If you wish to
-include files you can use a glob pattern prefixed with `!` such as `!re-include-me/**`. Serverless will run the glob patterns in order.
+Exclude and include allows you to define globs that will be excluded / included from the resulting artifact. If you wish to
+include files you can use a glob pattern prefixed with `!` such as `!re-include-me/**` in `exclude` or the dedicated `include` config.
+Serverless will run the glob patterns in order.
 
-## Example
+At first it will apply the globs defined in `exclude`. After that it'll add all the globs from `include`. This way you can always re-include
+previously excluded files and directories.
 
-Exclude all node_modules but then re-include a specific modules (in this case node-fetch)
+## Examples
 
-``` yaml
+Exclude all node_modules but then re-include a specific modules (in this case node-fetch) using `exclude` exclusively
+
+``` yml
 package:
   exclude:
     - node_modules/**
     - '!node_modules/node-fetch/**'
 ```
 
-Exclude all files but `handler.js`
+Exclude all files but `handler.js` using `exclude` and `include`
 
-``` yaml
+``` yml
 package:
   exclude:
-    - "!src/function/handler.js"
+    - src/**
+  include:
+    - src/function/handler.js
 ```
+
+**Note:** Don't forget to use the correct glob syntax if you want to exclude directories
 
 ```
 exclude:
@@ -48,16 +56,18 @@ exclude:
 
 ## Artifact
 
-For complete control over the packaging process you can specify your own zip file for your service. Serverless won't zip your service if this is configured so `exclude` will be ignored.
+For complete control over the packaging process you can specify your own zip file for your service. Serverless won't zip your service if this is configured so `exclude` and `include` will be ignored.
 
 ## Example
 
-```yaml
+```yml
 service: my-service
 package:
   exclude:
     - tmp/**
     - .git/**
+  include:
+    - some-file
   artifact: path/to/my-artifact.zip
 ```
 
@@ -65,9 +75,9 @@ package:
 
 If you want even more controls over your functions for deployment you can configure them to be packaged independently. This allows you more control for optimizing your deployment. To enable individual packaging set `individually` to true in the service wide packaging settings.
 
-Then for every function you can use the same `exclude / artifact` config options as you can service wide. The `exclude` option will be merged with the service wide options to create one `exclude` config per function during packaging.
+Then for every function you can use the same `exclude`, `include` or `artifact` config options as you can service wide. The `exclude` and `include` option will be merged with the service wide options to create one `exclude` and `include` config per function during packaging.
 
-```yaml
+```yml
 service: my-service
 package:
   individually: true
@@ -77,9 +87,9 @@ functions:
   hello:
     handler: handler.hello
     package:
-      exclude:
-        # We're including this file so it will be in the final package of this function only
-        - '!excluded-by-default.json'
+      # We're including this file so it will be in the final package of this function only
+      include:
+        - excluded-by-default.json
   world:
     handler: handler.hello
     package:

--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -56,7 +56,9 @@ exclude:
 
 ## Artifact
 
-For complete control over the packaging process you can specify your own zip file for your service. Serverless won't zip your service if this is configured so `exclude` and `include` will be ignored.
+For complete control over the packaging process you can specify your own artifact zip file. Serverless won't zip your service if this is configured and therefor `exclude` and `include` will be ignored. Either you use artifact or include/exclude.
+
+The artifact option is especially useful in case your development environment allows you to generate a deployable artifact like Maven does for Java.
 
 ## Example
 

--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -56,7 +56,8 @@ exclude:
 
 ## Artifact
 
-For complete control over the packaging process you can specify your own artifact zip file. Serverless won't zip your service if this is configured and therefor `exclude` and `include` will be ignored. Either you use artifact or include/exclude.
+For complete control over the packaging process you can specify your own artifact zip file.
+Serverless won't zip your service if this is configured and therefore `exclude` and `include` will be ignored. Either you use artifact or include / exclude.
 
 The artifact option is especially useful in case your development environment allows you to generate a deployable artifact like Maven does for Java.
 

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -153,7 +153,8 @@ describe('Serverless', () => {
           google: {},
         },
         package: {
-          exclude: ['exclude-me.js'],
+          exclude: ['exclude-me'],
+          include: ['include-me'],
           artifact: 'some/path/foo.zip',
         },
       };

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -97,6 +97,7 @@ class Service {
           that.package.individually = serverlessFile.package.individually;
           that.package.artifact = serverlessFile.package.artifact;
           that.package.exclude = serverlessFile.package.exclude;
+          that.package.include = serverlessFile.package.include;
         }
 
         if (serverlessFile.defaults && serverlessFile.defaults.stage) {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -54,7 +54,8 @@ describe('Service', () => {
           google: {},
         },
         package: {
-          exclude: ['exclude-me.js'],
+          exclude: ['exclude-me'],
+          include: ['include-me'],
           artifact: 'some/path/foo.zip',
         },
       };
@@ -69,7 +70,10 @@ describe('Service', () => {
       expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
       expect(serviceInstance.resources.azure).to.deep.equal({});
       expect(serviceInstance.resources.google).to.deep.equal({});
-      expect(serviceInstance.package.exclude[0]).to.equal('exclude-me.js');
+      expect(serviceInstance.package.exclude.length).to.equal(1);
+      expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+      expect(serviceInstance.package.include.length).to.equal(1);
+      expect(serviceInstance.package.include[0]).to.equal('include-me');
       expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
     });
 
@@ -135,7 +139,8 @@ describe('Service', () => {
           google: {},
         },
         package: {
-          exclude: ['exclude-me.js'],
+          exclude: ['exclude-me'],
+          include: ['include-me'],
           artifact: 'some/path/foo.zip',
         },
       };
@@ -157,7 +162,9 @@ describe('Service', () => {
         expect(serviceInstance.resources.azure).to.deep.equal({});
         expect(serviceInstance.resources.google).to.deep.equal({});
         expect(serviceInstance.package.exclude.length).to.equal(1);
-        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me.js');
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
         expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
       });
     });
@@ -184,7 +191,8 @@ describe('Service', () => {
           google: {},
         },
         package: {
-          exclude: ['exclude-me.js'],
+          exclude: ['exclude-me'],
+          include: ['include-me'],
           artifact: 'some/path/foo.zip',
         },
       };

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -42,6 +42,8 @@ provider:
 
 # you can add packaging information here
 package:
+#  include:
+#    - include-me.java
 #  exclude:
 #    - exclude-me.java
   artifact: build/distributions/hello.zip

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -44,8 +44,10 @@ provider:
 package:
 #  include:
 #    - include-me.java
+#    - include-me-dir/**
 #  exclude:
 #    - exclude-me.java
+#    - exclude-me-dir/**
   artifact: build/distributions/hello.zip
 
 functions:

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -42,12 +42,6 @@ provider:
 
 # you can add packaging information here
 package:
-#  include:
-#    - include-me.java
-#    - include-me-dir/**
-#  exclude:
-#    - exclude-me.java
-#    - exclude-me-dir/**
   artifact: build/distributions/hello.zip
 
 functions:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -42,12 +42,6 @@ provider:
 
 # you can add packaging information here
 package:
-#  include:
-#    - include-me.java
-#    - include-me-dir/**
-#  exclude:
-#    - exclude-me.java
-#    - exclude-me-dir/**
   artifact: target/hello-dev.jar
 
 functions:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -44,8 +44,10 @@ provider:
 package:
 #  include:
 #    - include-me.java
+#    - include-me-dir/**
 #  exclude:
 #    - exclude-me.java
+#    - exclude-me-dir/**
   artifact: target/hello-dev.jar
 
 functions:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -42,6 +42,8 @@ provider:
 
 # you can add packaging information here
 package:
+#  include:
+#    - include-me.java
 #  exclude:
 #    - exclude-me.java
   artifact: target/hello-dev.jar

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -42,6 +42,8 @@ provider:
 
 # you can add packaging information here
 #package:
+#  include:
+#    - include-me.js
 #  exclude:
 #    - exclude-me.js
 #  artifact: my-service-code.zip

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -48,7 +48,6 @@ provider:
 #  exclude:
 #    - exclude-me.js
 #    - exclude-me-dir/**
-#  artifact: my-service-code.zip
 
 functions:
   hello:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -44,8 +44,10 @@ provider:
 #package:
 #  include:
 #    - include-me.js
+#    - include-me-dir/**
 #  exclude:
 #    - exclude-me.js
+#    - exclude-me-dir/**
 #  artifact: my-service-code.zip
 
 functions:

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -48,7 +48,6 @@ provider:
 #  exclude:
 #    - exclude-me.py
 #    - exclude-me-dir/**
-#  artifact: my-service-code.zip
 
 functions:
   hello:

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -42,6 +42,8 @@ provider:
 
 # you can add packaging information here
 #package:
+#  include:
+#    - include-me.py
 #  exclude:
 #    - exclude-me.py
 #  artifact: my-service-code.zip

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -44,8 +44,10 @@ provider:
 #package:
 #  include:
 #    - include-me.py
+#    - include-me-dir/**
 #  exclude:
 #    - exclude-me.py
+#    - exclude-me-dir/**
 #  artifact: my-service-code.zip
 
 functions:

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -44,8 +44,10 @@ provider:
 package:
 #  include:
 #    - include-me.jar
+#    - include-me-dir/**
 #  exclude:
 #    - exclude-me.jar
+#    - exclude-me-dir/**
   artifact: target/scala-2.11/hello.jar
 
 functions:

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -42,12 +42,6 @@ provider:
 
 # you can add packaging information here
 package:
-#  include:
-#    - include-me.jar
-#    - include-me-dir/**
-#  exclude:
-#    - exclude-me.jar
-#    - exclude-me-dir/**
   artifact: target/scala-2.11/hello.jar
 
 functions:

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -42,6 +42,8 @@ provider:
 
 # you can add packaging information here
 package:
+#  include:
+#    - include-me.jar
 #  exclude:
 #    - exclude-me.jar
   artifact: target/scala-2.11/hello.jar

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -14,7 +14,12 @@ module.exports = {
     '.serverless/**',
   ],
 
-  getExcludedPaths(exclude) {
+  getIncludes(include) {
+    const packageIncludes = this.serverless.service.package.include || [];
+    return _.union(packageIncludes, include);
+  },
+
+  getExcludes(exclude) {
     const packageExcludes = this.serverless.service.package.exclude || [];
 
     // add defaults for exclude
@@ -51,10 +56,11 @@ module.exports = {
   packageAll() {
     const servicePath = this.serverless.config.servicePath;
 
-    const exclude = this.getExcludedPaths();
+    const exclude = this.getExcludes();
+    const include = this.getIncludes();
     const zipFileName = this.getServiceArtifactName();
 
-    return this.zipDirectory(servicePath, exclude, zipFileName).then(filePath => {
+    return this.zipDirectory(servicePath, exclude, include, zipFileName).then(filePath => {
       this.serverless.service.package.artifact = filePath;
       return filePath;
     });
@@ -73,10 +79,11 @@ module.exports = {
 
     const servicePath = this.serverless.config.servicePath;
 
-    const exclude = this.getExcludedPaths(funcPackageConfig.exclude);
+    const exclude = this.getExcludes(funcPackageConfig.exclude);
+    const include = this.getIncludes(funcPackageConfig.include);
     const zipFileName = this.getFunctionArtifactName(functionObject);
 
-    return this.zipDirectory(servicePath, exclude, zipFileName).then((artifactPath) => {
+    return this.zipDirectory(servicePath, exclude, include, zipFileName).then((artifactPath) => {
       functionObject.artifact = artifactPath;
       return artifactPath;
     });

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -18,9 +18,6 @@ module.exports = {
       }
     });
 
-    // exclude the whole .serverless directory
-    patterns.push('!.serverless/**');
-
     // push the include globs to the end of the array
     // (files and folders will be re-added again even if they were excluded beforehand)
     include.forEach((pattern) => {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -7,8 +7,9 @@ const fs = require('fs');
 const glob = require('glob-all');
 
 module.exports = {
-  zipDirectory(servicePath, exclude, zipFileName) {
+  zipDirectory(servicePath, exclude, include, zipFileName) {
     const patterns = ['**'];
+
     exclude.forEach((pattern) => {
       if (pattern.charAt(0) !== '!') {
         patterns.push(`!${pattern}`);
@@ -17,6 +18,13 @@ module.exports = {
       }
     });
 
+    // push the include globs to the end of the array
+    // (files and folders will be re-added again even if they were excluded beforehand)
+    include.forEach((pattern) => {
+      patterns.push(pattern);
+    });
+
+    // exclude the whole .serverless directory
     patterns.push('!.serverless/**');
 
     const zip = archiver.create('zip');

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -18,14 +18,14 @@ module.exports = {
       }
     });
 
+    // exclude the whole .serverless directory
+    patterns.push('!.serverless/**');
+
     // push the include globs to the end of the array
     // (files and folders will be re-added again even if they were excluded beforehand)
     include.forEach((pattern) => {
       patterns.push(pattern);
     });
-
-    // exclude the whole .serverless directory
-    patterns.push('!.serverless/**');
 
     const zip = archiver.create('zip');
 

--- a/lib/plugins/package/tests/packageService.js
+++ b/lib/plugins/package/tests/packageService.js
@@ -17,9 +17,47 @@ describe('#packageService()', () => {
     packageService.serverless.cli = new serverless.classes.CLI();
   });
 
-  describe('#getExcludedPaths()', () => {
+  describe('#getIncludes()', () => {
+    it('should return an empty array if no includes are provided', () => {
+      const include = packageService.getIncludes();
+
+      expect(include).to.deep.equal([]);
+    });
+
+    it('should merge package includes', () => {
+      const packageIncludes = [
+        'dir', 'file.js',
+      ];
+
+      serverless.service.package.include = packageIncludes;
+
+      const include = packageService.getIncludes();
+      expect(include).to.deep.equal([
+        'dir', 'file.js',
+      ]);
+    });
+
+    it('should merge package and func includes', () => {
+      const funcIncludes = [
+        'lib', 'other.js',
+      ];
+      const packageIncludes = [
+        'dir', 'file.js',
+      ];
+
+      serverless.service.package.include = packageIncludes;
+
+      const include = packageService.getIncludes(funcIncludes);
+      expect(include).to.deep.equal([
+        'dir', 'file.js',
+        'lib', 'other.js',
+      ]);
+    });
+  });
+
+  describe('#getExcludes()', () => {
     it('should exclude defaults', () => {
-      const exclude = packageService.getExcludedPaths();
+      const exclude = packageService.getExcludes();
       expect(exclude).to.deep.equal(packageService.defaultExcludes);
     });
 
@@ -30,7 +68,7 @@ describe('#packageService()', () => {
 
       serverless.service.package.exclude = packageExcludes;
 
-      const exclude = packageService.getExcludedPaths();
+      const exclude = packageService.getExcludes();
       expect(exclude).to.deep.equal([
         '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log',
@@ -40,7 +78,7 @@ describe('#packageService()', () => {
     });
 
     it('should merge defaults with package and func excludes', () => {
-      const funcExclude = [
+      const funcExcludes = [
         'lib', 'other.js',
       ];
       const packageExcludes = [
@@ -49,7 +87,7 @@ describe('#packageService()', () => {
 
       serverless.service.package.exclude = packageExcludes;
 
-      const exclude = packageService.getExcludedPaths(funcExclude);
+      const exclude = packageService.getExcludes(funcExcludes);
       expect(exclude).to.deep.equal([
         '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log',
@@ -94,7 +132,7 @@ describe('#packageService()', () => {
       });
     });
 
-    it('should package functions all', () => {
+    it('should package all functions', () => {
       serverless.service.package.individually = false;
 
       const packageAllStub = sinon
@@ -129,13 +167,16 @@ describe('#packageService()', () => {
     it('should call zipService with settings', () => {
       const servicePath = 'test';
       const exclude = ['test-exclude'];
+      const include = ['test-include'];
       const artifactName = 'test-artifact.zip';
       const artifactFilePath = '/some/fake/path/test-artifact.zip';
 
       serverless.config.servicePath = servicePath;
 
-      const getExcludedPathsStub = sinon
-        .stub(packageService, 'getExcludedPaths').returns(exclude);
+      const getExcludesStub = sinon
+        .stub(packageService, 'getExcludes').returns(exclude);
+      const getIncludesStub = sinon
+        .stub(packageService, 'getIncludes').returns(include);
       const getServiceArtifactNameStub = sinon
         .stub(packageService, 'getServiceArtifactName').returns(artifactName);
 
@@ -143,13 +184,15 @@ describe('#packageService()', () => {
         .stub(packageService, 'zipDirectory').returns(BbPromise.resolve(artifactFilePath));
 
       return packageService.packageAll().then(() => {
-        expect(getExcludedPathsStub.calledOnce).to.be.equal(true);
+        expect(getExcludesStub.calledOnce).to.be.equal(true);
+        expect(getIncludesStub.calledOnce).to.be.equal(true);
         expect(getServiceArtifactNameStub.calledOnce).to.be.equal(true);
 
         expect(zipDirectoryStub.calledOnce).to.be.equal(true);
         expect(zipDirectoryStub.args[0][0]).to.be.equal(servicePath);
         expect(zipDirectoryStub.args[0][1]).to.be.equal(exclude);
-        expect(zipDirectoryStub.args[0][2]).to.be.equal(artifactName);
+        expect(zipDirectoryStub.args[0][2]).to.be.equal(include);
+        expect(zipDirectoryStub.args[0][3]).to.be.equal(artifactName);
 
         expect(serverless.service.package.artifact).to.be.equal(artifactFilePath);
       });
@@ -162,6 +205,7 @@ describe('#packageService()', () => {
       const funcName = 'test-func';
 
       const exclude = ['test-exclude'];
+      const include = ['test-include'];
       const artifactName = 'test-artifact.zip';
       const artifactFilePath = '/some/fake/path/test-artifact.zip';
 
@@ -169,8 +213,10 @@ describe('#packageService()', () => {
       serverless.service.functions = {};
       serverless.service.functions[funcName] = { name: `test-proj-${funcName}` };
 
-      const getExcludedPathsStub = sinon
-        .stub(packageService, 'getExcludedPaths').returns(exclude);
+      const getExcludesStub = sinon
+        .stub(packageService, 'getExcludes').returns(exclude);
+      const getIncludesStub = sinon
+        .stub(packageService, 'getIncludes').returns(include);
       const getFunctionArtifactNameStub = sinon
         .stub(packageService, 'getFunctionArtifactName').returns(artifactName);
 
@@ -178,13 +224,15 @@ describe('#packageService()', () => {
         .stub(packageService, 'zipDirectory').returns(BbPromise.resolve(artifactFilePath));
 
       return packageService.packageFunction(funcName).then((filePath) => {
-        expect(getExcludedPathsStub.calledOnce).to.be.equal(true);
+        expect(getExcludesStub.calledOnce).to.be.equal(true);
+        expect(getIncludesStub.calledOnce).to.be.equal(true);
         expect(getFunctionArtifactNameStub.calledOnce).to.be.equal(true);
 
         expect(zipDirectoryStub.calledOnce).to.be.equal(true);
         expect(zipDirectoryStub.args[0][0]).to.be.equal(servicePath);
         expect(zipDirectoryStub.args[0][1]).to.be.equal(exclude);
-        expect(zipDirectoryStub.args[0][2]).to.be.equal(artifactName);
+        expect(zipDirectoryStub.args[0][2]).to.be.equal(include);
+        expect(zipDirectoryStub.args[0][3]).to.be.equal(artifactName);
 
         expect(filePath).to.be.equal(artifactFilePath);
       });

--- a/lib/plugins/package/tests/packageService.js
+++ b/lib/plugins/package/tests/packageService.js
@@ -189,12 +189,18 @@ describe('#packageService()', () => {
         expect(getServiceArtifactNameStub.calledOnce).to.be.equal(true);
 
         expect(zipDirectoryStub.calledOnce).to.be.equal(true);
-        expect(zipDirectoryStub.args[0][0]).to.be.equal(servicePath);
-        expect(zipDirectoryStub.args[0][1]).to.be.equal(exclude);
-        expect(zipDirectoryStub.args[0][2]).to.be.equal(include);
-        expect(zipDirectoryStub.args[0][3]).to.be.equal(artifactName);
-
+        expect(zipDirectoryStub.calledWithExactly(
+          servicePath,
+          exclude,
+          include,
+          artifactName
+        )).to.be.equal(true);
         expect(serverless.service.package.artifact).to.be.equal(artifactFilePath);
+
+        packageService.getExcludes.restore();
+        packageService.getIncludes.restore();
+        packageService.getServiceArtifactName.restore();
+        packageService.zipDirectory.restore();
       });
     });
   });
@@ -229,12 +235,19 @@ describe('#packageService()', () => {
         expect(getFunctionArtifactNameStub.calledOnce).to.be.equal(true);
 
         expect(zipDirectoryStub.calledOnce).to.be.equal(true);
-        expect(zipDirectoryStub.args[0][0]).to.be.equal(servicePath);
-        expect(zipDirectoryStub.args[0][1]).to.be.equal(exclude);
-        expect(zipDirectoryStub.args[0][2]).to.be.equal(include);
-        expect(zipDirectoryStub.args[0][3]).to.be.equal(artifactName);
+        expect(zipDirectoryStub.calledWithExactly(
+          servicePath,
+          exclude,
+          include,
+          artifactName
+        )).to.be.equal(true);
 
         expect(filePath).to.be.equal(artifactFilePath);
+
+        packageService.getExcludes.restore();
+        packageService.getIncludes.restore();
+        packageService.getFunctionArtifactName.restore();
+        packageService.zipDirectory.restore();
       });
     });
   });

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -92,12 +92,13 @@ describe('#zipService()', () => {
     servicePath = tmpDirPath;
   });
 
-  it('should zip a whole service', () => {
+  it('should zip a whole service (without include / exclude usage)', () => {
     const exclude = [];
+    const include = [];
     const zipFileName = getTestArtifactFileName('whole-service');
 
     return packageService
-      .zipDirectory(servicePath, exclude, zipFileName).then((artifact) => {
+      .zipDirectory(servicePath, exclude, include, zipFileName).then((artifact) => {
         const data = fs.readFileSync(artifact);
 
         return zip.loadAsync(data);
@@ -150,9 +151,10 @@ describe('#zipService()', () => {
 
   it('should keep file permissions', () => {
     const exclude = [];
+    const include = [];
     const zipFileName = getTestArtifactFileName('file-permissions');
 
-    return packageService.zipDirectory(servicePath, exclude, zipFileName)
+    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
       .then((artifact) => {
         const data = fs.readFileSync(artifact);
         return zip.loadAsync(data);
@@ -181,10 +183,11 @@ describe('#zipService()', () => {
       'exclude-me/**',
       'exclude-me.js',
     ];
+    const include = [];
 
     const zipFileName = getTestArtifactFileName('re-include');
 
-    return packageService.zipDirectory(servicePath, exclude, zipFileName)
+    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
     .then((artifact) => {
       const data = fs.readFileSync(artifact);
 
@@ -224,10 +227,11 @@ describe('#zipService()', () => {
       'exclude-me/**',
       '!include-me.js',
     ];
+    const include = [];
 
-    const zipFileName = getTestArtifactFileName('re-include');
+    const zipFileName = getTestArtifactFileName('re-include-with-globs');
 
-    return packageService.zipDirectory(servicePath, exclude, zipFileName)
+    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
     .then((artifact) => {
       const data = fs.readFileSync(artifact);
 
@@ -236,7 +240,56 @@ describe('#zipService()', () => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-             .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
+       .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
+
+      expect(unzippedFileData['handler.js'].name)
+        .to.equal('handler.js');
+
+      expect(unzippedFileData['lib/function.js'].name)
+        .to.equal('lib/function.js');
+
+      expect(unzippedFileData['include-me.js'].name)
+        .to.equal('include-me.js');
+
+      expect(unzippedFileData['include-me/some-file'].name)
+        .to.equal('include-me/some-file');
+
+      expect(unzippedFileData['a-serverless-plugin.js'].name)
+        .to.equal('a-serverless-plugin.js');
+
+      expect(unzippedFileData['node_modules/include-me/include'].name)
+        .to.equal('node_modules/include-me/include');
+
+      expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
+        .to.equal('node_modules/include-me/include-aswell');
+
+      expect(unzippedFileData['include-me.js'].name)
+        .to.equal('include-me.js');
+    });
+  });
+
+  it('should re-include files using include config', () => {
+    const exclude = [
+      'node_modules/exclude-me/**',
+      'exclude-me/**',
+      'include-me.js',
+    ];
+    const include = [
+      'include-me.js',
+    ];
+
+    const zipFileName = getTestArtifactFileName('re-include-with-include');
+
+    return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
+    .then((artifact) => {
+      const data = fs.readFileSync(artifact);
+
+      return zip.loadAsync(data);
+    }).then(unzippedData => {
+      const unzippedFileData = unzippedData.files;
+
+      expect(Object.keys(unzippedFileData)
+        .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
 
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -17,38 +17,39 @@ describe('#zipService()', () => {
   let servicePath;
 
   const testDirectory = {
+    // root
     '.': {
-      'a-serverless-plugin.js': 'a-serverless-plugin.js file content',
-      'handler.js': 'handler.js file content',
-      'exclude-me.js': 'exclude-me.js file content',
-      'include-me.js': 'include-me.js file content',
+      'event.json': 'some content',
+      'handler.js': 'some content',
+      'file-1': 'some content',
+      'file-2': 'some content',
     },
+    // bin
     bin: {
-      'some-binary': {
-        content: 'some-binary executable file content',
+      'binary-777': {
+        content: 'some content',
         permissions: 777,
       },
-      'read-only': {
-        content: 'read-only executable file content',
+      'binary-444': {
+        content: 'some content',
         permissions: 444,
       },
     },
-    'node_modules/include-me': {
-      include: 'some-file-content',
-      'include-aswell': 'some-file content',
-    },
-    'node_modules/exclude-me': {
-      exclude: 'some-file-content',
-      'exclude-aswell': 'some-file content',
-    },
-    'exclude-me': {
-      'some-file': 'some-file content',
-    },
-    'include-me': {
-      'some-file': 'some-file content',
-    },
+    // lib
     lib: {
-      'function.js': 'function.js file content',
+      'file-1.js': 'some content',
+    },
+    'lib/directory-1': {
+      'file-1.js': 'some content',
+    },
+    // node_modules
+    'node_modules/directory-1': {
+      'file-1': 'some content',
+      'file-2': 'some content',
+    },
+    'node_modules/directory-2': {
+      'file-1': 'some content',
+      'file-2': 'some content',
     },
   };
 
@@ -106,46 +107,39 @@ describe('#zipService()', () => {
         const unzippedFileData = unzippedData.files;
 
         expect(Object.keys(unzippedFileData)
-               .filter(file => !unzippedFileData[file].dir).length).to.equal(13);
+         .filter(file => !unzippedFileData[file].dir).length).to.equal(12);
 
+        // root directory
+        expect(unzippedFileData['event.json'].name)
+          .to.equal('event.json');
         expect(unzippedFileData['handler.js'].name)
           .to.equal('handler.js');
+        expect(unzippedFileData['file-1'].name)
+          .to.equal('file-1');
+        expect(unzippedFileData['file-2'].name)
+          .to.equal('file-2');
 
-        expect(unzippedFileData['lib/function.js'].name)
-          .to.equal('lib/function.js');
+        // bin directory
+        expect(unzippedFileData['bin/binary-777'].name)
+          .to.equal('bin/binary-777');
+        expect(unzippedFileData['bin/binary-444'].name)
+          .to.equal('bin/binary-444');
 
-        expect(unzippedFileData['exclude-me.js'].name)
-          .to.equal('exclude-me.js');
+        // lib directory
+        expect(unzippedFileData['lib/file-1.js'].name)
+          .to.equal('lib/file-1.js');
+        expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+          .to.equal('lib/directory-1/file-1.js');
 
-        expect(unzippedFileData['exclude-me/some-file'].name)
-          .to.equal('exclude-me/some-file');
-
-        expect(unzippedFileData['include-me.js'].name)
-          .to.equal('include-me.js');
-
-        expect(unzippedFileData['bin/some-binary'].name)
-          .to.equal('bin/some-binary');
-
-        expect(unzippedFileData['bin/read-only'].name)
-          .to.equal('bin/read-only');
-
-        expect(unzippedFileData['include-me/some-file'].name)
-          .to.equal('include-me/some-file');
-
-        expect(unzippedFileData['a-serverless-plugin.js'].name)
-          .to.equal('a-serverless-plugin.js');
-
-        expect(unzippedFileData['node_modules/include-me/include'].name)
-          .to.equal('node_modules/include-me/include');
-
-        expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
-          .to.equal('node_modules/include-me/include-aswell');
-
-        expect(unzippedFileData['node_modules/exclude-me/exclude'].name)
-          .to.equal('node_modules/exclude-me/exclude');
-
-        expect(unzippedFileData['node_modules/exclude-me/exclude-aswell'].name)
-          .to.equal('node_modules/exclude-me/exclude-aswell');
+        // node_modules directory
+        expect(unzippedFileData['node_modules/directory-1/file-1'].name)
+          .to.equal('node_modules/directory-1/file-1');
+        expect(unzippedFileData['node_modules/directory-1/file-2'].name)
+          .to.equal('node_modules/directory-1/file-2');
+        expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+          .to.equal('node_modules/directory-2/file-1');
+        expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+          .to.equal('node_modules/directory-2/file-2');
       });
   });
 
@@ -163,29 +157,29 @@ describe('#zipService()', () => {
 
         if (os.platform() === 'win32') {
           // chmod does not work right on windows. this is better than nothing?
-          expect(unzippedFileData['bin/some-binary'].unixPermissions)
-            .to.not.equal(unzippedFileData['bin/read-only'].unixPermissions);
+          expect(unzippedFileData['bin/binary-777'].unixPermissions)
+            .to.not.equal(unzippedFileData['bin/binary-444'].unixPermissions);
         } else {
           // binary file is set with chmod of 777
-          expect(unzippedFileData['bin/some-binary'].unixPermissions)
+          expect(unzippedFileData['bin/binary-777'].unixPermissions)
             .to.equal(Math.pow(2, 15) + 777);
 
           // read only file is set with chmod of 444
-          expect(unzippedFileData['bin/read-only'].unixPermissions)
+          expect(unzippedFileData['bin/binary-444'].unixPermissions)
             .to.equal(Math.pow(2, 15) + 444);
         }
       });
   });
 
-  it('should exclude globs', () => {
+  it('should exclude with globs', () => {
     const exclude = [
-      'node_modules/exclude-me/**',
-      'exclude-me/**',
-      'exclude-me.js',
+      'event.json',
+      'lib/**',
+      'node_modules/directory-1/**',
     ];
     const include = [];
 
-    const zipFileName = getTestArtifactFileName('re-include');
+    const zipFileName = getTestArtifactFileName('exclude-with-globs');
 
     return packageService.zipDirectory(servicePath, exclude, include, zipFileName)
     .then((artifact) => {
@@ -196,36 +190,38 @@ describe('#zipService()', () => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-             .filter(file => !unzippedFileData[file].dir).length).to.equal(9);
+        .filter(file => !unzippedFileData[file].dir).length).to.equal(7);
 
+      // root directory
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
+      expect(unzippedFileData['file-1'].name)
+        .to.equal('file-1');
+      expect(unzippedFileData['file-2'].name)
+        .to.equal('file-2');
 
-      expect(unzippedFileData['lib/function.js'].name)
-        .to.equal('lib/function.js');
+      // bin directory
+      expect(unzippedFileData['bin/binary-777'].name)
+        .to.equal('bin/binary-777');
+      expect(unzippedFileData['bin/binary-444'].name)
+        .to.equal('bin/binary-444');
 
-      expect(unzippedFileData['include-me.js'].name)
-        .to.equal('include-me.js');
-
-      expect(unzippedFileData['include-me/some-file'].name)
-        .to.equal('include-me/some-file');
-
-      expect(unzippedFileData['a-serverless-plugin.js'].name)
-        .to.equal('a-serverless-plugin.js');
-
-      expect(unzippedFileData['node_modules/include-me/include'].name)
-        .to.equal('node_modules/include-me/include');
-
-      expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
-        .to.equal('node_modules/include-me/include-aswell');
+      // node_modules directory
+      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+        .to.equal('node_modules/directory-2/file-1');
+      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+        .to.equal('node_modules/directory-2/file-2');
     });
   });
 
   it('should re-include files using ! glob pattern', () => {
     const exclude = [
-      'node_modules/exclude-me/**',
-      'exclude-me/**',
-      '!include-me.js',
+      'event.json',
+      'lib/**',
+      'node_modules/directory-1/**',
+
+      '!event.json', // re-include
+      '!lib/**', // re-include
     ];
     const include = [];
 
@@ -240,42 +236,47 @@ describe('#zipService()', () => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-       .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
+        .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
 
+      // root directory
+      expect(unzippedFileData['event.json'].name)
+        .to.equal('event.json');
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
+      expect(unzippedFileData['file-1'].name)
+        .to.equal('file-1');
+      expect(unzippedFileData['file-2'].name)
+        .to.equal('file-2');
 
-      expect(unzippedFileData['lib/function.js'].name)
-        .to.equal('lib/function.js');
+      // bin directory
+      expect(unzippedFileData['bin/binary-777'].name)
+        .to.equal('bin/binary-777');
+      expect(unzippedFileData['bin/binary-444'].name)
+        .to.equal('bin/binary-444');
 
-      expect(unzippedFileData['include-me.js'].name)
-        .to.equal('include-me.js');
+      // lib directory
+      expect(unzippedFileData['lib/file-1.js'].name)
+        .to.equal('lib/file-1.js');
+      expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+        .to.equal('lib/directory-1/file-1.js');
 
-      expect(unzippedFileData['include-me/some-file'].name)
-        .to.equal('include-me/some-file');
-
-      expect(unzippedFileData['a-serverless-plugin.js'].name)
-        .to.equal('a-serverless-plugin.js');
-
-      expect(unzippedFileData['node_modules/include-me/include'].name)
-        .to.equal('node_modules/include-me/include');
-
-      expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
-        .to.equal('node_modules/include-me/include-aswell');
-
-      expect(unzippedFileData['include-me.js'].name)
-        .to.equal('include-me.js');
+      // node_modules directory
+      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+        .to.equal('node_modules/directory-2/file-1');
+      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+        .to.equal('node_modules/directory-2/file-2');
     });
   });
 
   it('should re-include files using include config', () => {
     const exclude = [
-      'node_modules/exclude-me/**',
-      'exclude-me/**',
-      'include-me.js',
+      'event.json',
+      'lib/**',
+      'node_modules/directory-1/**',
     ];
     const include = [
-      'include-me.js',
+      'event.json',
+      'lib/**',
     ];
 
     const zipFileName = getTestArtifactFileName('re-include-with-include');
@@ -291,29 +292,33 @@ describe('#zipService()', () => {
       expect(Object.keys(unzippedFileData)
         .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
 
+      // root directory
+      expect(unzippedFileData['event.json'].name)
+        .to.equal('event.json');
       expect(unzippedFileData['handler.js'].name)
         .to.equal('handler.js');
+      expect(unzippedFileData['file-1'].name)
+        .to.equal('file-1');
+      expect(unzippedFileData['file-2'].name)
+        .to.equal('file-2');
 
-      expect(unzippedFileData['lib/function.js'].name)
-        .to.equal('lib/function.js');
+      // bin directory
+      expect(unzippedFileData['bin/binary-777'].name)
+        .to.equal('bin/binary-777');
+      expect(unzippedFileData['bin/binary-444'].name)
+        .to.equal('bin/binary-444');
 
-      expect(unzippedFileData['include-me.js'].name)
-        .to.equal('include-me.js');
+      // lib directory
+      expect(unzippedFileData['lib/file-1.js'].name)
+        .to.equal('lib/file-1.js');
+      expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+        .to.equal('lib/directory-1/file-1.js');
 
-      expect(unzippedFileData['include-me/some-file'].name)
-        .to.equal('include-me/some-file');
-
-      expect(unzippedFileData['a-serverless-plugin.js'].name)
-        .to.equal('a-serverless-plugin.js');
-
-      expect(unzippedFileData['node_modules/include-me/include'].name)
-        .to.equal('node_modules/include-me/include');
-
-      expect(unzippedFileData['node_modules/include-me/include-aswell'].name)
-        .to.equal('node_modules/include-me/include-aswell');
-
-      expect(unzippedFileData['include-me.js'].name)
-        .to.equal('include-me.js');
+      // node_modules directory
+      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+        .to.equal('node_modules/directory-2/file-1');
+      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+        .to.equal('node_modules/directory-2/file-2');
     });
   });
 });

--- a/lib/plugins/package/tests/zipService.js
+++ b/lib/plugins/package/tests/zipService.js
@@ -107,7 +107,7 @@ describe('#zipService()', () => {
         const unzippedFileData = unzippedData.files;
 
         expect(Object.keys(unzippedFileData)
-         .filter(file => !unzippedFileData[file].dir).length).to.equal(12);
+         .filter(file => !unzippedFileData[file].dir).length).to.equal(13);
 
         // root directory
         expect(unzippedFileData['event.json'].name)
@@ -190,7 +190,7 @@ describe('#zipService()', () => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir).length).to.equal(7);
+        .filter(file => !unzippedFileData[file].dir).length).to.equal(8);
 
       // root directory
       expect(unzippedFileData['handler.js'].name)
@@ -236,7 +236,7 @@ describe('#zipService()', () => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
+        .filter(file => !unzippedFileData[file].dir).length).to.equal(11);
 
       // root directory
       expect(unzippedFileData['event.json'].name)
@@ -290,7 +290,7 @@ describe('#zipService()', () => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir).length).to.equal(10);
+        .filter(file => !unzippedFileData[file].dir).length).to.equal(11);
 
       // root directory
       expect(unzippedFileData['event.json'].name)


### PR DESCRIPTION
## What did you implement:

Closes #2460

Brings back the `include` configuration on a per-service and per-function level.

## How did you implement it:

Added the include configuration and updated the zipping and packaging configuration so that the `include` definitions (globs) are appended to the `exclude` array. This way `globs.sync` will re-add the files (see https://github.com/jpillora/node-glob-all#usage).

## How can we verify it:

Create the following directory structure:

![bildschirmfoto 2016-11-09 um 14 22 54](https://cloud.githubusercontent.com/assets/1606004/20139767/0c0dcadc-a688-11e6-967e-557a30a11817.png)

With this `serverless.yml`

```yml
service: reword-include-exclude

provider:
  name: aws
  runtime: nodejs4.3

#### NOT INDIVIDUALLY

package:
  exclude:
    - excluded-by-default.json
    - excluded-directory/**
  include:
    - excluded-directory/should-be-included.js
    - excluded-directory/include-directory/**

functions:
  hello:
    handler: handler.hello

#### INDIVIDUALLY

#package:
#  individually: true
#  exclude:
#    - excluded-by-default.json

#functions:
#  hello:
#    handler: handler.hello
#    package:
#      include:
#        - excluded-by-default.json
#  world:
#    handler: handler.hello
#    package:
#      exclude:
#        - event.json
```

Comment out the stuff you want to test and run `serverless deploy --noDeploy`. After that inspect the `.zip` file.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES