### PR TITLE
Allow the package artifact to contain wildcards.

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -60,6 +60,7 @@ For complete control over the packaging process you can specify your own artifac
 Serverless won't zip your service if this is configured and therefore `exclude` and `include` will be ignored. Either you use artifact or include / exclude.
 
 The artifact option is especially useful in case your development environment allows you to generate a deployable artifact like Maven does for Java.
+The artifact string can contain wildcards (so it could include a build number, for example), but it must resolve to a single file.
 
 ## Example
 

--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
+const glob = require('glob');
 
 class AwsCompileFunctions {
   constructor(serverless, options) {
@@ -68,12 +69,29 @@ class AwsCompileFunctions {
     const newFunction = this.cfLambdaFunctionTemplate();
     const functionObject = this.serverless.service.getFunction(functionName);
 
-    const artifactFilePath = this.serverless.service.package.individually ?
+    let artifactFilePath = this.serverless.service.package.individually ?
       functionObject.artifact :
       this.serverless.service.package.artifact;
 
     if (!artifactFilePath) {
       throw new Error(`No artifact path is set for function: "${functionName}"`);
+    }
+
+    // if the package artifact includes wildcards, allow iff it matches exactly one file
+    const files = glob.sync(artifactFilePath, null);
+    if (files === null) {
+      throw new this.serverless.classes
+        .Error(`No file matches the artifact path for function: "${functionName}"`);
+    }
+    if (files.length === 1) {
+      artifactFilePath = files[0];
+    } else {
+      const errorMessage = [
+        `More than one file matches the artifact path for function: "${functionName}".`,
+        ' Maybe you need to clean the output directory?',
+      ].join('');
+      throw new this.serverless.classes
+        .Error(errorMessage);
     }
 
     if (this.serverless.service.package.deploymentBucket) {

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -5,6 +5,8 @@ const expect = require('chai').expect;
 const AwsProvider = require('../../../provider/awsProvider');
 const AwsCompileFunctions = require('./index');
 const Serverless = require('../../../../../Serverless');
+const sinon = require('sinon');
+const glob = require('glob');
 
 describe('AwsCompileFunctions', () => {
   let serverless;
@@ -87,6 +89,44 @@ describe('AwsCompileFunctions', () => {
 
       expect(functionResource.Properties.Code.S3Key)
         .to.deep.equal(`${s3Folder}/${s3FileName}`);
+    });
+
+    it('should accept an artifact pattern that matches exactly one file', () => {
+      const artifactFilePathWildcard = 'artifact*.zip';
+      const artifactFilePathExact = 'artifact-1.zip';
+      serverless.utils.writeFileSync(artifactFilePathExact, 'foobar');
+
+      sinon.stub(glob, 'sync').returns([artifactFilePathExact]);
+
+      awsCompileFunctions.serverless.service.package.artifact = artifactFilePathWildcard;
+      awsCompileFunctions.serverless.service.package.individually = true;
+      awsCompileFunctions.compileFunctions();
+
+      const functionResource = awsCompileFunctions.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources[compiledFunctionName];
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = artifactFilePathExact;
+
+      expect(functionResource.Properties.Code.S3Key)
+        .to.deep.equal(`${s3Folder}/${s3FileName}`);
+
+      glob.sync.restore();
+    });
+
+    it('should fail if the artifact pattern matches no files', () => {
+      sinon.stub(glob, 'sync').returns(null);
+
+      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
+
+      glob.sync.restore();
+    });
+
+    it('should fail if the artifact pattern matches multiple files', () => {
+      sinon.stub(glob, 'sync').returns(['artifact-1.zip', 'artifact-2.zip']);
+
+      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
+
+      glob.sync.restore();
     });
 
     it('should add an ARN provider role', () => {

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const BbPromise = require('bluebird');
 const filesize = require('filesize');
+const glob = require('glob');
 
 module.exports = {
   uploadCloudFormationFile() {
@@ -62,9 +63,18 @@ module.exports = {
       return BbPromise.all(uploadPromises);
     }
 
-    const stats = fs.statSync(this.serverless.service.package.artifact);
+    let artifact = this.serverless.service.package.artifact;
+    if (artifact) {
+      // if the package artifact includes wildcards, proceed iff it matches exactly one file
+      const files = glob.sync(artifact, null);
+      if (files && files.length === 1) {
+        artifact = files[0];
+      }
+    }
+
+    const stats = fs.statSync(artifact);
     this.serverless.cli.log(`Uploading service .zip file to S3 (${filesize(stats.size)})...`);
-    return this.uploadZipFile(this.serverless.service.package.artifact);
+    return this.uploadZipFile(artifact);
   },
 
   uploadArtifacts() {

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -9,6 +9,7 @@ const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 const testUtils = require('../../../../../tests/utils');
 const fs = require('fs');
+const glob = require('glob');
 
 describe('uploadArtifacts', () => {
   let serverless;
@@ -145,6 +146,45 @@ describe('uploadArtifacts', () => {
         fs.statSync.restore();
         awsDeploy.uploadZipFile.restore();
       });
+    });
+
+    it('should upload a single matching service artifact file to the S3 bucket', () => {
+      const artifactFilePathWildcard = 'artifact*.zip';
+      const artifactFilePathExact = 'artifact-1.zip';
+
+      sinon.stub(glob, 'sync').returns([artifactFilePathExact]);
+      sinon.stub(fs, 'statSync').withArgs(artifactFilePathExact)
+        .returns({ size: 0 });
+
+      awsDeploy.serverless.service.package.artifact = artifactFilePathWildcard;
+
+      const uploadZipFileStub = sinon
+        .stub(awsDeploy, 'uploadZipFile').returns(BbPromise.resolve());
+
+      return awsDeploy.uploadFunctions().then(() => {
+        expect(uploadZipFileStub.calledOnce).to.be.equal(true);
+        expect(uploadZipFileStub.args[0][0]).to.be.equal(artifactFilePathExact);
+        fs.statSync.restore();
+        glob.sync.restore();
+      });
+    });
+
+    it('should fail if multiple files match the service artifact containing a wildcard', () => {
+      const artifactFilePathWildcard = 'artifact*.zip';
+      const artifactFilePathExact = 'artifact-1.zip';
+
+      sinon.stub(glob, 'sync').returns([artifactFilePathExact, 'artifact-2.zip']);
+      sinon.stub(fs, 'statSync').withArgs(artifactFilePathWildcard).throws()
+        .withArgs(artifactFilePathExact)
+        .returns({ size: 0 });
+
+      awsDeploy.serverless.service.package.artifact = artifactFilePathWildcard;
+
+      expect(() => {
+        awsDeploy.uploadFunctions();
+      }).to.throw();
+      fs.statSync.restore();
+      glob.sync.restore();
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #3267
Allow the package artifact to contain wildcards.

## How did you implement it:
If a wildcard pattern if specified as the package artifact in serverless.yml, it is expanded and checked to see whether exactly one file matches.  If one file matches, use that file.  Otherwise, fail with a warning message.

## How can we verify it:
In serverless.yml, specify a pattern with wildcards artifact, for example:

```yml
package:
   artifact: "myProject-*.jar"
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
