### PR TITLE
Missing indentation for Fn::Join params

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -47,7 +47,7 @@ provider:
          Fn::Join:
            - ''
            - - 'arn:aws:s3:::'
-           - Ref: ServerlessDeploymentBucket
+             - Ref: ServerlessDeploymentBucket
   stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except deleting/replacing EC2 instances (use with caution!)
     - Effect: Allow
       Principal: "*"


### PR DESCRIPTION
## What did you implement:

Documentation fix of Fn::Join YAML syntax - similar to https://github.com/serverless/serverless/pull/2874

## How did you implement it:


## How can we verify it:


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
