### PR TITLE
Add imports and exports functionality (Cross-Stack-References)

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -21,6 +21,7 @@ class Service {
     this.custom = {};
     this.plugins = [];
     this.functions = {};
+    this.imports = {};
     this.resources = {};
     this.package = {};
 
@@ -96,6 +97,7 @@ class Service {
         that.plugins = serverlessFile.plugins;
         that.resources = serverlessFile.resources;
         that.functions = serverlessFile.functions || {};
+        that.imports = serverlessFile.imports || {};
 
         // merge so that the default settings are still in place and
         // won't be overwritten

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -22,6 +22,7 @@ class Service {
     this.plugins = [];
     this.functions = {};
     this.imports = {};
+    this.exports = {};
     this.resources = {};
     this.package = {};
 
@@ -98,6 +99,7 @@ class Service {
         that.resources = serverlessFile.resources;
         that.functions = serverlessFile.functions || {};
         that.imports = serverlessFile.imports || {};
+        that.exports = serverlessFile.exports || {};
 
         // merge so that the default settings are still in place and
         // won't be overwritten

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -17,6 +17,7 @@ class Variables {
     this.envRefSyntax = RegExp(/^env:/g);
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
+    this.importsRefSyntax = RegExp(/^imports:/g);
   }
 
   loadVariableSyntax() {
@@ -130,10 +131,12 @@ class Variables {
       valueToPopulate = this.getValueFromSelf(variableString);
     } else if (variableString.match(this.fileRefSyntax)) {
       valueToPopulate = this.getValueFromFile(variableString);
+    } else if (variableString.match(this.importsRefSyntax)) {
+      valueToPopulate = this.getValueFromImports(variableString);
     } else {
       const errorMessage = [
         `Invalid variable reference syntax for variable ${variableString}.`,
-        ' You can only reference env vars, options, & files.',
+        ' You can only reference env vars, options, self, files & imports.',
         ' You can check our docs for more info.',
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
@@ -168,6 +171,23 @@ class Variables {
     const deepProperties = variableString.split(':')[1].split('.');
     valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
     return valueToPopulate;
+  }
+
+  getValueFromImports(variableString) {
+    const removedPrefix = variableString.split(':')[1];
+    const stack = removedPrefix.split('.')[0];
+    const found = this.serverless.service.imports[stack];
+
+    if (!found) {
+      const errorMessage = [
+        `Variable "${variableString}" not resolvable.`,
+        ' Please import it explicitly with the "imports" config.',
+        ' Check the docs on "imports" and "exports" for more info.',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+
+    return variableString;
   }
 
   getValueFromFile(variableString) {
@@ -260,6 +280,8 @@ class Variables {
         varType = 'service attribute';
       } else if (variableString.match(this.fileRefSyntax)) {
         varType = 'file';
+      } else if (variableString.match(this.importsRefSyntax)) {
+        varType = 'imports';
       }
       logWarning(
         `A valid ${varType} to satisfy the declaration '${variableString}' could not be found.`

--- a/lib/plugins/Plugins.json
+++ b/lib/plugins/Plugins.json
@@ -25,6 +25,7 @@
     "./aws/rollback/index.js",
     "./aws/package/compile/functions/index.js",
     "./aws/package/compile/imports/imports.js",
+    "./aws/package/compile/exports/exports.js",
     "./aws/package/compile/events/schedule/index.js",
     "./aws/package/compile/events/s3/index.js",
     "./aws/package/compile/events/apiGateway/index.js",

--- a/lib/plugins/Plugins.json
+++ b/lib/plugins/Plugins.json
@@ -24,6 +24,7 @@
     "./aws/remove/index.js",
     "./aws/rollback/index.js",
     "./aws/package/compile/functions/index.js",
+    "./aws/package/compile/imports/imports.js",
     "./aws/package/compile/events/schedule/index.js",
     "./aws/package/compile/events/s3/index.js",
     "./aws/package/compile/events/apiGateway/index.js",

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -278,4 +278,9 @@ module.exports = {
     return `${this.getNormalizedFunctionName(functionName)
     }LambdaPermissionLogsSubscriptionFilterCloudWatchLog${logsIndex}`;
   },
+
+  // Export
+  getExportOutputLogicalId(key) {
+    return `Exported${_.capitalize(key)}`;
+  },
 };

--- a/lib/plugins/aws/package/compile/exports/exports.js
+++ b/lib/plugins/aws/package/compile/exports/exports.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const _ = require('lodash');
+
+class AwsCompileExports {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+    this.provider = this.serverless.getProvider('aws');
+
+    this.compileExports = this.compileExports.bind(this);
+
+    this.hooks = {
+      'package:compileExports': this.compileExports,
+    };
+  }
+
+  compileExports() {
+    const exports = this.serverless.service.exports;
+    _.forEach(exports, (value, key) => {
+      const stackName = this.provider.naming.getStackName();
+      const exportOutputLogicalId = this.provider.naming.getExportOutputLogicalId(key);
+      const newExportOutput = this.cfOutputExportTemplate();
+
+      newExportOutput.Description = `Exported ${key}`;
+      newExportOutput.Value = value;
+      newExportOutput.Export.Name = `${stackName}-${key}`;
+
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+        [exportOutputLogicalId]: newExportOutput,
+      });
+    });
+  }
+
+  cfOutputExportTemplate() {
+    return {
+      Description: 'Exported value',
+      Value: 'Value',
+      Export: {
+        Name: 'Name',
+      },
+    };
+  }
+}
+
+module.exports = AwsCompileExports;

--- a/lib/plugins/aws/package/compile/imports/imports.js
+++ b/lib/plugins/aws/package/compile/imports/imports.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const traverse = require('traverse');
+
+class AwsCompileImports {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+    this.provider = this.serverless.getProvider('aws');
+
+    this.compileImports = this.compileImports.bind(this);
+
+    this.hooks = {
+      'package:compileImports': this.compileImports,
+    };
+  }
+
+  compileImports() {
+    const that = this; // save this because of the upcoming scope switch
+    traverse(this.serverless.service).forEach(function (propertyParam) {
+      if (typeof propertyParam === 'string' && propertyParam.match(/imports:.+/)) {
+        const removedPrefix = propertyParam.split(':')[1];
+        const parts = removedPrefix.split('.');
+        const stack = parts[0];
+        const value = parts[1];
+
+        const newImportValue = that.cfImportValueTemplate();
+        newImportValue['Fn::ImportValue'] = `${stack}-${value}`;
+
+        this.update(newImportValue);
+      }
+    });
+  }
+
+  cfImportValueTemplate() {
+    return {
+      'Fn::ImportValue': 'Value',
+    };
+  }
+}
+
+module.exports = AwsCompileImports;

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -13,6 +13,7 @@ class Package {
           'initialize',
           'setupProviderConfiguration',
           'createDeploymentArtifacts',
+          'compileImports',
           'compileFunctions',
           'compileEvents',
           'finalize',

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -14,6 +14,7 @@ class Package {
           'setupProviderConfiguration',
           'createDeploymentArtifacts',
           'compileImports',
+          'compileExports',
           'compileFunctions',
           'compileEvents',
           'finalize',


### PR DESCRIPTION
## What did you implement:

Closes #3442

This WIP PR implements the `imports` and `exports` support as described in #3442.

/cc @brianneisler @eahefnawy 

## How did you implement it:

**Imports**

Import values can be defined with the help of the `imports` keyword.

Those values are then translated into Serverless variables and can therefore be placed anywhere in the `serverless.yml` file.

The `AwsCompileImports` plugin checks for the populated variable in the `serverless.yml` file and replaces this value with the corresponding `CloudFormation` `Fn::ImportValue` statement. It's furthermore checked if the Serverless `imports` variable is imported beforehand so that a population is not happening if it's not explicitly imported.

**Exports**

Export values can be specified with the help of the `exports` config variable in the `serverless.yml` file

 Those values are then compiled into corresponding `CloudFormation` `Outputs` by the `AwsCompileExports` plugin.

## How can we verify it:

Here's a `serverless.yml` file which shows how this looks like:

```yml
service: service

provider:
  name: aws
  runtime: nodejs6.10

exports:
  writeKey: QWERTY1234

imports:
  users-dev: # the stack which exports this values
    - bucketName # the value which should be imported from that stack

functions:
  hello:
    handler: handler.hello

resources:
  Resources:
    Type: "AWS::S3::Bucket"
    Properties:
      BucketName: ${imports:users-dev.bucketName}
```

Just run `serverless package` and take a look in the generated `CloudFormation` output.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO