### PR TITLE
Fixed broken link to Config Credentials in documentation site.

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -81,7 +81,7 @@ Here's an example how you can configure the `default` AWS profile:
 serverless config credentials --provider aws --key AKIAIOSFODNN7EXAMPLE --secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
-Take a look at the [`config` CLI reference](../cli-reference/config-credentials) for more information about credential configuration.
+Take a look at the [`config` CLI reference](../cli-reference/config-credentials.md) for more information about credential configuration.
 
 ##### Setup with the `aws-cli`
 

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -81,7 +81,7 @@ Here's an example how you can configure the `default` AWS profile:
 serverless config credentials --provider aws --key AKIAIOSFODNN7EXAMPLE --secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
-Take a look at the [`config` CLI reference](../cli-reference/config.md) for more information about credential configuration.
+Take a look at the [`config` CLI reference](../cli-reference/config-credentials) for more information about credential configuration.
 
 ##### Setup with the `aws-cli`
 


### PR DESCRIPTION

## What did you implement:

The link gave a 404. Updated to what seems to be the correct URL.

## How did you implement it:

Amended link in markdown.

## How can we verify it:

* Navigate to https://serverless.com/framework/docs/providers/aws/guide/credentials/
* Find link labelled `CLI reference` 
* Note that this links to a 404

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [ ] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ x] Change ready for review message below


***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
