### PR TITLE
Control command flow for deploy at framework level.

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -69,9 +69,7 @@ class AwsDeploy {
         .then(() => this.serverless.pluginManager.spawn('aws:common:validate'))
         .then(() => {
           if (!this.options.package && !this.serverless.service.package.path) {
-            return BbPromise.bind(this)
-              .then(() => this.serverless.pluginManager.spawn('package'))
-              .then(this.extendedValidate);
+            return this.extendedValidate();
           }
           return BbPromise.bind(this)
             .then(() => this.serverless.pluginManager.spawn('aws:common:moveArtifactsToTemp'))

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -126,8 +126,7 @@ describe('AwsDeploy', () => {
 
         return awsDeploy.hooks['before:deploy:deploy']().then(() => {
           expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
-          expect(spawnPackageStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(true);
-          expect(extendedValidateStub.calledAfter(spawnPackageStub)).to.equal(true);
+          expect(extendedValidateStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(true);
           expect(spawnAwsCommonMoveArtifactsToTemp.calledOnce).to.equal(false);
         });
       });

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -3,8 +3,9 @@
 const BbPromise = require('bluebird');
 
 class Deploy {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options || {};
 
     this.commands = {
       deploy: {

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const BbPromise = require('bluebird');
+
 class Deploy {
   constructor(serverless) {
     this.serverless = serverless;
@@ -67,6 +69,16 @@ class Deploy {
           },
         },
       },
+    };
+
+    this.hooks = {
+      'before:deploy:deploy': () => BbPromise.bind(this)
+      .then(() => {
+        if (!this.options.package && !this.serverless.service.package.path) {
+          return this.serverless.pluginManager.spawn('package');
+        }
+        return BbPromise.resolve();
+      }),
     };
   }
 }

--- a/lib/plugins/deploy/deploy.test.js
+++ b/lib/plugins/deploy/deploy.test.js
@@ -3,18 +3,67 @@
 const expect = require('chai').expect;
 const Deploy = require('./deploy');
 const Serverless = require('../../Serverless');
-
+const sinon = require('sinon');
 
 describe('Deploy', () => {
   let deploy;
   let serverless;
+  let options;
 
   beforeEach(() => {
     serverless = new Serverless();
-    deploy = new Deploy(serverless);
+    options = {};
+    deploy = new Deploy(serverless, options);
   });
 
   describe('#constructor()', () => {
     it('should have commands', () => expect(deploy.commands).to.be.not.empty);
+    it('should have hooks', () => expect(deploy.hooks).to.be.not.empty);
+    it('should work without options', () => {
+      const noOptionDeploy = new Deploy(serverless);
+      expect(noOptionDeploy).to.have.property('options').to.be.eql({});
+    });
+  });
+
+  describe('"before:deploy:deploy" hook', () => {
+    let spawnStub;
+    let spawnPackageStub;
+
+    beforeEach(() => {
+      spawnStub = sinon
+        .stub(serverless.pluginManager, 'spawn');
+      spawnPackageStub = spawnStub.withArgs('package').resolves();
+    });
+
+    afterEach(() => {
+      serverless.pluginManager.spawn.restore();
+    });
+
+    it('should resolve if the package option is set', () => {
+      deploy.options.package = false;
+      deploy.serverless.service.package.path = 'some_path';
+
+      return deploy.hooks['before:deploy:deploy']().then(() => {
+        expect(spawnPackageStub.called).to.equal(false);
+      });
+    });
+
+    it('should resolve if the service package path is set', () => {
+      deploy.options.package = 'some_path';
+      deploy.serverless.service.package.path = false;
+
+      return deploy.hooks['before:deploy:deploy']().then(() => {
+        expect(spawnPackageStub.called).to.equal(false);
+      });
+    });
+
+    it('should use the default packaging mechanism if no packaging config is provided', () => {
+      deploy.options.package = false;
+      deploy.serverless.service.package.path = false;
+
+      return deploy.hooks['before:deploy:deploy']().then(() => {
+        expect(spawnPackageStub.calledOnce).to.equal(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Support extended lifecycle at framework level. See #3344 

The new lifecycle is now triggered at framework level. This will keep other provider plugins compatible, as the package command is spawned from the uppermost deploy, depending on the existence of the package option.

## How can we verify it:

This is still work in progress. Can someone test my branch with the other providers and use just a plain "serverless deploy" without package switch.
The expected behavior would be that it runs through as it did with before the package/deploy split.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO - It's a "restore non-breaking one" ;-)
