### PR TITLE
Update status code regex to match newlines

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -8,28 +8,28 @@ const DEFAULT_STATUS_CODES = {
     pattern: '',
   },
   400: {
-    pattern: '.*\\[400\\].*',
+    pattern: '[\\s\\S]*\\[400\\][\\s\\S]*',
   },
   401: {
-    pattern: '.*\\[401\\].*',
+    pattern: '[\\s\\S]*\\[401\\][\\s\\S]*',
   },
   403: {
-    pattern: '.*\\[403\\].*',
+    pattern: '[\\s\\S]*\\[403\\][\\s\\S]*',
   },
   404: {
-    pattern: '.*\\[404\\].*',
+    pattern: '[\\s\\S]*\\[404\\][\\s\\S]*',
   },
   422: {
-    pattern: '.*\\[422\\].*',
+    pattern: '[\\s\\S]*\\[422\\][\\s\\S]*',
   },
   500: {
-    pattern: '.*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\]).*',
+    pattern: '[\\s\\S]*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\])[\\s\\S]*',
   },
   502: {
-    pattern: '.*\\[502\\].*',
+    pattern: '[\\s\\S]*\\[502\\][\\s\\S]*',
   },
   504: {
-    pattern: '.*\\[504\\].*',
+    pattern: '[\\s\\S]*\\[504\\][\\s\\S]*',
   },
 };
 


### PR DESCRIPTION
## What did you implement:

Closes #2950

Update the status code regexes for the response template so that they match newlines as well.

## How did you implement it:

Updated the status codes.

## How can we verify it:

Play around with different errors in your handler such as the following:

```
callback(new Error('[500] something went wrong'));
```

```
const message = "[500] Value of \"{\n  contactUsURL,\n  featuredBlogPosts\n}\" violates contract.\n\nExpected:\nHomePageProps\n\nGot:\n{\n  contactUsURL: void;\n  featuredBlogPosts: {\n      slug: string;\n      category: string;\n      title: string;\n      author: {\n        role: string;\n        name: string;\n      };\n    }[];\n}";

callback(new Error(message));
```

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES