### PR TITLE
Fix credentials setup bug

### DIFF
--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -2,6 +2,7 @@
 
 const BbPromise = require('bluebird');
 const path = require('path');
+const fse = require('fs-extra');
 
 class AwsConfigCredentials {
   constructor(serverless, options) {
@@ -88,6 +89,9 @@ class AwsConfigCredentials {
           `Failed! ~/.aws/credentials exists and already has a "${this.options.profile}" profile.`);
         return BbPromise.resolve();
       }
+    } else {
+      // create the credentials file alongside the .aws directory if it's not yet present
+      fse.ensureFileSync(credsPath);
     }
 
     // write credentials file with 'default' profile

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -71,11 +71,12 @@ describe('AwsConfigCredentials', () => {
 
   describe('#configureCredentials()', () => {
     let homeDir;
+    let tmpDirPath;
     let credentialsFilePath;
 
     beforeEach(() => {
       // create a new tmpDir for the homeDir path
-      const tmpDirPath = testUtils.getTmpDirPath();
+      tmpDirPath = testUtils.getTmpDirPath();
       fse.mkdirsSync(tmpDirPath);
 
       // create the .aws/credetials directory and file
@@ -128,13 +129,25 @@ describe('AwsConfigCredentials', () => {
       awsConfigCredentials.options.key = 'my-profile-key';
       awsConfigCredentials.options.secret = 'my-profile-secret';
 
-      awsConfigCredentials.configureCredentials().then(() => {
+      return awsConfigCredentials.configureCredentials().then(() => {
         const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
         const lineByLineContent = credentialsFileContent.split('\n');
 
         expect(lineByLineContent[0]).to.equal('[my-profile]');
         expect(lineByLineContent[1]).to.equal('aws_access_key_id=my-profile-key');
         expect(lineByLineContent[2]).to.equal('aws_secret_access_key=my-profile-secret');
+      });
+    });
+
+    it('should create the .aws/credentials file if not yet present', () => {
+      // remove the .aws directory which was created in the before hook of the test
+      const awsDirectoryPath = path.join(tmpDirPath, '.aws');
+      fse.removeSync(awsDirectoryPath);
+
+      return awsConfigCredentials.configureCredentials().then(() => {
+        const isCredentialsFilePresent = fs.existsSync(path.join(awsDirectoryPath, 'credentials'));
+
+        expect(isCredentialsFilePresent).to.equal(true);
       });
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #2878

Fixes a bug where the credentials setup errors when the `.aws/credentials` file was not present.

## How did you implement it:

The `.aws` directory and the `credentials` file will now be created if not in place.

## How can we verify it:

Look at the code and run the test suite.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES