### PR TITLE
Implementing Error tests (per issue #3169)

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -12,7 +12,7 @@ const PluginManager = require('./classes/PluginManager');
 const Utils = require('./classes/Utils');
 const Service = require('./classes/Service');
 const Variables = require('./classes/Variables');
-const SError = require('./classes/Error').SError;
+const ServerlessError = require('./classes/Error').ServerlessError;
 const Version = require('./../package.json').version;
 
 class Serverless {
@@ -42,7 +42,7 @@ class Serverless {
     this.classes.Utils = Utils;
     this.classes.Service = Service;
     this.classes.Variables = Variables;
-    this.classes.Error = SError;
+    this.classes.Error = ServerlessError;
 
     this.serverlessDirPath = path.join(os.homedir(), '.serverless');
   }

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -13,7 +13,7 @@ const PluginManager = require('../lib/classes/PluginManager');
 const Utils = require('../lib/classes/Utils');
 const Service = require('../lib/classes/Service');
 const CLI = require('../lib/classes/CLI');
-const Error = require('../lib/classes/Error').SError;
+const ServerlessError = require('../lib/classes/Error').ServerlessError;
 const testUtils = require('../tests/utils');
 
 describe('Serverless', () => {
@@ -105,7 +105,7 @@ describe('Serverless', () => {
     });
 
     it('should store the Error class inside the classes object', () => {
-      expect(serverless.classes.Error).to.deep.equal(Error);
+      expect(serverless.classes.Error).to.deep.equal(ServerlessError);
     });
   });
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -21,7 +21,7 @@ describe('CLI', () => {
     serverless = new Serverless({});
   });
 
-  describe('#construtor()', () => {
+  describe('#constructor()', () => {
     it('should set the serverless instance', () => {
       cli = new CLI(serverless);
       expect(cli.serverless).to.deep.equal(serverless);

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -2,7 +2,7 @@
 const chalk = require('chalk');
 const version = require('./../../package.json').version;
 
-module.exports.SError = class ServerlessError extends Error {
+module.exports.ServerlessError = class ServerlessError extends Error {
   constructor(message, statusCode) {
     super(message);
     this.name = this.constructor.name;
@@ -11,6 +11,9 @@ module.exports.SError = class ServerlessError extends Error {
     Error.captureStackTrace(this, this.constructor);
   }
 };
+
+// Deprecated - use ServerlessError instead
+module.exports.SError = module.exports.ServerlessError;
 
 module.exports.logError = (e) => {
   try {

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -1,0 +1,149 @@
+'use strict';
+/* eslint-disable no-console */
+
+const expect = require('chai').expect;
+const ServerlessError = require('../../lib/classes/Error').ServerlessError;
+const logError = require('../../lib/classes/Error').logError;
+
+describe('ServerlessError', () => {
+  describe('#constructor()', () => {
+    it('should store message', () => {
+      const error = new ServerlessError('a message', 'a status code');
+      expect(error.message).to.be.equal('a message');
+    });
+
+    it('should store name', () => {
+      const error = new ServerlessError('a message', 'a status code');
+      expect(error.name).to.be.equal('ServerlessError');
+    });
+
+    it('should store status code', () => {
+      const error = new ServerlessError('a message', 'a status code');
+      expect(error.statusCode).to.be.equal('a status code');
+    });
+
+    it('should have stack trace', () => {
+      let expectedError;
+      function testStackFrame() {
+        expectedError = new ServerlessError('a message', 'a status code');
+        throw expectedError;
+      }
+
+      let thrownError;
+      try {
+        testStackFrame();
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).to.exist; // eslint-disable-line no-unused-expressions
+      expect(thrownError).to.deep.equal(expectedError);
+      expect(thrownError.stack).to.exist; // eslint-disable-line no-unused-expressions
+      expect(thrownError.stack).to.have.string('testStackFrame');
+      expect(thrownError.stack).to.not.have.string('new ServerlessError');
+      expect(thrownError.stack).to.not.have.string('Error.js');
+    });
+  });
+});
+
+describe('Error', () => {
+  describe('#logError()', () => {
+    beforeEach(() => {
+      this.cbProcessExit = null;
+      this.processExitCodes = [];
+      this.processExit = process.exit;
+      process.exit = (code) => {
+        this.processExitCodes.push(code);
+        if (this.cbProcessExit) {
+          this.cbProcessExit();
+        }
+      };
+
+      this.consoleLogMessages = [];
+      this.consoleLog = console.log;
+      console.log = (msg) => {
+        this.consoleLogMessages.push(msg);
+      };
+    });
+
+    afterEach(() => {
+      process.exit = this.processExit;
+      console.log = this.consoleLog;
+
+      delete process.env.SLS_DEBUG;
+    });
+
+    it('should log error and exit', () => {
+      const error = new ServerlessError('a message', 'a status code');
+      logError(error);
+      console.log = this.consoleLog;  // For mocha to echo status of the test
+
+      expect(this.processExitCodes.length).to.be.equal(1);
+      expect(this.processExitCodes).gt(0);
+
+      const message = this.consoleLogMessages.join('\n');
+      expect(message).to.have.string('Serverless Error');
+      expect(message).to.have.string('a message');
+    });
+
+    it('should shorten long messages', () => {
+      const error = new ServerlessError(
+        'a message which is way to long so it gets shortened automatically to fit');
+      logError(error);
+      console.log = this.consoleLog;
+
+      const message = this.consoleLogMessages.join('\n');
+      expect(message).to.have.string('Serverless Error');
+      expect(message).to.have.string('a message which is way to long so it gets shortened');
+      expect(message).to.not.have.string(
+        'a message which is way to long so it gets shortened automatically to fit');
+    });
+
+    it('should notify about SLS_DEBUG and ask report for unexpected errors', () => {
+      const error = new Error('an unexpected error');
+      logError(error);
+      console.log = this.consoleLog;
+
+      const message = this.consoleLogMessages.join('\n');
+      expect(message).to.have.string('SLS_DEBUG=*');
+      expect(message).to.have.string('Please report this error');
+    });
+
+    it('should print stack trace with SLS_DEBUG', () => {
+      process.env.SLS_DEBUG = 1;
+      const error = new ServerlessError('a message');
+      logError(error);
+      console.log = this.consoleLog;
+
+      const message = this.consoleLogMessages.join('\n');
+      expect(message).to.have.string('Stack Trace');
+      expect(message).to.have.string(error.stack);
+    });
+
+    it('should not print stack trace without SLS_DEBUG', () => {
+      const error = new ServerlessError('a message');
+      logError(error);
+      console.log = this.consoleLog;
+
+      const message = this.consoleLogMessages.join('\n');
+      expect(message).to.not.have.string('Stack Trace');
+      expect(message).to.not.have.string(error.stack);
+    });
+
+    it('should re-throw error when handling raises an exception itself', () => {
+      const error = new ServerlessError('a message');
+      const handlingError = new Error('an unexpected error');
+      this.cbProcessExit = () => { throw handlingError; };
+
+      let thrownError = null;
+      try {
+        logError(error);
+      } catch (e) {
+        thrownError = e;
+      }
+      console.log = this.consoleLog;
+
+      expect(thrownError).to.deep.equal(handlingError);
+    });
+  });
+});

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const SError = require('./Error').SError;
+const ServerlessError = require('./Error').ServerlessError;
 const path = require('path');
 const _ = require('lodash');
 const BbPromise = require('bluebird');
@@ -59,13 +59,13 @@ class Service {
             `The Serverless version (${version}) does not satisfy the`,
             ` "frameworkVersion" (${ymlVersion}) in serverless.yml`,
           ].join('');
-          throw new SError(errorMessage);
+          throw new ServerlessError(errorMessage);
         }
         if (!serverlessFile.service) {
-          throw new SError('"service" property is missing in serverless.yml');
+          throw new ServerlessError('"service" property is missing in serverless.yml');
         }
         if (!serverlessFile.provider) {
-          throw new SError('"provider" property is missing in serverless.yml');
+          throw new ServerlessError('"provider" property is missing in serverless.yml');
         }
 
         if (typeof serverlessFile.provider !== 'object') {
@@ -82,7 +82,7 @@ class Service {
             ` Valid values for provider are: ${providers.join(', ')}.`,
             ' Please provide one of those values to the "provider" property in serverless.yml.',
           ].join('');
-          throw new SError(errorMessage);
+          throw new ServerlessError(errorMessage);
         }
 
         if (Array.isArray(serverlessFile.resources)) {
@@ -128,7 +128,7 @@ class Service {
   validate() {
     _.forEach(this.functions, (functionObj, functionName) => {
       if (!_.isArray(functionObj.events)) {
-        throw new SError(`Events for "${functionName}" must be an array,` +
+        throw new ServerlessError(`Events for "${functionName}" must be an array,` +
                           ` not an ${typeof functionObj.events}`);
       }
     });
@@ -148,14 +148,14 @@ class Service {
     if (functionName in this.functions) {
       return this.functions[functionName];
     }
-    throw new SError(`Function "${functionName}" doesn't exist in this Service`);
+    throw new ServerlessError(`Function "${functionName}" doesn't exist in this Service`);
   }
 
   getEventInFunction(eventName, functionName) {
     if (eventName in this.getFunction(functionName).events) {
       return this.getFunction(functionName).events[eventName];
     }
-    throw new SError(`Event "${eventName}" doesn't exist in function "${functionName}"`);
+    throw new ServerlessError(`Event "${eventName}" doesn't exist in function "${functionName}"`);
   }
 
   getAllEventsInFunction(functionName) {


### PR DESCRIPTION
## What did you implement:

Let me try once more - as previous PR was closed by GitHub, when I changed the master branch (didn't know about that behavior, sorry).

So this one is for the issue #3169 - Error tests implementation

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I was checking this Serverless framework you folks are developing, and it looked interesting. So I've decided to spend some time contributing to it. For the initial PR I've decided to start with something simple - like covering a class with tests.

`lib/classes/Error.js` was not covered - so it was a good thing to start with.

Note, that this PR contains the following changes:

1. Error coverage - major change, pretty straightforward.
2. For the `Error.js` export I renamed `SError` export to `ServerlessError` (the backwards compatibility was left, though). A couple of reasons for that. First, it brought back the correct class name right to the export. Second - searching source code by string (for refactoring or just to find class usage) now will return all the places where the class is directly imported.
3. Changed "construtor" to "constructor" - a trivial typo fix. It was almost the first thing I saw in tests log, which was shouting to have it fixed :)

## How can we verify it:

Run testing and check the coverage:
```
npm test
```

Or verify my [Travis](https://travis-ci.org/zerkella/serverless/builds/196887744) and [Coveralls](https://coveralls.io/builds/9920471) results.

## Todos:

- [x] Write tests
- [ ] N/A - Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO