### PR TITLE
Reduce dependency tree depth between IAM & Log Groups

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -155,6 +155,9 @@ class AwsCompileFunctions {
       delete newFunction.Properties.VpcConfig;
     }
 
+    newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)]
+      .concat(newFunction.DependsOn || []);
+
     const functionLogicalId = this.provider.naming
       .getLambdaLogicalId(functionName);
     const newFunctionObject = {

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -102,7 +102,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.compileFunctions();
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction).not.to.have.property('DependsOn');
+        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
@@ -122,7 +122,7 @@ describe('AwsCompileFunctions', () => {
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['LogicalNameRole']);
+      ).to.deep.equal(['FuncLogGroup', 'LogicalNameRole']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal({
@@ -152,7 +152,7 @@ describe('AwsCompileFunctions', () => {
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['LogicalRoleName']);
+      ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
@@ -171,7 +171,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.compileFunctions();
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction).not.to.have.property('DependsOn');
+        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
@@ -191,7 +191,7 @@ describe('AwsCompileFunctions', () => {
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['LogicalRoleName']);
+      ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal({
@@ -221,7 +221,7 @@ describe('AwsCompileFunctions', () => {
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['LogicalRoleName']);
+      ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
@@ -242,7 +242,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.compileFunctions();
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction).not.to.have.property('DependsOn');
+        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
@@ -262,7 +262,7 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.compileFunctions();
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction).not.to.have.property('DependsOn');
+        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.FuncLambdaFunction.Properties.Role
       ).to.equal(awsCompileFunctions.serverless.service.functions.func.role);
@@ -286,13 +286,13 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.compileFunctions();
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func0LambdaFunction).not.to.have.property('DependsOn');
+        .Resources.Func0LambdaFunction.DependsOn).to.deep.equal(['Func0LogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.Func0LambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func0.role);
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func1LambdaFunction).not.to.have.property('DependsOn');
+        .Resources.Func1LambdaFunction.DependsOn).to.deep.equal(['Func1LogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.Func1LambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func1.role);
@@ -316,13 +316,13 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.compileFunctions();
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func0LambdaFunction).not.to.have.property('DependsOn');
+        .Resources.Func0LambdaFunction.DependsOn).to.deep.equal(['Func0LogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.Func0LambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
 
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func1LambdaFunction).not.to.have.property('DependsOn');
+        .Resources.Func1LambdaFunction.DependsOn).to.deep.equal(['Func1LogGroup']);
       expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
         .Resources.Func1LambdaFunction.Properties.Role
       ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func1.role);
@@ -348,6 +348,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -388,6 +389,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -431,6 +433,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -479,6 +482,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -525,6 +529,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -570,6 +575,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -618,6 +624,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -675,6 +682,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -715,6 +723,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -749,6 +758,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -787,6 +797,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {
@@ -827,6 +838,7 @@ describe('AwsCompileFunctions', () => {
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
+          'FuncLogGroup',
           'IamRoleLambdaExecution',
         ],
         Properties: {

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -72,6 +72,7 @@ module.exports = {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const logGroupLogicalId = this.provider.naming
         .getLogGroupLogicalId(functionName);
+      const functionObject = this.serverless.service.getFunction(functionName);
 
       this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.provider.naming.getRoleLogicalId()]
@@ -80,7 +81,8 @@ module.exports = {
         .PolicyDocument
         .Statement[0]
         .Resource
-        .push({ 'Fn::GetAtt': [logGroupLogicalId, 'Arn'] });
+        .push({ 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}' +
+          `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}` });
 
       this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.provider.naming.getRoleLogicalId()]
@@ -89,7 +91,8 @@ module.exports = {
         .PolicyDocument
         .Statement[1]
         .Resource
-        .push({ 'Fn::Join': [':', [{ 'Fn::GetAtt': [logGroupLogicalId, 'Arn'] }, '*']] });
+        .push({ 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}' +
+          `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*` });
     });
 
     if (this.serverless.service.provider.iamRoleStatements) {

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -70,8 +70,6 @@ module.exports = {
     );
 
     this.serverless.service.getAllFunctions().forEach((functionName) => {
-      const logGroupLogicalId = this.provider.naming
-        .getLogGroupLogicalId(functionName);
       const functionObject = this.serverless.service.getFunction(functionName);
 
       this.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
@@ -51,6 +51,7 @@ describe('#mergeIamTemplates()', () => {
     () => awsDeploy.mergeIamTemplates()
       .then(() => {
         const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
+        const qualifiedFunction = awsDeploy.serverless.service.getFunction(functionName).name;
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[awsDeploy.provider.naming.getRoleLogicalId()]
         ).to.deep.equal({
@@ -95,7 +96,7 @@ describe('#mergeIamTemplates()', () => {
                       ],
                       Resource: [
                         {
-                          'Fn::GetAtt': [normalizedName, 'Arn'],
+                          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction,
                         },
                       ],
                     },
@@ -106,13 +107,7 @@ describe('#mergeIamTemplates()', () => {
                       ],
                       Resource: [
                         {
-                          'Fn::Join': [
-                            ':',
-                            [
-                              { 'Fn::GetAtt': [normalizedName, 'Arn'] },
-                              '*',
-                            ],
-                          ],
+                          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction + ':*',
                         },
                       ],
                     },
@@ -285,6 +280,7 @@ describe('#mergeIamTemplates()', () => {
 
   it('should update IamRoleLambdaExecution with a logging resource for the function', () => {
     const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
+    const qualifiedFunction = awsDeploy.serverless.service.getFunction(functionName).name;
     return awsDeploy.mergeIamTemplates().then(() => {
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[awsDeploy.provider.naming.getRoleLogicalId()]
@@ -293,7 +289,11 @@ describe('#mergeIamTemplates()', () => {
         .PolicyDocument
         .Statement[0]
         .Resource
-      ).to.deep.equal([{ 'Fn::GetAtt': [normalizedName, 'Arn'] }]);
+      ).to.deep.equal([
+        {
+          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction,
+        },
+      ]);
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[awsDeploy.provider.naming.getRoleLogicalId()]
         .Properties
@@ -301,7 +301,11 @@ describe('#mergeIamTemplates()', () => {
         .PolicyDocument
         .Statement[1]
         .Resource
-      ).to.deep.equal([{ 'Fn::Join': [':', [{ 'Fn::GetAtt': [normalizedName, 'Arn'] }, '*']] }]);
+      ).to.deep.equal([
+        {
+          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction + ':*',
+        },
+      ]);
     });
   });
 
@@ -331,8 +335,8 @@ describe('#mergeIamTemplates()', () => {
         .Resource
       ).to.deep.equal(
         [
-          { 'Fn::GetAtt': [normalizedNames[0], 'Arn'] },
-          { 'Fn::GetAtt': [normalizedNames[1], 'Arn'] },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func0' },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func1' },
         ]
       );
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -344,8 +348,8 @@ describe('#mergeIamTemplates()', () => {
         .Resource
       ).to.deep.equal(
         [
-          { 'Fn::Join': [':', [{ 'Fn::GetAtt': [normalizedNames[0], 'Arn'] }, '*']] },
-          { 'Fn::Join': [':', [{ 'Fn::GetAtt': [normalizedNames[1], 'Arn'] }, '*']] },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func0:*' },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func1:*' },
         ]
       );
     });

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
@@ -50,7 +50,6 @@ describe('#mergeIamTemplates()', () => {
   it('should merge the IamRoleLambdaExecution template into the CloudFormation template',
     () => awsDeploy.mergeIamTemplates()
       .then(() => {
-        const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
         const qualifiedFunction = awsDeploy.serverless.service.getFunction(functionName).name;
         expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[awsDeploy.provider.naming.getRoleLogicalId()]
@@ -96,7 +95,8 @@ describe('#mergeIamTemplates()', () => {
                       ],
                       Resource: [
                         {
-                          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction,
+                          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+                            + `log-group:/aws/lambda/${qualifiedFunction}`,
                         },
                       ],
                     },
@@ -107,7 +107,8 @@ describe('#mergeIamTemplates()', () => {
                       ],
                       Resource: [
                         {
-                          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction + ':*',
+                          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+                            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
                         },
                       ],
                     },
@@ -279,7 +280,6 @@ describe('#mergeIamTemplates()', () => {
   });
 
   it('should update IamRoleLambdaExecution with a logging resource for the function', () => {
-    const normalizedName = awsDeploy.provider.naming.getLogGroupLogicalId(functionName);
     const qualifiedFunction = awsDeploy.serverless.service.getFunction(functionName).name;
     return awsDeploy.mergeIamTemplates().then(() => {
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -291,7 +291,8 @@ describe('#mergeIamTemplates()', () => {
         .Resource
       ).to.deep.equal([
         {
-          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction,
+          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+            + `log-group:/aws/lambda/${qualifiedFunction}`,
         },
       ]);
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -303,7 +304,8 @@ describe('#mergeIamTemplates()', () => {
         .Resource
       ).to.deep.equal([
         {
-          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/' + qualifiedFunction + ':*',
+          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
         },
       ]);
     });
@@ -320,11 +322,6 @@ describe('#mergeIamTemplates()', () => {
         name: 'func1',
       },
     };
-    const f = awsDeploy.serverless.service.functions; // avoid 100 char lines below
-    const normalizedNames = [
-      awsDeploy.provider.naming.getLogGroupLogicalId(f.func0.name),
-      awsDeploy.provider.naming.getLogGroupLogicalId(f.func1.name),
-    ];
     return awsDeploy.mergeIamTemplates().then(() => {
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[awsDeploy.provider.naming.getRoleLogicalId()]
@@ -335,8 +332,10 @@ describe('#mergeIamTemplates()', () => {
         .Resource
       ).to.deep.equal(
         [
-          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func0' },
-          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func1' },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+              + 'log-group:/aws/lambda/func0' },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+              + 'log-group:/aws/lambda/func1' },
         ]
       );
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -348,8 +347,10 @@ describe('#mergeIamTemplates()', () => {
         .Resource
       ).to.deep.equal(
         [
-          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func0:*' },
-          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/func1:*' },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+              + 'log-group:/aws/lambda/func0:*' },
+          { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
+              + 'log-group:/aws/lambda/func1:*' },
         ]
       );
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

In CloudFormation, resources are created based on a DAG built from the template file. Previously, the Lambda function IAM policy had references to all log groups like this: `{"Fn::Join": [":", [{"Fn::GetAtt": ["TestFunctionLogGroup", "Arn"]}, "*"]]},` for every log group. This made the IAM policy depend on *all* the log groups completing so they could be referenced in the policy. This patch makes use of the `AWS::Region` and `AWS::AccountID` pseudo-parameters to fill in a full ARN for the group. 

After this change, IAM policy lines look like:

```
{"Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/myservice-dev-test-function:*"}
```

The upshot here is that there's no reference to the CFN `AWS::Logs::LogGroup` resource, so the dependency graph becomes more parallel (allowing CloudFormation to do more at once) and makes deploys faster. 

The one downside to this change is that it *could* result in Lambdas being deployed before their log groups, because currently the Lambda depends on the IAM role which then depends on the log group. I can add a `DependsOn` for each Lambda to its respective log group. In practice, I haven't seen this occur because the IAM role takes much longer to deploy than the log groups. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
