### PR TITLE
Use globby instead of glob-all

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -4,7 +4,7 @@ const archiver = require('archiver');
 const BbPromise = require('bluebird');
 const path = require('path');
 const fs = require('fs');
-const glob = require('glob-all');
+const globby = require('globby');
 
 module.exports = {
   zipDirectory(servicePath, exclude, include, zipFileName) {
@@ -39,7 +39,7 @@ module.exports = {
     output.on('open', () => {
       zip.pipe(output);
 
-      const files = glob.sync(patterns, {
+      const files = globby.sync(patterns, {
         cwd: servicePath,
         dot: true,
         silent: true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -322,10 +322,10 @@
       "from": "glob@>=7.0.0 <8.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
     },
-    "glob-all": {
-      "version": "3.1.0",
-      "from": "glob-all@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz"
+    "globby": {
+      "version": "6.1.0",
+      "from": "globby@>=6.1.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz"
     },
     "got": {
       "version": "6.6.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "filesize": "^3.3.0",
     "fs-extra": "^0.26.7",
     "get-stdin": "^5.0.1",
-    "glob-all": "^3.1.0",
+    "globby": "^6.1.0",
     "https-proxy-agent": "^1.0.0",
     "js-yaml": "^3.6.1",
     "json-refs": "^2.1.5",


### PR DESCRIPTION
## What did you implement:

Closes #3348

The globby module uses for loops instead of recursion.

## How did you implement it:

Swapping a module name!

## How can we verify it:

`npm test` passes, this change is mostly unrelated to serverless itself but rather my plugin `serverless-plugin-include-dependencies` needs it for 2.0 since it produces a large list of files to include.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
