### PR TITLE
Improved tests for `logBreakingChange()` function (see #3265):

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ language: node_js
 matrix:
   include:
     - node_js: '4.4'
+      env:
+        SLS_IGNORE_WARNING=*
     - node_js: '5.11'
+      env:
+        SLS_IGNORE_WARNING=*
     - node_js: '6.2'
+      env:
+        SLS_IGNORE_WARNING=*
     - node_js: '6.2'
       env:
         - INTEGRATION_TEST=true

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -307,67 +307,85 @@ describe('CLI', () => {
 
   describe('#logBreakingChanges()', () => {
     let consoleLogStub;
+    let origIgnoreWarning;
 
     beforeEach(() => {
       cli = new CLI(serverless);
       consoleLogStub = sinon.stub(cli, 'consoleLog').returns();
+      origIgnoreWarning = process.env.SLS_IGNORE_WARNING;
     });
 
     afterEach(() => {
       cli.consoleLog.restore();
-      delete process.env.SLS_IGNORE_WARNING;
+      if (origIgnoreWarning === undefined) {
+        delete process.env.SLS_IGNORE_WARNING;
+      } else {
+        process.env.SLS_IGNORE_WARNING = origIgnoreWarning;
+      }
     });
 
-    it('should log breaking changes when they are provided', () => {
-      const nextVersion = 'Next';
+    // Test all possible combinations of provided changes and "ignored" setting
+    [
+      {
+        name: 'should NOT LOG breaking changes when changes are NOT PROVIDED and NOT IGNORED',
+        isProvided: false,
+        isIgnored: false,
+        isLogExpected: false,
+      },
+      {
+        name: 'should NOT LOG breaking changes when changes are NOT PROVIDED and IGNORED',
+        isProvided: false,
+        isIgnored: true,
+        isLogExpected: false,
+      },
+      {
+        name: 'should LOG breaking changes when changes are PROVIDED and NOT IGNORED',
+        isProvided: true,
+        isIgnored: false,
+        isLogExpected: true,
+      },
+      {
+        name: 'should NOT LOG breaking changes when changes are PROVIDED and IGNORED',
+        isProvided: true,
+        isIgnored: true,
+        isLogExpected: false,
+      },
+    ].forEach((testCase) => {
+      it(testCase.name, () => {
+        // Stubs
+        const nextVersion = 'Next';
 
-      cli.breakingChanges = [
-        'x is broken',
-        'y will be updated',
-      ];
+        let outMessage = '\n';
+        outMessage += chalk.yellow(`  WARNING: You are running v${serverlessVersion}. v${nextVersion} will include the following breaking changes:\n`); //eslint-disable-line
+        outMessage += chalk.yellow('    - x is broken\n');
+        outMessage += chalk.yellow('    - y will be updated\n');
+        outMessage += '\n';
+        outMessage += chalk.yellow('  You can opt-out from these warnings by setting the "SLS_IGNORE_WARNING=*" environment variable.\n'); //eslint-disable-line
 
-      let expectedMessage = '\n';
-      expectedMessage += chalk.yellow(`  WARNING: You are running v${serverlessVersion}. v${nextVersion} will include the following breaking changes:\n`); //eslint-disable-line
-      expectedMessage += chalk.yellow('    - x is broken\n');
-      expectedMessage += chalk.yellow('    - y will be updated\n');
-      expectedMessage += '\n';
-      expectedMessage += chalk.yellow('  You can opt-out from these warnings by setting the "SLS_IGNORE_WARNING=*" environment variable.\n'); //eslint-disable-line
+        const breakingChanges = [
+          'x is broken',
+          'y will be updated',
+        ];
 
-      const message = cli.logBreakingChanges(nextVersion);
+        // Prepare the test environment
+        cli.breakingChanges = testCase.isProvided ? breakingChanges : [];
 
-      expect(consoleLogStub.calledOnce).to.equal(true);
-      expect(message).to.equal(expectedMessage);
-    });
+        if (testCase.isIgnored) {
+          process.env.SLS_IGNORE_WARNING = '*';
+        } else {
+          delete process.env.SLS_IGNORE_WARNING;
+        }
 
-    it('should not log breaking changes when they are not provided', () => {
-      cli.breakingChanges = [];
+        // Test expectations
+        const expectedResult = testCase.isLogExpected ? outMessage : '';
+        const expectedLogCalled = testCase.isLogExpected;
 
-      const expectedMessage = '';
+        // Carry the test
+        const actualResult = cli.logBreakingChanges(nextVersion);
 
-      const message = cli.logBreakingChanges();
-
-      expect(consoleLogStub.calledOnce).to.equal(false);
-      expect(message).to.equal(expectedMessage);
-    });
-
-    it('should not log breaking changes when the "disable environment variable" is set', () => {
-      // we have some breaking changes
-      cli.breakingChanges = [
-        'x is broken',
-        'y will be updated',
-      ];
-
-      // this should prevent the breaking changes from being logged
-      process.env.SLS_IGNORE_WARNING = '*';
-
-      cli.breakingChanges = [];
-
-      const expectedMessage = '';
-
-      const message = cli.logBreakingChanges();
-
-      expect(consoleLogStub.calledOnce).to.equal(false);
-      expect(message).to.equal(expectedMessage);
+        expect(actualResult).to.equal(expectedResult);
+        expect(consoleLogStub.calledOnce).to.equal(expectedLogCalled);
+      });
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3265

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

* Fixed the tests when `SLS_IGNORE_WARNING` is set in the shell environment
* Refactored the tests to clearly expose the tested input combinations (+ added the missing combination, so that we have a formally complete verification)
* Added the `SLS_IGNORE_WARNING=*` setting to Travis builds, so that their output doesn't contain unnecessary noise about upcoming changes

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

See [Travis CI builds](https://travis-ci.org/zerkella/serverless/builds/202528488) - no more breaking changes output there. See [Coveralls](https://coveralls.io/github/zerkella/serverless?branch=improve-breaking-changes-testing) - the coverage didn't decrease.

## Todos:
- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
