### PR TITLE
Adding OpenWhisk NodeJS template to create plugin.

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -13,6 +13,7 @@ const validTemplates = [
   'aws-java-gradle',
   'aws-scala-sbt',
   'aws-csharp',
+  'openwhisk-nodejs',
   'plugin',
 ];
 

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -258,6 +258,26 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "openwhisk-nodejs" template', () => {
+      const cwd = process.cwd();
+      fse.mkdirsSync(tmpDir);
+      process.chdir(tmpDir);
+      create.options.template = 'openwhisk-nodejs';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'package.json')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.js')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+
+        process.chdir(cwd);
+      });
+    });
+
     // this test should live here because of process.cwd() which might cause trouble when using
     // nested dirs like its done here
     it('should create a plugin in the current directory', () => {

--- a/lib/plugins/create/templates/openwhisk-nodejs/.gitignore
+++ b/lib/plugins/create/templates/openwhisk-nodejs/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/openwhisk-nodejs/README.md
+++ b/lib/plugins/create/templates/openwhisk-nodejs/README.md
@@ -1,0 +1,58 @@
+# Serverless OpenWhisk Node.js Template
+
+Hello! 😎
+
+This is a template Node.js service for the OpenWhisk platform. Before you can deploy your service, please follow the instructions below…
+
+### Have you set up your account credentials?
+
+Before you can deploy your service to OpenWhisk, you need to have an account registered with the platform.
+
+- *Want to run the platform locally?* Please read the project's [*Quick Start*](https://github.com/openwhisk/openwhisk#quick-start) guide for deploying it locally.
+- *Want to use a hosted provider?* Please sign up for an account with [IBM Bluemix](https://console.ng.bluemix.net/) and then follow the instructions for getting access to [OpenWhisk on Bluemix](https://console.ng.bluemix.net/openwhisk/). 
+
+Account credentials for OpenWhisk can be provided through a configuration file or environment variables. This plugin requires the API endpoint, namespace and authentication credentials.
+
+**Do you want to use a configuration file for storing these values?** Please [follow the instructions](https://console.ng.bluemix.net/openwhisk/cli) for setting up the OpenWhisk command-line utility. This tool stores account credentials in the `.wskprops` file in the user's home directory. The plugin automatically extracts credentials from this file at runtime.  No further configuration is needed.
+
+**Do you want to use environment variables for credentials?** Use the following environment variables to be pass in account credentials. These values override anything extracted from the configuration file.
+
+- *OW_APIHOST* - Platform endpoint, e.g. `openwhisk.ng.bluemix.net`
+- *OW_AUTH* - Authentication key, e.g. `xxxxxx:yyyyy
+
+
+
+### Have you installed and setup the provider plugin?
+
+Using the framework with the OpenWhisk platform needs you to install the provider plugin and link this to your service. 
+
+####  Install the provider plugin
+
+```
+$ sudo npm install --global serverless-openwhisk
+```
+
+*Due to an [outstanding issue](https://github.com/serverless/serverless/issues/2895) with provider plugins, the [OpenWhisk provider](https://github.com/serverless/serverless-openwhisk) must be installed as a global module.*
+
+
+#### Link provider plugin to service directory
+
+Using `npm link` will import the provider plugin into the service directory. Running `npm install` will automatically perform this using a `post install` script.
+
+```
+$ npm link serverless-openwhisk
+or
+$ npm install
+```
+
+
+
+**_…and that's it!_**
+
+### Deploy Service
+
+Use the `serverless` command to deploy your service. The sample `handler.js` file can be deployed without modification.
+
+```shell
+serverless deploy
+```

--- a/lib/plugins/create/templates/openwhisk-nodejs/README.md
+++ b/lib/plugins/create/templates/openwhisk-nodejs/README.md
@@ -29,7 +29,7 @@ Using the framework with the OpenWhisk platform needs you to install the provide
 ####  Install the provider plugin
 
 ```
-$ sudo npm install --global serverless-openwhisk
+$ npm install --global serverless-openwhisk
 ```
 
 *Due to an [outstanding issue](https://github.com/serverless/serverless/issues/2895) with provider plugins, the [OpenWhisk provider](https://github.com/serverless/serverless-openwhisk) must be installed as a global module.*
@@ -56,3 +56,11 @@ Use the `serverless` command to deploy your service. The sample `handler.js` fil
 ```shell
 serverless deploy
 ```
+
+
+
+### Issues / Feedback / Feature Requests?
+
+If you have any issues, comments or want to see new features, please file an issue in the project repository:
+
+https://github.com/serverless/serverless-openwhisk

--- a/lib/plugins/create/templates/openwhisk-nodejs/handler.js
+++ b/lib/plugins/create/templates/openwhisk-nodejs/handler.js
@@ -1,0 +1,8 @@
+'use strict';
+
+function hello(params) {
+  const name = params.name || 'World';
+  return { payload: `Hello, ${name}!` };
+}
+
+exports.hello = hello;

--- a/lib/plugins/create/templates/openwhisk-nodejs/package.json
+++ b/lib/plugins/create/templates/openwhisk-nodejs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "openwhisk-nodejs",
+  "version": "1.0.0",
+  "description": "Sample OpenWhisk NodeJS serverless framework service.",
+  "main": "handler.js",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk"
+  },
+  "keywords": [
+    "serverless",
+    "openwhisk"
+  ]
+}

--- a/lib/plugins/create/templates/openwhisk-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/openwhisk-nodejs/serverless.yml
@@ -1,0 +1,67 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: openwhisk-nodejs # NOTE: update this with your service name
+
+# Please ensure the serverless-openwhisk provider plugin is installed globally.
+# $ npm install -g serverless-openwhisk
+# ...before installing project dependencies to register this provider.
+# $ npm install
+provider:
+  name: openwhisk
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.js
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.js
+#    - exclude-me-dir/**
+
+functions:
+  hello:
+    handler: handler.hello
+
+#    Functions can be defined using sequences rather than referring 
+#    to a handler.
+#    sequence:
+#      - parse_input
+#      - do_some_algorithm
+#      - construct_output
+
+#    The following are a few example events you can configure
+#    Check the event documentation for details
+#    events:
+#      - http: GET /api/users/create
+#      - trigger: trigger_name
+
+
+# extend the framework using plugins listed here:
+# https://github.com/serverless/plugins
+plugins:
+  - serverless-openwhisk
+
+# you can define custom triggers and trigger feeds using the resources section.
+#
+#resources:
+#  triggers:
+#    my_trigger:
+#      parameters: 
+#        hello: world    
+#    alarm_trigger:
+#      parameters: 
+#        hello: world
+#     feed: /whisk.system/alarms/alarm
+#     feed_parameters: 
+#       cron: '*/8 * * * * *'


### PR DESCRIPTION
## What did you implement:

Further to my conversation with @ac360 and @nikgraf about getting framework ready for openwhisk provider support, I've added OpenWhisk templates and updated the create plugin to support this template identifier.

## How did you implement it:

Trivial changes to create plugin and use AWS provider template as source material. 

## How can we verify it:

```
npm test
```

I've added the test case to verify this works for the template identifier.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [ ] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO