### PR TITLE
Enable Long Stack Traces

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -5,6 +5,8 @@
 const BbPromise = require('bluebird');
 const logError = require('../lib/classes/Error').logError;
 
+BbPromise.longStackTraces();
+
 process.on('unhandledRejection', (e) => logError(e));
 process.noDeprecation = true;
 

--- a/bin/serverless
+++ b/bin/serverless
@@ -5,7 +5,9 @@
 const BbPromise = require('bluebird');
 const logError = require('../lib/classes/Error').logError;
 
-BbPromise.longStackTraces();
+BbPromise.config({
+  longStackTraces: true,
+});
 
 process.on('unhandledRejection', (e) => logError(e));
 process.noDeprecation = true;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When an error occurs, we get the immediate stack trace but not the entire stack trace.  This often results in traces like:

```
[Container] 2017/01/26 21:33:22 ServerlessError: Access Denied
[Container] 2017/01/26 21:33:22 at (/usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:177:20)
[Container] 2017/01/26 21:33:22 at Request.<anonymous> (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:355:18)
[Container] 2017/01/26 21:33:22 at Request.callListeners (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
[Container] 2017/01/26 21:33:22 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
[Container] 2017/01/26 21:33:22 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:668:14)
[Container] 2017/01/26 21:33:22 at Request.transition (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:22:10)
[Container] 2017/01/26 21:33:22 at AcceptorStateMachine.runTo (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:14:12)
[Container] 2017/01/26 21:33:22 at /usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:26:10
[Container] 2017/01/26 21:33:22 at Request.<anonymous> (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:38:9)
[Container] 2017/01/26 21:33:22 at Request.<anonymous> (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:670:12)
[Container] 2017/01/26 21:33:22 at Request.callListeners (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
[Container] 2017/01/26 21:33:22 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
[Container] 2017/01/26 21:33:22 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:668:14)
[Container] 2017/01/26 21:33:22 at Request.transition (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:22:10)
[Container] 2017/01/26 21:33:22 at AcceptorStateMachine.runTo (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:14:12)
[Container] 2017/01/26 21:33:22 at /usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:26:10
```

This tells me nothing about where the operation originated from that resulted in the "Access Denied" error.  Thus, my sad face surfaces.

I like my happy face and its probability of showing increases when I have messages that look like:

```
[Container] 2017/01/26 22:33:13 ServerlessError: Access Denied
[Container] 2017/01/26 22:33:13 at Response.<anonymous> (/usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:162:20)
[Container] 2017/01/26 22:33:13 at Request.<anonymous> (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:355:18)
[Container] 2017/01/26 22:33:13 at Request.callListeners (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
[Container] 2017/01/26 22:33:13 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
[Container] 2017/01/26 22:33:13 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:668:14)
[Container] 2017/01/26 22:33:13 at Request.transition (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:22:10)
[Container] 2017/01/26 22:33:13 at AcceptorStateMachine.runTo (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:14:12)
[Container] 2017/01/26 22:33:13 at /usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:26:10
[Container] 2017/01/26 22:33:13 at Request.<anonymous> (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:38:9)
[Container] 2017/01/26 22:33:13 at Request.<anonymous> (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:670:12)
[Container] 2017/01/26 22:33:13 at Request.callListeners (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
[Container] 2017/01/26 22:33:13 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
[Container] 2017/01/26 22:33:13 at Request.emit (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:668:14)
[Container] 2017/01/26 22:33:13 at Request.transition (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/request.js:22:10)
[Container] 2017/01/26 22:33:13 at AcceptorStateMachine.runTo (/usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:14:12)
[Container] 2017/01/26 22:33:13 at /usr/local/lib/node_modules/serverless/node_modules/aws-sdk/lib/state_machine.js:26:10
[Container] 2017/01/26 22:33:13 From previous event:
[Container] 2017/01/26 22:33:13 at /usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:150:14
[Container] 2017/01/26 22:33:13 at doCall (/usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:129:9)
[Container] 2017/01/26 22:33:13 at /usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:140:14
[Container] 2017/01/26 22:33:13 From previous event:
[Container] 2017/01/26 22:33:13 at BbPromise (/usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:127:38)
[Container] 2017/01/26 22:33:13 at AwsProvider.request (/usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:143:12)
[Container] 2017/01/26 22:33:13 at AwsDeploy.<anonymous> (/usr/local/lib/node_modules/serverless/lib/plugins/aws/deploy/lib/configureStack.js:23:35)
[Container] 2017/01/26 22:33:13 From previous event:
[Container] 2017/01/26 22:33:13 at AwsDeploy.configureStack (/usr/local/lib/node_modules/serverless/lib/plugins/aws/deploy/lib/configureStack.js:23:10)
[Container] 2017/01/26 22:33:13 From previous event:
[Container] 2017/01/26 22:33:13 at AwsDeploy.hooks.deploy:initialize (/usr/local/lib/node_modules/serverless/lib/plugins/aws/deploy/index.js:42:10)
[Container] 2017/01/26 22:33:13 at /usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:160:50
[Container] 2017/01/26 22:33:13 at processImmediate [as _immediateCallback] (timers.js:383:17)
[Container] 2017/01/26 22:33:13 From previous event:
[Container] 2017/01/26 22:33:13 at PluginManager.run (/usr/local/lib/node_modules/serverless/lib/classes/PluginManager.js:160:22)
[Container] 2017/01/26 22:33:13 at Serverless.run (/usr/local/lib/node_modules/serverless/lib/Serverless.js:91:31)
[Container] 2017/01/26 22:33:13 at /usr/local/lib/node_modules/serverless/bin/serverless:21:50
```

That is **clearly** (relatively speaking) a lack of S3 rights and I can fix that (and did)!

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

add the following line to `~/bin/serverless`:

```
BbPromise.longStackTraces();
```

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

0. use a different branch
1. `export SLS_DEBUG=*`
2. configure SLS to use bad credentials
3. try to take an action and see the stack trace
4. update to this branch
5. try to take the same action.
6. note that it still fails but also that you get a deeper stack trace

## Todos:

- [x] Write tests (N/A)
- [x] Write documentation (docs for configuring debugging were removed, I really don't know why)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
