### PR TITLE
BREAKING - change core CF template to use a shortened bucket name. Fixes #2791

### DIFF
--- a/docs/providers/aws/cli-reference/info.md
+++ b/docs/providers/aws/cli-reference/info.md
@@ -75,5 +75,5 @@ ScreenshotBucket: dev-svdgraaf-screenshots
 CreateThumbnailsLambdaFunctionArn: arn:aws:lambda:us-east-1:377024778620:function:lambda-screenshots-dev-createThumbnails
 TakeScreenshotLambdaFunctionArn: arn:aws:lambda:us-east-1:377024778620:function:lambda-screenshots-dev-takeScreenshot
 ServiceEndpoint: https://12341jc801.execute-api.us-east-1.amazonaws.com/dev
-ServerlessDeploymentBucketName: lambda-screenshots-dev-serverlessdeploymentbucket-15b7pkc04f98a
+ServerlessDeploymentBucketName: lambda-screenshots-dev-slsdeploy-15b7pkc04f98a
 ```

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -138,7 +138,7 @@ provider:
       -  Effect: "Allow"
          Action:
            - "s3:ListBucket"
-         Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket"} ] ] } # You can put CloudFormation syntax in here.  No one will judge you.  Remember, this all gets translated to CloudFormation.
+         Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "SlsDeploy"} ] ] } # You can put CloudFormation syntax in here.  No one will judge you.  Remember, this all gets translated to CloudFormation.
       -  Effect: "Allow"
          Action:
            - "s3:PutObject"
@@ -146,7 +146,7 @@ provider:
            Fn::Join:
              - ""
              - - "arn:aws:s3:::"
-               - "Ref" : "ServerlessDeploymentBucket"
+               - "Ref" : "SlsDeploy"
 
 functions:
   functionOne:

--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -33,7 +33,7 @@ provider:
          Fn::Join:
            - ""
            - - "arn:aws:s3:::"
-           - Ref: ServerlessDeploymentBucket
+           - Ref: SlsDeploy
     -  Effect: "Allow"
        Action:
          - "s3:PutObject"
@@ -41,7 +41,7 @@ provider:
          Fn::Join:
            - ""
            - - "arn:aws:s3:::"
-           - Ref : "ServerlessDeploymentBucket"
+           - Ref : "SlsDeploy"
 
 ```
 
@@ -113,7 +113,7 @@ resources:
                      Fn::Join:
                        - ""
                        - - "arn:aws:s3:::"
-                         - "Ref" : "ServerlessDeploymentBucket"
+                         - "Ref" : "SlsDeploy"
 ```
 
 ### Custom IAM Roles For Each Function
@@ -197,7 +197,7 @@ resources:
                      Fn::Join:
                        - ""
                        - - "arn:aws:s3:::"
-                         - "Ref" : "ServerlessDeploymentBucket"
+                         - "Ref" : "SlsDeploy"
 ```
 
 ### A Custom Default Role & Custom Function Roles
@@ -249,7 +249,7 @@ resources:
                      Fn::Join:
                        - ""
                        - - "arn:aws:s3:::"
-                         - "Ref" : "ServerlessDeploymentBucket"
+                         - "Ref" : "SlsDeploy"
     myCustRole0:
       Type: AWS::IAM::Role
       Properties:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -47,7 +47,7 @@ provider:
          Fn::Join:
            - ''
            - - 'arn:aws:s3:::'
-           - Ref: ServerlessDeploymentBucket
+           - Ref: SlsDeploy
   stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except deleting/replacing EC2 instances (use with caution!)
     - Effect: Allow
       Principal: "*"

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -190,7 +190,7 @@ class AwsCompileFunctions {
       Properties: {
         Code: {
           S3Bucket: {
-            Ref: 'ServerlessDeploymentBucket',
+            Ref: 'SlsDeploy',
           },
           S3Key: 'S3Key',
         },

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -302,7 +302,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -338,7 +338,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -389,7 +389,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -438,7 +438,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -486,7 +486,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -537,7 +537,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -597,7 +597,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'customized-func-function',
           Handler: 'func.function.handler',
@@ -634,7 +634,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -665,7 +665,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',
@@ -700,7 +700,7 @@ describe('AwsCompileFunctions', () => {
           Code: {
             S3Key: `${awsCompileFunctions.serverless.service.package.artifactDirectoryName}/${
               awsCompileFunctions.serverless.service.package.artifact}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Bucket: { Ref: 'SlsDeploy' },
           },
           FunctionName: 'new-service-dev-func',
           Handler: 'func.function.handler',

--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -42,7 +42,7 @@ module.exports = {
             .Outputs.ServerlessDeploymentBucketName.Value = bucketName;
 
           delete this.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ServerlessDeploymentBucket;
+            .Resources.SlsDeploy;
         });
     }
 

--- a/lib/plugins/aws/deploy/lib/configureStack.test.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.test.js
@@ -106,7 +106,7 @@ describe('#configureStack', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(
           awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ServerlessDeploymentBucket
+            .Resources.SlsDeploy
         ).to.not.exist;
       });
   });

--- a/lib/plugins/aws/deploy/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/deploy/lib/core-cloudformation-template.json
@@ -2,14 +2,14 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "The AWS CloudFormation template for this Serverless application",
   "Resources": {
-    "ServerlessDeploymentBucket": {
+    "SlsDeploy": {
       "Type" : "AWS::S3::Bucket"
     }
   },
   "Outputs": {
     "ServerlessDeploymentBucketName": {
       "Value": {
-        "Ref": "ServerlessDeploymentBucket"
+        "Ref": "SlsDeploy"
       }
     }
   }

--- a/lib/plugins/aws/deploy/lib/mergeCustomProviderResources.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeCustomProviderResources.test.js
@@ -67,7 +67,7 @@ describe('mergeCustomProviderResources', () => {
     it('should be able to overwrite existing object properties', () => {
       const customResourcesMock = {
         Resources: {
-          ServerlessDeploymentBucket: {
+          SlsDeploy: {
             Type: 'Some::New::Type',
             FakeResource1: 'FakePropValue',
             FakeResource2: {
@@ -81,8 +81,8 @@ describe('mergeCustomProviderResources', () => {
 
       return awsDeploy.mergeCustomProviderResources().then(() => {
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ServerlessDeploymentBucket
-        ).to.deep.equal(customResourcesMock.Resources.ServerlessDeploymentBucket);
+          .Resources.SlsDeploy
+        ).to.deep.equal(customResourcesMock.Resources.SlsDeploy);
       });
     });
 
@@ -151,9 +151,9 @@ describe('mergeCustomProviderResources', () => {
         );
 
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ServerlessDeploymentBucket
+          .Resources.SlsDeploy
         ).to.deep.equal(
-          coreCloudFormationTemplate.Resources.ServerlessDeploymentBucket
+          coreCloudFormationTemplate.Resources.SlsDeploy
         );
 
         expect(

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -174,7 +174,7 @@ module.exports = {
 
   // S3
   getDeploymentBucketLogicalId() {
-    return 'ServerlessDeploymentBucket';
+    return 'SlsDeploy';
   },
   getDeploymentBucketOutputLogicalId() {
     return 'ServerlessDeploymentBucketName';

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -351,8 +351,8 @@ describe('#naming()', () => {
   });
 
   describe('#getDeploymentBucketLogicalId()', () => {
-    it('should return "ServerlessDeploymentBucket"', () => {
-      expect(sdk.naming.getDeploymentBucketLogicalId()).to.equal('ServerlessDeploymentBucket');
+    it('should return "SlsDeploy"', () => {
+      expect(sdk.naming.getDeploymentBucketLogicalId()).to.equal('SlsDeploy');
     });
   });
 

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -30,7 +30,7 @@ provider:
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:ListBucket"
-#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "SlsDeploy" } ] ]  }
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:PutObject"
@@ -38,7 +38,7 @@ provider:
 #        Fn::Join:
 #          - ""
 #          - - "arn:aws:s3:::"
-#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "Ref" : "SlsDeploy"
 
 # you can define service wide environment variables here
 #  environment:

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -30,7 +30,7 @@ provider:
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:ListBucket"
-#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "SlsDeploy" } ] ]  }
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:PutObject"
@@ -38,7 +38,7 @@ provider:
 #        Fn::Join:
 #          - ""
 #          - - "arn:aws:s3:::"
-#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "Ref" : "SlsDeploy"
 
 # you can define service wide environment variables here
 #  environment:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -30,7 +30,7 @@ provider:
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:ListBucket"
-#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "SlsDeploy" } ] ]  }
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:PutObject"
@@ -38,7 +38,7 @@ provider:
 #        Fn::Join:
 #          - ""
 #          - - "arn:aws:s3:::"
-#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "Ref" : "SlsDeploy"
 
 # you can define service wide environment variables here
 #  environment:

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -30,7 +30,7 @@ provider:
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:ListBucket"
-#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "SlsDeploy" } ] ]  }
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:PutObject"
@@ -38,7 +38,7 @@ provider:
 #        Fn::Join:
 #          - ""
 #          - - "arn:aws:s3:::"
-#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "Ref" : "SlsDeploy"
 
 # you can define service wide environment variables here
 #  environment:

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -30,7 +30,7 @@ provider:
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:ListBucket"
-#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "SlsDeploy" } ] ]  }
 #    - Effect: "Allow"
 #      Action:
 #        - "s3:PutObject"
@@ -38,7 +38,7 @@ provider:
 #        Fn::Join:
 #          - ""
 #          - - "arn:aws:s3:::"
-#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "Ref" : "SlsDeploy"
 
 # you can define service wide environment variables here
 #  environment:


### PR DESCRIPTION
## What did you implement:

Closes #2791

## How did you implement it:

I shortened the bucket name in the core template by 17 characters to give projects more freedom before hitting Amazon's S3 bucket name limitations (63 characters).

## How can we verify it:

Deploying a Serverless project (such as the integration tests) results in a shorten bucket name. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below

***Is this ready for review?:*** Yes