### PR TITLE
Improve responses in `invoke local`

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -58,21 +58,26 @@ class AwsInvokeLocal {
   }
 
   invokeLocalNodeJs(handlerPath, handlerName, event) {
-    /*
-     * we need require() here to load the handler from the file system
-     * which the user has to supply by passing the function name
-     */
-    const lambda = require(path // eslint-disable-line global-require
-      .join(this.serverless.config.servicePath, handlerPath))[handlerName];
+    let lambda;
+
+    try {
+      /*
+       * we need require() here to load the handler from the file system
+       * which the user has to supply by passing the function name
+       */
+      lambda = require(path // eslint-disable-line global-require
+        .join(this.serverless.config.servicePath, handlerPath))[handlerName];
+    } catch (error) {
+      this.serverless.cli.consoleLog(error);
+      process.exit(0);
+    }
+
     const callback = (err, result) => {
       if (err) {
         throw err;
       } else {
-        this.serverless.cli.log('Your function ran successfully.');
         if (result) {
-          this.serverless.cli.consoleLog('');
           this.serverless.cli.consoleLog(JSON.stringify(result, null, 4));
-          this.serverless.cli.consoleLog('');
         }
         process.exit(0);
       }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2620 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
- On success, invoke local returns only the response. Removed the message `Serverless: successfully invoked your function`.

- On error, it returns the code is wrong, the line, stacktrace as  follow
```
$../serverless/bin/serverless invoke local --function function1
/Users/horike/src/develop-serverless/src/function1/handler.js:7
  sss{
     ^
SyntaxError: Unexpected token {
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:528:28)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at AwsInvokeLocal.invokeLocalNodeJs (/Users/horike/src/serverless/lib/plugins/aws/invokeLocal/index.js:68:16)
    at AwsInvokeLocal.invokeLocal (/Users/horike/src/serverless/lib/plugins/aws/invokeLocal/index.js:50:19)
    at AwsInvokeLocal.tryCatcher (/Users/horike/src/serverless/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/horike/src/serverless/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/horike/src/serverless/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/Users/horike/src/serverless/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/horike/src/serverless/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/Users/horike/src/serverless/node_modules/bluebird/js/release/async.js:138:16)
    at Async._drainQueues (/Users/horike/src/serverless/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues (/Users/horike/src/serverless/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:574:20)
    at tryOnImmediate (timers.js:554:5)
    at processImmediate [as _immediateCallback] (timers.js:533:5)

```
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

