### PR TITLE
Configurable plugins directory

### DIFF
--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -47,7 +47,16 @@ custom:
 
 ## Service local plugin
 
-If you are working on a plugin or have a plugin that is just designed for one project you can add them to the `.serverless_plugins` directory at the root of your service, and in the `plugins` array in `serverless.yml`.
+If you are working on a plugin or have a plugin that is just designed for one project you can add them to the `.serverless_plugins` directory at the root of your service, and in the `plugins` array in `serverless.yml`. You can change the directory in which Serverless looks for plugins by setting the `plugins_directory` variable:
+
+```yml
+# serverless.yml
+
+plugins_directory: plugins/
+
+plugins:
+  - custom-serverless-plugin
+```
 
 The plugin will be loaded based on being named `custom-serverless-plugin.js` or `custom-serverless-plugin\index.js` in the root of `.serverless_plugins` folder.
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -81,7 +81,7 @@ class PluginManager {
 
     // we want to load plugins installed locally in the service
     if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
-      module.paths.unshift(path.join(this.serverless.config.servicePath, '.serverless_plugins'));
+      module.paths.unshift(path.join(this.serverless.config.servicePath, this.serverless.service.pluginsDirectory));
     }
 
     this.loadPlugins(servicePlugins);

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -81,7 +81,8 @@ class PluginManager {
 
     // we want to load plugins installed locally in the service
     if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
-      module.paths.unshift(path.join(this.serverless.config.servicePath, this.serverless.service.pluginsDirectory));
+      const pluginsDirectory = this.serverless.service.pluginsDirectory;
+      module.paths.unshift(path.join(this.serverless.config.servicePath, pluginsDirectory));
     }
 
     this.loadPlugins(servicePlugins);

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -19,6 +19,7 @@ class Service {
       variableSyntax: '\\${([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}',
     };
     this.custom = {};
+    this.pluginsDirectory = '.serverless_plugins';
     this.plugins = [];
     this.functions = {};
     this.resources = {};
@@ -61,6 +62,7 @@ class Service {
           ].join('');
           throw new ServerlessError(errorMessage);
         }
+
         if (!serverlessFile.service) {
           throw new ServerlessError('"service" property is missing in serverless.yml');
         }
@@ -89,6 +91,10 @@ class Service {
           serverlessFile.resources = serverlessFile.resources.reduce((memo, value) =>
             Object.assign(memo, value)
           , {});
+        }
+
+        if (serverlessFile.plugins_directory) {
+          that.pluginsDirectory = serverlessFile.plugins_directory;
         }
 
         that.service = serverlessFile.service;

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -293,6 +293,43 @@ describe('Service', () => {
       });
     });
 
+    it('should support setting custom plugins directory', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: 'my-service',
+        provider: 'aws',
+        plugins_directory: 'test/example/',
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load().then(() => {
+        expect(serviceInstance.pluginsDirectory).to.be.equal('test/example/');
+      });
+    });
+
+    it('should use .serverless_plugins as default plugins directory', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: 'my-service',
+        provider: 'aws',
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load().then(() => {
+        expect(serviceInstance.pluginsDirectory).to.be.equal('.serverless_plugins');
+      });
+    });
+
     it('should throw error if service property is missing', () => {
       const SUtils = new Utils();
       const serverlessYml = {

--- a/tests/integration/general/local-plugins-custom-directory/service/handler.js
+++ b/tests/integration/general/local-plugins-custom-directory/service/handler.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Your first function handler
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/tests/integration/general/local-plugins-custom-directory/service/serverless.yml
+++ b/tests/integration/general/local-plugins-custom-directory/service/serverless.yml
@@ -1,0 +1,15 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  hello:
+    handler: handler.hello
+
+plugins_directory: serverless/plugins/
+plugins:
+  - one
+  - two

--- a/tests/integration/general/local-plugins-custom-directory/service/serverless/plugins/one.js
+++ b/tests/integration/general/local-plugins-custom-directory/service/serverless/plugins/one.js
@@ -1,0 +1,27 @@
+'use strict';
+
+class ServerlessPlugin {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.commands = {
+      one: {
+        usage: 'test plugin',
+        lifecycleEvents: [
+          'hello',
+        ],
+      },
+    };
+
+    this.hooks = {
+      'before:one:hello': this.beforeWelcome.bind(this),
+    };
+  }
+
+  beforeWelcome() {
+    this.serverless.cli.log('plugin one ran successfully!');
+  }
+}
+
+module.exports = ServerlessPlugin;

--- a/tests/integration/general/local-plugins-custom-directory/service/serverless/plugins/two/index.js
+++ b/tests/integration/general/local-plugins-custom-directory/service/serverless/plugins/two/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+class ServerlessPlugin {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.commands = {
+      two: {
+        usage: 'test plugin',
+        lifecycleEvents: [
+          'hello',
+        ],
+      },
+    };
+
+    this.hooks = {
+      'before:two:hello': this.beforeWelcome.bind(this),
+    };
+  }
+
+  beforeWelcome() {
+    this.serverless.cli.log('plugin two ran successfully!');
+  }
+}
+
+module.exports = ServerlessPlugin;

--- a/tests/integration/general/local-plugins-custom-directory/tests.js
+++ b/tests/integration/general/local-plugins-custom-directory/tests.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const execSync = require('child_process').execSync;
+
+const Utils = require('../../../utils/index');
+
+describe('General: Local plugins in custom directory test', () => {
+  beforeAll(() => {
+    Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+  });
+
+  it('should successfully run the one command', () => {
+    const pluginExecution = execSync(`${Utils.serverlessExec} one`);
+    const result = new Buffer(pluginExecution, 'base64').toString();
+    expect(/plugin one ran successfully/g.test(result)).to.equal(true);
+  });
+
+  it('should successfully run the two command', () => {
+    const pluginExecution = execSync(`${Utils.serverlessExec} two`);
+    const result = new Buffer(pluginExecution, 'base64').toString();
+    expect(/plugin two ran successfully/g.test(result)).to.equal(true);
+  });
+});


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add `plugins_directory` variable to `serverless.yml`

## How did you implement it:

There is a new `serverless.service.pluginsDirectory` variable with a default value of `.serverless_plugins` that can be overwritten by setting `plugins_directory` in `serverless.yml`.

## How can we verify it:

I added `tests/integration/general/local-plugins-custom-directory`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
