### PR TITLE
Remove slightly misleading error message

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -80,11 +80,6 @@ module.exports.logError = (e) => {
     consoleLog(`${chalk.yellow('     Chat:          ')}${chalk
             .white('gitter.im/serverless/serverless')}`);
 
-    if (e.name !== 'ServerlessError') {
-      consoleLog(' ');
-      consoleLog(chalk.red('     Please report this error. We think it might be a bug.'));
-    }
-
     consoleLog(' ');
     consoleLog(chalk.yellow('  Your Environment Information -----------------------------'));
     consoleLog(chalk.yellow(`     OS:                 ${process.platform}`));

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -107,7 +107,6 @@ describe('Error', () => {
 
       const message = this.consoleLogMessages.join('\n');
       expect(message).to.have.string('SLS_DEBUG=*');
-      expect(message).to.have.string('Please report this error');
     });
 
     it('should print stack trace with SLS_DEBUG', () => {


### PR DESCRIPTION
Removes the call to action to immediately report the issue since AWS / CloudFormation quirks and not Framework related problems will also show this message.

It might be sufficient to only show the links to the Forums, the GitHub repo etc. to check out for help about AWS issues.

/cc @eahefnawy @brianneisler 