### PR TITLE
added default lambda env vars to local invoke

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -52,10 +52,31 @@ class AwsInvokeLocal {
   }
 
   loadEnvVars() {
+    const lambdaName = this.options.functionObj.name;
+    const MemorySize = Number(this.options.functionObj.memorySize)
+      || Number(this.serverless.service.provider.memorySize)
+      || 1024;
+
+    const lambdaDefaultEnvVars = {
+      PATH: '/usr/local/lib64/node-v4.3.x/bin:/usr/local/bin:/usr/bin/:/bin',
+      LANG: 'en_US.UTF-8',
+      LD_LIBRARY_PATH: '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib', // eslint-disable-line max-len
+      LAMBDA_TASK_ROOT: '/var/task',
+      LAMBDA_RUNTIME_DIR: '/var/runtime',
+      AWS_REGION: this.options.region || 'us-east-1',
+      AWS_DEFAULT_REGION: this.options.region || 'us-east-1',
+      AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
+      AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',
+      AWS_LAMBDA_FUNCTION_NAME: lambdaName,
+      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: MemorySize,
+      AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
+      NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
+    };
+
     const providerEnvVars = this.serverless.service.provider.environment || {};
     const functionEnvVars = this.options.functionObj.environment || {};
 
-    _.merge(process.env, providerEnvVars, functionEnvVars);
+    _.merge(process.env, lambdaDefaultEnvVars, providerEnvVars, functionEnvVars);
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -53,7 +53,7 @@ class AwsInvokeLocal {
 
   loadEnvVars() {
     const lambdaName = this.options.functionObj.name;
-    const MemorySize = Number(this.options.functionObj.memorySize)
+    const memorySize = Number(this.options.functionObj.memorySize)
       || Number(this.serverless.service.provider.memorySize)
       || 1024;
 
@@ -68,7 +68,7 @@ class AwsInvokeLocal {
       AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
       AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',
       AWS_LAMBDA_FUNCTION_NAME: lambdaName,
-      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: MemorySize,
+      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: memorySize,
       AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
     };

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -63,8 +63,8 @@ class AwsInvokeLocal {
       LD_LIBRARY_PATH: '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib', // eslint-disable-line max-len
       LAMBDA_TASK_ROOT: '/var/task',
       LAMBDA_RUNTIME_DIR: '/var/runtime',
-      AWS_REGION: this.options.region || 'us-east-1',
-      AWS_DEFAULT_REGION: this.options.region || 'us-east-1',
+      AWS_REGION: this.options.region,
+      AWS_DEFAULT_REGION: this.options.region,
       AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
       AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',
       AWS_LAMBDA_FUNCTION_NAME: lambdaName,

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -186,6 +186,7 @@ describe('AwsInvokeLocal', () => {
 
       awsInvokeLocal.options = {
         functionObj: {
+          name: 'serviceName-dev-hello',
           environment: {
             functionVar: 'functionValue',
           },
@@ -202,6 +203,26 @@ describe('AwsInvokeLocal', () => {
     it('it should load function env vars', () => awsInvokeLocal
       .loadEnvVars().then(() => {
         expect(process.env.functionVar).to.be.equal('functionValue');
+      })
+    );
+
+    it('it should load default lambda env vars', () => awsInvokeLocal
+      .loadEnvVars().then(() => {
+        expect(process.env.PATH)
+          .to.equal('/usr/local/lib64/node-v4.3.x/bin:/usr/local/bin:/usr/bin/:/bin');
+        expect(process.env.LANG).to.equal('en_US.UTF-8');
+        expect(process.env.LD_LIBRARY_PATH)
+          .to.equal('/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib'); // eslint-disable-line max-len
+        expect(process.env.LAMBDA_TASK_ROOT).to.equal('/var/task');
+        expect(process.env.LAMBDA_RUNTIME_DIR).to.equal('/var/runtime');
+        expect(process.env.AWS_REGION).to.equal('us-east-1');
+        expect(process.env.AWS_LAMBDA_LOG_GROUP_NAME).to.equal('/aws/lambda/serviceName-dev-hello');
+        expect(process.env.AWS_LAMBDA_LOG_STREAM_NAME)
+          .to.equal('2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad');
+        expect(process.env.AWS_LAMBDA_FUNCTION_NAME).to.equal('serviceName-dev-hello');
+        expect(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE).to.equal('1024');
+        expect(process.env.AWS_LAMBDA_FUNCTION_VERSION).to.equal('$LATEST');
+        expect(process.env.NODE_PATH).to.equal('/var/runtime:/var/task:/var/runtime/node_modules');
       })
     );
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -185,6 +185,7 @@ describe('AwsInvokeLocal', () => {
       };
 
       awsInvokeLocal.options = {
+        region: 'us-east-1',
         functionObj: {
           name: 'serviceName-dev-hello',
           environment: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2700 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
added default lambda env vars to local invoke
## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

make sure handler console.logs `process.env` and run the function locally, you should see something like the following:

```
{ PATH: '/usr/local/lib64/node-v4.3.x/bin:/usr/local/bin:/usr/bin/:/bin',
  LANG: 'en_US.UTF-8',
  LD_LIBRARY_PATH: '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib',
  LAMBDA_TASK_ROOT: '/var/task',
  LAMBDA_RUNTIME_DIR: '/var/runtime',
  AWS_REGION: 'us-west-2',
  AWS_DEFAULT_REGION: 'us-west-2',
  AWS_LAMBDA_LOG_GROUP_NAME: '/aws/lambda/lambda-default-env-vars-dev-hello',
  AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45sda9a9ebcec6bc9cad',
  AWS_LAMBDA_FUNCTION_NAME: 'lambda-default-env-vars-dev-hello',
  AWS_LAMBDA_FUNCTION_MEMORY_SIZE: 1024,
  AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
  NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules' }

```
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
