### PR TITLE
Fix s3 event bucket reference

### DIFF
--- a/docs/providers/aws/events/s3.md
+++ b/docs/providers/aws/events/s3.md
@@ -73,3 +73,26 @@ functions:
           bucket: photos
           event: s3:ObjectRemoved:*
 ```
+
+## Advanced bucket configuration
+
+If you want to provide more advanced configuration for the S3 bucket, you can
+provide a separate resource configuration.
+
+
+```yaml
+functions:
+  users:
+    handler: users.handler
+    events:
+      - s3:
+          bucket: photos
+
+resources:
+  Resources:
+    Bucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: photos
+        AccessControl: PublicRead
+```

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -81,44 +81,29 @@ class AwsCompileS3Events {
             const lambdaLogicalId = this.provider.naming
               .getLambdaLogicalId(functionName);
 
+            let newLambdaConfiguration = {
+              Event: notificationEvent,
+              Function: {
+                'Fn::GetAtt': [
+                  lambdaLogicalId,
+                  'Arn',
+                ],
+              },
+            };
+
+            // Assign 'filter' if not empty
+            newLambdaConfiguration = _.assign(
+              newLambdaConfiguration,
+              filter
+            );
+
             // check if the bucket already defined
             // in another S3 event in the service
-            if (bucketsLambdaConfigurations[bucketName]) {
-              let newLambdaConfiguration = {
-                Event: notificationEvent,
-                Function: {
-                  'Fn::GetAtt': [
-                    lambdaLogicalId,
-                    'Arn',
-                  ],
-                },
-              };
-
-              // Assign 'filter' if not empty
-              newLambdaConfiguration = _.assign(
-                newLambdaConfiguration,
-                filter
-              );
-              bucketsLambdaConfigurations[bucketName]
-                .push(newLambdaConfiguration);
-            } else {
-              bucketsLambdaConfigurations[bucketName] = [
-                {
-                  Event: notificationEvent,
-                  Function: {
-                    'Fn::GetAtt': [
-                      lambdaLogicalId,
-                      'Arn',
-                    ],
-                  },
-                },
-              ];
-              // Assign 'filter' if not empty
-              bucketsLambdaConfigurations[bucketName][0] = _.assign(
-                bucketsLambdaConfigurations[bucketName][0],
-                filter
-              );
+            if (!bucketsLambdaConfigurations[bucketName]) {
+              bucketsLambdaConfigurations[bucketName] = [];
             }
+            bucketsLambdaConfigurations[bucketName].push(newLambdaConfiguration);
+
             const s3EnabledFunction = { functionName, bucketName };
             s3EnabledFunctions.push(s3EnabledFunction);
           }

--- a/lib/plugins/aws/deploy/compile/events/s3/index.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.js
@@ -97,7 +97,7 @@ class AwsCompileS3Events {
               filter
             );
 
-            // check if the bucket already defined
+            // check if the bucket is already defined
             // in another S3 event in the service
             if (!bucketsLambdaConfigurations[bucketName]) {
               bucketsLambdaConfigurations[bucketName] = [];
@@ -111,26 +111,42 @@ class AwsCompileS3Events {
       }
     });
 
+    const provider = this.serverless.service.provider;
+    const resources = provider.compiledCloudFormationTemplate.Resources;
+
     // iterate over all buckets to be created
     // and compile them to CF resources
     _.forEach(bucketsLambdaConfigurations, (bucketLambdaConfiguration, bucketName) => {
-      const bucketTemplate = {
-        Type: 'AWS::S3::Bucket',
-        Properties: {
-          BucketName: bucketName,
-          NotificationConfiguration: {
-            LambdaConfigurations: bucketLambdaConfiguration,
-          },
-        },
-      };
+      // check if the bucket is already defined
+      let bucketLogicalId = _.findKey(resources, (resource) =>
+          resource.Type
+          && resource.Type === 'AWS::S3::Bucket'
+          && resource.Properties
+          && resource.Properties.BucketName
+          && resource.Properties.BucketName === bucketName);
 
-      const bucketLogicalId = this.provider.naming
-        .getBucketLogicalId(bucketName);
+      let bucket;
+      if (bucketLogicalId) {
+        bucket = resources[bucketLogicalId];
+      } else {
+        bucketLogicalId = this.provider.naming.getBucketLogicalId(bucketName);
+        bucket = {
+          Type: 'AWS::S3::Bucket',
+          Properties: {
+            BucketName: bucketName,
+          },
+        };
+      }
+      _.merge(bucket.Properties, {
+        NotificationConfiguration: {
+          LambdaConfigurations: bucketLambdaConfiguration,
+        },
+      });
+
       const bucketCFResource = {
-        [bucketLogicalId]: bucketTemplate,
+        [bucketLogicalId]: bucket,
       };
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        bucketCFResource);
+      _.merge(resources, bucketCFResource);
     });
 
     // iterate over all functions with S3 events
@@ -163,8 +179,7 @@ class AwsCompileS3Events {
       const permissionCFResource = {
         [lambdaPermissionLogicalId]: permissionTemplate,
       };
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        permissionCFResource);
+      _.merge(resources, permissionCFResource);
     });
   }
 }

--- a/lib/plugins/aws/deploy/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/deploy/compile/events/s3/index.test.js
@@ -163,6 +163,39 @@ describe('AwsCompileS3Events', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should configure existing bucket resource', () => {
+      awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate = {
+        Resources: {
+          MyBucket: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              BucketName: 'existing-bucket',
+            },
+          },
+        },
+      };
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: 'existing-bucket',
+            },
+          ],
+        },
+      };
+
+      awsCompileS3Events.compileS3Events();
+
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.MyBucket.Type).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.MyBucket.Properties.NotificationConfiguration
+        .LambdaConfigurations.length).to.equal(1);
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstLambdaPermissionExistingbucketS3.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
     it('should not create corresponding resources when S3 events are not given', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -46,10 +46,10 @@ class AwsDeploy {
         .then(this.mergeIamTemplates),
 
       'before:deploy:compileFunctions': () => BbPromise.bind(this)
-        .then(this.generateArtifactDirectoryName),
+        .then(this.generateArtifactDirectoryName)
+        .then(this.mergeCustomProviderResources),
 
       'deploy:deploy': () => BbPromise.bind(this)
-        .then(this.mergeCustomProviderResources)
         .then(this.setBucketName)
         .then(this.uploadArtifacts)
         .then(this.updateStack)

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -51,9 +51,13 @@ describe('AwsDeploy', () => {
     it('should run "before:deploy:compileFunctions" promise chain in order', () => {
       const generateArtifactDirectoryNameStub = sinon
         .stub(awsDeploy, 'generateArtifactDirectoryName').returns(BbPromise.resolve());
+      const mergeCustomProviderResourcesStub = sinon
+        .stub(awsDeploy, 'mergeCustomProviderResources').returns(BbPromise.resolve());
 
       return awsDeploy.hooks['before:deploy:compileFunctions']().then(() => {
         expect(generateArtifactDirectoryNameStub.calledOnce).to.be.equal(true);
+        expect(mergeCustomProviderResourcesStub.calledAfter(generateArtifactDirectoryNameStub))
+          .to.be.equal(true);
       });
     });
 
@@ -67,8 +71,6 @@ describe('AwsDeploy', () => {
     });
 
     it('should run "deploy:deploy" promise chain in order', () => {
-      const mergeCustomProviderResourcesStub = sinon
-        .stub(awsDeploy, 'mergeCustomProviderResources').returns(BbPromise.resolve());
       const setBucketNameStub = sinon
         .stub(awsDeploy, 'setBucketName').returns(BbPromise.resolve());
       const cleanupS3BucketStub = sinon
@@ -79,10 +81,7 @@ describe('AwsDeploy', () => {
         .stub(awsDeploy, 'updateStack').returns(BbPromise.resolve());
 
       return awsDeploy.hooks['deploy:deploy']().then(() => {
-        expect(mergeCustomProviderResourcesStub.calledOnce)
-          .to.be.equal(true);
-        expect(setBucketNameStub.calledAfter(mergeCustomProviderResourcesStub))
-          .to.be.equal(true);
+        expect(setBucketNameStub.calledOnce).to.be.equal(true);
         expect(uploadArtifactsStub.calledAfter(setBucketNameStub))
           .to.be.equal(true);
         expect(updateStackStub.calledAfter(uploadArtifactsStub))


### PR DESCRIPTION
## What did you implement:

Closes #3257

## How did you implement it:

S3 events first check if a bucket is already defined with the given name. Only if no bucket is found, a new one is added to the CloudFormation template.

## How can we verify it:

Use the example at:
https://github.com/christophgysin/examples/blob/test-s3-event-existing-bucket/aws-node-upload-to-s3-and-postprocess/serverless.yml

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
