### PR TITLE
add support for lambda env vars in invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 const path = require('path');
 const validate = require('../lib/validate');
 
@@ -15,6 +16,7 @@ class AwsInvokeLocal {
     this.hooks = {
       'invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.extendedValidate)
+        .then(this.loadEnvVars)
         .then(this.invokeLocal),
     };
   }
@@ -34,6 +36,15 @@ class AwsInvokeLocal {
       }
       this.options.data = this.serverless.utils.readFileSync(absolutePath);
     }
+
+    return BbPromise.resolve();
+  }
+
+  loadEnvVars() {
+    const providerEnvVars = this.serverless.service.provider.environment || {};
+    const functionEnvVars = this.options.functionObj.environment || {};
+
+    _.merge(process.env, providerEnvVars, functionEnvVars);
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/aws/invokeLocal/tests/index.js
+++ b/lib/plugins/aws/invokeLocal/tests/index.js
@@ -28,15 +28,19 @@ describe('AwsInvokeLocal', () => {
     it('should run promise chain in order', () => {
       const validateStub = sinon
         .stub(awsInvokeLocal, 'extendedValidate').returns(BbPromise.resolve());
+      const loadEnvVarsStub = sinon
+        .stub(awsInvokeLocal, 'loadEnvVars').returns(BbPromise.resolve());
       const invokeLocalStub = sinon
         .stub(awsInvokeLocal, 'invokeLocal').returns(BbPromise.resolve());
 
 
       return awsInvokeLocal.hooks['invoke:local:invoke']().then(() => {
         expect(validateStub.calledOnce).to.be.equal(true);
-        expect(invokeLocalStub.calledAfter(validateStub)).to.be.equal(true);
+        expect(loadEnvVarsStub.calledAfter(validateStub)).to.be.equal(true);
+        expect(invokeLocalStub.calledAfter(loadEnvVarsStub)).to.be.equal(true);
 
         awsInvokeLocal.extendedValidate.restore();
+        awsInvokeLocal.loadEnvVars.restore();
         awsInvokeLocal.invokeLocal.restore();
       });
     });
@@ -147,6 +151,44 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.options.path = false;
 
       awsInvokeLocal.extendedValidate().then(() => done());
+    });
+  });
+
+  describe('#loadEnvVars()', () => {
+    beforeEach(() => {
+      serverless.config.servicePath = true;
+      serverless.service.provider = {
+        environment: {
+          providerVar: 'providerValue',
+        },
+      };
+
+      awsInvokeLocal.options = {
+        functionObj: {
+          environment: {
+            functionVar: 'functionValue',
+          },
+        },
+      };
+    });
+
+    it('it should load provider env vars', () => awsInvokeLocal
+      .loadEnvVars().then(() => {
+        expect(process.env.providerVar).to.be.equal('providerValue');
+      })
+    );
+
+    it('it should load function env vars', () => awsInvokeLocal
+      .loadEnvVars().then(() => {
+        expect(process.env.functionVar).to.be.equal('functionValue');
+      })
+    );
+
+    it('it should overwrite provider env vars', () => {
+      awsInvokeLocal.options.functionObj.environment.providerVar = 'providerValueOverwritten';
+      return awsInvokeLocal.loadEnvVars().then(() => {
+        expect(process.env.providerVar).to.be.equal('providerValueOverwritten');
+      });
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add support for lambda env vars in invoke local. Any env vars that you set in `serverless.yml` will be available when you run `sls invoke local` without having to load them manually.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Added a new `loadEnvVars()` method to invoke local that runs before running the function.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
#### serverless.yml
```yml
service: serverless-local-env-vars

provider:
  name: aws
  cfLogs: true
  environment:
    hello: world

functions:
  hello:
    environment:
      hello2: world2
      hello: worldOverwritten
    handler: handler.hello
```
#### handler.js:
```js
module.exports.hello = (event, context, callback) => {
  console.log(process.env.hello)
  console.log(process.env.hello2)
  const body = {
    message: 'Go Serverless v1.0! Your function executed successfully!',
    input: event,
  };

  const response = {
    statusCode: 200,
    headers: {
      'custom-header': 'Custom header value',
    },
    body: JSON.stringify(event),
  };

  return  callback(null, event);
};
```

run `serverless invoke local -f hello` and see the env vars values in the console
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
