### PR TITLE
support any AWS nodejs runtime, not just 4.3

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -110,7 +110,7 @@ class AwsInvokeLocal {
     const handlerPath = handler.split('.')[0];
     const handlerName = handler.split('.')[1];
 
-    if (runtime === 'nodejs4.3') {
+    if (runtime.startsWith('nodejs')) {
       return this.invokeLocalNodeJs(
         handlerPath,
         handlerName,

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -142,7 +142,7 @@ describe('AwsInvokeLocal', () => {
       const yamlContent = 'event: data';
 
       serverless.utils.writeFileSync(path
-          .join(serverless.config.servicePath, 'data.yml'), yamlContent);
+        .join(serverless.config.servicePath, 'data.yml'), yamlContent);
       awsInvokeLocal.options.path = 'data.yml';
 
       return awsInvokeLocal.extendedValidate().then(() => {
@@ -160,7 +160,7 @@ describe('AwsInvokeLocal', () => {
       ].join('\n');
 
       serverless.utils.writeFileSync(path
-          .join(serverless.config.servicePath, 'data.js'), jsContent);
+        .join(serverless.config.servicePath, 'data.js'), jsContent);
       awsInvokeLocal.options.path = 'data.js';
 
       return awsInvokeLocal.extendedValidate().then(() => {
@@ -303,9 +303,8 @@ describe('AwsInvokeLocal', () => {
             {}
           )).to.be.equal(true);
           awsInvokeLocal.invokeLocalNodeJs.restore();
-        })
-      }
-    );
+        });
+    });
 
     it('should call invokeLocalPython when python2.7 runtime is set', () => {
       awsInvokeLocal.options.functionObj.runtime = 'python2.7';
@@ -313,10 +312,10 @@ describe('AwsInvokeLocal', () => {
         .then(() => {
           expect(invokeLocalPythonStub.calledOnce).to.be.equal(true);
           expect(invokeLocalPythonStub.calledWithExactly(
-                'handler',
-                'hello',
-                {}
-                )).to.be.equal(true);
+            'handler',
+            'hello',
+            {}
+          )).to.be.equal(true);
           awsInvokeLocal.invokeLocalPython.restore();
         });
       delete awsInvokeLocal.options.functionObj.runtime;

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -292,6 +292,21 @@ describe('AwsInvokeLocal', () => {
       })
     );
 
+    it('should call invokeLocalNodeJs for any node.js runtime version', () => {
+      awsInvokeLocal.options.functionObj.runtime = 'nodejs6.10';
+      awsInvokeLocal.invokeLocal()
+        .then(() => {
+          expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
+          expect(invokeLocalNodeJsStub.calledWithExactly(
+            'handler',
+            'hello',
+            {}
+          )).to.be.equal(true);
+          awsInvokeLocal.invokeLocalNodeJs.restore();
+        })
+      }
+    );
+
     it('should call invokeLocalPython when python2.7 runtime is set', () => {
       awsInvokeLocal.options.functionObj.runtime = 'python2.7';
       awsInvokeLocal.invokeLocal()


### PR DESCRIPTION
## What did you implement:

Supporting local invokes for AWS lambda runtimes for node.js that are not 4.3

Refs #3397 

## How did you implement it:

Currently it checks for an exact match string for 'node43' in order to allow local invokes. I changed it to a prefix match for 'nodejs'.

## How can we verify it:

Change the runtime to node6.10 and try to invoke a function locally.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
