### PR TITLE
Remove unnecessary timeouts in tests

### DIFF
--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -271,11 +271,14 @@ describe('CLI', () => {
     });
   });
 
-  describe('integration tests', () => {
-    before(function () {
+  describe('Integration tests', function () {
+    this.timeout(0);
+    const that = this;
+
+    before(() => {
       const tmpDir = testUtils.getTmpDirPath();
 
-      this.cwd = process.cwd();
+      that.cwd = process.cwd();
 
       fse.mkdirSync(tmpDir);
       process.chdir(tmpDir);
@@ -286,16 +289,15 @@ describe('CLI', () => {
       // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
       const execPrefix = os.platform() === 'win32' ? 'node ' : '';
 
-      this.serverlessExec = execPrefix + path.join(serverless.config.serverlessPath,
+      that.serverlessExec = execPrefix + path.join(serverless.config.serverlessPath,
         '..', 'bin', 'serverless');
     });
 
-    after(function () { // eslint-disable-line prefer-arrow-callback
-      process.chdir(this.cwd);
+    after(() => {
+      process.chdir(that.cwd);
     });
 
-    it('prints general --help to stdout', function (done) {
-      this.timeout(10000);
+    it('should print general --help to stdout', (done) => {
       exec(`${this.serverlessExec} --help`, (err, stdout) => {
         if (err) {
           done(err);
@@ -307,8 +309,7 @@ describe('CLI', () => {
       });
     });
 
-    it('prints command --help to stdout', function (done) {
-      this.timeout(10000);
+    it('should print command --help to stdout', (done) => {
       exec(`${this.serverlessExec} deploy --help`, (err, stdout) => {
         if (err) {
           done(err);

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -736,27 +736,30 @@ describe('PluginManager', () => {
     });
   });
 
-  it('Plugin/CLI integration', function () {
-    this.timeout(10000);
-    const serverlessInstance = new Serverless();
-    serverlessInstance.init();
+  describe('Plugin / CLI integration', function () {
+    this.timeout(0);
 
-    // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
-    const execPrefix = os.platform() === 'win32' ? 'node ' : '';
-    const serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
-            '..', 'bin', 'serverless');
-    const tmpDir = testUtils.getTmpDirPath();
-    fse.mkdirSync(tmpDir);
-    const cwd = process.cwd();
-    process.chdir(tmpDir);
+    it('should expose a working integration between the CLI and the plugin system', () => {
+      const serverlessInstance = new Serverless();
+      serverlessInstance.init();
 
-    execSync(`${serverlessExec} create --template aws-nodejs`);
+      // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
+      const execPrefix = os.platform() === 'win32' ? 'node ' : '';
+      const serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
+              '..', 'bin', 'serverless');
+      const tmpDir = testUtils.getTmpDirPath();
+      fse.mkdirSync(tmpDir);
+      const cwd = process.cwd();
+      process.chdir(tmpDir);
 
-    expect(serverlessInstance.utils
-      .fileExistsSync(path.join(tmpDir, 'serverless.yml'))).to.equal(true);
-    expect(serverlessInstance.utils
-      .fileExistsSync(path.join(tmpDir, 'handler.js'))).to.equal(true);
+      execSync(`${serverlessExec} create --template aws-nodejs`);
 
-    process.chdir(cwd);
+      expect(serverlessInstance.utils
+        .fileExistsSync(path.join(tmpDir, 'serverless.yml'))).to.equal(true);
+      expect(serverlessInstance.utils
+        .fileExistsSync(path.join(tmpDir, 'handler.js'))).to.equal(true);
+
+      process.chdir(cwd);
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Remove unnecessary timeout definitions which caused the tests / build randomly to fail if the timeout was exceeded.

## How did you implement it:

Just set the timeout for the tests to `0`.

## How can we verify it:

Run `npm test` to see that everything is still working as expected.


## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES