### PR TITLE
Corrected Access-Control-Allow-Methods for ANY HTTP events

### DIFF
--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.js
@@ -19,7 +19,7 @@ module.exports = {
         'Access-Control-Allow-Credentials': `'${config.allowCredentials}'`,
       };
 
-      if(config.methods.indexOf('ANY') > -1){
+      if( _.includes(config.methods, 'ANY')){
         preflightHeaders['Access-Control-Allow-Methods'] =
           preflightHeaders['Access-Control-Allow-Methods'].replace('ANY', 'DELETE,GET,HEAD,PATCH,POST,PUT');
       }

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.js
@@ -19,9 +19,10 @@ module.exports = {
         'Access-Control-Allow-Credentials': `'${config.allowCredentials}'`,
       };
 
-      if( _.includes(config.methods, 'ANY')){
+      if (_.includes(config.methods, 'ANY')) {
         preflightHeaders['Access-Control-Allow-Methods'] =
-          preflightHeaders['Access-Control-Allow-Methods'].replace('ANY', 'DELETE,GET,HEAD,PATCH,POST,PUT');
+          preflightHeaders['Access-Control-Allow-Methods']
+            .replace('ANY', 'DELETE,GET,HEAD,PATCH,POST,PUT');
       }
 
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.js
@@ -19,6 +19,11 @@ module.exports = {
         'Access-Control-Allow-Credentials': `'${config.allowCredentials}'`,
       };
 
+      if(config.methods.indexOf('ANY') > -1){
+        preflightHeaders['Access-Control-Allow-Methods'] =
+          preflightHeaders['Access-Control-Allow-Methods'].replace('ANY', 'DELETE,GET,HEAD,PATCH,POST,PUT');
+      }
+
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [corsMethodLogicalId]: {
           Type: 'AWS::ApiGateway::Method',

--- a/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/deploy/compile/events/apiGateway/lib/cors.test.js
@@ -39,12 +39,14 @@ describe('#compileCors()', () => {
       'users/list': 'ApiGatewayResourceUsersList',
       'users/update': 'ApiGatewayResourceUsersUpdate',
       'users/delete': 'ApiGatewayResourceUsersDelete',
+      'users/any': 'ApiGatewayResourceUsersAny',
     };
     awsCompileApigEvents.apiGatewayResourceNames = {
       'users/create': 'UsersCreate',
       'users/list': 'UsersList',
       'users/update': 'UsersUpdate',
       'users/delete': 'UsersDelete',
+      'users/any': 'UsersAny',
     };
     awsCompileApigEvents.validated = {};
   });
@@ -67,6 +69,12 @@ describe('#compileCors()', () => {
         origins: ['*'],
         headers: ['CustomHeaderA', 'CustomHeaderB'],
         methods: ['OPTIONS', 'DELETE'],
+        allowCredentials: false,
+      },
+      'users/any': {
+        origins: ['*'],
+        headers: ['*'],
+        methods: ['OPTIONS', 'ANY'],
         allowCredentials: false,
       },
     };
@@ -144,6 +152,34 @@ describe('#compileCors()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersDeleteOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
+      ).to.equal('\'false\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersAnyOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
+      ).to.equal('\'*\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersAnyOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Headers']
+      ).to.equal('\'*\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersAnyOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Methods']
+      ).to.equal('\'OPTIONS,DELETE,GET,HEAD,PATCH,POST,PUT\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersAnyOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
       ).to.equal('\'false\'');


### PR DESCRIPTION
The Access-Control-Allow-Methods OPTIONS response header for ANY http
verb requests now correctly includes all HTTP verbs.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless/serverless/issues/3303

## How did you implement it:

This PR checks if the methods array includes the `ANY` verb. If so, it replaces the unrecognised `ANY` method in the `Access-Control-Allow-Methods` header with the correct HTTP verbs `'DELETE,GET,HEAD,PATCH,POST,PUT'`.

## How can we verify it:

The appropriate tests have been updated to include the ANY method.

-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO