### PR TITLE
fix casing of dotnet artifact

### DIFF
--- a/docs/providers/aws/examples/hello-world/csharp/serverless.yml
+++ b/docs/providers/aws/examples/hello-world/csharp/serverless.yml
@@ -46,7 +46,7 @@ provider:
 
 # you can add packaging information here
 package:
- artifact: bin/Release/netcoreapp1.0/publish/deploy-package.zip
+ artifact: bin/release/netcoreapp1.0/publish/deploy-package.zip
 #  exclude:
 #    - exclude-me.js
 #    - exclude-me-dir/**

--- a/docs/providers/aws/examples/hello-world/csharp/serverless.yml
+++ b/docs/providers/aws/examples/hello-world/csharp/serverless.yml
@@ -46,7 +46,7 @@ provider:
 
 # you can add packaging information here
 package:
- artifact: bin/release/netcoreapp1.0/publish/deploy-package.zip
+  artifact: bin/release/netcoreapp1.0/publish/deploy-package.zip
 #  exclude:
 #    - exclude-me.js
 #    - exclude-me-dir/**

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -46,7 +46,7 @@ provider:
 
 # you can add packaging information here
 package:
- artifact: bin/Release/netcoreapp1.0/publish/deploy-package.zip
+ artifact: bin/release/netcoreapp1.0/publish/deploy-package.zip
 #  exclude:
 #    - exclude-me.js
 #    - exclude-me-dir/**

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -46,7 +46,7 @@ provider:
 
 # you can add packaging information here
 package:
- artifact: bin/release/netcoreapp1.0/publish/deploy-package.zip
+  artifact: bin/release/netcoreapp1.0/publish/deploy-package.zip
 #  exclude:
 #    - exclude-me.js
 #    - exclude-me-dir/**

--- a/tests/templates/test_all_templates
+++ b/tests/templates/test_all_templates
@@ -8,7 +8,7 @@ function integration-test {
   $DIR/integration-test-template $@
 }
 
-integration-test aws-csharp 'apt-get -qq update && apt-get -qq -y install zip && dotnet restore && dotnet publish -c release && pushd bin/Release/netcoreapp1.0/publish && zip -r ./deploy-package.zip ./* && popd'
+integration-test aws-csharp 'apt-get -qq update && apt-get -qq -y install zip && dotnet restore && dotnet publish -c release && pushd bin/release/netcoreapp1.0/publish && zip -r ./deploy-package.zip ./* && popd'
 integration-test aws-java-gradle ./gradlew build
 integration-test aws-java-maven mvn package
 integration-test aws-scala-sbt sbt assembly


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3109 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

In the csharp template, I changed the path of the build artifact from `[...]Release[...]` to `[...]release[...]`.

Windows paths are case-insensitive and OSX path sensitivity is  tricky so this wasn't noticed until @daves0 encountered this on Ubuntu.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

On an Ubuntu install, run the following:

- `sls create -t aws-csharp -p foo`
- `cd foo`
- `chmod +x ./build.sh`
- `./build.sh`
- `sls deploy`

Before this fix, the deploy would fail with `no such file: /bin/Release/[...]` since it was looking for `Release` when the zip lived in `release`.


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests (templates aren't tested at this level of granularity)
- [ ] Write documentation (since the C# docs were updated to reference the build scritps, this is typically invisible to the user)
- [ ] Fix linting errors 
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO (as long as people aren't making assumptions about the currently inconsistent casing of the `release` path)
