### PR TITLE
fix bug in event source mapping with custom IAM role

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -65,10 +65,16 @@ class AwsCompileStreamEvents {
             const streamLogicalId = this.provider.naming
               .getStreamLogicalId(functionName, streamType, streamName);
 
+            const funcRole = this.serverless.service.provider.role || functionObj.role;
+            const dependsOn = (typeof funcRole !== 'object'
+              && (funcRole && funcRole.indexOf(':') !== -1))
+              ? '[]'
+              : '"IamPolicyLambdaExecution"';
+
             const streamTemplate = `
               {
                 "Type": "AWS::Lambda::EventSourceMapping",
-                "DependsOn": "IamPolicyLambdaExecution",
+                "DependsOn": ${dependsOn},
                 "Properties": {
                   "BatchSize": ${BatchSize},
                   "EventSourceArn": "${EventSourceArn}",

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -65,11 +65,12 @@ class AwsCompileStreamEvents {
             const streamLogicalId = this.provider.naming
               .getStreamLogicalId(functionName, streamType, streamName);
 
-            const funcRole = this.serverless.service.provider.role || functionObj.role;
-            const dependsOn = (typeof funcRole !== 'object'
-              && (funcRole && funcRole.indexOf(':') !== -1))
-              ? '[]'
-              : '"IamPolicyLambdaExecution"';
+            const funcRole = functionObj.role || this.serverless.service.provider.role;
+            let dependsOn = '"IamPolicyLambdaExecution"';
+            // check whether we have custom IAM role in format arn:aws:iam::account:role/foo
+            if (typeof funcRole === 'string' && funcRole.indexOf(':') !== -1) {
+              dependsOn = '[]';
+            }
 
             const streamTemplate = `
               {

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -87,6 +87,66 @@ describe('AwsCompileStreamEvents', () => {
       ).to.equal(null);
     });
 
+    it('should not throw error if custom IAM role is set in function', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          role: 'arn:aws:iam::account:role/foo',
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamPolicyLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .IamPolicyLambdaExecution = null;
+
+      expect(() => { awsCompileStreamEvents.compileStreamEvents(); }).to.not.throw(Error);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn).to.be.instanceof(Array);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn.length).to.equal(0);
+      expect(awsCompileStreamEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .IamPolicyLambdaExecution
+      ).to.equal(null);
+    });
+
+    it('should not throw error if custom IAM role is set in provider', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamPolicyLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .IamPolicyLambdaExecution = null;
+
+      awsCompileStreamEvents.serverless.service.provider
+        .role = 'arn:aws:iam::account:role/foo';
+
+      expect(() => { awsCompileStreamEvents.compileStreamEvents(); }).to.not.throw(Error);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn).to.be.instanceof(Array);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn.length).to.equal(0);
+      expect(awsCompileStreamEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .IamPolicyLambdaExecution
+      ).to.equal(null);
+    });
+
     describe('when a DynamoDB stream ARN is given', () => {
       it('should create event source mappings when a DynamoDB stream ARN is given', () => {
         awsCompileStreamEvents.serverless.service.functions = {


### PR DESCRIPTION
## What did you implement:
I put a condition whether we have custom IAM role or not in order to create a proper EventSourceMapping template.

Fixes [#2813](https://github.com/serverless/serverless/issues/2813)

## How did you implement it:
I simply check provider.role and function.role whether we have custom IAM role in ARN format `arn:aws:iam::account:role/foo` and if so, I change DependOn to be empty array, instead of `IamPolicyLambdaExecution`. Empty array behaves like there wouldn't be DependOn at all.
Note: I decided to go this way to keep `streamTemplate` the same without condition concatenating of strings. 

## How can we verify it:
We should be able to successfully build this serverless.yaml script:
```yaml
service: hello-service

provider:
  name: aws
  runtime: nodejs4.3
  cfLogs: true
  role: arn:aws:iam::account:role/foo

functions:
  hello:
    handler: handler.hello
    events:
      - stream:
          arn: arn:aws:kinesis:region:account:stream/bar
          batchSize: 100
          startingPosition: LATEST
```


## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

