### PR TITLE
Slstatsfix

### DIFF
--- a/lib/plugins/slstats/slstats.js
+++ b/lib/plugins/slstats/slstats.js
@@ -33,22 +33,30 @@ class SlStats {
     };
   }
 
-  toggleStats() {
-    const serverlessDirPath = path.join(os.homedir(), '.serverless');
-    const statsDisabledFilePath = path.join(serverlessDirPath, 'stats-disabled');
-    const statsEnabledFilePath = path.join(serverlessDirPath, 'stats-enabled');
+  createStatsFile(oldPath, newPath) {
+    const oldFileExists = this.serverless.utils.fileExistsSync(oldPath);
+    const newFileExists = this.serverless.utils.fileExistsSync(newPath);
+    const isFileToBeRenamed = !newFileExists && oldFileExists;
+    const isFileToBeCreated = !newFileExists;
+    if (isFileToBeRenamed) {
+      fse.renameSync(oldPath, newPath);
+    } else if (isFileToBeCreated) {
+      this.serverless.utils.writeFileSync(newPath);
+    }
+  }
 
+  toggleStats() {
     try {
-      if (this.options.enable && !this.options.disable) {
-        if (fse.lstatSync(statsDisabledFilePath).isFile()) {
-          fse.renameSync(statsDisabledFilePath, statsEnabledFilePath);
-        }
+      const serverlessDirPath = path.join(os.homedir(), '.serverless');
+      const statsDisabledFilePath = path.join(serverlessDirPath, 'stats-disabled');
+      const statsEnabledFilePath = path.join(serverlessDirPath, 'stats-enabled');
+      const isStatsEnabled = this.options.enable && !this.options.disable;
+      const isStatsDisabled = this.options.disable && !this.options.enable;
+      if (isStatsEnabled) {
+        this.createStatsFile(statsDisabledFilePath, statsEnabledFilePath);
         this.serverless.cli.log('Stats successfully enabled');
-      }
-      if (this.options.disable && !this.options.enable) {
-        if (fse.lstatSync(statsEnabledFilePath).isFile()) {
-          fse.renameSync(statsEnabledFilePath, statsDisabledFilePath);
-        }
+      } else if (isStatsDisabled) {
+        this.createStatsFile(statsEnabledFilePath, statsDisabledFilePath);
         this.serverless.cli.log('Stats successfully disabled');
       }
     } catch (error) {

--- a/lib/plugins/slstats/slstats.test.js
+++ b/lib/plugins/slstats/slstats.test.js
@@ -114,11 +114,13 @@ describe('SlStats', () => {
     });
 
     it('should throw an error if unable to create the stats file', () => {
-      const slStatsStub = sinon.stub(SlStats.prototype, 'createStatsFile').throws(new Error('ENOENT: no such file or directory'));
+      const slStatsStub = sinon.stub(SlStats.prototype, 'createStatsFile').throws(
+        new Error('EACCESS: Permission denied')
+      );
       slStats.options = { enable: true };
 
       expect(() => slStats.toggleStats()).to.throw(Error,
-      /Enabling \/ Disabling of statistics failed: ENOENT: no such file or directory/);
+      /Enabling \/ Disabling of statistics failed: EACCESS: Permission denied/);
       expect(
         serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-enabled'))
       ).to.equal(false);

--- a/lib/plugins/slstats/slstats.test.js
+++ b/lib/plugins/slstats/slstats.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const path = require('path');
 const fse = require('fs-extra');
 const os = require('os');
+const sinon = require('sinon');
 const SlStats = require('./slstats');
 const Serverless = require('../../Serverless');
 const testUtils = require('../../../tests/utils');
@@ -47,8 +48,7 @@ describe('SlStats', () => {
     it('should rename the stats file to stats-disabled if disabled', () => {
       // create a stats-enabled file
       serverless.utils.writeFileSync(
-        path.join(serverlessDirPath, 'stats-enabled'),
-        'some content'
+        path.join(serverlessDirPath, 'stats-enabled')
       );
 
       slStats.options = { disable: true };
@@ -66,8 +66,7 @@ describe('SlStats', () => {
     it('should rename the stats file to stats-enabled if enabled', () => {
       // create a stats-disabled file
       serverless.utils.writeFileSync(
-        path.join(serverlessDirPath, 'stats-disabled'),
-        'some content'
+        path.join(serverlessDirPath, 'stats-disabled')
       );
 
       slStats.options = { enable: true };
@@ -82,17 +81,51 @@ describe('SlStats', () => {
       ).to.equal(false);
     });
 
-    it('should throw an error if the stats file does not exist', () => {
+
+    it('should create the stats-enabled file if no stats-enabled file exists', () => {
+      slStats.options = { enable: true };
+
+      slStats.toggleStats();
+
+      expect(
+        serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-enabled'))
+      ).to.equal(true);
+      expect(
+        serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-disabled'))
+      ).to.equal(false);
+    });
+
+    it('should do nothing if the stats-enabled file already exists', () => {
+      // create a stats-disabled file
+      serverless.utils.writeFileSync(
+        path.join(serverlessDirPath, 'stats-enabled')
+      );
+
+      slStats.options = { enable: true };
+
+      slStats.toggleStats();
+
+      expect(
+        serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-enabled'))
+      ).to.equal(true);
+      expect(
+        serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-disabled'))
+      ).to.equal(false);
+    });
+
+    it('should throw an error if unable to create the stats file', () => {
+      const slStatsStub = sinon.stub(SlStats.prototype, 'createStatsFile').throws(new Error('ENOENT: no such file or directory'));
       slStats.options = { enable: true };
 
       expect(() => slStats.toggleStats()).to.throw(Error,
-      /Enabling \/ Disabling of statistics failed: ENOENT: no such file or directory, lstat/);
+      /Enabling \/ Disabling of statistics failed: ENOENT: no such file or directory/);
       expect(
         serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-enabled'))
       ).to.equal(false);
       expect(
         serverless.utils.fileExistsSync(path.join(serverlessDirPath, 'stats-disabled'))
       ).to.equal(false);
+      slStatsStub.restore();
     });
 
     afterEach(() => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2784

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I moved the code to rename the stats file to a new function called createStatsFile.
This renames the current stats file or creates it if none has been created. If there is an error in writing the file or renaming the file, fse will throw an error. (I was being mindful of #1604 and #2313.)

The code won't throw an error if the file is not found as a new one should be created.

I have moved all the code in the toggleStats method to the try, catch block so any error in the process is caught.

I have added 2 tests and modified 1.
1. Created a test for the creation of the stats file.
2. Created a test if the current file exists and the same command is run again, that the file remains.
3. Modified the error thrown test, so it will catch an example error message instead of the 'file not found' as that was misleading. A file not found means one should be created.

## How can we verify it:

Run `npm run test`.
or
Run `serverless slstats --enable` or `serverless slstats --disable`


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below

***Is this ready for review?:*** YES