### PR TITLE
Extend OpenWhisk Runtime Support

### DIFF
--- a/docs/providers/openwhisk/cli-reference/create.md
+++ b/docs/providers/openwhisk/cli-reference/create.md
@@ -41,6 +41,8 @@ To see a list of available templates run `serverless create --help`
 Most commonly used templates:
 
 - openwhisk-nodejs
+- openwhisk-python
+- openwhisk-swift
 - plugin
 
 ## Examples
@@ -51,8 +53,7 @@ Most commonly used templates:
 serverless create --template openwhisk-nodejs --name my-special-service
 ```
 
-This example will generate scaffolding for a service with `openwhisk` as a provider and `nodejs:6` as runtime. The scaffolding
-will be generated in the current working directory.
+This example will generate scaffolding for a service with `openwhisk` as a provider and `nodejs:6` as runtime. The scaffolding will be generated in the current working directory.
 
 The provider which is used for deployment later on is Apache OpenWhisk.
 
@@ -62,12 +63,9 @@ The provider which is used for deployment later on is Apache OpenWhisk.
 serverless create --template openwhisk-nodejs --path my-new-service
 ```
 
-This example will generate scaffolding for a service with `openwhisk` as a provider and `nodejs` as runtime. The scaffolding
-will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless
-will use the already present directory.
+This example will generate scaffolding for a service with `openwhisk` as a provider and `nodejs` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
-Additionally Serverless will rename the service according to the path you provide. In this example the service will be
-renamed to `my-new-service`.
+Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
 
 ### Creating a new plugin
 

--- a/docs/providers/openwhisk/cli-reference/info.md
+++ b/docs/providers/openwhisk/cli-reference/info.md
@@ -52,4 +52,7 @@ my-hello-world-event-rule
 
 endpoints:
 GET https://xxx-gws.api-gw.mybluemix.net/api/path --> hello-world-dev-helloWorld
+
+endpoints (web actions):
+**no web actions deployed**
 ```

--- a/docs/providers/openwhisk/cli-reference/invoke-local.md
+++ b/docs/providers/openwhisk/cli-reference/invoke-local.md
@@ -18,6 +18,8 @@ This runs your code locally by emulating the Apache OpenWhisk environment. Pleas
 serverless invoke local --function functionName
 ```
 
+__*Please note that only the JavaScript and Python runtimes are supported with this command.*__
+
 ## Options
 
 - `--function` or `-f` The name of the function in your service that you want to invoke locally. **Required**.
@@ -60,4 +62,4 @@ This example will pass the json data in the `lib/data.json` file (relative to th
 
 ### Limitations
 
-Currently, `invoke local` only supports the NodeJs
+Currently, `invoke local` only supports the NodeJs and Python runtimes.

--- a/docs/providers/openwhisk/examples/README.md
+++ b/docs/providers/openwhisk/examples/README.md
@@ -12,8 +12,10 @@ layout: Doc
 
 Have an example? Submit a PR or [open an issue](https://github.com/serverless/examples/issues). ⚡️
 
-| Example | Runtime  |
-|:--------------------------- |:-----|
-| [OpenWhisk Node Simple](https://github.com/serverless/examples/tree/master/openwhisk-node-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | nodeJS |
+| Example                                  | Runtime |
+| :--------------------------------------- | :------ |
+| [OpenWhisk Node Simple](https://github.com/serverless/examples/tree/master/openwhisk-node-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | nodeJS  |
+| [OpenWhisk Python Simple](https://github.com/serverless/examples/tree/master/openwhisk-python-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | python |
+| [OpenWhisk Swift Simple](https://github.com/serverless/examples/tree/master/openwhisk-swift-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | swift |
 
 If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/openwhisk/examples/hello-world/README.md
+++ b/docs/providers/openwhisk/examples/hello-world/README.md
@@ -1,7 +1,7 @@
 <!--
 title: Hello World Example
 menuText: Hello World Example
-description: Example of creating a Hello World function in Node.js with the Serverless framework
+description: Example of creating Hello World functions with the Serverless framework
 layout: Doc
 -->
 
@@ -16,5 +16,7 @@ Welcome to the Hello World example.
 Pick your language of choice:
 
 * [JavaScript](./node)
+* [Python](./python)
+* [Swift](./swift)
 
 [View all examples](https://www.serverless.com/framework/docs/providers/openwhisk/examples/)

--- a/docs/providers/openwhisk/examples/hello-world/python/README.md
+++ b/docs/providers/openwhisk/examples/hello-world/python/README.md
@@ -1,0 +1,38 @@
+<!--
+title: Hello World Python Example
+menuText: Hello World Python Example
+description: Create a Python Hello World OpenWhisk function
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/openwhisk/examples/hello-world/python/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Hello World Python Example
+
+Make sure `serverless` is installed. [See installation guide](../../../guide/installation.md).
+
+## 1. Create a service
+`serverless create --template openwhisk-python --path myService` or `sls create --template openwhisk-python --path myService`, where 'myService' is a new folder to be created with template service files.  Change directories into this new folder.
+
+## 2. Install Provider Plugin
+`npm install -g serverless-openwhisk` followed by `npm install` in the service directory.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+## 4. Invoke deployed function
+`serverless invoke --function helloWorld` or `serverless invoke -f helloWorld`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+{
+    "payload": "Hello, World!"
+}
+```
+
+Congrats you have just deployed and run your Hello World function!

--- a/docs/providers/openwhisk/examples/hello-world/python/handler.py
+++ b/docs/providers/openwhisk/examples/hello-world/python/handler.py
@@ -1,0 +1,5 @@
+def index(params):
+    name = params.get("name", "stranger")
+    greeting = "Hello " + name + "!"
+    print(greeting)
+    return {"greeting": greeting}

--- a/docs/providers/openwhisk/examples/hello-world/python/package.json
+++ b/docs/providers/openwhisk/examples/hello-world/python/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "serverless-openwhisk-hello-world",
+  "version": "0.1.0",
+  "description": "Hello World example for OpenWhisk provider with Serverless Framework.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/docs/providers/openwhisk/examples/hello-world/python/serverless.yml
+++ b/docs/providers/openwhisk/examples/hello-world/python/serverless.yml
@@ -1,0 +1,16 @@
+# Hello World for Apache OpenWhisk
+service: hello-world # Service Name
+
+provider:
+  name: openwhisk
+  runtime: python
+
+functions:
+  helloWorld:
+    handler: handler.index
+    events:
+      - http: GET hello
+
+# remember to run npm install to download the provider plugin.        
+plugins:
+    - serverless-openwhisk

--- a/docs/providers/openwhisk/examples/hello-world/swift/README.md
+++ b/docs/providers/openwhisk/examples/hello-world/swift/README.md
@@ -1,0 +1,38 @@
+<!--
+title: Hello World Swift Example
+menuText: Hello World Swift Example
+description: Create a Swift Hello World OpenWhisk function
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/openwhisk/examples/hello-world/swift/)
+<!-- DOCS-SITE-LINK:END -->
+
+# Hello World Swift Example
+
+Make sure `serverless` is installed. [See installation guide](../../../guide/installation.md).
+
+## 1. Create a service
+`serverless create --template openwhisk-swift --path myService` or `sls create --template openwhisk-swift --path myService`, where 'myService' is a new folder to be created with template service files.  Change directories into this new folder.
+
+## 2. Install Provider Plugin
+`npm install -g serverless-openwhisk` followed by `npm install` in the service directory.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+## 4. Invoke deployed function
+`serverless invoke --function helloWorld` or `serverless invoke -f helloWorld`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+{
+    "payload": "Hello, World!"
+}
+```
+
+Congrats you have just deployed and run your Hello World function!

--- a/docs/providers/openwhisk/examples/hello-world/swift/handler.swift
+++ b/docs/providers/openwhisk/examples/hello-world/swift/handler.swift
@@ -1,0 +1,7 @@
+func main(args: [String:Any]) -> [String:Any] {
+    if let name = args["name"] as? String {
+      return [ "greeting" : "Hello \(name)!" ]
+    } else {
+      return [ "greeting" : "Hello stranger!" ]
+    }
+}

--- a/docs/providers/openwhisk/examples/hello-world/swift/package.json
+++ b/docs/providers/openwhisk/examples/hello-world/swift/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "serverless-openwhisk-hello-world",
+  "version": "0.1.0",
+  "description": "Hello World example for OpenWhisk provider with Serverless Framework.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/docs/providers/openwhisk/examples/hello-world/swift/serverless.yml
+++ b/docs/providers/openwhisk/examples/hello-world/swift/serverless.yml
@@ -1,0 +1,16 @@
+# Hello World for Apache OpenWhisk
+service: hello-world # Service Name
+
+provider:
+  name: openwhisk
+  runtime: swift
+
+functions:
+  greeting:
+    handler: handler.main
+    events:
+      - http: GET hello
+
+# remember to run npm install to download the provider plugin.        
+plugins:
+    - serverless-openwhisk

--- a/docs/providers/openwhisk/guide/functions.md
+++ b/docs/providers/openwhisk/guide/functions.md
@@ -95,3 +95,18 @@ functions:
     handler: handler.functionOne
     memory: 512 # function specific
 ```
+
+## Runtimes
+
+The OpenWhisk provider plugin supports the following runtimes. 
+
+- Node.js
+- Python
+- Swift
+- Binary
+- Docker
+
+Please see the following repository for sample projects using those runtimes. 
+
+[https://github.com/serverless/examples/](https://github.com/serverless/examples/)
+

--- a/docs/providers/openwhisk/guide/serverless.yml.md
+++ b/docs/providers/openwhisk/guide/serverless.yml.md
@@ -44,6 +44,8 @@ functions:
     namespace: 'custom' # use custom namespace, defaults to '_'
     annotations:
         parameter_name: value
+    parameters:
+    	parameter_name: value
     events: # The Events that trigger this Function
     # This creates an API Gateway HTTP endpoint which can be used to trigger this function.  Learn more in "events/apigateway"
       - http: METHOD /path/to/url

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -16,6 +16,8 @@ const validTemplates = [
   'aws-csharp',
   'azure-nodejs',
   'openwhisk-nodejs',
+  'openwhisk-python',
+  'openwhisk-swift',
   'plugin',
 ];
 

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -323,6 +323,47 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "openwhisk-python" template', () => {
+      const cwd = process.cwd();
+      fse.mkdirsSync(tmpDir);
+      process.chdir(tmpDir);
+      create.options.template = 'openwhisk-python';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'package.json')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.py')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+
+        process.chdir(cwd);
+      });
+    });
+
+    it('should generate scaffolding for "openwhisk-swift" template', () => {
+      const cwd = process.cwd();
+      fse.mkdirsSync(tmpDir);
+      process.chdir(tmpDir);
+      create.options.template = 'openwhisk-swift';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'package.json')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'ping.swift')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+
+        process.chdir(cwd);
+      });
+    });
+
+
     it('should generate scaffolding for "azure-nodejs" template', () => {
       const cwd = process.cwd();
       fse.mkdirsSync(tmpDir);

--- a/lib/plugins/create/templates/openwhisk-python/README.md
+++ b/lib/plugins/create/templates/openwhisk-python/README.md
@@ -1,0 +1,66 @@
+# Serverless OpenWhisk Python Template
+
+Hello! 😎
+
+This is a template Python service for the OpenWhisk platform. Before you can deploy your service, please follow the instructions below…
+
+### Have you set up your account credentials?
+
+Before you can deploy your service to OpenWhisk, you need to have an account registered with the platform.
+
+- *Want to run the platform locally?* Please read the project's [*Quick Start*](https://github.com/openwhisk/openwhisk#quick-start) guide for deploying it locally.
+- *Want to use a hosted provider?* Please sign up for an account with [IBM Bluemix](https://console.ng.bluemix.net/) and then follow the instructions for getting access to [OpenWhisk on Bluemix](https://console.ng.bluemix.net/openwhisk/). 
+
+Account credentials for OpenWhisk can be provided through a configuration file or environment variables. This plugin requires the API endpoint, namespace and authentication credentials.
+
+**Do you want to use a configuration file for storing these values?** Please [follow the instructions](https://console.ng.bluemix.net/openwhisk/cli) for setting up the OpenWhisk command-line utility. This tool stores account credentials in the `.wskprops` file in the user's home directory. The plugin automatically extracts credentials from this file at runtime.  No further configuration is needed.
+
+**Do you want to use environment variables for credentials?** Use the following environment variables to be pass in account credentials. These values override anything extracted from the configuration file.
+
+- *OW_APIHOST* - Platform endpoint, e.g. `openwhisk.ng.bluemix.net`
+- *OW_AUTH* - Authentication key, e.g. `xxxxxx:yyyyy
+
+
+
+### Have you installed and setup the provider plugin?
+
+Using the framework with the OpenWhisk platform needs you to install the provider plugin and link this to your service. 
+
+####  Install the provider plugin
+
+```
+$ npm install --global serverless-openwhisk
+```
+
+*Due to an [outstanding issue](https://github.com/serverless/serverless/issues/2895) with provider plugins, the [OpenWhisk provider](https://github.com/serverless/serverless-openwhisk) must be installed as a global module.*
+
+
+#### Link provider plugin to service directory
+
+Using `npm link` will import the provider plugin into the service directory. Running `npm install` will automatically perform this using a `post install` script.
+
+```
+$ npm link serverless-openwhisk
+or
+$ npm install
+```
+
+
+
+**_…and that's it!_**
+
+### Deploy Service
+
+Use the `serverless` command to deploy your service. The sample `handler.js` file can be deployed without modification.
+
+```shell
+serverless deploy
+```
+
+
+
+### Issues / Feedback / Feature Requests?
+
+If you have any issues, comments or want to see new features, please file an issue in the project repository:
+
+https://github.com/serverless/serverless-openwhisk

--- a/lib/plugins/create/templates/openwhisk-python/gitignore
+++ b/lib/plugins/create/templates/openwhisk-python/gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/openwhisk-python/handler.py
+++ b/lib/plugins/create/templates/openwhisk-python/handler.py
@@ -1,0 +1,5 @@
+def hello(params):
+    name = params.get("name", "stranger")
+    greeting = "Hello " + name + "!"
+    print(greeting)
+    return {"greeting": greeting}

--- a/lib/plugins/create/templates/openwhisk-python/package.json
+++ b/lib/plugins/create/templates/openwhisk-python/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "openwhisk-python",
+  "version": "1.0.0",
+  "description": "Sample OpenWhisk Python serverless framework service.",
+  "main": "handler.js",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk"
+  },
+  "keywords": [
+    "serverless",
+    "openwhisk"
+  ]
+}

--- a/lib/plugins/create/templates/openwhisk-python/serverless.yml
+++ b/lib/plugins/create/templates/openwhisk-python/serverless.yml
@@ -1,0 +1,68 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: openwhisk-python # NOTE: update this with your service name
+
+# Please ensure the serverless-openwhisk provider plugin is installed globally.
+# $ npm install -g serverless-openwhisk
+# ...before installing project dependencies to register this provider.
+# $ npm install
+provider:
+  name: openwhisk
+  runtime: python
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.js
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.js
+#    - exclude-me-dir/**
+
+functions:
+  hello:
+    handler: handler.hello
+
+#    Functions can be defined using sequences rather than referring 
+#    to a handler.
+#    sequence:
+#      - parse_input
+#      - do_some_algorithm
+#      - construct_output
+
+#    The following are a few example events you can configure
+#    Check the event documentation for details
+#    events:
+#      - http: GET /api/users/create
+#      - trigger: trigger_name
+
+
+# extend the framework using plugins listed here:
+# https://github.com/serverless/plugins
+plugins:
+  - serverless-openwhisk
+
+# you can define custom triggers and trigger feeds using the resources section.
+#
+#resources:
+#  triggers:
+#    my_trigger:
+#      parameters: 
+#        hello: world    
+#    alarm_trigger:
+#      parameters: 
+#        hello: world
+#     feed: /whisk.system/alarms/alarm
+#     feed_parameters: 
+#       cron: '*/8 * * * * *'

--- a/lib/plugins/create/templates/openwhisk-swift/README.md
+++ b/lib/plugins/create/templates/openwhisk-swift/README.md
@@ -1,0 +1,66 @@
+# Serverless OpenWhisk Swift Template
+
+Hello! 😎
+
+This is a template Swift service for the OpenWhisk platform. Before you can deploy your service, please follow the instructions below…
+
+### Have you set up your account credentials?
+
+Before you can deploy your service to OpenWhisk, you need to have an account registered with the platform.
+
+- *Want to run the platform locally?* Please read the project's [*Quick Start*](https://github.com/openwhisk/openwhisk#quick-start) guide for deploying it locally.
+- *Want to use a hosted provider?* Please sign up for an account with [IBM Bluemix](https://console.ng.bluemix.net/) and then follow the instructions for getting access to [OpenWhisk on Bluemix](https://console.ng.bluemix.net/openwhisk/). 
+
+Account credentials for OpenWhisk can be provided through a configuration file or environment variables. This plugin requires the API endpoint, namespace and authentication credentials.
+
+**Do you want to use a configuration file for storing these values?** Please [follow the instructions](https://console.ng.bluemix.net/openwhisk/cli) for setting up the OpenWhisk command-line utility. This tool stores account credentials in the `.wskprops` file in the user's home directory. The plugin automatically extracts credentials from this file at runtime.  No further configuration is needed.
+
+**Do you want to use environment variables for credentials?** Use the following environment variables to be pass in account credentials. These values override anything extracted from the configuration file.
+
+- *OW_APIHOST* - Platform endpoint, e.g. `openwhisk.ng.bluemix.net`
+- *OW_AUTH* - Authentication key, e.g. `xxxxxx:yyyyy
+
+
+
+### Have you installed and setup the provider plugin?
+
+Using the framework with the OpenWhisk platform needs you to install the provider plugin and link this to your service. 
+
+####  Install the provider plugin
+
+```
+$ npm install --global serverless-openwhisk
+```
+
+*Due to an [outstanding issue](https://github.com/serverless/serverless/issues/2895) with provider plugins, the [OpenWhisk provider](https://github.com/serverless/serverless-openwhisk) must be installed as a global module.*
+
+
+#### Link provider plugin to service directory
+
+Using `npm link` will import the provider plugin into the service directory. Running `npm install` will automatically perform this using a `post install` script.
+
+```
+$ npm link serverless-openwhisk
+or
+$ npm install
+```
+
+
+
+**_…and that's it!_**
+
+### Deploy Service
+
+Use the `serverless` command to deploy your service. The sample `handler.js` file can be deployed without modification.
+
+```shell
+serverless deploy
+```
+
+
+
+### Issues / Feedback / Feature Requests?
+
+If you have any issues, comments or want to see new features, please file an issue in the project repository:
+
+https://github.com/serverless/serverless-openwhisk

--- a/lib/plugins/create/templates/openwhisk-swift/gitignore
+++ b/lib/plugins/create/templates/openwhisk-swift/gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/openwhisk-swift/package.json
+++ b/lib/plugins/create/templates/openwhisk-swift/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "openwhisk-python",
+  "version": "1.0.0",
+  "description": "Sample OpenWhisk Python serverless framework service.",
+  "main": "handler.js",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk"
+  },
+  "keywords": [
+    "serverless",
+    "openwhisk"
+  ]
+}

--- a/lib/plugins/create/templates/openwhisk-swift/package.json
+++ b/lib/plugins/create/templates/openwhisk-swift/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "openwhisk-python",
+  "name": "openwhisk-swift",
   "version": "1.0.0",
-  "description": "Sample OpenWhisk Python serverless framework service.",
+  "description": "Sample OpenWhisk Swift serverless framework service.",
   "main": "handler.js",
   "scripts": {
     "postinstall": "npm link serverless-openwhisk"

--- a/lib/plugins/create/templates/openwhisk-swift/ping.swift
+++ b/lib/plugins/create/templates/openwhisk-swift/ping.swift
@@ -1,0 +1,12 @@
+func main(args: [String:Any]) -> [String:Any] {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    let now = formatter.string(from: Date())
+ 
+    if let name = args["name"] as? String {
+      return [ "greeting" : "Hello \(name)! The time is \(now)" ]
+    } else {
+      return [ "greeting" : "Hello stranger! The time is \(now)" ]
+    }
+}
+

--- a/lib/plugins/create/templates/openwhisk-swift/serverless.yml
+++ b/lib/plugins/create/templates/openwhisk-swift/serverless.yml
@@ -1,0 +1,68 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: openwhisk-swift # NOTE: update this with your service name
+
+# Please ensure the serverless-openwhisk provider plugin is installed globally.
+# $ npm install -g serverless-openwhisk
+# ...before installing project dependencies to register this provider.
+# $ npm install
+provider:
+  name: openwhisk
+  runtime: swift
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.js
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.js
+#    - exclude-me-dir/**
+
+functions:
+  hello:
+    handler: ping.main
+
+#    Functions can be defined using sequences rather than referring 
+#    to a handler.
+#    sequence:
+#      - parse_input
+#      - do_some_algorithm
+#      - construct_output
+
+#    The following are a few example events you can configure
+#    Check the event documentation for details
+#    events:
+#      - http: GET /api/users/create
+#      - trigger: trigger_name
+
+
+# extend the framework using plugins listed here:
+# https://github.com/serverless/plugins
+plugins:
+  - serverless-openwhisk
+
+# you can define custom triggers and trigger feeds using the resources section.
+#
+#resources:
+#  triggers:
+#    my_trigger:
+#      parameters: 
+#        hello: world    
+#    alarm_trigger:
+#      parameters: 
+#        hello: world
+#     feed: /whisk.system/alarms/alarm
+#     feed_parameters: 
+#       cron: '*/8 * * * * *'


### PR DESCRIPTION
## What did you implement:

New version (0.6) of the OpenWhisk plugin will include support for non-Node.js runtimes. I have added templates to the `create` plugin and also updated the documentation with new features.

## How did you implement it:

Trivial changes to the `create` plugin for the new templates. Docs updated based upon the new features.

## How can we verify it:

```
sls create --template openwhisk-python
sls create --template openwhisk-swift
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
