### PR TITLE
Fix validateS3BucketName Bug

### DIFF
--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -2,6 +2,7 @@
 
 const BbPromise = require('bluebird');
 const path = require('path');
+const validate = require('../lib/validate');
 const mergeCustomProviderResources = require('./lib/mergeCustomProviderResources');
 const generateArtifactDirectoryName = require('./lib/generateArtifactDirectoryName');
 const generateCoreTemplate = require('./lib/generateCoreTemplate');
@@ -23,6 +24,7 @@ class AwsPackage {
 
     Object.assign(
       this,
+      validate,
       packageService,
       zipService,
       generateCoreTemplate,


### PR DESCRIPTION
See comments on https://github.com/serverless/serverless/pull/3344

Load validate back into the context and assign it to make that method available again.

 Meta-commentary.  The validation of the bucket to use seems more appropraitely placed into the deployment workflow.  The template generation capability seems more appropriately responsible for simply noting that it does not need to supply and create (and should thereby remove the by-default included) a deployment bucket.  The validation of the specified bucket as usable for purpose seems more appropriately part of the deploy workflow.  No fixes or alterations for that matter here.

  Also not fixed: the failure to support projects with a valid `${self:} reference` (i.e. an object cycle)

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
