### PR TITLE
Re-Add Google Cloud Functions documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ layout: Doc
 menuItems:
   - {menuText: AWS, path: /framework/docs/providers/aws/}
   - {menuText: Azure, path: /framework/docs/providers/azure/}
+  - {menuText: Google, path: /framework/docs/providers/google/}
   - {menuText: OpenWhisk, path: /framework/docs/providers/openwhisk/}
 -->
 
@@ -14,7 +15,7 @@ menuItems:
 
 # Documentation
 
-The Serverless Framework allows you to deploy auto-scaling, pay-per-execution, event-driven functions to any cloud. We currently support AWS Lambda, Apache OpenWhisk, Microsoft Azure, and are expanding to support other cloud providers.
+The Serverless Framework allows you to deploy auto-scaling, pay-per-execution, event-driven functions to any cloud. We currently support AWS Lambda, Apache OpenWhisk, Microsoft Azure, Google Cloud Functions and are expanding to support other cloud providers.
 
 <div class="docsSections">
   <div class="docsSection">
@@ -261,6 +262,78 @@ The Serverless Framework allows you to deploy auto-scaling, pay-per-execution, e
       <div>
         <ul>
           <li><a href="./providers/azure/examples/hello-world">Hello World</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="docsSections">
+  <div class="docsSection">
+    <div class="docsSectionHeader">
+      <a href="./providers/google/guide/">
+      <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/docs_guide_google.jpg" alt="Serverless Framework Google Cloud Functions Guide" width="250" draggable="false"/>
+      </a>
+    </div>
+    <div class="test">
+      <ul>
+        <li><a href="./providers/google/guide/intro.md">Intro</a></li>
+        <li><a href="./providers/google/guide/quickstart.md">Quickstart</a></li>
+        <li><a href="./providers/google/guide/installation.md">Installation</a></li>
+        <li><a href="./providers/google/guide/credentials.md">Credentials</a></li>
+        <li><a href="./providers/google/guide/services.md">Services</a></li>
+        <li><a href="./providers/google/guide/functions.md">Functions</a></li>
+        <li><a href="./providers/google/guide/events.md">Events</a></li>
+        <li><a href="./providers/google/guide/deploying.md">Deploying</a></li>
+        <li><a href="./providers/google/guide/variables.md">Variables</a></li>
+        <li><a href="./providers/google/guide/plugins.md">Plugins</a></li>
+        <li><a href="./providers/google/guide/workflow.md">Workflow</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="docsSection">
+    <div class="docsSectionHeader">
+      <a href="./providers/google/cli-reference/">
+      <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/docs_cli_google.jpg" alt="Serverless Framework Google Cloud Functions CLI Reference" width="250" draggable="false"/>
+      </a>
+    </div>
+    <div>
+      <ul>
+        <li><a href="./providers/google/cli-reference/install.md">Install</a></li>
+        <li><a href="./providers/google/cli-reference/deploy.md">Deploy</a></li>
+        <li><a href="./providers/google/cli-reference/info.md">Info</a></li>
+        <li><a href="./providers/google/cli-reference/invoke.md">Invoke</a></li>
+        <li><a href="./providers/google/cli-reference/logs.md">Logs</a></li>
+        <li><a href="./providers/google/cli-reference/remove.md">Remove</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="docsSection">
+    <div class="docsSectionHeader">
+      <a href="./providers/google/events/">
+      <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/docs_events_google.jpg" alt="Serverless Framework Google Cloud Functions EventsEvents"  width="250" draggable="false"/>
+      </a>
+    </div>
+    <div>
+      <ul>
+        <li><a href="./providers/google/events/http.md">HTTP</a></li>
+        <li><a href="./providers/google/events/event.md">Event</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="docsSection">
+    <div class="docsSectionHeader">
+      <a href="./providers/google/examples/">
+      <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/docs_examples_google.jpg" alt="Serverless Framework Microsoft Google Cloud Functions Examples" width="250" draggable="false"/>
+      </a>
+    </div>
+    <div>
+      <div>
+        <ul>
+          <li><a href="./providers/google/examples/hello-world">Hello World</a></li>
         </ul>
       </div>
     </div>

--- a/docs/providers/google/README.md
+++ b/docs/providers/google/README.md
@@ -1,0 +1,19 @@
+<!--
+title: Serverless - Google Cloud Functions Documentation
+menuText: Google
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Serverless Google Cloud Functions Provider Documentation
+
+Welcome to the Serverless Google Cloud Functions documentation!
+
+Please select a section on the left to get started.
+
+If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://gitter.im/serverless/serverless)
+
+**Note:** Before continuing [Google Cloud system credentials](./guide/credentials.md) are required for using the CLI.

--- a/docs/providers/google/cli-reference/README.md
+++ b/docs/providers/google/cli-reference/README.md
@@ -1,0 +1,17 @@
+<!--
+title: Serverless - Google Cloud Functions - CLI Reference
+menuText: CLI Reference
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Serverless Google Cloud Functions CLI Reference
+
+Welcome to the Serverless Google Cloud Functions CLI Reference!  Please select a section on the left to get started.
+
+If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+
+**Note:** Before continuing [Google Cloud system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/google/cli-reference/deploy.md
+++ b/docs/providers/google/cli-reference/deploy.md
@@ -1,0 +1,23 @@
+<!--
+title: Serverless Framework Commands - Google Cloud Functions - Deploy
+menuText: Deploy
+menuOrder: 4
+description: Deploy your service to the specified provider
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/deploy)
+<!-- DOCS-SITE-LINK:END -->
+
+# Deploy
+
+The `serverless deploy` command deploys your entire service via the Google Cloud API. Run this command when you have made service changes (i.e., you edited `serverless.yml`).
+
+```bash
+serverless deploy
+```
+
+## Artifacts
+
+After the `serverless deploy` command runs all created deployment artifacts are placed in the `.serverless` folder of the service.

--- a/docs/providers/google/cli-reference/info.md
+++ b/docs/providers/google/cli-reference/info.md
@@ -1,0 +1,19 @@
+<!--
+title: Serverless Framework Commands - Google Cloud Functions - Info
+menuText: Info
+menuOrder: 5
+description: Get information about your deployed service
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/info)
+<!-- DOCS-SITE-LINK:END -->
+
+# Info
+
+The `serverless info` command displays information about the deployed service. Make sure to run this command in your services directory.
+
+```bash
+serverless info
+```

--- a/docs/providers/google/cli-reference/install.md
+++ b/docs/providers/google/cli-reference/install.md
@@ -1,0 +1,50 @@
+<!--
+title: Serverless Framework Commands - Google Cloud Functions - Install
+menuText: Install
+menuOrder: 3
+description: Install pre-written Google Cloud Functions Functions, Events and Resources with the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/install)
+<!-- DOCS-SITE-LINK:END -->
+
+# Install
+
+Installs a service from a GitHub URL in the current working directory.
+
+```bash
+serverless install --url https://github.com/some/service
+```
+
+## Options
+
+- `--url` or `-u` The services GitHub URL. **Required**.
+- `--name` or `-n` Name for the service.
+
+## Examples
+
+### Installing a service from a GitHub URL
+
+```bash
+serverless install --url https://github.com/serverless/boilerplate-googlecloudfunctions-nodejs
+```
+
+This example will download the .zip file of the `boilerplate-googlecloudfunctions-nodejs` service from GitHub, create a new directory with the name `boilerplate-googlecloudfunctions-nodejs` in the current working directory and unzips the files in this directory.
+
+### Installing a service from a GitHub URL with a new service name
+
+```bash
+serverless install --url https://github.com/serverless/boilerplate-googlecloudfunctions-nodejs --name my-gcloud-service
+```
+
+This example will download the .zip file of the `boilerplate-googlecloudfunctions-nodejs` service from GitHub, create a new directory with the name `my-gcloud-service` in the current working directory and unzips the files in this directory and renames the service to `my-gcloud-service` if `serverless.yml` exists in the service root.
+
+### Installing a service from a directory in a GitHub URL
+
+```bash
+serverless install --url https://github.com/serverless/examples/tree/master/google-node-simple-http-endpoint
+```
+
+This example will download the `google-node-simple-http-endpoint` service from GitHub.

--- a/docs/providers/google/cli-reference/invoke.md
+++ b/docs/providers/google/cli-reference/invoke.md
@@ -1,0 +1,42 @@
+<!--
+title: Serverless Framework Commands - Google Cloud Functions - Invoke
+menuText: Invoke
+menuOrder: 7
+description: Invoke an Google Cloud Functions Function using the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/invoke)
+<!-- DOCS-SITE-LINK:END -->
+
+# Invoke
+
+Invokes deployed function. It allows to send event data to the function, read logs and display other important information of the function invocation.
+
+```bash
+serverless invoke --function functionName
+```
+
+## Options
+
+- `--function` or `-f` The name of the function in your service that you want to invoke. **Required**.
+- `--data` or `-d` Data you want to pass into the function.
+
+## Examples
+
+### Simple function invocation
+
+```bash
+serverless invoke --function functionName
+```
+
+This example will invoke the deployed function and output the result of the invocation in the terminal.
+
+### Function invocation with data
+
+```bash
+serverless invoke --function functionName --data '{"name": "Bernie"}'
+```
+
+This example will invoke the function with the provided data and output the result in the terminal.

--- a/docs/providers/google/cli-reference/logs.md
+++ b/docs/providers/google/cli-reference/logs.md
@@ -1,0 +1,34 @@
+<!--
+title: Serverless Framework Commands - Google Cloud Functions - Logs
+menuText: Logs
+menuOrder: 9
+description: View logs of your Google Cloud Functions Function within your terminal using the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/logs)
+<!-- DOCS-SITE-LINK:END -->
+
+# Logs
+
+Lets you watch the logs of a specific function.
+
+```bash
+serverless logs --function functionName
+```
+
+## Options
+
+- `--function` or `-f` The function you want to fetch the logs for. **Required**
+- `--count` or `-c` The number of logs to display.
+
+## Examples
+
+### Retrieving logs
+
+```bash
+serverless logs --function functionName
+```
+
+This will display logs for the specified function.

--- a/docs/providers/google/cli-reference/remove.md
+++ b/docs/providers/google/cli-reference/remove.md
@@ -1,0 +1,31 @@
+<!--
+title: Serverless Framework Commands - Google Cloud Functions - Remove
+menuText: Remove
+menuOrder: 13
+description: Remove a deployed Service and all of its Google Cloud Functions Functions, Events and Resources
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/cli-reference/remove)
+<!-- DOCS-SITE-LINK:END -->
+
+# Remove
+
+The `serverless remove` command will remove the deployed service, defined in your current working directory, from the provider.
+
+**Note:** Only the deployed service with all its resources will be removed. The code on your local machine will remain.
+
+```bash
+serverless remove
+```
+
+## Examples
+
+### Service removal
+
+```bash
+serverless remove
+```
+
+This example will remove the deployed service of your current working directory.

--- a/docs/providers/google/events/README.md
+++ b/docs/providers/google/events/README.md
@@ -1,0 +1,19 @@
+<!--
+title: Serverless - Google Cloud Functions - Events
+menuText: Google Cloud Functions Events
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/events/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Serverless Google Cloud Functions Events
+
+Welcome to the Serverless Google Cloud Functions Events Glossary!
+
+Please select a section on the left to get started.
+
+If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+
+**Note:** Before continuing [Google Cloud system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/google/events/event.md
+++ b/docs/providers/google/events/event.md
@@ -1,0 +1,42 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Events - Event
+menuText: Event
+menuOrder: 2
+description: Setting up Event events with Google Cloud Functions via the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/events/event)
+<!-- DOCS-SITE-LINK:END -->
+
+## Event
+
+Your Google Cloud Function can be triggered by different `event` sources. Those event sources can be defined and configured with the help of the `event` event.
+
+## Event events
+
+This example sets up a `pubSub` event which will trigger the `first` function whenever a message is published to the `my-topic` topic.
+
+```yml
+# serverless.yml
+
+functions:
+  first:
+    handler: pubSub
+    events:
+      - event:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: projects/*/topics/my-topic
+```
+
+```javascript
+// index.js
+
+exports.pubSub = (event, callback) => {
+  console.log('Hello World!');
+  callback();
+};
+```
+
+**Note:** See the documentation about the [function handlers](../guide/functions.md) to learn how your handler signature should look like to work this type of event.

--- a/docs/providers/google/events/http.md
+++ b/docs/providers/google/events/http.md
@@ -1,0 +1,48 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Events - HTTP
+menuText: HTTP
+menuOrder: 1
+description: Setting up HTTP events with Google Cloud Functions via the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/events/http)
+<!-- DOCS-SITE-LINK:END -->
+
+# HTTP
+
+Google Cloud Functions can create function based API endpoints.
+
+To create HTTP endpoints as event sources for your Google Cloud Functions, use the `http` event syntax.
+
+It might be helpful to read the Google Cloud Functions [HTTP docs](https://cloud.google.com/functions/docs/writing/http) to learn the full functionality.
+
+## HTTP events
+
+### HTTP endpoint
+
+This setup specifies that the `first` function should be run when someone accesses the Functions API endpoint via a `GET` request. You can get the URL for the endpoint by running the `serverless info` command after deploying your service.
+
+Here's an example:
+
+```yml
+# serverless.yml
+
+functions:
+  first:
+    handler: http
+    events:
+      - http: path
+```
+
+```javascript
+// index.js
+
+
+exports.first = (request, response) => {
+  response.status(200).send('Hello World!');
+};
+```
+
+**Note:** See the documentation about the [function handlers](../guide/functions.md) to learn how your handler signature should look like to work with this type of event.

--- a/docs/providers/google/examples/README.md
+++ b/docs/providers/google/examples/README.md
@@ -1,0 +1,19 @@
+<!--
+title: Serverless - Google Cloud Functions - Examples
+menuText: Examples
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/examples/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Serverless Google Cloud Functions Examples
+
+Have an example? Submit a PR or [open an issue](https://github.com/serverless/examples/issues). ⚡️
+
+| Example | Runtime  |
+|:--------------------------- |:-----|
+| [Google Node Simple](https://github.com/serverless/examples/tree/master/google-node-simple-http-endpoint) <br/> Boilerplate project repository for Google Cloud provider with Serverless Framework. | nodeJS |
+
+If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/google/examples/hello-world/README.md
+++ b/docs/providers/google/examples/hello-world/README.md
@@ -1,0 +1,20 @@
+<!--
+title: Hello World Example
+menuText: Hello World Example
+description: Example of creating a Hello World function in Node.js with the Serverless framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/examples/hello-world/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Hello World Serverless Example 🌍
+
+Welcome to the Hello World example.
+
+Pick your language of choice:
+
+* [JavaScript](./node)
+
+[View all examples](https://www.serverless.com/framework/docs/providers/google/examples/)

--- a/docs/providers/google/examples/hello-world/node/README.md
+++ b/docs/providers/google/examples/hello-world/node/README.md
@@ -1,0 +1,38 @@
+<!--
+title: Hello World Node.js Example
+menuText: Hello World Node.js Example
+description: Create a Node.js Hello World Google Cloud Functions function
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/examples/hello-world/node/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Hello World Node.js Example
+
+Make sure [`serverless` is installed](../../../guide/installation.md) and you have [setup your credentials](../../../guide/credentials.md).
+
+## 1. Create a service
+
+`serverless install --url https://github.com/serverless/boilerplate-googlecloudfunctions-nodejs --name <my-service>`
+
+## 2. Install Provider Plugin
+
+`npm install` in the service directory.
+
+## 3. Update the `provider` property
+
+Update the `credentials` and your `project` property in the `serverless.yml` file.
+
+## 4. Deploy
+
+`serverless deploy`
+
+## 5. Invoke deployed function
+
+`serverless invoke --function helloWorld`
+
+In your terminal window you should see a response from the Google Cloud
+
+Congrats you have just deployed and run your Hello World function!

--- a/docs/providers/google/examples/hello-world/node/index.js
+++ b/docs/providers/google/examples/hello-world/node/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.http = (request, response) => {
+  response.status(200).send('Hello World!');
+};

--- a/docs/providers/google/examples/hello-world/node/package.json
+++ b/docs/providers/google/examples/hello-world/node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "serverless-google-hello-world",
+  "version": "0.1.0",
+  "description": "Hello World example for google provider with Serverless Framework.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "serverless.com",
+  "license": "MIT",
+  "dependencies": {
+    "serverless-google-cloudfunctions": "^1.0.0"
+  }
+}

--- a/docs/providers/google/examples/hello-world/node/serverless.yml
+++ b/docs/providers/google/examples/hello-world/node/serverless.yml
@@ -1,0 +1,24 @@
+service: hello-world # NOTE: Don't put the word "google" in here
+
+provider:
+  name: google
+  runtime: nodejs
+  project: my-project-1234
+  # the path to the credentials file needs to be absolute
+  credentials: ~/.gcloud/keyfile.json
+
+plugins:
+  - serverless-google-cloudfunctions
+
+package:
+  exclude:
+    - node_modules/**
+    - .gitignore
+    - package.json
+    - .git/**
+
+functions:
+  helloWorld:
+    handler: http
+    events:
+      - http: path

--- a/docs/providers/google/guide/README.md
+++ b/docs/providers/google/guide/README.md
@@ -1,0 +1,19 @@
+<!--
+title: Serverless - Google Cloud Functions
+menuText: Guide
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Serverless Google Cloud Functions Guide
+
+Welcome to the Serverless Google Cloud Functions Guide!
+
+Get started with the **[Introduction to the framework](./intro.md)**
+
+If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+
+**Note:** Before continuing [Google Cloud user credentials](./credentials.md) are required for using the CLI.

--- a/docs/providers/google/guide/credentials.md
+++ b/docs/providers/google/guide/credentials.md
@@ -1,0 +1,74 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Credentials
+menuText: Credentials
+menuOrder: 3
+description: How to set up the Serverless Framework with your Google Cloud Functions credentials
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/credentials)
+<!-- DOCS-SITE-LINK:END -->
+
+# Credentials
+
+The Serverless Framework needs access to account credentials for your Google Cloud account so that it can create and manage resources on your behalf.
+
+## Create a Google Cloud Billing Account
+
+You need a Billing Account with a credit card attached to use Google Cloud Functions. Here's how to create one:
+
+1. <a href="https://console.cloud.google.com/billing/create" target="_blank">Click here</a>, to go to the screen to create a new Billing Account.
+2. Enter the name of the Billing Account and enter your billing information. Then click Submit to enable billing.
+3. A Billing Account will exist already offering you a free trial. Please note that this will not work for Google Cloud Functions. Only a Billing Account with a valid credit card will work.
+
+If necessary, a more detailed guide on creating a Billing Account can be found <a href="https://support.google.com/cloud/answer/6288653?hl=en" target="_blank">here</a>.
+
+## Create a new Google Cloud Project
+
+A Google Cloud Project is required to use Google Cloud Functions. Here's how to create one:
+
+1. Go to the <a href="https://console.cloud.google.com" target="_blank">Google Cloud Console Console</a>.
+2. There is a dropdown near the top left of the screen (near the search bar that lists your projects). Click it and select "Create Project".
+3. Enter a Project name and select the Billing Account you created in the steps above (or any Billing Account with a valid credit card attached).
+3. Click on "Create" to start the creation process.
+4. Wait until the Project was successfully created and Google will redirect you to your new Project.
+5. Verify your currently within your new Project by looking at the dropdown next to the search bar. This should mark your new Project as selected.
+
+## Enable the necessary APIs
+
+You need to enable the following APIs so that Serverless can create the corresponding resources.
+
+Go to the <a href="https://console.cloud.google.com/apis/dashboard" target="_blank">API dashboard</a>, select your project and enable the following APIs (if not already enabled):
+
+- Google Cloud Functions
+- Google Cloud Deployment Manager
+- Google Cloud Storage
+- Stackdriver Logging
+
+## Get credentials
+
+You need to create credentials Serverless can use to create resources in your Project.
+
+1. Go to the <a href="https://console.cloud.google.com/apis" target="_blank">Google Cloud API Manager</a> and select "Credentials" on the left.
+2. Click on "Create credentials" and select "Service account key".
+3. Select "New service account" in the "Service account" dropdown.
+4. Enter a name for your "Service account name" (e.g. "serverless-framework").
+5. Select "Project" --> "Owner" as the "Role".
+6. The "Key type" should be "JSON".
+7. Click on "Create" to create your private key.
+8. That's your so called `keyfile` which should be downloaded on your machine.
+9. Save the `keyfile` somewhere secure. We recommend making a folder in your root folder and putting it there. Like this, `~/.gcloud/keyfile.json`. You can change the file name from `keyfile` to anything. Remember the path you saved it to.
+
+## Update the `provider` config in `serverless.yml`
+
+Open up your `serverless.yml` file and update the `provider` section with your Google Cloud Project id and
+the path to your `keyfile.json` file (this path needs to be absolute!). It should look something like this:
+
+```yml
+provider:
+  name: google
+  runtime: nodejs
+  project: my-serverless-project-1234
+  credentials: ~/.gcloud/keyfile.json
+```

--- a/docs/providers/google/guide/deploying.md
+++ b/docs/providers/google/guide/deploying.md
@@ -1,0 +1,39 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Deploying
+menuText: Deploying
+menuOrder: 8
+description: How to deploy your Google Cloud Functions functions and their required infrastructure
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/deploying)
+<!-- DOCS-SITE-LINK:END -->
+
+# Deploying
+
+The Serverless Framework was designed to provision your Google Cloud Functions Functions, Events and Resources safely and quickly.
+
+## Deploy All
+
+This is the main method for doing deployments with the Serverless Framework:
+
+```bash
+serverless deploy
+```
+
+Use this method when you have updated your Function, Events or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to the Google Cloud.
+
+### How It Works
+
+The Serverless Framework translates all syntax in `serverless.yml` to a Google Deployment Manager configuration template.
+
+- The provider plugin parses `serverless.yml` configuration and translates it to Google Cloud resources
+- The code of your Functions is then packaged into a directory, zipped and uploaded to the deployment bucket
+- Resources are deployed
+
+### Tips
+
+- Use this in your CI/CD systems, as it is the safest method of deployment.
+
+Check out the [deploy command docs](../cli-reference/deploy.md) for all details and options.

--- a/docs/providers/google/guide/events.md
+++ b/docs/providers/google/guide/events.md
@@ -1,0 +1,44 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Events
+menuText: Events
+menuOrder: 6
+description: Configuring Google Cloud Functions Events in the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/events)
+<!-- DOCS-SITE-LINK:END -->
+
+# Events
+
+Simply put, events are the things that trigger your functions to run.
+
+If you are using Google Cloud Functions as your provider, all `events` in the service are anything in Google Cloud Functions that can trigger your Functions, like HTTP endpoints, pubSub messages, storage events, etc..
+
+[View the Google Cloud Functions events section for a list of supported events](../events)
+
+Upon deployment, the framework will set up the corresponding event configuration your `function` should listen to.
+
+## Configuration
+
+Events belong to each Function and can be found in the `events` property in `serverless.yml`.
+
+```yml
+# serverless.yml
+functions:
+  first: # Function name
+    handler: http # Reference to file index.js & exported function 'http'
+    events: # All events associated with this function
+      - http: path
+```
+
+**Note:** Currently only one event definition per function is supported.
+
+## Types
+
+The Serverless Framework supports all of Google Cloud Functions events. Instead of listing them here, we've put them in a separate section. [Check out the events section for more information.](../events)
+
+## Deploying
+
+To deploy or update your Functions and Events run `serverless deploy`.

--- a/docs/providers/google/guide/functions.md
+++ b/docs/providers/google/guide/functions.md
@@ -1,0 +1,103 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Functions
+menuText: Functions
+menuOrder: 5
+description: How to configure Google Cloud Functions in the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/functions)
+<!-- DOCS-SITE-LINK:END -->
+
+# Functions
+
+If you are using Google Cloud Functions as a provider, all *functions* inside the service are Google Cloud Functions.
+
+## Configuration
+
+All of the Google Cloud Functions in your serverless service can be found in `serverless.yml` under the `functions` property.
+
+```yml
+# serverless.yml
+service: my-gcloud-service
+
+provider:
+  name: google
+
+plugins:
+  - serverless-google-cloudfunctions
+
+functions:
+  first:
+    handler: http
+    events:
+      - http: path
+```
+
+The `handler` property points to the file (default filename: index.js) and module containing the code you want to run in your function.
+
+```javascript
+// index.js
+exports.http = (request, response) => {}
+```
+
+**Note:** The file which contains the handlers needs to have the name `index.js`.
+
+You can add as many functions as you want within this property.
+
+```yml
+# serverless.yml
+...
+
+functions:
+  functionOne:
+    handler: http
+  functionTwo:
+    handler: http
+  functionThree:
+    handler: otherHandler
+```
+
+## Memory size and timeout
+
+The `memorySize` and `timeout` for the functions can be specified on the provider or function level. The provider wide definition causes all functions to share this config, whereas the function wide definition means that this configuration is only valid for the function.
+
+The default `memorySize` is 256 and the default timeout is `60s` if not specified.
+
+```yml
+# serverless.yml
+
+provider:
+  memorySize: 1024
+  timeout: 90s
+
+functions:
+  first:
+    handler: first
+  second:
+    handler: second
+    memorySize: 512
+    timeout: 120s
+```
+
+## Handler signatures
+
+Google Cloud Functions have different handler signatures dependent on the event type which will trigger them.
+
+### `http` events
+
+```javascript
+exports.http = (request, response) => {
+  response.status(200).send('Hello World!');
+};
+```
+
+### `event` events
+
+```javascript
+exports.event = (event, callback) => {
+  console.log('Hello World!');
+  callback();
+};
+```

--- a/docs/providers/google/guide/installation.md
+++ b/docs/providers/google/guide/installation.md
@@ -1,0 +1,57 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Installing The Serverless Framework
+menuText: Installation
+menuOrder: 2
+description: How to install the Serverless Framework and start using Google Cloud Functions
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/installation)
+<!-- DOCS-SITE-LINK:END -->
+
+# Installation
+
+### Installing Node.js
+
+Serverless is a [Node.js](https://nodejs.org) CLI tool so the first thing you need to do is to install Node.js on your machine.
+
+Go to the official [Node.js website](https://nodejs.org), download and follow the [installation instructions](https://nodejs.org/en/download/) to install Node.js on your local machine.
+
+You can verify that Node.js is installed successfully by runnning `node --version` in your terminal. You should see the corresponding Node version number printed out.
+
+### Installing the Serverless Framework
+
+Next, install the Serverless Framework via [npm](https://npmjs.org) which was already installed when you installed Node.js.
+
+Open up a terminal and type `npm install -g serverless` to install Serverless.
+
+```bash
+npm install -g serverless
+```
+
+Once the installation process is done you can verify that Serverless is installed successfully by running the following command in your terminal:
+
+```bash
+serverless
+```
+
+To see which version of serverless you have installed run:
+
+```bash
+serverless --version
+```
+
+### Installing the Google Cloud Functions Provider Plugin
+
+Install the latest package from npm by running:
+
+```
+npm install --save serverless-google-cloudfunctions
+```
+
+### Setting up Google Cloud Functions
+
+To run Serverless commands that issue requests to the Google Cloud, you will need to setup your Google Cloud credentials on your machine.
+
+[Follow these instructions on setting up your Google Cloud credentials](./credentials.md)

--- a/docs/providers/google/guide/intro.md
+++ b/docs/providers/google/guide/intro.md
@@ -1,0 +1,74 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Introduction
+menuText: Intro
+menuOrder: 1
+description: An introduction to using Google Cloud Functions the Serverless Framework.
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/intro)
+<!-- DOCS-SITE-LINK:END -->
+
+# Introduction
+
+The Serverless Framework helps you develop and deploy serverless applications using Google Cloud Functions. It's a CLI that offers structure, automation and best practices out-of-the-box, allowing you to focus on building sophisticated, event-driven, serverless architectures, comprised of [Functions](#functions) and [Events](#events).
+
+The Serverless Framework is different than other application frameworks because:
+
+- It manages your code as well as your infrastructure
+- It supports multiple languages (Node.js, Python, Java, and more)
+
+## Core Concepts
+
+Here are the Framework's main concepts and how they pertain to Google Cloud Functions...
+
+### Functions
+
+A Function is an [Google Cloud Function](https://cloud.google.com/functions/). It's an independent unit of deployment, like a microservice. It's merely code, deployed in the cloud, that is most often written to perform a single job such as:
+
+- *Saving a user to the database*
+- *Processing a file in a database*
+- *Performing a scheduled task*
+
+You can perform multiple jobs in your code, but we don't recommend doing that without good reason. Separation of concerns is best and the Framework is designed to help you easily develop and deploy Functions, as well as manage lots of them.
+
+### Events
+
+Anything that triggers a Google Cloud Function to execute is regarded by the Framework as an **Event**. Events are platform events on Google Cloud Functions such as:
+
+- *An HTTP Trigger (e.g., for a REST API)*
+- *A pubSub event (e.g., run function when message is sent to topic)*
+- *A Storage event (e.g., Image uploaded into bucket)*
+- *And more...*
+
+When you define an event for your Google Cloud Function in the Serverless Framework, the Framework will automatically translate the event with its function into a corresponding [deployment resource](https://cloud.google.com/deployment-manager/docs/configuration/supported-resource-types). This way the event is configured so that your functions can listen to it.
+
+### Services
+
+A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml`. It looks like this:
+
+```yml
+# serverless.yml
+
+service: users
+
+functions: # Your "Functions"
+  usersCreate:
+    events: # The "Events" that trigger this function
+      - http: create
+```
+
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+
+### Plugins
+
+You can overwrite or extend the functionality of the Framework using **Plugins**. Every `serverless.yml` can contain a `plugins:` property, which features multiple plugins.
+
+```yml
+# serverless.yml
+
+plugins:
+  - serverless-plugin-identifier
+  - serverless-another-plugin
+```

--- a/docs/providers/google/guide/plugins.md
+++ b/docs/providers/google/guide/plugins.md
@@ -1,0 +1,320 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Plugins
+menuText: Plugins
+menuOrder: 13
+description: How to install and create Plugins to extend or overwrite the functionality of the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/plugins)
+<!-- DOCS-SITE-LINK:END -->
+
+# Plugins
+
+A Plugin is custom Javascript code that creates new or extends existing commands within the Serverless Framework. The Serverless Framework is merely a group of Plugins that are provided in the core.  If you or your organization have a specific workflow, install a pre-written Plugin or write a plugin to customize the Framework to your needs.  External Plugins are written exactly the same way as the core Plugins.
+
+- [How to create serverless plugins - Part 1](https://serverless.com/blog/writing-serverless-plugins/)
+- [How to create serverless plugins - Part 2](https://serverless.com/blog/writing-serverless-plugins-2/)
+
+## Installing Plugins
+
+External Plugins are added on a per service basis and are not applied globally.  Make sure you are in your Service's root directory, then install the corresponding Plugin with the help of npm:
+
+```
+npm install --save custom-serverless-plugin
+```
+
+We need to tell Serverless that we want to use the plugin inside our service. We do this by adding the name of the Plugin to the `plugins` section in the `serverless.yml` file.
+
+```yml
+# serverless.yml file
+
+plugins:
+  - custom-serverless-plugin
+```
+
+Plugins might want to add extra information which should be accessible to Serverless. The `custom` section in the `serverless.yml` file is the place where you can add necessary configurations for your plugins (the plugins author / documentation will tell you if you need to add anything there):
+
+```yml
+plugins:
+  - custom-serverless-plugin
+
+custom:
+  customkey: customvalue
+```
+
+## Service local plugin
+
+If you are working on a plugin or have a plugin that is just designed for one project you can add them to the `.serverless_plugins` directory at the root of your service, and in the `plugins` array in `serverless.yml`.
+
+The plugin will be loaded based on being named `custom-serverless-plugin.js` or `custom-serverless-plugin\index.js` in the root of `.serverless_plugins` folder.
+
+### Load Order
+
+Keep in mind that the order you define your plugins matters. When Serverless loads all the core plugins and then the custom plugins in the order you've defined them.
+
+```yml
+# serverless.yml
+
+plugins:
+  - plugin1
+  - plugin2
+```
+
+In this case `plugin1` is loaded before `plugin2`.
+
+## Writing Plugins
+
+### Concepts
+
+#### Plugin
+
+Code which defines *Commands*, any *Events* within a *Command*, and any *Hooks* assigned to an *Lifecycle Event*.
+
+- Command // CLI configuration, commands, subcommands, options
+  - LifecycleEvent(s) // Events that happen sequentially when the command is run
+    - Hook(s)  // Code that runs when a Lifecycle Event happens during a Command
+
+#### Command
+
+A CLI *Command* that can be called by a user, e.g. `serverless deploy`.  A Command has no logic, but simply defines the CLI configuration (e.g. command, subcommands, parameters) and the *Lifecycle Events* for the command. Every command defines its own lifecycle events.
+
+```javascript
+'use strict';
+
+class MyPlugin {
+  constructor() {
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'resources',
+          'functions'
+        ]
+      },
+    };
+  }
+}
+
+module.exports = MyPlugin;
+```
+
+#### Lifecycle Events
+
+Events that fire sequentially during a Command.  The above example list two Events. However, for each Event, and additional `before` and `after` event is created.  Therefore, six Events exist in the above example:
+
+- `before:deploy:resources`
+- `deploy:resources`
+- `after:deploy:resources`
+- `before:deploy:functions`
+- `deploy:functions`
+- `after:deploy:functions`
+
+The name of the command in front of lifecycle events when they are used for Hooks.
+
+#### Hooks
+
+A Hook binds code to any lifecycle event from any command.
+
+```javascript
+'use strict';
+
+class Deploy {
+  constructor() {
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'resources',
+          'functions'
+        ]
+      },
+    };
+
+    this.hooks = {
+      'before:deploy:resources': this.beforeDeployResources,
+      'deploy:resources': this.deployResources,
+      'after:deploy:functions': this.afterDeployFunctions
+    };
+  }
+
+  beforeDeployResources() {
+    console.log('Before Deploy Resources');
+  }
+
+  deployResources() {
+    console.log('Deploy Resources');
+  }
+
+  afterDeployFunctions() {
+    console.log('After Deploy Functions');
+  }
+}
+
+module.exports = Deploy;
+```
+
+### Nesting Commands
+
+You can also nest commands, e.g. if you want to provide a command `serverless deploy single`. Those nested commands have their own lifecycle events and do not inherit them from their parents.
+
+```javascript
+'use strict';
+
+class MyPlugin {
+  constructor() {
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'resources',
+          'functions'
+        ],
+        commands: {
+          function: {
+            lifecycleEvents: [
+              'package',
+              'deploy'
+            ],
+          },
+        },
+      },
+    }
+  }
+}
+
+module.exports = MyPlugin;
+```
+
+### Defining Options
+
+Each (sub)command can have multiple Options.
+
+Options are passed in with a double dash (`--`) like this: `serverless function deploy --function functionName`.
+
+Option Shortcuts are passed in with a single dash (`-`) like this: `serverless function deploy -f functionName`.
+
+The `options` object will be passed in as the second parameter to the constructor of your plugin.
+
+In it, you can optionally add a `shortcut` property, as well as a `required` property.  The Framework will return an error if a `required` Option is not included.
+
+**Note:** At this time, the Serverless Framework does not use parameters.
+
+```javascript
+'use strict';
+
+class Deploy {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'functions'
+        ],
+        options: {
+          function: {
+            usage: 'Specify the function you want to deploy (e.g. "--function myFunction")',
+            shortcut: 'f',
+            required: true
+          }
+        }
+      },
+    };
+
+    this.hooks = {
+      'deploy:functions': this.deployFunction.bind(this)
+    }
+  }
+
+  deployFunction() {
+    console.log('Deploying function: ', this.options.function);
+  }
+}
+
+module.exports = Deploy;
+```
+
+### Provider Specific Plugins
+
+Plugins can be provider specific which means that they are bound to a provider.
+
+**Note:** Binding a plugin to a provider is optional. Serverless will always consider your plugin if you don't specify a `provider`.
+
+The provider definition should be added inside the plugins constructor:
+
+```javascript
+'use strict';
+
+class ProviderDeploy {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    // set the providers name here
+    this.provider = this.serverless.getProvider('providerName');
+
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'functions'
+        ],
+        options: {
+          function: {
+            usage: 'Specify the function you want to deploy (e.g. "--function myFunction")',
+            required: true
+          }
+        }
+      },
+    };
+
+    this.hooks = {
+      'deploy:functions': this.deployFunction.bind(this)
+    }
+  }
+
+  deployFunction() {
+    console.log('Deploying function: ', this.options.function);
+  }
+}
+
+module.exports = ProviderDeploy;
+```
+
+The Plugin's functionality will now only be executed when the Serverless Service's provider matches the provider name which is defined inside the plugins constructor.
+
+### Serverless Instance
+
+The `serverless` instance which enables access to global service config during runtime is passed in as the first parameter to the plugin constructor.
+
+```javascript
+'use strict';
+
+class MyPlugin {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.commands = {
+      log: {
+        lifecycleEvents: [
+          'serverless'
+        ],
+      },
+    };
+
+    this.hooks = {
+      'log:serverless': this.logServerless.bind(this)
+    }
+  }
+
+  logServerless() {
+    console.log('Serverless instance: ', this.serverless);
+  }
+}
+
+module.exports = MyPlugin;
+```
+
+### Command Naming
+
+Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.

--- a/docs/providers/google/guide/quickstart.md
+++ b/docs/providers/google/guide/quickstart.md
@@ -1,0 +1,52 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Quickstart
+menuText: Quickstart
+menuOrder: 2
+description: Get started with Google Cloud Functions in 5 minutes or less
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/intro)
+<!-- DOCS-SITE-LINK:END -->
+
+# Quickstart
+
+This guide is designed to help you get started as quick as possible.
+
+## 1. Set up boilerplate
+
+To setup the boilerplate, follow these instructions:
+
+1. Install the boilerplate
+
+```bash
+serverless install --url https://github.com/serverless/boilerplate-googlecloudfunctions-nodejs --name <my-service>
+```
+
+2. Install the dependencies
+
+```bash
+cd <my-service>
+npm install
+```
+
+## 2. Set up the credentials
+
+Read through [credentials doc](./credentials.md) to setup the credentials.
+
+# 3. Deploy
+
+Run the [deploy command](../cli-reference/deploy.md)
+
+```bash
+serverless deploy
+```
+
+# 4. Invoke
+
+Run the [invoke command](../cli-reference/invoke.md)
+
+```bash
+serverless invoke --function first
+```

--- a/docs/providers/google/guide/services.md
+++ b/docs/providers/google/guide/services.md
@@ -1,0 +1,139 @@
+<!--
+title: Serverless Framework - Google Cloud Functions Guide - Services
+menuText: Services
+menuOrder: 4
+description: How to manage and configure Serverless services, which contain your Google Cloud Functions, their events and resources.
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/services)
+<!-- DOCS-SITE-LINK:END -->
+
+# Services
+
+A `service` is like a project. It's where you define your Google Cloud Functions, the `events` that trigger them and any `resources` they require, all in a file called `serverless.yml`.
+
+To get started building your first Serverless Framework project, create a `service`.
+
+## Organization
+
+In the beginning of an application, many people use a single Service to define all of the Functions, Events and Resources for that project. This is what we recommend in the beginning.
+
+```bash
+myService/
+  serverless.yml  # Contains all functions and infrastructure resources
+```
+
+However, as your application grows, you can break it out into multiple services.  A lot of people organize their services by workflows or data models, and group the functions related to those workflows and data models together in the service.
+
+```bash
+users/
+  serverless.yml # Contains 4 functions that do Users CRUD operations and the Users database
+posts/
+  serverless.yml # Contains 4 functions that do Posts CRUD operations and the Posts database
+comments/
+  serverless.yml # Contains 4 functions that do Comments CRUD operations and the Comments database
+```
+
+This makes sense since related functions usually use common infrastructure resources, and you want to keep those functions and resources together as a single unit of deployment, for better organization and separation of concerns.
+
+## Creation
+
+There isn't yet a `serverless create` command, so to get started you can instead start by installing the boilerplate from GitHub.
+
+```bash
+serverless install --url https://github.com/serverless/boilerplate-googlecloudfunctions-nodejs --name <my-service>
+```
+
+## Contents
+
+You'll see the following files in your working directory:
+- `serverless.yml`
+- `index.js`
+
+### serverless.yml
+
+Each `service` configuration is managed in the `serverless.yml` file. The main responsibilities of this file are:
+
+- Declare a Serverless service
+- Define one or more functions in the service
+  - Define the provider the service will be deployed to (and the runtime if provided)
+  - Define any custom plugins to be used
+  - Define events that trigger each function to execute (e.g. HTTP requests)
+  - Allow events listed in the `events` section to automatically create the resources required for the event upon deployment
+  - Allow flexible configuration using Serverless Variables
+
+You can see the name of the service, the provider configuration and the first function inside the `functions` definition. Any further service configuration will be done in this file.
+
+```yml
+# serverless.yml
+
+service: my-gcloud-service
+
+provider:
+  name: google
+
+plugins:
+  - serverless-google-cloudfunctions
+
+functions:
+  first:
+    handler: http
+    events:
+      - http: path
+```
+
+### index.js
+
+The `index.js` file contains your function code. The function definition in `serverless.yml` will point to this `index.js` file and the function exported here.
+
+## Deployment
+
+When you deploy a Service, all of the Functions, and Events in your `serverless.yml` are translated into calls to the Google Cloud API to dynamically define those resources.
+
+To deploy a service, use the `deploy` command:
+
+```bash
+serverless deploy
+```
+
+Check out the [deployment guide](./deploying.md) to learn more about deployments and how they work.  Or, check out the [deploy command docs](../cli-reference/deploy.md) for all the details and options.
+
+## Removal
+
+To easily remove your Service from your Google Cloud project, you can use the `remove` command.
+
+Run `serverless remove` to trigger the removal process.
+
+Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole service is removed.
+
+The removal process will only remove the service on your provider's infrastructure. The service directory will still remain on your local machine so you can still modify and (re)deploy it to another stage, region or provider later on.
+
+## Version Pinning
+
+The Serverless framework is usually installed globally via `npm install -g serverless`. This way you have the Serverless CLI available for all your services.
+
+Installing tools globally has the downside that the version can't be pinned inside package.json. This can lead to issues if you upgrade Serverless, but your colleagues or CI system don't. You can use a feature in your serverless.yml without worrying that your CI system will deploy with an old version of Serverless.
+
+### Pinning a Version
+
+To configure version pinning define a `frameworkVersion` property in your serverless.yaml. Whenever you run a Serverless command from the CLI it checks if your current Serverless version is matching the `frameworkVersion` range. The CLI uses [Semantic Versioning](http://semver.org/) so you can pin it to an exact version or provide a range. In general we recommend to pin to an exact version to ensure everybody in your team has the exact same setup and no unexpected problems happen.
+
+### Examples
+
+#### Exact Version
+
+```yml
+# serverless.yml
+
+frameworkVersion: "=1.0.3"
+```
+
+#### Version Range
+
+```yml
+# serverless.yml
+
+frameworkVersion: ">=1.0.0 <2.0.0"
+```

--- a/docs/providers/google/guide/testing.md
+++ b/docs/providers/google/guide/testing.md
@@ -1,0 +1,108 @@
+<!--
+title: Serverless Framework - Azure Functions Guide - Testing
+menuText: Testing
+menuOrder: 9
+description: Recommendations and best practices for testing Azure Functions Functions with the Serverless Framework
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/azure/guide/testing)
+<!-- DOCS-SITE-LINK:END -->
+
+# Testing
+
+While the Serverless Architecture introduces a lot of simplicity when it comes to serving business logic, some of its characteristics present challenges for testing.  They are:
+
+* The Serverless Architecture is an integration of separate, distributed services, which must be tested both independently, and together.
+* The Serverless Architecture is dependent on internet/cloud services, which are hard to emulate locally.
+* The Serverless Architecture can feature event-driven, asynchronous workflows, which are hard to emulate entirely.
+
+To get through these challenges, and to keep the [test pyramid](http://martinfowler.com/bliki/TestPyramid.html) in mind, keep the following principles in mind:
+
+* Write your business logic so that it is separate from your FaaS provider (e.g., Azure Functions), to keep it provider-independent, reusable and more easily testable.
+* When your business logic is written separately from the FaaS provider, you can write traditional Unit Tests to ensure it is working properly.
+* Write Integration Tests to verify integrations with other services are working correctly.
+
+## A Poor Example
+
+Here is an example in Node.js of how to follow the practices above. The job this Function should perform is to save a user in a database and then send a welcome email:
+
+```javascript
+const db = require('db').connect();
+const mailer = require('mailer');
+
+module.exports.saveUser = (context, req) => {
+  return Promise((resolve, reject) => {
+    const user = {
+      email: req.params.email,
+      created_at: Date.now()
+    }
+
+    db.saveUser(user, function (err) {
+      if (err) {
+        reject(err);
+      } else {
+        mailer.sendWelcomeEmail(event.email);
+        resolve();
+      }
+    });
+  })
+};
+```
+
+There are two main problems with this function:
+
+* The business logic is not separate from the FaaS Provider.  It's bounded to how Azure Functions passes incoming data (`params` object).
+* Testing this function will rely on separate services.  Specifically, running a database instance and a mail server.
+
+## Writing Testable Azure Functions Functions
+
+Let's refactor the above example to separate the business logic from the FaaS Provider.
+
+```javascript
+class Users {
+  constructor(db, mailer) {
+    this.db = db;
+    this.mailer = mailer;
+  }
+
+  save(email) {
+    return new Promise((resolve, reject) => {
+      const user = {
+        email: email,
+        created_at: Date.now()
+      }
+
+      this.db.saveUser(user, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          this.mailer.sendWelcomeEmail(email);
+          resolve();
+        }
+      });
+    })
+  }
+}
+
+module.exports = Users;
+```
+
+```javascript
+const db = require('db').connect();
+const mailer = require('mailer');
+const Users = require('users');
+
+let users = new Users(db, mailer);
+
+module.exports.saveUser = (context, req) => {
+  return users.save(req.params.email);
+};
+```
+
+Now, the above class keeps business logic separate.  Further, the code responsible for setting up dependencies, injecting them, calling business logic functions and interacting with Azure Functions is in its own file, which will be changed less often.  This way, the business logic is not provider dependent, easier to re-use, and easier to test.
+
+Further, this code doesn't require running any external services.  Instead of a real `db` and `mailer` services, we can pass mocks and assert if `saveUser` and `sendWelcomeEmail` has been called with proper arguments.
+
+Unit Tests can easily be written to cover the above class.  An integration test can be added by invoking the function (`serverless invoke`) with fixture email address, check if user is actually saved to DB and check if email was received to see if everything is working together.

--- a/docs/providers/google/guide/variables.md
+++ b/docs/providers/google/guide/variables.md
@@ -1,0 +1,128 @@
+<!--
+title: Serverless Variables
+menuText: Variables
+menuOrder: 10
+description: How to use Serverless Variables to insert dynamic configuration info into your serverless.yml
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/variables)
+<!-- DOCS-SITE-LINK:END -->
+
+# Variables
+
+The Serverless framework provides a powerful variable system which allows you to add dynamic data into your `serverless.yml`. With Serverless Variables, you'll be able to do the following:
+
+- Reference & load variables from environment variables
+- Reference & load variables from CLI options
+- Recursively reference properties of any type from the same `serverless.yml` file
+- Recursively reference properties of any type from other YAML / JSON files
+- Recursively nest variable references within each other for ultimate flexibility
+- Combine multiple variable references to overwrite each other
+
+**Note:** You can only use variables in `serverless.yml` property **values**, not property keys. So you can't use variables to generate dynamic logical IDs in the custom resources section for example.
+
+## Reference Properties In serverless.yml
+To self-reference properties in `serverless.yml`, use the `${self:someProperty}` syntax in your `serverless.yml`. This functionality is recursive, so you can go as deep in the object tree as you want.
+
+```yml
+service: new-service
+provider: google
+
+custom:
+  resource: projects/*/topics/my-topic
+
+functions:
+  first:
+    handler: firstPubSub
+    events:
+      - event:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: ${self:custom.resource}
+  second:
+    handler: secondPubSub
+    events:
+      - event:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: ${self:custom.resource}
+```
+
+In the above example you're setting a global event resource for all functions by referencing the `resource` property in the same `serverless.yml` file. This way, you can easily change the event resource for all functions whenever you like.
+
+## Reference Variables in JavaScript Files
+
+To add dynamic data into your variables, reference javascript files by putting `${file(./myFile.js):someModule}` syntax in your `serverless.yml`.  Here's an example:
+
+```javascript
+// myCustomFile.js
+module.exports.resource = () => {
+   // Code that generates dynamic data
+   return 'projects/*/topics/my-topic';
+}
+```
+
+```yml
+# serverless.yml
+service: new-service
+
+provider: google
+
+functions:
+  first:
+    handler: pubSub
+    events:
+      - event:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: ${file(./myCustomFile.js):resource} # Reference a specific module
+```
+
+You can also return an object and reference a specific property. Just make sure you are returning a valid object and referencing a valid property:
+
+```javascript
+// myCustomFile.js
+module.exports.pubSub = () => {
+   // Code that generates dynamic data
+   return {
+     resource: 'projects/*/topics/my-topic'
+   };
+}
+```
+
+```yml
+# serverless.yml
+service: new-service
+
+provider: google
+
+functions:
+  first:
+    handler: pubSub
+    events:
+      - event:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: ${file(./myCustomFile.js):pubSub.resource} # Reference a specific module
+```
+
+## Multiple Configuration Files
+
+Adding many custom resources to your `serverless.yml` file could bloat the whole file, so you can use the Serverless Variable syntax to split this up.
+
+```yml
+resources:
+  Resources: ${file(google-cloud-resources.json)}
+```
+
+The corresponding resources which are defined inside the `google-cloud-resources.json` file will be resolved and loaded into the `Resources` section.
+
+## Migrating serverless.env.yml
+
+Previously we used the `serverless.env.yml` file to track Serverless Variables. It was a completely different system with different concepts. To migrate your variables from `serverless.env.yml`, you'll need to decide where you want to store your variables.
+
+**Using a config file:** You can still use `serverless.env.yml`, but the difference now is that you can structure the file however you want, and you'll need to reference each variable/property correctly in `serverless.yml`. For more info, you can check the file reference section above.
+
+**Using the same `serverless.yml` file:** You can store your variables in `serverless.yml` if they don't contain sensitive data, and then reference them elsewhere in the file using `self:someProperty`. For more info, you can check the self reference section above.
+
+**Using environment variables:** You can instead store your variables in environment variables and reference them with `env.someEnvVar`. For more info, you can check the environment variable reference section above.
+
+Now you don't need `serverless.env.yml` at all, but you can still use it if you want. It's just not required anymore. Migrating to the new variable system is easy and you just need to know how the new system works and make small adjustments to how you store & reference your variables.

--- a/docs/providers/google/guide/workflow.md
+++ b/docs/providers/google/guide/workflow.md
@@ -1,0 +1,81 @@
+<!--
+title: Serverless Framework Guide - Google Cloud Functions - Workflow
+menuText: Workflow
+menuOrder: 14
+description: A guide and cheatsheet containing CLI commands and workflow recommendations.
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/google/guide/workflow)
+<!-- DOCS-SITE-LINK:END -->
+
+# Workflow
+
+Intro. Quick recommendations and tips for various processes.
+
+## Development Workflow
+
+1. Write your functions
+2. Use `serverless deploy` when you've made changes to `serverless.yml` and in CI/CD systems
+3. Use `serverless invoke --function myFunction ` to test your Google Cloud Functions
+4. Open up a separate tab in your console and see logs in there via `serverless logs --function myFunction`
+5. Write tests to run locally
+
+### Larger Projects
+
+- Break your application / project into multiple Serverless Services
+-  Model your Serverless Services around Data Models or Workflows
+-  Keep the Functions and Resources in your Serverless Services to a minimum
+
+## Cheat Sheet
+
+A handy list of commands to use when developing with the Serverless Framework.
+
+### Create A Service:
+
+Install the boilerplate application.
+
+```bash
+serverless install --url https://github.com/serverless/boilerplate-googlecloudfunctions-nodejs --name <my-service>
+```
+
+### Install A Service
+
+This is a convenience method to install a pre-made Serverless Service locally by downloading the Github repo and unzipping it.
+
+```
+serverless install -u [GITHUB URL OF SERVICE]
+```
+
+### Deploy
+
+Use this when you have made changes to your Functions, Events or Resources in `serverless.yml` or you simply want to deploy all changes within your Service at the same time.
+
+```
+serverless deploy
+```
+
+### Invoke Function
+
+Invokes an Google Cloud Function
+
+```
+serverless invoke function --function [FUNCTION NAME]
+```
+
+### Logs
+
+Open up a separate tab in your console and see logs for a specific function using the following command.
+
+```
+serverless logs --function [FUNCTION NAME]
+```
+
+### Info
+
+See information about your deployed service by running the `info` command in your service directory.
+
+```
+serverless info
+```


### PR DESCRIPTION
Reverts serverless/serverless#3363

Adds the documentation for the Google Cloud Functions provider plugin (https://github.com/serverless/serverless-google-cloudfunctions).

**NOTE: PLEASE TAKE A LOOK AT THE TODOS BELOW BEFORE MERGING**

---

**TODOS before merge**

- [ ] Add docs about the `info` lifecycle events in plugin docs https://github.com/serverless/serverless/pull/3507 introduced
- [ ] Add docs about deploying a package (see: https://github.com/serverless/serverless/pull/3533)
- [ ] Add docs about updated packaging (see: https://github.com/serverless/serverless/pull/3541)
- [ ] Add docs for `login` command (see: https://github.com/serverless/serverless/pull/3558)
- [ ] Lowercase CLI commands (see: https://github.com/serverless/serverless/pull/3572)