### PR TITLE
Use STS getCallerIdentity instead of IAM getUser

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -227,11 +227,8 @@ class AwsProvider {
   }
 
   getAccountId() {
-    return this.request('IAM', 'getUser', {})
-      .then((result) => {
-        const arn = result.User.Arn;
-        return arn.split(':')[4];
-      });
+    return this.request('STS', 'getCallerIdentity', {})
+      .then((result) => result.Account);
   }
 }
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -550,17 +550,18 @@ describe('AwsProvider', () => {
       it('should return the AWS account id', () => {
         const accountId = '12345678';
 
-        const getUserStub = sinon
+        const stsGetCallerIdentityStub = sinon
           .stub(awsProvider, 'request')
           .returns(BbPromise.resolve({
-            User: {
-              Arn: `arn:aws:iam::${accountId}:user/serverless-user`,
-            },
+            ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
+            UserId: 'ABCDEFGHIJKLMNOPQRSTU:VWXYZ',
+            Account: accountId,
+            Arn: 'arn:aws:sts::123456789012:assumed-role/ROLE-NAME/VWXYZ',
           }));
 
         return awsProvider.getAccountId()
           .then((result) => {
-            expect(getUserStub.calledOnce).to.equal(true);
+            expect(stsGetCallerIdentityStub.calledOnce).to.equal(true);
             expect(result).to.equal(accountId);
             awsProvider.request.restore();
           });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

A possible fix for https://github.com/serverless/serverless/issues/3151

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Switch from using IAM `getUser` to get the account ID of the current user to calling STS `getCallerIdentity`.  It is expected that this is a less protected segment of rights and will, as a result, impact fewer users.  Of course, this is hard to guarantee.
Changes tests appropriately

Related Docs:
http://docs.aws.amazon.com/STS/latest/APIReference/API_Operations.html
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#getCallerIdentity-property

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

See awsProvider.spec.js tests.  Use this to deploy any project.

## Todos:

- [x] Write tests
- [x] Write documentation (N/A)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
