### PR TITLE
Add support for directories in url of install command

### DIFF
--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -29,7 +29,7 @@ serverless install --url https://github.com/some/service
 ### Installing a service from a GitHub URL
 
 ```bash
-serverless install --url https://github.com/serverless/examples
+serverless install --url https://github.com/pmuens/serverless-crud
 ```
 
 This example will download the .zip file of the `examples` service from GitHub, create a new directory with the name `examples` in the current working directory and unzips the files in this directory.

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -33,3 +33,11 @@ serverless install --url https://github.com/johndoe/authentication
 ```
 
 This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `authentication` in the current working directory and unzips the files in this directory.
+
+### Installing a service from directories in a GitHub URL
+
+```bash
+serverless install --url https://github.com/johndoe/authentication/tree/master/todo/someauth
+```
+
+This example will download the `someauth` service from directory in GitHub.

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -37,7 +37,7 @@ This example will download the .zip file of the `authentication` service from Gi
 ### Installing a service from directories in a GitHub URL
 
 ```bash
-serverless install --url https://github.com/johndoe/authentication/tree/master/todo/someauth
+serverless install --url https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb
 ```
 
-This example will download the `someauth` service from directory in GitHub.
+This example will download the `rest-api-with-dynamodb` service from directory in GitHub.

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -29,10 +29,10 @@ serverless install --url https://github.com/some/service
 ### Installing a service from a GitHub URL
 
 ```bash
-serverless install --url https://github.com/johndoe/authentication
+serverless install --url https://github.com/serverless/rest-api-with-dynamodb
 ```
 
-This example will download the .zip file of the `authentication` service from GitHub, create a new directory with the name `authentication` in the current working directory and unzips the files in this directory.
+This example will download the .zip file of the `rest-api-with-dynamodb` service from GitHub, create a new directory with the name `rest-api-with-dynamodb` in the current working directory and unzips the files in this directory.
 
 ### Installing a service from directories in a GitHub URL
 
@@ -40,4 +40,4 @@ This example will download the .zip file of the `authentication` service from Gi
 serverless install --url https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb
 ```
 
-This example will download the `rest-api-with-dynamodb` service from directory in GitHub.
+This example will download the `rest-api-with-dynamodb` from a directory in GitHub.

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -29,15 +29,15 @@ serverless install --url https://github.com/some/service
 ### Installing a service from a GitHub URL
 
 ```bash
-serverless install --url https://github.com/serverless/rest-api-with-dynamodb
+serverless install --url https://github.com/serverless/examples
 ```
 
-This example will download the .zip file of the `rest-api-with-dynamodb` service from GitHub, create a new directory with the name `rest-api-with-dynamodb` in the current working directory and unzips the files in this directory.
+This example will download the .zip file of the `examples` service from GitHub, create a new directory with the name `examples` in the current working directory and unzips the files in this directory.
 
-### Installing a service from directories in a GitHub URL
+### Installing a service from a directory in a GitHub URL
 
 ```bash
 serverless install --url https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb
 ```
 
-This example will download the `rest-api-with-dynamodb` from a directory in GitHub.
+This example will download the `rest-api-with-dynamodb` service from GitHub.

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -86,12 +86,12 @@ class Install {
       { timeout: 30000, extract: true, strip: 1, mode: '755' }
     ).then(() => {
       if (parts.length > 4) {
-        let dirctory = servicePath;
+        let directory = servicePath;
         for (let i = 5; i <= endIndex; i++) {
-          dirctory = path.join(dirctory, parts[i]);
+          directory = path.join(directory, parts[i]);
         }
         that.serverless.utils
-        .copyDirContentsSync(dirctory, path.join(process.cwd(), parts[endIndex]));
+        .copyDirContentsSync(directory, path.join(process.cwd(), parts[endIndex]));
       }
       that.serverless.cli.log(`Successfully installed "${dirName}".`);
     });

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -5,7 +5,7 @@ const path = require('path');
 const URL = require('url');
 const download = require('download');
 const os = require('os');
-const fs = require('fs-extra');
+const fse = require('fs-extra');
 
 class Install {
   constructor(serverless, options) {
@@ -70,8 +70,11 @@ class Install {
     const endIndex = parts.length - 1;
     let dirName;
     let servicePath;
+
+    // check if it's a directory or the whole repository
     if (parts.length > 4) {
       dirName = parts[endIndex];
+      // download the repo into a temporary directory
       servicePath = path.join(os.tmpdir(), parsedGitHubUrl.repo);
     } else {
       dirName = parsedGitHubUrl.repo;
@@ -82,24 +85,28 @@ class Install {
       const errorMessage = `A folder named "${dirName}" already exists.`;
       throw new this.serverless.classes.Error(errorMessage);
     }
+
     this.serverless.cli.log(`Downloading and installing "${dirName}"...`);
+
     const that = this;
+
     // download service
     return download(
       downloadUrl,
       servicePath,
       { timeout: 30000, extract: true, strip: 1, mode: '755' }
     ).then(() => {
+      // if it's a directory inside of git
       if (parts.length > 4) {
         let directory = servicePath;
         for (let i = 5; i <= endIndex; i++) {
           directory = path.join(directory, parts[i]);
         }
         that.serverless.utils
-        .copyDirContentsSync(directory, path.join(process.cwd(), parts[endIndex]));
-        fs.removeSync(servicePath);
+          .copyDirContentsSync(directory, path.join(process.cwd(), parts[endIndex]));
+        fse.removeSync(servicePath);
       }
-      that.serverless.cli.log(`Successfully installed "${dirName}".`);
+      that.serverless.cli.log(`Successfully installed service "${dirName}".`);
     });
   }
 }

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const path = require('path');
 const URL = require('url');
 const download = require('download');
+const fs = require('fs-extra');
 
 class Install {
   constructor(serverless, options) {
@@ -33,7 +34,7 @@ class Install {
   }
 
   install() {
-    const url = URL.parse(this.options.url);
+    const url = URL.parse(this.options.url.replace(/\/$/, ''));
 
     // check if url parameter is a valid url
     if (!url.host) {
@@ -44,9 +45,8 @@ class Install {
     const parsedGitHubUrl = {
       owner: parts[1],
       repo: parts[2],
-      branch: 'master',
+      branch: parts[4] || 'master',
     };
-
     // validate if given url is a valid GitHub url
     if (url.hostname !== 'github.com' || !parsedGitHubUrl.owner || !parsedGitHubUrl.repo) {
       const errorMessage = [
@@ -67,23 +67,40 @@ class Install {
     ].join('');
 
     const servicePath = path.join(process.cwd(), parsedGitHubUrl.repo);
-
-    // throw an error if service path already exists
-    if (this.serverless.utils.dirExistsSync(servicePath)) {
-      const errorMessage = `A folder named "${parsedGitHubUrl.repo}" already exists.`;
-      throw new this.serverless.classes.Error(errorMessage);
+    const endIndex = parts.length - 1;
+    let repoPath;
+    if (parts.length > 4) {
+      repoPath = path.join(process.cwd(), parts[endIndex]);
+      if (this.serverless.utils.dirExistsSync(parts[endIndex])) {
+        const errorMessage = `A folder named "${parts[endIndex]}" already exists.`;
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+      this.serverless.cli.log(`Downloading and installing "${parts[endIndex]}"...`);
+    } else {
+      if (this.serverless.utils.dirExistsSync(servicePath)) {
+        const errorMessage = `A folder named "${parsedGitHubUrl.repo}" already exists.`;
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+      this.serverless.cli.log(`Downloading and installing "${parsedGitHubUrl.repo}"...`);
     }
-
-    this.serverless.cli.log(`Downloading and installing "${parsedGitHubUrl.repo}"...`);
     const that = this;
-
     // download service
     return download(
       downloadUrl,
       servicePath,
       { timeout: 30000, extract: true, strip: 1, mode: '755' }
     ).then(() => {
-      that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}".`);
+      if (parts.length > 4) {
+        let dirctory = servicePath;
+        for (let i = 5; i <= endIndex; i++) {
+          dirctory = path.join(dirctory, parts[i]);
+        }
+        that.serverless.utils.copyDirContentsSync(dirctory, repoPath);
+        fs.removeSync(servicePath);
+        that.serverless.cli.log(`Successfully installed "${parts[endIndex]}".`);
+      } else {
+        that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}".`);
+      }
     });
   }
 }

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -4,6 +4,8 @@ const BbPromise = require('bluebird');
 const path = require('path');
 const URL = require('url');
 const download = require('download');
+const os = require('os');
+const fs = require('fs-extra');
 
 class Install {
   constructor(serverless, options) {
@@ -65,15 +67,18 @@ class Install {
       '.zip',
     ].join('');
 
-    const servicePath = path.join(process.cwd(), parsedGitHubUrl.repo);
     const endIndex = parts.length - 1;
     let dirName;
+    let servicePath;
     if (parts.length > 4) {
       dirName = parts[endIndex];
+      servicePath = path.join(os.tmpdir(), parsedGitHubUrl.repo);
     } else {
       dirName = parsedGitHubUrl.repo;
+      servicePath = path.join(process.cwd(), dirName);
     }
-    if (this.serverless.utils.dirExistsSync(servicePath)) {
+
+    if (this.serverless.utils.dirExistsSync(path.join(process.cwd(), dirName))) {
       const errorMessage = `A folder named "${dirName}" already exists.`;
       throw new this.serverless.classes.Error(errorMessage);
     }
@@ -92,6 +97,7 @@ class Install {
         }
         that.serverless.utils
         .copyDirContentsSync(directory, path.join(process.cwd(), parts[endIndex]));
+        fs.removeSync(servicePath);
       }
       that.serverless.cli.log(`Successfully installed "${dirName}".`);
     });

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -4,7 +4,6 @@ const BbPromise = require('bluebird');
 const path = require('path');
 const URL = require('url');
 const download = require('download');
-const fs = require('fs-extra');
 
 class Install {
   constructor(serverless, options) {
@@ -68,21 +67,17 @@ class Install {
 
     const servicePath = path.join(process.cwd(), parsedGitHubUrl.repo);
     const endIndex = parts.length - 1;
-    let repoPath;
+    let dirName;
     if (parts.length > 4) {
-      repoPath = path.join(process.cwd(), parts[endIndex]);
-      if (this.serverless.utils.dirExistsSync(parts[endIndex])) {
-        const errorMessage = `A folder named "${parts[endIndex]}" already exists.`;
-        throw new this.serverless.classes.Error(errorMessage);
-      }
-      this.serverless.cli.log(`Downloading and installing "${parts[endIndex]}"...`);
+      dirName = parts[endIndex];
     } else {
-      if (this.serverless.utils.dirExistsSync(servicePath)) {
-        const errorMessage = `A folder named "${parsedGitHubUrl.repo}" already exists.`;
-        throw new this.serverless.classes.Error(errorMessage);
-      }
-      this.serverless.cli.log(`Downloading and installing "${parsedGitHubUrl.repo}"...`);
+      dirName = parsedGitHubUrl.repo;
     }
+    if (this.serverless.utils.dirExistsSync(servicePath)) {
+      const errorMessage = `A folder named "${dirName}" already exists.`;
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+    this.serverless.cli.log(`Downloading and installing "${dirName}"...`);
     const that = this;
     // download service
     return download(
@@ -95,12 +90,10 @@ class Install {
         for (let i = 5; i <= endIndex; i++) {
           dirctory = path.join(dirctory, parts[i]);
         }
-        that.serverless.utils.copyDirContentsSync(dirctory, repoPath);
-        fs.removeSync(servicePath);
-        that.serverless.cli.log(`Successfully installed "${parts[endIndex]}".`);
-      } else {
-        that.serverless.cli.log(`Successfully installed "${parsedGitHubUrl.repo}".`);
+        that.serverless.utils
+        .copyDirContentsSync(dirctory, path.join(process.cwd(), parts[endIndex]));
       }
+      that.serverless.cli.log(`Successfully installed "${dirName}".`);
     });
   }
 }

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -77,5 +77,34 @@ describe('Install', () => {
         expect(downloadStub.args[0][0]).to.equal(`${install.options.url}/archive/master.zip`);
       });
     });
+
+    it('should download the service based on directories in the GitHub URL', () => {
+      install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
+      const tmpDir = testUtils.getTmpDirPath();
+      const serviceDirName = path.join(tmpDir, 'examples', 'rest-api-with-dynamodb');
+      fse.mkdirsSync(serviceDirName);
+
+      const cwd = process.cwd();
+      process.chdir(tmpDir);
+
+      return install.install().then(() => {
+        expect(downloadStub.calledTwice).to.equal(true);
+        expect(downloadStub.args[1][0]).to.equal('https://github.com/serverless/examples/archive/master.zip');
+        process.chdir(cwd);
+      });
+    });
+
+    it('should throw an error if the same service name does exists as directory in Github', () => {
+      install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
+      const tmpDir = testUtils.getTmpDirPath();
+      const serviceDirName = path.join(tmpDir, 'rest-api-with-dynamodb');
+      fse.mkdirsSync(serviceDirName);
+
+      const cwd = process.cwd();
+      process.chdir(tmpDir);
+
+      expect(() => install.install()).to.throw(Error);
+      process.chdir(cwd);
+    });
   });
 });

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -9,16 +9,17 @@ const fse = require('fs-extra');
 const path = require('path');
 const proxyquire = require('proxyquire');
 
-const downloadStub = sinon.stub().returns(BbPromise.resolve());
-const Install = proxyquire('./install.js', {
-  download: downloadStub,
-});
-
 describe('Install', () => {
   let install;
   let serverless;
+  let downloadStub;
+  let Install;
 
   beforeEach(() => {
+    downloadStub = sinon.stub().returns(BbPromise.resolve());
+    Install = proxyquire('./install.js', {
+      download: downloadStub,
+    });
     serverless = new Serverless();
     install = new Install(serverless);
     serverless.init();
@@ -81,11 +82,16 @@ describe('Install', () => {
     it('should download the service based on directories in the GitHub URL', () => {
       install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
       sinon.stub(serverless.utils, 'copyDirContentsSync').returns(true);
+      sinon.stub(fse, 'removeSync').returns(true);
+
       return install.install().then(() => {
-        expect(downloadStub.calledTwice).to.equal(true);
-        expect(downloadStub.args[1][0]).to.equal('https://github.com/serverless/examples/archive/master.zip');
+        expect(downloadStub.calledOnce).to.equal(true);
+        expect(downloadStub.args[0][0]).to.equal('https://github.com/serverless/examples/archive/master.zip');
         expect(serverless.utils.copyDirContentsSync.calledOnce).to.equal(true);
+        expect(fse.removeSync.calledOnce).to.equal(true);
+
         serverless.utils.copyDirContentsSync.restore();
+        fse.removeSync.restore();
       });
     });
 

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -80,24 +80,18 @@ describe('Install', () => {
 
     it('should download the service based on directories in the GitHub URL', () => {
       install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
-      const tmpDir = testUtils.getTmpDirPath();
-      const serviceDirName = path.join(tmpDir, 'examples', 'rest-api-with-dynamodb');
-      fse.mkdirsSync(serviceDirName);
-
-      const cwd = process.cwd();
-      process.chdir(tmpDir);
-
+      sinon.stub(serverless.utils, 'copyDirContentsSync').returns(true);
       return install.install().then(() => {
         expect(downloadStub.calledTwice).to.equal(true);
         expect(downloadStub.args[1][0]).to.equal('https://github.com/serverless/examples/archive/master.zip');
-        process.chdir(cwd);
+        serverless.utils.copyDirContentsSync.restore();
       });
     });
 
-    it('should throw an error if the same service name does exists as directory in Github', () => {
+    it('should throw an error if the same service name exists as directory in Github', () => {
       install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
       const tmpDir = testUtils.getTmpDirPath();
-      const serviceDirName = path.join(tmpDir, 'rest-api-with-dynamodb');
+      const serviceDirName = path.join(tmpDir, 'examples');
       fse.mkdirsSync(serviceDirName);
 
       const cwd = process.cwd();

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -84,6 +84,7 @@ describe('Install', () => {
       return install.install().then(() => {
         expect(downloadStub.calledTwice).to.equal(true);
         expect(downloadStub.args[1][0]).to.equal('https://github.com/serverless/examples/archive/master.zip');
+        expect(serverless.utils.copyDirContentsSync.calledOnce).to.equal(true);
         serverless.utils.copyDirContentsSync.restore();
       });
     });

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -92,7 +92,7 @@ describe('Install', () => {
     it('should throw an error if the same service name exists as directory in Github', () => {
       install.options = { url: 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb' };
       const tmpDir = testUtils.getTmpDirPath();
-      const serviceDirName = path.join(tmpDir, 'examples');
+      const serviceDirName = path.join(tmpDir, 'rest-api-with-dynamodb');
       fse.mkdirsSync(serviceDirName);
 
       const cwd = process.cwd();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2721

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
- Download zip that the Github repo whole things.
- Delete except for specific directories.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Please run as follow:
```
serverless install --url=https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

