### PR TITLE
Fix for authorizer claims: multiple claims and custom property claims  (#3088)

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
@@ -46,9 +46,12 @@ module.exports = {
       if (event.http.authorizer) {
         const claims = event.http.authorizer.claims || [];
         extraCognitoPoolClaims = _.map(claims, (claim) => {
-          if (typeof claim === 'string' && claim.startsWith('custom:')) {
-            const subClaim = claim.substring(7);
-            return `"${subClaim}": "$context.authorizer.claims['${claim}']"`;
+          if (typeof claim === 'string') {
+            const colonIndex = claim.indexOf(':');
+            if (colonIndex !== -1) {
+              const subClaim = claim.substring(colonIndex + 1);
+              return `"${subClaim}": "$context.authorizer.claims['${claim}']"`;
+            }
           }
           return `"${claim}": "$context.authorizer.claims.${claim}"`;
         });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
@@ -48,17 +48,16 @@ module.exports = {
         extraCognitoPoolClaims = _.map(claims, (claim) => {
           if (typeof claim === 'string' && claim.startsWith('custom:')) {
             const subClaim = claim.substring(7);
-            return `"${subClaim}": "$context.authorizer.claims['${claim}']"`
-          } else {
-            return `"${claim}": "$context.authorizer.claims.${claim}"`
+            return `"${subClaim}": "$context.authorizer.claims['${claim}']"`;
           }
+          return `"${claim}": "$context.authorizer.claims.${claim}"`;
         });
       }
       const requestTemplates = template.Properties.Integration.RequestTemplates;
       _.forEach(requestTemplates, (value, key) => {
         let claimsString = '';
         if (extraCognitoPoolClaims && extraCognitoPoolClaims.length > 0) {
-          claimsString = extraCognitoPoolClaims.join(",") + ",";
+          claimsString = extraCognitoPoolClaims.join(',').concat(',');
         }
         requestTemplates[key] = value.replace('extraCognitoPoolClaims', claimsString);
       });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
@@ -48,16 +48,19 @@ module.exports = {
         extraCognitoPoolClaims = _.map(claims, (claim) => {
           if (typeof claim === 'string' && claim.startsWith('custom:')) {
             const subClaim = claim.substring(7);
-            return `"${subClaim}": "$context.authorizer.claims['${claim}']",`
+            return `"${subClaim}": "$context.authorizer.claims['${claim}']"`
           } else {
-            return `"${claim}": "$context.authorizer.claims.${claim}",`
+            return `"${claim}": "$context.authorizer.claims.${claim}"`
           }
         });
       }
       const requestTemplates = template.Properties.Integration.RequestTemplates;
       _.forEach(requestTemplates, (value, key) => {
-        requestTemplates[key] =
-          value.replace('extraCognitoPoolClaims', extraCognitoPoolClaims || '');
+        let claimsString = '';
+        if (extraCognitoPoolClaims && extraCognitoPoolClaims.length > 0) {
+          claimsString = extraCognitoPoolClaims.join(",") + ",";
+        }
+        requestTemplates[key] = value.replace('extraCognitoPoolClaims', claimsString);
       });
 
       this.apiGatewayMethodLogicalIds.push(methodLogicalId);

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.js
@@ -45,9 +45,14 @@ module.exports = {
       let extraCognitoPoolClaims;
       if (event.http.authorizer) {
         const claims = event.http.authorizer.claims || [];
-        extraCognitoPoolClaims = _.map(claims, claim =>
-            `"${claim}": "$context.authorizer.claims.${claim}",`
-        );
+        extraCognitoPoolClaims = _.map(claims, (claim) => {
+          if (typeof claim === 'string' && claim.startsWith('custom:')) {
+            const subClaim = claim.substring(7);
+            return `"${subClaim}": "$context.authorizer.claims['${claim}']",`
+          } else {
+            return `"${claim}": "$context.authorizer.claims.${claim}",`
+          }
+        });
       }
       const requestTemplates = template.Properties.Integration.RequestTemplates;
       _.forEach(requestTemplates, (value, key) => {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.test.js
@@ -219,13 +219,74 @@ describe('#compileMethods()', () => {
     ];
 
     return awsCompileApigEvents.compileMethods().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersCreatePost.Properties
-          .Integration.RequestTemplates['application/json']
-          ).to.match(/email/);
+          .Integration.RequestTemplates['application/json'];
+      const cognitoPoolClaimsRegex = /"cognitoPoolClaims"\s*:\s*(\{[^}]*\})/;
+      const cognitoPoolClaimsString = jsonRequestTemplatesString.match(cognitoPoolClaimsRegex)[1];
+      const cognitoPoolClaims = JSON.parse(cognitoPoolClaimsString);
+      expect(cognitoPoolClaims.email).to.equal(`$context.authorizer.claims.email`);
     });
   });
+
+  it('should set multiple claims for a cognito user pool', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          authorizer: {
+            name: 'authorizer',
+            arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+            claims: ['email', 'gender'],
+          },
+          integration: 'AWS',
+          path: 'users/create',
+          method: 'post',
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties
+          .Integration.RequestTemplates['application/json'];
+      const cognitoPoolClaimsRegex = /"cognitoPoolClaims"\s*:\s*(\{[^}]*\})/;
+      const cognitoPoolClaimsString = jsonRequestTemplatesString.match(cognitoPoolClaimsRegex)[1];
+      const cognitoPoolClaims = JSON.parse(cognitoPoolClaimsString);
+      expect(cognitoPoolClaims.email).to.equal(`$context.authorizer.claims.email`);
+      expect(cognitoPoolClaims.gender).to.equal(`$context.authorizer.claims.gender`);
+    });
+  });
+
+    it('should properly set claims for custom properties inside the cognito user pool', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          authorizer: {
+            name: 'authorizer',
+            arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+            claims: ['email', 'custom:score'],
+          },
+          integration: 'AWS',
+          path: 'users/create',
+          method: 'post',
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties
+          .Integration.RequestTemplates['application/json'];
+      const cognitoPoolClaimsRegex = /"cognitoPoolClaims"\s*:\s*(\{[^}]*\})/;
+      const cognitoPoolClaimsString = jsonRequestTemplatesString.match(cognitoPoolClaimsRegex)[1];
+      const cognitoPoolClaims = JSON.parse(cognitoPoolClaimsString);
+      expect(cognitoPoolClaims.email).to.equal(`$context.authorizer.claims.email`);
+      expect(cognitoPoolClaims.score).to.equal(`$context.authorizer.claims['custom:score']`);
+    });
+  });
+
 
   it('should replace the extra claims in the template if there are none', () => {
     awsCompileApigEvents.validated.events = [

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/index.test.js
@@ -219,13 +219,13 @@ describe('#compileMethods()', () => {
     ];
 
     return awsCompileApigEvents.compileMethods().then(() => {
-      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ApiGatewayMethodUsersCreatePost.Properties
+      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.ApiGatewayMethodUsersCreatePost.Properties
           .Integration.RequestTemplates['application/json'];
       const cognitoPoolClaimsRegex = /"cognitoPoolClaims"\s*:\s*(\{[^}]*\})/;
       const cognitoPoolClaimsString = jsonRequestTemplatesString.match(cognitoPoolClaimsRegex)[1];
       const cognitoPoolClaims = JSON.parse(cognitoPoolClaimsString);
-      expect(cognitoPoolClaims.email).to.equal(`$context.authorizer.claims.email`);
+      expect(cognitoPoolClaims.email).to.equal('$context.authorizer.claims.email');
     });
   });
 
@@ -247,18 +247,18 @@ describe('#compileMethods()', () => {
     ];
 
     return awsCompileApigEvents.compileMethods().then(() => {
-      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ApiGatewayMethodUsersCreatePost.Properties
+      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.ApiGatewayMethodUsersCreatePost.Properties
           .Integration.RequestTemplates['application/json'];
       const cognitoPoolClaimsRegex = /"cognitoPoolClaims"\s*:\s*(\{[^}]*\})/;
       const cognitoPoolClaimsString = jsonRequestTemplatesString.match(cognitoPoolClaimsRegex)[1];
       const cognitoPoolClaims = JSON.parse(cognitoPoolClaimsString);
-      expect(cognitoPoolClaims.email).to.equal(`$context.authorizer.claims.email`);
-      expect(cognitoPoolClaims.gender).to.equal(`$context.authorizer.claims.gender`);
+      expect(cognitoPoolClaims.email).to.equal('$context.authorizer.claims.email');
+      expect(cognitoPoolClaims.gender).to.equal('$context.authorizer.claims.gender');
     });
   });
 
-    it('should properly set claims for custom properties inside the cognito user pool', () => {
+  it('should properly set claims for custom properties inside the cognito user pool', () => {
     awsCompileApigEvents.validated.events = [
       {
         functionName: 'First',
@@ -276,14 +276,14 @@ describe('#compileMethods()', () => {
     ];
 
     return awsCompileApigEvents.compileMethods().then(() => {
-      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.ApiGatewayMethodUsersCreatePost.Properties
+      const jsonRequestTemplatesString = awsCompileApigEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.ApiGatewayMethodUsersCreatePost.Properties
           .Integration.RequestTemplates['application/json'];
       const cognitoPoolClaimsRegex = /"cognitoPoolClaims"\s*:\s*(\{[^}]*\})/;
       const cognitoPoolClaimsString = jsonRequestTemplatesString.match(cognitoPoolClaimsRegex)[1];
       const cognitoPoolClaims = JSON.parse(cognitoPoolClaimsString);
-      expect(cognitoPoolClaims.email).to.equal(`$context.authorizer.claims.email`);
-      expect(cognitoPoolClaims.score).to.equal(`$context.authorizer.claims['custom:score']`);
+      expect(cognitoPoolClaims.email).to.equal('$context.authorizer.claims.email');
+      expect(cognitoPoolClaims.score).to.equal('$context.authorizer.claims[\'custom:score\']');
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #3088 

Also fixes the claims for custom properties from the cognito pool. 
In short unlike for regular cognito pool properties for which the mappings need to look like this:
`propertyName = $context.authorizer.claims.propertyName`
 for custom properties the mapping for the claim should be: 
`propertyName = $context.authorizer.claims['custom:propertyName']` ( according to [aws specs](http://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html#apigateway-enable-cognito-user-pool). ). 
 
## How did you implement it:

As for 3088, it was simply a bug of how commas are added between and after the claims when constructing the string for the integration request template.
To cover claims for custom properties, I changed the generated string from `$context.authorizer.claims.${claim}`  to `$context.authorizer.claims['${claim}']`

## How can we verify it:

Use something like in your serverless.yml:

```
events:
      - http:
          path: person
          method: post
          cors: true
          integration: lambda
          authorizer:
            arn: your-cognito-user-pool-arn-here
            claims:
              - email
              - name
              - custom:score
```

Go and check the create API Gateway, then go into Integration Request, Body Mapping Templates, check mapping for application/json. You should see all the claims properly specified:

```
  "cognitoPoolClaims" : {
       "email": "$context.authorizer.claims.email","name": "$context.authorizer.claims.name","score": "$context.authorizer.claims['custom:score']",
       "sub": "$context.authorizer.claims.sub"
    },
```

Testing in a full scenario I think would require quite a complex setup, where
- a custom property "score" is added to the cognito user pool
- an app with appID is created and it is given at least read privileges to email. name and custom:score properties
- a user is added to the pool, and the email, name and custom score property is set-up
- the user logs in via the app that uses appID, using cognito user pool login, and gets Access ID Token
- call the API GW endpoint for the lambda, with the Access ID Token in the Authorizer header 
- In the lambda check:
event.cognitoPoolClaims.score;
event.cognitoPoolClaims.email; etc...
- they should have the values that were set up for that user.

Note: I tried the above, and it does work.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO