### PR TITLE
Fix for limited retries if describeStackEvents has no StackEvents member

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -4,6 +4,8 @@ const BbPromise = require('bluebird');
 const async = require('async');
 const chalk = require('chalk');
 
+const MAX_EMPTY_STACK_EVENTS = 20;
+
 module.exports = {
   monitorStack(action, cfData, frequency) {
     // Skip monitoring if a deployment should not be performed
@@ -23,6 +25,7 @@ module.exports = {
     let monitoredSince = null;
     let stackStatus = null;
     let stackLatestError = null;
+    let emptyStackEventsCount = 0;
 
     this.serverless.cli.log(`Checking Stack ${action} progress...`);
 
@@ -41,6 +44,15 @@ module.exports = {
               this.options.region)
               .then((data) => {
                 const stackEvents = data.StackEvents;
+
+                if (stackEvents === undefined) {
+                  if (++emptyStackEventsCount > MAX_EMPTY_STACK_EVENTS) {
+                    const msg = 'describeStackEvents response has no StackEvents field';
+                    throw new this.serverless.classes.Error(msg);
+                  }
+                  return callback();
+                }
+                emptyStackEventsCount = 0;
 
                 // look through all the stack events and find the first relevant
                 // event which is a "Stack" event and has a CREATE, UPDATE or DELETE status

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -660,5 +660,86 @@ describe('monitorStack', () => {
         awsPlugin.provider.request.restore();
       });
     });
+
+    it('should keep monitoring when encountering a response with no StackEvents', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const notReadyYetEvent = {
+        StackEvents: undefined,
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateFinishedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_COMPLETE',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).returns(BbPromise.resolve(notReadyYetEvent));
+      describeStackEventsStub.onCall(1).returns(BbPromise.resolve(updateStartEvent));
+      describeStackEventsStub.onCall(2).returns(BbPromise.resolve(updateFinishedEvent));
+
+      return awsPlugin.monitorStack('update', cfDataMock, 10).then((stackStatus) => {
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        expect(stackStatus).to.be.equal('UPDATE_COMPLETE');
+        awsPlugin.provider.request.restore();
+      });
+    });
+
+    it('should give up after 20 responses with no StackEvents field', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const notReadyYetEvent = {
+        StackEvents: undefined,
+      };
+
+      describeStackEventsStub.returns(BbPromise.resolve(notReadyYetEvent));
+
+      return awsPlugin.monitorStack('update', cfDataMock, 10).catch((e) => {
+        expect(e.name).to.be.equal('ServerlessError');
+        expect(e.message).to.be.equal('describeStackEvents response has no StackEvents field');
+        expect(describeStackEventsStub.callCount).to.be.equal(21);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        awsPlugin.provider.request.restore();
+      });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #3387

## How did you implement it:

Because this is a sporadic issue, my proposal is to retry when it occurs, for a limited number of times. This should have no effect on normal behavior, but make it likely that the deploy can succeed in the (current) error case, too.

## How can we verify it:

Unfortunately, I don't have any way to repro, aside from deploying several services every hour or so (we use a Jenkins-based pipeline), and waiting. I have seen this on a few different serverless projects, so I'm not aware of any requirements to reproduce: it just seems to happen occasionally when doing many deployments.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
