### PR TITLE
fix test as it not always have to be exactly x digits

### DIFF
--- a/tests/integration/aws/general/package/tests.js
+++ b/tests/integration/aws/general/package/tests.js
@@ -30,7 +30,7 @@ describe('AWS - General: Deployment with --noDeploy', () => {
     expect(deployedFiles[0]).to.equal('cloudformation-template-create-stack.json');
     expect(deployedFiles[1]).to.equal('cloudformation-template-update-stack.json');
     // Note: noticed the seconds section can vary a lot
-    expect(deployedFiles[2]).to.match(/test-[0-9]{1,}-[0-9]{9}.zip/);
+    expect(deployedFiles[2]).to.match(/test-[0-9]{1,}-[0-9]{1,}.zip/);
   });
 
   it('should not found stack from AWS', (done) => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Noticed that not all test ran. This is a fix for a new issue: https://travis-ci.org/serverless/serverless/jobs/185111559#L1811
The other ones only happen on Travis and are not reproducible for me so far.

## How did you implement it:

The match now is more flexible.

## How can we verify it:

Run the integration test suite

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Change ready for review message below


***Is this ready for review?:*** YES
