### PR TITLE
Copy necessary permission grant command to azure quickstart guide

### DIFF
--- a/docs/providers/azure/guide/quickstart.md
+++ b/docs/providers/azure/guide/quickstart.md
@@ -72,6 +72,12 @@ We'll set up an Azure Subscription and our service principal. You can learn more
 
     This should return an object which has the `servicePrincipalNames` property on it. Save one of the names in the array and the password you provided for later. If you need to look up your service principal later, you can use `azure ad sp -c <name>` where `<name>` is the name provided originally. Note that the `<name>` you provided is not the name you'll provide later, it is a name in the `servicePrincipalNames` array.
 
+    Then grant the SP contributor access with the ObjectId
+
+    ```bash
+    azure role assignment create --objectId <objectIDFromCreateStep> -o Contributor
+    ```
+
 6. Set up environment variables
 
      You need to set up environment variables for your subscription id, tenant id, service principal name, and password.


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

As written prior to this commit, the Azure quickstart guide does not grant the created service principal access to perform a deploy.

## How did you implement it:

I copied the relevant instructions from the Azure credentials guide into the quickstart guide. The credential section of the quickstart guide was previously identical to the credential guide apart from the section I copied in.

## How can we verify it:

Follow the instructions in the quickstart guide and verify that `serverless invoke -f hello` produces the output "Hello World"

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
