### PR TITLE
Info command: always display "custom" stack outputs

### DIFF
--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -68,11 +68,15 @@ module.exports = {
 
     message += functionsMessage;
 
-    // when verbose info is requested, add the stack outputs to the output
-    if (this.options.verbose) {
+    let hasCustomOutput = _.some(this.gatheredData.outputs, output => output.CustomOutput)
+
+    // when verbose info is requested, display all the stack outputs
+    if (hasCustomOutput || this.options.verbose) {
       message += `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
       _.forEach(this.gatheredData.outputs, (output) => {
-        message += `${chalk.yellow(output.OutputKey)}: ${output.OutputValue}\n`;
+        if (output.CustomOutput || this.options.verbose) {
+          message += `${chalk.yellow(output.OutputKey)}: ${output.OutputValue}\n`;
+        }
       });
     }
 

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -68,7 +68,7 @@ module.exports = {
 
     message += functionsMessage;
 
-    let hasCustomOutput = _.some(this.gatheredData.outputs, output => output.CustomOutput)
+    const hasCustomOutput = _.some(this.gatheredData.outputs, output => output.CustomOutput);
 
     // when verbose info is requested, display all the stack outputs
     if (hasCustomOutput || this.options.verbose) {

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -186,7 +186,45 @@ describe('#display()', () => {
     expect(message).to.equal(expectedMessage);
   });
 
-  it('should display CloudFormation outputs when verbose output is requested', () => {
+  it('should display custom CloudFormation outputs', () => {
+    awsInfo.options.verbose = false;
+
+    awsInfo.gatheredData.outputs = [
+      {
+        Description: 'Lambda function info',
+        OutputKey: 'Function1FunctionArn',
+        OutputValue: 'arn:function1',
+        CustomOutput: true,
+      },
+      {
+        Description: 'Lambda function info',
+        OutputKey: 'Function2FunctionArn',
+        OutputValue: 'arn:function2',
+        CustomOutput: false,
+      },
+    ];
+
+    let expectedMessage = '';
+
+    expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
+    expectedMessage += `${chalk.yellow('service:')} my-first\n`;
+    expectedMessage += `${chalk.yellow('stage:')} dev\n`;
+    expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
+    expectedMessage += `\n${chalk.yellow('api keys:')}`;
+    expectedMessage += '\n  None';
+    expectedMessage += `\n${chalk.yellow('endpoints:')}`;
+    expectedMessage += '\n  None';
+    expectedMessage += `\n${chalk.yellow('functions:')}`;
+    expectedMessage += '\n  None';
+    expectedMessage += `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
+    expectedMessage += `${chalk.yellow('Function1FunctionArn')}: ${'arn:function1'}\n`;
+
+    const message = awsInfo.display();
+    expect(consoleLogStub.calledOnce).to.equal(true);
+    expect(message).to.equal(expectedMessage);
+  });
+
+  it('should display all CloudFormation outputs when verbose output is requested', () => {
     awsInfo.options.verbose = true;
 
     awsInfo.gatheredData.outputs = [
@@ -194,11 +232,13 @@ describe('#display()', () => {
         Description: 'Lambda function info',
         OutputKey: 'Function1FunctionArn',
         OutputValue: 'arn:function1',
+        CustomOutput: false,
       },
       {
         Description: 'Lambda function info',
         OutputKey: 'Function2FunctionArn',
         OutputValue: 'arn:function2',
+        CustomOutput: false,
       },
     ];
 

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -33,6 +33,15 @@ module.exports = {
         const serviceEndpointOutputRegex = this.provider.naming
           .getServiceEndpointRegex();
 
+        const lambdaFunctionOutputRegex = this.provider.naming
+            .getLambdaFunctionOutputRegex();
+
+        const apiKeyLogicalIdRegex = this.provider.naming
+            .getApiKeyLogicalIdRegex();
+
+        const deploymentBucketOutputLogicalId = this.provider.naming
+            .getDeploymentBucketOutputLogicalId();
+
         // Outputs
         this.gatheredData.outputs = outputs;
 
@@ -45,11 +54,19 @@ module.exports = {
           this.gatheredData.info.functions.push(functionInfo);
         });
 
+        this.gatheredData.outputs.forEach( x => {
+          x.CustomOutput = !!! (x.OutputKey.match(serviceEndpointOutputRegex)
+                                || x.OutputKey.match(lambdaFunctionOutputRegex)
+                                || x.OutputKey.match(apiKeyLogicalIdRegex)
+                                || x.OutputKey == deploymentBucketOutputLogicalId)                            
+        });
+
         // Endpoints
         outputs.filter(x => x.OutputKey.match(serviceEndpointOutputRegex))
           .forEach(x => {
             this.gatheredData.info.endpoint = x.OutputValue;
           });
+
       }
 
       return BbPromise.resolve();

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -43,7 +43,13 @@ module.exports = {
             .getDeploymentBucketOutputLogicalId();
 
         // Outputs
-        this.gatheredData.outputs = outputs;
+        this.gatheredData.outputs = outputs.map(o => {
+          const custom = !(o.OutputKey.match(serviceEndpointOutputRegex)
+                                || o.OutputKey.match(lambdaFunctionOutputRegex)
+                                || o.OutputKey.match(apiKeyLogicalIdRegex)
+                                || o.OutputKey === deploymentBucketOutputLogicalId);
+          return Object.assign(o, { CustomOutput: custom });
+        });
 
         // Functions
         this.serverless.service.getAllFunctions().forEach((func) => {
@@ -54,19 +60,11 @@ module.exports = {
           this.gatheredData.info.functions.push(functionInfo);
         });
 
-        this.gatheredData.outputs.forEach( x => {
-          x.CustomOutput = !!! (x.OutputKey.match(serviceEndpointOutputRegex)
-                                || x.OutputKey.match(lambdaFunctionOutputRegex)
-                                || x.OutputKey.match(apiKeyLogicalIdRegex)
-                                || x.OutputKey == deploymentBucketOutputLogicalId)                            
-        });
-
         // Endpoints
         outputs.filter(x => x.OutputKey.match(serviceEndpointOutputRegex))
           .forEach(x => {
             this.gatheredData.info.endpoint = x.OutputValue;
           });
-
       }
 
       return BbPromise.resolve();

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -61,7 +61,7 @@ describe('#getStackInfo()', () => {
               Description: 'custom',
               OutputKey: 'CustomOutput',
               OutputValue: 'zzz',
-            },            
+            },
           ],
           StackStatusReason: null,
           CreationTime: '2013-08-23T01:02:15.422Z',

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -57,6 +57,11 @@ describe('#getStackInfo()', () => {
               OutputKey: 'ApiGatewayApiKey2Value',
               OutputValue: 'yyy',
             },
+            {
+              Description: 'custom',
+              OutputKey: 'CustomOutput',
+              OutputValue: 'zzz',
+            },            
           ],
           StackStatusReason: null,
           CreationTime: '2013-08-23T01:02:15.422Z',
@@ -92,16 +97,25 @@ describe('#getStackInfo()', () => {
           Description: 'URL of the service endpoint',
           OutputKey: 'ServiceEndpoint',
           OutputValue: 'ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev',
+          CustomOutput: false,
         },
         {
           Description: 'first',
           OutputKey: 'ApiGatewayApiKey1Value',
           OutputValue: 'xxx',
+          CustomOutput: false,
         },
         {
           Description: 'second',
           OutputKey: 'ApiGatewayApiKey2Value',
           OutputValue: 'yyy',
+          CustomOutput: false,
+        },
+        {
+          Description: 'custom',
+          OutputKey: 'CustomOutput',
+          OutputValue: 'zzz',
+          CustomOutput: true,
         },
       ],
     };

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -44,6 +44,10 @@ module.exports = {
     return /^ServiceEndpoint/;
   },
 
+  getLambdaFunctionOutputRegex() {
+    return /.+LambdaFunctionQualifiedArn$/;
+  },
+
   // Stack
   getStackName() {
     return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -93,6 +93,18 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getLambdaFunctionOutputRegex()', () => {
+    it('should not match a name with just the suffix', () => {
+      expect(sdk.naming.getLambdaFunctionOutputRegex()
+        .test('LambdaFunctionQualifiedArn')).to.equal(false);
+    });
+
+    it('should match a name with the suffix', () => {
+      expect(sdk.naming.getLambdaFunctionOutputRegex()
+        .test('ALambdaFunctionQualifiedArn')).to.equal(true);
+    });
+  });
+
   describe('#getStackName()', () => {
     it('should use the service name and stage from the service and config', () => {
       serverless.service.service = 'myService';


### PR DESCRIPTION
## What did you implement:

Closes #2788 

Info command now always displays custom stack outputs.

## How did you implement it:

Adds an attribute to the internal output data to track if the output is a serverless framework output or custom from the developer. Uses this attribute to output.

## How can we verify it:

Run `info` in a serverless project containing a custom output. This output should be displayed but not the default serverless framework outputs. 

If the verbose flag is on, displays all outputs. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
