### PR TITLE
fix Provider keeps default stage and region

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -100,16 +100,6 @@ class Service {
           that.package.include = serverlessFile.package.include;
         }
 
-        if (serverlessFile.defaults && serverlessFile.defaults.stage) {
-          this.defaults.stage = serverlessFile.defaults.stage;
-        }
-        if (serverlessFile.defaults && serverlessFile.defaults.region) {
-          this.defaults.region = serverlessFile.defaults.region;
-        }
-        if (serverlessFile.defaults && serverlessFile.defaults.variableSyntax) {
-          this.defaults.variableSyntax = serverlessFile.defaults.variableSyntax;
-        }
-
         // load defaults property for backward compatibility
         if (serverlessFile.defaults) {
           const warningMessage = [
@@ -120,35 +110,22 @@ class Service {
           ].join('');
           this.serverless.cli.log(warningMessage);
 
-          if (serverlessFile.defaults.stage) {
-            this.defaults.stage = serverlessFile.defaults.stage;
-          }
-          if (serverlessFile.defaults.region) {
-            this.defaults.region = serverlessFile.defaults.region;
-          }
-          if (serverlessFile.defaults.variableSyntax) {
-            this.defaults.variableSyntax = serverlessFile.defaults.variableSyntax;
-          }
+          Object.assign(this.defaults, serverlessFile.defaults);
         }
 
-        // if exists, move provider to defaults for backward compatibility
-        if (serverlessFile.provider.stage) {
-          this.defaults.stage = serverlessFile.provider.stage;
-        }
-        if (serverlessFile.provider.region) {
-          this.defaults.region = serverlessFile.provider.region;
-        }
-        if (serverlessFile.provider.variableSyntax) {
-          this.defaults.variableSyntax = serverlessFile.provider.variableSyntax;
-        }
+        ['stage', 'region', 'variableSyntax'].forEach((property) => {
+          if (serverlessFile.provider[property]) {
+            this.provider[property] = serverlessFile.provider[property];
+          } else {
+            this.provider[property] = options[property] || this.defaults[property];
+          }
 
-        // make sure provider obj is in sync with default for backward compatibility
-        this.provider.stage = this.defaults.stage;
-        this.provider.region = this.defaults.region;
-        this.provider.variableSyntax = this.defaults.variableSyntax;
+          // move provider to defaults for backward compatibility
+          this.defaults[property] = this.provider[property];
+        });
 
         // setup function.name property
-        const stageNameForFunction = options.stage || this.provider.stage;
+        const stageNameForFunction = this.provider.stage;
         _.forEach(that.functions, (functionObj, functionName) => {
           if (!functionObj.events) {
             that.functions[functionName].events = [];

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -210,6 +210,32 @@ describe('Service', () => {
       });
     });
 
+    it('should set provider.stage and provider.region from options', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: 'new-service',
+        provider: 'aws',
+        defaults: {
+          stage: 'dev',
+          region: 'us-east-1',
+          variableSyntax: '\\${{([\\s\\S]+?)}}',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless();
+      serverless.init();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load({ stage: 'x', region: 'outer-space' }).then(() => {
+        expect(serviceInstance.provider.stage).to.be.equal('x');
+        expect(serviceInstance.provider.region).to.be.equal('outer-space');
+      });
+    });
+
     it('should support Serverless file with a non-aws provider', () => {
       const SUtils = new Utils();
       const serverlessYaml = {


### PR DESCRIPTION
## What did you implement:

Closes #2824

This keeps everything the same except `provider.stage` and `provider.region` get set to whatever came in via `options`, if it was set.

## How can we verify it:

Unit tests pass; I'm having trouble with integration tests just off of master. I deployed a service manually and it worked as I expected.


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

