### PR TITLE
BREAKING - Refactor function arn generation for info plugin

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -158,8 +158,6 @@ class AwsCompileFunctions {
 
     const functionLogicalId = this.provider.naming
       .getLambdaLogicalId(functionName);
-    const functionOutputLogicalId = this.provider.naming
-      .getLambdaOutputLogicalId(functionName);
     const newFunctionObject = {
       [functionLogicalId]: newFunction,
     };
@@ -191,17 +189,7 @@ class AwsCompileFunctions {
         newVersionObject);
     }
 
-    // Add function to Outputs section
-    const newOutput = this.cfOutputDescriptionTemplate();
-    newOutput.Value = { 'Fn::GetAtt': [functionLogicalId, 'Arn'] };
-
-    const newOutputObject = {
-      [functionOutputLogicalId]: newOutput,
-    };
-
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
-      newOutputObject);
-
+    // Add function versions to Outputs section
     const functionVersionOutputLogicalId = this.provider.naming
       .getLambdaVersionOutputLogicalId(functionName);
     const newVersionOutput = this.cfOutputLatestVersionTemplate();

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -244,13 +244,6 @@ class AwsCompileFunctions {
     };
   }
 
-  cfOutputDescriptionTemplate() {
-    return {
-      Description: 'Lambda function info',
-      Value: 'Value',
-    };
-  }
-
   cfOutputLatestVersionTemplate() {
     return {
       Description: 'Current Lambda function version',

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -887,17 +887,9 @@ describe('AwsCompileFunctions', () => {
       };
 
       const expectedOutputs = {
-        FuncLambdaFunctionArn: {
-          Description: 'Lambda function info',
-          Value: { 'Fn::GetAtt': ['FuncLambdaFunction', 'Arn'] },
-        },
         FuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
           Value: { Ref: 'FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
-        },
-        AnotherFuncLambdaFunctionArn: {
-          Description: 'Lambda function info',
-          Value: { 'Fn::GetAtt': ['AnotherFuncLambdaFunction', 'Arn'] },
         },
         AnotherFuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -909,7 +909,7 @@ describe('AwsCompileFunctions', () => {
       );
     });
 
-    it('should not create function output objects when `versionFunctions` is false', () => {
+    it('should not create function output objects when "versionFunctions" is false', () => {
       awsCompileFunctions.serverless.service.provider.versionFunctions = false;
       awsCompileFunctions.serverless.service.functions = {
         func: {
@@ -920,16 +920,7 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      const expectedOutputs = {
-        FuncLambdaFunctionArn: {
-          Description: 'Lambda function info',
-          Value: { 'Fn::GetAtt': ['FuncLambdaFunction', 'Arn'] },
-        },
-        AnotherFuncLambdaFunctionArn: {
-          Description: 'Lambda function info',
-          Value: { 'Fn::GetAtt': ['AnotherFuncLambdaFunction', 'Arn'] },
-        },
-      };
+      const expectedOutputs = {};
 
       awsCompileFunctions.compileFunctions();
 

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -30,24 +30,11 @@ module.exports = {
       if (result) {
         outputs = result.Stacks[0].Outputs;
 
-        const lambdaArnOutputRegex = this.provider.naming
-          .getLambdaOutputLogicalIdRegex();
-
         const serviceEndpointOutputRegex = this.provider.naming
           .getServiceEndpointRegex();
 
         // Outputs
         this.gatheredData.outputs = outputs;
-
-        // Functions
-        this.gatheredData.info.functions = [];
-        outputs.filter(x => x.OutputKey.match(lambdaArnOutputRegex))
-          .forEach(x => {
-            const functionInfo = {};
-            functionInfo.arn = x.OutputValue;
-            functionInfo.name = functionInfo.arn.substring(x.OutputValue.lastIndexOf(':') + 1);
-            this.gatheredData.info.functions.push(functionInfo);
-          });
 
         // Endpoints
         outputs.filter(x => x.OutputKey.match(serviceEndpointOutputRegex))
@@ -55,6 +42,24 @@ module.exports = {
             this.gatheredData.info.endpoint = x.OutputValue;
           });
       }
+
+      return BbPromise.resolve();
+    })
+    .then(() => this.provider.getAccountId())
+    .then((accountId) => {
+      const stage = this.provider.getStage();
+      const region = this.provider.getRegion();
+
+      this.gatheredData.info.functions = [];
+
+      this.serverless.service.getAllFunctions().forEach((func) => {
+        const functionInfo = {};
+        const name = `${this.serverless.service.service}-${stage}-${func}`;
+        const arn = `arn:aws:lambda:${region}:${accountId}:function:${name}`;
+        functionInfo.name = name;
+        functionInfo.arn = arn;
+        this.gatheredData.info.functions.push(functionInfo);
+      });
 
       return BbPromise.resolve();
     });

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -47,15 +47,12 @@ module.exports = {
     })
     .then(() => this.provider.getAccountId())
     .then((accountId) => {
-      const stage = this.provider.getStage();
-      const region = this.provider.getRegion();
-
       this.gatheredData.info.functions = [];
 
       this.serverless.service.getAllFunctions().forEach((func) => {
         const functionInfo = {};
-        const name = `${this.serverless.service.service}-${stage}-${func}`;
-        const arn = `arn:aws:lambda:${region}:${accountId}:function:${name}`;
+        const name = `${this.serverless.service.service}-${this.options.stage}-${func}`;
+        const arn = `arn:aws:lambda:${this.options.region}:${accountId}:function:${name}`;
         functionInfo.name = name;
         functionInfo.arn = arn;
         this.gatheredData.info.functions.push(functionInfo);

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -10,20 +10,31 @@ const BbPromise = require('bluebird');
 describe('#getStackInfo()', () => {
   let serverless;
   let awsInfo;
+  let describeStacksStub;
+  let getAccountIdStub;
 
   beforeEach(() => {
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
+    serverless.service.functions = {
+      hello: {},
+      world: {},
+    };
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
     awsInfo = new AwsInfo(serverless, options);
+
+    describeStacksStub = sinon.stub(awsInfo.provider, 'request');
+    getAccountIdStub = sinon.stub(awsInfo.provider, 'getAccountId')
+      .returns(BbPromise.resolve(12345678));
   });
 
   afterEach(() => {
     awsInfo.provider.request.restore();
+    awsInfo.provider.getAccountId.restore();
   });
 
   it('attach info from describeStack call to this.gatheredData if result is available', () => {
@@ -36,16 +47,6 @@ describe('#getStackInfo()', () => {
             'Sample template showing how to create a publicly accessible S3 bucket.',
           Tags: [],
           Outputs: [
-            {
-              Description: 'Lambda function info',
-              OutputKey: 'HelloLambdaFunctionArn',
-              OutputValue: 'arn:aws:iam::12345678:function:hello',
-            },
-            {
-              Description: 'Lambda function info',
-              OutputKey: 'WorldLambdaFunctionArn',
-              OutputValue: 'arn:aws:iam::12345678:function:world',
-            },
             {
               Description: 'URL of the service endpoint',
               OutputKey: 'ServiceEndpoint',
@@ -72,19 +73,18 @@ describe('#getStackInfo()', () => {
       ],
     };
 
-    const describeStackStub = sinon.stub(awsInfo.provider, 'request')
-      .returns(BbPromise.resolve(describeStacksResponse));
+    describeStacksStub.returns(BbPromise.resolve(describeStacksResponse));
 
     const expectedGatheredDataObj = {
       info: {
         functions: [
           {
-            arn: 'arn:aws:iam::12345678:function:hello',
-            name: 'hello',
+            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-hello',
+            name: 'my-service-dev-hello',
           },
           {
-            arn: 'arn:aws:iam::12345678:function:world',
-            name: 'world',
+            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-world',
+            name: 'my-service-dev-world',
           },
         ],
         endpoint: 'ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev',
@@ -93,16 +93,6 @@ describe('#getStackInfo()', () => {
         region: 'us-east-1',
       },
       outputs: [
-        {
-          Description: 'Lambda function info',
-          OutputKey: 'HelloLambdaFunctionArn',
-          OutputValue: 'arn:aws:iam::12345678:function:hello',
-        },
-        {
-          Description: 'Lambda function info',
-          OutputKey: 'WorldLambdaFunctionArn',
-          OutputValue: 'arn:aws:iam::12345678:function:world',
-        },
         {
           Description: 'URL of the service endpoint',
           OutputKey: 'ServiceEndpoint',
@@ -122,8 +112,8 @@ describe('#getStackInfo()', () => {
     };
 
     return awsInfo.getStackInfo().then(() => {
-      expect(describeStackStub.calledOnce).to.equal(true);
-      expect(describeStackStub.calledWithExactly(
+      expect(describeStacksStub.calledOnce).to.equal(true);
+      expect(describeStacksStub.calledWithExactly(
         'CloudFormation',
         'describeStacks',
         {
@@ -133,6 +123,8 @@ describe('#getStackInfo()', () => {
         awsInfo.options.region
       )).to.equal(true);
 
+      expect(getAccountIdStub.calledOnce).to.equal(true);
+
       expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);
     });
   });
@@ -140,12 +132,20 @@ describe('#getStackInfo()', () => {
   it('should resolve if result is empty', () => {
     const describeStacksResponse = null;
 
-    const describeStackStub = sinon.stub(awsInfo.provider, 'request')
-      .returns(BbPromise.resolve(describeStacksResponse));
+    describeStacksStub.returns(BbPromise.resolve(describeStacksResponse));
 
     const expectedGatheredDataObj = {
       info: {
-        functions: [],
+        functions: [
+          {
+            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-hello',
+            name: 'my-service-dev-hello',
+          },
+          {
+            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-world',
+            name: 'my-service-dev-world',
+          },
+        ],
         endpoint: '',
         service: 'my-service',
         stage: 'dev',
@@ -155,8 +155,8 @@ describe('#getStackInfo()', () => {
     };
 
     return awsInfo.getStackInfo().then(() => {
-      expect(describeStackStub.calledOnce).to.equal(true);
-      expect(describeStackStub.calledWithExactly(
+      expect(describeStacksStub.calledOnce).to.equal(true);
+      expect(describeStacksStub.calledWithExactly(
         'CloudFormation',
         'describeStacks',
         {
@@ -165,6 +165,8 @@ describe('#getStackInfo()', () => {
         awsInfo.options.stage,
         awsInfo.options.region
       )).to.equal(true);
+
+      expect(getAccountIdStub.calledOnce).to.equal(true);
 
       expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);
     });

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -118,12 +118,6 @@ module.exports = {
   getLambdaLogicalIdRegex() {
     return /LambdaFunction$/;
   },
-  getLambdaOutputLogicalId(functionName) {
-    return `${this.getLambdaLogicalId(functionName)}Arn`;
-  },
-  getLambdaOutputLogicalIdRegex() {
-    return /LambdaFunctionArn$/;
-  },
   getLambdaVersionLogicalId(functionName, sha) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaVersion${sha
       .replace(/[^0-9a-z]/gi, '')}`;

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -218,33 +218,6 @@ describe('#naming()', () => {
     });
   });
 
-  describe('#getLambdaOutputLogicalId()', () => {
-    it('should normalize the function name and add the logical arn suffix', () => {
-      expect(
-        sdk.naming.getLambdaOutputLogicalId('functionName')
-      ).to.equal('FunctionNameLambdaFunctionArn');
-    });
-  });
-
-  describe('#getLambdaOutputLogicalIdRegex()', () => {
-    it('should match the suffix', () => {
-      expect(sdk.naming.getLambdaOutputLogicalIdRegex()
-        .test('aLambdaFunctionArn')).to.equal(true);
-    });
-
-    it('should not match a name without the suffix', () => {
-      expect(sdk.naming.getLambdaOutputLogicalIdRegex()
-        .test('LambdaFunctionArnNotTheSuffix'))
-        .to.equal(false);
-    });
-
-    it('should match a name with the suffix', () => {
-      expect(sdk.naming.getLambdaOutputLogicalIdRegex()
-        .test('AFunctionArnNameLambdaFunctionArn'))
-        .to.equal(true);
-    });
-  });
-
   describe('#getApiGatewayName()', () => {
     it('should return the composition of stage and service name', () => {
       serverless.service.service = 'myService';

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -240,6 +240,14 @@ class AwsProvider {
     }
     return returnValue;
   }
+
+  getAccountId() {
+    return this.request('IAM', 'getUser', {})
+      .then((result) => {
+        const arn = result.User.Arn;
+        return arn.split(':')[4];
+      });
+  }
 }
 
 module.exports = AwsProvider;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -545,5 +545,26 @@ describe('AwsProvider', () => {
         expect(awsProvider.getStage()).to.equal('dev');
       });
     });
+
+    describe('#getAccountId()', () => {
+      it('should return the AWS account id', () => {
+        const accountId = '12345678';
+
+        const getUserStub = sinon
+          .stub(awsProvider, 'request')
+          .returns(BbPromise.resolve({
+            User: {
+              Arn: `arn:aws:iam::${accountId}:user/serverless-user`,
+            },
+          }));
+
+        return awsProvider.getAccountId()
+          .then((result) => {
+            expect(getUserStub.calledOnce).to.equal(true);
+            expect(result).to.equal(accountId);
+            awsProvider.request.restore();
+          });
+      });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #1825 and refs #2853

The function ARNs are now computed on the fly. Function ARN outputs are no longer generated which reduces the size of CloudFormation Outputs dramatically.

## How did you implement it:

Added a `getAccountId()` method in the provider plugin. Furthermore the adding of the function output is removed in the compile functions step. The arns will be computed on the fly when invoking the `info` command.

## How can we verify it:

Deploy a service and run `serverless info`. Furthermore look into the CloudFormation Outputs section in the AWS console.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES