### PR TITLE
fixed logical id for lambda version

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -69,7 +69,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |IAM::Role              | IamRoleLambdaExecution                                  | IamRoleLambdaExecution        |
 |IAM::Policy            | IamPolicyLambdaExecution                                | IamPolicyLambdaExecution      |
 |Lambda::Function       | {normalizedFunctionName}LambdaFunction                  | HelloLambdaFunction           |
-|Lambda::Version        | {functionName}Version{sha256}                           | helloVersionr3pgoTvv1xT4E4NiCL6JG02fl6vIyi7OS1aW0FwAI |
+|Lambda::Version        | {normalizedFunctionName}LambdaVersion{sha256}                           | HelloLambdaVersionr3pgoTvv1xT4E4NiCL6JG02fl6vIyi7OS1aW0FwAI |
 |Logs::LogGroup         | {normalizedFunctionName}LogGroup                        | HelloLogGroup                 |
 |Lambda::Permission     | <ul><li>**Schedule**: {normalizedFunctionName}LambdaPermissionEventsRuleSchedule{index} </li><li>**S3**: {normalizedFunctionName}LambdaPermission{normalizedBucketName}S3</li><li>**APIG**: {normalizedFunctionName}LambdaPermissionApiGateway</li><li>**SNS**: {normalizedFunctionName}LambdaPermission{normalizedTopicName}SNS</li> | <ul><li>**Schedule**: HelloLambdaPermissionEventsRuleSchedule1 </li><li>**S3**: HelloLambdaPermissionBucketS3</li><li>**APIG**: HelloLambdaPermissionApiGateway</li><li>**SNS**: HelloLambdaPermissionTopicSNS</li> |
 |Events::Rule           | {normalizedFuntionName}EventsRuleSchedule{SequentialID} | HelloEventsRuleSchedule1      |

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -800,7 +800,7 @@ describe('AwsCompileFunctions', () => {
         },
         FuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
-          Value: { Ref: 'funcVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
+          Value: { Ref: 'FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
         },
         AnotherFuncLambdaFunctionArn: {
           Description: 'Lambda function info',
@@ -809,7 +809,7 @@ describe('AwsCompileFunctions', () => {
         AnotherFuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
           Value: {
-            Ref: 'anotherFuncVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
+            Ref: 'AnotherFuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
           },
         },
       };

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -125,7 +125,8 @@ module.exports = {
     return /LambdaFunctionArn$/;
   },
   getLambdaVersionLogicalId(functionName, sha) {
-    return `${functionName}Version${sha.replace(/[^0-9a-z]/gi, '')}`;
+    return `${this.getNormalizedFunctionName(functionName)}LambdaVersion${sha
+      .replace(/[^0-9a-z]/gi, '')}`;
   },
   getLambdaVersionOutputLogicalId(functionName) {
     return `${this.getLambdaLogicalId(functionName)}QualifiedArn`;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Quick fix for the Lambda::Version logical ID to stay consistent with our pattern. Compliments PR #2676.. (Thanks @ryansb 😊 )

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** NO

