### PR TITLE
Fixed documentation.

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -76,7 +76,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |AWS::IoT::TopicRule    | {normalizedFuntionName}IotTopicRule{SequentialID}       | HelloIotTopicRule1            |
 |ApiGateway::RestApi    | ApiGatewayRestApi                                       | ApiGatewayRestApi             |
 |ApiGateway::Resource   | ApiGatewayResource{normalizedPath}                      | ApiGatewayResourceUsers       |
-|ApiGateway::Method     | ApiGatewayResource{normalizedPath}{normalizedMethod}    | ApiGatewayResourceUsersGet    |
+|ApiGateway::Method     | ApiGatewayMethod{normalizedPath}{normalizedMethod}      | ApiGatewayMethodUsersGet      |
 |ApiGateway::Authorizer | {normalizedFunctionName}ApiGatewayAuthorizer            | HelloApiGatewayAuthorizer     |
 |ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |


### PR DESCRIPTION
Changed the documentation for ApiGatewayResourcePathMethod resource name. should be ApiGatewayMethod{

Was:
ApiGateway::Method -> ApiGatewayResource{normalizedPath}{normalizedMethod} -> ApiGatewayResourceUsersGet

Should be:
ApiGateway::Method -> ApiGatewayMethod{normalizedPath}{normalizedMethod} -> ApiGatewayMethodUsersGet

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
