### PR TITLE
Fix for cfnRole attribute in createFallback method

### DIFF
--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -35,6 +35,10 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
+    if (this.serverless.service.provider.cfnRole) {
+      params.RoleARN = this.serverless.service.provider.cfnRole;
+    }
+
     return this.provider.request('CloudFormation',
       'createStack',
       params,

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -78,6 +78,20 @@ describe('updateStack', () => {
         awsDeploy.monitorStack.restore();
       });
     });
+
+    it('should use CloudFormation service role if it is specified', () => {
+      awsDeploy.serverless.service.provider.cfnRole = 'arn:aws:iam::123456789012:role/myrole';
+
+      const createStackStub = sinon.stub(awsDeploy.provider, 'request').resolves();
+      sinon.stub(awsDeploy, 'monitorStack').resolves();
+
+      return awsDeploy.createFallback().then(() => {
+        expect(createStackStub.args[0][2].RoleARN)
+        .to.equal('arn:aws:iam::123456789012:role/myrole');
+        awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
+      });
+    });
   });
 
   describe('#update()', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fix for https://github.com/serverless/serverless/issues/3061

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

The original PR didn't cover every place where a Cloudformation stack is created. It missed the `createFallback` method. 

## How can we verify it:

Remove `lambda` from your IAM permissions so that you're unable to deploy a project. You should see the below error even if using the `cfnRole` attribute
```
     An error occurred while provisioning your stack: HelloLambdaFunction
     - User: <arn>
     is not authorized to perform: lambda:GetFunction on
     resource: <arn>.
```
The error is gone with this fix.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
