### PR TITLE
chore(readme): removes why-serverless section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Serverless is an MIT open-source project, actively maintained by a full-time, ve
 * [Features](#features)
 * [Plugins](#v1-plugins)
 * [Example Projects](#v1-projects)
-* [Why Serverless?](#why-serverless)
 * [Contributing](#contributing)
 * [Community](#community)
 * [Consultants](#consultants)


### PR DESCRIPTION
## What did you implement:

Chore: the `why-serverless` section was removed in commit 45e7f4e6c65a3d7cf9bbc7a9c350fb65a0586de7, but the anchor was left behind.

## How did you implement it:

Deleted the link

## How can we verify it:

---

## Todos:

---

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
