### PR TITLE
Add serverless-alpha autoloading

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -25,10 +25,10 @@ class Serverless {
     this.version = Version;
 
     this.yamlParser = new YamlParser(this);
-    this.pluginManager = new PluginManager(this);
     this.utils = new Utils(this);
     this.service = new Service(this);
     this.variables = new Variables(this);
+    this.pluginManager = new PluginManager(this);
 
     // use the servicePath from the options or try to find it in the CWD
     configObject.servicePath = configObject.servicePath || this.utils.findServicePath();
@@ -38,11 +38,11 @@ class Serverless {
     this.classes = {};
     this.classes.CLI = CLI;
     this.classes.YamlParser = YamlParser;
-    this.classes.PluginManager = PluginManager;
     this.classes.Utils = Utils;
     this.classes.Service = Service;
     this.classes.Variables = Variables;
     this.classes.Error = ServerlessError;
+    this.classes.PluginManager = PluginManager;
 
     this.serverlessDirPath = path.join(os.homedir(), '.serverless');
   }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const os = require('os');
 const Module = require('module');
 const BbPromise = require('bluebird');
 const _ = require('lodash');
@@ -15,6 +16,33 @@ class PluginManager {
     this.plugins = [];
     this.commands = {};
     this.hooks = {};
+
+    this.autoloadServerlessAlphaPlugin();
+  }
+
+  autoloadServerlessAlphaPlugin() {
+    // get the path to the global node_modules dir
+    // see: https://docs.npmjs.com/files/folders
+    let prefixPath;
+    let globalNodeModulesPath;
+    if (os.platform === 'win32') {
+      const nodeExecPath = path.join(path.sep, 'node.exe');
+      prefixPath = process.execPath.replace(nodeExecPath, '');
+      globalNodeModulesPath = path.join(prefixPath, 'node_modules');
+    } else {
+      const nodeExecPath = path.join(path.sep, 'bin', 'node');
+      prefixPath = process.execPath.replace(nodeExecPath, '');
+      globalNodeModulesPath = path.join(prefixPath, 'lib', 'node_modules');
+    }
+
+    const serverlessAlphaPluginPath = path
+      .join(path.join(globalNodeModulesPath, 'serverless-alpha'));
+
+    if (this.serverless.utils.dirExistsSync(serverlessAlphaPluginPath)) {
+       // eslint-disable-next-line
+      const ServerlessAlpha = require(serverlessAlphaPluginPath);
+      this.addPlugin(ServerlessAlpha);
+    }
   }
 
   setCliOptions(options) {

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -216,6 +216,67 @@ describe('PluginManager', () => {
     });
   });
 
+  describe('#loadServerlessAlphaPlugin()', () => {
+    let processExecPath;
+    let tmpDirPath;
+    let globalNodeModulesPath;
+    let prefixPath;
+
+    beforeEach(() => {
+      // create global node_modules dir
+      // see: https://docs.npmjs.com/files/folders
+      let nodeExecPath;
+      if (os.platform === 'win32') {
+        nodeExecPath = path.join(path.sep, 'node.exe');
+        prefixPath = process.execPath.replace(nodeExecPath, '');
+        globalNodeModulesPath = path.join(prefixPath, 'node_modules');
+      } else {
+        nodeExecPath = path.join(path.sep, 'bin', 'node');
+        prefixPath = process.execPath.replace(nodeExecPath, '');
+        globalNodeModulesPath = path.join(prefixPath, 'lib', 'node_modules');
+      }
+
+      // create a new tmpDir for the homeDir path
+      tmpDirPath = testUtils.getTmpDirPath();
+      fse.mkdirsSync(tmpDirPath);
+
+      const tmpExecPath = path.join(tmpDirPath, prefixPath);
+      fse.mkdirsSync(tmpExecPath);
+      fse.mkdirsSync(path.join(tmpDirPath, globalNodeModulesPath));
+
+      // save the process.execPath so that we can reset this later on
+      processExecPath = process.execPath;
+      process.execPath = tmpExecPath;
+    });
+
+    afterEach(() => {
+      // recover the process.execPath
+      process.execPath = processExecPath;
+    });
+
+    it('should auto load the serverless-alpha plugin if globally installed', () => {
+      // add a mock for the serverless-alpha plugin in the tmpDir
+      class ServerlessAlpha {}
+
+      const globalAlphaPluginPath = path.join(tmpDirPath,
+        globalNodeModulesPath, 'serverless-alpha');
+
+      fse.mkdirsSync(globalAlphaPluginPath);
+      testUtils.installPlugin(globalAlphaPluginPath, ServerlessAlpha);
+
+      pluginManager.autoloadServerlessAlphaPlugin();
+
+      expect(pluginManager.plugins.length).to.equal(1);
+      expect(pluginManager.plugins[0].constructor.name).to.equal('ServerlessAlpha');
+    });
+
+    it('should not load the serverless-alpha plugin if not globally installed', () => {
+      pluginManager.autoloadServerlessAlphaPlugin();
+
+      expect(pluginManager.plugins.length).to.equal(0);
+    });
+  });
+
   describe('#setCliOptions()', () => {
     it('should set the cliOptions object', () => {
       const options = { foo: 'bar' };


### PR DESCRIPTION
Adds autoloading for `serverless-alpha`.

Would be great if this could be tested with a real, globally installed plugin (on Windows as well). The tests should cover everything, but some "hacking" was required to get the correct path to the global `node_modules`.

## Steps to verify

1. Install the alpha plugin globally via npm

---

Or

---

1. Run `serverless help` to see that there's no `ServerlessAlpha` plugin yet
2. Run `npm root -g --silent` to get the path to your global `node_modules` directory (in my case this is `/usr/local/lib/node_modules`)
3. Create a new directory with the name `serverless-alpha` in the global `node_modules` directory
4. Create a `index.js` and `package.json` file in the `serverless-alpha` directory (see file content below)
5. Run `serverless help` again and see that the `ServerlessAlpha` plugin was automatically added

**`index.js`**
```js
class ServerlessAlpha {}

module.exports = ServerlessAlpha;
```

**`package.json`**
```json
{
  "name": "serverless-alpha",
  "main": "index.js"
}
```

/cc @eahefnawy @nikgraf @mthenw @brianneisler 