### PR TITLE
PR #3360 introduced an incorrect IAM policy for log groups

### DIFF
--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.js
@@ -80,7 +80,7 @@ module.exports = {
         .Statement[0]
         .Resource
         .push({ 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}` });
+          `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*` });
 
       this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.provider.naming.getRoleLogicalId()]
@@ -90,7 +90,7 @@ module.exports = {
         .Statement[1]
         .Resource
         .push({ 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*` });
+          `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*:*` });
     });
 
     if (this.serverless.service.provider.iamRoleStatements) {

--- a/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/deploy/lib/mergeIamTemplates.test.js
@@ -96,7 +96,7 @@ describe('#mergeIamTemplates()', () => {
                       Resource: [
                         {
                           'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-                            + `log-group:/aws/lambda/${qualifiedFunction}`,
+                            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
                         },
                       ],
                     },
@@ -108,7 +108,7 @@ describe('#mergeIamTemplates()', () => {
                       Resource: [
                         {
                           'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-                            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
+                            + `log-group:/aws/lambda/${qualifiedFunction}:*:*`,
                         },
                       ],
                     },
@@ -292,7 +292,7 @@ describe('#mergeIamTemplates()', () => {
       ).to.deep.equal([
         {
           'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-            + `log-group:/aws/lambda/${qualifiedFunction}`,
+            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
         },
       ]);
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -305,7 +305,7 @@ describe('#mergeIamTemplates()', () => {
       ).to.deep.equal([
         {
           'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
+            + `log-group:/aws/lambda/${qualifiedFunction}:*:*`,
         },
       ]);
     });
@@ -333,9 +333,9 @@ describe('#mergeIamTemplates()', () => {
       ).to.deep.equal(
         [
           { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func0' },
+              + 'log-group:/aws/lambda/func0:*' },
           { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func1' },
+              + 'log-group:/aws/lambda/func1:*' },
         ]
       );
       expect(awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -348,9 +348,9 @@ describe('#mergeIamTemplates()', () => {
       ).to.deep.equal(
         [
           { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func0:*' },
+              + 'log-group:/aws/lambda/func0:*:*' },
           { 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func1:*' },
+              + 'log-group:/aws/lambda/func1:*:*' },
         ]
       );
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Related to #3360 

This is a fix to the IAM policies for log streams that were broken by the change of where those ARNs come from. 

cc/ @eahefnawy 

## How can we verify it:

Create a new project and using the base config, deploy it.

Run:

```
$ sls invoke -f hello
$ sls logs -f hello
```

In the screenshot are 3 IAM policies. The top is from 1.9.0, middle from current master, and bottom from this patch. 

![policies](https://cloud.githubusercontent.com/assets/636610/24249696/9d89a5f4-0faa-11e7-8d7e-084d9ea18a62.png)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
