### PR TITLE
Lambda environment variables

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -220,19 +220,38 @@ Then, when you run `serverless deploy`, VPC configuration will be deployed along
 
 ## Environment Variables
 
-We're working on great environment variable support. Until then, you'll be able to use the following tools for different languages to set environment variables and make them available to your code.
+You can add Environment Variable configuration to a specific function in `serverless.yml` by adding an `environment` object property in the function configuration. This object should contain a a key/value collection of string:string:
 
-## Javascript
+```yml
+# serverless.yml
+service: service-name
+provider: aws
 
-You can use [dotenv](https://www.npmjs.com/package/dotenv) to load files with environment variables. Those variables can be set during your CI process or locally and then packaged and deployed together with your function code.
+functions:
+  hello:
+    handler: handler.hello
+    environment:
+      TABLE_NAME: tableName
+```
 
-## Python
+Or if you want to apply Environment Variable configuration to all functions in your service, you can add the configuration to the higher level `provider` object, and overwrite these service level config at the function level. For example:
 
-You can use [python-dotenv](https://github.com/theskumar/python-dotenv) to load files with environment variables. Those variables can be set during your CI process or locally and then packaged and deployed together with your function code.
+```yml
+# serverless.yml
+service: service-name
+provider:
+  name: aws
+  environment:
+    TABLE_NAME: tableName1
 
-## Java
-
-For Java the easiest way to set up environment like configuration is through [property files](https://docs.oracle.com/javase/tutorial/essential/environment/properties.html). While those will not be available as environment variables they are very commonly used configuration mechanisms throughout Java.
+functions:
+  hello: # this function will overwrite the service level environment config above
+    handler: handler.hello
+    environment:
+      TABLE_NAME: tableName2
+  users: # this function will inherit the service level environment config above
+    handler: handler.users
+```
 
 ## Log Group Resources
 

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -81,6 +81,13 @@ class AwsCompileFunctions {
       newFunction.Properties.Description = functionObject.description;
     }
 
+    if (functionObject.environment) {
+      Object.assign(newFunction.Properties.Environment.Variables,
+          this.serverless.service.provider.environment);
+      Object.assign(newFunction.Properties.Environment.Variables,
+          functionObject.environment);
+    }
+
     if ('role' in functionObject) {
       newFunction.Properties.Role = this.compileRole(functionObject.role);
     } else if ('role' in this.serverless.service.provider) {
@@ -142,6 +149,9 @@ class AwsCompileFunctions {
             Ref: 'ServerlessDeploymentBucket',
           },
           S3Key: 'S3Key',
+        },
+        Environment: {
+          Variables:{}
         },
         FunctionName: 'FunctionName',
         Handler: 'Handler',

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -82,17 +82,17 @@ class AwsCompileFunctions {
     }
 
     newFunction.Properties.Environment.Variables = Object.assign(
-      {}, 
-      this.serverless.service.provider.environment, 
+      {},
+      this.serverless.service.provider.environment,
       functionObject.environment
-    )
+    );
 
-    for(var key in newFunction.Properties.Environment.Variables){
+    Object.keys(newFunction.Properties.Environment.Variables).forEach((key) => {
       // I pulled this from the bash man pages
-      if(!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)){
-        throw new Error("Invalid characters in environment variable");
+      if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
+        throw new Error('Invalid characters in environment variable');
       }
-    }
+    });
 
     if ('role' in functionObject) {
       newFunction.Properties.Role = this.compileRole(functionObject.role);

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -86,6 +86,12 @@ class AwsCompileFunctions {
       this.serverless.service.provider.environment, 
       functionObject.environment
     )
+
+    for(var key in newFunction.Properties.Environment.Variables){
+      // I pulled this from the bash man pages
+      if(!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)){
+        throw new Error("Invalid characters in environment variable");
+      }
     }
 
     if ('role' in functionObject) {

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -81,11 +81,11 @@ class AwsCompileFunctions {
       newFunction.Properties.Description = functionObject.description;
     }
 
-    if (functionObject.environment) {
-      Object.assign(newFunction.Properties.Environment.Variables,
-          this.serverless.service.provider.environment);
-      Object.assign(newFunction.Properties.Environment.Variables,
-          functionObject.environment);
+    newFunction.Properties.Environment.Variables = Object.assign(
+      {}, 
+      this.serverless.service.provider.environment, 
+      functionObject.environment
+    )
     }
 
     if ('role' in functionObject) {

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -81,18 +81,22 @@ class AwsCompileFunctions {
       newFunction.Properties.Description = functionObject.description;
     }
 
-    newFunction.Properties.Environment.Variables = Object.assign(
-      {},
-      this.serverless.service.provider.environment,
-      functionObject.environment
-    );
+    if (functionObject.environment || this.serverless.service.provider.environment) {
+      newFunction.Properties.Environment = {};
+      newFunction.Properties.Environment.Variables = Object.assign(
+        {},
+        this.serverless.service.provider.environment,
+        functionObject.environment
+      );
 
-    Object.keys(newFunction.Properties.Environment.Variables).forEach((key) => {
-      // I pulled this from the bash man pages
-      if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
-        throw new Error('Invalid characters in environment variable');
-      }
-    });
+      Object.keys(newFunction.Properties.Environment.Variables).forEach((key) => {
+        // taken from the bash man pages
+        if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
+          const errorMessage = 'Invalid characters in environment variable';
+          throw new this.serverless.classes.Error(errorMessage);
+        }
+      });
+    }
 
     if ('role' in functionObject) {
       newFunction.Properties.Role = this.compileRole(functionObject.role);
@@ -155,9 +159,6 @@ class AwsCompileFunctions {
             Ref: 'ServerlessDeploymentBucket',
           },
           S3Key: 'S3Key',
-        },
-        Environment: {
-          Variables: {},
         },
         FunctionName: 'FunctionName',
         Handler: 'Handler',

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -151,7 +151,7 @@ class AwsCompileFunctions {
           S3Key: 'S3Key',
         },
         Environment: {
-          Variables:{}
+          Variables: {},
         },
         FunctionName: 'FunctionName',
         Handler: 'Handler',

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -379,7 +379,7 @@ describe('AwsCompileFunctions', () => {
       };
 
       awsCompileFunctions.serverless.service.provider.environment = {
-        providerTest1: 'providerTest1'
+        providerTest1: 'providerTest1',
       };
 
       const compliedFunction = {
@@ -400,8 +400,8 @@ describe('AwsCompileFunctions', () => {
             Variables: {
               test1: 'test1',
               test2: 'test2',
-              providerTest1: 'providerTest1'
-            }
+              providerTest1: 'providerTest1',
+            },
           },
         },
       };

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -379,7 +379,7 @@ describe('AwsCompileFunctions', () => {
       };
 
       awsCompileFunctions.serverless.service.provider.environment = {
-        "providerTest1":"providerTest1"
+        providerTest1: 'providerTest1'
       };
 
       const compliedFunction = {
@@ -391,9 +391,6 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           FunctionName: 'new-service-dev-func',
-          Environment: {
-            Variables: {},
-          },
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -420,6 +420,22 @@ describe('AwsCompileFunctions', () => {
       };
     });
 
+
+    it('should throw if invalid environment variable name', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          environment: {
+            '1test1': 'test1',
+            test2: 'test2',
+          },
+        },
+      };
+
+      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
+    });
+
     it('should consider function based config when creating a function resource', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -297,6 +297,9 @@ describe('AwsCompileFunctions', () => {
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
+          Environment: {
+            Variables:{}
+          },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
           MemorySize: 1024,
@@ -334,6 +337,9 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           FunctionName: 'new-service-dev-func',
+          Environment: {
+            Variables:{}
+          },
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
@@ -342,6 +348,63 @@ describe('AwsCompileFunctions', () => {
           VpcConfig: {
             SecurityGroupIds: ['xxx'],
             SubnetIds: ['xxx'],
+          },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+      ).to.deep.equal(compliedFunction);
+
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+      };
+    });
+
+    it('should create a function resource with Environment config', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          environment: {
+            test1: 'test1',
+            test2: 'test2',
+          },
+        },
+      };
+
+      awsCompileFunctions.serverless.service.provider.environment = {
+        "providerTest1":"providerTest1"
+      }
+
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
+              awsCompileFunctions.serverless.service.package.artifact}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Environment: {
+            Variables:{}
+          },
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Environment: {
+            Variables: {
+              test1: 'test1',
+              test2: 'test2',
+              providerTest1: 'providerTest1'
+            }
           },
         },
       };
@@ -378,6 +441,9 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           FunctionName: 'customized-func-function',
+          Environment: {
+            Variables:{}
+          },
           Handler: 'func.function.handler',
           MemorySize: 128,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
@@ -414,6 +480,9 @@ describe('AwsCompileFunctions', () => {
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
+          Environment: {
+            Variables:{}
+          },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
           MemorySize: 1024,
@@ -444,6 +513,9 @@ describe('AwsCompileFunctions', () => {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          Environment: {
+            Variables:{}
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -479,6 +551,9 @@ describe('AwsCompileFunctions', () => {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          Environment: {
+            Variables:{}
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -516,6 +591,9 @@ describe('AwsCompileFunctions', () => {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: bucketName,
+          },
+          Environment: {
+            Variables:{}
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -297,9 +297,6 @@ describe('AwsCompileFunctions', () => {
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
-          Environment: {
-            Variables: {},
-          },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
           MemorySize: 1024,
@@ -337,9 +334,6 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           FunctionName: 'new-service-dev-func',
-          Environment: {
-            Variables: {},
-          },
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
@@ -421,7 +415,7 @@ describe('AwsCompileFunctions', () => {
     });
 
 
-    it('should throw if invalid environment variable name', () => {
+    it('should throw an error if environment variable has invalid name', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -454,9 +448,6 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           FunctionName: 'customized-func-function',
-          Environment: {
-            Variables: {},
-          },
           Handler: 'func.function.handler',
           MemorySize: 128,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
@@ -493,9 +484,6 @@ describe('AwsCompileFunctions', () => {
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
-          Environment: {
-            Variables: {},
-          },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
           MemorySize: 1024,
@@ -526,9 +514,6 @@ describe('AwsCompileFunctions', () => {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          Environment: {
-            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -564,9 +549,6 @@ describe('AwsCompileFunctions', () => {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          Environment: {
-            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -604,9 +586,6 @@ describe('AwsCompileFunctions', () => {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
             S3Bucket: bucketName,
-          },
-          Environment: {
-            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -298,7 +298,7 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -338,7 +338,7 @@ describe('AwsCompileFunctions', () => {
           },
           FunctionName: 'new-service-dev-func',
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           Handler: 'func.function.handler',
           MemorySize: 1024,
@@ -380,7 +380,7 @@ describe('AwsCompileFunctions', () => {
 
       awsCompileFunctions.serverless.service.provider.environment = {
         "providerTest1":"providerTest1"
-      }
+      };
 
       const compliedFunction = {
         Type: 'AWS::Lambda::Function',
@@ -392,7 +392,7 @@ describe('AwsCompileFunctions', () => {
           },
           FunctionName: 'new-service-dev-func',
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           Handler: 'func.function.handler',
           MemorySize: 1024,
@@ -442,7 +442,7 @@ describe('AwsCompileFunctions', () => {
           },
           FunctionName: 'customized-func-function',
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           Handler: 'func.function.handler',
           MemorySize: 128,
@@ -481,7 +481,7 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -515,7 +515,7 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -553,7 +553,7 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
           },
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -593,7 +593,7 @@ describe('AwsCompileFunctions', () => {
             S3Bucket: bucketName,
           },
           Environment: {
-            Variables:{}
+            Variables: {},
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',

--- a/lib/plugins/aws/deploy/compile/functions/tests/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/tests/index.js
@@ -360,7 +360,7 @@ describe('AwsCompileFunctions', () => {
       };
     });
 
-    it('should create a function resource with Environment config', () => {
+    it('should create a function resource with environment config', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -414,6 +414,100 @@ describe('AwsCompileFunctions', () => {
       };
     });
 
+    it('should create a function resource with function level environment config', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          environment: {
+            test1: 'test1',
+          },
+        },
+      };
+
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
+              awsCompileFunctions.serverless.service.package.artifact}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Environment: {
+            Variables: {
+              test1: 'test1',
+            },
+          },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+      ).to.deep.equal(compliedFunction);
+
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+      };
+    });
+
+    it('should create a function resource with provider level environment config', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+        },
+      };
+
+      awsCompileFunctions.serverless.service.provider.environment = {
+        providerTest1: 'providerTest1',
+      };
+
+      const compliedFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
+              awsCompileFunctions.serverless.service.package.artifact}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Environment: {
+            Variables: {
+              providerTest1: 'providerTest1',
+            },
+          },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+      ).to.deep.equal(compliedFunction);
+
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+      };
+    });
 
     it('should throw an error if environment variable has invalid name', () => {
       awsCompileFunctions.serverless.service.functions = {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Lambda environment variable support.

Closes #2673

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added a new property to the function template object and then used Object.assign to merge the dictionaries from the provider object and the function object.

## How can we verify it:

### `serverless.yml`

```yml
service: environment-variables

provider:
  environment:
    provider_level: provider
  name: aws
  runtime: nodejs4.3
  cfLogs: true

functions:
  hello:
    environment:
      FUNCTION_LEVEL: function
    handler: handler.hello
    events:
      - http:
          integration: lambda
          path: hello
          method: get
```

### `handler.js`

```javascript
'use strict';

module.exports.hello = (event, context, callback) => {
  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
  callback(null, {
    message: 'Go Serverless v1.0! Your function executed successfully!',
    event,
    context,
    env: process.env,
  });
};
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.
Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
