### PR TITLE
Reduce memory consumption on deploy by at least 50%

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -32,14 +32,13 @@ module.exports = {
       throw new this.serverless.classes.Error('artifactFilePath was not supplied');
     }
 
-    const body = fs.readFileSync(artifactFilePath);
 
     const fileName = artifactFilePath.split(path.sep).pop();
 
     const params = {
       Bucket: this.bucketName,
       Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
-      Body: body,
+      Body: fs.createReadStream(artifactFilePath),
       ContentType: 'application/zip',
     };
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -71,10 +71,6 @@ describe('uploadArtifacts', () => {
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
-      const artifactFileBuffer = new Buffer(
-        serverless.utils.readFileSync(artifactFilePath), 'binary'
-      );
-
       const putObjectStub = sinon
         .stub(awsDeploy.provider, 'request').returns(BbPromise.resolve());
 
@@ -86,7 +82,7 @@ describe('uploadArtifacts', () => {
           {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/artifact.zip`,
-            Body: artifactFileBuffer,
+            Body: sinon.match.object.and(sinon.match.has('path', artifactFilePath)),
             ContentType: 'application/zip',
           },
           awsDeploy.options.stage,


### PR DESCRIPTION
## What did you implement:

I've been having an issue with a particularly large project that's been eating 8+ gigabytes of memory at deploytime (15+ functions, individual deploy zips). 

## How did you implement it:

I switched to using a stream to read artifacts at upload, because it was being read into a `const` that the AWS SDK had to then copy to a bytearray that was wrapped in a TLSStream object, duplicating the artifact several times. 

## How can we verify it:

Create a new template project (I used `aws-python`). Edit serverless.yml to package individually & have 4 functions.

```
service: aws-python # NOTE: update this with your service name
provider:
  name: aws
  runtime: python2.7
  cfLogs: true
  versionFunctions: false

package:
  artifact: ./deployable.zip

functions:
  hello1:
    handler: handler.hello
    package: {artifact: ./deployable.zip}
  hello2:
    handler: handler.hello
    package: {artifact: ./deployable.zip}
  hello3:
    handler: handler.hello
    package: {artifact: ./deployable.zip}
  hello4:
    handler: handler.hello
    package: {artifact: ./deployable.zip}
```

Run a deploy, using the `time` command to show the total CPU time, total wallclock time, and max memory used. 

```
$ time -f 'CPU: %U user/%S kernel\nMax Memory: %M Kbytes' sls deploy
... deploy stuff ...
CPU: 1.27 user/0.08 kernel
Max Memory: 96760 Kbytes
```

_Assume all `sls` commands are prefixed with that same `time` command for brevity_

Reasonable. The deploy zip size is 387 bytes here, which is totally fine. This will be our baseline. Now, I'll add a 49MB file of random data so that the artifacts are bigger (but still always under 50MB).

```
$ dd if=/dev/urandom of=random.bytes bs=1M count=49
49+0 records in
49+0 records out
51380224 bytes (51 MB, 49 MiB) copied, 0.267294 s, 192 MB/s
$ du -h random.bytes
49M     random.bytes
```

Redeploy time!

```
# this is *without* this patch
$ sls deploy
CPU: 1.85 user/0.29 kernel
Max Memory: 384004 Kbytes
# again, with the patch
$ sls deploy
CPU: 2.05 user/0.27 kernel
Max Memory: 238988 Kbytes
```

So the total memory usage is way more than the collective artifact size. The artifacts are 50192K, so and the difference between the two runs is `586036-96760`, and dividing by the artifact size gets us `(384004-96760)/50192 = 5.7` so our artifact is getting 5x bigger in RAM. 

The patched version `(238988-96760)/50192 = 2.8` which is half the increase (same artifact and such).


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
