### PR TITLE
fixed breaking change with apig resource with variable

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -12,9 +12,12 @@ module.exports = {
     return this.normalizeName(name.replace(/[^0-9A-Za-z]/g, ''));
   },
   normalizePathPart(path) {
-    return this.normalizeNameToAlphaNumericOnly(
-      path.replace(/-/g, 'Dash')
-        .replace(/\{(.*)\}/g, '$1Var'));
+    return _.upperFirst(
+      _.capitalize(path)
+        .replace(/-/g, 'Dash')
+        .replace(/\{(.*)\}/g, '$1Var')
+        .replace(/[^0-9A-Za-z]/g, '')
+    );
   },
 
   getServiceEndpointRegex() {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -44,7 +44,7 @@ describe('#naming()', () => {
     });
   });
 
-  describe('#normalizeNameToCapitalAlphaNumbericOnly()', () => {
+  describe('#normalizePathPart()', () => {
     it('converts `-` to `Dash`', () => {
       expect(sdk.naming.normalizePathPart(
         'a-path'
@@ -60,7 +60,7 @@ describe('#naming()', () => {
     it('converts variable declarations prefixes to `VariableVarPath`', () => {
       expect(sdk.naming.normalizePathPart(
         '${variable}Path'
-      )).to.equal('VariableVarPath');
+      )).to.equal('VariableVarpath');
     });
 
     it('converts variable declarations suffixes to `PathvariableVar`', () => {
@@ -72,7 +72,7 @@ describe('#naming()', () => {
     it('converts variable declarations in center to `PathvariableVarDir`', () => {
       expect(sdk.naming.normalizePathPart(
         'path${variable}Dir'
-      )).to.equal('PathvariableVarDir');
+      )).to.equal('PathvariableVardir');
     });
   });
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -57,7 +57,7 @@ describe('#naming()', () => {
       )).to.equal('VariableVar');
     });
 
-    it('converts variable declarations prefixes to `VariableVarPath`', () => {
+    it('converts variable declarations prefixes to `VariableVarpath`', () => {
       expect(sdk.naming.normalizePathPart(
         '${variable}Path'
       )).to.equal('VariableVarpath');
@@ -69,7 +69,7 @@ describe('#naming()', () => {
       )).to.equal('PathvariableVar');
     });
 
-    it('converts variable declarations in center to `PathvariableVarDir`', () => {
+    it('converts variable declarations in center to `PathvariableVardir`', () => {
       expect(sdk.naming.normalizePathPart(
         'path${variable}Dir'
       )).to.equal('PathvariableVardir');


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2771 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
There was an accidental change in the logical ID name of the APIG resource. A very tiny change in capitalization.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Check the issue
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** NO
