### PR TITLE
Merge LogGroup Resources, even when no Role resources were merged

### DIFF
--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -11,6 +11,22 @@ module.exports = {
   },
 
   merge() {
+    this.serverless.service.getAllFunctions().forEach((functionName) => {
+      const functionObject = this.serverless.service.getFunction(functionName);
+      const logGroupLogicalId = this.provider.naming
+        .getLogGroupLogicalId(functionName);
+      const newLogGroup = {
+        [logGroupLogicalId]: {
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: this.provider.naming.getLogGroupName(functionObject.name),
+          },
+        },
+      };
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+        newLogGroup);
+    });
+
     if (!this.serverless.service.getAllFunctions().length) {
       return BbPromise.resolve();
     }
@@ -69,19 +85,8 @@ module.exports = {
       );
 
       this.serverless.service.getAllFunctions().forEach((functionName) => {
-        const functionObject = this.serverless.service.getFunction(functionName);
         const logGroupLogicalId = this.provider.naming
           .getLogGroupLogicalId(functionName);
-        const newLogGroup = {
-          [logGroupLogicalId]: {
-            Type: 'AWS::Logs::LogGroup',
-            Properties: {
-              LogGroupName: this.provider.naming.getLogGroupName(functionObject.name),
-            },
-          },
-        };
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-          newLogGroup);
 
         this.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[this.provider.naming.getPolicyLogicalId()]

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
@@ -208,6 +208,29 @@ describe('#mergeIamTemplates()', () => {
     });
   });
 
+  it('should add a CloudWatch LogGroup resource if all functions use custom roles', () => {
+    awsDeploy.serverless.service.functions[functionName].role = 'something';
+    const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
+    return awsDeploy.mergeIamTemplates().then(() => {
+      expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources[normalizedName]
+      ).to.deep.equal(
+        {
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: awsDeploy.provider.naming.getLogGroupName(functionName),
+          },
+        }
+      );
+
+      const roleLogicalId = awsDeploy.provider.naming.getRoleLogicalId();
+      expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources[roleLogicalId]
+      ).to.equal(undefined);
+      delete awsDeploy.serverless.service.functions[functionName].role;
+    });
+  });
+
   it('should update IamPolicyLambdaExecution with a logging resource for the function', () => {
     awsDeploy.serverless.service.functions = {
       func0: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Closes #3174

Fixed a bug where LogGroup resources are not created if all your functions use custom roles.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Moved the logic that adds LogGroups resources at the top of the merge method, so that they're always merged, even when no roles are merged, like in the case of custom roles.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Using this config:

```yml
service: log-group-bug

provider:
  name: aws

functions:
  hello:
    role: something
    handler: handler.hello

  world:
    role: somethingelse
    handler: handler.world
```
All functions use custom roles, so no role resources are added. Run `sls deploy --noDeploy` and you'll see that the roles resources are not added, while the LogGroup resources are added.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO