### PR TITLE
Fix "No updates to be performed." throwing Error code 1

### DIFF
--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -81,7 +81,13 @@ module.exports = {
       params,
       this.options.stage,
       this.options.region)
-      .then((cfData) => this.monitorStack('update', cfData));
+      .then((cfData) => this.monitorStack('update', cfData))
+      .catch((e) => {
+        console.log(e);
+        if(e.message === 'No updates are to be performed.') {
+          return;
+        }
+      });
   },
 
   updateStack() {

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -84,12 +84,10 @@ module.exports = {
       .then((cfData) => this.monitorStack('update', cfData))
       .catch((e) => {
         console.log(e);
-        if(e.message == 'No updates are to be performed.') {
-          return
+        if (e.message === 'No updates are to be performed.') {
+          return;
         }
-        else {
-          throw e;
-        }
+        throw e;
       });
   },
 

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -83,7 +83,13 @@ module.exports = {
       this.options.region)
       .then((cfData) => this.monitorStack('update', cfData))
       .catch((e) => {
-        // No updates to template error is caught here
+        console.log(e);
+        if(e.message == 'No updates are to be performed.') {
+          return
+        }
+        else {
+          throw e;
+        }
       });
   },
 

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -83,10 +83,7 @@ module.exports = {
       this.options.region)
       .then((cfData) => this.monitorStack('update', cfData))
       .catch((e) => {
-        console.log(e);
-        if(e.message === 'No updates are to be performed.') {
-          return;
-        }
+        console.log('If this error states \"No updates are to be performed.\", it is not really an error', e);
       });
   },
 

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -83,7 +83,7 @@ module.exports = {
       this.options.region)
       .then((cfData) => this.monitorStack('update', cfData))
       .catch((e) => {
-        console.log('If this error states \"No updates are to be performed.\", it is not really an error', e);
+        // No updates to template error is caught here
       });
   },
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -164,7 +164,7 @@ class AwsProvider {
               ].join('');
               err.message = errorMessage;
             }
-            else if (err.message === 'No updates are to be performed') {
+            else if (err.message === 'No updates are to be performed.') {
               resolve(data);
             }
             reject(new this.serverless.classes.Error(err.message, err.statusCode));

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -165,7 +165,7 @@ class AwsProvider {
               err.message = errorMessage;
             }
             else if (err.message === 'No updates are to be performed') {
-              resolve(err.message);
+              resolve(data);
             }
             reject(new this.serverless.classes.Error(err.message, err.statusCode));
           } else {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -164,9 +164,9 @@ class AwsProvider {
               ].join('');
               err.message = errorMessage;
             }
-            else if (err.message === 'No updates are to be performed.') {
-              resolve(data);
-            }
+            //else if (err.message === 'No updates are to be performed.') {
+              //resolve(data);
+            //}
             reject(new this.serverless.classes.Error(err.message, err.statusCode));
           } else {
             resolve(data);

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -164,9 +164,6 @@ class AwsProvider {
               ].join('');
               err.message = errorMessage;
             }
-            //else if (err.message === 'No updates are to be performed.') {
-              //resolve(data);
-            //}
             reject(new this.serverless.classes.Error(err.message, err.statusCode));
           } else {
             resolve(data);


### PR DESCRIPTION
## What did you implement:

Closes #2981

## How did you implement it:
Catch the error, then check for specific error message "No updates to be performed".  continue execution if it is this message, otherwise throw the error to be caught by the next Error handler

## How can we verify it:
Re-deploy an already deployed service without any changes and verify that it does not error out with Error code 1

```yml
service: service

provider:
  name: aws
  runtime: nodejs4.3

# remove need for functions so that a re-deploy will bring up the error
#functions:
#  hello:
#    handler: handler.hello

resources:
  Resources:
    S3Bucket:
      Type: "AWS::S3::Bucket"
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
