### PR TITLE
Adds PowerShell script for automatically generating a deployment package.

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -26,7 +26,7 @@ Here's how to set up the Serverless Framework with your Amazon Web Services acco
 
 If you're new to Amazon Web Services, make sure you put in a credit card.  
 
-All AWS users get access to the Free Tier for [AWS Lambda](https://aws.amazon.com/lambda/pricing/). ASW Lambda is part of the non-expiring [AWS Free Tier](https://aws.amazon.com/free/#AWS_FREE_TIER).
+All AWS users get access to the Free Tier for [AWS Lambda](https://aws.amazon.com/lambda/pricing/). AWS Lambda is part of the non-expiring [AWS Free Tier](https://aws.amazon.com/free/#AWS_FREE_TIER).
 
 If you don't have a credit card set up, you may not be able to deploy your resources and you may run into this error:
 

--- a/lib/plugins/create/templates/aws-csharp/build.ps1
+++ b/lib/plugins/create/templates/aws-csharp/build.ps1
@@ -1,0 +1,55 @@
+#
+#  build.ps1: A PowerShell script to create deployment packages for serverless 
+#
+#  Options:
+#    Configuration: the project configuration to build (default: Release)  
+#
+#  This script uses the ZipFile class from .NET Framework 4.5 to create the
+#  deployment package.
+#
+param (
+ [String]$Configuration="Release"
+)
+
+$curDir = Split-Path -parent $MyInvocation.MyCommand.Definition
+$deploymentDir = Join-Path $curDir "bin/$Configuration/netcoreapp1.0/publish"
+$deploymentPackageName = "deploy-package.zip"
+$deploymentPackagePath = Join-Path $deploymentDir $deploymentPackageName
+$tempDeploymentPackagePath = [System.IO.Path]::GetTempFileName()
+
+# Load ZipFile support from .NET 4.5
+try
+{
+  Add-Type -AssemblyName "system.io.compression.filesystem"
+}
+catch 
+{
+  echo "Unable to load assembly 'System.IO.Compression.Filesystem' (we need .NET 4.5 to have been installed)"
+  exit
+}
+
+# Move to the project folder
+pushd $curDir
+try
+{
+  #build handlers
+  dotnet restore
+  # As of 1.0.1, publish does not clean out the target folder, so 
+  # we'll clean it to be safe.
+  if (Test-Path $deploymentDir) {rm $(Join-Path $deploymentDir "*")}
+  dotnet publish -c $Configuration
+
+  # Create the deployment package. Unfortunately, the ZipFile class:
+  # A) only zips up the contents of an entire folder
+  # B) will attempt to include the zip file being created if it is in said folder.
+  # To handle that we zip to a temp file and then move it afterwards.
+  if (Test-Path $tempDeploymentPackagePath) {rm $tempDeploymentPackagePath }  
+  [IO.Compression.ZipFile]::CreateFromDirectory($deploymentDir, $tempDeploymentPackagePath)
+  cp $tempDeploymentPackagePath $deploymentPackagePath
+}
+finally
+{
+  popd
+  # If we have a dangling zip file, nuke it.
+  if (Test-Path $tempDeploymentPackagePath) {rm $tempDeploymentPackagePath}
+}


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added PowerShell support for generating deployment package (primarily to support folks who are working on Windows machines and not under the Ubuntu bash shell).

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

This is a functional replication of the bash script (build.sh) written as a PowerShell script (build.ps1).

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

This script uses roughly the same process as the build.sh script; namely, invoking dotnet restore, dotnet publish, and generating a Zip file from the output. The only major change is adding a step to flush the contents of the publication target folder in order to eliminate the possibility of picking up "stale" content. It is worthwhile to note that the class we're using in the PowerShell script requires .NET 4.5 be installed on the machine, which should be practically every Windows box running PowerShell. However, we do have a failure mode that reports that requirement in the event that the assembly cannot be loaded.

## How can we verify it:
1) Install dotnet core on a Windows 8+ machine
2) Install a recent release of Nodejs on said machine
3) Install the serverless framework per the documentation on serverless.com
4) Create a new C# service using "serverless create --name <<name>> --template aws-csharp"
5) Execute the build.ps1 script using "./build.ps1"
6) Verify the existence of a deployment package named "deploy-package.zip" under bin\Release\netcoreapp1.0\publish, and that the contents match the contents of the bin\Release\netcoreapp1.0\publish (minus the zip file).

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** NO
