### PR TITLE
Allow "Fn::ImportValue" to specify the pool for API GW Default Authorizer (Fixes #3129)

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/authorizers.js
@@ -23,7 +23,11 @@ module.exports = {
 
         const authorizerLogicalId = this.provider.naming.getAuthorizerLogicalId(authorizer.name);
 
-        if (typeof authorizer.arn === 'string' && authorizer.arn.match(/^arn:aws:cognito-idp/)) {
+        if (authorizer.poolarn) {
+          authorizerProperties.Type = 'COGNITO_USER_POOLS';
+          authorizerProperties.ProviderARNs = [authorizer.poolarn];
+        } else if (typeof authorizer.arn === 'string'
+          && authorizer.arn.match(/^arn:aws:cognito-idp/)) {
           authorizerProperties.Type = 'COGNITO_USER_POOLS';
           authorizerProperties.ProviderARNs = [authorizer.arn];
         } else {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/method/authorization.js
@@ -8,7 +8,8 @@ module.exports = {
 
       let authorizationType;
       const authorizerArn = http.authorizer.arn;
-      if (typeof authorizerArn === 'string' && authorizerArn.match(/^arn:aws:cognito-idp/)) {
+      if (http.authorizer.poolarn ||
+        (typeof authorizerArn === 'string' && authorizerArn.match(/^arn:aws:cognito-idp/))) {
         authorizationType = 'COGNITO_USER_POOLS';
       } else {
         authorizationType = 'CUSTOM';

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/permissions.js
@@ -39,7 +39,8 @@ module.exports = {
         const authorizerPermissionLogicalId = this.provider.naming
           .getLambdaApiGatewayPermissionLogicalId(authorizer.name);
 
-        if (typeof authorizer.arn === 'string' && authorizer.arn.match(/^arn:aws:cognito-idp/)) {
+        if ((typeof authorizer.arn === 'string' && authorizer.arn.match(/^arn:aws:cognito-idp/))
+          || authorizer.poolarn) {
           return;
         }
 

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/validate.js
@@ -186,6 +186,7 @@ module.exports = {
 
     let name;
     let arn;
+    let poolarn;
     let identitySource;
     let resultTtlInSeconds;
     let identityValidationExpression;
@@ -200,7 +201,14 @@ module.exports = {
         name = this.provider.naming.extractAuthorizerNameFromArn(arn);
       }
     } else if (typeof authorizer === 'object') {
-      if (authorizer.arn) {
+      if (authorizer.poolarn) {
+        poolarn = authorizer.poolarn;
+        if (authorizer.name) {
+          name = authorizer.name;
+        } else {
+          name = this.provider.naming.getDefaultAuthorizerName(functionName);
+        }
+      } else if (authorizer.arn) {
         arn = authorizer.arn;
         name = this.provider.naming.extractAuthorizerNameFromArn(arn);
       } else if (authorizer.name) {
@@ -231,8 +239,8 @@ module.exports = {
     }
 
     const integration = this.getIntegration(http);
-    if (integration === 'AWS_PROXY'
-        && typeof arn === 'string' && arn.match(/^arn:aws:cognito-idp/) && authorizer.claims) {
+    if (integration === 'AWS_PROXY' && authorizer.claims &&
+      (poolarn || (typeof arn === 'string' && arn.match(/^arn:aws:cognito-idp/)))) {
       const errorMessage = [
         'Cognito claims can\'t be retrieved when using lambda-proxy as the integration type',
       ];
@@ -242,6 +250,7 @@ module.exports = {
     return {
       name,
       arn,
+      poolarn,
       resultTtlInSeconds,
       identitySource,
       identityValidationExpression,

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -112,6 +112,9 @@ module.exports = {
     const splitName = splitArn[splitArn.length - 1].split('-');
     return splitName[splitName.length - 1];
   },
+  getDefaultAuthorizerName(functionName) {
+    return `${this.getNormalizedFunctionName(functionName)}DefaultAuthorizer`;
+  },
   getLambdaLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaFunction`;
   },


### PR DESCRIPTION
## What did you implement:

Closes #3129

Explanation of the issue:
In  the `authorizer` section of the `http` event, the `arn` parameter serves double role:
-If it refers to arn of a lambda, then it is assumed that the lambda is a custom authorizer
-if on another hand it refres to arn of a cognito user pool (which is checked by parsing the arn), it is assumed that we want the default cognito pool authorizer.
So, when someone tries to use Fn::Import or Ref , it is impossible for the parser to figure out which of those two is the case

## How did you implement it:

I added possibility for the user to specify `poolarn` parameter. So they can explicitly state that they want to use Default Cognito Authorizer. and beside the hardcoded arn, now they can use  Fn::Import or Ref. 

## How can we verify it:

Export Cognito Pool Arn as part of another cloud formation stack , for example with name `Example-UserPool`.
After that in the serverless.yml use something like the following configuration:
 ```
  functionX:
    handler: handler.functionX
    events:
      - http:
          path: functionx
          method: get
          integration: lambda
          cors: true
          authorizer:
            poolarn:
              "Fn::ImportValue": Example-UserPool
            name: RandomAuthorizerName
            claims:
              - email
```
Observe that the Default Authorizer is properly set for the functionx endpoint.

## NOTE

I didn't write the tests yet, because I'm not sure if this way of fixing the problem is acceptable. 
If it is acceptable, I will go ahead and write the tests.
Also there will be need to update the documentation.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
