### PR TITLE
Split up config CLI doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ The Serverless Framework allows you to deploy auto-scaling, pay-per-execution, e
     </div>
     <div>
       <ul>
-        <li><a href="./providers/aws/cli-reference/config.md">Config</a></li>
+        <li><a href="./providers/aws/cli-reference/config-credentials.md">Config Credentials</a></li>
         <li><a href="./providers/aws/cli-reference/create.md">Create</a></li>
         <li><a href="./providers/aws/cli-reference/install.md">Install</a></li>
         <li><a href="./providers/aws/cli-reference/deploy.md">Deploy</a></li>

--- a/docs/providers/aws/cli-reference/config-credentials.md
+++ b/docs/providers/aws/cli-reference/config-credentials.md
@@ -1,39 +1,35 @@
 <!--
-title: Serverless Framework Commands - AWS Lambda - Config
-menuText: Config
+title: Serverless Framework Commands - AWS Lambda - Config Credentials
+menuText: Config Credentials
 menuOrder: 1
-description: Configure Serverless.
+description: Configure Serverless credentials
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/aws/cli-reference/config)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/aws/cli-reference/config-credentials)
 <!-- DOCS-SITE-LINK:END -->
 
-# Config
-
-This plugin helps you to configure Serverless.
-
-## Configure credentials
+# Config Credentials
 
 ```bash
 serverless config credentials --provider provider --key key --secret secret
 ```
 
-### Options
+## Options
 
 - `--provider` or `-p` The provider (in this case `aws`). **Required**.
 - `--key` or `-k` The `aws_access_key_id`. **Required**.
 - `--secret` or `-s` The `aws_secret_access_key`. **Required**.
 - `--profile` or `-n` The name of the profile which should be created.
 
-### Provided lifecycle events
+## Provided lifecycle events
 
 - `config:credentials:config`
 
-### Examples
+## Examples
 
-#### Configure the `default` profile
+### Configure the `default` profile
 
 ```bash
 serverless config credentials --provider aws --key 1234 --secret 5678
@@ -41,7 +37,7 @@ serverless config credentials --provider aws --key 1234 --secret 5678
 
 This example will configure the `default` profile with the `aws_access_key_id` of `1234` and the `aws_secret_access_key` of `5678`.
 
-#### Configure a custom profile
+### Configure a custom profile
 
 ```bash
 serverless config credentials --provider aws --key 1234 --secret 5678 --profile custom-profile


### PR DESCRIPTION
## What did you implement:

Split up the `config` CLI doc so that it now covers `config credentials`.

## How did you implement it:

Split up the old doc.

## How can we verify it:

Read the docs.

## Todos:

- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES