### PR TITLE
add support for stdin in invoke command

### DIFF
--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -12,7 +12,7 @@ layout: Doc
 
 # Invoke
 
-Invokes a previously deployed function. It allows to send event data to the function and read logs and display other important information of the function invoke.
+Invokes deployed function. It allows to send event data to the function, read logs and display other important information of the function invocation.
 
 ```bash
 serverless invoke [local] --function functionName
@@ -22,11 +22,10 @@ serverless invoke [local] --function functionName
 - `--function` or `-f` The name of the function in your service that you want to invoke. **Required**.
 - `--stage` or `-s` The stage in your service you want to invoke your function in.
 - `--region` or `-r` The region in your stage that you want to invoke your function in.
+- `--data` or `-d` String data to be passed as an event to your function. By default data is read from standard input.
 - `--path` or `-p` The path to a json file with input data to be passed to the invoked function. This path is relative to the root directory of the service.
 - `--type` or `-t` The type of invocation. Either `RequestResponse`, `Event` or `DryRun`. Default is `RequestResponse`.
-- `--log` or `-l` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation.
-Default is `false`.
-- `--data` or `-d` String data to be passed as an event to your function.
+- `--log` or `-l` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation. Default is `false`.
 
 ## Provided lifecycle events
 - `invoke:invoke`
@@ -57,6 +56,18 @@ serverless invoke --function functionName --stage dev --region us-east-1
 This example will invoke your deployed function named `functionName` in region `us-east-1` in stage `dev`. This will
 output the result of the invocation in your terminal.
 
+#### Function invocation with data
+
+```bash
+serverless invoke --function functionName --stage dev --region us-east-1 --data "hello world"
+```
+
+#### Function invocation with data from standard input
+
+```bash
+dataGenerator.js | serverless invoke --function functionName --stage dev --region us-east-1
+```
+
 #### Function invocation with logging
 
 ```bash
@@ -81,7 +92,6 @@ serverless invoke local --function functionName
 ```
 
 This example will locally invoke your function.
-
 
 #### Local function invocation with event data
 

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const path = require('path');
 const moment = require('moment');
 const validate = require('../lib/validate');
+const stdin = require('get-stdin');
 
 class AwsInvoke {
   constructor(serverless, options) {
@@ -28,27 +29,31 @@ class AwsInvoke {
     // validate function exists in service
     this.options.functionObj = this.serverless.service.getFunction(this.options.function);
 
-    // if data is provided via CLI, sanitize it
-    if (typeof this.options.data === 'string') {
+    return new BbPromise(resolve => {
+      if (this.options.data) {
+        resolve();
+      } else if (this.options.path) {
+        const absolutePath = path.isAbsolute(this.options.path) ?
+          this.options.path :
+          path.join(this.serverless.config.servicePath, this.options.path);
+        if (!this.serverless.utils.fileExistsSync(absolutePath)) {
+          throw new this.serverless.classes.Error('The file you provided does not exist.');
+        }
+        this.options.data = this.serverless.utils.readFileSync(absolutePath);
+        resolve();
+      } else {
+        stdin().then(input => {
+          this.options.data = input;
+          resolve();
+        });
+      }
+    }).then(() => {
       try {
         this.options.data = JSON.parse(this.options.data);
       } catch (exception) {
-        // do nothing if it's a simple string
+        // do nothing if it's a simple string or object already
       }
-    }
-
-    // if path is provided, load data from path
-    if (this.options.path) {
-      const absolutePath = path.isAbsolute(this.options.path) ?
-        this.options.path :
-        path.join(this.serverless.config.servicePath, this.options.path);
-      if (!this.serverless.utils.fileExistsSync(absolutePath)) {
-        throw new this.serverless.classes.Error('The file you provided does not exist.');
-      }
-      this.options.data = this.serverless.utils.readFileSync(absolutePath);
-    }
-
-    return BbPromise.resolve();
+    });
   }
 
   invoke() {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -22,8 +22,8 @@ describe('AwsInvoke', () => {
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsInvoke.hooks).to.be.not.empty);
 
-    it('should set the provider variable to an instance of AwsProvider', () =>
-      expect(awsInvoke.provider).to.be.instanceof(AwsProvider));
+    it('should set the provider variable to an instance of AwsProvider',
+      () => expect(awsInvoke.provider).to.be.instanceof(AwsProvider));
 
     it('should run promise chain in order', () => {
       const validateStub = sinon
@@ -72,6 +72,8 @@ describe('AwsInvoke', () => {
           handler: true,
         },
       };
+      awsInvoke.options.data = null;
+      awsInvoke.options.path = false;
     });
 
     it('it should throw error if function is not provided', () => {
@@ -99,6 +101,14 @@ describe('AwsInvoke', () => {
       });
     });
 
+    it('should parse data if it is a json string', () => {
+      awsInvoke.options.data = '{"key": "value"}';
+
+      return awsInvoke.extendedValidate().then(() => {
+        expect(awsInvoke.options.data).to.deep.equal({ key: 'value' });
+      });
+    });
+
     it('it should parse file if relative file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {
@@ -110,8 +120,6 @@ describe('AwsInvoke', () => {
 
       return awsInvoke.extendedValidate().then(() => {
         expect(awsInvoke.options.data).to.deep.equal(data);
-        awsInvoke.options.path = false;
-        serverless.config.servicePath = true;
       });
     });
 
@@ -126,8 +134,6 @@ describe('AwsInvoke', () => {
 
       return awsInvoke.extendedValidate().then(() => {
         expect(awsInvoke.options.data).to.deep.equal(data);
-        awsInvoke.options.path = false;
-        serverless.config.servicePath = true;
       });
     });
 
@@ -136,32 +142,29 @@ describe('AwsInvoke', () => {
       const yamlContent = 'testProp: testValue';
 
       serverless.utils.writeFileSync(path
-          .join(serverless.config.servicePath, 'data.yml'), yamlContent);
+        .join(serverless.config.servicePath, 'data.yml'), yamlContent);
       awsInvoke.options.path = 'data.yml';
 
       return awsInvoke.extendedValidate().then(() => {
         expect(awsInvoke.options.data).to.deep.equal({
           testProp: 'testValue',
         });
-        awsInvoke.options.path = false;
-        serverless.config.servicePath = true;
       });
     });
 
     it('it should throw error if service path is not set', () => {
       serverless.config.servicePath = false;
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);
-      serverless.config.servicePath = true;
     });
 
     it('it should throw error if file path does not exist', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       awsInvoke.options.path = 'some/path';
 
-      expect(() => awsInvoke.extendedValidate()).to.throw(Error);
-
-      awsInvoke.options.path = false;
-      serverless.config.servicePath = true;
+      return awsInvoke.extendedValidate().catch((err) => {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.equal('The file you provided does not exist.');
+      });
     });
 
     it('should resolve if path is not given', (done) => {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -81,18 +81,6 @@ describe('AwsInvoke', () => {
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);
     });
 
-    it('should parse JSON data if it is provided via CLI', () => {
-      awsInvoke.options.data = '{ "key1" : "pwd" }';
-
-      const parsedData = {
-        key1: 'pwd',
-      };
-
-      return awsInvoke.extendedValidate().then(() => {
-        expect(awsInvoke.options.data).to.deep.equal(parsedData);
-      });
-    });
-
     it('should keep data if it is a simple string', () => {
       awsInvoke.options.data = 'simple-string';
 

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const path = require('path');
 const validate = require('../lib/validate');
 const chalk = require('chalk');
+const stdin = require('get-stdin');
 
 class AwsInvokeLocal {
   constructor(serverless, options) {
@@ -28,27 +29,31 @@ class AwsInvokeLocal {
     // validate function exists in service
     this.options.functionObj = this.serverless.service.getFunction(this.options.function);
 
-    // if data is provided via CLI, sanitize it
-    if (typeof this.options.data === 'string') {
+    return new BbPromise(resolve => {
+      if (this.options.data) {
+        resolve();
+      } else if (this.options.path) {
+        const absolutePath = path.isAbsolute(this.options.path) ?
+          this.options.path :
+          path.join(this.serverless.config.servicePath, this.options.path);
+        if (!this.serverless.utils.fileExistsSync(absolutePath)) {
+          throw new this.serverless.classes.Error('The file you provided does not exist.');
+        }
+        this.options.data = this.serverless.utils.readFileSync(absolutePath);
+        resolve();
+      } else {
+        stdin().then(input => {
+          this.options.data = input;
+          resolve();
+        });
+      }
+    }).then(() => {
       try {
         this.options.data = JSON.parse(this.options.data);
       } catch (exception) {
-        // do nothing if it's a simple string
+        // do nothing if it's a simple string or object already
       }
-    }
-
-    // if path is provided, load data from path
-    if (this.options.path) {
-      const absolutePath = path.isAbsolute(this.options.path) ?
-        this.options.path :
-        path.join(this.serverless.config.servicePath, this.options.path);
-      if (!this.serverless.utils.fileExistsSync(absolutePath)) {
-        throw new this.serverless.classes.Error('The file you provided does not exist.');
-      }
-      this.options.data = this.serverless.utils.readFileSync(absolutePath);
-    }
-
-    return BbPromise.resolve();
+    });
   }
 
   loadEnvVars() {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -83,18 +83,6 @@ describe('AwsInvokeLocal', () => {
       expect(() => awsInvokeLocal.extendedValidate()).to.throw(Error);
     });
 
-    it('should parse JSON data if it is provided via CLI', () => {
-      awsInvokeLocal.options.data = '{ "key1" : "pwd" }';
-
-      const parsedData = {
-        key1: 'pwd',
-      };
-
-      return awsInvokeLocal.extendedValidate().then(() => {
-        expect(awsInvokeLocal.options.data).to.deep.equal(parsedData);
-      });
-    });
-
     it('should keep data if it is a simple string', () => {
       awsInvokeLocal.options.data = 'simple-string';
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -74,6 +74,8 @@ describe('AwsInvokeLocal', () => {
           handler: true,
         },
       };
+      awsInvokeLocal.options.data = null;
+      awsInvokeLocal.options.path = false;
     });
 
     it('it should throw error if function is not provided', () => {
@@ -101,12 +103,18 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
-    it('it should parse mock file if provided', () => {
+    it('should parse data if it is a json string', () => {
+      awsInvokeLocal.options.data = '{"key": "value"}';
+
+      return awsInvokeLocal.extendedValidate().then(() => {
+        expect(awsInvokeLocal.options.data).to.deep.equal({ key: 'value' });
+      });
+    });
+
+    it('it should parse file if relative file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {
-        event: {
-          testProp: 'testValue',
-        },
+        testProp: 'testValue',
       };
       serverless.utils.writeFileSync(path
         .join(serverless.config.servicePath, 'data.json'), JSON.stringify(data));
@@ -114,8 +122,6 @@ describe('AwsInvokeLocal', () => {
 
       return awsInvokeLocal.extendedValidate().then(() => {
         expect(awsInvokeLocal.options.data).to.deep.equal(data);
-        awsInvokeLocal.options.path = false;
-        serverless.config.servicePath = true;
       });
     });
 
@@ -132,8 +138,6 @@ describe('AwsInvokeLocal', () => {
 
       return awsInvokeLocal.extendedValidate().then(() => {
         expect(awsInvokeLocal.options.data).to.deep.equal(data);
-        awsInvokeLocal.options.path = false;
-        serverless.config.servicePath = true;
       });
     });
 
@@ -147,25 +151,21 @@ describe('AwsInvokeLocal', () => {
 
       return awsInvokeLocal.extendedValidate().then(() => {
         expect(awsInvokeLocal.options.data).to.deep.equal({ event: 'data' });
-        awsInvokeLocal.options.path = false;
-        serverless.config.servicePath = true;
       });
     });
 
     it('it should throw error if service path is not set', () => {
       serverless.config.servicePath = false;
       expect(() => awsInvokeLocal.extendedValidate()).to.throw(Error);
-      serverless.config.servicePath = true;
     });
 
-    it('it should throw error if file path does not exist', () => {
+    it('it should reject error if file path does not exist', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       awsInvokeLocal.options.path = 'some/path';
 
-      expect(() => awsInvokeLocal.extendedValidate()).to.throw(Error);
-
-      awsInvokeLocal.options.path = false;
-      serverless.config.servicePath = true;
+      return awsInvokeLocal.extendedValidate().catch((err) => {
+        expect(err).to.be.instanceOf(Error);
+      });
     });
 
     it('should resolve if path is not given', (done) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -308,9 +308,9 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      "version": "5.0.1",
+      "from": "get-stdin@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
     },
     "get-stream": {
       "version": "2.3.1",
@@ -669,7 +669,14 @@
     "strip-dirs": {
       "version": "1.1.1",
       "from": "strip-dirs@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+      "dependencies": {
+        "get-stdin": {
+          "version": "4.0.1",
+          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        }
+      }
     },
     "strip-json-comments": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "download": "^5.0.2",
     "filesize": "^3.3.0",
     "fs-extra": "^0.26.7",
+    "get-stdin": "^5.0.1",
     "glob-all": "^3.1.0",
     "https-proxy-agent": "^1.0.0",
     "js-yaml": "^3.6.1",


### PR DESCRIPTION
## What did you implement:

Closes #2211

## How can we verify it:

```
echo 123 | serverless invoke -f testfunc
echo "hello" | serverless invoke -f testfunc
echo "{\"a\": 123}" | serverless invoke -f testfunc
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES

