### PR TITLE
link to FaunaDB CRUD example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The following are services you can instantly install and use by running `serverl
 
 * [serverless-examples](https://github.com/serverless/examples)
 * [CRUD](https://github.com/pmuens/serverless-crud) - CRUD service, [Scala Port](https://github.com/jahangirmohammed/serverless-crud-scala)
+* [CRUD with FaunaDB](https://github.com/faunadb/serverless-crud) - CRUD service using FaunaDB
 * [CRUD with S3](https://github.com/tscanlin/serverless-s3-crud) - CRUD service using S3
 * [GraphQL Boilerplate](https://github.com/serverless/serverless-graphql) - GraphQL application Boilerplate service
 * [Authentication](https://github.com/laardee/serverless-authentication-boilerplate) - Authentication boilerplate service


### PR DESCRIPTION
This links to a fork of the CRUD example that uses FaunaDB instead of DynamoDB.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

A version of the CRUD example using FaunaDB.

## How did you implement it:

Forked the CRUD example and changed a little code.

## How can we verify it:

I've updated the readme so that you can run it by following the steps. FaunaDB is free to try.

## Todos:


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO