### PR TITLE
fix deployment monitoring

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -48,7 +48,7 @@ module.exports = {
                   let eventStatus = event.ResourceStatus || null;
                   if (eventInRange && eventNotLogged) {
                     // Keep track of stack status
-                    if (event.ResourceType === 'AWS::CloudFormation::Stack') {
+                    if (event.ResourceType === 'AWS::CloudFormation::Stack' && event.StackName === event.LogicalResourceId) {
                       stackStatus = eventStatus;
                     }
                     // Keep track of first failed event

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -48,7 +48,8 @@ module.exports = {
                   let eventStatus = event.ResourceStatus || null;
                   if (eventInRange && eventNotLogged) {
                     // Keep track of stack status
-                    if (event.ResourceType === 'AWS::CloudFormation::Stack' && event.StackName === event.LogicalResourceId) {
+                    if (event.ResourceType === 'AWS::CloudFormation::Stack'
+                      && event.StackName === event.LogicalResourceId) {
                       stackStatus = eventStatus;
                     }
                     // Keep track of first failed event

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -64,6 +64,153 @@ describe('monitorStack', () => {
           },
         ],
       };
+      const updateFinishedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_COMPLETE',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+
+      return awsPlugin.monitorStack('create', cfDataMock, 10).then((stackStatus) => {
+        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        expect(stackStatus).to.be.equal('CREATE_COMPLETE');
+        awsPlugin.provider.request.restore();
+      });
+    });
+
+    it('should keep monitoring until UPDATE_COMPLETE stack status', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateFinishedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_COMPLETE',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+
+      return awsPlugin.monitorStack('update', cfDataMock, 10).then((stackStatus) => {
+        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        expect(stackStatus).to.be.equal('UPDATE_COMPLETE');
+        awsPlugin.provider.request.restore();
+      });
+    });
+
+    it('should keep monitoring until DELETE_COMPLETE stack status', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'DELETE_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateFinishedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'DELETE_COMPLETE',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+
+      return awsPlugin.monitorStack('removal', cfDataMock, 10).then((stackStatus) => {
+        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        expect(stackStatus).to.be.equal('DELETE_COMPLETE');
+        awsPlugin.provider.request.restore();
+      });
+    });
+
+    it('should not stop monitoring on CREATE_COMPLETE nested stack status', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_IN_PROGRESS',
+          },
+        ],
+      };
       const nestedStackEvent = {
         StackEvents: [
           {
@@ -109,7 +256,7 @@ describe('monitorStack', () => {
       });
     });
 
-    it('should keep monitoring until UPDATE_COMPLETE stack status', () => {
+    it('should not stop monitoring on UPDATE_COMPLETE nested stack status', () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',
@@ -171,7 +318,7 @@ describe('monitorStack', () => {
       });
     });
 
-    it('should keep monitoring until DELETE_COMPLETE stack status', () => {
+    it('should not stop monitoring on DELETE_COMPLETE nested stack status', () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -56,10 +56,23 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'CREATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const nestedStackEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4z',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'nested-stack-name',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_COMPLETE',
           },
         ],
       };
@@ -67,7 +80,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1e2f3g4h',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'CREATE_COMPLETE',
@@ -76,10 +90,11 @@ describe('monitorStack', () => {
       };
 
       describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
-      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(nestedStackEvent));
+      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateFinishedEvent));
 
       return awsPlugin.monitorStack('create', cfDataMock, 10).then((stackStatus) => {
-        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
         expect(describeStackEventsStub.calledWithExactly(
           'CloudFormation',
           'describeStackEvents',
@@ -103,10 +118,23 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const nestedStackEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4z',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'nested-stack-name',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_COMPLETE',
           },
         ],
       };
@@ -114,7 +142,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1e2f3g4h',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_COMPLETE',
@@ -123,10 +152,11 @@ describe('monitorStack', () => {
       };
 
       describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
-      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(nestedStackEvent));
+      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateFinishedEvent));
 
       return awsPlugin.monitorStack('update', cfDataMock, 10).then((stackStatus) => {
-        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
         expect(describeStackEventsStub.calledWithExactly(
           'CloudFormation',
           'describeStackEvents',
@@ -150,10 +180,23 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'DELETE_IN_PROGRESS',
+          },
+        ],
+      };
+      const nestedStackEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4z',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'nested-stack-name',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'DELETE_COMPLETE',
           },
         ],
       };
@@ -161,7 +204,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1e2f3g4h',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'DELETE_COMPLETE',
@@ -170,10 +214,11 @@ describe('monitorStack', () => {
       };
 
       describeStackEventsStub.onCall(0).returns(BbPromise.resolve(updateStartEvent));
-      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateFinishedEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(nestedStackEvent));
+      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateFinishedEvent));
 
       return awsPlugin.monitorStack('removal', cfDataMock, 10).then((stackStatus) => {
-        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
         expect(describeStackEventsStub.calledWithExactly(
           'CloudFormation',
           'describeStackEvents',
@@ -197,7 +242,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'DELETE_IN_PROGRESS',
@@ -237,7 +283,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_IN_PROGRESS',
@@ -248,6 +295,7 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
             LogicalResourceId: 'mochaS3',
             ResourceType: 'S3::Bucket',
             Timestamp: new Date(),
@@ -260,7 +308,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1i2j3k4l',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
@@ -271,7 +320,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1m2n3o4p',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'ROLLBACK_COMPLETE',
@@ -311,6 +361,7 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
             LogicalResourceId: 'somebucket',
             ResourceType: 'AWS::S3::Bucket',
             Timestamp: new Date(),
@@ -321,7 +372,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1a2b3c4d',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_IN_PROGRESS',
@@ -332,7 +384,8 @@ describe('monitorStack', () => {
         StackEvents: [
           {
             EventId: '1m2n3o4p',
-            LogicalResourceId: 'mocha',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_COMPLETE',


### PR DESCRIPTION
## What did you implement:

Closes #2898

## How did you implement it:

Changed ine 51 of monitorStack.js:
~~~~
if (event.ResourceType === 'AWS::CloudFormation::Stack')
~~~~
to
~~~~
if (event.ResourceType === 'AWS::CloudFormation::Stack' && event.StackName === event.LogicalResourceId)
~~~~

I first thought about:
~~~~
if (event.ResourceType === 'AWS::CloudFormation::Stack' 
    && event.StackId === event.PhysicalResourceId)
~~~~
which also works, however as the event.StackId is sometimes used for the name, it seemed that comparing the equality between StackName and LogicalResourceId  is even better.

I also changed test scripts, so that the existing tests don't fail, but also so that CREATE_COMPLETE, UPDATE_COMPLETE and DELETE_COMPLETE tests make sure that the monitoring doesn't stop if the event comes from the nested stack.

## How can we verify it:

1. Use a setup like this in serverless.yml
~~~~
resources:
  Resources:
    outsideStack:
      Type: AWS::CloudFormation::Stack
      Properties:
        TemplateURL: 'https://xxx.s3.amazonaws.com/user-pool-client.cform'
    IamRoleLambdaExecution:
      DependsOn:
        - outsideStack
~~~~

2. do sls deploy
3a. open cloudformation console on aws, and notice that the deployments are finished when the serverless command is finished
or
3b.  notice that the `functions` and `endpoints` are properly returned

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

fix for #2898, when there is a nested stack, serverless needs to distinguish its events from the main stack events.