### PR TITLE
Fix serverless invoke command example

### DIFF
--- a/docs/providers/aws/guide/workflow.md
+++ b/docs/providers/aws/guide/workflow.md
@@ -63,7 +63,7 @@ serverless deploy function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME]
 ##### Invoke Function
 Invokes an AWS Lambda Function on AWS and returns logs.
 ```
-serverless invoke function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME] -l
+serverless invoke -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME] -l
 ```
 
 ##### Streaming Logs


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

Minor mistake in the `serverless invoke` command example on the Workflow page of the AWS guide

## How did you implement it:

Fixed markdown file

## How can we verify it:

Review documentation change and confirm that `serverless invoke -f hello` is the proper command (based on a newly created serverless project) rather than `serverless invoke function -f hello` as was previously in the guide.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
