### PR TITLE
fix #2936. Enable schedule event by default.

### DIFF
--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -25,6 +25,8 @@ functions:
 
 ## Enabling/Disabling functions
 
+Schedule events are enabled by default.
+
 This will create and attach a schedule event for the `aggregate` function which is disabled. If enabled it will call
 the `aggregate` function every 10 minutes.
 

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -41,7 +41,6 @@ class AwsCompileScheduledEvents {
                   .Error(errorMessage);
               }
               ScheduleExpression = event.schedule.rate;
-              event.schedule.enabled = typeof(event.schedule.enabled) === 'boolean' ? event.schedule.enabled : true;
               State = 'ENABLED';
               if(event.schedule.enabled === false) {
                 State = 'DISABLED';

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -41,6 +41,7 @@ class AwsCompileScheduledEvents {
                   .Error(errorMessage);
               }
               ScheduleExpression = event.schedule.rate;
+              event.schedule.enabled = typeof(event.schedule.enabled) === 'boolean') ? event.schedule.enabled : true;
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
               Input = event.schedule.input;
               InputPath = event.schedule.inputPath;

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -42,7 +42,7 @@ class AwsCompileScheduledEvents {
               }
               ScheduleExpression = event.schedule.rate;
               State = 'ENABLED';
-              if(event.schedule.enabled === false) {
+              if (event.schedule.enabled === false) {
                 State = 'DISABLED';
               }
               Input = event.schedule.input;

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -42,7 +42,10 @@ class AwsCompileScheduledEvents {
               }
               ScheduleExpression = event.schedule.rate;
               event.schedule.enabled = typeof(event.schedule.enabled) === 'boolean' ? event.schedule.enabled : true;
-              State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
+              State = 'ENABLED';
+              if(event.schedule.enabled === false) {
+                State = 'DISABLED';
+              }
               Input = event.schedule.input;
               InputPath = event.schedule.inputPath;
               Name = event.schedule.name;

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.js
@@ -41,7 +41,7 @@ class AwsCompileScheduledEvents {
                   .Error(errorMessage);
               }
               ScheduleExpression = event.schedule.rate;
-              event.schedule.enabled = typeof(event.schedule.enabled) === 'boolean') ? event.schedule.enabled : true;
+              event.schedule.enabled = typeof(event.schedule.enabled) === 'boolean' ? event.schedule.enabled : true;
               State = event.schedule.enabled ? 'ENABLED' : 'DISABLED';
               Input = event.schedule.input;
               InputPath = event.schedule.inputPath;

--- a/lib/plugins/aws/deploy/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/schedule/index.test.js
@@ -101,6 +101,54 @@ describe('AwsCompileScheduledEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should respect enabled variable, defaulting to true', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+              },
+            },
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: true,
+              },
+            },
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+              },
+            },
+            {
+              schedule: 'rate(10 minutes)',
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.State
+      ).to.equal('DISABLED');
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule2
+        .Properties.State
+      ).to.equal('ENABLED');
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule3
+        .Properties.State
+      ).to.equal('ENABLED');
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule4
+        .Properties.State
+      ).to.equal('ENABLED');
+    });
+
     it('should respect name variable', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2936

Schedule event always defaults to being enabled

## How did you implement it:
## How can we verify it:

```yml
# my service
service: simple-service

provider:
  name: aws
  runtime: nodejs4.3
  cfLogs: true

functions:
  hello:
    handler: handler.hello
    events:
      - schedule:
          rate: rate(1 minute)
  world:
    handler: handler.world
    events:
      - schedule: rate(1 minute)
```

Look into the AWS Lambda console to see that it's enabled by default.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES

