### PR TITLE
Crank up ZIP settings to maximum

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -24,7 +24,7 @@ module.exports = {
       patterns.push(pattern);
     });
 
-    const zip = archiver.create('zip');
+    const zip = archiver.create('zip', {zlib: {level: 9, memLevel: 9}});
 
     const artifactFilePath = path.join(
       servicePath,

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -24,7 +24,7 @@ module.exports = {
       patterns.push(pattern);
     });
 
-    const zip = archiver.create('zip', {zlib: {level: 9, memLevel: 9}});
+    const zip = archiver.create('zip', { zlib: { level: 9, memLevel: 9 } });
 
     const artifactFilePath = path.join(
       servicePath,


### PR DESCRIPTION
## What did you implement:

Set ZIP compression settings to maximum.

This will reduce the size of the package zip, reducing upload times and bucket space usage.

For very large projects this may increase the time to package, however given the age and simplicity of DEFLATE, that shouldn't be much on a modern machine.

## How did you implement it:

## How can we verify it:

Just compare the package zip file before and after applying the patch.

## Todos:

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
