### PR TITLE
adding replaceAll to turn any escaped single quotes back to regular s…

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/integration.js
@@ -146,7 +146,7 @@ module.exports = {
         #if( $keyValSize >= 1 )
           #set( $key = $util.escapeJavaScript($util.urlDecode($keyVal[0])) )
           #if( $keyValSize >= 2 )
-            #set( $val = $util.escapeJavaScript($util.urlDecode($keyVal[1])) )
+            #set( $val = $util.escapeJavaScript($util.urlDecode($keyVal[1])).replaceAll("\\'","'") )
           #else
             #set( $val = '' )
           #end

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/integration.js
@@ -146,7 +146,7 @@ module.exports = {
         #if( $keyValSize >= 1 )
           #set( $key = $util.escapeJavaScript($util.urlDecode($keyVal[0])) )
           #if( $keyValSize >= 2 )
-            #set( $val = $util.escapeJavaScript($util.urlDecode($keyVal[1])).replaceAll("\\\\'","'") )
+            #set($val = $util.escapeJavaScript($util.urlDecode($keyVal[1])).replaceAll("\\\\'","'"))
           #else
             #set( $val = '' )
           #end
@@ -188,5 +188,4 @@ module.exports = {
       "stageVariables": $loop
     }
   `,
-
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/integration.js
@@ -146,7 +146,7 @@ module.exports = {
         #if( $keyValSize >= 1 )
           #set( $key = $util.escapeJavaScript($util.urlDecode($keyVal[0])) )
           #if( $keyValSize >= 2 )
-            #set( $val = $util.escapeJavaScript($util.urlDecode($keyVal[1])).replaceAll("\\'","'") )
+            #set( $val = $util.escapeJavaScript($util.urlDecode($keyVal[1])).replaceAll("\\\\'","'") )
           #else
             #set( $val = '' )
           #end


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Correctly replaces single quotes in urlencoded values

Fixes #2807

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added `.replaceAll("\\'","'")` to the DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE following the instructions in the API Gateway documentation [here](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) since escapeJavaScript was added in #2271

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

You should be able to confirm the fix by running the same repo from the bug

```
curl -v -X POST -d "payload=%7B%22testkey%22%3A%22what%27s+up%22%7D" -H "Accept: application/x-www-form-urlencoded" <your test endpoint>
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:***  Yes

Fixes #2807 