### PR TITLE
Optionally add -r to CloudFormation stacknames to allow Serverless v0.x resources to be migrated towards v1.x

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -62,6 +62,7 @@ provider:
         StringEquals:
           ResourceType:
             - AWS::EC2::Instance
+  preV1Resources: true # Optionally adds a -r to calculated CloudFormation stacknames in order to migrate pre v0.x CloudFormation resources towards v1.x
 
 functions:
   usersCreate: # A Function

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -46,7 +46,13 @@ module.exports = {
 
   // Stack
   getStackName() {
-    return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
+    const name = `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
+
+    if (this.provider.serverless.service.provider.preV1Resources) {
+      return `${name}-r`;
+    }
+
+    return name;
   },
 
   // Role

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -98,6 +98,13 @@ describe('#naming()', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getStackName()).to.equal(`${serverless.service.service}-${options.stage}`);
     });
+
+    it('should prepend stack name with -r when preV1Resources flag is enabled', () => {
+      serverless.service.service = 'myService';
+      serverless.service.provider.preV1Resources = true;
+      expect(sdk.naming.getStackName())
+        .to.equal(`${serverless.service.service}-${options.stage}-r`);
+    });
   });
 
   describe('#getRolePath()', () => {


### PR DESCRIPTION
## What did you implement:

Currently we’re updating some v0.x projects which include some important CF Resources which we don’t want to migrate to a new v1.x stack. This PR add an optional -r to CloudFormation stacknames to allow Serverless v0.x resources to be migrated towards v1.x.

## How did you implement it:

Updated `lib/plugins/aws/lib/naming.js` which support an new optional `preV1Resources` flag (open to a better property name).

## How can we verify it:

```yml
# serverless.yml

service: foo

frameworkVersion: '=1.4.0'

provider:
  cfLogs: true
  name: aws
  preV1Resources: true
  runtime: nodejs4.3
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
