### PR TITLE
Add the `versionFunctions` provider flag that will reduce the default nu…

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -14,6 +14,11 @@ class AwsCompileFunctions {
     this.compileFunctions = this.compileFunctions.bind(this);
     this.compileFunction = this.compileFunction.bind(this);
 
+    if (this.serverless.service.provider.versionFunctions === undefined ||
+        this.serverless.service.provider.versionFunctions === null) {
+      this.serverless.service.provider.versionFunctions = true;
+    }
+
     this.hooks = {
       'deploy:compileFunctions': this.compileFunctions,
     };
@@ -181,8 +186,10 @@ class AwsCompileFunctions {
       [versionLogicalId]: newVersion,
     };
 
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-      newVersionObject);
+    if (this.serverless.service.provider.versionFunctions) {
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+        newVersionObject);
+    }
 
     // Add function to Outputs section
     const newOutput = this.cfOutputDescriptionTemplate();
@@ -201,9 +208,11 @@ class AwsCompileFunctions {
 
     newVersionOutput.Value = { Ref: versionLogicalId };
 
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-      [functionVersionOutputLogicalId]: newVersionOutput,
-    });
+    if (this.serverless.service.provider.versionFunctions) {
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+        [functionVersionOutputLogicalId]: newVersionOutput,
+      });
+    }
   }
 
   compileFunctions() {

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -916,6 +916,7 @@ describe('AwsCompileFunctions', () => {
         expectedOutputs
       );
     });
+
     it('should not create function output objects when `versionFunctions` is false', () => {
       awsCompileFunctions.serverless.service.provider.versionFunctions = false;
       awsCompileFunctions.serverless.service.functions = {

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -876,7 +876,7 @@ describe('AwsCompileFunctions', () => {
       ).to.equal('Lambda function description');
     });
 
-    it('should create corresponding function output objects', () => {
+    it('should create corresponding function output and version objects', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -904,6 +904,37 @@ describe('AwsCompileFunctions', () => {
           Value: {
             Ref: 'AnotherFuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
           },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Outputs
+      ).to.deep.equal(
+        expectedOutputs
+      );
+    });
+    it('should not create function output objects when `versionFunctions` is false', () => {
+      awsCompileFunctions.serverless.service.provider.versionFunctions = false;
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+        anotherFunc: {
+          handler: 'anotherFunc.function.handler',
+        },
+      };
+
+      const expectedOutputs = {
+        FuncLambdaFunctionArn: {
+          Description: 'Lambda function info',
+          Value: { 'Fn::GetAtt': ['FuncLambdaFunction', 'Arn'] },
+        },
+        AnotherFuncLambdaFunctionArn: {
+          Description: 'Lambda function info',
+          Value: { 'Fn::GetAtt': ['AnotherFuncLambdaFunction', 'Arn'] },
         },
       };
 

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -25,9 +25,6 @@ class Deploy {
             usage: 'Region of the service',
             shortcut: 'r',
           },
-          versionFunctions: {
-            usage: 'Cut an addressable version for every deploy. These are never pruned',
-          },
           noDeploy: {
             usage: 'Build artifacts without deploying',
             shortcut: 'n',

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -25,6 +25,9 @@ class Deploy {
             usage: 'Region of the service',
             shortcut: 'r',
           },
+          versionFunctions: {
+            usage: 'Cut an addressable version for every deploy. These are never pruned',
+          },
           noDeploy: {
             usage: 'Build artifacts without deploying',
             shortcut: 'n',


### PR DESCRIPTION
…mber of stack outputs.

## What did you implement:

Per #2853, having versions as resources/outputs can trigger some limits
related to CloudFormation stack outputs. This will (by default) reduce
the number of outputs by N, where N is the number of functions total.

## How did you implement it:

Added an option `--versionFunctions` so that version resources aren't autocreated. This will also save code storage space as a side effect.

## How can we verify it:

1. Run `serverless deploy --noDeploy` on any project
2. Look at the generated `project-stack-update.json` and note the `AWS::Lambda::Version` resources created
3. Add `versionFunctions: false` to the AWS provider in `serverless.yml`
4. Run `serverless deploy --noDeploy` on the same project
5. Note lack of same `::Version` objects. 


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
