### PR TITLE
make sure the integration set suite works cross-platform (not depedent on gnu sed)

### DIFF
--- a/tests/integration/simple-integration-test.js
+++ b/tests/integration/simple-integration-test.js
@@ -29,8 +29,8 @@ describe('Service Lifecyle Integration Test', function () {
 
   it('should create service in tmp directory', () => {
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
-    execSync(`sed -i.bak s/${templateName}/${newServiceName}/g serverless.yml`);
-    execSync("sed -i.bak '/provider:/a \\  cfLogs: true' serverless.yml");
+    testUtils.replaceTextInFile('serverless.yml', templateName, newServiceName);
+    testUtils.replaceTextInFile('serverless.yml', 'name: aws', 'name: aws\n  cfLogs: true');
     expect(serverless.utils
       .fileExistsSync(path.join(tmpDir, 'serverless.yml'))).to.be.equal(true);
     expect(serverless.utils

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -48,7 +48,6 @@ module.exports = {
     }
 
     replaceTextInFile('serverless.yml', templateName, serviceName);
-    execSync(`sed -i.bak s/${templateName}/${serviceName}/g serverless.yml`);
 
     process.env.TOPIC_1 = `${serviceName}-1`;
     process.env.TOPIC_2 = `${serviceName}-1`;

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
@@ -18,10 +19,16 @@ const getTmpDirPath = () => path.join(os.tmpdir(),
 
 const getTmpFilePath = (fileName) => path.join(getTmpDirPath(), fileName);
 
+const replaceTextInFile = (filePath, subString, newSubString) => {
+  const fileContent = fs.readFileSync(filePath).toString();
+  fs.writeFileSync(filePath, fileContent.replace(subString, newSubString));
+};
+
 module.exports = {
   serverlessExec,
   getTmpDirPath,
   getTmpFilePath,
+  replaceTextInFile,
 
   createTestService: (templateName, testServiceDir) => {
     const serviceName = `service-${(new Date()).getTime().toString()}`;
@@ -40,6 +47,7 @@ module.exports = {
       fse.copySync(testServiceDir, tmpDir, { clobber: true, preserveTimestamps: true });
     }
 
+    replaceTextInFile('serverless.yml', templateName, serviceName);
     execSync(`sed -i.bak s/${templateName}/${serviceName}/g serverless.yml`);
 
     process.env.TOPIC_1 = `${serviceName}-1`;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I tried to run the simple integration test suite on OSX and it failed. The test suite assumed to use Gnu `sed`. This is not very beginner friendly for contributors. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Replaced sed with a simple node function

## How can we verify it:

Run the simple & complex integration test suite (or at least a part of it).

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->



***Is this ready for review?:*** YES

