### PR TITLE
show warning instead of error when there are no hooks

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -226,9 +226,9 @@ class PluginManager {
     const events = this.getEvents(command);
     const hooks = this.getHooks(events);
 
-    if (hooks.length === 0) {
-      const errorMessage = 'The command you entered did not catch on any hooks';
-      throw new this.serverless.classes.Error(errorMessage);
+    if (hooks.length === 0 && process.env.SLS_DEBUG) {
+      const warningMessage = 'Warning: The command you entered did not catch on any hooks';
+      this.serverless.cli.log(warningMessage);
     }
 
     return BbPromise.reduce(hooks, (__, hook) => hook.hook(), null);

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -914,7 +914,9 @@ describe('PluginManager', () => {
       expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
     });
 
-    it('should throw an error when the given command has no hooks', () => {
+    it('should show warning if in debug mode and the given command has no hooks', () => {
+      const consoleLogStub = sinon.stub(pluginManager.serverless.cli, 'log').returns();
+      process.env.SLS_DEBUG = '*';
       class HooklessPlugin {
         constructor() {
           this.commands = {
@@ -927,7 +929,11 @@ describe('PluginManager', () => {
 
       const commandsArray = ['foo'];
 
-      expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
+      return pluginManager.run(commandsArray).then(() => {
+        expect(consoleLogStub.called).is.equal(true);
+        pluginManager.serverless.cli.log.restore();
+        process.env.SLS_DEBUG = undefined;
+      });
     });
 
     it('should run the hooks in the correct order', () => {
@@ -1072,7 +1078,9 @@ describe('PluginManager', () => {
       expect(() => { pluginManager.spawn(commandsArray); }).to.throw(Error);
     });
 
-    it('should throw an error when the given command has no hooks', () => {
+    it('should show warning in debug mode and when the given command has no hooks', () => {
+      const consoleLogStub = sinon.stub(pluginManager.serverless.cli, 'log').returns();
+      process.env.SLS_DEBUG = '*';
       class HooklessPlugin {
         constructor() {
           this.commands = {
@@ -1085,7 +1093,11 @@ describe('PluginManager', () => {
 
       const commandsArray = ['foo'];
 
-      expect(() => { pluginManager.spawn(commandsArray); }).to.throw(Error);
+      return pluginManager.run(commandsArray).then(() => {
+        expect(consoleLogStub.called).is.equal(true);
+        pluginManager.serverless.cli.log.restore();
+        process.env.SLS_DEBUG = undefined;
+      });
     });
 
     describe('when invoking a command', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Show warning instead of throwing an error when the command has no hooks. Throwing an error unnecessarily breaks the Azure plugin after the recent hook deprecation feature because Azure doesn't have any deprecated hooks.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Log instead of throwing an error

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
set the `SLS_DEBUG` env var and run the Azure plugin, you'll see the warning but execution continues.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO