### PR TITLE
Upgrade AWS SDK shrinkwrap version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,9 +52,9 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "aws-sdk": {
-      "version": "2.7.8",
+      "version": "2.7.13",
       "from": "aws-sdk@>=2.3.17 <3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.7.8.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.7.13.tgz",
       "dependencies": {
         "uuid": {
           "version": "3.0.0",


### PR DESCRIPTION
My colleague and I are working on a plugin that requires an SDK version of at least 2.7.10.

Please sync the shrinkwrap file!