### PR TITLE
Adding Azure Functions/Node create template

### DIFF
--- a/docs/providers/azure/cli-reference/create.md
+++ b/docs/providers/azure/cli-reference/create.md
@@ -1,0 +1,67 @@
+<!--
+title: Serverless Framework Commands - Azure Functions - Create
+menuText: Create
+menuOrder: 2
+description: Creates a new Service in your current working directory
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/azure/cli-reference/deploy)
+<!-- DOCS-SITE-LINK:END -->
+
+# Azure - Create
+
+Creates a new service in the current working directory based on the specified template.
+
+**Create service in current working directory:**
+
+```bash
+serverless create --template azure-nodejs
+```
+
+**Create service in new folder:**
+
+```bash
+serverless create --template azure-nodejs --path myService
+```
+
+## Options
+- `--template` or `-t` The name of one of the available templates. **Required**.
+- `--path` or `-p` The path where the service should be created.
+- `--name` or `-n` the name of the service in `serverless.yml`.
+
+## Provided lifecycle events
+- `create:create`
+
+## Available Templates
+
+To see a list of available templates run `serverless create --help`
+
+Most commonly used templates:
+
+- azure-nodejs
+
+## Examples
+
+### Creating a new service
+
+```bash
+serverless create --template azure-nodejs --name my-special-service
+```
+
+This example will generate scaffolding for a service with `Azure` as a provider and `nodejs` as runtime. The scaffolding
+will be generated in the current working directory.
+
+### Creating a named service in a (new) directory
+
+```bash
+serverless create --template azure-nodejs --path my-new-service
+```
+
+This example will generate scaffolding for a service with `Azure` as a provider and `nodejs` as runtime. The scaffolding
+will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless
+will use the already present directory.
+
+Additionally Serverless will rename the service according to the path you provide. In this example the service will be
+renamed to `my-new-service`.

--- a/docs/providers/azure/guide/quickstart.md
+++ b/docs/providers/azure/guide/quickstart.md
@@ -21,7 +21,7 @@ To setup the boilerplate, follow these instructions:
 1. Install the boilerplate
 
     ```bash
-    serverless install --url https://github.com/azure/boilerplate-azurefunctions --name <my-app>
+    serverless create -t azure-nodejs --path <my-app>
     ```
 
 2. Install the dependencies
@@ -105,5 +105,5 @@ serverless deploy
 Run the [invoke command](../cli-reference/invoke.md)
 
 ```bash
-serverless invoke -f httpjs
+serverless invoke -f hello
 ```

--- a/docs/providers/azure/guide/services.md
+++ b/docs/providers/azure/guide/services.md
@@ -39,16 +39,18 @@ This makes sense since related functions usually use common infrastructure resou
 
 ## Creation
 
-There isn't yet a `serverless create` command, so to get started you can instead start by installing the boilerplate from GitHub.
+To get started, you can simply use the `create` command to generate a new service:
 
 ```bash
-serverless install --url https://github.com/azure/boilerplate-azurefunctions --name my-app
+serverless create -t azure-nodejs --path <my-app>
 ```
+
+> Alternatively, you can use the `install` command to create a new service, based on an existing GitHub boilerplate: `serverless install --url https://github.com/azure/boilerplate-azurefunctions --name my-app`
 
 ## Contents
 
 You'll see the following files in your working directory:
-- `templates/serverless.yml`
+- `serverless.yml`
 - `handler.js`
 
 ### serverless.yml
@@ -79,7 +81,7 @@ plugins:
 
 functions:
   hello: 
-     handler: templates/handler.hello
+     handler: handler.hello
      events: 
        - http: true
          x-azure-settings:
@@ -88,7 +90,7 @@ functions:
 
 ### handler.js
 
-The `templates/handler.js` file contains your function code. The function definition in `serverless.yml` will point to this `templates/handler.js` file and the function exported here.
+The `handler.js` file contains your function code. The function definition in `serverless.yml` will point to this `handler.js` file and the function exported here.
 
 ### event.json
 

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -13,6 +13,7 @@ const validTemplates = [
   'aws-java-gradle',
   'aws-scala-sbt',
   'aws-csharp',
+  'azure-nodejs',
   'openwhisk-nodejs',
   'plugin',
 ];

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -278,6 +278,26 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "azure-nodejs" template', () => {
+      const cwd = process.cwd();
+      fse.mkdirsSync(tmpDir);
+      process.chdir(tmpDir);
+      create.options.template = 'azure-nodejs';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'package.json')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.js')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+
+        process.chdir(cwd);
+      });
+    });
+
     // this test should live here because of process.cwd() which might cause trouble when using
     // nested dirs like its done here
     it('should create a plugin in the current directory', () => {

--- a/lib/plugins/create/templates/azure-nodejs/.gitignore
+++ b/lib/plugins/create/templates/azure-nodejs/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/azure-nodejs/README.md
+++ b/lib/plugins/create/templates/azure-nodejs/README.md
@@ -1,0 +1,54 @@
+# Serverless Azure Functions Node.js Template
+
+This starter template allows quickly creating a Node.js-based service to Azure Functions. It relies on the `serverless-azure-functions` plugin, and therefore, before you can deploy it, you simply need to run `npm install` in order to acquire it (this dependency is already saved in the `package.json` file).
+
+### Setting up your Azure credentials
+
+Once the `serverless-azure-functions` plugin is installed, it expects to find your Azure credentials via a set of well-known environment variables. These will be used to actually authenticate with your Azure account, so that the Serverless CLI can generate the neccessary Azure resources on your behalf when you request a deployment (see below).
+
+The following environment variables must be set, with their respective values:
+
+- *azureSubId* - ID of the Azure subscription you want to create your service within
+- *azureServicePrincipalTenantId* - ID of the tenant that your service principal was created within
+- *azureServicePrincipalClientId* - ID of the service principal you want to use to authenticate with Azure
+- *azureServicePrincipalPassword* - Password of the service principal you want to use to autheticate with Azure
+
+For details on how to create a service principal and/or acquire your Azure account's subscription/tenant ID, refer to the [Azure credentials](https://serverless.com/framework/docs/providers/azure/guide/credentials/) documentation.
+
+### Deploying the service
+
+Once your Azure credentials are set, you can immediately deploy your service via the following command:
+
+```shell
+serverless deploy
+```
+
+This will create the neccessary Azure resources to support the service and events that are defined in your `serverless.yml` file. 
+
+### Invoking and inspecting a function
+
+With the service deployed, you can test it's functions using the following command:
+
+```shell
+serverless invoke -f hello
+```
+
+Additionally, if you'd like to view the logs that a function generates (either via the runtime, or create by your handler by calling `context.log`), you can simply run the following command:
+
+```shell
+serverless logs -f hello
+```
+
+### Cleaning up
+
+Once you're finished with your service, you can remove all of the generated Azure resources by simply running the following command:
+
+```shell
+serveless remove
+```
+
+### Issues / Feedback / Feature Requests?
+
+If you have any issues, comments or want to see new features, please file an issue in the project repository:
+
+https://github.com/serverless/serverless-azure-functions

--- a/lib/plugins/create/templates/azure-nodejs/handler.js
+++ b/lib/plugins/create/templates/azure-nodejs/handler.js
@@ -1,10 +1,10 @@
 'use strict';
 
 module.exports.hello = function (context, req) {
-    // Add any neccessary telemetry to support diagnosing your function
-    context.log('HTTP trigger occured!');
-    
-    // Read properties from the incoming request, and respond as appropriate.
-    const name = req.query.name || (req.body && req.body.name) || 'World';
-    context.done(null, { body: `Hello ${name}` });
+  // Add any neccessary telemetry to support diagnosing your function
+  context.log('HTTP trigger occured!');
+
+  // Read properties from the incoming request, and respond as appropriate.
+  const name = req.query.name || (req.body && req.body.name) || 'World';
+  context.done(null, { body: `Hello ${name}` });
 };

--- a/lib/plugins/create/templates/azure-nodejs/handler.js
+++ b/lib/plugins/create/templates/azure-nodejs/handler.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports.hello = function (context, req) {
+    // Add any neccessary telemetry to support diagnosing your function
+    context.log('HTTP trigger occured!');
+    
+    // Read properties from the incoming request, and respond as appropriate.
+    const name = req.query.name || (req.body && req.body.name) || 'World';
+    context.done(null, { body: `Hello ${name}` });
+};

--- a/lib/plugins/create/templates/azure-nodejs/package.json
+++ b/lib/plugins/create/templates/azure-nodejs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "azure-nodejs",
+  "version": "1.0.0",
+  "description": "Azure Functions sample for the Serverless framework",
+  "main": "handler.js",
+  "keywords": [
+    "azure",
+    "serverless"
+  ],
+  "devDependencies": {
+    "serverless-azure-functions": "*"
+  }
+}

--- a/lib/plugins/create/templates/azure-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/azure-nodejs/serverless.yml
@@ -1,0 +1,53 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: azure-nodejs # NOTE: update this with your service name
+
+# You can pin your service to only deploy with a specific Serverless version
+# Check out our docs for more details
+# frameworkVersion: "=X.X.X"
+
+provider:
+  name: azure
+  location: West US
+
+plugins:
+  - serverless-azure-functions
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.js
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.js
+#    - exclude-me-dir/**
+
+functions:
+  hello: 
+    handler: handler.hello
+    events: 
+      - http: true
+        x-azure-settings:
+          authLevel : anonymous
+
+# The following are a few examples of other events you can configure:
+#
+# events: 
+#   - queue: YourQueueName
+#     x-azure-settings:
+#       connection : StorageAppSettingName
+#   - blob:
+#     x-azure-settings:
+#       name: bindingName
+#       direction: in


### PR DESCRIPTION
## Why did you implement:

Closes #3333 (at least for Node.js)

## What did you implement:

I added a new template to the `create` plugin, which allows scaffolding a simple Node.js-based Azure Function, without needing to rely in `install` ing a Git repo.

This enables running the following command in order to get started quickly: `sls create -t azure-nodejs`

## How did you implement it:

Added a new template called `azure-nodejs` to the existing set of templates for the `create` plugin, and added a reference to this to the list of well-known templates.

I also updated the tests and docs to make use of the new `create` support.

## How can we verify it:

After setting the necessary [environment variables](https://serverless.com/framework/docs/providers/azure/guide/quickstart#2-set-up-credentials) for your Azure account, run the following commands, and verify that you see "Hello World" at the end:

```shell
$ sls create -t azure-nodejs --path <path>
$ cd <path>
$ npm i
$ sls deploy
$ sls invoke -f hello
"Hello World"
```

Alternatively, you could simply run `sls create -t azure-nodejs` and verify that it outputted valid `serverless.yml`, `handler.js`, and `package.json` files.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO