### PR TITLE
WIP: Fix monitorStack sync error

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -3,15 +3,19 @@
 const BbPromise = require('bluebird');
 const async = require('async');
 const chalk = require('chalk');
+const ntp = require('ntp-client');
 
 module.exports = {
-  monitorStack(action, cfData, frequency) {
-    // Skip monitoring if a deployment should not be performed
-    if (this.options.noDeploy) return BbPromise.bind(this).then(BbPromise.resolve());
+  getCurrentDate() {
+    return new BbPromise((resolve) => {
+      ntp.getNetworkTime('pool.ntp.org', 123, (error, date) => {
+        if (error) return resolve(new Date());
+        return resolve(date);
+      });
+    });
+  },
 
-    // Skip monitoring if stack was already created
-    if (cfData === 'alreadyCreated') return BbPromise.bind(this).then(BbPromise.resolve());
-
+  monitor(action, cfData, frequency, date) {
     // Monitor stack creation/update/removal
     const validStatuses = [
       'CREATE_COMPLETE',
@@ -19,7 +23,7 @@ module.exports = {
       'DELETE_COMPLETE',
     ];
     const loggedEvents = [];
-    const monitoredSince = new Date();
+    const monitoredSince = date;
     monitoredSince.setSeconds(monitoredSince.getSeconds() - 5);
 
     let stackStatus = null;
@@ -110,5 +114,17 @@ module.exports = {
           resolve(stackStatus);
         });
     });
+  },
+
+  monitorStack(action, cfData, frequency) {
+    // Skip monitoring if a deployment should not be performed
+    if (this.options.noDeploy) return BbPromise.bind(this).then(BbPromise.resolve());
+
+    // Skip monitoring if stack was already created
+    if (cfData === 'alreadyCreated') return BbPromise.bind(this).then(BbPromise.resolve());
+
+    return BbPromise.bind(this)
+      .then(this.getCurrentDate)
+      .then((date) => this.monitor(action, cfData, frequency, date));
   },
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,6 +531,11 @@
       "from": "normalize-path@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
+    "ntp-client": {
+      "version": "0.5.3",
+      "from": "ntp-client@latest",
+      "resolved": "https://registry.npmjs.org/ntp-client/-/ntp-client-0.5.3.tgz"
+    },
     "object-assign": {
       "version": "4.1.0",
       "from": "object-assign@>=4.0.1 <5.0.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "minimist": "^1.2.0",
     "moment": "^2.13.0",
     "node-fetch": "^1.5.3",
+    "ntp-client": "^0.5.3",
     "replaceall": "^0.1.6",
     "semver": "^5.0.3",
     "semver-regex": "^1.0.0",


### PR DESCRIPTION
## What did you implement:

Closes #2691
Closes #3025

Fixes the bug where the stack was monitored indefinitely.

## How did you implement it:

Added a method which syncs with ntp and takes that time if available. Otherwise it'll fallback to the time of the users system.

This will prevent clock drifting and should prevent the stack from getting in a state where monitoring will hang.

**Note:** The package I've added is self-contained, lightweight and has no other dependencies...

## How can we verify it:

Just deploy a stack with this PR. You shouldn't see any difference.

## Todos:

- [ ] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO