### PR TITLE
fixed the bug when Multi-line values is given in iot events

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/iot/index.js
+++ b/lib/plugins/aws/deploy/compile/events/iot/index.js
@@ -55,12 +55,13 @@ class AwsCompileIoTEvents {
               {
                 "Type": "AWS::IoT::TopicRule",
                 "Properties": {
-                  ${RuleName ? `"RuleName": "${RuleName}",` : ''}
+                  ${RuleName ? `"RuleName": "${RuleName.replace(/\r?\n/g, '')}",` : ''}
                   "TopicRulePayload": {
-                    ${AwsIotSqlVersion ? `"AwsIotSqlVersion": "${AwsIotSqlVersion}",` : ''}
-                    ${Description ? `"Description": "${Description}",` : ''}
+                    ${AwsIotSqlVersion ? `"AwsIotSqlVersion":
+                      "${AwsIotSqlVersion.replace(/\r?\n/g, '')}",` : ''}
+                    ${Description ? `"Description": "${Description.replace(/\r?\n/g, '')}",` : ''}
                     "RuleDisabled": "${RuleDisabled}",
-                    "Sql": "${Sql}",
+                    "Sql": "${Sql.replace(/\r?\n/g, '')}",
                     "Actions": [
                       {
                         "Lambda": {

--- a/lib/plugins/aws/deploy/compile/events/iot/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/iot/index.test.js
@@ -95,7 +95,7 @@ describe('AwsCompileIoTEvents', () => {
           events: [
             {
               iot: {
-                name: 'iotEvantName',
+                name: 'iotEventName',
                 sql: "SELECT * FROM 'topic_1'",
               },
             },
@@ -108,7 +108,7 @@ describe('AwsCompileIoTEvents', () => {
       expect(awsCompileIoTEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstIotTopicRule1.Properties.RuleName
-      ).to.equal('iotEvantName');
+      ).to.equal('iotEventName');
     });
 
     it('should respect "enabled" variable', () => {
@@ -218,10 +218,10 @@ describe('AwsCompileIoTEvents', () => {
           events: [
             {
               iot: {
-                description: 'iot event description\n',
-                sql: "SELECT * FROM 'topic_1'\n",
+                description: 'iot event description\n with newline',
+                sql: "SELECT * FROM 'topic_1'\n WHERE value = 2",
                 sqlVersion: 'beta\n',
-                name: 'iotEvantName\n',
+                name: 'iotEventName\n',
               },
             },
           ],
@@ -232,7 +232,7 @@ describe('AwsCompileIoTEvents', () => {
       expect(awsCompileIoTEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstIotTopicRule1.Properties.TopicRulePayload.Sql
-      ).to.equal("SELECT * FROM 'topic_1'");
+      ).to.equal("SELECT * FROM 'topic_1' WHERE value = 2");
       expect(awsCompileIoTEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstIotTopicRule1.Properties.TopicRulePayload.AwsIotSqlVersion
@@ -240,11 +240,11 @@ describe('AwsCompileIoTEvents', () => {
       expect(awsCompileIoTEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstIotTopicRule1.Properties.TopicRulePayload.Description
-      ).to.equal('iot event description');
+      ).to.equal('iot event description with newline');
       expect(awsCompileIoTEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstIotTopicRule1.Properties.RuleName
-      ).to.equal('iotEvantName');
+      ).to.equal('iotEventName');
     });
 
     it('should not create corresponding resources when iot events are not given', () => {

--- a/lib/plugins/aws/deploy/compile/events/iot/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/iot/index.test.js
@@ -212,6 +212,41 @@ describe('AwsCompileIoTEvents', () => {
       ).to.equal('false');
     });
 
+    it('should respect variables if multi-line variables is given', () => {
+      awsCompileIoTEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              iot: {
+                description: 'iot event description\n',
+                sql: "SELECT * FROM 'topic_1'\n",
+                sqlVersion: 'beta\n',
+                name: 'iotEvantName\n',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileIoTEvents.compileIoTEvents();
+      expect(awsCompileIoTEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstIotTopicRule1.Properties.TopicRulePayload.Sql
+      ).to.equal("SELECT * FROM 'topic_1'");
+      expect(awsCompileIoTEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstIotTopicRule1.Properties.TopicRulePayload.AwsIotSqlVersion
+      ).to.equal('beta');
+      expect(awsCompileIoTEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstIotTopicRule1.Properties.TopicRulePayload.Description
+      ).to.equal('iot event description');
+      expect(awsCompileIoTEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstIotTopicRule1.Properties.RuleName
+      ).to.equal('iotEvantName');
+    });
+
     it('should not create corresponding resources when iot events are not given', () => {
       awsCompileIoTEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3094 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Removed line feed code from Cloudformation's JSON
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
set serverless.yml as follow:

```
events:
      - iot:
          description: >
            My multi-
            line value.
          name: enrollPlayer
          sql: >
            SELECT * FROM 'path/#'
            WHERE prop = 'value'
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
