### PR TITLE
Remove skipping of Travis builds for .md changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,8 @@ matrix:
       env:
         - DISABLE_TESTS=true
         - LINTING=true
-sudo: false
 
-before_install:
-- |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
-    fi
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs))/' || {
-      echo "No code was updated. Stopping build process."
-      exit
-    }
+sudo: false
 
 install:
   - travis_retry npm install

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -98,7 +98,6 @@ functions:
     memorySize: 512 # function specific
 ```
 
-
 ## Permissions
 
 Every AWS Lambda function needs permission to interact with other AWS infrastructure resources within your account.  These permissions are set via an AWS IAM Role.  You can set permission policy statements within this role via the `provider.iamRoleStatements` property.


### PR DESCRIPTION
## What did you implement:

Closes #2790 

Remove the build skipping.

## How did you implement it:

Remove the `before_install` script.

## How can we verify it:

Look at Travis.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES