### PR TITLE
add features on AWSInvokeLocal Plugin.

### DIFF
--- a/lib/plugins/aws/invokeLocal/fixture/handlerWithSuccess.js
+++ b/lib/plugins/aws/invokeLocal/fixture/handlerWithSuccess.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports.withErrorByDone = (event, context) => {
+  context.done(new Error('failed'));
+};
+
+module.exports.withMessageByDone = (event, context) => {
+  context.done(null, 'Succeed');
+};
+
+module.exports.withMessageByLambdaProxy = (event, context) => {
+  context.done(null, {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      result: true,
+      message: 'Whatever',
+    }),
+  });
+};

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -40,7 +40,15 @@ class AwsInvokeLocal {
         if (!this.serverless.utils.fileExistsSync(absolutePath)) {
           throw new this.serverless.classes.Error('The file you provided does not exist.');
         }
-        this.options.data = this.serverless.utils.readFileSync(absolutePath);
+        //
+
+        if (absolutePath.endsWith('.js')) {
+          // to support js - export as an input data
+          this.options.data = require(absolutePath); // eslint-disable-line global-require
+        } else {
+          this.options.data = this.serverless.utils.readFileSync(absolutePath);
+        }
+
         resolve();
       } else {
         try {
@@ -119,8 +127,15 @@ class AwsInvokeLocal {
        * we need require() here to load the handler from the file system
        * which the user has to supply by passing the function name
        */
-      lambda = require(path // eslint-disable-line global-require
-        .join(this.serverless.config.servicePath, handlerPath))[handlerName];
+
+      const handlersContainer = require( // eslint-disable-line global-require
+        path.join(
+          this.serverless.config.servicePath,
+          this.options.extraServicePath || '',
+          handlerPath
+        )
+      );
+      lambda = handlersContainer[handlerName];
     } catch (error) {
       this.serverless.cli.consoleLog(error);
       process.exit(0);
@@ -143,10 +158,24 @@ class AwsInvokeLocal {
         this.serverless.cli.consoleLog(chalk.red(JSON.stringify(errorResult, null, 4)));
         process.exitCode = 1;
       } else if (result) {
+        if (result.headers && result.headers['Content-Type'] === 'application/json') {
+          if (result.body) {
+            try {
+              Object.assign(result, {
+                body: JSON.parse(result.body),
+              });
+            } catch (e) {
+              throw new Error('Content-Type of response is application/json but body is not json');
+            }
+          }
+        }
+
         this.serverless.cli.consoleLog(JSON.stringify(result, null, 4));
       }
     };
 
+
+    const startTime = new Date();
     const context = {
       awsRequestId: 'id',
       invokeid: 'id',
@@ -164,11 +193,11 @@ class AwsInvokeLocal {
       fail(error) {
         return callback(error);
       },
-      done() {
-        return callback();
+      done(error, result) {
+        return callback(error, result);
       },
       getRemainingTimeInMillis() {
-        return 5000;
+        return (new Date()).valueOf() - startTime.valueOf();
       },
     };
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -150,6 +150,28 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
+    it('it should require a js file if file path is provided', () => {
+      serverless.config.servicePath = testUtils.getTmpDirPath();
+      const jsContent = [
+        'module.exports = {',
+        '  headers: { "Content-Type" : "application/json" },',
+        '  body: JSON.stringify([100, 200]),',
+        '}',
+      ].join('\n');
+
+      serverless.utils.writeFileSync(path
+          .join(serverless.config.servicePath, 'data.js'), jsContent);
+      awsInvokeLocal.options.path = 'data.js';
+
+      return awsInvokeLocal.extendedValidate().then(() => {
+        expect(awsInvokeLocal.options.data).to.deep.equal({
+          headers: { 'Content-Type': 'application/json' },
+          body: '[100,200]',
+        });
+      });
+    });
+
+
     it('it should throw error if service path is not set', () => {
       serverless.config.servicePath = false;
       expect(() => awsInvokeLocal.extendedValidate()).to.throw(Error);
@@ -287,6 +309,45 @@ describe('AwsInvokeLocal', () => {
 
     afterEach(() => {
       serverless.cli.consoleLog.restore();
+    });
+
+    describe('with done method', () => {
+      it('should exit with error exit code', () => {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+        awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withErrorByDone');
+
+        expect(process.exitCode).to.be.equal(1);
+      });
+
+      it('should succeed if succeed', () => {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+        awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withMessageByDone');
+
+        expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
+      });
+    });
+
+    describe('with Lambda Proxy with application/json response', () => {
+      it('should succeed if succeed', () => {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+        awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withMessageByLambdaProxy');
+
+        expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('{\n    "statusCode": 200,\n    "headers": {\n        "Content-Type": "application/json"\n    },\n    "body": {\n        "result": true,\n        "message": "Whatever"\n    }\n}'); // eslint-disable-line
+      });
+    });
+
+    describe('with extraServicePath', () => {
+      it('should succeed if succeed', () => {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+        awsInvokeLocal.options.extraServicePath = 'fixture';
+
+        awsInvokeLocal.invokeLocalNodeJs('handlerWithSuccess', 'withMessageByLambdaProxy');
+
+        expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('{\n    "statusCode": 200,\n    "headers": {\n        "Content-Type": "application/json"\n    },\n    "body": {\n        "result": true,\n        "message": "Whatever"\n    }\n}'); // eslint-disable-line
+      });
     });
 
     it('should exit with error exit code', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

- few improvements and fix for invoke-local plugin. it's pretty much same description, but  you can see issue from [here](https://github.com/serverless/serverless/issues/3036)
 
**1. Added support js file that has export as an data input**

**2. You can specify the location of handlers, such as `"/dst"`**
- this might seem controversial, (and i'd love to fix this from outside of this plugin!) but there is no way to specify extra servicePath for severless. for example i'm using Typescript with serverless, which gives me seperated `src` and `dst` folders. (as you can guess, `dst` is js transpiled). in this case, deploying is not a problem since serverless supports `package.artifact`, (which could be just dst.zip, easily) but for invoke-local there is no such thing.   

**3. Support `context.done(err, result)`**
- check [reference](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-using-old-runtime.html#nodejs-prog-model-oldruntime-context-methods) (search context.done)

**4. Show JSON.parse result if `Content-Type = "application/json"`**
- this could be also vary i guess, but if you configured AWS lambda as proxy (which is default these days) and serve responses, you'll see
    ```
    {
        "statusCode": 200,
        "headers": {
            "Content-Type": "application/json"
        },
        "body": "{\"result\": true, \"message\": "Whatever"} 
    }
    ```
    , not 
    ```
    {
        "statusCode": 200,
        "headers": {
            "Content-Type": "application/json"
        },
        "body": {
        "result": true,
        "message": "whatever"
        }
    }
    ```

i guess it could be more safer by checking is the function use `lambda-proxy` or not.

## How did you implement it:

1. Added support js file that has export as an data input
    - logic for check file extension and `require()` it instead of `readFileSync` if it's `.js` file
2. You can specify the location of handlers, such as `"/dst"` 
    - added `options.extraServicePath` and use that to require handler
3. Support `context.done(err, result)`
    - change mock `done()` method implementation
4. Show JSON.parse result if `Content-Type = "application/json"`
    - check response data format from handler and   

## How can we verify it:

1. Added support js file that has export as an data input
    - You can see the test!
2. You can specify the location of handlers, such as `"/dst"` 
    - You can see the test!
    - Also you can try out command like..
        ```
        $(npm bin)/sls invoke local 
            -s=staging 
            -f=track-ticket 
            --path ./dst/handlers/track_ticket/__test__/mock_event.js 
            --extraServicePath dst
        ```
        (After putting copy of handlers under dst, and putting function 
        ```
        functions:
            track-ticket:
                handler: handlers.track_ticket
        ```
        on serverless.yml
3. Support `context.done(err, result)`
    - You can see the test!
4. Show JSON.parse result if `Content-Type = "application/json"`
    - You can see the test!

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
