### PR TITLE
Generate a single policy statement to cover all stream events

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -114,9 +114,9 @@ class AwsCompileStreamEvents {
 
             // create type specific PolicyDocument statements
             if (streamType === 'dynamodb') {
-              dynamodbStreamStatement.Resource.push(EventSourceArn)
+              dynamodbStreamStatement.Resource.push(EventSourceArn);
             } else {
-              kinesisStreamStatement.Resource.push(EventSourceArn)
+              kinesisStreamStatement.Resource.push(EventSourceArn);
             }
 
             const newStreamObject = {
@@ -137,11 +137,11 @@ class AwsCompileStreamEvents {
             .Properties
             .PolicyDocument
             .Statement;
-          if(dynamodbStreamStatement.Resource.length) {
-            statement.push(dynamodbStreamStatement)
+          if (dynamodbStreamStatement.Resource.length) {
+            statement.push(dynamodbStreamStatement);
           }
-          if(kinesisStreamStatement.Resource.length) {
-            statement.push(kinesisStreamStatement)
+          if (kinesisStreamStatement.Resource.length) {
+            statement.push(kinesisStreamStatement);
           }
         }
       }

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -17,6 +17,27 @@ class AwsCompileStreamEvents {
       const functionObj = this.serverless.service.getFunction(functionName);
 
       if (functionObj.events) {
+        const dynamodbStreamStatement = {
+          Effect: 'Allow',
+          Action: [
+            'dynamodb:GetRecords',
+            'dynamodb:GetShardIterator',
+            'dynamodb:DescribeStream',
+            'dynamodb:ListStreams',
+          ],
+          Resource: [],
+        };
+        const kinesisStreamStatement = {
+          Effect: 'Allow',
+          Action: [
+            'kinesis:GetRecords',
+            'kinesis:GetShardIterator',
+            'kinesis:DescribeStream',
+            'kinesis:ListStreams',
+          ],
+          Resource: [],
+        };
+
         functionObj.events.forEach(event => {
           if (event.stream) {
             let EventSourceArn;
@@ -92,47 +113,10 @@ class AwsCompileStreamEvents {
             `;
 
             // create type specific PolicyDocument statements
-            let streamStatement = {};
             if (streamType === 'dynamodb') {
-              streamStatement = {
-                Effect: 'Allow',
-                Action: [
-                  'dynamodb:GetRecords',
-                  'dynamodb:GetShardIterator',
-                  'dynamodb:DescribeStream',
-                  'dynamodb:ListStreams',
-                ],
-                Resource: EventSourceArn,
-              };
+              dynamodbStreamStatement.Resource.push(EventSourceArn)
             } else {
-              streamStatement = {
-                Effect: 'Allow',
-                Action: [
-                  'kinesis:GetRecords',
-                  'kinesis:GetShardIterator',
-                  'kinesis:DescribeStream',
-                  'kinesis:ListStreams',
-                ],
-                Resource: EventSourceArn,
-              };
-            }
-
-            // update the PolicyDocument statements (if default policy is used)
-            if (this.serverless.service.provider.compiledCloudFormationTemplate
-              .Resources.IamPolicyLambdaExecution) {
-              const statement = this.serverless.service.provider.compiledCloudFormationTemplate
-                .Resources
-                .IamPolicyLambdaExecution
-                .Properties
-                .PolicyDocument
-                .Statement;
-
-              this.serverless.service.provider.compiledCloudFormationTemplate
-                .Resources
-                .IamPolicyLambdaExecution
-                .Properties
-                .PolicyDocument
-                .Statement = statement.concat([streamStatement]);
+              kinesisStreamStatement.Resource.push(EventSourceArn)
             }
 
             const newStreamObject = {
@@ -143,6 +127,23 @@ class AwsCompileStreamEvents {
               newStreamObject);
           }
         });
+
+        // update the PolicyDocument statements (if default policy is used)
+        if (this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.IamPolicyLambdaExecution) {
+          const statement = this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources
+            .IamPolicyLambdaExecution
+            .Properties
+            .PolicyDocument
+            .Statement;
+          if(dynamodbStreamStatement.Resource.length) {
+            statement.push(dynamodbStreamStatement)
+          }
+          if(kinesisStreamStatement.Resource.length) {
+            statement.push(kinesisStreamStatement)
+          }
+        }
       }
     });
   }

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -112,7 +112,7 @@ class AwsCompileStreamEvents {
               }
             `;
 
-            // create type specific PolicyDocument statements
+            // add event source ARNs to PolicyDocument statements
             if (streamType === 'dynamodb') {
               dynamodbStreamStatement.Resource.push(EventSourceArn);
             } else {

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -275,6 +275,9 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
               },
+              {
+                stream: 'arn:aws:dynamodb:region:account:table/bar/stream/2',
+              },
             ],
           },
         };
@@ -288,7 +291,10 @@ describe('AwsCompileStreamEvents', () => {
               'dynamodb:DescribeStream',
               'dynamodb:ListStreams',
             ],
-            Resource: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            Resource: [
+              'arn:aws:dynamodb:region:account:table/foo/stream/1',
+              'arn:aws:dynamodb:region:account:table/bar/stream/2',
+            ]
           },
         ];
 
@@ -430,6 +436,9 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: 'arn:aws:kinesis:region:account:stream/foo',
               },
+              {
+                stream: 'arn:aws:kinesis:region:account:stream/bar',
+              },
             ],
           },
         };
@@ -443,7 +452,10 @@ describe('AwsCompileStreamEvents', () => {
               'kinesis:DescribeStream',
               'kinesis:ListStreams',
             ],
-            Resource: 'arn:aws:kinesis:region:account:stream/foo',
+            Resource: [
+              'arn:aws:kinesis:region:account:stream/foo',
+              'arn:aws:kinesis:region:account:stream/bar',
+            ]
           },
         ];
 

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -294,7 +294,7 @@ describe('AwsCompileStreamEvents', () => {
             Resource: [
               'arn:aws:dynamodb:region:account:table/foo/stream/1',
               'arn:aws:dynamodb:region:account:table/bar/stream/2',
-            ]
+            ],
           },
         ];
 
@@ -455,7 +455,7 @@ describe('AwsCompileStreamEvents', () => {
             Resource: [
               'arn:aws:kinesis:region:account:stream/foo',
               'arn:aws:kinesis:region:account:stream/bar',
-            ]
+            ],
           },
         ];
 


### PR DESCRIPTION
## What did you implement:

Closes #2508 

## How did you implement it:

Create a single policy statement to cover all DynamoDB/Kinesis stream events, greatly decreasing policy verbosity.

## How can we verify it:

Deploy a function with 50+ stream events. Previously this would fail as described in #2508.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES