### PR TITLE
moved stage to its own resource

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -79,6 +79,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |ApiGateway::Method     | ApiGatewayResource{normalizedPath}{normalizedMethod}    | ApiGatewayResourceUsersGet    |
 |ApiGateway::Authorizer | {normalizedFunctionName}ApiGatewayAuthorizer            | HelloApiGatewayAuthorizer     |
 |ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
+|ApiGateway::Stage      | ApiGatewayStage                                         | ApiGatewayStage               |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |
 |SNS::Subscription      | {normalizedFunctionName}SnsSubscription{normalizedTopicName}   | HelloSnsSubscriptionSomeTopic             |

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.js
@@ -10,6 +10,7 @@ const compileCors = require('./lib/cors');
 const compileMethods = require('./lib/method/index');
 const compileAuthorizers = require('./lib/authorizers');
 const compileDeployment = require('./lib/deployment');
+const compileStage = require('./lib/stage');
 const compilePermissions = require('./lib/permissions');
 const getMethodAuthorization = require('./lib/method/authorization');
 const getMethodIntegration = require('./lib/method/integration');
@@ -31,6 +32,7 @@ class AwsCompileApigEvents {
       compileMethods,
       compileAuthorizers,
       compileDeployment,
+      compileStage,
       compilePermissions,
       getMethodAuthorization,
       getMethodIntegration,
@@ -52,6 +54,7 @@ class AwsCompileApigEvents {
           .then(this.compileMethods)
           .then(this.compileAuthorizers)
           .then(this.compileDeployment)
+          .then(this.compileStage)
           .then(this.compileApiKeys)
           .then(this.compilePermissions);
       },

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/index.test.js
@@ -59,6 +59,8 @@ describe('AwsCompileApigEvents', () => {
         .stub(awsCompileApigEvents, 'compileMethods').returns(BbPromise.resolve());
       const compileDeploymentStub = sinon
         .stub(awsCompileApigEvents, 'compileDeployment').returns(BbPromise.resolve());
+      const compileStageStub = sinon
+        .stub(awsCompileApigEvents, 'compileStage').returns(BbPromise.resolve());
       const compilePermissionsStub = sinon
         .stub(awsCompileApigEvents, 'compilePermissions').returns(BbPromise.resolve());
 
@@ -68,13 +70,15 @@ describe('AwsCompileApigEvents', () => {
         expect(compileResourcesStub.calledAfter(compileRestApiStub)).to.be.equal(true);
         expect(compileMethodsStub.calledAfter(compileResourcesStub)).to.be.equal(true);
         expect(compileDeploymentStub.calledAfter(compileMethodsStub)).to.be.equal(true);
-        expect(compilePermissionsStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compileStageStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compilePermissionsStub.calledAfter(compileStageStub)).to.be.equal(true);
 
         awsCompileApigEvents.validate.restore();
         awsCompileApigEvents.compileRestApi.restore();
         awsCompileApigEvents.compileResources.restore();
         awsCompileApigEvents.compileMethods.restore();
         awsCompileApigEvents.compileDeployment.restore();
+        awsCompileApigEvents.compileStage.restore();
         awsCompileApigEvents.compilePermissions.restore();
       });
     });

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.js
@@ -13,27 +13,11 @@ module.exports = {
         Type: 'AWS::ApiGateway::Deployment',
         Properties: {
           RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
-          StageName: this.options.stage,
         },
         DependsOn: this.apiGatewayMethodLogicalIds,
       },
     });
 
-    // create CLF Output for endpoint
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-      ServiceEndpoint: {
-        Description: 'URL of the service endpoint',
-        Value: {
-          'Fn::Join': ['',
-            [
-              'https://',
-              { Ref: this.apiGatewayRestApiLogicalId },
-              `.execute-api.${this.options.region}.amazonaws.com/${this.options.stage}`,
-            ],
-          ],
-        },
-      },
-    });
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/deployment.test.js
@@ -18,7 +18,6 @@ describe('#compileDeployment()', () => {
     };
     const options = {
       stage: 'dev',
-      region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
@@ -39,28 +38,6 @@ describe('#compileDeployment()', () => {
         DependsOn: ['method-dependency1', 'method-dependency2'],
         Properties: {
           RestApiId: { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
-          StageName: 'dev',
-        },
-      });
-    })
-  );
-
-  it('should add service endpoint output', () =>
-    awsCompileApigEvents.compileDeployment().then(() => {
-      expect(
-        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Outputs.ServiceEndpoint
-      ).to.deep.equal({
-        Description: 'URL of the service endpoint',
-        Value: {
-          'Fn::Join': [
-            '',
-            [
-              'https://',
-              { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
-              '.execute-api.us-east-1.amazonaws.com/dev',
-            ],
-          ],
         },
       });
     })

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/stage.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/stage.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  compileStage() {
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      ApiGatewayStage: {
+        Type: 'AWS::ApiGateway::Stage',
+        Properties: {
+          RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
+          DeploymentId: { Ref: this.apiGatewayDeploymentLogicalId },
+          StageName: this.options.stage,
+        },
+        DependsOn: [this.apiGatewayDeploymentLogicalId],
+      },
+    });
+
+    // create CLF Output for endpoint
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+      ServiceEndpoint: {
+        Description: 'URL of the service endpoint',
+        Value: {
+          'Fn::Join': ['',
+            [
+              'https://',
+              { Ref: this.apiGatewayRestApiLogicalId },
+              `.execute-api.${this.options.region}.amazonaws.com/${this.options.stage}`,
+            ],
+          ],
+        },
+      },
+    });
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/stage.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/stage.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileApigEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+const AwsProvider = require('../../../../../provider/awsProvider');
+
+describe('#compileStage()', () => {
+  let serverless;
+  let awsCompileApigEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+      Outputs: {},
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeployment';
+  });
+
+  it('should create a stage resource', () => awsCompileApigEvents
+    .compileStage().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayStage
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::Stage',
+        DependsOn: [awsCompileApigEvents.apiGatewayDeploymentLogicalId],
+        Properties: {
+          RestApiId: { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
+          DeploymentId: { Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId },
+          StageName: 'dev',
+        },
+      });
+    })
+  );
+
+  it('should add service endpoint output', () =>
+    awsCompileApigEvents.compileStage().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Outputs.ServiceEndpoint
+      ).to.deep.equal({
+        Description: 'URL of the service endpoint',
+        Value: {
+          'Fn::Join': [
+            '',
+            [
+              'https://',
+              { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
+              '.execute-api.us-east-1.amazonaws.com/dev',
+            ],
+          ],
+        },
+      });
+    })
+  );
+});


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #1918 #2665 #1704

<!--
Briefly describe the feature if no issue exists for this PR
-->

Make API Gateway stage configuration available, including but not limited to logging, throttling and stage variables.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

By adding an actual `AWS::ApiGateway::Stage` resource instead of simply using the `StageName`property of `AWS::Apigateway::Deployment`.

I have also moved the service endpoint output from the deployment to the stage, since that is where it logically belongs.

The reason this is a breaking change is that using `StageName` from `AWS::ApiGateway::Deployment` implicitly creates a stage which conflicts with `AWS::ApiGateway::Stage` when using the same name, so I had to remove it. This makes updating existing deployments that were created using previous versions of serverless impossible (a workaround would be to create an intermediary stage, manually delete the stage implicitly created by the previous deployment, and then recreate the original stage).

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

To verify that everything works as before, simply deploy a Lambda function with an `http` event as usual.

To verify that it is now possible to configure the stage, add a `ApiGatewayStage` resource with some configuration (see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html for available options).

For example, to enable logging and add a stage variable:

```yaml
resources:
  Resources:
    ApiGatewayStage:
      Type: "AWS::ApiGateway::Stage"
      Properties:
        MethodSettings:
          - DataTraceEnabled: true
            HttpMethod: "*"
            LoggingLevel: ERROR
            ResourcePath: "/*"
            MetricsEnabled: true
        Variables:
          foo: "bar"
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES