### PR TITLE
Remove API Keys integration tests

### DIFF
--- a/tests/integration/all.js
+++ b/tests/integration/all.js
@@ -11,12 +11,10 @@ require('./aws/general/overwrite-resources/tests');
 require('./aws/api-gateway/integration-lambda/simple-api/tests');
 require('./aws/api-gateway/integration-lambda/custom-authorizers/tests');
 require('./aws/api-gateway/integration-lambda/cors/tests');
-require('./aws/api-gateway/integration-lambda/api-keys/tests');
 // Integration: Lambda Proxy
 require('./aws/api-gateway/integration-lambda-proxy/simple-api/tests');
 require('./aws/api-gateway/integration-lambda-proxy/custom-authorizers/tests');
 require('./aws/api-gateway/integration-lambda-proxy/cors/tests');
-require('./aws/api-gateway/integration-lambda-proxy/api-keys/tests');
 
 // Schedule
 require('./aws/schedule/multiple-schedules-multiple-functions/tests');


### PR DESCRIPTION
## What did you implement:

Closes #2655

Remove the API Keys tests for now.

## How did you implement it:

Just removed the tests.

## How can we verify it:

Run `npm run complex-integration-test`.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES