### PR TITLE
Fix node_modules (serverless plugins) lookup

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const Module = require('module');
 const BbPromise = require('bluebird');
 const _ = require('lodash');
 
@@ -75,20 +76,15 @@ class PluginManager {
   loadServicePlugins(servicePlugs) {
     const servicePlugins = Array.isArray(servicePlugs) ? servicePlugs : [];
 
+    // eslint-disable-next-line no-underscore-dangle
+    module.paths = Module._nodeModulePaths(process.cwd());
+
     // we want to load plugins installed locally in the service
     if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
-      module.paths.unshift(
-        path.join(this.serverless.config.servicePath, 'node_modules'),
-        path.join(this.serverless.config.servicePath, '.serverless_plugins')
-        );
+      module.paths.unshift(path.join(this.serverless.config.servicePath, '.serverless_plugins'));
     }
 
     this.loadPlugins(servicePlugins);
-
-    // restore module paths
-    if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
-      module.paths.shift();
-    }
   }
 
   loadCommand(pluginName, details, key) {

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -6,6 +6,7 @@ const Serverless = require('../../lib/Serverless');
 const Create = require('../../lib/plugins/create/create');
 
 const path = require('path');
+const fs = require('fs');
 const fse = require('fs-extra');
 const execSync = require('child_process').execSync;
 const mockRequire = require('mock-require');
@@ -739,26 +740,50 @@ describe('PluginManager', () => {
   describe('Plugin / CLI integration', function () {
     this.timeout(0);
 
-    it('should expose a working integration between the CLI and the plugin system', () => {
-      const serverlessInstance = new Serverless();
+    const cwd = process.cwd();
+    let serverlessInstance;
+    let serviceDir;
+    let serverlessExec;
+
+    beforeEach(function () { // eslint-disable-line prefer-arrow-callback
+      serverlessInstance = new Serverless();
       serverlessInstance.init();
 
       // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
       const execPrefix = os.platform() === 'win32' ? 'node ' : '';
-      const serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
+      serverlessExec = execPrefix + path.join(serverlessInstance.config.serverlessPath,
               '..', 'bin', 'serverless');
       const tmpDir = testUtils.getTmpDirPath();
-      fse.mkdirsSync(tmpDir);
-      const cwd = process.cwd();
-      process.chdir(tmpDir);
+      serviceDir = path.join(tmpDir, 'service');
+      fse.mkdirsSync(serviceDir);
+      process.chdir(serviceDir);
 
       execSync(`${serverlessExec} create --template aws-nodejs`);
+    });
 
+    it('should expose a working integration between the CLI and the plugin system', () => {
       expect(serverlessInstance.utils
-        .fileExistsSync(path.join(tmpDir, 'serverless.yml'))).to.equal(true);
+        .fileExistsSync(path.join(serviceDir, 'serverless.yml'))).to.equal(true);
       expect(serverlessInstance.utils
-        .fileExistsSync(path.join(tmpDir, 'handler.js'))).to.equal(true);
+        .fileExistsSync(path.join(serviceDir, 'handler.js'))).to.equal(true);
+    });
 
+    it('should load plugins relatively to the working directory', () => {
+      const localPluginDir = path.join(serviceDir, 'node_modules', 'local-plugin');
+      const parentPluginDir = path.join(serviceDir, '..', 'node_modules', 'parent-plugin');
+      testUtils.installPlugin(localPluginDir, SynchronousPluginMock);
+      testUtils.installPlugin(parentPluginDir, PromisePluginMock);
+
+      fs.appendFileSync(path.join(serviceDir, 'serverless.yml'),
+        'plugins:\n  - local-plugin\n  - parent-plugin');
+
+      const output = execSync(serverlessExec);
+      const stringifiedOutput = (new Buffer(output, 'base64').toString());
+      expect(stringifiedOutput).to.contain('SynchronousPluginMock');
+      expect(stringifiedOutput).to.contain('PromisePluginMock');
+    });
+
+    afterEach(function () { // eslint-disable-line prefer-arrow-callback
       process.chdir(cwd);
     });
   });

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -84,6 +84,14 @@ module.exports = {
     return SNS.createTopicPromised(params);
   },
 
+  installPlugin: (installDir, PluginClass) => {
+    const pluginPkg = { name: path.basename(installDir), version: '0.0.0' };
+    const className = (new PluginClass()).constructor.name;
+    fse.outputFileSync(path.join(installDir, 'package.json'), JSON.stringify(pluginPkg), 'utf8');
+    fse.outputFileSync(path.join(installDir, 'index.js'),
+      `"use strict";\n${PluginClass.toString()}\nmodule.exports = ${className}`, 'utf8');
+  },
+
   removeSnsTopic(topicName) {
     const SNS = new AWS.SNS({ region: 'us-east-1' });
     BbPromise.promisifyAll(SNS, { suffix: 'Promised' });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2619

Fix to allow plugins to be installed in parent directory. i.e for when you have some transpiling/bundling mechanism that doesn't require to package and deploy the whole `node_modules` directory nor maintain a big list of `excludes`/`includes` in the config.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

This reset the `module.paths` relatively to the current working directory
`process.cwd()`. So the array of paths used to resolve packages is relative
to where the `serverless` CLI is run.

```node
const Module = require('module')
module.paths = Module._nodeModulePaths(process.cwd())

// /path_to_service/.serverless-plugins path is still added
```

Similar to i.e `babel-cli` https://github.com/babel/babel/blob/396634a51df1941b3a46f81fbee5904ceb72471a/packages/babel-cli/src/_babel-node.js#L84-L88

## How can we verify it:

```shell
$ mkdir testit && cd testit
$ npm i serverless-webpack
$ mkdir service && cd service
$ serverless create --template aws-nodejs
$ cat <<EOT>> serverless.yml
plugins:
  - serverless-webpack
EOT
$ serverless | grep "Cannot find module" > /dev/null && echo "NOT OK 👎"
$ npm uninstall -g serverless
$ npm i -g nrako/serverless#4c3673a
$ serverless | grep "Cannot find module" > /dev/null || echo "OK 👍"
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests???
- ~~[ ] Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO