### PR TITLE
BREAKING - Create Log Group Resources By Default

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -256,16 +256,8 @@ functions:
 
 ## Log Group Resources
 
-By default, the framework does not create LogGroups for your Lambdas. However this behavior will be deprecated soon and we'll be adding CloudFormation LogGroups resources as part of the stack. This makes it easy to clean up your log groups in the case you remove your service, and make the lambda IAM permissions much more specific and secure.
+By default, the framework will create LogGroups for your Lambdas. This makes it easy to clean up your log groups in the case you remove your service, and make the lambda IAM permissions much more specific and secure.
 
-To opt in for this feature now to avoid breaking changes later, add the following to your provider config in serverless.yml:
-
-```yml
-provider:
-  cfLogs: true
-```
-
-If you get a CloudFormation error saying that log group already exists, you have to remove it first from AWS console, then deploy, otherwise for new services this should work out of the box.
 
 ## Versioning Deployed Functions
 

--- a/lib/plugins/aws/deploy/lib/iam-policy-lambda-execution-template.json
+++ b/lib/plugins/aws/deploy/lib/iam-policy-lambda-execution-template.json
@@ -11,6 +11,7 @@
         {
           "Effect": "Allow",
           "Action": [
+            "logs:CreateLogStream",
             "logs:PutLogEvents"
           ],
           "Resource": []

--- a/lib/plugins/aws/deploy/lib/iam-policy-lambda-execution-template.json
+++ b/lib/plugins/aws/deploy/lib/iam-policy-lambda-execution-template.json
@@ -11,14 +11,6 @@
         {
           "Effect": "Allow",
           "Action": [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream"
-          ],
-          "Resource": []
-        },
-        {
-          "Effect": "Allow",
-          "Action": [
             "logs:PutLogEvents"
           ],
           "Resource": []

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -68,61 +68,37 @@ module.exports = {
         }
       );
 
-      if (!this.serverless.service.provider.cfLogs) {
+      this.serverless.service.getAllFunctions().forEach((functionName) => {
+        const functionObject = this.serverless.service.getFunction(functionName);
+        const logGroupLogicalId = this.provider.naming
+          .getLogGroupLogicalId(functionName);
+        const newLogGroup = {
+          [logGroupLogicalId]: {
+            Type: 'AWS::Logs::LogGroup',
+            Properties: {
+              LogGroupName: this.provider.naming.getLogGroupName(functionObject.name),
+            },
+          },
+        };
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+          newLogGroup);
+
         this.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[this.provider.naming.getPolicyLogicalId()]
           .Properties
           .PolicyDocument
           .Statement[0]
-          .Resource = `arn:aws:logs:${this.options.region}:*:*`;
-
-        this.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources[this.provider.naming.getPolicyLogicalId()]
-          .Properties
-          .PolicyDocument
-          .Statement[1]
-          .Resource = `arn:aws:logs:${this.options.region}:*:*`;
-      } else {
-        this.serverless.service.getAllFunctions().forEach((functionName) => {
-          const functionObject = this.serverless.service.getFunction(functionName);
-          const logGroupLogicalId = this.provider.naming
-            .getLogGroupLogicalId(functionName);
-          const newLogGroup = {
-            [logGroupLogicalId]: {
-              Type: 'AWS::Logs::LogGroup',
-              Properties: {
-                LogGroupName: this.provider.naming.getLogGroupName(functionObject.name),
-              },
-            },
-          };
-          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-            newLogGroup);
-
-          this.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources[this.provider.naming.getPolicyLogicalId()]
-            .Properties
-            .PolicyDocument
-            .Statement[0]
-            .Resource
-            .push({ 'Fn::GetAtt': [`${logGroupLogicalId}`, 'Arn'] });
-
-          this.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources[this.provider.naming.getPolicyLogicalId()]
-            .Properties
-            .PolicyDocument
-            .Statement[1]
-            .Resource
-            .push({
-              'Fn::Join': [
-                ':',
-                [
-                  { 'Fn::GetAtt': [`${logGroupLogicalId}`, 'Arn'] },
-                  '*',
-                ],
+          .Resource
+          .push({
+            'Fn::Join': [
+              ':',
+              [
+                { 'Fn::GetAtt': [`${logGroupLogicalId}`, 'Arn'] },
+                '*',
               ],
-            });
-        });
-      }
+            ],
+          });
+      });
 
       if (this.serverless.service.provider.iamRoleStatements) {
         // add custom iam role statements

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
@@ -193,7 +193,6 @@ describe('#mergeIamTemplates()', () => {
   });
 
   it('should add a CloudWatch LogGroup resource', () => {
-    awsDeploy.serverless.service.provider.cfLogs = true;
     const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
     return awsDeploy.mergeIamTemplates().then(() => {
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -210,7 +209,6 @@ describe('#mergeIamTemplates()', () => {
   });
 
   it('should update IamPolicyLambdaExecution with a logging resource for the function', () => {
-    awsDeploy.serverless.service.provider.cfLogs = true;
     awsDeploy.serverless.service.functions = {
       func0: {
         handler: 'func.function.handler',
@@ -251,7 +249,6 @@ describe('#mergeIamTemplates()', () => {
   });
 
   it('should update IamPolicyLambdaExecution with a logging resource for the function', () => {
-    awsDeploy.serverless.service.provider.cfLogs = true;
     const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
     return awsDeploy.mergeIamTemplates().then(() => {
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -260,19 +257,11 @@ describe('#mergeIamTemplates()', () => {
         .PolicyDocument
         .Statement[0]
         .Resource
-      ).to.deep.equal([{ 'Fn::GetAtt': [normalizedName, 'Arn'] }]);
-      expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[awsDeploy.provider.naming.getPolicyLogicalId()]
-        .Properties
-        .PolicyDocument
-        .Statement[1]
-        .Resource
       ).to.deep.equal([{ 'Fn::Join': [':', [{ 'Fn::GetAtt': [normalizedName, 'Arn'] }, '*']] }]);
     });
   });
 
   it('should update IamPolicyLambdaExecution with each function\'s logging resources', () => {
-    awsDeploy.serverless.service.provider.cfLogs = true;
     awsDeploy.serverless.service.functions = {
       func0: {
         handler: 'func.function.handler',
@@ -289,23 +278,12 @@ describe('#mergeIamTemplates()', () => {
       awsDeploy.provider.naming.getLogGroupLogicalId(f.func1.name),
     ];
     return awsDeploy.mergeIamTemplates().then(() => {
+
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[awsDeploy.provider.naming.getPolicyLogicalId()]
         .Properties
         .PolicyDocument
         .Statement[0]
-        .Resource
-      ).to.deep.equal(
-        [
-          { 'Fn::GetAtt': [normalizedNames[0], 'Arn'] },
-          { 'Fn::GetAtt': [normalizedNames[1], 'Arn'] },
-        ]
-      );
-      expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[awsDeploy.provider.naming.getPolicyLogicalId()]
-        .Properties
-        .PolicyDocument
-        .Statement[1]
         .Resource
       ).to.deep.equal(
         [

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
@@ -120,7 +120,7 @@ describe('#mergeIamTemplates()', () => {
           .Resources[awsDeploy.provider.naming.getPolicyLogicalId()]
           .Properties
           .PolicyDocument
-          .Statement[2]
+          .Statement[1]
         ).to.deep.equal(awsDeploy.serverless.service.provider.iamRoleStatements[0]);
       });
   });
@@ -278,7 +278,6 @@ describe('#mergeIamTemplates()', () => {
       awsDeploy.provider.naming.getLogGroupLogicalId(f.func1.name),
     ];
     return awsDeploy.mergeIamTemplates().then(() => {
-
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[awsDeploy.provider.naming.getPolicyLogicalId()]
         .Properties

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/custom-resources/service/serverless.yml
+++ b/tests/integration/aws/general/custom-resources/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/environment-variables/service/serverless.yml
+++ b/tests/integration/aws/general/environment-variables/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
   environment:
     provider_level_variable_1: provider_level_1
     provider_level_variable_2: provider_level_2

--- a/tests/integration/aws/general/nested-handlers/service/serverless.yml
+++ b/tests/integration/aws/general/nested-handlers/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/overwrite-resources/service/serverless.yml
+++ b/tests/integration/aws/general/overwrite-resources/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/general/package/service/serverless.yml
+++ b/tests/integration/aws/general/package/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/s3/multiple-events-multiple-functions-multiple-buckets/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-multiple-functions-multiple-buckets/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/s3/multiple-events-multiple-functions-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-multiple-functions-single-bucket/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   create:

--- a/tests/integration/aws/s3/multiple-events-single-function-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-single-function-single-bucket/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/s3/single-event-single-function-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/single-event-single-function-single-bucket/service/serverless.yml
@@ -4,7 +4,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/existing-topic/service/serverless.yml
+++ b/tests/integration/aws/sns/existing-topic/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/general/custom-plugins/service/serverless.yml
+++ b/tests/integration/general/custom-plugins/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/integration/general/local-plugins/service/serverless.yml
+++ b/tests/integration/general/local-plugins/service/serverless.yml
@@ -3,7 +3,6 @@ service: aws-nodejs # NOTE: update this with your service name
 provider:
   name: aws
   runtime: nodejs4.3
-  cfLogs: true
 
 functions:
   hello:

--- a/tests/simple-suite/tests.js
+++ b/tests/simple-suite/tests.js
@@ -26,7 +26,7 @@ describe('Service Lifecyle Integration Test', () => {
   it('should create service in tmp directory', () => {
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
     testUtils.replaceTextInFile('serverless.yml', templateName, newServiceName);
-    testUtils.replaceTextInFile('serverless.yml', 'name: aws', 'name: aws\n  cfLogs: true');
+    testUtils.replaceTextInFile('serverless.yml', 'name: aws', 'name: aws');
     expect(fs.existsSync(path.join(tmpDir, 'serverless.yml'))).to.be.equal(true);
     expect(fs.existsSync(path.join(tmpDir, 'handler.js'))).to.be.equal(true);
   });

--- a/tests/simple-suite/tests.js
+++ b/tests/simple-suite/tests.js
@@ -26,7 +26,6 @@ describe('Service Lifecyle Integration Test', () => {
   it('should create service in tmp directory', () => {
     execSync(`${serverlessExec} create --template ${templateName}`, { stdio: 'inherit' });
     testUtils.replaceTextInFile('serverless.yml', templateName, newServiceName);
-    testUtils.replaceTextInFile('serverless.yml', 'name: aws', 'name: aws');
     expect(fs.existsSync(path.join(tmpDir, 'serverless.yml'))).to.be.equal(true);
     expect(fs.existsSync(path.join(tmpDir, 'handler.js'))).to.be.equal(true);
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3115 
Closes #2725 
Closes #2724

This PR removes the optional `cfLogs` property and creates log group CF resources by default. This is a breaking change if you have deployed a service previously without `cfLogs` set to true, and have invoked any function at least once (which implicitly creates a log group outside of the stack template).

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Removed the `CreateLogGroup` IAM statement as it's no longer needed, removed cfLogs option and added the LogGroup resources by default.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

1. Create new service
2. Deploy the service. You'll see in the CF template the new LogGroups resources, even though you haven't set the `cfLogs` to be true.
3. Invoke some of your functions and make sure the log streams are created successfully by running `sls logs`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Enable ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for this PR
- [x] Change ready for review message below


***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES