### PR TITLE
Support AWS_SHARED_CREDENTIALS_FILE environment 

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -81,7 +81,7 @@ Default region name [None]: us-west-2
 Default output format [None]: ENTER
 ```
 
-Credentials are stored in INI format in `~/.aws/credentials`, which you can edit directly if needed. Read more about that file in the [AWS documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files)
+Credentials are stored in INI format in `~/.aws/credentials`, which you can edit directly if needed. You can change the path to the credentials file via the AWS_SHARED_CREDENTIALS_FILE environment variable. Read more about that file in the [AWS documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files)
 
 You can even set up different profiles for different accounts, which can be used by Serverless as well. To specify a default profile to use, you can add a `profile` setting to your `provider` configuration in `serverless.yml`:
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -4,6 +4,7 @@ const AWS = require('aws-sdk');
 const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
+const _ = require('lodash');
 
 const naming = require('../lib/naming.js');
 
@@ -56,12 +57,19 @@ const impl = {
    */
   addProfileCredentials: (credentials, profile) => {
     if (profile) {
-      const profileCredentials = new AWS.SharedIniFileCredentials({ profile });
+      const profileCredentials = impl.getIniProfileCredentials(profile);
       if (Object.keys(profileCredentials).length) {
         credentials.profile = profile; // eslint-disable-line no-param-reassign
       }
       impl.addCredentials(credentials, profileCredentials);
     }
+  },
+  getIniProfileCredentials: (profile) => {
+    const params = _.pickBy({
+      profile,
+      filename: process.env.AWS_SHARED_CREDENTIALS_FILE,
+    });
+    return new AWS.SharedIniFileCredentials(params);
   },
   /**
    * Add credentials, if present, from a profile that is specified within the environment

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -353,7 +353,7 @@ describe('AwsProvider', () => {
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
 
-    it.only('should pay attention to AWS_SHARED_CREDENTIALS_FILE', () => {
+    it('should pay attention to AWS_SHARED_CREDENTIALS_FILE', () => {
       // make up some fake credentials
       const tmpAccessKeyId = 'AABBCCDDEEFF';
       const tmpSecretAccessKey = '0123456789876543';

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -354,6 +354,13 @@ describe('AwsProvider', () => {
     });
 
     it('should pay attention to AWS_SHARED_CREDENTIALS_FILE', () => {
+      const prevFileVal = process.env.AWS_SHARED_CREDENTIALS_FILE;
+      const prevProfile = process.env.AWS_PROFILE;
+      const prevStageProfile = process.env.AWS_TESTSTAGE_PROFILE;
+      delete process.env.AWS_SHARED_CREDENTIALS_FILE;
+      delete process.env.AWS_PROFILE;
+      delete process.env.AWS_TESTSTAGE_PROFILE;
+
       // make up some fake credentials
       const tmpAccessKeyId = 'AABBCCDDEEFF';
       const tmpSecretAccessKey = '0123456789876543';
@@ -368,7 +375,6 @@ describe('AwsProvider', () => {
       );
 
       // set envar
-      const prevVal = process.env.AWS_SHARED_CREDENTIALS_FILE;
       process.env.AWS_SHARED_CREDENTIALS_FILE = tmpFilePath;
 
       // use profile defined in credentials file
@@ -382,8 +388,10 @@ describe('AwsProvider', () => {
         secretAccessKey: tmpSecretAccessKey,
       });
 
-      // Reset envar
-      process.env.AWS_SHARED_CREDENTIALS_FILE = prevVal;
+      // Reset envars
+      process.env.AWS_SHARED_CREDENTIALS_FILE = prevFileVal;
+      process.env.AWS_PROFILE = prevProfile;
+      process.env.AWS_TESTSTAGE_PROFILE = prevStageProfile;
     });
   });
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 
 const AwsProvider = require('./awsProvider');
 const Serverless = require('../../../Serverless');
+const testUtils = require('../../../../tests/utils');
 
 describe('AwsProvider', () => {
   let awsProvider;
@@ -350,6 +351,39 @@ describe('AwsProvider', () => {
       const credentials = newAwsProvider.getCredentials();
       process.env.AWS_TESTSTAGE_PROFILE = prevVal;
       expect(credentials.credentials.profile).to.equal('notDefault');
+    });
+
+    it.only('should pay attention to AWS_SHARED_CREDENTIALS_FILE', () => {
+      // make up some fake credentials
+      const tmpAccessKeyId = 'AABBCCDDEEFF';
+      const tmpSecretAccessKey = '0123456789876543';
+
+      // make temporary credentials file
+      const tmpFilePath = testUtils.getTmpFilePath('credentials');
+      serverless.utils.writeFileSync(
+        tmpFilePath,
+        '[notDefault]\n'
+        + `aws_access_key_id = ${tmpAccessKeyId}\n`
+        + `aws_secret_access_key = ${tmpSecretAccessKey}\n`
+      );
+
+      // set envar
+      const prevVal = process.env.AWS_SHARED_CREDENTIALS_FILE;
+      process.env.AWS_SHARED_CREDENTIALS_FILE = tmpFilePath;
+
+      // use profile defined in credentials file
+      serverless.service.provider.profile = 'notDefault';
+
+      // now check that our fake credentials are loaded
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials).to.eql({
+        profile: 'notDefault',
+        accessKeyId: tmpAccessKeyId,
+        secretAccessKey: tmpSecretAccessKey,
+      });
+
+      // Reset envar
+      process.env.AWS_SHARED_CREDENTIALS_FILE = prevVal;
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #2694.

## How did you implement it:

Modified the instatation of AWS.SharedIniFileCredentials in awsProvider.js to pass in a filename if AWS_SHARED_CREDENTIALS_FILE exists in the environment.

## How can we verify it:

First, you'll need a working serverless.yml that uses an AWS profile stored in ~/.aws/credentials.

Move your credentials file:
```
mv $HOME/.aws/credentials $HOME/.aws/credentials-new
```

Test that sls no longer works:
```
sls deploy
```

Point AWS_SHARED_CREDENTIALS_FILE to your new file:
```
export AWS_SHARED_CREDENTIALS_FILE=$HOME/.aws/credentials-new
```

Test that sls now works again:
```
sls deploy
```

Cleanup:
```
mv $HOME/.aws/credentials-new $HOME/.aws/credentials
unset AWS_SHARED_CREDENTIALS_FILE
```

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config/commands/resources
- [X] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
