### PR TITLE
Add CloudWatchEvent rule name and description fields

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ The Serverless Framework allows you to deploy auto-scaling, pay-per-execution, e
         <li><a href="./providers/aws/guide/iam.md">IAM</a></li>
         <li><a href="./providers/aws/guide/plugins.md">Plugins</a></li>
         <li><a href="./providers/aws/guide/workflow.md">Workflow</a></li>
+        <li><a href="./providers/aws/guide/serverless.yml.md">Serverless.yml</a></li>
       </ul>
     </div>
   </div>

--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -56,5 +56,5 @@ events:
   - schedule:
       name: your-scheduled-rate-event-name
       description: 'your scheduled rate event description'
-      rate(2 hours)
+      rate: rate(2 hours)
 ```

--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -34,8 +34,6 @@ functions:
     handler: statistics.handler
     events:
       - schedule:
-          name: your-scheduled-rate-event-name
-          description: 'your scheduled rate event description'
           rate: rate(10 minutes)
           enabled: false
           input:
@@ -44,9 +42,19 @@ functions:
             stageParams:
               stage: dev
       - schedule:
-          name: your-scheduled-cron-event-name
-          description: 'your scheduled cron event description'
           rate: cron(0 12 * * ? *)
           enabled: false
           inputPath: '$.stageVariables'
+```
+
+## Specify Name and Description
+
+Name and Description can be specified for a schedule event. These are not required properties.
+
+```yaml
+events:
+  - schedule:
+      name: your-scheduled-rate-event-name
+      description: 'your scheduled rate event description'
+      rate(2 hours)
 ```

--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -34,6 +34,8 @@ functions:
     handler: statistics.handler
     events:
       - schedule:
+          name: your-scheduled-rate-event-name
+          description: 'your scheduled rate event description'
           rate: rate(10 minutes)
           enabled: false
           input:
@@ -42,6 +44,8 @@ functions:
             stageParams:
               stage: dev
       - schedule:
+          name: your-scheduled-cron-event-name
+          description: 'your scheduled cron event description'
           rate: cron(0 12 * * ? *)
           enabled: false
           inputPath: '$.stageVariables'

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -25,6 +25,8 @@ class AwsCompileScheduledEvents {
             let State;
             let Input;
             let InputPath;
+            let Name;
+            let Description;
 
             // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
@@ -42,6 +44,8 @@ class AwsCompileScheduledEvents {
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
               Input = event.schedule.input;
               InputPath = event.schedule.inputPath;
+              Name = event.schedule.name;
+              Description = event.schedule.description;
 
               if (Input && InputPath) {
                 const errorMessage = [
@@ -88,6 +92,8 @@ class AwsCompileScheduledEvents {
                 "Properties": {
                   "ScheduleExpression": "${ScheduleExpression}",
                   "State": "${State}",
+                  ${Name ? `"Name": "${Name}",` : ''}
+                  ${Description ? `"Description": "${Description}",` : ''}
                   "Targets": [{
                     ${Input ? `"Input": "${Input}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath}",` : ''}

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.test.js
@@ -101,6 +101,52 @@ describe('AwsCompileScheduledEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should respect name variable', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                name: 'your-scheduled-event-name',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Name
+      ).to.equal('your-scheduled-event-name');
+    });
+
+    it('should respect description variable', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                description: 'your scheduled event description',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Description
+      ).to.equal('your scheduled event description');
+    });
+
     it('should respect inputPath variable', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2832

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
It is possible to add name and description property of scheduled event in CloudFormation.
These are not required properties.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
set property as follow
```yml
 events:
      - schedule:
          name: my-scheduled-event
          description: 'my scheduled event'
          rate: rate(10 minutes)
```

deployed name and description to a scheduled event Lambda 
<img width="621" alt="2016-12-10 13 49 14" src="https://cloud.githubusercontent.com/assets/1301012/21071292/d27ad15a-bedf-11e6-8bb8-bba77393d08e.png">


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:
Linting errors occurs in master branch. But my implementaion is no problem.
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

