### PR TITLE
BREAKING - Remove on-the-fly arn generation for displayed functions

### DIFF
--- a/docs/providers/aws/cli-reference/info.md
+++ b/docs/providers/aws/cli-reference/info.md
@@ -47,7 +47,7 @@ api keys:
 endpoints:
   GET - https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/users
 functions:
-  my-serverless-service-dev-hello: arn:aws:lambda:us-east-1:377024778620:function:my-serverless-service-dev-hello
+  my-serverless-service-dev-hello
 ```
 
 #### Verbose
@@ -66,14 +66,11 @@ api keys:
 endpoints:
   GET - https://dxaynpuzd4.execute-api.us-east-1.amazonaws.com/dev/users
 functions:
-  my-serverless-service-dev-hello: arn:aws:lambda:us-east-1:377024778620:function:my-serverless-service-dev-hello
+  my-serverless-service-dev-hello
 
 Stack Outputs
 CloudFrontUrl: d2d10e2tyk1pei.cloudfront.net
-ListScreenshotsLambdaFunctionArn: arn:aws:lambda:us-east-1:377024778620:function:lambda-screenshots-dev-listScreenshots
 ScreenshotBucket: dev-svdgraaf-screenshots
-CreateThumbnailsLambdaFunctionArn: arn:aws:lambda:us-east-1:377024778620:function:lambda-screenshots-dev-createThumbnails
-TakeScreenshotLambdaFunctionArn: arn:aws:lambda:us-east-1:377024778620:function:lambda-screenshots-dev-takeScreenshot
 ServiceEndpoint: https://12341jc801.execute-api.us-east-1.amazonaws.com/dev
 ServerlessDeploymentBucketName: lambda-screenshots-dev-serverlessdeploymentbucket-15b7pkc04f98a
 ```

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -60,7 +60,7 @@ module.exports = {
 
     if (info.functions && info.functions.length > 0) {
       info.functions.forEach((f) => {
-        functionsMessage += `\n  ${f.name}: ${f.arn}`;
+        functionsMessage += `\n  ${f.name}`;
       });
     } else {
       functionsMessage += '\n  None';

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -154,15 +154,12 @@ describe('#display()', () => {
     awsInfo.gatheredData.info.functions = [
       {
         name: 'function1',
-        arn: 'arn:aws:iam::12345678:function:function1',
       },
       {
         name: 'function2',
-        arn: 'arn:aws:iam::12345678:function:function2',
       },
       {
         name: 'function3',
-        arn: 'arn:aws:iam::12345678:function:function3',
       },
     ];
 
@@ -177,9 +174,9 @@ describe('#display()', () => {
     expectedMessage += `\n${chalk.yellow('endpoints:')}`;
     expectedMessage += '\n  None';
     expectedMessage += `\n${chalk.yellow('functions:')}`;
-    expectedMessage += '\n  function1: arn:aws:iam::12345678:function:function1';
-    expectedMessage += '\n  function2: arn:aws:iam::12345678:function:function2';
-    expectedMessage += '\n  function3: arn:aws:iam::12345678:function:function3';
+    expectedMessage += '\n  function1';
+    expectedMessage += '\n  function2';
+    expectedMessage += '\n  function3';
 
     const message = awsInfo.display();
     expect(consoleLogStub.calledOnce).to.equal(true);

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -36,27 +36,19 @@ module.exports = {
         // Outputs
         this.gatheredData.outputs = outputs;
 
+        // Functions
+        this.serverless.service.getAllFunctions().forEach((func) => {
+          const functionInfo = {};
+          functionInfo.name = `${this.serverless.service.service}-${this.options.stage}-${func}`;
+          this.gatheredData.info.functions.push(functionInfo);
+        });
+
         // Endpoints
         outputs.filter(x => x.OutputKey.match(serviceEndpointOutputRegex))
           .forEach(x => {
             this.gatheredData.info.endpoint = x.OutputValue;
           });
       }
-
-      return BbPromise.resolve();
-    })
-    .then(() => this.provider.getAccountId())
-    .then((accountId) => {
-      this.gatheredData.info.functions = [];
-
-      this.serverless.service.getAllFunctions().forEach((func) => {
-        const functionInfo = {};
-        const name = `${this.serverless.service.service}-${this.options.stage}-${func}`;
-        const arn = `arn:aws:lambda:${this.options.region}:${accountId}:function:${name}`;
-        functionInfo.name = name;
-        functionInfo.arn = arn;
-        this.gatheredData.info.functions.push(functionInfo);
-      });
 
       return BbPromise.resolve();
     });

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -11,7 +11,6 @@ describe('#getStackInfo()', () => {
   let serverless;
   let awsInfo;
   let describeStacksStub;
-  let getAccountIdStub;
 
   beforeEach(() => {
     serverless = new Serverless();
@@ -28,13 +27,10 @@ describe('#getStackInfo()', () => {
     awsInfo = new AwsInfo(serverless, options);
 
     describeStacksStub = sinon.stub(awsInfo.provider, 'request');
-    getAccountIdStub = sinon.stub(awsInfo.provider, 'getAccountId')
-      .returns(BbPromise.resolve(12345678));
   });
 
   afterEach(() => {
     awsInfo.provider.request.restore();
-    awsInfo.provider.getAccountId.restore();
   });
 
   it('attach info from describeStack call to this.gatheredData if result is available', () => {
@@ -79,11 +75,9 @@ describe('#getStackInfo()', () => {
       info: {
         functions: [
           {
-            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-hello',
             name: 'my-service-dev-hello',
           },
           {
-            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-world',
             name: 'my-service-dev-world',
           },
         ],
@@ -123,8 +117,6 @@ describe('#getStackInfo()', () => {
         awsInfo.options.region
       )).to.equal(true);
 
-      expect(getAccountIdStub.calledOnce).to.equal(true);
-
       expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);
     });
   });
@@ -136,16 +128,7 @@ describe('#getStackInfo()', () => {
 
     const expectedGatheredDataObj = {
       info: {
-        functions: [
-          {
-            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-hello',
-            name: 'my-service-dev-hello',
-          },
-          {
-            arn: 'arn:aws:lambda:us-east-1:12345678:function:my-service-dev-world',
-            name: 'my-service-dev-world',
-          },
-        ],
+        functions: [],
         endpoint: '',
         service: 'my-service',
         stage: 'dev',
@@ -165,8 +148,6 @@ describe('#getStackInfo()', () => {
         awsInfo.options.stage,
         awsInfo.options.region
       )).to.equal(true);
-
-      expect(getAccountIdStub.calledOnce).to.equal(true);
 
       expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);
     });


### PR DESCRIPTION
## What did you implement:

Removes the generation of arns. Now only the function name will be displayed on the console. This way we save one additional request and prevent deployment failures because the `accountId` retrieval might be not allowed for some users (although @erikerikson already PRed a change for that).

## How did you implement it:

Remove the arn generation. Now only the names are shown.

## How can we verify it:

Deploy a services and look at the output on the console (or use `serverless info`).

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES