### PR TITLE
Skip Travis builds on .md changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ matrix:
         - LINTING=true
 sudo: false
 
+before_install:
+- |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+    fi
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs))/' || {
+      echo "No code was updated. Stopping build process."
+      exit
+    }
+
 install:
   - travis_retry npm install
 

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -98,6 +98,7 @@ functions:
     memorySize: 512 # function specific
 ```
 
+
 ## Permissions
 
 Every AWS Lambda function needs permission to interact with other AWS infrastructure resources within your account.  These permissions are set via an AWS IAM Role.  You can set permission policy statements within this role via the `provider.iamRoleStatements` property.


### PR DESCRIPTION
## What did you implement:

Closes #2699

Skips builds which only contains `.md` / `docs` changes.

## How did you implement it:

Add a `before_install` script.

## How can we verify it:

I ran the following tests:
- Change `README.md` --> Build skipped
- Change `docs/*.md` --> Build skipped
- Change `*.js` file --> Build ran
- Change `*.md` and `*.js` file --> Build ran

## Todos:

- [x] Change ready for review message below

***Is this ready for review?:*** YES