### PR TITLE
Temporarily remove provider.variableSyntax during variable population

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -32,6 +32,7 @@ class Variables {
 
     // temporally remove variable syntax from service otherwise it'll match
     this.service.defaults.variableSyntax = true;
+    this.service.provider.variableSyntax = true;
 
     /*
      * we can't use an arrow function in this case cause that would
@@ -48,6 +49,7 @@ class Variables {
     });
 
     this.service.defaults.variableSyntax = variableSyntaxProperty;
+    this.service.provider.variableSyntax = variableSyntaxProperty;
     return this.service;
   }
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -56,6 +56,7 @@ describe('Variables', () => {
       const barValue = 'test';
 
       serverless.service.defaults.variableSyntax = variableSyntax;
+      serverless.service.provider.variableSyntax = variableSyntax;
 
       serverless.service.custom = {
         var: barValue,


### PR DESCRIPTION
## What did you implement:
Closes #2890

## How did you implement it:
Temporarily remove provider.variableSyntax during variable population. This will prevent the service from matching on itself.

## How can we verify it:
Run `sls deploy --noDeploy` with a minimal `serverless.yml`

```
service: test-sls-proj

provider:
  name: aws
  runtime: nodejs4.3
  cfLogs: false
  variableSyntax: '\${{([\s\S]+?)}}'
```


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** Yes

