### PR TITLE
fix returning error from local invocation

### DIFF
--- a/lib/plugins/aws/invokeLocal/fixture/handlerWithError.js
+++ b/lib/plugins/aws/invokeLocal/fixture/handlerWithError.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports.withError = (event, context, callback) => {
+  callback(new Error('failed'));
+};
+
+module.exports.withMessage = (event, context, callback) => {
+  callback('failed');
+};

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -109,12 +109,9 @@ class AwsInvokeLocal {
         }
 
         this.serverless.cli.consoleLog(chalk.red(JSON.stringify(errorResult, null, 4)));
-        process.exit(1);
-      } else {
-        if (result) {
-          this.serverless.cli.consoleLog(JSON.stringify(result, null, 4));
-        }
-        process.exit(0);
+        process.exitCode = 1;
+      } else if (result) {
+        this.serverless.cli.consoleLog(JSON.stringify(result, null, 4));
       }
     };
 

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const _ = require('lodash');
 const path = require('path');
 const validate = require('../lib/validate');
+const chalk = require('chalk');
 
 class AwsInvokeLocal {
   constructor(serverless, options) {
@@ -95,7 +96,20 @@ class AwsInvokeLocal {
 
     const callback = (err, result) => {
       if (err) {
-        throw err;
+        let errorResult;
+        if (err instanceof Error) {
+          errorResult = {
+            errorMessage: err.message,
+            errorType: err.constructor.name,
+          };
+        } else {
+          errorResult = {
+            errorMessage: err,
+          };
+        }
+
+        this.serverless.cli.consoleLog(chalk.red(JSON.stringify(errorResult, null, 4)));
+        process.exit(1);
       } else {
         if (result) {
           this.serverless.cli.consoleLog(JSON.stringify(result, null, 4));

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const AwsInvokeLocal = require('./index');
 const AwsProvider = require('../provider/awsProvider');
 const Serverless = require('../../../Serverless');
+const CLI = require('../../../classes/CLI');
 const BbPromise = require('bluebird');
 const testUtils = require('../../../../tests/utils');
 
@@ -213,9 +214,12 @@ describe('AwsInvokeLocal', () => {
   });
 
   describe('#invokeLocal()', () => {
-    const invokeLocalNodeJsStub = sinon
-      .stub(awsInvokeLocal, 'invokeLocalNodeJs').returns(BbPromise.resolve());
+    let invokeLocalNodeJsStub;
+
     beforeEach(() => {
+      invokeLocalNodeJsStub =
+        sinon.stub(awsInvokeLocal, 'invokeLocalNodeJs').returns(BbPromise.resolve());
+
       awsInvokeLocal.serverless.service.service = 'new-service';
       awsInvokeLocal.options = {
         stage: 'dev',
@@ -226,6 +230,10 @@ describe('AwsInvokeLocal', () => {
         },
         data: {},
       };
+    });
+
+    afterEach(() => {
+      invokeLocalNodeJsStub.restore();
     });
 
     it('should call invokeLocalNodeJs when no runtime is set', () => awsInvokeLocal.invokeLocal()
@@ -244,6 +252,50 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.options.functionObj.runtime = 'python';
       expect(() => awsInvokeLocal.invokeLocal()).to.throw(Error);
       delete awsInvokeLocal.options.functionObj.runtime;
+    });
+  });
+
+  describe('#invokeLocalNodeJs', () => {
+    beforeEach(() => {
+      awsInvokeLocal.options = {
+        functionObj: {
+          name: '',
+        },
+      };
+
+      serverless.cli = new CLI(serverless);
+      sinon.stub(serverless.cli, 'consoleLog');
+      sinon.stub(process, 'exit');
+    });
+
+    afterEach(() => {
+      serverless.cli.consoleLog.restore();
+      process.exit.restore();
+    });
+
+    it('should exit with error exit code', () => {
+      awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+      awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
+
+      expect(process.exit.calledWith(1)).to.be.equal(true);
+    });
+
+    it('should log Error instance when called back', () => {
+      awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+      awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
+
+      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
+      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorType": "Error"');
+    });
+
+    it('should log error when called back', () => {
+      awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+      awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withMessage');
+
+      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
     });
   });
 });

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -265,12 +265,10 @@ describe('AwsInvokeLocal', () => {
 
       serverless.cli = new CLI(serverless);
       sinon.stub(serverless.cli, 'consoleLog');
-      sinon.stub(process, 'exit');
     });
 
     afterEach(() => {
       serverless.cli.consoleLog.restore();
-      process.exit.restore();
     });
 
     it('should exit with error exit code', () => {
@@ -278,7 +276,7 @@ describe('AwsInvokeLocal', () => {
 
       awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
 
-      expect(process.exit.calledWith(1)).to.be.equal(true);
+      expect(process.exitCode).to.be.equal(1);
     });
 
     it('should log Error instance when called back', () => {


### PR DESCRIPTION
## What did you implement:

Closes #2612

This implements AWS Lambda behaviour.

## How can we verify it:

Run `sls invoke local` against function calling back error

## Note

we shouldn't format or color error messages all over the codebase. There should be one place with logs styling. I will create issue for that becuase right now it's like inline css styles.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** Yes

