### PR TITLE
Reduce test time by 50%

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -130,9 +130,10 @@ class AwsProvider {
         f()
           .then(resolve)
           .catch((e) => {
+            const retryInterval = process.env.AWS_CLIENT_RETRY_INTERVAL || 5000;
             if (e.statusCode === 429) {
               that.serverless.cli.log("'Too many requests' received, sleeping 5 seconds");
-              setTimeout(doCall, 5000);
+              setTimeout(doCall, parseInt(retryInterval, 10));
             } else {
               reject(e);
             }

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -130,10 +130,9 @@ class AwsProvider {
         f()
           .then(resolve)
           .catch((e) => {
-            const retryInterval = process.env.AWS_CLIENT_RETRY_INTERVAL || 5000;
             if (e.statusCode === 429) {
               that.serverless.cli.log("'Too many requests' received, sleeping 5 seconds");
-              setTimeout(doCall, parseInt(retryInterval, 10));
+              setTimeout(doCall, 5000);
             } else {
               reject(e);
             }

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -98,7 +98,7 @@ describe('AwsProvider', () => {
     });
 
     it('should retry if error code is 429', function (done) {
-      this.timeout(10000);
+      this.timeout(1000);
       let first = true;
       const error = {
         statusCode: 429,
@@ -125,10 +125,12 @@ describe('AwsProvider', () => {
       awsProvider.sdk = {
         S3: FakeS3,
       };
+      process.env.AWS_CLIENT_RETRY_INTERVAL = '250';
       awsProvider.request('S3', 'error', {})
         .then(data => {
           expect(data).to.exist; // eslint-disable-line no-unused-expressions
           expect(first).to.be.false; // eslint-disable-line no-unused-expressions
+          delete process.env.AWS_CLIENT_RETRY_INTERVAL;
           done();
         })
         .catch(done);

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -97,8 +97,8 @@ describe('AwsProvider', () => {
       });
     });
 
-    it('should retry if error code is 429', function (done) {
-      this.timeout(1000);
+    it('should retry if error code is 429', (done) => {
+      sinon.stub(global, 'setTimeout', (cb) => { cb(); });
       let first = true;
       const error = {
         statusCode: 429,
@@ -125,12 +125,10 @@ describe('AwsProvider', () => {
       awsProvider.sdk = {
         S3: FakeS3,
       };
-      process.env.AWS_CLIENT_RETRY_INTERVAL = '250';
       awsProvider.request('S3', 'error', {})
         .then(data => {
           expect(data).to.exist; // eslint-disable-line no-unused-expressions
           expect(first).to.be.false; // eslint-disable-line no-unused-expressions
-          delete process.env.AWS_CLIENT_RETRY_INTERVAL;
           done();
         })
         .catch(done);


### PR DESCRIPTION
This commit removes a hardcoded 5 second sleep intended to help handle
rate limits. The retry interval is changed during the test to 250ms from
5 seconds, with no change to the runtime behavior of the framework.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:


Run `npm test` with and without this patch. It will be 2x faster with this patch. 
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
