### PR TITLE
Merge custom s3 bucket templates with the same bucket name. fixes #2717

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -110,3 +110,40 @@ resources:
       Properties:
         RetentionInDays: "30"
 ```
+
+
+## Override S3 Bucket Resource
+S3 buckets can be overridden by using a matching bucket name in the s3 event and resources section:
+```yml
+functions:
+ upload-hook:
+    handler: api/upload-hook/index.handler
+    events:
+      - s3:
+          bucket: ${self:service}.${self:custom.stage}.assets
+          event: s3:ObjectCreated:*
+
+resources:
+  Resources:
+    AssetsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        AccessControl: Private
+        BucketName: "${self:service}.${self:custom.stage}.assets"
+        CorsConfiguration:
+          CorsRules:
+          - AllowedOrigins:
+              - http://example.dev:3001
+            AllowedHeaders:
+              - "*"
+            AllowedMethods:
+              - PUT
+              - GET
+          - AllowedOrigins:
+              - https://dev.example.com
+            AllowedHeaders:
+              - "*"
+            AllowedMethods:
+              - PUT
+              - GET
+```

--- a/lib/plugins/aws/deploy/lib/data/compiled-cloudformation-template-with-s3-event.json
+++ b/lib/plugins/aws/deploy/lib/data/compiled-cloudformation-template-with-s3-event.json
@@ -1,0 +1,132 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "The AWS CloudFormation template for this Serverless application",
+  "Resources": {
+    "ServerlessDeploymentBucket": {
+      "Type": "AWS::S3::Bucket"
+    },
+    "IamRoleLambdaExecution": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/"
+      }
+    },
+    "IamPolicyLambdaExecution": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "dev-example-api-lambda",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream"
+              ],
+              "Resource": "arn:aws:logs:us-east-1:*:*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "logs:PutLogEvents"
+              ],
+              "Resource": "arn:aws:logs:us-east-1:*:*"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "IamRoleLambdaExecution"
+          }
+        ]
+      }
+    },
+    "UploadDashhookLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/example-api/dev/1479672395453-2016-11-20T20:06:35.453Z/example-api-dev-upload-hook.zip"
+        },
+        "FunctionName": "example-api-dev-upload-hook",
+        "Handler": "_optimize/example-api-dev-upload-hook.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Timeout": 6
+      }
+    },
+    "S3Bucketexampleapidevassets": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketName": "example-api.dev.assets",
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Event": "s3:ObjectCreated:*",
+              "Function": {
+                "Fn::GetAtt": [
+                  "UploadDashhookLambdaFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "UploadDashhookLambdaPermissionS3": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "UploadDashhookLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "s3.amazonaws.com"
+      }
+    }
+  },
+  "Outputs": {
+    "ServerlessDeploymentBucketName": {
+      "Value": {
+        "Ref": "ServerlessDeploymentBucket"
+      }
+    },
+    "UploadDashhookLambdaFunctionArn": {
+      "Description": "Lambda function info",
+      "Value": {
+        "Fn::GetAtt": [
+          "UploadDashhookLambdaFunction",
+          "Arn"
+        ]
+      }
+    }
+  }
+}

--- a/lib/plugins/aws/deploy/lib/data/custom-resources-with-s3.json
+++ b/lib/plugins/aws/deploy/lib/data/custom-resources-with-s3.json
@@ -1,0 +1,40 @@
+{
+  "Resources": {
+    "AssetsBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "Private",
+        "BucketName": "example-api.dev.assets",
+        "CorsConfiguration": {
+          "CorsRules": [
+            {
+              "AllowedOrigins": [
+                "http://example.dev:3001"
+              ],
+              "AllowedHeaders": [
+                "*"
+              ],
+              "AllowedMethods": [
+                "PUT",
+                "GET"
+              ]
+            },
+            {
+              "AllowedOrigins": [
+                "https://dev.example.com"
+              ],
+              "AllowedHeaders": [
+                "*"
+              ],
+              "AllowedMethods": [
+                "PUT",
+                "GET"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {}
+}

--- a/lib/plugins/aws/deploy/lib/mergeCustomProviderResources.js
+++ b/lib/plugins/aws/deploy/lib/mergeCustomProviderResources.js
@@ -3,6 +3,37 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
+function indexS3Buckets(resources) {
+  const result = {};
+  _.forEach(resources, (resource, logicalId) => {
+    if (resource.Type === 'AWS::S3::Bucket' &&
+      resource.Properties && resource.Properties.BucketName) {
+      result[resource.Properties.BucketName] = { logicalId, resource };
+    }
+  });
+  return result;
+}
+
+function mergeS3Buckets(compiledResources, customResources) {
+  const customBuckets = indexS3Buckets(customResources);
+
+  if (!_.isEmpty(customBuckets)) {
+    const compiledBuckets = indexS3Buckets(compiledResources);
+
+    _.forEach(customBuckets, (customBucket, name) => {
+      const compiledBucket = compiledBuckets[name];
+      if (compiledBucket) {
+        // eslint-disable-next-line no-param-reassign
+        compiledResources[customBucket.logicalId] =
+          _.merge({}, compiledBucket.resource, customBucket.resource);
+        // eslint-disable-next-line no-param-reassign
+        delete compiledResources[compiledBucket.logicalId];
+      }
+    });
+  }
+}
+
+
 module.exports = {
   mergeCustomProviderResources() {
     if (this.serverless.service.resources && !this.serverless.service.resources.Resources) {
@@ -12,6 +43,12 @@ module.exports = {
       this.serverless.service.resources.Outputs = {};
     }
 
+    mergeS3Buckets(
+      this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+      this.serverless.service.resources.Resources
+    );
+
+    // merge rest
     _.merge(
       this.serverless.service.provider.compiledCloudFormationTemplate,
       this.serverless.service.resources

--- a/lib/plugins/aws/deploy/lib/mergeCustomProviderResources.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeCustomProviderResources.test.js
@@ -4,6 +4,11 @@ const path = require('path');
 const expect = require('chai').expect;
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+const _ = require('lodash');
+
+const customResourcesWithS3 = require('./data/custom-resources-with-s3.json');
+const compiledCloudFormationTemplateWithS3 =
+  require('./data/compiled-cloudformation-template-with-s3-event.json');
 
 describe('mergeCustomProviderResources', () => {
   let serverless;
@@ -162,6 +167,70 @@ describe('mergeCustomProviderResources', () => {
         ).to.deep.equal(
           coreCloudFormationTemplate.Outputs.ServerlessDeploymentBucketName
         );
+      });
+    });
+
+
+    it('should merge custom s3 bucket templates with the same bucket name', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate =
+        _.clone(compiledCloudFormationTemplateWithS3);
+
+      awsDeploy.serverless.service.resources = _.clone(customResourcesWithS3);
+
+      const expected = {
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          BucketName: 'example-api.dev.assets',
+          NotificationConfiguration: {
+            LambdaConfigurations: [
+              {
+                Event: 's3:ObjectCreated:*',
+                Function: {
+                  'Fn::GetAtt': [
+                    'UploadDashhookLambdaFunction',
+                    'Arn',
+                  ],
+                },
+              },
+            ],
+          },
+          AccessControl: 'Private',
+          CorsConfiguration: {
+            CorsRules: [
+              {
+                AllowedOrigins: [
+                  'http://example.dev:3001',
+                ],
+                AllowedHeaders: [
+                  '*',
+                ],
+                AllowedMethods: [
+                  'PUT',
+                  'GET',
+                ],
+              },
+              {
+                AllowedOrigins: [
+                  'https://dev.example.com',
+                ],
+                AllowedHeaders: [
+                  '*',
+                ],
+                AllowedMethods: [
+                  'PUT',
+                  'GET',
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      return awsDeploy.mergeCustomProviderResources().then(() => {
+        expect(
+          awsDeploy.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources.AssetsBucket
+        ).to.deep.equal(expected);
       });
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2717

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I updated `mergeCustomProviderResources.js` to merge s3 bucket templates based on bucket name. If a custom bucket template exists in the custom resources section of `serverless.yml` and the same bucket is referenced in a function event the two are merged.

## How can we verify it:

Unit tests

1. Create a function with an s3 event in `serverless.yml`
1. Add an s3 bucket in the `resources` section of `serverless.yml`
1. Add custom configuration to the bucket in `resources`. For example add CORS settings.
1. Run `sls deploy -v`
1. Verify the s3 bucket template was properly merged in`.serverless/cloudformation-template-update-stack.json` with the logical id of the custom resource.
1. Verify that the s3 bucket is created with the merged config.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

