### PR TITLE
Remove breaking change logging

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -5,9 +5,9 @@ This checklist should be worked through when releasing a new Serverless version.
 ## Pre-Release
 - [ ] Look through all open issues and PRs (if any) of that milestone and close them / move them to another
 milestone if still open
-- [ ] Look through all closed issues and PRs of that milestone to see what has changed. Run `./scripts/pr-since-last tag` or if you want to run against a specific tag `./scripts/pr-since-last tag v1.0.3` to get a list of all merged PR's since a specific tag.
+- [ ] Look through all closed issues and PRs of that milestone to see what has changed. Run `./scripts/pr-since-last tag` or if you want to run against a specific tag `./scripts/pr-since-last tag v1.0.3` to get a list of all merged PR's since a specific tag
 - [ ] Close milestone on Github
-- [ ] Create a new release in GitHub for Release Notes.
+- [ ] Create a new release in GitHub for Release Notes (including breaking changes)
 
 # Testing
 - [ ] Create a Serverless service (with some events), deploy and test it intensively
@@ -21,9 +21,8 @@ milestone if still open
 - [ ] Create a new branch to bump version in package.json
 - [ ] Install the latest NPM version or Docker container with latest Node and NPM
 - [ ] Bump version in package.json, remove `node_modules` folder and run `npm install` and `npm prune --production && npm shrinkwrap`
-- [ ] Update CHANGELOG.md
-- [ ] Update upcoming breaking changes list in the CLI
-- [ ] Make sure all files that need to be pushed are included in `package.json->files`
+- [ ] Update CHANGELOG.md (including breaking changes)
+- [ ] Make sure all files that need to be pushed are included in `package.json -> files`
 - [ ] Send PR and merge PR with new version to be released
 - [ ] Go back to branch you want to release from (e.g. master or v1) and pull bumped version changes from Github
 - [ ] Make sure there are no local changes to your repository (or reset with `git reset --hard HEAD`)

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -12,11 +12,6 @@ class CLI {
     this.inputArray = inputArray || null;
     this.loadedPlugins = [];
     this.loadedCommands = {};
-
-    // Add the BREAKING CHANGES here
-    const breakingChangeMessage = 'Certain lifecycle events for the deploy plugin will move to a new package plugin. \n For more information see -> https://git.io/vy1zC';
-    this.breakingChanges = [breakingChangeMessage];
-    this.logBreakingChanges('1.10.0');
   }
 
   setLoadedPlugins(plugins) {
@@ -191,30 +186,6 @@ class CLI {
 
   consoleLog(message) {
     console.log(message); // eslint-disable-line no-console
-  }
-
-  logBreakingChanges(nextVersion) {
-    let message = '';
-    const currentVersion = chalk.inverse(`v${version}`);
-    const nVersion = chalk.inverse(`v${nextVersion}`);
-
-    if (this.breakingChanges.length !== 0 && !process.env.SLS_IGNORE_WARNING) {
-      message += '\n';
-      message += '------------\n';
-      message += chalk.yellow('WARNING: Updating and Breaking Changes\n');
-      message += chalk.white(`Current Serverless Version: ${currentVersion}\n`);
-      message += chalk.white(`Serverless ${nVersion} will include the following breaking changes:\n`); // eslint-disable-line max-len
-      this.breakingChanges.forEach(breakingChange => {
-        message += chalk.dim(`- ${breakingChange}\n`);
-      });
-      message += '\n';
-      message += chalk.yellow('To ignore these warnings set the "SLS_IGNORE_WARNING=*" environment variable.\n'); // eslint-disable-line max-len
-      message += '------------';
-      message += '\n';
-      this.consoleLog(message);
-    }
-
-    return message;
   }
 }
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -9,10 +9,7 @@ const CLI = require('../../lib/classes/CLI');
 const os = require('os');
 const fse = require('fs-extra');
 const exec = require('child_process').exec;
-const serverlessVersion = require('../../package.json').version;
 const path = require('path');
-const sinon = require('sinon');
-const chalk = require('chalk');
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
 
@@ -302,98 +299,6 @@ describe('CLI', () => {
       const expectedObject = { commands: ['deploy', 'functions'], options: { f: 'function1' } };
 
       expect(inputToBeProcessed).to.deep.equal(expectedObject);
-    });
-  });
-
-  describe('#logBreakingChanges()', () => {
-    let consoleLogStub;
-    let origIgnoreWarning;
-
-    beforeEach(() => {
-      cli = new CLI(serverless);
-      consoleLogStub = sinon.stub(cli, 'consoleLog').returns();
-      origIgnoreWarning = process.env.SLS_IGNORE_WARNING;
-    });
-
-    afterEach(() => {
-      cli.consoleLog.restore();
-      if (origIgnoreWarning === undefined) {
-        delete process.env.SLS_IGNORE_WARNING;
-      } else {
-        process.env.SLS_IGNORE_WARNING = origIgnoreWarning;
-      }
-    });
-
-    // Test all possible combinations of provided changes and "ignored" setting
-    [
-      {
-        name: 'should NOT LOG breaking changes when changes are NOT PROVIDED and NOT IGNORED',
-        isProvided: false,
-        isIgnored: false,
-        isLogExpected: false,
-      },
-      {
-        name: 'should NOT LOG breaking changes when changes are NOT PROVIDED and IGNORED',
-        isProvided: false,
-        isIgnored: true,
-        isLogExpected: false,
-      },
-      {
-        name: 'should LOG breaking changes when changes are PROVIDED and NOT IGNORED',
-        isProvided: true,
-        isIgnored: false,
-        isLogExpected: true,
-      },
-      {
-        name: 'should NOT LOG breaking changes when changes are PROVIDED and IGNORED',
-        isProvided: true,
-        isIgnored: true,
-        isLogExpected: false,
-      },
-    ].forEach((testCase) => {
-      it(testCase.name, () => {
-        // Stubs
-        const nextVersion = 'Next';
-
-        let outMessage = '';
-        const currentVersion = chalk.inverse(`v${serverlessVersion}`);
-        const nVersion = chalk.inverse(`v${nextVersion}`);
-        const breakingChanges = [
-          'x is broken',
-          'y will be updated',
-        ];
-        outMessage += '\n';
-        outMessage += '------------\n';
-        outMessage += chalk.yellow('WARNING: Updating and Breaking Changes\n');
-        outMessage += chalk.white(`Current Serverless Version: ${currentVersion}\n`);
-        outMessage += chalk.white(`Serverless ${nVersion} will include the following breaking changes:\n`); // eslint-disable-line max-len
-        breakingChanges.forEach(breakingChange => {
-          outMessage += chalk.dim(`- ${breakingChange}\n`);
-        });
-        outMessage += '\n';
-        outMessage += chalk.yellow('To ignore these warnings set the "SLS_IGNORE_WARNING=*" environment variable.\n'); // eslint-disable-line max-len
-        outMessage += '------------';
-        outMessage += '\n';
-
-        // Prepare the test environment
-        cli.breakingChanges = testCase.isProvided ? breakingChanges : [];
-
-        if (testCase.isIgnored) {
-          process.env.SLS_IGNORE_WARNING = '*';
-        } else {
-          delete process.env.SLS_IGNORE_WARNING;
-        }
-
-        // Test expectations
-        const expectedResult = testCase.isLogExpected ? outMessage : '';
-        const expectedLogCalled = testCase.isLogExpected;
-
-        // Carry the test
-        const actualResult = cli.logBreakingChanges(nextVersion);
-
-        expect(actualResult).to.equal(expectedResult);
-        expect(consoleLogStub.calledOnce).to.equal(expectedLogCalled);
-      });
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Reverts #3217 and #3375

Removes the breaking change logging since it harms DX.

/cc @ac360 @eahefnawy @brianneisler @DavidWells 

## How did you implement it:

Just removed the previously added log message.

## How can we verify it:

Look at the tests or run `serverless help` to see that the logging of breaking changes is not around anymore...

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO