### PR TITLE
Fixes info plugin endpoint path issue

### DIFF
--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -177,7 +177,7 @@ ${chalk.yellow('region:')} ${info.region}`;
               method = event.http.split(' ')[0].toUpperCase();
               path = event.http.split(' ')[1];
             }
-            path = path.length > 1 ? `/${path.split('/').filter(p => p !== '').join('/')}` : '';
+            path = path !== '/' ? `/${path.split('/').filter(p => p !== '').join('/')}` : '';
             endpointsMessage = endpointsMessage.concat(`\n  ${method} - ${info.endpoint}${path}`);
           }
         });

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -177,8 +177,8 @@ ${chalk.yellow('region:')} ${info.region}`;
               method = event.http.split(' ')[0].toUpperCase();
               path = event.http.split(' ')[1];
             }
-
-            endpointsMessage = endpointsMessage.concat(`\n  ${method} - ${info.endpoint}/${path}`);
+            path = path.length > 1 ? `/${path.split('/').filter(p => p !== '').join('/')}` : '';
+            endpointsMessage = endpointsMessage.concat(`\n  ${method} - ${info.endpoint}${path}`);
           }
         });
       });

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -387,7 +387,71 @@ ${chalk.yellow('functions:')}
       expect(awsInfo.display(data)).to.equal(expectedMessage);
     });
 
-    it("should display only general information when stack doesn't exist", () => {
+    it('should format information message correctly with additional endpoints', () => {
+      serverless.cli = new CLI(serverless);
+      const additionalFunctions = [
+        {
+          http: {
+            path: '/',
+            method: 'POST',
+          },
+        },
+        {
+          http: {
+            path: '/both/',
+            method: 'POST',
+          },
+        },
+        {
+          http: {
+            path: '/both/add/',
+            method: 'POST',
+          },
+        },
+        {
+          http: {
+            path: 'e',
+            method: 'POST',
+          },
+        },
+      ];
+      serverless.service.functions.function2.events =
+        serverless.service.functions.function2.events.concat(additionalFunctions);
+
+      sinon.stub(serverless.cli, 'consoleLog').returns();
+
+      const data = {
+        info: {
+          service: 'my-first',
+          stage: 'dev',
+          region: 'eu-west-1',
+          endpoint: 'ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev',
+          functions: [],
+        },
+      };
+
+      const expectedMessage = `
+${chalk.yellow.underline('Service Information')}
+${chalk.yellow('service:')} my-first
+${chalk.yellow('stage:')} dev
+${chalk.yellow('region:')} eu-west-1
+${chalk.yellow('api keys:')}
+  None
+${chalk.yellow('endpoints:')}
+  GET - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/function1
+  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/function2
+  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev
+  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both
+  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both/add
+  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/e
+${chalk.yellow('functions:')}
+  None
+`;
+
+      expect(awsInfo.display(data)).to.equal(expectedMessage);
+    });
+
+    it('should display only general information when stack doesn\'t exist', () => {
       serverless.cli = new CLI(serverless);
       sinon.stub(serverless.cli, 'consoleLog').returns();
 

--- a/lib/plugins/aws/info/tests/index.js
+++ b/lib/plugins/aws/info/tests/index.js
@@ -387,9 +387,9 @@ ${chalk.yellow('functions:')}
       expect(awsInfo.display(data)).to.equal(expectedMessage);
     });
 
-    it('should format information message correctly with additional endpoints', () => {
+    it('should format information message correctly with slashed endpoint events', () => {
       serverless.cli = new CLI(serverless);
-      const additionalFunctions = [
+      const additionalEvents = [
         {
           http: {
             path: '/',
@@ -415,8 +415,11 @@ ${chalk.yellow('functions:')}
           },
         },
       ];
-      serverless.service.functions.function2.events =
-        serverless.service.functions.function2.events.concat(additionalFunctions);
+      serverless.service.functions = {
+        function1: {
+          events: additionalEvents,
+        },
+      };
 
       sinon.stub(serverless.cli, 'consoleLog').returns();
 
@@ -438,8 +441,6 @@ ${chalk.yellow('region:')} eu-west-1
 ${chalk.yellow('api keys:')}
   None
 ${chalk.yellow('endpoints:')}
-  GET - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/function1
-  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/function2
   POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev
   POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both
   POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both/add


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless/serverless/issues/2671

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I split the path to array and filtered empty fractions.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create a service with endpoints
```
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: without
          method: get
      - http:
          path: /starting
          method: get
      - http:
          path: /
          method: get
      - http:
          path: /both/
          method: get
      - http:
          path: e
          method: get
```
deploy service `serverless deploy` and run `serveless info` and output should be:

```
Service Information
service: fix-endpoints
stage: dev
region: us-east-1
api keys:
  None
endpoints:
  GET - https://154rulmui7.execute-api.us-east-1.amazonaws.com/dev/without
  GET - https://154rulmui7.execute-api.us-east-1.amazonaws.com/dev/starting
  GET - https://154rulmui7.execute-api.us-east-1.amazonaws.com/dev
  GET - https://154rulmui7.execute-api.us-east-1.amazonaws.com/dev/both
  GET - https://154rulmui7.execute-api.us-east-1.amazonaws.com/dev/e
functions:
  fix-endpoints-dev-hello: arn:aws:lambda:us-east-1:414122178905:function:fix-endpoints-dev-hello
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

