### PR TITLE
Fix monitorStack freezing bug

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -19,9 +19,8 @@ module.exports = {
       'DELETE_COMPLETE',
     ];
     const loggedEvents = [];
-    const monitoredSince = new Date();
-    monitoredSince.setSeconds(monitoredSince.getSeconds() - 5);
 
+    let monitoredSince = null;
     let stackStatus = null;
     let stackLatestError = null;
 
@@ -41,9 +40,33 @@ module.exports = {
               this.options.stage,
               this.options.region)
               .then((data) => {
+                const stackEvents = data.StackEvents;
+
+                // look through all the stack events and find the first relevant
+                // event which is a "Stack" event and has a CREATE, UPDATE or DELETE status
+                const firstRelevantEvent = stackEvents.find((event) => {
+                  const isStack = 'AWS::CloudFormation::Stack';
+                  const updateIsInProgress = 'UPDATE_IN_PROGRESS';
+                  const createIsInProgress = 'CREATE_IN_PROGRESS';
+                  const deleteIsInProgress = 'DELETE_IN_PROGRESS';
+
+                  return event.ResourceType === isStack
+                    && (event.ResourceStatus === updateIsInProgress
+                      || event.ResourceStatus === createIsInProgress
+                      || event.ResourceStatus === deleteIsInProgress);
+                });
+
+                // set the date some time before the first found
+                // stack event of recently issued stack modification
+                if (firstRelevantEvent) {
+                  const eventDate = new Date(firstRelevantEvent.Timestamp);
+                  const updatedDate = eventDate.setSeconds(eventDate.getSeconds() - 5);
+                  monitoredSince = new Date(updatedDate);
+                }
+
                 // Loop through stack events
-                data.StackEvents.reverse().forEach((event) => {
-                  const eventInRange = (monitoredSince < event.Timestamp);
+                stackEvents.reverse().forEach((event) => {
+                  const eventInRange = (monitoredSince <= event.Timestamp);
                   const eventNotLogged = (loggedEvents.indexOf(event.EventId) === -1);
                   let eventStatus = event.ResourceStatus || null;
                   if (eventInRange && eventNotLogged) {


### PR DESCRIPTION
## What did you implement:

Closes #2691
Closes #3025

Fixes the bug where the stack was monitored indefinitely.

## How did you implement it:

The new functionality doesn't need the local dev machines time.

It looks through the stack events which are returned by AWS and finds the first event which is a "Stack" event and started the UPDATE, CREATE or REMOVE operation. Then it uses the timestamp of this event, subtracts 5 seconds and uses this value for `monitoredSince`.

The benefits are:

- We don't rely on the correct time of the local dev machine
- The time is derived from AWSs time so it's always correct
- No need to fetch data from an external source (like it was done in the first WIP [here](#3200)

## How can we verify it:

Just run simple `deploy`, `update` and `remove` commands. Optionally with the `--verbose` option.

Furthermore you can take a look at the unit and integration tests.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES