### PR TITLE
Allow DynamoDB and Kinesis streams to use GetAtt/ImportValue

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -12,8 +12,13 @@ layout: Doc
 
 # DynamoDB / Kinesis Streams
 
-This setup specifies that the `compute` function should be triggered whenever the corresponding DynamoDB table is modified (e.g. a new entry is added).
+This setup specifies that the `compute` function should be triggered whenever:
+  1. the corresponding DynamoDB table is modified (e.g. a new entry is added).
+  2. the Lambda checkpoint has not reached the end of the Kinesis stream (e.g. a new record is added).
 
+The ARN for the stream can be specified as a string, the reference to the ARN of a resource by logical ID, or the import of an ARN that was exported by a different service or CloudFormation stack.
+
+This is shown in each of the valid
 **Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
 
 ```yml
@@ -22,6 +27,26 @@ functions:
     handler: handler.compute
     events:
       - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+      - stream:
+        type: dynamodb
+        arn:
+          Fn::GetAtt:
+            - MyDynamoDbTable
+            - Arn
+      - stream:
+        type: dynamodb
+        arn:
+          Fn::ImportValue: MyExportedDynamoDbStreamArnId
+      - stream:
+        type: kinesis
+        arn:
+          Fn::GetAtt:
+            - MyKinesisStream
+            - Arn
+      - stream:
+        type: kinesis
+        arn:
+          Fn::ImportValue: MyExportedKinesisStreamArnId
 ```
 
 ## Setting the BatchSize and StartingPosition

--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -18,7 +18,6 @@ This setup specifies that the `compute` function should be triggered whenever:
 
 The ARN for the stream can be specified as a string, the reference to the ARN of a resource by logical ID, or the import of an ARN that was exported by a different service or CloudFormation stack.
 
-This is shown in each of the valid
 **Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
 
 ```yml
@@ -32,7 +31,7 @@ functions:
           arn:
             Fn::GetAtt:
               - MyDynamoDbTable
-              - Arn
+              - StreamArn
       - stream:
           type: dynamodb
           arn:

--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -28,25 +28,25 @@ functions:
     events:
       - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
       - stream:
-        type: dynamodb
-        arn:
-          Fn::GetAtt:
-            - MyDynamoDbTable
-            - Arn
+          type: dynamodb
+          arn:
+            Fn::GetAtt:
+              - MyDynamoDbTable
+              - Arn
       - stream:
-        type: dynamodb
-        arn:
-          Fn::ImportValue: MyExportedDynamoDbStreamArnId
+          type: dynamodb
+          arn:
+            Fn::ImportValue: MyExportedDynamoDbStreamArnId
       - stream:
-        type: kinesis
-        arn:
-          Fn::GetAtt:
-            - MyKinesisStream
-            - Arn
+          type: kinesis
+          arn:
+            Fn::GetAtt:
+              - MyKinesisStream
+              - Arn
       - stream:
-        type: kinesis
-        arn:
-          Fn::ImportValue: MyExportedKinesisStreamArnId
+          type: kinesis
+          arn:
+            Fn::ImportValue: MyExportedKinesisStreamArnId
 ```
 
 ## Setting the BatchSize and StartingPosition

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -57,15 +57,30 @@ class AwsCompileStreamEvents {
                 throw new this.serverless.classes
                   .Error(errorMessage);
               }
-              if (typeof event.stream.arn !== 'string' && !event.stream.type) {
-                const errorMessage = [
-                  `Missing "type" property for stream event in function "${functionName}"`,
-                  ' If the "arn" property on a stream is a complex type (such as Fn::GetAtt)',
-                  ' then a "type" must be provided for the stream, either "kinesis" or "dynamodb".',
-                  ' Please check the docs for more info.',
-                ].join('');
-                throw new this.serverless.classes
-                  .Error(errorMessage);
+              if (typeof event.stream.arn !== 'string') {
+                // for dynamic arns (GetAtt/ImportValue)
+                if (!event.stream.type) {
+                  const errorMessage = [
+                    `Missing "type" property for stream event in function "${functionName}"`,
+                    ' If the "arn" property on a stream is a complex type (such as Fn::GetAtt)',
+                    ' then a "type" must be provided for the stream, either "kinesis" or,',
+                    ' "dynamodb". Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes
+                    .Error(errorMessage);
+                }
+                if (Object.keys(event.stream.arn).length !== 1
+                    || !(_.has(event.stream.arn, 'Fn::ImportValue')
+                          || _.has(event.stream.arn, 'Fn::GetAtt'))) {
+                  const errorMessage = [
+                    `Bad dynamic ARN property on stream event in function "${functionName}"`,
+                    ' If you use a dynamic "arn" (such as with Fn::GetAtt or Fn::ImportValue)',
+                    ' there must only be one key (either Fn::GetAtt or Fn::ImportValue) in the arn',
+                    ' object. Please check the docs for more info.',
+                  ].join('');
+                  throw new this.serverless.classes
+                    .Error(errorMessage);
+                }
               }
               EventSourceArn = event.stream.arn;
               BatchSize = event.stream.batchSize

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -57,6 +57,16 @@ class AwsCompileStreamEvents {
                 throw new this.serverless.classes
                   .Error(errorMessage);
               }
+              if (typeof event.stream.arn !== 'string' && !event.stream.type) {
+                const errorMessage = [
+                  `Missing "type" property for stream event in function "${functionName}"`,
+                  ' If the "arn" property on a stream is a complex type (such as Fn::GetAtt)',
+                  ' then a "type" must be provided for the stream, either "kinesis" or "dynamodb".',
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes
+                  .Error(errorMessage);
+              }
               EventSourceArn = event.stream.arn;
               BatchSize = event.stream.batchSize
                 || BatchSize;
@@ -78,8 +88,18 @@ class AwsCompileStreamEvents {
                 .Error(errorMessage);
             }
 
-            const streamType = EventSourceArn.split(':')[2];
-            const streamName = EventSourceArn.split('/')[1];
+            const streamType = event.stream.type || EventSourceArn.split(':')[2];
+            const streamName = () => {
+                if (typeof EventSourceArn === 'string') {
+                    // we need to add quotes to the string if it's not a GetAtt or other expression
+                    //EventSourceArn = `"${EventSourceArn}"`;
+                    return EventSourceArn.split('/')[1]
+                } else if (EventSourceArn['Fn::GetAtt']) {
+                    return EventSourceArn['Fn::GetAtt'][0]
+                } else if (EventSourceArn['Fn::ImportValue']) {
+                    return EventSourceArn['Fn::ImportValue'];
+                }
+            }();
 
             const lambdaLogicalId = this.provider.naming
               .getLambdaLogicalId(functionName);
@@ -112,7 +132,7 @@ class AwsCompileStreamEvents {
                 "DependsOn": ${dependsOn},
                 "Properties": {
                   "BatchSize": ${BatchSize},
-                  "EventSourceArn": "${EventSourceArn}",
+                  "EventSourceArn": ${JSON.stringify(EventSourceArn)},
                   "FunctionName": {
                     "Fn::GetAtt": [
                       "${lambdaLogicalId}",

--- a/lib/plugins/aws/deploy/compile/events/stream/index.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.js
@@ -89,17 +89,14 @@ class AwsCompileStreamEvents {
             }
 
             const streamType = event.stream.type || EventSourceArn.split(':')[2];
-            const streamName = () => {
-                if (typeof EventSourceArn === 'string') {
-                    // we need to add quotes to the string if it's not a GetAtt or other expression
-                    //EventSourceArn = `"${EventSourceArn}"`;
-                    return EventSourceArn.split('/')[1]
-                } else if (EventSourceArn['Fn::GetAtt']) {
-                    return EventSourceArn['Fn::GetAtt'][0]
-                } else if (EventSourceArn['Fn::ImportValue']) {
-                    return EventSourceArn['Fn::ImportValue'];
-                }
-            }();
+            const streamName = (function () {
+              if (EventSourceArn['Fn::GetAtt']) {
+                return EventSourceArn['Fn::GetAtt'][0];
+              } else if (EventSourceArn['Fn::ImportValue']) {
+                return EventSourceArn['Fn::ImportValue'];
+              }
+              return EventSourceArn.split('/')[1];
+            }());
 
             const lambdaLogicalId = this.provider.naming
               .getLambdaLogicalId(functionName);

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -416,6 +416,26 @@ describe('AwsCompileStreamEvents', () => {
         expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
       });
 
+      it('fails if keys other than Fn::GetAtt/ImportValue are used for dynamic stream ARN', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  type: 'dynamodb',
+                  arn: {
+                    'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'],
+                    batchSize: 1,
+                  },
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
+      });
+
       it('should add the necessary IAM role statements', () => {
         awsCompileStreamEvents.serverless.service.functions = {
           first: {

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -346,13 +346,13 @@ describe('AwsCompileStreamEvents', () => {
             events: [
               {
                 stream: {
-                  arn: {'Fn::GetAtt': ['SomeDdbTable', 'StreamArn']},
+                  arn: { 'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'] },
                   type: 'dynamodb',
                 },
               },
               {
                 stream: {
-                  arn: {'Fn::ImportValue': 'ForeignKinesis'},
+                  arn: { 'Fn::ImportValue': 'ForeignKinesis' },
                   type: 'kinesis',
                 },
               },
@@ -364,39 +364,39 @@ describe('AwsCompileStreamEvents', () => {
 
         // dynamodb version
         expect(awsCompileStreamEvents.serverless.service
-          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbSomeDdbTable
-          .Properties.EventSourceArn
+          .provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbSomeDdbTable.Properties.EventSourceArn
         ).to.deep.equal(
-          {'Fn::GetAtt': ['SomeDdbTable', 'StreamArn']}
+          { 'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'] }
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution
           .Properties.Policies[0].PolicyDocument.Statement[0]
         ).to.deep.equal(
           {
-            "Action": [
-              "dynamodb:GetRecords",
-              "dynamodb:GetShardIterator",
-              "dynamodb:DescribeStream",
-              "dynamodb:ListStreams"
+            Action: [
+              'dynamodb:GetRecords',
+              'dynamodb:GetShardIterator',
+              'dynamodb:DescribeStream',
+              'dynamodb:ListStreams',
             ],
-            "Effect": "Allow",
-            "Resource": [
+            Effect: 'Allow',
+            Resource: [
               {
-                "Fn::GetAtt": [
-                  "SomeDdbTable",
-                  "StreamArn"
-                ]
-              }
-            ]
+                'Fn::GetAtt': [
+                  'SomeDdbTable',
+                  'StreamArn',
+                ],
+              },
+            ],
           }
         );
         // and now kinesis
         expect(awsCompileStreamEvents.serverless.service
-          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisForeignKinesis
-          .Properties.EventSourceArn
+          .provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingKinesisForeignKinesis.Properties.EventSourceArn
         ).to.deep.equal(
-          {'Fn::ImportValue': 'ForeignKinesis'}
+          { 'Fn::ImportValue': 'ForeignKinesis' }
         );
       });
 
@@ -406,7 +406,7 @@ describe('AwsCompileStreamEvents', () => {
             events: [
               {
                 stream: {
-                  arn: {'Fn::GetAtt': ['SomeDdbTable', 'StreamArn']},
+                  arn: { 'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'] },
                 },
               },
             ],

--- a/lib/plugins/aws/deploy/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/stream/index.test.js
@@ -340,6 +340,82 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('True');
       });
 
+      it('should allow specifying DynamoDB and Kinesis streams as CFN reference types', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  arn: {'Fn::GetAtt': ['SomeDdbTable', 'StreamArn']},
+                  type: 'dynamodb',
+                },
+              },
+              {
+                stream: {
+                  arn: {'Fn::ImportValue': 'ForeignKinesis'},
+                  type: 'kinesis',
+                },
+              },
+            ],
+          },
+        };
+
+        awsCompileStreamEvents.compileStreamEvents();
+
+        // dynamodb version
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbSomeDdbTable
+          .Properties.EventSourceArn
+        ).to.deep.equal(
+          {'Fn::GetAtt': ['SomeDdbTable', 'StreamArn']}
+        );
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution
+          .Properties.Policies[0].PolicyDocument.Statement[0]
+        ).to.deep.equal(
+          {
+            "Action": [
+              "dynamodb:GetRecords",
+              "dynamodb:GetShardIterator",
+              "dynamodb:DescribeStream",
+              "dynamodb:ListStreams"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+              {
+                "Fn::GetAtt": [
+                  "SomeDdbTable",
+                  "StreamArn"
+                ]
+              }
+            ]
+          }
+        );
+        // and now kinesis
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisForeignKinesis
+          .Properties.EventSourceArn
+        ).to.deep.equal(
+          {'Fn::ImportValue': 'ForeignKinesis'}
+        );
+      });
+
+      it('fails if Fn::GetAtt/dynamic stream ARN is used without a type', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  arn: {'Fn::GetAtt': ['SomeDdbTable', 'StreamArn']},
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
+      });
+
       it('should add the necessary IAM role statements', () => {
         awsCompileStreamEvents.serverless.service.functions = {
           first: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2365 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

This looks at the `arn:` specification and if it's a string, uses the existing string-splitting logic. If it's an object, it uses a conditional to get a useful name to use as the streamName:

1. If the object is an `Fn::GetAtt`, it gets the first value in the GetAtt list (the logical ID of the DynamoDB table or Kinesis stream) and uses that
2. If it's using `Fn::ImportValue`, it uses the string key for the variable name.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
