### PR TITLE
I need to be able to get the serverless stage from the resources sect…

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -34,6 +34,16 @@ module.exports = {
         },
       },
     });
+
+    // Create a CloudFormation Ref for the stage
+    // then you can use it in a resources: Resource
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+      ServerlessStage: {
+        Description: 'The Stage option from serverless',
+        Value: this.options.stage,
+      },
+    });
+
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.test.js
@@ -65,4 +65,17 @@ describe('#compileDeployment()', () => {
       });
     })
   );
+
+  it('should add serverless stage output', () =>
+    awsCompileApigEvents.compileDeployment().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Outputs.ServerlessStage
+      ).to.deep.equal({
+        Description: 'The Stage option from serverless',
+        Value: 'dev',
+      });
+    })
+  );
+
 });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.test.js
@@ -77,5 +77,4 @@ describe('#compileDeployment()', () => {
       });
     })
   );
-
 });


### PR DESCRIPTION
## What did you implement:
I need to be able to get the serverless stage from the resources section of the serverless.yml, and this is the shortest distance to that as "${opts:stage}" does not expand in the resources section of serverless.yml and I am javascript noidea dog

Closes #2911 

## How did you implement it:
I added a CloudFormation output that could be gotten via `{ "Ref": "ServerlessStage" }` . That might not be the way you'd like to solve it.  I'm not a javascriptologist, so this was a good solution for me. 

## How can we verify it:

The serverless.yml attached to #2911 provides an example of how to manifest the issue. 


## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below

***Is this ready for review?:*** YES