### PR TITLE
Final command doesn't work

### DIFF
--- a/docs/providers/azure/guide/quickstart.md
+++ b/docs/providers/azure/guide/quickstart.md
@@ -105,5 +105,5 @@ serverless deploy
 Run the [invoke command](../cli-reference/invoke.md)
 
 ```bash
-serverless invoke function -f httpjs
+serverless invoke -f httpjs
 ```


### PR DESCRIPTION
Needs to either be --function or -f, not function -f

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes one bad command in the quickstart documentatoin

<!--
Briefly describe the feature if no issue exists for this PR
-->

Removed a few characters

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Trivial



## Todos:


***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
