### PR TITLE
Use ARN for SNS Event Declaration

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -98,9 +98,7 @@ functions:
             key2: value2
             stageParams:
               stage: dev
-      - sns:
-          topicName: aggregate
-          displayName: Data aggregation pipeline
+      - sns: arn:aws:sns:REGION:XXXXXX:TopicName
       - stream:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           batchSize: 100


### PR DESCRIPTION
Deploying using the original method in this example file did not hook up the SNS event trigger to my Lambda function. Explicitly providing the ARN for the SNS Topic does.
