### PR TITLE
Add dependsOn to Lambda permissions

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -6,6 +6,7 @@ const monitorStack = require('../lib/monitorStack');
 const createStack = require('./lib/createStack');
 const mergeCustomProviderResources = require('./lib/mergeCustomProviderResources');
 const generateArtifactDirectoryName = require('./lib/generateArtifactDirectoryName');
+const addDependsOnToLambdaPermissions = require('./lib/addDependsOnToLambdaPermissions');
 const setBucketName = require('../lib/setBucketName');
 const cleanupS3Bucket = require('./lib/cleanupS3Bucket');
 const uploadArtifacts = require('./lib/uploadArtifacts');
@@ -24,6 +25,7 @@ class AwsDeploy {
       validate,
       createStack,
       generateArtifactDirectoryName,
+      addDependsOnToLambdaPermissions,
       mergeCustomProviderResources,
       setBucketName,
       cleanupS3Bucket,
@@ -47,6 +49,9 @@ class AwsDeploy {
 
       'before:deploy:compileFunctions': () => BbPromise.bind(this)
         .then(this.generateArtifactDirectoryName),
+
+      'after:deploy:compileEvents': () => BbPromise.bind(this)
+        .then(this.addDependsOnToLambdaPermissions),
 
       'deploy:deploy': () => BbPromise.bind(this)
         .then(this.mergeCustomProviderResources)

--- a/lib/plugins/aws/deploy/lib/addDependsOnToLambdaPermissions.js
+++ b/lib/plugins/aws/deploy/lib/addDependsOnToLambdaPermissions.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  addDependsOnToLambdaPermissions() {
+    const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+
+    let dependsOn = null;
+    _.forEach(template.Resources, (value, key) => {
+      const resource = value;
+      if (resource.Type === 'AWS::Lambda::Permission') {
+        if (dependsOn !== null) {
+          if (Array.isArray(resource.DependsOn)) {
+            resource.DependsOn = _.union(resource.DependsOn, [dependsOn]);
+          } else {
+            resource.DependsOn = [dependsOn];
+          }
+        }
+        dependsOn = key;
+      }
+    });
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/deploy/tests/addDependsOnToLambdaPermissions.js
+++ b/lib/plugins/aws/deploy/tests/addDependsOnToLambdaPermissions.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsDeploy = require('../index');
+const AwsProvider = require('../../provider/awsProvider');
+const Serverless = require('../../../../Serverless');
+
+describe('addDependsOnToLambdaPermissions', () => {
+  let serverless;
+  let awsDeploy;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.service = 'add-depends-on-to-lambda-permissions';
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.provider.serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {
+        Permission1: {
+          Type: 'AWS::Lambda::Permission',
+        },
+        Permission2: {
+          Type: 'AWS::Lambda::Permission',
+        },
+        Permission3: {
+          Type: 'AWS::Lambda::Permission',
+        },
+        Permission4: {
+          Type: 'AWS::Lambda::Permission',
+        },
+        Permission5: {
+          Type: 'AWS::Lambda::Permission',
+          DependsOn: ['Permission4'],
+        },
+        Permission6: {
+          Type: 'AWS::Lambda::Permission',
+          DependsOn: ['SomeOtherDependsOn'],
+        },
+      },
+    };
+    awsDeploy.bucketName = 'deployment-bucket';
+    awsDeploy.serverless.cli = new serverless.classes.CLI();
+  });
+
+  describe('#addDependsOnToLambdaPermissions()', () => {
+    it('should add missing DependsOn definitions which reference previous permissions', () =>
+      awsDeploy.addDependsOnToLambdaPermissions().then(() => {
+        expect(
+          awsDeploy.provider.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .Permission1
+        ).to.deep.equal(
+          { Type: 'AWS::Lambda::Permission' }
+        );
+        expect(
+          awsDeploy.provider.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .Permission2
+        ).to.deep.equal(
+          { Type: 'AWS::Lambda::Permission', DependsOn: ['Permission1'] }
+        );
+        expect(
+          awsDeploy.provider.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .Permission3
+        ).to.deep.equal(
+          { Type: 'AWS::Lambda::Permission', DependsOn: ['Permission2'] }
+        );
+        expect(
+          awsDeploy.provider.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .Permission4
+        ).to.deep.equal(
+          { Type: 'AWS::Lambda::Permission', DependsOn: ['Permission3'] }
+        );
+        expect(
+          awsDeploy.provider.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .Permission5
+        ).to.deep.equal(
+          { Type: 'AWS::Lambda::Permission', DependsOn: ['Permission4'] }
+        );
+        expect(
+          awsDeploy.provider.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .Permission6
+        ).to.deep.equal(
+          { Type: 'AWS::Lambda::Permission', DependsOn: ['SomeOtherDependsOn', 'Permission5'] }
+        );
+      })
+    );
+  });
+});

--- a/lib/plugins/aws/deploy/tests/all.js
+++ b/lib/plugins/aws/deploy/tests/all.js
@@ -2,6 +2,7 @@
 
 require('./createStack');
 require('./generateArtifactDirectoryName');
+require('./addDependsOnToLambdaPermissions');
 require('./mergeCustomProviderResources');
 require('./cleanupS3Bucket');
 require('./uploadArtifacts');

--- a/lib/plugins/aws/deploy/tests/index.js
+++ b/lib/plugins/aws/deploy/tests/index.js
@@ -57,6 +57,15 @@ describe('AwsDeploy', () => {
       });
     });
 
+    it('should run "after:deploy:compileEvents" promise chain in order', () => {
+      const addDependsOnToLambdaPermissionsStub = sinon
+        .stub(awsDeploy, 'addDependsOnToLambdaPermissions').returns(BbPromise.resolve());
+
+      return awsDeploy.hooks['after:deploy:compileEvents']().then(() => {
+        expect(addDependsOnToLambdaPermissionsStub.calledOnce).to.be.equal(true);
+      });
+    });
+
     it('should run "deploy:initialize" promise chain in order', () => {
       const configureStackStub = sinon
         .stub(awsDeploy, 'configureStack').returns(BbPromise.resolve());


### PR DESCRIPTION
## What did you implement:

Closes #1995 

Adds a `dependsOn` of the previous Lambda permission so that all the permissions are in place during deployment.

## How did you implement it:

Add code which adds the `dependsOn` definitions after the `compileEvents` lifecycle event (Thanks to @kmfk who came up with a proposal for the implementation 🙌 ).

## How can we verify it:

Run the tests with `npm test` or use the following `serverless.yml` and run `serverless deploy --noDeploy`

```yml
service: depends-on

provider:
  name: aws
  runtime: nodejs4.3

functions:
  hello:
    handler: handler.hello
    events:
      - http: GET hello
      - http:
          path: hello/test
          method: GET
      - sns: hello-topic-1
      - sns: hello-topic-2
      - s3: hello-bucket-1
      - s3: hello-bucket-2
      - schedule: rate(10 minutes)
      - schedule: rate(20 minutes)
  world:
    handler: handler.world
    events:
      - http:
          path: world
          method: GET
          integration: LAMBDA
      - http:
          path: world/test
          method: GET
      - sns: world-topic-1
      - sns: world-topic-2
      - s3: world-bucket-1
      - s3: world-bucket-2
      - schedule: rate(20 minutes)
      - schedule: rate(30 minutes)
```

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES