### PR TITLE
remove the lifecycle event from config to hide it in the command list

### DIFF
--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -13,9 +13,6 @@ class AwsConfigCredentials {
     // this will be merged with the core config commands
     this.commands = {
       config: {
-        lifecycleEvents: [
-          'config',
-        ],
         commands: {
           credentials: {
             lifecycleEvents: [

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -35,10 +35,8 @@ describe('AwsConfigCredentials', () => {
       expect(awsConfigCredentials.commands.config.commands.credentials).to.not.equal(undefined);
     });
 
-    it('should have the lifecycle event "config"', () => {
-      expect(awsConfigCredentials.commands.config.lifecycleEvents).to.deep.equal([
-        'config',
-      ]);
+    it('should have no lifecycle event', () => {
+      expect(awsConfigCredentials.commands.config.lifecycleEvents).to.equal(undefined);
     });
 
     it('should have the lifecycle event "config" for the "credentials" sub-command', () => {

--- a/lib/plugins/config/config.js
+++ b/lib/plugins/config/config.js
@@ -19,9 +19,6 @@ class Config {
     this.commands = {
       config: {
         usage: 'Configure Serverless',
-        lifecycleEvents: [
-          'config',
-        ],
         commands: {
           credentials: {
             usage: 'Configures a new provider profile for the Serverless Framework',

--- a/lib/plugins/config/config.test.js
+++ b/lib/plugins/config/config.test.js
@@ -25,10 +25,8 @@ describe('Config', () => {
       expect(config.commands.config.commands.credentials).to.not.equal(undefined);
     });
 
-    it('should have the lifecycle event "config"', () => {
-      expect(config.commands.config.lifecycleEvents).to.deep.equal([
-        'config',
-      ]);
+    it('should have no lifecycle event', () => {
+      expect(config.commands.config.lifecycleEvents).to.deep.equal(undefined);
     });
 
     it('should have the lifecycle event "config" for the "credentials" sub-command', () => {


### PR DESCRIPTION
## What did you implement:

Closes #2839

## How did you implement it:

I noticed that command which don't have any life-cycle event are filtered out anyway. I didn't expect this, but comes quite handy in this case without introducing any weird edge cases.

## How can we verify it:

run `serverless --help` or  just `serverless` and config should not be in the list

## Todos:

- [x] Write tests
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

