### PR TITLE
Update to latest Node.js runtime

### DIFF
--- a/docs/providers/aws/examples/hello-world/node/serverless.yml
+++ b/docs/providers/aws/examples/hello-world/node/serverless.yml
@@ -3,7 +3,7 @@ service: hello-world # Service Name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   helloWorld:

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -101,7 +101,7 @@ You can even set up different profiles for different accounts, which can be used
 service: new-service
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   stage: dev
   profile: devProfile
 ```
@@ -138,7 +138,7 @@ This example `serverless.yml` snippet will load the profile depending upon the s
 service: new-service
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   stage: ${opt:stage, self:custom.defaultStage}
   profile: ${self:custom.profiles.${self:provider.stage}}
 custom:

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -24,7 +24,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   memorySize: 512 # optional, default is 1024
   timeout: 10 # optional, default is 6
   versionFunctions: false # optional, default is true
@@ -55,7 +55,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   functionOne:
@@ -75,7 +75,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   memorySize: 512 # will be inherited by all functions
 
 functions:
@@ -91,7 +91,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   functionOne:
@@ -109,7 +109,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   iamRoleStatements: # permissions for all of your functions can be set here
     - Effect: Allow
       Action: # Gives permission to DynamoDB tables in a specific region

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -23,7 +23,7 @@ frameworkVersion: ">=1.0.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
   profile: production # The default profile to use with this service

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -88,7 +88,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
   profile: production # The default profile to use with this service
@@ -203,7 +203,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   memorySize: 512
 
 …
@@ -220,7 +220,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   memorySize: 512
 
 …

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -90,14 +90,14 @@ describe('Service', () => {
       const data = {
         provider: {
           name: 'testProvider',
-          runtime: 'nodejs4.3',
+          runtime: 'nodejs6.10',
         },
       };
 
       const serviceInstance = new Service(serverless, data);
 
       expect(serviceInstance.provider.name).to.be.equal('testProvider');
-      expect(serviceInstance.provider.runtime).to.be.equal('nodejs4.3');
+      expect(serviceInstance.provider.runtime).to.be.equal('nodejs6.10');
     });
   });
 

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -394,7 +394,7 @@ describe('Utils', () => {
         service: 'new-service',
         provider: {
           name: 'aws',
-          runtime: 'nodejs4.3',
+          runtime: 'nodejs6.10',
           stage: 'dev',
           region: 'us-east-1',
           variableSyntax: '\\${foo}',

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -19,7 +19,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 # you can overwrite defaults here
 #  stage: dev

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/cloud-watch-event/multiple-events-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/multiple-events-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   cwe1:

--- a/tests/integration/aws/cloud-watch-event/multiple-events-single-function/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/multiple-events-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   cwe1:

--- a/tests/integration/aws/cloud-watch-event/single-event-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/single-event-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   cwe1:

--- a/tests/integration/aws/cloud-watch-event/single-event-single-function/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/single-event-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   cwe1:

--- a/tests/integration/aws/general/custom-resources/service/serverless.yml
+++ b/tests/integration/aws/general/custom-resources/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/general/environment-variables/service/serverless.yml
+++ b/tests/integration/aws/general/environment-variables/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   environment:
     provider_level_variable_1: provider_level_1
     provider_level_variable_2: provider_level_2

--- a/tests/integration/aws/general/nested-handlers/service/serverless.yml
+++ b/tests/integration/aws/general/nested-handlers/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/general/overwrite-resources/service/serverless.yml
+++ b/tests/integration/aws/general/overwrite-resources/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/general/package/service/serverless.yml
+++ b/tests/integration/aws/general/package/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/iot/multiple-rules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/iot/multiple-rules-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   iot1:

--- a/tests/integration/aws/iot/multiple-rules-single-function/service/serverless.yml
+++ b/tests/integration/aws/iot/multiple-rules-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   iot1:

--- a/tests/integration/aws/iot/single-rule-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/iot/single-rule-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   iot1:

--- a/tests/integration/aws/iot/single-rule-single-function/service/serverless.yml
+++ b/tests/integration/aws/iot/single-rule-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   iot1:

--- a/tests/integration/aws/s3/multiple-events-multiple-functions-multiple-buckets/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-multiple-functions-multiple-buckets/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/s3/multiple-events-multiple-functions-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-multiple-functions-single-bucket/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   create:

--- a/tests/integration/aws/s3/multiple-events-single-function-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-single-function-single-bucket/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/s3/single-event-single-function-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/single-event-single-function-single-bucket/service/serverless.yml
@@ -3,7 +3,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/sns/existing-topic/service/serverless.yml
+++ b/tests/integration/aws/sns/existing-topic/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/general/custom-plugins/service/serverless.yml
+++ b/tests/integration/general/custom-plugins/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:

--- a/tests/integration/general/local-plugins/service/serverless.yml
+++ b/tests/integration/general/local-plugins/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 functions:
   hello:


### PR DESCRIPTION
## What did you implement:

Refs #3397

Changes the templates and other, relevant files to use `nodejs6.10` as the default runtime.

Serverless still defaults to `nodejs4.3` if no `runtime` property is given. #3405 covers the deprecation process of this.

/cc @brianneisler @eahefnawy 

## How did you implement it:

Did a global strg + f and looked for relevant files to update them.

## How can we verify it:

Run the unit tests, simple and complex integration tests.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO