### PR TITLE
Fixing typos in CloudWatch log docs

### DIFF
--- a/docs/providers/aws/events/cloudwatch-log.md
+++ b/docs/providers/aws/events/cloudwatch-log.md
@@ -46,7 +46,7 @@ There's currently one gotcha you might face if you use this event definition.
 
 The deployment will fail with an error that a resource limit exceeded if you replace the `logGroup` name of one function with the `logGroup` name of another function in your `serverless.yml` file and run `serverless deploy` (see below for an in-depth example).
 
-This is caused by the fact that CloudFormation tries to attach the new subscription filter before detaching the old one. CloudWatch Logs only support one subscription fitlter per log group as you can read in the documentation about [CloudWatch Logs Limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).
+This is caused by the fact that CloudFormation tries to attach the new subscription filter before detaching the old one. CloudWatch Logs only support one subscription filter per log group as you can read in the documentation about [CloudWatch Logs Limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).
 
 Please keep this gotcha in mind when using this event. We will fix it in an upcoming release.
 
@@ -66,7 +66,7 @@ functions:
       - cloudwatchLog: '/aws/lambda/hello2'
 ```
 
-Next up, edit `serverless.yml` and swap out the `logGroup` names. After that run `serverless deploy` again (the dpeloyment will fail).
+Next up, edit `serverless.yml` and swap out the `logGroup` names. After that run `serverless deploy` again (the deployment will fail).
 
 ```yml
 functions:


### PR DESCRIPTION
## What did you implement:

Fixed a couple of spelling errors in CloudWatch Logs documentation

***Is this ready for review?:*** YES
