### PR TITLE
Provide example how to switch between AWS profiles

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -119,11 +119,12 @@ aws_access_key_id=***************
 aws_secret_access_key=***************
 ```
 
-Now you can switch per project (/ API) by executing
+Now you can switch per project (/ API) by executing once when you start your project:
 
 `export AWS_PROFILE="profileName2" && export AWS_REGION=eu-west-1`.
 
-in the Terminal. The AWS region setting is to prevent issues with specific services, so adapt if you need another default region.
+in the Terminal. Now everything is set to execute all the `serverless` CLI options like `sls deploy`. 
+The AWS region setting is to prevent issues with specific services, so adapt if you need another default region.
 
 #### Per Stage Profiles
 

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -104,6 +104,27 @@ provider:
   profile: devProfile
 ```
 
+##### Use an existing AWS Profile
+
+To easily switch between projects without the need to do `aws configure` every time you can use environment variables.
+For example you define different profiles in `~/.aws/credentials`
+
+```ini
+[profileName1]
+aws_access_key_id=***************
+aws_secret_access_key=***************
+
+[profileName2]
+aws_access_key_id=***************
+aws_secret_access_key=***************
+```
+
+Now you can switch per project (/ API) by executing
+
+`export AWS_PROFILE="profileName2" && export AWS_REGION=eu-west-1`.
+
+in the Terminal. The AWS region setting is to prevent issues with specific services, so adapt if you need another default region.
+
 #### Per Stage Profiles
 
 As an advanced use-case, you can deploy different stages to different accounts by using different profiles per stage. In order to use different profiles per stage, you must leverage [variables](https://serverless.com/framework/docs/providers/aws/guide/variables) and the provider profile setting.


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Wrote an example how to switch AWS profiles without credentials or profile names inside `serverless.yml` for maximum flexibility when developing multiple projects on the same computer.

So how to define your AWS profile in `~/.aws/credentials` and then once `export AWS_xxxxx` before `sls deploy` and everything works.

## How did you implement it:

Edited the documentation with another paragraph.

## How can we verify it:

Run the code on your own computer by using 2 AWS profiles and switch between them. This is btw default functionality so you only need to verify the remark.

## Question / bug

I've experienced that I sometimes got errors complaining that the region was not set, while I added the correct AWS region inside `serverless.yml` for my Lambda function. By adding `export AWS_REGION=eu-west-1` I fixed this issue, but perhaps I am missing functionality or misread the documentation. Still, this workaround helps easily switching between regions with the same code without any changes to the `serverless.yml` configuration file.

## Todos:

- [ ] Write tests
- [X] Write documentation
- [ ] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
