### PR TITLE
remove request and response config when using proxy integration

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -98,7 +98,7 @@ module.exports = {
               const warningMessage = [
                 'Warning! You\'re using the LAMBDA-PROXY in combination with request / response',
                 ` configuration in your function "${functionName}".`,
-                ' This configuration will be ignored during deployment.',
+                ' Serverless will remove this configuration automatically before deployment.',
               ].join('');
               this.serverless.cli.log(warningMessage);
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -62,7 +62,7 @@ module.exports = {
             corsPreflight[http.path] = cors;
           }
 
-          http.integration = this.getIntegration(http);
+          http.integration = this.getIntegration(http, functionName);
 
           if (http.integration === 'AWS') {
             if (http.request) {
@@ -101,6 +101,9 @@ module.exports = {
                 ' This configuration will be ignored during deployment.',
               ].join('');
               this.serverless.cli.log(warningMessage);
+
+              delete http.request;
+              delete http.response;
             }
           }
 
@@ -277,7 +280,7 @@ module.exports = {
     return cors;
   },
 
-  getIntegration(http) {
+  getIntegration(http, functionName) {
     if (http.integration) {
       const allowedIntegrations = [
         'LAMBDA-PROXY', 'LAMBDA',
@@ -288,7 +291,7 @@ module.exports = {
       if (allowedIntegrations.indexOf(normalizedIntegration) === NOT_FOUND) {
         const errorMessage = [
           `Invalid APIG integration "${http.integration}"`,
-          ` in function "${http.functionName}".`,
+          ` in function "${functionName}".`,
           ' Supported integrations are: lambda, lambda-proxy.',
         ].join('');
         throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.test.js
@@ -1038,6 +1038,38 @@ describe('#validate()', () => {
     expect(logStub.args[0][0].length).to.be.at.least(1);
   });
 
+  it('should remove request/response config with LAMBDA-PROXY', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda-proxy',
+              request: {
+                template: {
+                  'template/1': '{ "stage" : "$context.stage" }',
+                },
+              },
+              response: {},
+            },
+          },
+        ],
+      },
+    };
+    // initialize so we get the log method from the CLI in place
+    serverless.init();
+
+    // don't want to print the logs in this test
+    sinon.stub(serverless.cli, 'log');
+
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events).to.be.an('Array').with.length(1);
+    expect(validated.events[0].http.request).to.equal(undefined);
+    expect(validated.events[0].http.response).to.equal(undefined);
+  });
+
   it('should throw an error when an invalid integration type was provided', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {


### PR DESCRIPTION
## What did you implement:

Closes #2798

## How did you implement it:

What was being 'ignored' was the parsing of the request/response configuration, not the configuration itself.

## How can we verify it:

Tests pass, and example yaml in the issue now deploys.


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors (* other code on master is having linting problems??)
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

