### PR TITLE
Persist package.artifact correctly

### DIFF
--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -19,8 +19,10 @@ module.exports = {
       .utils.readFileSync(serviceStateFilePath);
     _.assign(this.serverless.service, state.service);
     this.serverless.service.package.artifactDirectoryName = state.package.artifactDirectoryName;
-    this.serverless.service.package.artifact = path
-      .join(this.serverless.config.servicePath, '.serverless', state.package.artifact);
+    if (!_.isEmpty(state.package.artifact)) {
+      this.serverless.service.package.artifact = path
+        .join(this.serverless.config.servicePath, '.serverless', state.package.artifact);
+    }
 
     if (this.serverless.service.package.individually) {
       // artifact file validation (multiple function artifacts)

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -19,6 +19,8 @@ module.exports = {
       .utils.readFileSync(serviceStateFilePath);
     _.assign(this.serverless.service, state.service);
     this.serverless.service.package.artifactDirectoryName = state.package.artifactDirectoryName;
+    this.serverless.service.package.artifact = path
+      .join(this.serverless.config.servicePath, '.serverless', state.package.artifact);
 
     if (this.serverless.service.package.individually) {
       // artifact file validation (multiple function artifacts)

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -14,11 +14,14 @@ module.exports = {
       serviceStateFileName
     );
 
+    const artifact = this.serverless.service.package.artifact.split(path.sep).pop();
+
     const state = {
       service: _.assign({}, _.omit(this.serverless.service, ['serverless', 'package'])),
       package: {
         individually: this.serverless.service.package.individually,
         artifactDirectoryName: this.serverless.service.package.artifactDirectoryName,
+        artifact,
       },
     };
 

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -14,7 +14,11 @@ module.exports = {
       serviceStateFileName
     );
 
-    const artifact = this.serverless.service.package.artifact.split(path.sep).pop();
+    const artifact = _.last(
+      _.split(
+        _.get(this.serverless.service, 'package.artifact', ''), path.sep
+      )
+    );
 
     const state = {
       service: _.assign({}, _.omit(this.serverless.service, ['serverless', 'package'])),

--- a/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -25,6 +25,7 @@ describe('#saveServiceState()', () => {
       package: {
         individually: false,
         artifactDirectoryName: 'artifact-directory',
+        artifact: 'service.zip',
       },
     };
     getServiceStateFileNameStub = sinon
@@ -56,6 +57,7 @@ describe('#saveServiceState()', () => {
         package: {
           individually: false,
           artifactDirectoryName: 'artifact-directory',
+          artifact: 'service.zip',
         },
       };
 

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -28,6 +28,7 @@ module.exports = {
 
   packageService() {
     this.serverless.cli.log('Packaging service...');
+    _.set(this.serverless.service, 'package.artifacts', {});
     let shouldPackageService = false;
     const allFunctions = this.serverless.service.getAllFunctions();
     const packagePromises = _.map(allFunctions, functionName => {
@@ -35,6 +36,8 @@ module.exports = {
       functionObject.package = functionObject.package || {};
       if (functionObject.package.individually || this.serverless.service
           .package.individually) {
+        this.serverless.service.package.artifacts[functionName] =
+          this.provider.naming.getFunctionArtifactName(functionName);
         return this.packageFunction(functionName);
       }
       shouldPackageService = true;

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -28,7 +28,6 @@ module.exports = {
 
   packageService() {
     this.serverless.cli.log('Packaging service...');
-    _.set(this.serverless.service, 'package.artifacts', {});
     let shouldPackageService = false;
     const allFunctions = this.serverless.service.getAllFunctions();
     const packagePromises = _.map(allFunctions, functionName => {
@@ -36,8 +35,6 @@ module.exports = {
       functionObject.package = functionObject.package || {};
       if (functionObject.package.individually || this.serverless.service
           .package.individually) {
-        this.serverless.service.package.artifacts[functionName] =
-          this.provider.naming.getFunctionArtifactName(functionName);
         return this.packageFunction(functionName);
       }
       shouldPackageService = true;


### PR DESCRIPTION
The `service.package.artifact` property was missing in the saveState function, so it was not available in the deploy phase.
This PR saves and restores the property correctly, and for AWS additionally sets it during packaging. For AWS the initialization of the property also was missing, possibly due to a merge conflict.

Should be merged as soon as possible!