### PR TITLE
Pass Logical Role identifier to stream event source mapping

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -126,6 +126,8 @@ class AwsCompileStreamEvents {
                 funcRole.indexOf(':') !== -1
               ) {
                 dependsOn = '[]';
+              } else if (typeof funcRole === 'string') {
+                dependsOn = `"${funcRole}"`;
               } else if ( // otherwise, check if we have an in-service reference to a role ARN
                 typeof funcRole === 'object' &&
                 'Fn::GetAtt' in funcRole &&

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -217,6 +217,31 @@ describe('AwsCompileStreamEvents', () => {
       ).to.equal(null);
     });
 
+    it('function role value should be passed to EventSourceMapping DependsOn', () => {
+      const roleLogicalId = 'RoleLogicalId';
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          role: roleLogicalId,
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamRoleLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamRoleLambdaExecution = null;
+
+      expect(() => { awsCompileStreamEvents.compileStreamEvents(); }).to.not.throw(Error);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn).to.equal(roleLogicalId);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamRoleLambdaExecution).to.equal(null);
+    });
+
     it('should not throw error if custom IAM role reference is set in provider', () => {
       const roleLogicalId = 'RoleLogicalId';
       awsCompileStreamEvents.serverless.service.functions = {


### PR DESCRIPTION
## What did you implement:

Closes #3499

Passes a Logical Role identifier through to the Event Source Mapping template for use as DependsOn value. 


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
