### PR TITLE
Allow Role 'Fn::GetAtt' for Lambda `role`

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -88,11 +88,24 @@ class AwsCompileStreamEvents {
 
             const funcRole = functionObj.role || this.serverless.service.provider.role;
             let dependsOn = '"IamPolicyLambdaExecution"';
-            // check whether we have custom IAM role in format arn:aws:iam::account:role/foo
-            if (typeof funcRole === 'string' && funcRole.indexOf(':') !== -1) {
-              dependsOn = '[]';
+            if (funcRole) {
+              if ( // check whether the custom role is an ARN
+                typeof funcRole === 'string' &&
+                funcRole.indexOf(':') !== -1
+              ) {
+                dependsOn = '[]';
+              } else if ( // otherwise, check if we have an in-service reference to a role ARN
+                typeof funcRole === 'object' &&
+                'Fn::GetAtt' in funcRole &&
+                Array.isArray(funcRole['Fn::GetAtt']) &&
+                funcRole['Fn::GetAtt'].length === 2 &&
+                typeof funcRole['Fn::GetAtt'][0] === 'string' &&
+                typeof funcRole['Fn::GetAtt'][1] === 'string' &&
+                funcRole['Fn::GetAtt'][1] === 'Arn'
+              ) {
+                dependsOn = `"${funcRole['Fn::GetAtt'][0]}"`;
+              }
             }
-
             const streamTemplate = `
               {
                 "Type": "AWS::Lambda::EventSourceMapping",

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -116,6 +116,31 @@ describe('AwsCompileStreamEvents', () => {
       ).to.equal(null);
     });
 
+    it('should not throw error if custom IAM role reference is set in function', () => {
+      const roleLogicalId = 'RoleLogicalId';
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          role: { 'Fn::GetAtt': [roleLogicalId, 'Arn'] },
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamPolicyLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamPolicyLambdaExecution = null;
+
+      expect(() => { awsCompileStreamEvents.compileStreamEvents(); }).to.not.throw(Error);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn).to.equal(roleLogicalId);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamPolicyLambdaExecution).to.equal(null);
+    });
+
     it('should not throw error if custom IAM role is set in provider', () => {
       awsCompileStreamEvents.serverless.service.functions = {
         first: {
@@ -145,6 +170,33 @@ describe('AwsCompileStreamEvents', () => {
         .compiledCloudFormationTemplate.Resources
         .IamPolicyLambdaExecution
       ).to.equal(null);
+    });
+
+    it('should not throw error if custom IAM role reference is set in provider', () => {
+      const roleLogicalId = 'RoleLogicalId';
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamPolicyLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamPolicyLambdaExecution = null;
+
+      awsCompileStreamEvents.serverless.service.provider
+        .role = { 'Fn::GetAtt': [roleLogicalId, 'Arn'] };
+
+      expect(() => { awsCompileStreamEvents.compileStreamEvents(); }).to.not.throw(Error);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn).to.equal(roleLogicalId);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamPolicyLambdaExecution).to.equal(null);
     });
 
     describe('when a DynamoDB stream ARN is given', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes https://github.com/serverless/serverless/issues/3081 by allowing the role defined for a Lambda to be a reference (e.g. `{ 'Fn::GetAtt', [ 'LambdaLogicalId', 'Arn'] }`) to a role in the current service.  If the `role` attribute is defined, check whether it is a role reference and if it is, fill the `DependsOn` attribute for the event mapping to be that logical ID.
Add tests that make sure this use case is covered in future incarnations of the code.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

evaluate the role attribute (from either function or provider) and if it is a `Fn::GetAtt` to an ARN (which uses a LogicalId) use that logical ID as the value for `DependsOn`.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

See tests in this PR.  Alternatively, define a role in your service.  Then use that role by reference by defining role on the provider and subsequently on the function.  Deploy with both configurations. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below

Note that with regards to the documentation, this shouldn't be a change.  I didn't check.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO