### PR TITLE
Fix Preuninstall Promise problem

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,10 +1,9 @@
-const BbPromise = require('bluebird');
 const Serverless = require('../lib/Serverless');
 
 const serverless = new Serverless();
 
 (() => {
   serverless.init().then(() => {
-    serverless.utils.logStat(serverless, 'install').catch(() => BbPromise.resolve());
+    serverless.utils.logStat(serverless, 'install').catch(() => Promise.resolve());
   });
 })();

--- a/scripts/preuninstall.js
+++ b/scripts/preuninstall.js
@@ -1,10 +1,9 @@
-const BbPromise = require('bluebird');
 const Serverless = require('../lib/Serverless');
 
 const serverless = new Serverless();
 
 (() => {
   serverless.init().then(() => {
-    serverless.utils.logStat(serverless, 'uninstall').catch(() => BbPromise.resolve());
+    serverless.utils.logStat(serverless, 'uninstall').catch(() => Promise.resolve());
   });
 })();


### PR DESCRIPTION
## What did you implement:

Closes #3079 

Fix problem with Bluebird Promise package (might be already removed when the package is uninstalled).

## How did you implement it:

Switch to native Promise support for resolving in a `catch` case.

## How can we verify it:

Run `npm run postinstall` and `npm run preuninstall`

## Todos:

- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO