### PR TITLE
rename provider identifier from 'ibm' to 'openwhisk'.

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -76,7 +76,7 @@ class Service {
           };
         }
 
-        const providers = ['aws', 'azure', 'google', 'ibm'];
+        const providers = ['aws', 'azure', 'google', 'openwhisk'];
         if (providers.indexOf(serverlessFile.provider.name) === -1) {
           const errorMessage = [
             `Provider "${serverlessFile.provider.name}" is not supported.`,

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -214,7 +214,7 @@ describe('Service', () => {
       const SUtils = new Utils();
       const serverlessYaml = {
         service: 'my-service',
-        provider: 'ibm',
+        provider: 'openwhisk',
         functions: {
           functionA: {
             name: 'customFunctionName',
@@ -236,7 +236,7 @@ describe('Service', () => {
           },
         };
         expect(serviceInstance.service).to.be.equal('my-service');
-        expect(serviceInstance.provider.name).to.deep.equal('ibm');
+        expect(serviceInstance.provider.name).to.deep.equal('openwhisk');
         expect(serviceInstance.functions).to.deep.equal(expectedFunc);
       });
     });


### PR DESCRIPTION
## What did you implement:

Rename provider name from 'ibm' to 'openwhisk'.

OpenWhisk is open-source and the platform instance is not tied to IBM's cloud. This change is related to the upcoming OpenWhisk provider implementation.
https://github.com/serverless/serverless-ibm-openwhisk

## How did you implement it:

Simple string replacement. 

## How can we verify it:

Updated Service.test.js to verify this functionality change.

```
npm test
```

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config/commands/resources
- [X] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [X] Change ready for review message below


***Is this ready for review?:*** YES

