### PR TITLE
Support assume-role policies

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -47,6 +47,7 @@ const impl = {
    * Add credentials from a profile, if the profile exists
    * @param credentials The credentials to add profile credentials to
    * @param prefix The prefix to the profile environment variable
+   * @returns Promise
    */
   addProfileCredentials: (credentials, profile) => {
     if (profile) {
@@ -56,17 +57,20 @@ const impl = {
       }
       impl.addCredentials(credentials, profileCredentials);
     }
+    return BbPromise.resolve(undefined);
   },
   /**
    * Add credentials, if present, from a profile that is specified within the environment
    * @param credentials The prefix of the profile's declaration in the environment
    * @param prefix The prefix for the environment variable
+   * @returns Promise
    */
   addEnvironmentProfile: (credentials, prefix) => {
     if (prefix) {
       const profile = process.env[`${prefix}_PROFILE`];
-      impl.addProfileCredentials(credentials, profile);
+      return impl.addProfileCredentials(credentials, profile);
     }
+    return BbPromise.resolve(undefined);
   },
 };
 
@@ -159,22 +163,34 @@ class AwsProvider {
    * @returns Promise that resolves to: {{region: *}}
    */
   getCredentials(stage, region) {
+    const that = this;
     const ret = { region };
     const credentials = {};
     const stageUpper = stage ? stage.toUpperCase() : null;
 
     // add specified credentials, overriding with more specific declarations
-    impl.addCredentials(credentials, this.serverless.service.provider.credentials); // config creds
-    impl.addProfileCredentials(credentials, this.serverless.service.provider.profile);
-    impl.addEnvironmentCredentials(credentials, 'AWS'); // creds for all stages
-    impl.addEnvironmentProfile(credentials, 'AWS');
-    impl.addEnvironmentCredentials(credentials, `AWS_${stageUpper}`); // stage specific creds
-    impl.addEnvironmentProfile(credentials, `AWS_${stageUpper}`);
 
-    if (Object.keys(credentials).length) {
-      ret.credentials = credentials;
-    }
-    return BbPromise.resolve(ret);
+    return BbPromise.try(() => {
+      // config creds
+      impl.addCredentials(credentials, that.serverless.service.provider.credentials);
+      return impl.addProfileCredentials(credentials, that.serverless.service.provider.profile);
+    })
+    .then(() => {
+      // creds for all stages
+      impl.addEnvironmentCredentials(credentials, 'AWS');
+      return impl.addEnvironmentProfile(credentials, 'AWS');
+    })
+    .then(() => {
+      // stage specific creds
+      impl.addEnvironmentCredentials(credentials, `AWS_${stageUpper}`);
+      return impl.addEnvironmentProfile(credentials, `AWS_${stageUpper}`);
+    })
+    .then(() => {
+      if (Object.keys(credentials).length) {
+        ret.credentials = credentials;
+      }
+      return ret;
+    });
   }
 
   getServerlessDeploymentBucketName(stage, region) {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -54,11 +54,11 @@ const impl = {
 
     const profileCredentials = new AWS.SharedIniFileCredentials({
       profile,
-      filename: process.env['AWS_SHARED_CREDENTIALS_FILE'],
+      filename: process.env.AWS_SHARED_CREDENTIALS_FILE,
     });
     const getAsync = BbPromise.promisify(
       profileCredentials.get,
-      {context: profileCredentials}
+      { context: profileCredentials }
     );
 
     return getAsync().then(() => {
@@ -132,7 +132,7 @@ class AwsProvider {
         const awsService = new that.sdk[service](credentials);
         const awsMethodAsync = BbPromise.promisify(
           awsService[method],
-          {context: awsService}
+          { context: awsService }
         );
         return that.persistentRequest(awsMethodAsync, params);
       })
@@ -143,6 +143,7 @@ class AwsProvider {
             ' You can find more info on how to set up provider',
             ' credentials in our docs here: https://git.io/vXsdd',
           ].join('');
+          // eslint-disable-next-line no-param-reassign
           err.message = errorMessage;
         }
         throw new that.serverless.classes.Error(err.message, err.statusCode);

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -73,11 +73,8 @@ const impl = {
    * @returns Promise
    */
   addEnvironmentProfile: (credentials, prefix) => {
-    if (prefix) {
-      const profile = process.env[`${prefix}_PROFILE`];
-      return impl.addProfileCredentials(credentials, profile);
-    }
-    return BbPromise.resolve(undefined);
+    const profile = process.env[`${prefix}_PROFILE`];
+    return impl.addProfileCredentials(credentials, profile);
   },
 };
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -52,7 +52,10 @@ const impl = {
   addProfileCredentials: (credentials, profile) => {
     if (!profile) return BbPromise.resolve(undefined);
 
-    const profileCredentials = new AWS.SharedIniFileCredentials({ profile });
+    const profileCredentials = new AWS.SharedIniFileCredentials({
+      profile,
+      filename: process.env['AWS_SHARED_CREDENTIALS_FILE'],
+    });
     const getAsync = BbPromise.promisify(
       profileCredentials.get,
       {context: profileCredentials}

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -50,14 +50,18 @@ const impl = {
    * @returns Promise
    */
   addProfileCredentials: (credentials, profile) => {
-    if (profile) {
-      const profileCredentials = new AWS.SharedIniFileCredentials({ profile });
-      if (Object.keys(profileCredentials).length) {
-        credentials.profile = profile; // eslint-disable-line no-param-reassign
-      }
+    if (!profile) return BbPromise.resolve(undefined);
+
+    const profileCredentials = new AWS.SharedIniFileCredentials({ profile });
+    const getAsync = BbPromise.promisify(
+      profileCredentials.get,
+      {context: profileCredentials}
+    );
+
+    return getAsync().then(() => {
+      credentials.profile = profile; // eslint-disable-line no-param-reassign
       impl.addCredentials(credentials, profileCredentials);
-    }
-    return BbPromise.resolve(undefined);
+    });
   },
   /**
    * Add credentials, if present, from a profile that is specified within the environment

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -103,7 +103,7 @@ class AwsProvider {
 
   request(service, method, params, stage, region) {
     const that = this;
-    const credentials = that.getCredentials(stage, region);
+
     const persistentRequest = (f) => new BbPromise((resolve, reject) => {
       const doCall = () => {
         f()
@@ -120,32 +120,35 @@ class AwsProvider {
       return doCall();
     });
 
-    return persistentRequest(() => {
-      const awsService = new that.sdk[service](credentials);
-      const req = awsService[method](params);
+    return that.getCredentials(stage, region)
+      .then((credentials) => {
+        const awsService = new that.sdk[service](credentials);
+        const req = awsService[method](params);
+        return persistentRequest(() => {
 
-      // TODO: Add listeners, put Debug statments here…
-      // req.on('send', function (r) {console.log(r)});
+          // TODO: Add listeners, put Debug statments here…
+          // req.on('send', function (r) {console.log(r)});
 
-      return new BbPromise((resolve, reject) => {
-        req.send((errParam, data) => {
-          const err = errParam;
-          if (err) {
-            if (err.message === 'Missing credentials in config') {
-              const errorMessage = [
-                'AWS provider credentials not found.',
-                ' You can find more info on how to set up provider',
-                ' credentials in our docs here: https://git.io/vXsdd',
-              ].join('');
-              err.message = errorMessage;
-            }
-            reject(new this.serverless.classes.Error(err.message, err.statusCode));
-          } else {
-            resolve(data);
-          }
+          return new BbPromise((resolve, reject) => {
+            req.send((errParam, data) => {
+              const err = errParam;
+              if (err) {
+                if (err.message === 'Missing credentials in config') {
+                  const errorMessage = [
+                    'AWS provider credentials not found.',
+                    ' You can find more info on how to set up provider',
+                    ' credentials in our docs here: https://git.io/vXsdd',
+                  ].join('');
+                  err.message = errorMessage;
+                }
+                reject(new this.serverless.classes.Error(err.message, err.statusCode));
+              } else {
+                resolve(data);
+              }
+            });
+          });
         });
       });
-    });
   }
 
   /**
@@ -153,7 +156,7 @@ class AwsProvider {
    * well known environment variables
    * @param stage
    * @param region
-   * @returns {{region: *}}
+   * @returns Promise that resolves to: {{region: *}}
    */
   getCredentials(stage, region) {
     const ret = { region };
@@ -171,7 +174,7 @@ class AwsProvider {
     if (Object.keys(credentials).length) {
       ret.credentials = credentials;
     }
-    return ret;
+    return BbPromise.resolve(ret);
   }
 
   getServerlessDeploymentBucketName(stage, region) {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -141,7 +141,7 @@ class AwsProvider {
           const errorMessage = [
             'AWS provider credentials not found.',
             ' You can find more info on how to set up provider',
-            ' credentials in our docs here: https://git.io/viZAC',
+            ' credentials in our docs here: https://git.io/vXsdd',
           ].join('');
           err.message = errorMessage;
         }

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -112,53 +112,40 @@ class AwsProvider {
     }
   }
 
+  persistentRequest(awsMethodAsync, params) {
+    const that = this;
+    return awsMethodAsync(params)
+      .catch((err) => {
+        if (err.statusCode === 429) {
+          that.serverless.cli.log("'Too many requests' received, sleeping 5 seconds");
+          return BbPromise.delay(5000)
+            .then(() => that.persistentRequest(awsMethodAsync, params));
+        }
+        throw err;
+      });
+  }
+
   request(service, method, params, stage, region) {
     const that = this;
-
-    const persistentRequest = (f) => new BbPromise((resolve, reject) => {
-      const doCall = () => {
-        f()
-          .then(resolve)
-          .catch((e) => {
-            if (e.statusCode === 429) {
-              that.serverless.cli.log("'Too many requests' received, sleeping 5 seconds");
-              setTimeout(doCall, 5000);
-            } else {
-              reject(e);
-            }
-          });
-      };
-      return doCall();
-    });
-
     return that.getCredentials(stage, region)
       .then((credentials) => {
         const awsService = new that.sdk[service](credentials);
-        const req = awsService[method](params);
-        return persistentRequest(() => {
-
-          // TODO: Add listeners, put Debug statments here…
-          // req.on('send', function (r) {console.log(r)});
-
-          return new BbPromise((resolve, reject) => {
-            req.send((errParam, data) => {
-              const err = errParam;
-              if (err) {
-                if (err.message === 'Missing credentials in config') {
-                  const errorMessage = [
-                    'AWS provider credentials not found.',
-                    ' You can find more info on how to set up provider',
-                    ' credentials in our docs here: https://git.io/vXsdd',
-                  ].join('');
-                  err.message = errorMessage;
-                }
-                reject(new this.serverless.classes.Error(err.message, err.statusCode));
-              } else {
-                resolve(data);
-              }
-            });
-          });
-        });
+        const awsMethodAsync = BbPromise.promisify(
+          awsService[method],
+          {context: awsService}
+        );
+        return that.persistentRequest(awsMethodAsync, params);
+      })
+      .catch((err) => {
+        if (err.message === 'Missing credentials in config') {
+          const errorMessage = [
+            'AWS provider credentials not found.',
+            ' You can find more info on how to set up provider',
+            ' credentials in our docs here: https://git.io/viZAC',
+          ].join('');
+          err.message = errorMessage;
+        }
+        throw new that.serverless.classes.Error(err.message, err.statusCode);
       });
   }
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -12,14 +12,14 @@ const _ = require('lodash');
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-var prevEnv;
+let prevEnv;
 const backupEnv = () => {
   prevEnv = _.clone(process.env);
 };
 
 const restoreEnv = () => {
   process.env = prevEnv;
-}
+};
 
 describe('AwsProvider', () => {
   let awsProvider;
@@ -204,12 +204,12 @@ describe('AwsProvider', () => {
               this.accessKeyId = 'XXXX';
               this.secretAccessKey = 'YYYY';
             } else if (this.profile) {
-              throw(`Profile ${this.profile} not found in ${this.filename}`);
+              throw new Error(`Profile ${this.profile} not found in ${this.filename}`);
             }
             cb();
           }
-        }
-      }
+        },
+      },
     });
 
     let newAwsProvider;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -2,10 +2,24 @@
 
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
-const expect = require('chai').expect;
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const Serverless = require('../../../Serverless');
 const AwsProvider = require('./awsProvider');
 const proxyquire = require('proxyquire');
+const _ = require('lodash');
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+var prevEnv;
+const backupEnv = () => {
+  prevEnv = _.clone(process.env);
+};
+
+const restoreEnv = () => {
+  process.env = prevEnv;
+}
 
 describe('AwsProvider', () => {
   let awsProvider;
@@ -69,10 +83,8 @@ describe('AwsProvider', () => {
           this.credentials = credentials;
         }
 
-        putObject() {
-          return {
-            send: (cb) => cb(null, { called: true }),
-          };
+        putObject(params, cb) {
+          cb(null, { called: true });
         }
       }
       awsProvider.sdk = {
@@ -107,17 +119,13 @@ describe('AwsProvider', () => {
           this.credentials = credentials;
         }
 
-        error() {
-          return {
-            send(cb) {
-              if (first) {
-                cb(error);
-              } else {
-                cb(undefined, {});
-              }
-              first = false;
-            },
-          };
+        error(params, cb) {
+          if (first) {
+            cb(error);
+          } else {
+            cb(undefined, {});
+          }
+          first = false;
         }
       }
       awsProvider.sdk = {
@@ -144,12 +152,8 @@ describe('AwsProvider', () => {
           this.credentials = credentials;
         }
 
-        error() {
-          return {
-            send(cb) {
-              cb(error);
-            },
-          };
+        error(params, cb) {
+          cb(error);
         }
       }
       awsProvider.sdk = {
@@ -170,12 +174,8 @@ describe('AwsProvider', () => {
           this.credentials = credentials;
         }
 
-        error() {
-          return {
-            send(cb) {
-              cb(error);
-            },
-          };
+        error(params, cb) {
+          cb(error);
         }
       }
       awsProvider.sdk = {
@@ -192,38 +192,58 @@ describe('AwsProvider', () => {
   });
 
   describe('#getCredentials()', () => {
-    const awsStub = sinon.stub().returns();
     const AwsProviderProxyquired = proxyquire('./awsProvider.js', {
-      'aws-sdk': awsStub,
+      'aws-sdk': {
+        SharedIniFileCredentials: class {
+          constructor(opts) {
+            this.profile = opts.profile;
+            this.filename = opts.filename || '/path/to/faked/credentials';
+          }
+          get(cb) {
+            if (this.profile === 'notDefault') {
+              this.accessKeyId = 'XXXX';
+              this.secretAccessKey = 'YYYY';
+            } else if (this.profile) {
+              throw(`Profile ${this.profile} not found in ${this.filename}`);
+            }
+            cb();
+          }
+        }
+      }
     });
 
     let newAwsProvider;
 
     beforeEach(() => {
       newAwsProvider = new AwsProviderProxyquired(serverless);
+      backupEnv();
+    });
+
+    afterEach(() => {
+      restoreEnv();
     });
 
     it('should set region for credentials', () => {
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials.region).to.equal('testregion');
+      expect(credentials).to.eventually.have.property('region', 'testregion');
     });
 
     it('should get credentials from provider', () => {
       serverless.service.provider.profile = 'notDefault';
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials).to.eventually.have.deep.property('credentials.profile', 'notDefault');
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials).to.eql({ region: 'testregion' });
+      expect(credentials).to.eventually.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if credentials is an empty object', () => {
       serverless.service.provider.credentials = {};
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials).to.eql({ region: 'testregion' });
+      expect(credentials).to.eventually.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if credentials has undefined values', () => {
@@ -233,7 +253,7 @@ describe('AwsProvider', () => {
         sessionToken: undefined,
       };
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials).to.eql({ region: 'testregion' });
+      expect(credentials).to.eventually.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if credentials has empty string values', () => {
@@ -243,14 +263,10 @@ describe('AwsProvider', () => {
         sessionToken: '',
       };
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials).to.eql({ region: 'testregion' });
+      expect(credentials).to.eventually.eql({ region: 'testregion' });
     });
 
     it('should get credentials from provider declared credentials', () => {
-      const tmpAccessKeyID = process.env.AWS_ACCESS_KEY_ID;
-      const tmpAccessKeySecret = process.env.AWS_SECRET_ACCESS_KEY;
-      const tmpSessionToken = process.env.AWS_SESSION_TOKEN;
-
       delete process.env.AWS_ACCESS_KEY_ID;
       delete process.env.AWS_SECRET_ACCESS_KEY;
       delete process.env.AWS_SESSION_TOKEN;
@@ -260,20 +276,13 @@ describe('AwsProvider', () => {
         secretAccessKey: 'secretAccessKey',
         sessionToken: 'sessionToken',
       };
-      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials.credentials).to.deep.eql(serverless.service.provider.credentials);
 
-      process.env.AWS_ACCESS_KEY_ID = tmpAccessKeyID;
-      process.env.AWS_SECRET_ACCESS_KEY = tmpAccessKeySecret;
-      process.env.AWS_SESSION_TOKEN = tmpSessionToken;
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
+      expect(credentials).to.eventually.have.deep.property('credentials')
+        .that.deep.equals(serverless.service.provider.credentials);
     });
 
     it('should get credentials from environment declared for-all-stages credentials', () => {
-      const prevVal = {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
-      };
       const testVal = {
         accessKeyId: 'accessKeyId',
         secretAccessKey: 'secretAccessKey',
@@ -282,19 +291,13 @@ describe('AwsProvider', () => {
       process.env.AWS_ACCESS_KEY_ID = testVal.accessKeyId;
       process.env.AWS_SECRET_ACCESS_KEY = testVal.secretAccessKey;
       process.env.AWS_SESSION_TOKEN = testVal.sessionToken;
+
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      process.env.AWS_ACCESS_KEY_ID = prevVal.accessKeyId;
-      process.env.AWS_SECRET_ACCESS_KEY = prevVal.secretAccessKey;
-      process.env.AWS_SESSION_TOKEN = prevVal.sessionToken;
-      expect(credentials.credentials).to.deep.eql(testVal);
+      expect(credentials).to.eventually.have.deep.property('credentials')
+        .that.deep.equals(testVal);
     });
 
     it('should get credentials from environment declared stage specific credentials', () => {
-      const prevVal = {
-        accessKeyId: process.env.AWS_TESTSTAGE_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_TESTSTAGE_SESSION_TOKEN,
-      };
       const testVal = {
         accessKeyId: 'accessKeyId',
         secretAccessKey: 'secretAccessKey',
@@ -303,45 +306,40 @@ describe('AwsProvider', () => {
       process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = testVal.accessKeyId;
       process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = testVal.secretAccessKey;
       process.env.AWS_TESTSTAGE_SESSION_TOKEN = testVal.sessionToken;
+
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = prevVal.accessKeyId;
-      process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = prevVal.secretAccessKey;
-      process.env.AWS_TESTSTAGE_SESSION_TOKEN = prevVal.sessionToken;
-      expect(credentials.credentials).to.deep.eql(testVal);
+      expect(credentials).to.eventually.have.deep.property('credentials')
+        .that.deep.equals(testVal);
     });
 
     it('should not set credentials if profile is not set', () => {
       serverless.service.provider.profile = undefined;
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials).to.eql({ region: 'testregion' });
+      expect(credentials).to.eventually.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      expect(credentials).to.eql({ region: 'testregion' });
+      expect(credentials).to.eventually.eql({ region: 'testregion' });
     });
 
     it('should get credentials from provider declared profile', () => {
       serverless.service.provider.profile = 'notDefault';
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials).to.eventually.have.deep.property('credentials.profile', 'notDefault');
     });
 
     it('should get credentials from environment declared for-all-stages profile', () => {
-      const prevVal = process.env.AWS_PROFILE;
       process.env.AWS_PROFILE = 'notDefault';
       const credentials = newAwsProvider.getCredentials();
-      process.env.AWS_PROFILE = prevVal;
-      expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials).to.eventually.have.deep.property('credentials.profile', 'notDefault');
     });
 
     it('should get credentials from environment declared stage-specific profile', () => {
-      const prevVal = process.env.AWS_TESTSTAGE_PROFILE;
       process.env.AWS_TESTSTAGE_PROFILE = 'notDefault';
       const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
-      process.env.AWS_TESTSTAGE_PROFILE = prevVal;
-      expect(credentials.credentials.profile).to.equal('notDefault');
+      expect(credentials).to.eventually.have.deep.property('credentials.profile', 'notDefault');
     });
   });
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -192,11 +192,6 @@ describe('AwsProvider', () => {
   });
 
   describe('#getCredentials()', () => {
-    const mockCreds = (configParam) => {
-      const config = configParam;
-      delete config.credentials;
-      return config;
-    };
     const awsStub = sinon.stub().returns();
     const AwsProviderProxyquired = proxyquire('./awsProvider.js', {
       'aws-sdk': awsStub,
@@ -221,13 +216,13 @@ describe('AwsProvider', () => {
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = mockCreds(newAwsProvider.getCredentials('teststage', 'testregion'));
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if credentials is an empty object', () => {
       serverless.service.provider.credentials = {};
-      const credentials = mockCreds(newAwsProvider.getCredentials('teststage', 'testregion'));
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -237,7 +232,7 @@ describe('AwsProvider', () => {
         secretAccessKey: undefined,
         sessionToken: undefined,
       };
-      const credentials = mockCreds(newAwsProvider.getCredentials('teststage', 'testregion'));
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -247,7 +242,7 @@ describe('AwsProvider', () => {
         secretAccessKey: '',
         sessionToken: '',
       };
-      const credentials = mockCreds(newAwsProvider.getCredentials('teststage', 'testregion'));
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
@@ -317,13 +312,13 @@ describe('AwsProvider', () => {
 
     it('should not set credentials if profile is not set', () => {
       serverless.service.provider.profile = undefined;
-      const credentials = mockCreds(newAwsProvider.getCredentials('teststage', 'testregion'));
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = mockCreds(newAwsProvider.getCredentials('teststage', 'testregion'));
+      const credentials = newAwsProvider.getCredentials('teststage', 'testregion');
       expect(credentials).to.eql({ region: 'testregion' });
     });
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.12",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",


### PR DESCRIPTION
## What did you implement:

Closes #2355.

This PR enhances the AWS credential code so that 'assume role' profiles are supported. This is similar to #917 that I did for v0.X.X.

Documentation for assume role profiles can be found here:

  http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-cli.html

I also added support for using the AWS_SHARED_CREDENTIALS_FILE environment variable to point to a different credentials file, mirroring the functionality in the AWS CLI tool.

## How did you implement it:

The guts of this PR revolve around refactoring awsProvider.getCredentials() to make a call to AWS.SharedIniFileCredentials.get(). This method automatically retrieves role credentials for us if a user is using an assume role policy.

In order to do so, I had to change awsProvider.getCredentials() to become asynchronous and return a promise.  In turn, I had to refactor all of its calling code to handle it as a promise.

In doing so, I also refactored awsProvider.request() a bit, because it was starting to get a little callback-hellish.

## How can we verify it:

You'll need to set up a role to test with. The following assumes you have an AWS
account with an IAM user who is setup in your AWS credentials file. It also
assumes you have the AWS CLI installed.

Store your AWS account id, aws user, the name of our role:

    aws_account_id=XXXXXXX
    aws_user=jdoe
    aws_role_name=sls-assume-role-test

Create the role:

    aws iam create-role \
      --role-name $aws_role_name \
      --assume-role-policy-document '{
        "Version": "2012-10-17",
        "Statement": [
          {
            "Effect": "Allow",
            "Principal": {
              "AWS": "arn:aws:iam::'$aws_account_id':user/'$aws_user'"
            },
            "Action": "sts:AssumeRole"
          }
        ]
      }'

Make sure to note the Arn in the response, you'll need that later.

Now give that role admin access:

    aws iam attach-role-policy \
      --role-name $aws_role_name \
      --policy-arn arn:aws:iam::aws:policy/AdministratorAccess

Edit your AWS credential file (~/.aws/credentials), and add a new profile that
will assume this role. 'source_profile' needs to refer to a profile in your
credentials file that maps to your AWS user.

    [my-new-profile]
    source_profile = [YOUR USER PROFILE]
    role_arn = [USE ARN FROM create-role COMMAND]

You can test that it's working correctly:

    aws --profile my-new-profile s3 ls

And now the critical part - setup Serverless to use this profile in your
serverless.yml file, and run 'sls deploy'.

To cleanup, remove the profile from the credentials file, then run:

    aws iam detach-role-policy \
      --role-name $aws_role_name \
      --policy-arn arn:aws:iam::aws:policy/AdministratorAccess

    aws iam delete-role \
      --role-name $aws_role_name

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [X] Provide verification config/commands/resources
- [X] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [X] Change ready for review message below


***Is this ready for review?:*** YES
