### PR TITLE
BREAKING - Update function name displaying for info plugin

### DIFF
--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -60,7 +60,7 @@ module.exports = {
 
     if (info.functions && info.functions.length > 0) {
       info.functions.forEach((f) => {
-        functionsMessage += `\n  ${f.name}`;
+        functionsMessage += `\n  ${f.name}: ${f.deployedName}`;
       });
     } else {
       functionsMessage += '\n  None';

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -154,12 +154,15 @@ describe('#display()', () => {
     awsInfo.gatheredData.info.functions = [
       {
         name: 'function1',
+        deployedName: 'my-first-dev-function1',
       },
       {
         name: 'function2',
+        deployedName: 'my-first-dev-function2',
       },
       {
         name: 'function3',
+        deployedName: 'my-first-dev-function3',
       },
     ];
 
@@ -174,9 +177,9 @@ describe('#display()', () => {
     expectedMessage += `\n${chalk.yellow('endpoints:')}`;
     expectedMessage += '\n  None';
     expectedMessage += `\n${chalk.yellow('functions:')}`;
-    expectedMessage += '\n  function1';
-    expectedMessage += '\n  function2';
-    expectedMessage += '\n  function3';
+    expectedMessage += '\n  function1: my-first-dev-function1';
+    expectedMessage += '\n  function2: my-first-dev-function2';
+    expectedMessage += '\n  function3: my-first-dev-function3';
 
     const message = awsInfo.display();
     expect(consoleLogStub.calledOnce).to.equal(true);

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -40,6 +40,8 @@ module.exports = {
         this.serverless.service.getAllFunctions().forEach((func) => {
           const functionInfo = {};
           functionInfo.name = func;
+          functionInfo.deployedName = `${
+            this.serverless.service.service}-${this.options.stage}-${func}`;
           this.gatheredData.info.functions.push(functionInfo);
         });
 

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -39,7 +39,7 @@ module.exports = {
         // Functions
         this.serverless.service.getAllFunctions().forEach((func) => {
           const functionInfo = {};
-          functionInfo.name = `${this.serverless.service.service}-${this.options.stage}-${func}`;
+          functionInfo.name = func;
           this.gatheredData.info.functions.push(functionInfo);
         });
 

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -76,9 +76,11 @@ describe('#getStackInfo()', () => {
         functions: [
           {
             name: 'hello',
+            deployedName: 'my-service-dev-hello',
           },
           {
             name: 'world',
+            deployedName: 'my-service-dev-world',
           },
         ],
         endpoint: 'ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev',

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -75,10 +75,10 @@ describe('#getStackInfo()', () => {
       info: {
         functions: [
           {
-            name: 'my-service-dev-hello',
+            name: 'hello',
           },
           {
-            name: 'my-service-dev-world',
+            name: 'world',
           },
         ],
         endpoint: 'ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev',


### PR DESCRIPTION
## What did you implement:

Updates the `name` so that it's the name one would use for e.g. the `invoke` command rather than the name on AWS (which introduces confusion).

/cc @brianneisler 

## How did you implement it:

Simply renamed the function name in the `awsInfo` plugin.

## How can we verify it:

See the tests or do a `serverless deploy` or `serverless info`.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES...for CI systems depending on stdout