### PR TITLE
BREAKING - Remove getStackName() method 

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -121,21 +121,6 @@ class AwsProvider {
     }
   }
 
-  /**
-   * Deprecated method. Moved to naming.js
-   * Kept here for backward compatibility
-   */
-  getStackName(stage) {
-    const warningMessage = [
-      'Deprecation Notice: provider.getStackName() method is deprecated.',
-      ' Please reference the naming.js file instead: ',
-      ' ex. naming.getStackName();',
-    ].join('');
-
-    this.serverless.cli.log(warningMessage);
-    return `${this.serverless.service.service}-${stage}`;
-  }
-
   request(service, method, params) {
     const that = this;
     const credentials = that.getCredentials();


### PR DESCRIPTION
## What did you implement:

Closes #2758

Removes the deprecated `getStackName()` method.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Change ready for review message below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES