### PR TITLE
Fix issue 2132 - Fail when incorrect format for additional IAM Role Statements causes them not to be included

### DIFF
--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -123,20 +123,27 @@ module.exports = {
         });
       }
 
-      // add custom iam role statements
-      if (this.serverless.service.provider.iamRoleStatements &&
-        this.serverless.service.provider.iamRoleStatements instanceof Array) {
-        this.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-          .IamPolicyLambdaExecution
-          .Properties
-          .PolicyDocument
-          .Statement = this.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-          .IamPolicyLambdaExecution
-          .Properties
-          .PolicyDocument
-          .Statement.concat(this.serverless.service.provider.iamRoleStatements);
+      if (this.serverless.service.provider.iamRoleStatements) {
+        // add custom iam role statements
+        if (this.serverless.service.provider.iamRoleStatements instanceof Array) {
+          this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources
+            .IamPolicyLambdaExecution
+            .Properties
+            .PolicyDocument
+            .Statement = this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources
+            .IamPolicyLambdaExecution
+            .Properties
+            .PolicyDocument
+            .Statement.concat(this.serverless.service.provider.iamRoleStatements);
+        } else {
+          const errorMessage = [
+            'iamRoleStatements should be an array of objects,',
+            ' where each object has Effect, Action, Resource fields.',
+          ].join('');
+          throw new this.serverless.classes.Error(errorMessage);
+        }
       }
     }
 

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -4,19 +4,6 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
 
-function checkStatements(statements) {
-  if (!(statements instanceof Array)) {
-    return 'not an array';
-  }
-  const flawed = statements.map((statement, i) => {
-    const missing = ['Effect', 'Action', 'Resource'].filter(prop => statement[prop] === undefined);
-    return missing.length === 0 ? null :
-      `entry ${i} is missing the following properties: ${missing.join(', ')}`;
-  }).filter(curr => curr);
-  return flawed.length === 0 ? null : `found flawed entries: ${flawed.join('; ')}`;
-}
-
-
 module.exports = {
   mergeIamTemplates() {
     if (!this.serverless.service.getAllFunctions().length) {
@@ -137,33 +124,50 @@ module.exports = {
       }
 
       if (this.serverless.service.provider.iamRoleStatements) {
-        const reason = checkStatements(this.serverless.service.provider.iamRoleStatements);
-        if (!reason) {
-          // add custom iam role statements
-          this.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources
-            .IamPolicyLambdaExecution
-            .Properties
-            .PolicyDocument
-            .Statement = this.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources
-            .IamPolicyLambdaExecution
-            .Properties
-            .PolicyDocument
-            .Statement.concat(this.serverless.service.provider.iamRoleStatements);
-        } else {
-          const errorMessage = [
-            'iamRoleStatements should be an array of objects,',
-            ' where each object has Effect, Action, Resource fields.',
-            ` Specifically: ${reason}`,
-          ].join('');
-          throw new this.serverless.classes.Error(errorMessage);
-        }
+        this.validateStatements(this.serverless.service.provider.iamRoleStatements);
+        // add custom iam role statements
+        this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamPolicyLambdaExecution
+          .Properties
+          .PolicyDocument
+          .Statement = this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+          .IamPolicyLambdaExecution
+          .Properties
+          .PolicyDocument
+          .Statement.concat(this.serverless.service.provider.iamRoleStatements);
       }
     }
 
     return BbPromise.resolve();
   },
 
+  validateStatements(statements) {
+    let reason;
+    if (!(statements instanceof Array)) {
+      reason = 'not an array';
+    } else {
+      const descriptions = statements.map((statement, i) => {
+        const missing = ['Effect', 'Action', 'Resource'].filter(
+            prop => statement[prop] === undefined);
+        return missing.length === 0 ? null :
+          `entry ${i} is missing the following properties: ${missing.join(', ')}`;
+      });
+      const flawed = descriptions.filter(curr => curr);
+      if (flawed.length) {
+        reason = `found flawed entries: ${flawed.join('; ')}`;
+      }
+    }
+
+    if (reason) {
+      const errorMessage = [
+        'iamRoleStatements should be an array of objects,',
+        ' where each object has Effect, Action, Resource fields.',
+        ` Specifically: ${reason}`,
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+  },
 };
 

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -146,17 +146,17 @@ module.exports = {
   validateStatements(statements) {
     let reason;
     if (!(statements instanceof Array)) {
-      reason = 'not an array';
+      reason = 'it is not an array';
     } else {
       const descriptions = statements.map((statement, i) => {
         const missing = ['Effect', 'Action', 'Resource'].filter(
             prop => statement[prop] === undefined);
         return missing.length === 0 ? null :
-          `entry ${i} is missing the following properties: ${missing.join(', ')}`;
+          `statement ${i} is missing the following properties: ${missing.join(', ')}`;
       });
       const flawed = descriptions.filter(curr => curr);
       if (flawed.length) {
-        reason = `found flawed entries: ${flawed.join('; ')}`;
+        reason = flawed.join('; ');
       }
     }
 
@@ -164,7 +164,7 @@ module.exports = {
       const errorMessage = [
         'iamRoleStatements should be an array of objects,',
         ' where each object has Effect, Action, Resource fields.',
-        ` Specifically: ${reason}`,
+        ` Specifically, ${reason}`,
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -123,9 +123,32 @@ module.exports = {
         });
       }
 
+      function check(statements) {
+        if (!(statements instanceof Array)) {
+          return 'not an array';
+        }
+        const flawed = statements.map((curr, i) => {
+          if (!curr.Effect) {
+            return 'missing Effect field in entry ' + i;
+          }
+          if (!curr.Action) {
+            return 'missing Action field in entry ' + i;
+          }
+          if (!curr.Resource) {
+            return 'missing Resource field in entry ' + i;
+          }
+          return null;
+        }).filter((curr) => (curr != null));
+        if (flawed.length) {
+          return 'found flawed entries: ' + flawed.join('; ');
+        }
+        return null;
+      }
+
       if (this.serverless.service.provider.iamRoleStatements) {
-        // add custom iam role statements
-        if (this.serverless.service.provider.iamRoleStatements instanceof Array) {
+        var reason = check(this.serverless.service.provider.iamRoleStatements);
+        if (!reason) {
+          // add custom iam role statements
           this.serverless.service.provider.compiledCloudFormationTemplate
             .Resources
             .IamPolicyLambdaExecution
@@ -141,6 +164,7 @@ module.exports = {
           const errorMessage = [
             'iamRoleStatements should be an array of objects,',
             ' where each object has Effect, Action, Resource fields.',
+            ' Specifically: ' + reason
           ].join('');
           throw new this.serverless.classes.Error(errorMessage);
         }

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -4,6 +4,19 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
 
+function checkStatements(statements) {
+  if (!(statements instanceof Array)) {
+    return 'not an array';
+  }
+  const flawed = statements.map((curr, i) => {
+    const missing = ['Effect', 'Action', 'Resource'].filter(
+        (prop) => (curr[prop] === undefined));
+    return missing.length === 0 ? null : `entry ${i} is missing: ${missing.join(', ')}`;
+  }).filter((curr) => (curr != null));
+  return flawed.length === 0 ? null : `found flawed entries: ${flawed.join('; ')}`;
+}
+
+
 module.exports = {
   mergeIamTemplates() {
     if (!this.serverless.service.getAllFunctions().length) {
@@ -123,20 +136,8 @@ module.exports = {
         });
       }
 
-      function check(statements) {
-        if (!(statements instanceof Array)) {
-          return 'not an array';
-        }
-        const flawed = statements.map((curr, i) => {
-          const missing = ['Effect', 'Action', 'Resource'].filter(
-              (prop) => (curr[prop] == undefined))
-          return missing.length == 0 ? null : `entry ${i} is missing: ${missing.join(', ')}`;
-        }).filter((curr) => (curr != null));
-        return flawed.length == 0 ? null : `found flawed entries: ${flawed.join('; ')}`;
-      }
-
       if (this.serverless.service.provider.iamRoleStatements) {
-        const reason = check(this.serverless.service.provider.iamRoleStatements);
+        const reason = checkStatements(this.serverless.service.provider.iamRoleStatements);
         if (!reason) {
           // add custom iam role statements
           this.serverless.service.provider.compiledCloudFormationTemplate
@@ -165,3 +166,4 @@ module.exports = {
   },
 
 };
+

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -148,6 +148,8 @@ module.exports = {
   },
 
   validateStatements(statements) {
+    // Verify that iamRoleStatements (if present) is an array of { Effect: ...,
+    // Action: ..., Resource: ... } objects.
     if (!statements) {
       return;
     }

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -128,25 +128,15 @@ module.exports = {
           return 'not an array';
         }
         const flawed = statements.map((curr, i) => {
-          if (!curr.Effect) {
-            return 'missing Effect field in entry ' + i;
-          }
-          if (!curr.Action) {
-            return 'missing Action field in entry ' + i;
-          }
-          if (!curr.Resource) {
-            return 'missing Resource field in entry ' + i;
-          }
-          return null;
+          const missing = ['Effect', 'Action', 'Resource'].filter(
+              (prop) => (curr[prop] == undefined))
+          return missing.length == 0 ? null : `entry ${i} is missing: ${missing.join(', ')}`;
         }).filter((curr) => (curr != null));
-        if (flawed.length) {
-          return 'found flawed entries: ' + flawed.join('; ');
-        }
-        return null;
+        return flawed.length == 0 ? null : `found flawed entries: ${flawed.join('; ')}`;
       }
 
       if (this.serverless.service.provider.iamRoleStatements) {
-        var reason = check(this.serverless.service.provider.iamRoleStatements);
+        const reason = check(this.serverless.service.provider.iamRoleStatements);
         if (!reason) {
           // add custom iam role statements
           this.serverless.service.provider.compiledCloudFormationTemplate
@@ -164,7 +154,7 @@ module.exports = {
           const errorMessage = [
             'iamRoleStatements should be an array of objects,',
             ' where each object has Effect, Action, Resource fields.',
-            ' Specifically: ' + reason
+            ` Specifically: ${reason}`,
           ].join('');
           throw new this.serverless.classes.Error(errorMessage);
         }

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -8,11 +8,11 @@ function checkStatements(statements) {
   if (!(statements instanceof Array)) {
     return 'not an array';
   }
-  const flawed = statements.map((curr, i) => {
-    const missing = ['Effect', 'Action', 'Resource'].filter(
-        (prop) => (curr[prop] === undefined));
-    return missing.length === 0 ? null : `entry ${i} is missing: ${missing.join(', ')}`;
-  }).filter((curr) => (curr != null));
+  const flawed = statements.map((statement, i) => {
+    const missing = ['Effect', 'Action', 'Resource'].filter(prop => statement[prop] === undefined);
+    return missing.length === 0 ? null :
+      `entry ${i} is missing the following properties: ${missing.join(', ')}`;
+  }).filter(curr => curr);
   return flawed.length === 0 ? null : `found flawed entries: ${flawed.join('; ')}`;
 }
 

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -6,6 +6,11 @@ const path = require('path');
 
 module.exports = {
   mergeIamTemplates() {
+    this.validateStatements(this.serverless.service.provider.iamRoleStatements);
+    return this.merge();
+  },
+
+  merge() {
     if (!this.serverless.service.getAllFunctions().length) {
       return BbPromise.resolve();
     }
@@ -124,7 +129,6 @@ module.exports = {
       }
 
       if (this.serverless.service.provider.iamRoleStatements) {
-        this.validateStatements(this.serverless.service.provider.iamRoleStatements);
         // add custom iam role statements
         this.serverless.service.provider.compiledCloudFormationTemplate
           .Resources
@@ -144,9 +148,12 @@ module.exports = {
   },
 
   validateStatements(statements) {
-    let reason;
+    if (!statements) {
+      return;
+    }
+    let violationsFound;
     if (!(statements instanceof Array)) {
-      reason = 'it is not an array';
+      violationsFound = 'it is not an array';
     } else {
       const descriptions = statements.map((statement, i) => {
         const missing = ['Effect', 'Action', 'Resource'].filter(
@@ -156,15 +163,15 @@ module.exports = {
       });
       const flawed = descriptions.filter(curr => curr);
       if (flawed.length) {
-        reason = flawed.join('; ');
+        violationsFound = flawed.join('; ');
       }
     }
 
-    if (reason) {
+    if (violationsFound) {
       const errorMessage = [
         'iamRoleStatements should be an array of objects,',
         ' where each object has Effect, Action, Resource fields.',
-        ` Specifically, ${reason}`,
+        ` Specifically, ${violationsFound}`,
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -105,7 +105,6 @@ describe('#mergeIamTemplates()', () => {
       },
     ];
 
-
     return awsDeploy.mergeIamTemplates()
       .then(() => {
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -116,6 +115,7 @@ describe('#mergeIamTemplates()', () => {
 
   it('should throw error if custom IAM policy statements is not an array', () => {
     awsDeploy.serverless.service.provider.iamRoleStatements = {
+      policy: 'some_value',
       statments: [
         {
           Effect: 'Allow',
@@ -126,6 +126,15 @@ describe('#mergeIamTemplates()', () => {
         },
       ]
     };
+
+    expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
+  });
+
+  it('should throw error if a custom IAM policy statement does not have an Action field', () => {
+    awsDeploy.serverless.service.provider.iamRoleStatements = [{
+        Effect: 'Allow',
+        Resource: '*'
+      }];
 
     expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
   });

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -160,6 +160,26 @@ describe('#mergeIamTemplates()', () => {
         'missing the following properties: Resource');
   });
 
+  it('should throw an error describing all problematics custom IAM policy statements', () => {
+    awsDeploy.serverless.service.provider.iamRoleStatements = [
+      {
+        Action: ['something:SomethingElse'],
+        Effect: 'Allow',
+      },
+      {
+        Action: ['something:SomethingElse'],
+        Resource: '*',
+        Effect: 'Allow',
+      },
+      {
+        Resource: '*',
+      },
+    ];
+
+    expect(() => awsDeploy.mergeIamTemplates())
+      .to.throw(/statement 0 is missing.*Resource; statement 2 is missing.*Effect, Action/);
+  });
+
   it('should add a CloudWatch LogGroup resource', () => {
     awsDeploy.serverless.service.provider.cfLogs = true;
     const normalizedName = `${functionName[0].toUpperCase()}${functionName.substr(1)}LogGroup`;

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -130,13 +130,34 @@ describe('#mergeIamTemplates()', () => {
     expect(() => awsDeploy.mergeIamTemplates()).to.throw('not an array');
   });
 
+  it('should throw error if a custom IAM policy statement does not have an Effect field', () => {
+    awsDeploy.serverless.service.provider.iamRoleStatements = [{
+      Action: ['something:SomethingElse'],
+      Resource: '*',
+    }];
+
+    expect(() => awsDeploy.mergeIamTemplates()).to.throw(
+        'missing the following properties: Effect');
+  });
+
   it('should throw error if a custom IAM policy statement does not have an Action field', () => {
     awsDeploy.serverless.service.provider.iamRoleStatements = [{
       Effect: 'Allow',
       Resource: '*',
     }];
 
-    expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
+    expect(() => awsDeploy.mergeIamTemplates()).to.throw(
+        'missing the following properties: Action');
+  });
+
+  it('should throw error if a custom IAM policy statement does not have a Resource field', () => {
+    awsDeploy.serverless.service.provider.iamRoleStatements = [{
+      Action: ['something:SomethingElse'],
+      Effect: 'Allow',
+    }];
+
+    expect(() => awsDeploy.mergeIamTemplates()).to.throw(
+        'missing the following properties: Resource');
   });
 
   it('should add a CloudWatch LogGroup resource', () => {

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -124,7 +124,7 @@ describe('#mergeIamTemplates()', () => {
           ],
           Resource: 'some:aws:arn:xxx:*:*',
         },
-      ]
+      ],
     };
 
     expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
@@ -132,9 +132,9 @@ describe('#mergeIamTemplates()', () => {
 
   it('should throw error if a custom IAM policy statement does not have an Action field', () => {
     awsDeploy.serverless.service.provider.iamRoleStatements = [{
-        Effect: 'Allow',
-        Resource: '*'
-      }];
+      Effect: 'Allow',
+      Resource: '*',
+    }];
 
     expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
   });

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -127,7 +127,7 @@ describe('#mergeIamTemplates()', () => {
       ],
     };
 
-    expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
+    expect(() => awsDeploy.mergeIamTemplates()).to.throw('not an array');
   });
 
   it('should throw error if a custom IAM policy statement does not have an Action field', () => {

--- a/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/tests/mergeIamTemplates.js
@@ -114,6 +114,22 @@ describe('#mergeIamTemplates()', () => {
       });
   });
 
+  it('should throw error if custom IAM policy statements is not an array', () => {
+    awsDeploy.serverless.service.provider.iamRoleStatements = {
+      statments: [
+        {
+          Effect: 'Allow',
+          Action: [
+            'something:SomethingElse',
+          ],
+          Resource: 'some:aws:arn:xxx:*:*',
+        },
+      ]
+    };
+
+    expect(() => awsDeploy.mergeIamTemplates()).to.throw(Error);
+  });
+
   it('should add a CloudWatch LogGroup resource', () => {
     awsDeploy.serverless.service.provider.cfLogs = true;
     const normalizedName = `${functionName[0].toUpperCase()}${functionName.substr(1)}LogGroup`;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -96,7 +96,7 @@ describe('AwsProvider', () => {
       });
     });
 
-    it('should retry if error code is 429', function (done) {
+    xit('should retry if error code is 429', function (done) {
       this.timeout(10000);
       let first = true;
       const error = {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -96,7 +96,7 @@ describe('AwsProvider', () => {
       });
     });
 
-    xit('should retry if error code is 429', function (done) {
+    it('should retry if error code is 429', function (done) {
       this.timeout(10000);
       let first = true;
       const error = {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2132: Yell when incorrect format for additional IAM Role Statements causes them not to be included

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

added a validateStatements() in lib/plugins/aws/deploy/lib/mergeIamTemplates.js
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->
```
$ cat > serverless.yml <<EOF
> service: wed-2253
> 
> provider:
>   name: aws
>   runtime: nodejs4.3
>   iamRoleStatements:
>     Version: "2012-10-17"
>     Statement:
>     - Effect: "Allow"
>       Action:
>         - "s3:ListBucket"
>       Resource: "*"
> 
> functions:
>   hello:
>     handler: handler.hello
> 
> EOF

$ sls deploy --noDeploy
 
  Serverless Error ---------------------------------------
 
     iamRoleStatements should be an array of objects, where
     each object has Effect, Action, Resource fields. Specifically,
     it is not an array
   ....

```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
