### PR TITLE
Reduce memory consumption during zipping process

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -55,7 +55,7 @@ module.exports = {
         const stats = fs.statSync(fullPath);
 
         if (!stats.isDirectory(fullPath)) {
-          zip.append(fs.readFileSync(fullPath), {
+          zip.append(fs.createReadStream(fullPath), {
             name: filePath,
             mode: stats.mode,
           });


### PR DESCRIPTION
## What did you implement:

Closes #3054 and refs #3100

Switch from `readFileSync` to `createReadStream` to reduce memory consumption.

## How did you implement it:

Changed from read file content to streaming file content.

## How can we verify it:

Taken from PR #3100 descriptions

- `serverless deploy --noDeploy`
- In order to notice larger difference, try packaging on this example repo https://github.com/pmuens/serverless-service-zip-testing + do the `npm install` *some large libs* for a more real-life example
- Make sure it creates same file structure, packages exotic filenames and so on.

## Todos:

- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO