### PR TITLE
Allow entrypoints to be defined and called by plugins.

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -117,9 +117,18 @@ class PluginManager {
     return this.commands;
   }
 
-  getCommand(commandsArray) {
+  /**
+   * Retrieve the command specified by a command list. The method can be configured
+   * to include entrypoint commands (which are invisible to the CLI and can only
+   * be used by plugins).
+   * @param commandsArray {Array<String>} Commands
+   * @param allowEntryPoints {undefined|boolean} Allow entrypoint commands to be returned
+   * @returns {Object} Command
+   */
+  getCommand(commandsArray, allowEntryPoints) {
     return _.reduce(commandsArray, (current, name, index) => {
-      if (name in current.commands) {
+      if (name in current.commands &&
+         (allowEntryPoints || current.commands[name].type !== 'entrypoint')) {
         return current.commands[name];
       }
       const commandName = commandsArray.slice(0, index + 1).join(' ');
@@ -143,8 +152,8 @@ class PluginManager {
     return this.plugins;
   }
 
-  run(commandsArray) {
-    const command = this.getCommand(commandsArray);
+  invoke(commandsArray, allowEntryPoints) {
+    const command = this.getCommand(commandsArray, allowEntryPoints);
 
     this.convertShortcutsIntoOptions(command);
     this.validateOptions(command);
@@ -160,6 +169,25 @@ class PluginManager {
     return BbPromise.reduce(hooks, (__, hook) => hook(), null);
   }
 
+  /**
+   * Invokes the given command and starts the command's lifecycle.
+   * This method can be called by plugins directly to spawn a separate sub lifecycle.
+   */
+  spawn(commandsArray) {
+    return this.invoke(commandsArray, true);
+  }
+
+  /**
+   * Called by the CLI to start a public command.
+   */
+  run(commandsArray) {
+    return this.invoke(commandsArray);
+  }
+
+  /**
+   * Check if the command is valid. Internally this function will only find
+   * CLI accessible commands (command.type !== 'entrypoint')
+   */
   validateCommand(commandsArray) {
     this.getCommand(commandsArray);
   }

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -188,6 +188,109 @@ describe('PluginManager', () => {
     }
   }
 
+  class EntrypointPluginMock {
+    constructor() {
+      this.commands = {
+        myep: {
+          type: 'entrypoint',
+          lifecycleEvents: [
+            'initialize',
+            'finalize',
+          ],
+          commands: {
+            // EP, not public command because its parent is decalred as EP
+            mysubep: {
+              lifecycleEvents: [
+                'initialize',
+                'finalize',
+              ],
+            },
+            // EP that will spawn sub lifecycles
+            spawnep: {
+              lifecycleEvents: [
+                'event1',
+                'event2',
+              ],
+            },
+          },
+        },
+        // public command
+        mycmd: {
+          lifecycleEvents: [
+            'run',
+          ],
+          commands: {
+            // public subcommand
+            mysubcmd: {
+              lifecycleEvents: [
+                'initialize',
+                'finalize',
+              ],
+            },
+            // command that will spawn sub lifecycles
+            spawncmd: {
+              lifecycleEvents: [
+                'event1',
+                'event2',
+              ],
+            },
+          },
+        },
+
+      };
+
+      this.hooks = {
+        'myep:initialize': this.initialize.bind(this),
+        'myep:finalize': this.finalize.bind(this),
+        'myep:mysubep:initialize': this.subEPInitialize.bind(this),
+        'myep:mysubep:finalize': this.subEPFinalize.bind(this),
+        'mycmd:mysubcmd:initialize': this.subInitialize.bind(this),
+        'mycmd:mysubcmd:finalize': this.subFinalize.bind(this),
+        'mycmd:run': this.run.bind(this),
+        // Event1 spawns mysubcmd, then myep
+        // Event2 spawns mycmd, then mysubep
+        'myep:spawnep:event1': () => pluginManager.spawn(['mycmd', 'mysubcmd'])
+          .then(() => pluginManager.spawn(['myep'])),
+        'myep:spawnep:event2': () => pluginManager.spawn(['mycmd'])
+          .then(() => pluginManager.spawn(['myep', 'mysubep'])),
+        'mycmd:spawncmd:event1': () => pluginManager.spawn(['mycmd', 'mysubcmd'])
+          .then(() => pluginManager.spawn(['myep'])),
+        'mycmd:spawncmd:event2': () => pluginManager.spawn(['mycmd'])
+          .then(() => pluginManager.spawn(['myep', 'mysubep'])),
+      };
+
+      this.callResult = '';
+    }
+
+    initialize() {
+      this.callResult += '>initialize';
+    }
+
+    finalize() {
+      this.callResult += '>finalize';
+    }
+
+    subEPInitialize() {
+      this.callResult += '>subEPInitialize';
+    }
+
+    subEPFinalize() {
+      this.callResult += '>subEPFinalize';
+    }
+
+    subInitialize() {
+      this.callResult += '>subInitialize';
+    }
+
+    subFinalize() {
+      this.callResult += '>subFinalize';
+    }
+
+    run() {
+      this.callResult += '>run';
+    }
+  }
+
   beforeEach(function () { // eslint-disable-line prefer-arrow-callback
     serverless = new Serverless();
     pluginManager = new PluginManager(serverless);
@@ -601,6 +704,22 @@ describe('PluginManager', () => {
       expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
     });
 
+    it('should throw an error when the given command is an entrypoint', () => {
+      pluginManager.addPlugin(EntrypointPluginMock);
+
+      const commandsArray = ['myep'];
+
+      expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
+    });
+
+    it('should throw an error when the given command is a child of an entrypoint', () => {
+      pluginManager.addPlugin(EntrypointPluginMock);
+
+      const commandsArray = ['mysubcmd'];
+
+      expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
+    });
+
     it('should throw an error when the given command has no hooks', () => {
       class HooklessPlugin {
         constructor() {
@@ -733,6 +852,108 @@ describe('PluginManager', () => {
           expect(pluginManager.plugins[1].provider).to.equal(undefined);
         });
       });
+    });
+
+    it('should run commands with internal lifecycles', () => {
+      pluginManager.addPlugin(EntrypointPluginMock);
+
+      const commandsArray = ['mycmd', 'spawncmd'];
+
+      return pluginManager.run(commandsArray)
+        .then(() => {
+          expect(pluginManager.plugins[0].callResult)
+          .to.equal(
+            '>subInitialize>subFinalize>initialize>finalize>run>subEPInitialize>subEPFinalize'
+          );
+        });
+    });
+  });
+
+  describe('#spawn()', () => {
+    it('should throw an error when the given command is not available', () => {
+      pluginManager.addPlugin(EntrypointPluginMock);
+
+      const commandsArray = ['foo'];
+
+      expect(() => { pluginManager.spawn(commandsArray); }).to.throw(Error);
+    });
+
+    it('should throw an error when the given command has no hooks', () => {
+      class HooklessPlugin {
+        constructor() {
+          this.commands = {
+            foo: {},
+          };
+        }
+      }
+
+      pluginManager.addPlugin(HooklessPlugin);
+
+      const commandsArray = ['foo'];
+
+      expect(() => { pluginManager.spawn(commandsArray); }).to.throw(Error);
+    });
+
+    describe('when invoking a command', () => {
+      it('should succeed', () => {
+        pluginManager.addPlugin(EntrypointPluginMock);
+
+        const commandsArray = ['mycmd'];
+
+        return pluginManager.spawn(commandsArray)
+          .then(() => {
+            expect(pluginManager.plugins[0].callResult).to.equal('>run');
+          });
+      });
+
+      it('should spawn nested commands', () => {
+        pluginManager.addPlugin(EntrypointPluginMock);
+
+        const commandsArray = ['mycmd', 'mysubcmd'];
+
+        return pluginManager.spawn(commandsArray)
+          .then(() => {
+            expect(pluginManager.plugins[0].callResult).to.equal('>subInitialize>subFinalize');
+          });
+      });
+    });
+
+    describe('when invoking an entrypoint', () => {
+      it('should succeed', () => {
+        pluginManager.addPlugin(EntrypointPluginMock);
+
+        const commandsArray = ['myep'];
+
+        return pluginManager.spawn(commandsArray)
+          .then(() => {
+            expect(pluginManager.plugins[0].callResult).to.equal('>initialize>finalize');
+          });
+      });
+
+      it('should spawn nested entrypoints', () => {
+        pluginManager.addPlugin(EntrypointPluginMock);
+
+        const commandsArray = ['myep', 'mysubep'];
+
+        return pluginManager.spawn(commandsArray)
+          .then(() => {
+            expect(pluginManager.plugins[0].callResult).to.equal('>subEPInitialize>subEPFinalize');
+          });
+      });
+    });
+
+    it('should spawn entrypoints with internal lifecycles', () => {
+      pluginManager.addPlugin(EntrypointPluginMock);
+
+      const commandsArray = ['myep', 'spawnep'];
+
+      return pluginManager.spawn(commandsArray)
+        .then(() => {
+          expect(pluginManager.plugins[0].callResult)
+          .to.equal(
+            '>subInitialize>subFinalize>initialize>finalize>run>subEPInitialize>subEPFinalize'
+          );
+        });
     });
   });
 


### PR DESCRIPTION
Commands can contain an optional type property. The only allowed value currently is 'entrypoint'. This declares the command as hidden from the CLI. It will not appear in the help screen, nor can it be called from there.
However, entrypoint type commands can be called by plugins via the new PluginManager.spawn(commandsArray) method. In contrast to PluginManager.run() this method allows access to entrypoint commands and can be used to enter a plugin internal sub lifecycle. With this mechanism in place, plugins can expose their own lifecycle events which become then part of the global lifecycle and can be hooked again by dependent plugins.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
