### PR TITLE
Add check for preexistent service directory

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -74,6 +74,15 @@ class Create {
     if (boilerplatePath) {
       const newPath = path.join(process.cwd(), boilerplatePath);
 
+      if (this.serverless.utils.dirExistsSync(newPath)) {
+        const errorMessage = [
+          `The directory "${newPath}" already exists, and serverless will not overwrite it. `,
+          'Rename or move the directory and try again if you want serverless to create it"',
+        ].join('');
+
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+
       this.serverless.cli.log(`Generating boilerplate in "${newPath}"`);
 
       fse.mkdirsSync(newPath);

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -325,5 +325,18 @@ describe('Create', () => {
         process.chdir(cwd);
       });
     });
+
+    it('should throw error if the directory for the service already exists in cwd', () => {
+      create.options.path = 'my-service';
+      create.options.template = 'aws-nodejs';
+
+      const cwd = process.cwd();
+      // create a directory with the pathname
+      fse.mkdirsSync(path.join(tmpDir, create.options.path));
+      process.chdir(tmpDir);
+
+      expect(() => create.create()).to.throw(Error);
+      process.chdir(cwd);
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Refs #2909, #2388 and #2972

This PR adds a check if the service directory which the user attempts to create already exists in the CWD. It's a follow-up PR of #2972 

## How did you implement it:

Just added a quick `if` check if the directory the user wants to create already exists.

## How can we verify it:

Run

```bash
serverless create -t aws-nodejs -p foo
```

and after that

```bash
serverless create -t aws-nodejs -p foo
```

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO