### PR TITLE
Add virtualenv support to Python invokeLocal

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -121,6 +121,9 @@ class AwsInvokeLocal {
   }
 
   invokeLocalPython(handlerPath, handlerName, event) {
+    if (process.env.VIRTUAL_ENV) {
+      process.env.PATH = `${process.env.VIRTUAL_ENV}/bin:${process.env.PATH}`;
+    }
     return new BbPromise(resolve => {
       const python = spawn(
         path.join(__dirname, 'invoke.py'), [handlerPath, handlerName], { env: process.env });


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Virtualenv support for python invoke local 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Since the invoke local functionality overrides `process.env.PATH`, only the
system python is found, not the python provided by an active virtualenv. This
checks for the `VIRTUAL_ENV` environment variable and if present, adds it's bin
dir to `PATH`.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
1. create a python serverless project
2. create & activate a virtualenv
3. install a dependency and import it in `handlers.py`
4. invoke the handler locally, you shouldn't get an error about the import.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
