### PR TITLE
fixed bug where you can now invoke without any input data

### DIFF
--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -28,6 +28,7 @@ class AwsInvoke {
 
     // validate function exists in service
     this.options.functionObj = this.serverless.service.getFunction(this.options.function);
+    this.options.data = this.options.data || '';
 
     return new BbPromise(resolve => {
       if (this.options.data) {

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -42,10 +42,15 @@ class AwsInvoke {
         this.options.data = this.serverless.utils.readFileSync(absolutePath);
         resolve();
       } else {
-        stdin().then(input => {
-          this.options.data = input;
+        try {
+          stdin().then(input => {
+            this.options.data = input;
+            resolve();
+          });
+        } catch (exception) {
+          // resolve if no stdin was provided
           resolve();
-        });
+        }
       }
     }).then(() => {
       try {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -85,7 +85,7 @@ describe('AwsInvoke', () => {
       awsInvoke.options.data = undefined;
 
       return awsInvoke.extendedValidate().then(() => {
-        expect(awsInvoke.options.data).to.equal(undefined);
+        expect(awsInvoke.options.data).to.equal('');
       });
     });
 

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -81,6 +81,14 @@ describe('AwsInvoke', () => {
       expect(() => awsInvoke.extendedValidate()).to.throw(Error);
     });
 
+    it('should not throw error when there are no input data', () => {
+      awsInvoke.options.data = undefined;
+
+      return awsInvoke.extendedValidate().then(() => {
+        expect(awsInvoke.options.data).to.equal(undefined);
+      });
+    });
+
     it('should keep data if it is a simple string', () => {
       awsInvoke.options.data = 'simple-string';
 

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -28,6 +28,7 @@ class AwsInvokeLocal {
 
     // validate function exists in service
     this.options.functionObj = this.serverless.service.getFunction(this.options.function);
+    this.options.data = this.options.data || '';
 
     return new BbPromise(resolve => {
       if (this.options.data) {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -42,10 +42,15 @@ class AwsInvokeLocal {
         this.options.data = this.serverless.utils.readFileSync(absolutePath);
         resolve();
       } else {
-        stdin().then(input => {
-          this.options.data = input;
+        try {
+          stdin().then(input => {
+            this.options.data = input;
+            resolve();
+          });
+        } catch (exception) {
+          // resolve if no stdin was provided
           resolve();
-        });
+        }
       }
     }).then(() => {
       try {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -78,6 +78,14 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.options.path = false;
     });
 
+    it('should not throw error when there are no input data', () => {
+      awsInvokeLocal.options.data = undefined;
+
+      return awsInvokeLocal.extendedValidate().then(() => {
+        expect(awsInvokeLocal.options.data).to.equal(undefined);
+      });
+    });
+
     it('it should throw error if function is not provided', () => {
       serverless.service.functions = null;
       expect(() => awsInvokeLocal.extendedValidate()).to.throw(Error);

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -82,7 +82,7 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.options.data = undefined;
 
       return awsInvokeLocal.extendedValidate().then(() => {
-        expect(awsInvokeLocal.options.data).to.equal(undefined);
+        expect(awsInvokeLocal.options.data).to.equal('');
       });
     });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixed a bug that prevented you from invoking (remotely or locally) functions without input data.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Try catch block wrapping stdin module
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

1. create service
2. invoke function locally without passing any data. It should fail with master but work with this fix.
3. deploy service
4. invoke function locally without passing any data. It should fail with master but work with this fix.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
