### PR TITLE
Fix order of CLI docs

### DIFF
--- a/docs/providers/aws/cli-reference/config.md
+++ b/docs/providers/aws/cli-reference/config.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Config
 menuText: Config
-menuOrder: 10
+menuOrder: 1
 description: Configure Serverless.
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Create
 menuText: Create
-menuOrder: 1
+menuOrder: 2
 description: Creates a new Service in your current working directory
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Deploy
 menuText: Deploy
-menuOrder: 3
+menuOrder: 4
 description: Deploy your service to the specified provider
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/info.md
+++ b/docs/providers/aws/cli-reference/info.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Info
 menuText: Info
-menuOrder: 7
+menuOrder: 8
 description: Display information about your deployed service and the AWS Lambda Functions, Events and AWS Resources it contains.
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Install
 menuText: Install
-menuOrder: 2
+menuOrder: 3
 description: Install pre-written AWS Lambda Functions, Events and Resources with the Serverless Framework
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Invoke
 menuText: Invoke
-menuOrder: 4
+menuOrder: 5
 description: Invoke an AWS Lambda Function using the Serverless Framework
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/logs.md
+++ b/docs/providers/aws/cli-reference/logs.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Logs
 menuText: Logs
-menuOrder: 5
+menuOrder: 6
 description: View logs of your AWS Lambda Function within your terminal using the Serverless Framework
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/metrics.md
+++ b/docs/providers/aws/cli-reference/metrics.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Metrics
 menuText: Metrics
-menuOrder: 6
+menuOrder: 7
 description: View metrics of your AWS Lambda Function within your terminal using the Serverless Framework
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/remove.md
+++ b/docs/providers/aws/cli-reference/remove.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Remove
 menuText: Remove
-menuOrder: 8
+menuOrder: 10
 description: Remove a deployed Service and all of its AWS Lambda Functions, Events and Resources
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/rollback.md
+++ b/docs/providers/aws/cli-reference/rollback.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Rollback CLI Command
 menuText: Rollback
-menuOrder: 10
+menuOrder: 9
 description: Rollback the Serverless service to a specific deployment
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/slstats.md
+++ b/docs/providers/aws/cli-reference/slstats.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Serverless Stats
 menuText: Serverless Stats
-menuOrder: 9
+menuOrder: 11
 description: Enables or disables Serverless Statistic logging within the Serverless Framework.
 layout: Doc
 -->


### PR DESCRIPTION
## What did you implement:

Updates the `menuOrder` property so that it matches the one in the overview `README.md` file.

## How did you implement it:

Updated the numbers.

## How can we verify it:

Look into the `.md` files.

## Todos:

- [x] Write documentation
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES