### PR TITLE
bring back provider.getStackName()

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -12,6 +12,21 @@ const constants = {
 };
 
 const impl = {
+
+  /**
+   * Deprecated method. Moved to naming.js
+   * Kept here for backward compatibility
+   */
+  getStackNmae(stage) {
+    const warningMessage = [
+      'Deprecation Notice: provider.getStackName() method is deprecated.',
+      ' Please reference the naming.js file instead: ',
+      ' ex. naming.getStackName();',
+    ].join('');
+
+    this.serverless.cli.log(warningMessage);
+    return `${this.serverless.service.service}-${stage}`;
+  },
   /**
    * Add credentials, if present, from the given credentials configuration
    * @param credentials The credentials to add credentials configuration to

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -12,21 +12,6 @@ const constants = {
 };
 
 const impl = {
-
-  /**
-   * Deprecated method. Moved to naming.js
-   * Kept here for backward compatibility
-   */
-  getStackName(stage) {
-    const warningMessage = [
-      'Deprecation Notice: provider.getStackName() method is deprecated.',
-      ' Please reference the naming.js file instead: ',
-      ' ex. naming.getStackName();',
-    ].join('');
-
-    this.serverless.cli.log(warningMessage);
-    return `${this.serverless.service.service}-${stage}`;
-  },
   /**
    * Add credentials, if present, from the given credentials configuration
    * @param credentials The credentials to add credentials configuration to
@@ -124,6 +109,21 @@ class AwsProvider {
     if (timeout) {
       AWS.config.httpOptions.timeout = parseInt(timeout, 10);
     }
+  }
+
+  /**
+   * Deprecated method. Moved to naming.js
+   * Kept here for backward compatibility
+   */
+  getStackName(stage) {
+    const warningMessage = [
+      'Deprecation Notice: provider.getStackName() method is deprecated.',
+      ' Please reference the naming.js file instead: ',
+      ' ex. naming.getStackName();',
+    ].join('');
+
+    this.serverless.cli.log(warningMessage);
+    return `${this.serverless.service.service}-${stage}`;
   }
 
   request(service, method, params) {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -17,7 +17,7 @@ const impl = {
    * Deprecated method. Moved to naming.js
    * Kept here for backward compatibility
    */
-  getStackNmae(stage) {
+  getStackName(stage) {
     const warningMessage = [
       'Deprecation Notice: provider.getStackName() method is deprecated.',
       ' Please reference the naming.js file instead: ',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #12345

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** NO

