### PR TITLE
Add default testing framework and unit test to aws-nodejs

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs/handler.spec.js
+++ b/lib/plugins/create/templates/aws-nodejs/handler.spec.js
@@ -1,0 +1,16 @@
+const { hello } = require('./handler');
+
+test('hello - should respond with `hello`', () => {
+  const event = 'hello';
+  const callback = jest.fn();
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Go Serverless v1.0! Your function executed successfully!',
+      input: event,
+    }),
+  };
+
+  hello(event, null, callback);
+  expect(callback).toHaveBeenCalledWith(null, response);
+});

--- a/lib/plugins/create/templates/aws-nodejs/package.json
+++ b/lib/plugins/create/templates/aws-nodejs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aws-nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "babel-jest": "^19.0.0",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-stage-0": "^6.22.0",
+    "jest": "^19.0.2",
+    "regenerator-runtime": "^0.10.3"
+  }
+}


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3436

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I added `jest`, the packages that jest requires, and a single unit test that simply tests the `hello` function to ensure it was called with the proper data.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Generate a new project with `aws-nodejs`, run `npm install && npm test`. You should get a passing test as well as an obvious starting point for writing more tests.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
