### PR TITLE
add version description from function

### DIFF
--- a/lib/plugins/aws/deploy/compile/functions/index.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.js
@@ -177,6 +177,9 @@ class AwsCompileFunctions {
 
     newVersion.Properties.CodeSha256 = hash.read();
     newVersion.Properties.FunctionName = { Ref: functionLogicalId };
+    if (functionObject.description) {
+      newVersion.Properties.Description = functionObject.description;
+    }
 
     // use the SHA in the logical resource ID of the version because
     // AWS::Lambda::Version resource will not support updates

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -923,12 +923,12 @@ describe('AwsCompileFunctions', () => {
         expectedOutputs
       );
     });
-    
+
     it('should include description under version too if function is specified', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
-          description: 'Lambda function description',
+          description: 'Lambda function description'
         }
       };
 
@@ -936,7 +936,8 @@ describe('AwsCompileFunctions', () => {
 
       expect(
         awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI.Properties.Description
+          .Resources.FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI
+        .Properties.Description
       ).to.equal('Lambda function description');
     });
 

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -923,6 +923,22 @@ describe('AwsCompileFunctions', () => {
         expectedOutputs
       );
     });
+    
+    it('should include description under version too if function is specified', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          description: 'Lambda function description',
+        }
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI.Properties.Description
+      ).to.equal('Lambda function description');
+    });
 
     it('should not create function output objects when "versionFunctions" is false', () => {
       awsCompileFunctions.serverless.service.provider.versionFunctions = false;

--- a/lib/plugins/aws/deploy/compile/functions/index.test.js
+++ b/lib/plugins/aws/deploy/compile/functions/index.test.js
@@ -928,8 +928,8 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
-          description: 'Lambda function description'
-        }
+          description: 'Lambda function description',
+        },
       };
 
       awsCompileFunctions.compileFunctions();


### PR DESCRIPTION
## What did you implement:

Closes #3428

Support `description` on Lambda Version

## How did you implement it:

Add a Property `description` on Lambda Version which Property is based on function's Property `description`.

## How can we verify it:

Use `mocha` for `lib/plugins/aws/deploy/compile/functions/index.test.js`.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
