### PR TITLE
add Visualize plugin for viewing lifecycle hooks

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -107,9 +107,13 @@ class PluginManager {
   }
 
   loadHooks(pluginInstance) {
-    _.forEach(pluginInstance.hooks, (hook, event) => {
+    const pluginName = pluginInstance.constructor.name;
+    _.forEach(pluginInstance.hooks, (fn, event) => {
       this.hooks[event] = this.hooks[event] || [];
-      this.hooks[event].push(hook);
+      this.hooks[event].push({
+        pluginName,
+        fn,
+      });
     });
   }
 
@@ -143,6 +147,10 @@ class PluginManager {
     return this.plugins;
   }
 
+  getHooks(events) {
+    return _.flatMap(events, (event) => this.hooks[event] || []);
+  }
+
   run(commandsArray) {
     const command = this.getCommand(commandsArray);
 
@@ -150,14 +158,14 @@ class PluginManager {
     this.validateOptions(command);
 
     const events = this.getEvents(command);
-    const hooks = _.flatMap(events, (event) => this.hooks[event] || []);
+    const hooks = this.getHooks(events);
 
     if (hooks.length === 0) {
       const errorMessage = 'The command you entered did not catch on any hooks';
       throw new this.serverless.classes.Error(errorMessage);
     }
 
-    return BbPromise.reduce(hooks, (__, hook) => hook(), null);
+    return BbPromise.reduce(hooks, (__, hook) => hook.fn(), null);
   }
 
   validateCommand(commandsArray) {

--- a/lib/plugins/Plugins.json
+++ b/lib/plugins/Plugins.json
@@ -10,6 +10,7 @@
     "./remove/remove.js",
     "./rollback/index.js",
     "./slstats/slstats.js",
+    "./visualize/visualize.js",
     "./aws/provider/awsProvider.js",
     "./aws/deploy/index.js",
     "./aws/invoke/index.js",

--- a/lib/plugins/visualize/visualize.js
+++ b/lib/plugins/visualize/visualize.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const chalk = require('chalk');
+const archy = require('archy');
+
+class Visualize {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.commands = {
+      visualize: {
+        commands: {
+          plugins: {
+            usage: 'Display plugin information',
+            lifecycleEvents: [
+              'plugins',
+            ],
+            options: {
+              command: {
+                usage: 'Specifies a command to visualize plugin execution',
+                shortcut: 'c',
+                required: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    this.hooks = {
+      'visualize:plugins:plugins': this.visualizePlugins.bind(this),
+    };
+  }
+
+  visualizePlugins() {
+    const commandsArray = this.options.command.split(' ');
+    const command = this.serverless.pluginManager.getCommand(commandsArray);
+    const events = this.serverless.pluginManager.getEvents(command);
+
+    const lifecycle = {
+      label: 'Plugin Lifecycle',
+      nodes: [],
+    };
+
+    // skip the first 'before:'
+    for (let i = 1; i < events.length; i += 3) {
+      const eventName = events[i];
+
+      lifecycle.nodes.push({
+        label: chalk.cyan(eventName),
+        nodes: [
+          this.makeNode('before', `before:${eventName}`),
+          this.makeNode('during', eventName),
+          this.makeNode('after', `after:${eventName}`),
+        ],
+      });
+    }
+
+    this.serverless.cli.consoleLog('');
+    this.serverless.cli.consoleLog(archy(lifecycle));
+  }
+
+  getHookDescription(hook, event) {
+    const functionName = hook.fn.name === event ?
+      '<function>'
+      :
+      hook.fn.name.replace('bound ', '');
+
+    return `${chalk.yellow(hook.pluginName)}:${functionName}`;
+  }
+
+  makeNode(label, event) {
+    const hooks = this.serverless.pluginManager.getHooks([event]);
+
+    if (hooks.length) {
+      return {
+        label,
+        nodes: hooks.map((hook) => this.getHookDescription(hook, event)),
+      };
+    }
+
+    return {
+      label: chalk.gray(label),
+    };
+  }
+}
+
+module.exports = Visualize;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -81,6 +81,11 @@
       "from": "archiver-utils@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz"
     },
+    "archy": {
+      "version": "1.0.0",
+      "from": "archy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+    },
     "argparse": {
       "version": "1.0.9",
       "from": "argparse@>=1.0.7 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "archiver": "^1.1.0",
+    "archy": "^1.0.0",
     "async": "^1.5.2",
     "aws-sdk": "^2.3.17",
     "bluebird": "^3.4.0",


### PR DESCRIPTION
## What did you implement:

Closes #1260

This adds a `visualize` command, via a Visualize plugin, which supports 1 subcommand currently:

`sls visualize plugins -c <command name>`

## How did you implement it:

A slight modification to PluginManager to expose hooks, and using `archy` which is what npm uses (last I checked) to perform `npm ls`.

## How can we verify it:

Go to a project, any project. If you do `sls help`, you should see `Visualize` in the list of plugins.

Now try something, such as `sls visualize plugins -c deploy`. If you want to visualize a subcommand, you must use quotes: `sls visualize plugins -c "deploy function"`

Here's a screenshot. I mostly guessed at colours:

<img width="323" alt="screen shot 2016-11-29 at 10 29 54 am" src="https://cloud.githubusercontent.com/assets/586516/20715991/e2cbc9f2-b61e-11e6-93c5-6cf9c4d949b9.png">

At the end of the screenshot you can see a best practice, [if the hook is done using a bound function](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/deploy/compile/functions/index.js#L14), I can display the function name within the plugin. Otherwise I just write `<function>`.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below



***Is this ready for review?:*** NO

