### PR TITLE
add Support for SNS Subscription to existing topics

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -38,9 +38,9 @@ functions:
 
 This will run both functions for a message sent to the dispatch topic.
 
-## Creating the permission for a pre-existing topic
+## Using a pre-existing topic
 
-If you want to run a function from a preexisting SNS topic you need to connect the topic to a Lambda function yourself. By defining a topic arn inside of the SNS topic we're able to set up the Lambda Permission so SNS is allowed to call this function.
+If an `arn:` is specified, the framework will give permission to the topic to invoke the function and subscribe the function to the topic.
 
 ```yml
 functions:
@@ -49,8 +49,6 @@ functions:
     events:
       - sns: arn:xxx
 ```
-
-Just make sure your function is already subscribed to the topic, as there's no way to add subscriptions to pre-existing topics in CF. The framework will just give permission to SNS to invoke the function.
 
 ## Setting a display name
 

--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -81,4 +81,5 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |
+|SNS::Subscription      | {normalizedFunctionName}SnsSubscription{normalizedTopicName}   | HelloSnsSubscriptionSomeTopic             |
 |AWS::Lambda::EventSourceMapping | <ul><li>**DynamoDB:** {normalizedFunctionName}EventSourceMappingDynamodb{tableName}</li><li>**Kinesis:** {normalizedFunctionName}EventSourceMappingKinesis{streamName}</li></ul> | <ul><li>**DynamoDB:** HelloLambdaEventSourceMappingDynamodbUsers</li><li>**Kinesis:** HelloLambdaEventSourceMappingKinesisMystream</li></ul> |

--- a/lib/plugins/aws/deploy/compile/events/sns/index.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/index.js
@@ -13,36 +13,47 @@ class AwsCompileSNSEvents {
   }
 
   compileSNSEvents() {
-    const topicsCreated = [];
+    const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionObj = this.serverless.service.getFunction(functionName);
 
       if (functionObj.events) {
         functionObj.events.forEach(event => {
           if (event.sns) {
+            let topicArn;
             let topicName;
             let displayName = '';
 
             if (typeof event.sns === 'object') {
-              if (!event.sns.topicName || !event.sns.displayName) {
+              ['topicName', 'displayName'].forEach((property) => {
+                if (typeof event.sns[property] === 'string') {
+                  return;
+                }
                 const errorMessage = [
-                  `Missing "topicName" property for sns event in function ${functionName}`,
-                  ' The correct syntax is: sns: topic-name',
-                  ' OR an object with "topicName" AND "displayName" properties.',
+                  `Missing or invalid "${property}" property for sns event`,
+                  ` in function ${functionName}`,
+                  ' The correct syntax is: sns: topic-name-or-arn',
+                  ' OR an object with "topicName" AND "displayName" strings.',
                   ' Please check the docs for more info.',
                 ].join('');
                 throw new this.serverless.classes
                   .Error(errorMessage);
-              } else {
-                topicName = event.sns.topicName;
-                displayName = event.sns.displayName;
-              }
+              });
+              topicName = event.sns.topicName;
+              displayName = event.sns.displayName;
             } else if (typeof event.sns === 'string') {
-              topicName = event.sns;
+              if (event.sns.indexOf('arn:') === 0) {
+                topicArn = event.sns;
+                const splitArn = topicArn.split(':');
+                topicName = splitArn[splitArn.length - 1];
+              } else {
+                topicName = event.sns;
+              }
             } else {
               const errorMessage = [
                 `SNS event of function ${functionName} is not an object nor a string`,
-                ' The correct syntax is: sns: topic-name',
+                ' The correct syntax is: sns: topic-name-or-arn',
                 ' OR an object with "topicName" AND "displayName" properties.',
                 ' Please check the docs for more info.',
               ].join('');
@@ -52,79 +63,77 @@ class AwsCompileSNSEvents {
 
             const lambdaLogicalId = this.provider.naming
               .getLambdaLogicalId(functionName);
-            const topicLogicalId = this.provider.naming
-              .getTopicLogicalId(topicName);
+
+            const endpoint = {
+              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+            };
+
+            if (topicArn) {
+              const subscriptionLogicalId = this.provider.naming
+                .getLambdaSnsSubscriptionLogicalId(functionName, topicName);
+
+              _.merge(template.Resources, {
+                [subscriptionLogicalId]: {
+                  Type: 'AWS::SNS::Subscription',
+                  Properties: {
+                    TopicArn: topicArn,
+                    Protocol: 'lambda',
+                    Endpoint: endpoint,
+                  },
+                },
+              });
+            } else {
+              topicArn = {
+                'Fn::Join': ['',
+                  [
+                    'arn:aws:sns:',
+                    { Ref: 'AWS::Region' },
+                    ':',
+                    { Ref: 'AWS::AccountId' },
+                    ':',
+                    topicName,
+                  ],
+                ],
+              };
+              const topicLogicalId = this.provider.naming
+                .getTopicLogicalId(topicName);
+
+              const subscription = {
+                Endpoint: endpoint,
+                Protocol: 'lambda',
+              };
+
+              if (topicLogicalId in template.Resources) {
+                template.Resources[topicLogicalId]
+                  .Properties.Subscription.push(subscription);
+              } else {
+                _.merge(template.Resources, {
+                  [topicLogicalId]: {
+                    Type: 'AWS::SNS::Topic',
+                    Properties: {
+                      TopicName: topicName,
+                      DisplayName: displayName,
+                      Subscription: [subscription],
+                    },
+                  },
+                });
+              }
+            }
+
             const lambdaPermissionLogicalId = this.provider.naming
               .getLambdaSnsPermissionLogicalId(functionName, topicName);
 
-            const snsTemplate = `
-              {
-                "Type": "AWS::SNS::Topic",
-                "Properties": {
-                  "TopicName": "${topicName}",
-                  "DisplayName": "${displayName}",
-                  "Subscription": [
-                    {
-                      "Endpoint": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
-                      "Protocol": "lambda"
-                    }
-                  ]
-                }
-              }
-            `;
-
-            const permissionTemplate = `
-              {
-                "Type": "AWS::Lambda::Permission",
-                "Properties": {
-                  "FunctionName": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
-                  "Action": "lambda:InvokeFunction",
-                  "Principal": "sns.amazonaws.com",
-                  "SourceArn": {
-                    "Fn::Join": ["",
-                      ["arn:aws:sns:",
-                      { "Ref": "AWS::Region"},
-                      ":",
-                      { "Ref": "AWS::AccountId"},
-                      ":",
-                      "${topicName}"]
-                     ]
-                  }
-                }
-              }
-            `;
-
-            const newSNSObject = {
-              [topicLogicalId]: JSON.parse(snsTemplate),
-            };
-
-            const newPermissionObject = {
-              [lambdaPermissionLogicalId]: JSON.parse(permissionTemplate),
-            };
-
-            // create new topic only if not created before
-            if (topicsCreated.indexOf(topicName) === -1) {
-              _.merge(this.serverless.service.provider
-                  .compiledCloudFormationTemplate.Resources,
-                newSNSObject);
-              topicsCreated.push(topicName);
-            } else {
-              const newSubscription = {
-                Protocol: 'lambda',
-                Endpoint: {
-                  'Fn::GetAtt': [
-                    lambdaLogicalId,
-                    'Arn',
-                  ],
+            _.merge(template.Resources, {
+              [lambdaPermissionLogicalId]: {
+                Type: 'AWS::Lambda::Permission',
+                Properties: {
+                  FunctionName: endpoint,
+                  Action: 'lambda:InvokeFunction',
+                  Principal: 'sns.amazonaws.com',
+                  SourceArn: topicArn,
                 },
-              };
-              this.serverless.service.provider.compiledCloudFormationTemplate
-                .Resources[topicLogicalId]
-                .Properties.Subscription.push(newSubscription);
-            }
-
-            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-              newPermissionObject);
+              },
+            });
           }
         });
       }

--- a/lib/plugins/aws/deploy/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/sns/index.test.js
@@ -88,6 +88,9 @@ describe('AwsCompileSNSEvents', () => {
 
       awsCompileSNSEvents.compileSNSEvents();
 
+      expect(Object.keys(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources)
+      ).to.have.length(2);
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.SNSTopicTopic1.Type
       ).to.equal('AWS::SNS::Topic');
@@ -129,6 +132,30 @@ describe('AwsCompileSNSEvents', () => {
         awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources
       ).to.deep.equal({});
+    });
+
+    it('should not create SNS topic when arn is given', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: 'arn:aws:foo',
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(Object.keys(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources)
+      ).to.have.length(2);
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionFoo.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionFooSNS.Type
+      ).to.equal('AWS::Lambda::Permission');
     });
   });
 });

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -223,6 +223,10 @@ module.exports = {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermission${
       this.normalizeTopicName(topicName)}SNS`;
   },
+  getLambdaSnsSubscriptionLogicalId(functionName, topicName) {
+    return `${this.getNormalizedFunctionName(functionName)}SnsSubscription${
+      this.normalizeTopicName(topicName)}`;
+  },
   getLambdaSchedulePermissionLogicalId(functionName, scheduleIndex) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionEventsRuleSchedule${
       scheduleIndex}`;

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -425,4 +425,11 @@ describe('#naming()', () => {
           .to.equal('FunctionNameLambdaPermissionAlexaSkill');
       });
   });
+
+  describe('#getLambdaSnsSubscriptionLogicalId()', () => {
+    it('should normalize the function name and append the standard suffix', () => {
+      expect(sdk.naming.getLambdaSnsSubscriptionLogicalId('functionName', 'topicName'))
+        .to.equal('FunctionNameSnsSubscriptionTopicName');
+    });
+  });
 });

--- a/tests/integration/aws/sns/existing-topic/service/handler.js
+++ b/tests/integration/aws/sns/existing-topic/service/handler.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  process.stdout.write(event.Records[0].EventSource);
+  process.stdout.write(event.Records[0].Sns.Message);
+  callback(null, { message: 'Hello from SNS!', event });
+};

--- a/tests/integration/aws/sns/existing-topic/service/serverless.yml
+++ b/tests/integration/aws/sns/existing-topic/service/serverless.yml
@@ -1,0 +1,12 @@
+service: aws-nodejs
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+  cfLogs: true
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - sns: ${env:EXISTING_TOPIC_ARN}

--- a/tests/integration/aws/sns/existing-topic/tests.js
+++ b/tests/integration/aws/sns/existing-topic/tests.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const Utils = require('../../../../utils/index');
+const uuid = require('uuid');
+
+describe('AWS - SNS: Existing topic with single function', function () {
+  this.timeout(0);
+
+  const snsTopic = uuid.v4();
+
+  before(() => Utils.createSnsTopic(snsTopic)
+    .then((result) => {
+      process.env.EXISTING_TOPIC_ARN = result.TopicArn;
+    }));
+
+  before(() => {
+    Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should trigger function when new message is published', () => Utils
+    .publishSnsMessage(snsTopic, 'hello world')
+    .delay(60000)
+    .then(() => {
+      const logs = Utils.getFunctionLogs('hello');
+      expect(/aws:sns/g.test(logs)).to.equal(true);
+      expect(/hello world/g.test(logs)).to.equal(true);
+    })
+  );
+
+  after(() => {
+    Utils.removeService();
+  });
+
+  after(() => {
+    Utils.removeSnsTopic(snsTopic);
+  });
+});

--- a/tests/integration/aws/sns/existing-topic/tests.js
+++ b/tests/integration/aws/sns/existing-topic/tests.js
@@ -5,20 +5,18 @@ const expect = require('chai').expect;
 const Utils = require('../../../../utils/index');
 const uuid = require('uuid');
 
-describe('AWS - SNS: Existing topic with single function', function () {
-  this.timeout(0);
-
+describe('AWS - SNS: Existing topic with single function', () => {
   const snsTopic = uuid.v4();
 
-  before(() => Utils.createSnsTopic(snsTopic)
+  beforeAll(() => Utils.createSnsTopic(snsTopic)
     .then((result) => {
       process.env.EXISTING_TOPIC_ARN = result.TopicArn;
-    }));
-
-  before(() => {
-    Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
-    Utils.deployService();
-  });
+    })
+    .then(() => {
+      Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+      Utils.deployService();
+    })
+  );
 
   it('should trigger function when new message is published', () => Utils
     .publishSnsMessage(snsTopic, 'hello world')
@@ -30,11 +28,8 @@ describe('AWS - SNS: Existing topic with single function', function () {
     })
   );
 
-  after(() => {
+  afterAll(() => {
     Utils.removeService();
-  });
-
-  after(() => {
     Utils.removeSnsTopic(snsTopic);
   });
 });

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -73,6 +73,34 @@ module.exports = {
       });
   },
 
+  createSnsTopic(topicName) {
+    const SNS = new AWS.SNS({ region: 'us-east-1' });
+    BbPromise.promisifyAll(SNS, { suffix: 'Promised' });
+
+    const params = {
+      Name: topicName,
+    };
+
+    return SNS.createTopicPromised(params);
+  },
+
+  removeSnsTopic(topicName) {
+    const SNS = new AWS.SNS({ region: 'us-east-1' });
+    BbPromise.promisifyAll(SNS, { suffix: 'Promised' });
+
+    return SNS.listTopicsPromised()
+      .then(data => {
+        const topicArn = data.Topics.find(topic => RegExp(topicName, 'g')
+          .test(topic.TopicArn)).TopicArn;
+
+        const params = {
+          TopicArn: topicArn,
+        };
+
+        return SNS.deleteTopicPromised(params);
+      });
+  },
+
   publishSnsMessage(topicName, message) {
     const SNS = new AWS.SNS({ region: 'us-east-1' });
     BbPromise.promisifyAll(SNS, { suffix: 'Promised' });


### PR DESCRIPTION
## What did you implement:

Closes #2183 

Also subscribes to the existing SNS topic when the ARN is specified.

## How did you implement it:

An if/else statement. I preserved the existing behavior at the expense of a small amount of code reuse, so that existing stacks do not change with this feature. (Which is to say: The "Subscription" is part of the "Topic" resource if the topic defined within serverless.yml. If the topic is an arn:, then a new Resource is added to CFN, which is an AWS:SNS:Subscription.

## How can we verify it:

There are unit tests and a new integration test.

```yml
service: new-service

provider:
  name: aws
  runtime: nodejs4.3

functions:
  hello:
    handler: handler.hello
    events:
      - sns: arn:aws:sns:us-east-1:XXXX:my-existing-topic
      - sns:
          topicName: new-sns-topic
          displayName: some description
      - sns: third-sns-topic
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

