### PR TITLE
Add support of numeric template creation path

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -3,6 +3,7 @@
 const BbPromise = require('bluebird');
 const path = require('path');
 const fse = require('fs-extra');
+const _ = require('lodash');
 
 // class wide constants
 const validTemplates = [
@@ -66,9 +67,8 @@ class Create {
     }
 
     // store the custom options for the service if given
-    const boilerplatePath = this.options
-      .path && this.options.path.length ? this.options.path : null;
-    const serviceName = this.options.name && this.options.name.length ? this.options.name : null;
+    const boilerplatePath = _.toString(this.options.path);
+    const serviceName = _.toString(this.options.name);
 
     // create (if not yet present) and chdir into the directory for the service
     if (boilerplatePath) {

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -311,6 +311,30 @@ describe('Create', () => {
       });
     });
 
+    it('should create a service in the directory if using the "path" option with digits', () => {
+      const cwd = process.cwd();
+      fse.mkdirsSync(tmpDir);
+      process.chdir(tmpDir);
+
+      create.options.path = 123;
+      create.options.name = null;
+
+      // using the nodejs template (this test is completely be independent from the template)
+      create.options.template = 'aws-nodejs';
+
+      return create.create().then(() => {
+        const serviceDir = path.join(tmpDir, String(create.options.path));
+
+        // check if files are created in the correct directory
+        expect(create.serverless.utils.fileExistsSync(
+          path.join(serviceDir, 'serverless.yml'))).to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(
+          path.join(serviceDir, 'handler.js'))).to.be.equal(true);
+
+        process.chdir(cwd);
+      });
+    });
+
     it('should create a custom renamed service in the directory if using ' +
        'the "path" and "name" option', () => {
       const cwd = process.cwd();


### PR DESCRIPTION
## What did you implement:

Closes #3063 

## How did you implement it:

Instead of checking `length` property which doesn't exist for numbers, we convert whatever value user provides to a string.

```diff
- const boilerplatePath = this.options
      .path && this.options.path.length ? this.options.path : null;
+ const boilerplatePath = _.toString(this.options.path);
```

Previously we assigned `null` to a var, but now it'll be an empty string, which is a falsy value as well. Checked the code, we don't explicitly check for `null`, so it's safe. All the `if / else` should continue to work as expected.

## How can we verify it:

```bash
$ serverless create --template aws-nodejs --path 123
```

This must create a folder `123` and a template inside.


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
