### PR TITLE
Extend js file import functionality for serverless.yaml

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -146,6 +146,7 @@ You can also return an object and reference a specific property.  Just make sure
 # serverless.yml
 service: new-service
 provider: aws
+custom: ${file(../myCustomFile.js)} # You can reference the entire file
 functions:
   scheduledFunction:
       handler: handler.scheduledFunction

--- a/docs/providers/azure/guide/variables.md
+++ b/docs/providers/azure/guide/variables.md
@@ -73,6 +73,7 @@ You can also return an object and reference a specific property.  Just make sure
 # serverless.yml
 service: new-service
 provider: azure
+custom: ${file(../myCustomFile.js)} # You can reference the entire file
 functions:
   scheduledFunction:
       handler: handler.scheduledFunction

--- a/docs/providers/openwhisk/guide/variables.md
+++ b/docs/providers/openwhisk/guide/variables.md
@@ -133,6 +133,7 @@ You can also return an object and reference a specific property.  Just make sure
 # serverless.yml
 service: new-service
 provider: openwhisk
+custom: ${file(../myCustomFile.js)} # You can reference the entire file
 functions:
   scheduledFunction:
       handler: handler.scheduledFunction
@@ -185,7 +186,7 @@ For example, if you want to reference the stage you're deploying to, but you don
 ```yml
 service: new-service
 provider:
-  name: openwhisk 
+  name: openwhisk
   stage: dev
 custom:
   myStage: ${opt:stage, self:provider.stage}

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -188,24 +188,29 @@ class Variables {
 
     // Process JS files
     if (fileExtension === 'js') {
-      const jsFile = require(referencedFileFullPath); // eslint-disable-line global-require
-      let jsModule = variableString.split(':')[1];
-      jsModule = jsModule.split('.')[0];
-      valueToPopulate = jsFile[jsModule]();
-      let deepProperties = variableString.replace(matchedFileRefString, '');
-      deepProperties = deepProperties.slice(1).split('.');
-      deepProperties.splice(0, 1);
-      valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
+      let jsExport = require(referencedFileFullPath); // eslint-disable-line global-require
 
-      if (typeof valueToPopulate === 'undefined') {
+      jsExport = this.resolveFunction(jsExport);
+
+      // Split as ':' or '.' and drop the `file(..)` part
+      let paths = _.compact(variableString.replace(this.fileRefSyntax, '').split(/:|\./));
+
+      if (!_.isEmpty(paths)) {
+        _.each(paths, (property) => {
+          jsExport = this.resolveFunction(_.get(jsExport, property))
+        });
+      }
+
+      if (_.isUndefined(jsExport)) {
         const errorMessage = [
           'Invalid variable syntax when referencing',
           ` file "${referencedFileRelativePath}".`,
           ' Check if your javascript is returning the correct data.',
         ].join('');
-        throw new this.serverless.classes
-          .Error(errorMessage);
+        throw new this.serverless.classes.Error(errorMessage);
       }
+
+      valueToPopulate = jsExport;
     }
 
     // Process everything except JS
@@ -265,6 +270,11 @@ class Variables {
         `A valid ${varType} to satisfy the declaration '${variableString}' could not be found.`
       );
     }
+  }
+
+  // Resolves any function else returns the input
+  resolveFunction(js) {
+    return _.isFunction(js) ? this.resolveFunction(js()) : js;
   }
 }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -193,11 +193,11 @@ class Variables {
       jsExport = this.resolveFunction(jsExport);
 
       // Split as ':' or '.' and drop the `file(..)` part
-      let paths = _.compact(variableString.replace(this.fileRefSyntax, '').split(/:|\./));
+      const paths = _.compact(variableString.replace(this.fileRefSyntax, '').split(/:|\./));
 
       if (!_.isEmpty(paths)) {
         _.each(paths, (property) => {
-          jsExport = this.resolveFunction(_.get(jsExport, property))
+          jsExport = this.resolveFunction(_.get(jsExport, property));
         });
       }
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -478,11 +478,28 @@ describe('Variables', () => {
       expect(valueToPopulate).to.equal(2);
     });
 
-    it('should populate from a javascript file', () => {
+    // Test the scenario `file(...js)`
+    it('should populate from the `module.exports` of a javascript file', () => {
       const serverless = new Serverless();
       const SUtils = new Utils();
       const tmpDirPath = testUtils.getTmpDirPath();
-      const jsData = 'module.exports.hello=function(){return "hello world";};';
+      const jsData = `module.exports = { hello: 'hello world' }`;
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+
+      serverless.config.update({ servicePath: tmpDirPath });
+
+      const valueToPopulate = serverless.variables
+        .getValueFromFile('file(./hello.js)');
+      expect(valueToPopulate).to.eql({ hello: 'hello world'});
+    });
+
+    // Tests the scenario `file(...js):export`
+    it('should populate from the `export.name` of a javascript file', () => {
+      const serverless = new Serverless();
+      const SUtils = new Utils();
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const jsData = `module.exports = { hello: 'hello world' }`;
 
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
 
@@ -493,7 +510,8 @@ describe('Variables', () => {
       expect(valueToPopulate).to.equal('hello world');
     });
 
-    it('should populate deep object from a javascript file', () => {
+    // Tests the scenario `file(...js):export.prop`
+    it('should populate from the `export.name.prop` of a javascript file', () => {
       const serverless = new Serverless();
       const SUtils = new Utils();
       const tmpDirPath = testUtils.getTmpDirPath();
@@ -504,11 +522,40 @@ describe('Variables', () => {
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
 
       serverless.config.update({ servicePath: tmpDirPath });
-      serverless.variables.loadVariableSyntax();
 
       const valueToPopulate = serverless.variables
         .getValueFromFile('file(./hello.js):hello.one.two.three');
       expect(valueToPopulate).to.equal('hello world');
+    });
+
+    // Tests the scenario `file(...js)` where a function is returned
+    it('should respect the type of the javascript export on evaluation', () => {
+      const serverless = new Serverless();
+      const SUtils = new Utils();
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const jsData = 'module.exports=function(){return "hello world";};';
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+
+      serverless.config.update({ servicePath: tmpDirPath });
+
+      const valueToPopulate = serverless.variables
+        .getValueFromFile('file(./hello.js)');
+      expect(valueToPopulate).to.equal('hello world');
+    });
+
+    it('should throw an error for unresolvable variables', () => {
+      const serverless = new Serverless();
+      const SUtils = new Utils();
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const jsData = 'module.exports=function(){return "hello world";};';
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+
+      serverless.config.update({ servicePath: tmpDirPath });
+
+      expect(() => serverless.variables
+        .getValueFromFile('file(./hello.js):hello.someone')).to.throw(Error);
     });
 
     it('should throw error if not using ":" syntax', () => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -483,7 +483,7 @@ describe('Variables', () => {
       const serverless = new Serverless();
       const SUtils = new Utils();
       const tmpDirPath = testUtils.getTmpDirPath();
-      const jsData = `module.exports = { hello: 'hello world' }`;
+      const jsData = 'module.exports = { hello: "hello world" }';
 
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
 
@@ -491,7 +491,7 @@ describe('Variables', () => {
 
       const valueToPopulate = serverless.variables
         .getValueFromFile('file(./hello.js)');
-      expect(valueToPopulate).to.eql({ hello: 'hello world'});
+      expect(valueToPopulate).to.eql({ hello: 'hello world' });
     });
 
     // Tests the scenario `file(...js):export`
@@ -499,7 +499,7 @@ describe('Variables', () => {
       const serverless = new Serverless();
       const SUtils = new Utils();
       const tmpDirPath = testUtils.getTmpDirPath();
-      const jsData = `module.exports = { hello: 'hello world' }`;
+      const jsData = 'module.exports = { hello: "hello world" }';
 
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
 


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Hello,

I had some free time so I implemented the feature that I requested in #3372. It was a trivial change so figured I would save time and get the PR open to review.

Thanks!

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Changes to the logic in the Variables.js. Is trivial, should be clear.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Added tests. Manual testing involves referencing an existing `.js` module that returns some useful object.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write tests
- [X] Write documentation - _minor change only..._
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
