### PR TITLE
Docs: Fix name of function in openwhisk tutorial

### DIFF
--- a/docs/providers/openwhisk/examples/hello-world/node/README.md
+++ b/docs/providers/openwhisk/examples/hello-world/node/README.md
@@ -23,7 +23,7 @@ Make sure `serverless` is installed. [See installation guide](../../../guide/ins
 `serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
 
 ## 4. Invoke deployed function
-`serverless invoke --function helloWorld` or `serverless invoke -f helloWorld`
+`serverless invoke --function hello` or `serverless invoke -f hello`
 
 `-f` is shorthand for `--function`
 


### PR DESCRIPTION
The `openwhisk-nodejs` template uses a function called `hello` not `helloWorld`

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
