### PR TITLE
Add cfLogs config to simple integration test

### DIFF
--- a/tests/integration/simple-integration-test.js
+++ b/tests/integration/simple-integration-test.js
@@ -30,6 +30,7 @@ describe('Service Lifecyle Integration Test', function () {
   it('should create service in tmp directory', () => {
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
     execSync(`sed -i.bak s/${templateName}/${newServiceName}/g serverless.yml`);
+    execSync("sed -i.bak '/provider:/a \\  cfLogs: true' serverless.yml");
     expect(serverless.utils
       .fileExistsSync(path.join(tmpDir, 'serverless.yml'))).to.be.equal(true);
     expect(serverless.utils


### PR DESCRIPTION
## What did you implement:

Ensures that the log groups of the simple integration tests are also removed once the service is removed.

## How did you implement it:

Use `sed` to add the config to the created `serverless.yml file`

## How can we verify it:

Just run `npm run simple-integration-test`

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES