### PR TITLE
update deprication message

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -14,7 +14,7 @@ class CLI {
     this.loadedCommands = {};
 
     // Add the BREAKING CHANGES here
-    const breakingChangeMessage = 'Some lifecycle events for the deploy plugin will move to a new package plugin. More info -> https://git.io/vy1zC';
+    const breakingChangeMessage = 'Certain lifecycle events for the deploy plugin will move to a new package plugin. \n For more information see -> https://git.io/vy1zC';
     this.breakingChanges = [breakingChangeMessage];
     this.logBreakingChanges('1.10.0');
   }
@@ -195,14 +195,22 @@ class CLI {
 
   logBreakingChanges(nextVersion) {
     let message = '';
+    const currentVersion = chalk.inverse(`v${version}`);
+    const nVersion = chalk.inverse(`v${nextVersion}`);
 
     if (this.breakingChanges.length !== 0 && !process.env.SLS_IGNORE_WARNING) {
       message += '\n';
-      message += chalk.yellow(`  WARNING: You are running v${version}. v${nextVersion} will include the following breaking changes:\n`); // eslint-disable-line max-len
-      this.breakingChanges
-        .forEach(breakingChange => { message += chalk.yellow(`    - ${breakingChange}\n`); });
+      message += '------------\n';
+      message += chalk.yellow('WARNING: Updating and Breaking Changes\n');
+      message += chalk.white(`Current Serverless Version: ${currentVersion}\n`);
+      message += chalk.white(`Serverless ${nVersion} will include the following breaking changes:\n`); // eslint-disable-line max-len
+      this.breakingChanges.forEach(breakingChange => {
+        message += chalk.dim(`- ${breakingChange}\n`);
+      });
       message += '\n';
-      message += chalk.yellow('  You can opt-out from these warnings by setting the "SLS_IGNORE_WARNING=*" environment variable.\n'); // eslint-disable-line max-len
+      message += chalk.yellow('To ignore these warnings set the "SLS_IGNORE_WARNING=*" environment variable.\n'); // eslint-disable-line max-len
+      message += '------------';
+      message += '\n';
       this.consoleLog(message);
     }
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -375,8 +375,6 @@ describe('CLI', () => {
         outMessage += '------------';
         outMessage += '\n';
 
-
-
         // Prepare the test environment
         cli.breakingChanges = testCase.isProvided ? breakingChanges : [];
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -355,17 +355,27 @@ describe('CLI', () => {
         // Stubs
         const nextVersion = 'Next';
 
-        let outMessage = '\n';
-        outMessage += chalk.yellow(`  WARNING: You are running v${serverlessVersion}. v${nextVersion} will include the following breaking changes:\n`); //eslint-disable-line
-        outMessage += chalk.yellow('    - x is broken\n');
-        outMessage += chalk.yellow('    - y will be updated\n');
-        outMessage += '\n';
-        outMessage += chalk.yellow('  You can opt-out from these warnings by setting the "SLS_IGNORE_WARNING=*" environment variable.\n'); //eslint-disable-line
-
+        let outMessage = '';
+        const currentVersion = chalk.inverse(`v${serverlessVersion}`);
+        const nVersion = chalk.inverse(`v${nextVersion}`);
         const breakingChanges = [
           'x is broken',
           'y will be updated',
         ];
+        outMessage += '\n';
+        outMessage += '------------\n';
+        outMessage += chalk.yellow('WARNING: Updating and Breaking Changes\n');
+        outMessage += chalk.white(`Current Serverless Version: ${currentVersion}\n`);
+        outMessage += chalk.white(`Serverless ${nVersion} will include the following breaking changes:\n`); // eslint-disable-line max-len
+        breakingChanges.forEach(breakingChange => {
+          outMessage += chalk.dim(`- ${breakingChange}\n`);
+        });
+        outMessage += '\n';
+        outMessage += chalk.yellow('To ignore these warnings set the "SLS_IGNORE_WARNING=*" environment variable.\n'); // eslint-disable-line max-len
+        outMessage += '------------';
+        outMessage += '\n';
+
+
 
         // Prepare the test environment
         cli.breakingChanges = testCase.isProvided ? breakingChanges : [];


### PR DESCRIPTION
Formatting update deprecation notice

Before:
```
  WARNING: You are running v1.9.0. v1.10.0 will include the following breaking changes:
    - Some lifecycle events for the deploy plugin will move to a new package plugin. More info -> https://git.io/vy1zC
```

After:
```
------------
WARNING: Updating and Breaking Changes
Current Serverless Version: v1.9.0
Serverless v1.10.0 will include the following breaking changes:
- Certain lifecycle events for the deploy plugin will move to a new package plugin.
 For more information see -> https://git.io/vy1zC

To ignore these warnings set the "SLS_IGNORE_WARNING=*" environment variable.
------------
```