### PR TITLE
Cleanup after event.json removal

### DIFF
--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -86,11 +86,11 @@ This example will locally invoke your function.
 #### Local function invocation with event data
 
 You can input test data in `event.json` file inside your service directory:
+
 ```json
 {
   "foo": "bar"
 }
-
 ```
 
 and then pass it with the command

--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -97,5 +97,5 @@ functions:
     handler: handler.hello
     package:
       exclude:
-        - event.json
+        - some-file.js
 ```

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -63,7 +63,6 @@ Check out the [create command docs](../cli-reference/create) for all the details
 You'll see the following files in your working directory:
 - `serverless.yml`
 - `handler.js`
-- `event.json`
 
 ### serverless.yml
 
@@ -146,7 +145,9 @@ The `handler.js` file contains your function code. The function definition in `s
 
 ### event.json
 
-This file contains event data you can use to invoke your function with via `serverless invoke -p event.json`
+**Note:** This file is not created by default
+
+Create this file and add event data so you can invoke your function with the data via `serverless invoke -p event.json`
 
 ## Deployment
 

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -127,8 +127,6 @@ describe('Create', () => {
       return create.create().then(() => {
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
           .to.be.equal(true);
-        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'event.json')))
-          .to.be.equal(true);
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'pom.xml')))
           .to.be.equal(true);
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'src', 'main', 'java',
@@ -158,8 +156,6 @@ describe('Create', () => {
 
       return create.create().then(() => {
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
-          .to.be.equal(true);
-        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'event.json')))
           .to.be.equal(true);
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'build.gradle')))
           .to.be.equal(true);
@@ -200,8 +196,6 @@ describe('Create', () => {
 
       return create.create().then(() => {
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
-          .to.be.equal(true);
-        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'event.json')))
           .to.be.equal(true);
         expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'build.sbt')))
           .to.be.equal(true);

--- a/tests/templates/integration-test-template
+++ b/tests/templates/integration-test-template
@@ -34,7 +34,7 @@ echo "Deploying Service"
 serverless deploy -v
 
 echo "Invoking Service"
-serverless invoke --function hello --path event.json -l
+serverless invoke --function hello
 
 echo "Removing Service"
 serverless remove -v


### PR DESCRIPTION
## What did you implement:

Merging #2787 brokes the tests and left some incorrect `event.json` references in the codebase. This PR fixes this.

## How did you implement it:

Removed unnecessarz `event.json` references.

## How can we verify it:

Look through the changes in this PR.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES