### PR TITLE
add #3188

### DIFF
--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -21,32 +21,32 @@ module.exports = {
           this.serverless.service.provider.deploymentBucket)
         )
         .then(bucketName => {
-          this.validateS3BucketName(bucketName)
-          .then(() => this.provider.request('S3',
-            'getBucketLocation',
-            {
-              Bucket: bucketName,
-            },
-            this.options.stage,
-            this.options.region
-          ))
-          .then(resultParam => {
-            const result = resultParam;
-            if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
-            if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
-            if (result.LocationConstraint !== this.options.region) {
-              throw new this.serverless.classes.Error(
-                'Deployment bucket is not in the same region as the lambda function'
-              );
-            }
-            this.bucketName = bucketName;
-            this.serverless.service.package.deploymentBucket = bucketName;
-            this.serverless.service.provider.compiledCloudFormationTemplate
-              .Outputs.ServerlessDeploymentBucketName.Value = bucketName;
+          this.bucketName = bucketName;
+          return this.validateS3BucketName(bucketName);
+        })
+        .then(() => this.provider.request('S3',
+          'getBucketLocation',
+          {
+            Bucket: this.bucketName,
+          },
+          this.options.stage,
+          this.options.region
+        ))
+        .then(resultParam => {
+          const result = resultParam;
+          if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
+          if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
+          if (result.LocationConstraint !== this.options.region) {
+            throw new this.serverless.classes.Error(
+              'Deployment bucket is not in the same region as the lambda function'
+            );
+          }
+          this.serverless.service.package.deploymentBucket = this.bucketName;
+          this.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs.ServerlessDeploymentBucketName.Value = this.bucketName;
 
-            delete this.serverless.service.provider.compiledCloudFormationTemplate
-              .Resources.ServerlessDeploymentBucket;
-          });
+          delete this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.ServerlessDeploymentBucket;
         });
     }
 

--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -15,35 +15,36 @@ module.exports = {
         'core-cloudformation-template.json')
     );
 
-    const bucketName = this.serverless.service.provider.deploymentBucket;
-
-    if (bucketName) {
+    if (this.serverless.service.provider.deploymentBucket) {
       return BbPromise.bind(this)
-        .then(() => this.validateS3BucketName(bucketName))
-        .then(() => this.provider.request('S3',
-          'getBucketLocation',
-          {
-            Bucket: bucketName,
-          },
-          this.options.stage,
-          this.options.region
-        ))
-        .then(resultParam => {
-          const result = resultParam;
-          if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
-          if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
-          if (result.LocationConstraint !== this.options.region) {
-            throw new this.serverless.classes.Error(
-              'Deployment bucket is not in the same region as the lambda function'
-            );
-          }
-          this.bucketName = bucketName;
-          this.serverless.service.package.deploymentBucket = bucketName;
-          this.serverless.service.provider.compiledCloudFormationTemplate
-            .Outputs.ServerlessDeploymentBucketName.Value = bucketName;
+        .then(() => this.provider.resolveExportValue(this.serverless.service.provider.deploymentBucket))
+        .then(bucketName => {
+          this.validateS3BucketName(bucketName)
+          .then(() => this.provider.request('S3',
+            'getBucketLocation',
+            {
+              Bucket: bucketName,
+            },
+            this.options.stage,
+            this.options.region
+          ))
+          .then(resultParam => {
+            const result = resultParam;
+            if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
+            if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
+            if (result.LocationConstraint !== this.options.region) {
+              throw new this.serverless.classes.Error(
+                'Deployment bucket is not in the same region as the lambda function'
+              );
+            }
+            this.bucketName = bucketName;
+            this.serverless.service.package.deploymentBucket = bucketName;
+            this.serverless.service.provider.compiledCloudFormationTemplate
+              .Outputs.ServerlessDeploymentBucketName.Value = bucketName;
 
-          delete this.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ServerlessDeploymentBucket;
+            delete this.serverless.service.provider.compiledCloudFormationTemplate
+              .Resources.ServerlessDeploymentBucket;
+          });
         });
     }
 

--- a/lib/plugins/aws/deploy/lib/configureStack.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.js
@@ -17,7 +17,9 @@ module.exports = {
 
     if (this.serverless.service.provider.deploymentBucket) {
       return BbPromise.bind(this)
-        .then(() => this.provider.resolveExportValue(this.serverless.service.provider.deploymentBucket))
+        .then(() => this.provider.resolveExportValue(
+          this.serverless.service.provider.deploymentBucket)
+        )
         .then(bucketName => {
           this.validateS3BucketName(bucketName)
           .then(() => this.provider.request('S3',

--- a/lib/plugins/aws/deploy/lib/configureStack.test.js
+++ b/lib/plugins/aws/deploy/lib/configureStack.test.js
@@ -77,6 +77,34 @@ describe('#configureStack', () => {
       .then(() => {});
   });
 
+  it('should resolve Fn::ImportValue if specified', () => {
+    const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
+    const bucketName = 'my-other-stack-s3bucket-148939fgnt22y';
+
+    awsPlugin.provider.options = awsPlugin.options;
+    awsPlugin.serverless.service.provider.deploymentBucket = deploymentBucket;
+
+    const requestStub = sinon.stub(awsPlugin.provider, 'request');
+    requestStub.onCall(0).returns(BbPromise.resolve({
+      ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
+      Exports: [
+        { Name: 'my-export-s3-bucket', Value: bucketName },
+      ],
+    }));
+    requestStub.onCall(1).returns(
+      BbPromise.resolve({ LocationConstraint: awsPlugin.options.region })
+    );
+
+    return awsPlugin.configureStack()
+      .then(() => {
+        expect(
+          awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs.ServerlessDeploymentBucketName.Value
+        ).to.equal(bucketName);
+        awsPlugin.provider.request.restore();
+      });
+  });
+
   it('should use a custom bucket if specified', () => {
     const bucketName = 'com.serverless.deploys';
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -203,6 +203,12 @@ class AwsProvider {
 
   getServerlessDeploymentBucketName() {
     if (this.serverless.service.provider.deploymentBucket) {
+      if (Object.prototype.hasOwnProperty.call(
+        this.serverless.service.provider.deploymentBucket, 'Fn::ImportValue'
+      )) {
+        return this.resolveExportValue(this.serverless.service.provider.deploymentBucket);
+      }
+
       return BbPromise.resolve(this.serverless.service.provider.deploymentBucket);
     }
     return this.request('CloudFormation',

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -230,6 +230,31 @@ class AwsProvider {
     return this.request('STS', 'getCallerIdentity', {})
       .then((result) => result.Account);
   }
+  
+  /**
+   * http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html
+   * Resolve Export Value if it passed as 'Fn::ImportValue'.
+   * @param exportName
+   */
+  resolveExportValue(exportName) {
+    if (typeof exportName !== 'object') 
+      return BbPromise.resolve(exportName);
+    
+    if (!exportName.hasOwnProperty('Fn::ImportValue')) {
+      throw new this.serverless.classes.Error(`${exportName} is object. Only 'Fn::ImportValue' supported. ${exportName}`);
+    }
+    
+    return this.request('CloudFormation',
+        'listExports',
+        { },
+        this.options.stage,
+        this.options.region
+      ).then(data => {
+        return data.Exports.filter((item) => {
+          return item.Name === exportName['Fn::ImportValue'];
+        })[0].Value;
+      });
+  }
 }
 
 module.exports = AwsProvider;

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -251,11 +251,10 @@ class AwsProvider {
         { },
         this.options.stage,
         this.options.region
-      ).then((data) => ({
-        return data.Exports.filter((item) => {
+      ).then((data) => data.Exports.filter((item) => {
           return item.Name === exportName['Fn::ImportValue'];
         })[0].Value;
-      }));
+      );
   }
 }
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -253,7 +253,7 @@ class AwsProvider {
         this.options.region
       ).then((data) => data.Exports.filter((item) => {
           return item.Name === exportName['Fn::ImportValue'];
-        })[0].Value;
+        })[0].Value
       );
   }
 }

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -251,10 +251,21 @@ class AwsProvider {
         { },
         this.options.stage,
         this.options.region
-      ).then((data) => data.Exports.filter((item) => {
-          return item.Name === exportName['Fn::ImportValue'];
-        })[0].Value
-      );
+      ).then((data) => {
+        if (!data.Exports || data.Exports.length === 0) {
+          const error = 'no exports in the region';
+          throw new this.serverless.classes.Error(error);
+        }
+
+        const found = data.Exports.filter((item) => item.Name === exportName['Fn::ImportValue']);
+
+        if (found.length === 0) {
+          const error = `Export (${exportName['Fn::ImportValue']}) not found`;
+          throw new this.serverless.classes.Error(error);
+        }
+
+        return found[0].Value;
+      });
   }
 }
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -230,28 +230,28 @@ class AwsProvider {
     return this.request('STS', 'getCallerIdentity', {})
       .then((result) => result.Account);
   }
-  
+
   /**
    * http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html
    * Resolve Export Value if it passed as 'Fn::ImportValue'.
    * @param exportName
    */
   resolveExportValue(exportName) {
-    if (typeof exportName !== 'object') { 
+    if (typeof exportName !== 'object') {
       return BbPromise.resolve(exportName);
     }
-    
+
     if (!Object.prototype.hasOwnProperty.call(exportName, 'Fn::ImportValue')) {
-      let error = `${exportName} is object. Only 'Fn::ImportValue' supported. ${exportName}`;
+      const error = `${exportName} is object. Only 'Fn::ImportValue' supported. ${exportName}`;
       throw new this.serverless.classes.Error(error);
     }
-    
+
     return this.request('CloudFormation',
         'listExports',
         { },
         this.options.stage,
         this.options.region
-      ).then(data => {
+      ).then((data) => {
         return data.Exports.filter((item) => {
           return item.Name === exportName['Fn::ImportValue'];
         })[0].Value;

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -237,11 +237,13 @@ class AwsProvider {
    * @param exportName
    */
   resolveExportValue(exportName) {
-    if (typeof exportName !== 'object') 
+    if (typeof exportName !== 'object') { 
       return BbPromise.resolve(exportName);
+    }
     
-    if (!exportName.hasOwnProperty('Fn::ImportValue')) {
-      throw new this.serverless.classes.Error(`${exportName} is object. Only 'Fn::ImportValue' supported. ${exportName}`);
+    if (!Object.prototype.hasOwnProperty.call(exportName, 'Fn::ImportValue')) {
+      let error = `${exportName} is object. Only 'Fn::ImportValue' supported. ${exportName}`;
+      throw new this.serverless.classes.Error(error);
     }
     
     return this.request('CloudFormation',

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -251,11 +251,11 @@ class AwsProvider {
         { },
         this.options.stage,
         this.options.region
-      ).then((data) => {
+      ).then((data) => ({
         return data.Exports.filter((item) => {
           return item.Name === exportName['Fn::ImportValue'];
         })[0].Value;
-      });
+      }));
   }
 }
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -499,6 +499,28 @@ describe('AwsProvider', () => {
         });
     });
 
+    it('should resolve Fn::ImportValue for deployment bucket', () => {
+      awsProvider.serverless.service.provider.deploymentBucket = {
+        'Fn::ImportValue': 'my-export-s3-bucket',
+      };
+
+      const listExportsStub = sinon
+        .stub(awsProvider, 'request')
+        .returns(BbPromise.resolve({
+          ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
+          Exports: [
+            { Name: 'my-export-s3-bucket', Value: 'my-other-stack-s3bucket-148939fgnt22y' },
+          ],
+        }));
+
+      return awsProvider.getServerlessDeploymentBucketName()
+        .then((bucketName) => {
+          expect(listExportsStub.calledOnce).to.equal(true);
+          expect(bucketName).to.equal('my-other-stack-s3bucket-148939fgnt22y');
+          awsProvider.request.restore();
+        });
+    });
+
     describe('#getStage()', () => {
       it('should prefer options over config or provider', () => {
         const newOptions = {
@@ -620,14 +642,14 @@ describe('AwsProvider', () => {
 
       it('should resolve the Export value if object with Fn::ImportValue property provided', () => {
         const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
-        const s3BucketName = 'my-other-stack-s3bucket-148939fgnt22y';
+        const bucketName = 'my-other-stack-s3bucket-148939fgnt22y';
 
         const listExportsStub = sinon
           .stub(awsProvider, 'request')
           .returns(BbPromise.resolve({
             ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
             Exports: [
-              { Name: 'my-export-s3-bucket', Value: s3BucketName },
+              { Name: 'my-export-s3-bucket', Value: bucketName },
               { Name: 'my-export-other-value', Value: 'any value here' },
             ],
           }));
@@ -635,7 +657,7 @@ describe('AwsProvider', () => {
         return awsProvider.resolveExportValue(deploymentBucket)
           .then((result) => {
             expect(listExportsStub.calledOnce).to.equal(true);
-            expect(result).to.equal(s3BucketName);
+            expect(result).to.equal(bucketName);
             awsProvider.request.restore();
           });
       });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -567,5 +567,37 @@ describe('AwsProvider', () => {
           });
       });
     });
+    
+    describe('#resolveExportValue()', () => {
+      it('should bypass original value if typof String', () => {
+        const deploymentBucket = 'deploymentBucketAsString';
+
+        return awsProvider.resolveExportValue(deploymentBucket)
+          .then((result) => {
+            expect(result).to.equal(deploymentBucket);
+          });
+      });
+      it('should resolve the Export value if object with Fn::ImportValue property provided', () => {
+        const deploymentBucket = {'Fn::ImportValue' : 'my-export-s3-bucket'};
+        const s3BucketName = 'my-other-stack-s3bucket-148939fgnt22y';
+
+        const stsGetCallerIdentityStub = sinon
+          .stub(awsProvider, 'request')
+          .returns(BbPromise.resolve({
+            ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
+            Exports: [
+              { Name: 'my-export-s3-bucket', Value: s3BucketName },
+              { Name: 'my-export-other-value', Value: 'any value here' }
+            ]
+          }));
+
+        return awsProvider.resolveExportValue(deploymentBucket)
+          .then((result) => {
+            expect(stsGetCallerIdentityStub.calledOnce).to.equal(true);
+            expect(result).to.equal(s3BucketName);
+            awsProvider.request.restore();
+          });
+      });
+    });
   });
 });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -578,7 +578,7 @@ describe('AwsProvider', () => {
           });
       });
       it('should resolve the Export value if object with Fn::ImportValue property provided', () => {
-        const deploymentBucket = {'Fn::ImportValue' : 'my-export-s3-bucket'};
+        const deploymentBucket = { 'Fn::ImportValue' : 'my-export-s3-bucket' };
         const s3BucketName = 'my-other-stack-s3bucket-148939fgnt22y';
 
         const stsGetCallerIdentityStub = sinon
@@ -587,8 +587,8 @@ describe('AwsProvider', () => {
             ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
             Exports: [
               { Name: 'my-export-s3-bucket', Value: s3BucketName },
-              { Name: 'my-export-other-value', Value: 'any value here' }
-            ]
+              { Name: 'my-export-other-value', Value: 'any value here' },
+            ],
           }));
 
         return awsProvider.resolveExportValue(deploymentBucket)

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -567,7 +567,7 @@ describe('AwsProvider', () => {
           });
       });
     });
-    
+
     describe('#resolveExportValue()', () => {
       it('should bypass original value if typof String', () => {
         const deploymentBucket = 'deploymentBucketAsString';
@@ -578,7 +578,7 @@ describe('AwsProvider', () => {
           });
       });
       it('should resolve the Export value if object with Fn::ImportValue property provided', () => {
-        const deploymentBucket = { 'Fn::ImportValue' : 'my-export-s3-bucket' };
+        const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
         const s3BucketName = 'my-other-stack-s3bucket-148939fgnt22y';
 
         const stsGetCallerIdentityStub = sinon

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -581,7 +581,7 @@ describe('AwsProvider', () => {
         const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
         const s3BucketName = 'my-other-stack-s3bucket-148939fgnt22y';
 
-        const stsGetCallerIdentityStub = sinon
+        const listExportsStub = sinon
           .stub(awsProvider, 'request')
           .returns(BbPromise.resolve({
             ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
@@ -593,7 +593,7 @@ describe('AwsProvider', () => {
 
         return awsProvider.resolveExportValue(deploymentBucket)
           .then((result) => {
-            expect(stsGetCallerIdentityStub.calledOnce).to.equal(true);
+            expect(listExportsStub.calledOnce).to.equal(true);
             expect(result).to.equal(s3BucketName);
             awsProvider.request.restore();
           });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -577,6 +577,47 @@ describe('AwsProvider', () => {
             expect(result).to.equal(deploymentBucket);
           });
       });
+
+      it('should notify if no exports available in AWS region', () => {
+        const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
+
+        const listExportsStub = sinon
+          .stub(awsProvider, 'request')
+          .returns(BbPromise.resolve({
+            ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
+            Exports: [],
+          }));
+
+        return awsProvider.resolveExportValue(deploymentBucket)
+          .catch((err) => {
+            expect(listExportsStub.calledOnce).to.equal(true);
+            expect(err.message).to.contain('no exports in the region');
+          })
+          .then(() => {});
+      });
+
+      it('should notify if export not found in AWS region', () => {
+        const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
+
+        const listExportsStub = sinon
+          .stub(awsProvider, 'request')
+          .returns(BbPromise.resolve({
+            ResponseMetadata: { RequestId: '12345678-1234-1234-1234-123456789012' },
+            Exports: [
+              { Name: 'his-and-not-mine-export-s3-bucket', Value: 'any value here' },
+            ],
+          }));
+
+        return awsProvider.resolveExportValue(deploymentBucket)
+          .catch((err) => {
+            expect(listExportsStub.calledOnce).to.equal(true);
+            expect(err.message).to.contain(
+              `Export (${deploymentBucket['Fn::ImportValue']}) not found`
+            );
+          })
+          .then(() => {});
+      });
+
       it('should resolve the Export value if object with Fn::ImportValue property provided', () => {
         const deploymentBucket = { 'Fn::ImportValue': 'my-export-s3-bucket' };
         const s3BucketName = 'my-other-stack-s3bucket-148939fgnt22y';


### PR DESCRIPTION
## What did you implement:

Closes #3188

## How did you implement it:

Introduced a **AwsProvider::resolveExportValue** function. It allows you to use http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html for the serverless properties. Right now it is hooked to resolve **deploymentBucket** property. But can be easily hooked for any other properties (e.g. SNS) 


## How can we verify it:

Examples:
 ```
provider:
  name: aws
  deploymentBucket: {"Fn::ImportValue" : "my-export-s3-bucket"}
 ```

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
