### PR TITLE
Automatic stack splitting

### DIFF
--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -36,7 +36,7 @@ The Serverless Framework translates all syntax in `serverless.yml` to a single A
 * The CloudFormation Stack is updated with the new CloudFormation template.
 * Each deployment publishes a new version for each function in your service.
 
-### Tips
+#### Tips
 
 * Use this in your CI/CD systems, as it is the safest method of deployment.
 * You can print the progress during the deployment if you use `verbose` mode, like this:
@@ -66,6 +66,37 @@ The Serverless Framework translates all syntax in `serverless.yml` to a single A
 
 Check out the [deploy command docs](../cli-reference/deploy.md) for all details and options.
 
+#### When reaching stack limitations
+
+AWS CloudFormation has various limitations. You can read more about those [in their docs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html).
+
+There are different ways how you can resolve those stack limits. Here you can read about possible solutions:
+
+1. Cross-Service communication
+
+Split up the stack manually and use Cross-Service communication (e.g. with the `${cf:}` Serverless Variable property) to share necessary information between the stacks
+
+2. Use `provider.useStackSplitting` config variable
+
+```yml
+service: service
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  useStackSplitting: true
+
+functions:
+  hello:
+    handler: handler.hello
+
+...
+```
+
+This tells Serverless to automatically split the stack into multiple nested stacks. Serverless will manage those for you from now on.
+
+**CAUTON:** This *experimental* feature provides a one-way road since it's harder to revert later on.
+
 ## Deploy Function
 
 This deployment method does not touch your AWS CloudFormation Stack.  Instead, it simply overwrites the zip file of the current function on AWS.  This method is much faster, since it does not rely on CloudFormation.
@@ -79,7 +110,7 @@ serverless deploy function --function myFunction
 * The Framework packages up the targeted AWS Lambda Function into a zip file.
 * That zip file is uploaded to your S3 bucket using the same name as the previous function, which the CloudFormation stack is pointing to.
 
-### Tips
+#### Tips
 
 * Use this when you are developing and want to test on AWS because it's much faster.
 * During development, people will often run this command several times, as opposed to `serverless deploy` which is only run when larger infrastructure provisioning is required.
@@ -96,5 +127,5 @@ serverless deploy --package path-to-package
 
 ### How It Works
 
-- The argument to the `--package` flag is a directory that has been previously packaged by Serverless (with `serverless package`).
-- The deploy process bypasses the package step and uses the existing package to deploy and update CloudFormation stacks.
+* The argument to the `--package` flag is a directory that has been previously packaged by Serverless (with `serverless package`).
+* The deploy process bypasses the package step and uses the existing package to deploy and update CloudFormation stacks.

--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -85,6 +85,7 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |
 |SNS::Subscription      | {normalizedFunctionName}SnsSubscription{normalizedTopicName}   | HelloSnsSubscriptionSomeTopic             |
 |AWS::Lambda::EventSourceMapping | <ul><li>**DynamoDB:** {normalizedFunctionName}EventSourceMappingDynamodb{tableName}</li><li>**Kinesis:** {normalizedFunctionName}EventSourceMappingKinesis{streamName}</li></ul> | <ul><li>**DynamoDB:** HelloLambdaEventSourceMappingDynamodbUsers</li><li>**Kinesis:** HelloLambdaEventSourceMappingKinesisMystream</li></ul> |
+|AWS::CloudFormation::Stack | NestedStack{SequentialID}       | NestedStack1            |
 |Cognito::UserPool      | CognitoUserPool{normalizedPoolId}                       | CognitoUserPoolPoolId         |
 
 ## Override AWS CloudFormation Resource

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -37,7 +37,6 @@ provider:
   role: arn:aws:iam::XXXXXX:role/role # Overwrite the default IAM role which is used for all functions
   cfnRole: arn:aws:iam::XXXXXX:role/role # ARN of an IAM role for CloudFormation service. If specified, CloudFormation uses the role's credentials
   versionFunctions: false # Optional function versioning
-  onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
   useStackSplitting: true # EXPERIMENTAL: let AWS automatically split the stack into nested stacks (useful when AWS CloudFormation stack limits are reached)
   environment: # Service wide environment variables
     serviceEnvVar: 123456789

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -37,6 +37,8 @@ provider:
   role: arn:aws:iam::XXXXXX:role/role # Overwrite the default IAM role which is used for all functions
   cfnRole: arn:aws:iam::XXXXXX:role/role # ARN of an IAM role for CloudFormation service. If specified, CloudFormation uses the role's credentials
   versionFunctions: false # Optional function versioning
+  onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
+  useStackSplitting: true # EXPERIMENTAL: let AWS automatically split the stack into nested stacks (useful when AWS CloudFormation stack limits are reached)
   environment: # Service wide environment variables
     serviceEnvVar: 123456789
   apiKeys: # List of API keys to be used by your service API Gateway REST API

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -13,6 +13,7 @@ const extendedValidate = require('./lib/extendedValidate');
 const monitorStack = require('../lib/monitorStack');
 const createStack = require('./lib/createStack');
 const setBucketName = require('../lib/setBucketName');
+const updateCloudFormationFiles = require('./lib/updateCloudFormationFiles');
 const cleanupS3Bucket = require('./lib/cleanupS3Bucket');
 const uploadArtifacts = require('./lib/uploadArtifacts');
 const validateTemplate = require('./lib/validateTemplate');
@@ -34,6 +35,7 @@ class AwsDeploy {
       extendedValidate,
       createStack,
       setBucketName,
+      updateCloudFormationFiles,
       cleanupS3Bucket,
       uploadArtifacts,
       validateTemplate,
@@ -96,6 +98,7 @@ class AwsDeploy {
 
       'aws:deploy:deploy:uploadArtifacts': () => BbPromise.bind(this)
         .then(this.setBucketName)
+        .then(this.updateCloudFormationFiles)
         .then(this.uploadArtifacts),
 
       'aws:deploy:deploy:validateTemplate': () => BbPromise.bind(this)

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -84,6 +84,7 @@ describe('AwsDeploy', () => {
     let spawnStub;
     let createStackStub;
     let setBucketNameStub;
+    let updateCloudFormationFilesStub;
     let uploadArtifactsStub;
     let validateTemplateStub;
     let updateStackStub;
@@ -95,6 +96,8 @@ describe('AwsDeploy', () => {
         .stub(awsDeploy, 'createStack').resolves();
       setBucketNameStub = sinon
         .stub(awsDeploy, 'setBucketName').resolves();
+      updateCloudFormationFilesStub = sinon
+        .stub(awsDeploy, 'updateCloudFormationFiles').resolves();
       uploadArtifactsStub = sinon
         .stub(awsDeploy, 'uploadArtifacts').resolves();
       validateTemplateStub = sinon
@@ -107,6 +110,7 @@ describe('AwsDeploy', () => {
       serverless.pluginManager.spawn.restore();
       awsDeploy.createStack.restore();
       awsDeploy.setBucketName.restore();
+      awsDeploy.updateCloudFormationFiles.restore();
       awsDeploy.uploadArtifacts.restore();
       awsDeploy.validateTemplate.restore();
       awsDeploy.updateStack.restore();
@@ -196,7 +200,8 @@ describe('AwsDeploy', () => {
     it('should run "aws:deploy:deploy:uploadArtifacts" hook', () => awsDeploy
       .hooks['aws:deploy:deploy:uploadArtifacts']().then(() => {
         expect(setBucketNameStub.calledOnce).to.equal(true);
-        expect(uploadArtifactsStub.calledAfter(setBucketNameStub)).to.equal(true);
+        expect(updateCloudFormationFilesStub.calledAfter(setBucketNameStub)).to.equal(true);
+        expect(uploadArtifactsStub.calledAfter(updateCloudFormationFilesStub)).to.equal(true);
       })
     );
 

--- a/lib/plugins/aws/deploy/lib/updateCloudFormationFiles.js
+++ b/lib/plugins/aws/deploy/lib/updateCloudFormationFiles.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const BbPromise = require('bluebird');
+const shell = require('shelljs');
+
+module.exports = {
+  updateCloudFormationFiles() {
+    const serverlessDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    const cfFileNameRegex = this.provider.naming.getCloudFormationFileNameRegex();
+    const filesInServiceDir = fs.readdirSync(serverlessDirPath);
+    const cfFiles = filesInServiceDir.filter((file) => file.match(cfFileNameRegex));
+
+    cfFiles.forEach((file) => {
+      const pathToFile = path.join(serverlessDirPath, file);
+      shell.sed('-i', '%DEPLOYMENT-BUCKET-NAME%', this.bucketName, pathToFile);
+    });
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/deploy/lib/updateCloudFormationFiles.test.js
+++ b/lib/plugins/aws/deploy/lib/updateCloudFormationFiles.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const AwsProvider = require('../../provider/awsProvider');
+const AwsDeploy = require('../index');
+const Serverless = require('../../../../Serverless');
+const testUtils = require('../../../../../tests/utils');
+const fse = require('fs-extra');
+
+describe('updateCloudFormationFiles', () => {
+  let serverless;
+  let awsDeploy;
+  let serverlessDirPath;
+  let cfFilePath;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.bucketName = 'deployment-bucket';
+    const tmpDirPath = testUtils.getTmpDirPath();
+    serverlessDirPath = path.join(tmpDirPath, '.serverless');
+    fse.mkdirsSync(serverlessDirPath);
+    awsDeploy.serverless.config.servicePath = tmpDirPath;
+    cfFilePath = path.join(serverlessDirPath, 'cloudformation-1.json');
+    fse.writeJsonSync(cfFilePath, {
+      deploymentBucketName: '%DEPLOYMENT-BUCKET-NAME%',
+    });
+  });
+
+  describe('#updateCloudFormationFiles()', () => {
+    it('should update the deployment bucket name placeholder', () => awsDeploy
+      .updateCloudFormationFiles().then(() => {
+        const updatedFile = fse.readJsonSync(cfFilePath);
+        expect(updatedFile.deploymentBucketName).to.equal('deployment-bucket');
+      })
+    );
+  });
+});

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -40,23 +40,6 @@ module.exports = {
       uploadPromises.push(uploadPromise);
     });
 
-    // TODO remove later on when this filename is deprecated
-    // upload old file as well (for backwards compatibility)
-    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
-    const body = JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate);
-    const params = {
-      Bucket: this.bucketName,
-      Key: `${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
-      Body: body,
-      ContentType: 'application/json',
-    };
-    const uploadPromise = this.provider.request('S3',
-      'putObject',
-      params,
-      this.options.stage,
-      this.options.region);
-    uploadPromises.push(uploadPromise);
-
     return BbPromise.all(uploadPromises);
   },
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -40,6 +40,23 @@ module.exports = {
       uploadPromises.push(uploadPromise);
     });
 
+    // TODO remove later on when this filename is deprecated
+    // upload old file as well (for backwards compatibility)
+    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
+    const body = JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate);
+    const params = {
+      Bucket: this.bucketName,
+      Key: `${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
+      Body: body,
+      ContentType: 'application/json',
+    };
+    const uploadPromise = this.provider.request('S3',
+      'putObject',
+      params,
+      this.options.stage,
+      this.options.region);
+    uploadPromises.push(uploadPromise);
+
     return BbPromise.all(uploadPromises);
   },
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -8,29 +8,39 @@ const filesize = require('filesize');
 const path = require('path');
 
 module.exports = {
-  uploadCloudFormationFile() {
-    this.serverless.cli.log('Uploading CloudFormation file to S3...');
+  uploadCloudFormationFiles() {
+    this.serverless.cli.log('Uploading CloudFormation files to S3...');
 
-    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
-
-    const body = JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate);
-    let params = {
-      Bucket: this.bucketName,
-      Key: `${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
-      Body: body,
-      ContentType: 'application/json',
-    };
+    const serverlessDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    const cfFileNameRegex = this.provider.naming.getCloudFormationFileNameRegex();
+    const filesInServiceDir = fs.readdirSync(serverlessDirPath);
+    const cfFiles = filesInServiceDir.filter((file) => file.match(cfFileNameRegex));
 
     const deploymentBucketObject = this.serverless.service.provider.deploymentBucketObject;
-    if (deploymentBucketObject) {
-      params = setServersideEncryptionOptions(params, deploymentBucketObject);
-    }
 
-    return this.provider.request('S3',
-      'putObject',
-      params,
-      this.options.stage,
-      this.options.region);
+    const uploadPromises = [];
+    cfFiles.forEach((file) => {
+      const body = fs.createReadStream(path.join(serverlessDirPath, file));
+      let params = {
+        Bucket: this.bucketName,
+        Key: `${this.serverless.service.package.artifactDirectoryName}/${file}`,
+        Body: body,
+        ContentType: 'application/json',
+      };
+
+      if (deploymentBucketObject) {
+        params = setServersideEncryptionOptions(params, deploymentBucketObject);
+      }
+
+      const uploadPromise = this.provider.request('S3',
+        'putObject',
+        params,
+        this.options.stage,
+        this.options.region);
+      uploadPromises.push(uploadPromise);
+    });
+
+    return BbPromise.all(uploadPromises);
   },
 
   uploadZipFile(artifactFilePath) {
@@ -92,7 +102,7 @@ module.exports = {
 
   uploadArtifacts() {
     return BbPromise.bind(this)
-      .then(this.uploadCloudFormationFile)
+      .then(this.uploadCloudFormationFiles)
       .then(this.uploadFunctions);
   },
 };

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -8,6 +8,7 @@ const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 const testUtils = require('../../../../../tests/utils');
 const fs = require('fs');
+const fse = require('fs-extra');
 
 describe('uploadArtifacts', () => {
   let serverless;
@@ -33,29 +34,48 @@ describe('uploadArtifacts', () => {
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });
 
-  describe('#uploadCloudFormationFile()', () => {
-    it('should upload the CloudFormation file to the S3 bucket', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+  describe('#uploadCloudFormationFiles()', () => {
+    it('should upload all CloudFormation files to the S3 bucket', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const serverlessDirPath = path.join(tmpDirPath, '.serverless');
+      fse.mkdirsSync(serverlessDirPath);
+      awsDeploy.serverless.config.servicePath = tmpDirPath;
+      const cfFile1Name = 'cloudformation-1.json';
+      const cfFile2Name = 'cloudformation-2.json';
+      const cfFile1Path = path.join(serverlessDirPath, cfFile1Name);
+      const cfFile2Path = path.join(serverlessDirPath, cfFile2Name);
+      fse.writeJsonSync(cfFile1Path, { foo: 'bar' });
+      fse.writeJsonSync(cfFile2Path, { baz: 'qux' });
 
       const putObjectStub = sinon
         .stub(awsDeploy.provider, 'request').resolves();
 
-      return awsDeploy.uploadCloudFormationFile().then(() => {
-        expect(putObjectStub.calledOnce).to.be.equal(true);
-        expect(putObjectStub.calledWithExactly(
-          'S3',
-          'putObject',
-          {
-            Bucket: awsDeploy.bucketName,
-            Key: `${awsDeploy.serverless.service.package
-              .artifactDirectoryName}/compiled-cloudformation-template.json`,
-            Body: JSON.stringify(awsDeploy.serverless.service.provider
-              .compiledCloudFormationTemplate),
-            ContentType: 'application/json',
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
+      return awsDeploy.uploadCloudFormationFiles().then(() => {
+        expect(putObjectStub.callCount).to.be.equal(2);
+
+        // the Body value of the putObject call is unpredictable
+        // we'll just test the other parts to ensure that this call is correct
+        const Key1 = path.join(
+          awsDeploy.serverless.service.package.artifactDirectoryName, cfFile1Name);
+        const Key2 = path.join(
+          awsDeploy.serverless.service.package.artifactDirectoryName, cfFile2Name);
+
+        expect(putObjectStub.firstCall.args[0]).to.equal('S3');
+        expect(putObjectStub.firstCall.args[1]).to.equal('putObject');
+        expect(putObjectStub.firstCall.args[2].Bucket).to.equal(awsDeploy.bucketName);
+        expect(putObjectStub.firstCall.args[2].Key).to.equal(Key1);
+        expect(putObjectStub.firstCall.args[2].ContentType).to.equal('application/json');
+        expect(putObjectStub.firstCall.args[3]).to.equal(awsDeploy.options.stage);
+        expect(putObjectStub.firstCall.args[4]).to.equal(awsDeploy.options.region);
+
+        expect(putObjectStub.secondCall.args[0]).to.equal('S3');
+        expect(putObjectStub.secondCall.args[1]).to.equal('putObject');
+        expect(putObjectStub.secondCall.args[2].Bucket).to.equal(awsDeploy.bucketName);
+        expect(putObjectStub.secondCall.args[2].Key).to.equal(Key2);
+        expect(putObjectStub.secondCall.args[2].ContentType).to.equal('application/json');
+        expect(putObjectStub.secondCall.args[3]).to.equal(awsDeploy.options.stage);
+        expect(putObjectStub.secondCall.args[4]).to.equal(awsDeploy.options.region);
+
         awsDeploy.provider.request.restore();
       });
     });
@@ -249,17 +269,17 @@ describe('uploadArtifacts', () => {
 
   describe('#uploadArtifacts()', () => {
     it('should run promise chain in order', () => {
-      const uploadCloudFormationFileStub = sinon
-        .stub(awsDeploy, 'uploadCloudFormationFile').resolves();
+      const uploadCloudFormationFilesStub = sinon
+        .stub(awsDeploy, 'uploadCloudFormationFiles').resolves();
       const uploadFunctionsStub = sinon
         .stub(awsDeploy, 'uploadFunctions').resolves();
 
       return awsDeploy.uploadArtifacts().then(() => {
-        expect(uploadCloudFormationFileStub.calledOnce)
+        expect(uploadCloudFormationFilesStub.calledOnce)
           .to.be.equal(true);
-        expect(uploadFunctionsStub.calledAfter(uploadCloudFormationFileStub)).to.be.equal(true);
+        expect(uploadFunctionsStub.calledAfter(uploadCloudFormationFilesStub)).to.be.equal(true);
 
-        awsDeploy.uploadCloudFormationFile.restore();
+        awsDeploy.uploadCloudFormationFiles.restore();
         awsDeploy.uploadFunctions.restore();
       });
     });

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -106,8 +106,11 @@ module.exports = {
   },
 
   // Log Group
+  getLogGroupLogicalIdSuffix() {
+    return 'LogGroup';
+  },
   getLogGroupLogicalId(functionName) {
-    return `${this.getNormalizedFunctionName(functionName)}LogGroup`;
+    return `${this.getNormalizedFunctionName(functionName)}${this.getLogGroupLogicalIdSuffix()}`;
   },
   getLogGroupName(functionName) {
     return `/aws/lambda/${functionName}`;

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -62,7 +62,7 @@ module.exports = {
   },
 
   getCloudFormationFileNameRegex() {
-    return /cloudformation-.+\.json/;
+    return /.*cloudformation-.+\.json/;
   },
 
   getCompiledTemplateFileName() {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -61,6 +61,10 @@ module.exports = {
     return 'serverless-state.json';
   },
 
+  getCloudFormationFileNameRegex() {
+    return /cloudformation-.+\.json/;
+  },
+
   getCompiledTemplateFileName() {
     return 'cloudformation-template-update-stack.json';
   },

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -44,6 +44,10 @@ module.exports = {
     return /^ServiceEndpoint/;
   },
 
+  getDeploymentBucketNamePlaceholder() {
+    return '%DEPLOYMENT-BUCKET-NAME%';
+  },
+
   // Stack
   getStackName() {
     return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
@@ -71,6 +75,14 @@ module.exports = {
 
   getCoreTemplateFileName() {
     return 'cloudformation-template-create-stack.json';
+  },
+
+  getCompiledNestedStackTemplateFileName(stackId) {
+    return `cloudformation-template-nested-stack-${stackId}.json`;
+  },
+
+  getNestedStackLogicalId(stackId) {
+    return `NestedStack${stackId}`;
   },
 
   // Role

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -93,10 +93,42 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getDeploymentBucketNamePlaceholder()', () => {
+    it('should return the placeholder for the deployment bucket name', () => {
+      expect(sdk.naming.getDeploymentBucketNamePlaceholder()).to.equal('%DEPLOYMENT-BUCKET-NAME%');
+    });
+  });
+
   describe('#getStackName()', () => {
     it('should use the service name and stage from the service and config', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getStackName()).to.equal(`${serverless.service.service}-${options.stage}`);
+    });
+  });
+
+  describe('#getCloudFormationFileNameRegex()', () => {
+    it('should match a valid CloudFormation .json file', () => {
+      expect(sdk.naming.getCloudFormationFileNameRegex().test('foo-cloudformation-bar.json'))
+        .to.equal(true);
+    });
+
+    it('should not match an invalid CloudFormation .json file', () => {
+      expect(sdk.naming.getCloudFormationFileNameRegex().test('cloudformation.json'))
+        .to.equal(false);
+    });
+  });
+
+  describe('#getCompiledNestedStackTemplateFileName()', () => {
+    it('should return the file name for the nested stack file', () => {
+      expect(sdk.naming.getCompiledNestedStackTemplateFileName(1))
+        .to.equal('cloudformation-template-nested-stack-1.json');
+    });
+  });
+
+  describe('#getNestedStackLogicalId()', () => {
+    it('should return the logical id for the nested stack resource', () => {
+      expect(sdk.naming.getNestedStackLogicalId(1))
+        .to.equal('NestedStack1');
     });
   });
 
@@ -142,6 +174,12 @@ describe('#naming()', () => {
           ],
         ],
       });
+    });
+  });
+
+  describe('#getLogGroupLogicalIdSuffix()', () => {
+    it('should return the log group suffix', () => {
+      expect(sdk.naming.getLogGroupLogicalIdSuffix()).to.equal('LogGroup');
     });
   });
 

--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -6,6 +6,7 @@ const mergeCustomProviderResources = require('./lib/mergeCustomProviderResources
 const generateArtifactDirectoryName = require('./lib/generateArtifactDirectoryName');
 const generateCoreTemplate = require('./lib/generateCoreTemplate');
 const saveServiceState = require('./lib/saveServiceState');
+const splitStack = require('./lib/splitStack');
 const saveCompiledTemplate = require('./lib/saveCompiledTemplate');
 const mergeIamTemplates = require('./lib/mergeIamTemplates');
 
@@ -26,6 +27,7 @@ class AwsPackage {
       generateArtifactDirectoryName,
       mergeCustomProviderResources,
       saveServiceState,
+      splitStack,
       saveCompiledTemplate
     );
 
@@ -77,6 +79,7 @@ class AwsPackage {
         .then(this.mergeCustomProviderResources),
 
       'aws:package:finalize:saveServiceState': () => BbPromise.bind(this)
+        .then(this.splitStack)
         .then(this.saveCompiledTemplate)
         .then(this.saveServiceState)
         .then(() => this.serverless.pluginManager.spawn('aws:common:moveArtifactsToPackage')),

--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 const mergeCustomProviderResources = require('./lib/mergeCustomProviderResources');
 const generateArtifactDirectoryName = require('./lib/generateArtifactDirectoryName');
 const generateCoreTemplate = require('./lib/generateCoreTemplate');
+const validateAgainstStackLimits = require('./lib/validateAgainstStackLimits');
 const saveServiceState = require('./lib/saveServiceState');
 const splitStack = require('./lib/splitStack');
 const saveCompiledTemplate = require('./lib/saveCompiledTemplate');
@@ -26,6 +27,7 @@ class AwsPackage {
       mergeIamTemplates,
       generateArtifactDirectoryName,
       mergeCustomProviderResources,
+      validateAgainstStackLimits,
       saveServiceState,
       splitStack,
       saveCompiledTemplate
@@ -77,6 +79,9 @@ class AwsPackage {
       // Package finalize inner lifecycle
       'aws:package:finalize:mergeCustomProviderResources': () => BbPromise.bind(this)
         .then(this.mergeCustomProviderResources),
+
+      'after:aws:package:finalize:mergeCustomProviderResources': () => BbPromise.bind(this)
+        .then(this.validateAgainstStackLimits),
 
       'aws:package:finalize:saveServiceState': () => BbPromise.bind(this)
         .then(this.splitStack)

--- a/lib/plugins/aws/package/index.test.js
+++ b/lib/plugins/aws/package/index.test.js
@@ -81,6 +81,7 @@ describe('AwsPackage', () => {
     let mergeIamTemplatesStub;
     let generateArtifactDirectoryNameStub;
     let mergeCustomProviderResourcesStub;
+    let validateAgainstStackLimitsStub;
     let splitStackStub;
     let saveCompiledTemplateStub;
     let saveServiceStateStub;
@@ -96,6 +97,8 @@ describe('AwsPackage', () => {
         .stub(awsPackage, 'generateArtifactDirectoryName').resolves();
       mergeCustomProviderResourcesStub = sinon
         .stub(awsPackage, 'mergeCustomProviderResources').resolves();
+      validateAgainstStackLimitsStub = sinon
+        .stub(awsPackage, 'validateAgainstStackLimits').resolves();
       splitStackStub = sinon
         .stub(awsPackage, 'splitStack').resolves();
       saveCompiledTemplateStub = sinon
@@ -110,6 +113,7 @@ describe('AwsPackage', () => {
       awsPackage.mergeIamTemplates.restore();
       awsPackage.generateArtifactDirectoryName.restore();
       awsPackage.mergeCustomProviderResources.restore();
+      awsPackage.validateAgainstStackLimits.restore();
       awsPackage.splitStack.restore();
       awsPackage.saveCompiledTemplate.restore();
       awsPackage.saveServiceState.restore();
@@ -156,6 +160,12 @@ describe('AwsPackage', () => {
     it('should run "aws:package:finalize:mergeCustomProviderResources" hook', () => awsPackage
       .hooks['aws:package:finalize:mergeCustomProviderResources']().then(() => {
         expect(mergeCustomProviderResourcesStub.calledOnce).to.equal(true);
+      })
+    );
+
+    it('should run "after:aws:package:finalize:mergeCustomProviderResources" hook', () => awsPackage
+      .hooks['after:aws:package:finalize:mergeCustomProviderResources']().then(() => {
+        expect(validateAgainstStackLimitsStub.calledOnce).to.equal(true);
       })
     );
 

--- a/lib/plugins/aws/package/index.test.js
+++ b/lib/plugins/aws/package/index.test.js
@@ -81,6 +81,7 @@ describe('AwsPackage', () => {
     let mergeIamTemplatesStub;
     let generateArtifactDirectoryNameStub;
     let mergeCustomProviderResourcesStub;
+    let splitStackStub;
     let saveCompiledTemplateStub;
     let saveServiceStateStub;
 
@@ -95,6 +96,8 @@ describe('AwsPackage', () => {
         .stub(awsPackage, 'generateArtifactDirectoryName').resolves();
       mergeCustomProviderResourcesStub = sinon
         .stub(awsPackage, 'mergeCustomProviderResources').resolves();
+      splitStackStub = sinon
+        .stub(awsPackage, 'splitStack').resolves();
       saveCompiledTemplateStub = sinon
         .stub(awsPackage, 'saveCompiledTemplate').resolves();
       saveServiceStateStub = sinon
@@ -107,6 +110,7 @@ describe('AwsPackage', () => {
       awsPackage.mergeIamTemplates.restore();
       awsPackage.generateArtifactDirectoryName.restore();
       awsPackage.mergeCustomProviderResources.restore();
+      awsPackage.splitStack.restore();
       awsPackage.saveCompiledTemplate.restore();
       awsPackage.saveServiceState.restore();
     });
@@ -160,7 +164,8 @@ describe('AwsPackage', () => {
         .withArgs('aws:common:moveArtifactsToPackage').resolves();
 
       return awsPackage.hooks['aws:package:finalize:saveServiceState']().then(() => {
-        expect(saveCompiledTemplateStub.calledOnce).to.equal(true);
+        expect(splitStackStub.calledOnce).to.equal(true);
+        expect(saveCompiledTemplateStub.calledAfter(splitStackStub)).to.equal(true);
         expect(saveServiceStateStub.calledAfter(saveCompiledTemplateStub)).to.equal(true);
         expect(spawnAwsCommonMoveArtifactsToPackageStub.calledAfter(saveServiceStateStub))
           .to.equal(true);

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.js
@@ -16,6 +16,17 @@ module.exports = {
     this.serverless.utils.writeFileSync(compiledTemplateFilePath,
       this.serverless.service.provider.compiledCloudFormationTemplate);
 
+    // also save the template under the "old" name
+    // TODO remove later on when old name is deprecated
+    const alternativeFileName = 'compiled-cloudformation-template.json';
+    const alternativeTemplateFilePath = path.join(
+      this.serverless.config.servicePath,
+      '.serverless',
+      alternativeFileName
+    );
+    this.serverless.utils.writeFileSync(alternativeTemplateFilePath,
+      this.serverless.service.provider.compiledCloudFormationTemplate);
+
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const expect = require('chai').expect;
-const sinon = require('sinon');
 const path = require('path');
+const fse = require('fs-extra');
+const testUtils = require('../../../../../tests/utils');
 const AwsPackage = require('../index');
 const Serverless = require('../../../../Serverless');
 const AwsProvider = require('../../provider/awsProvider');
@@ -10,41 +11,37 @@ const AwsProvider = require('../../provider/awsProvider');
 describe('#saveCompiledTemplate()', () => {
   let serverless;
   let awsPackage;
-  let getCompiledTemplateFileNameStub;
-  let writeFileSyncStub;
+  let serverlessDirPath;
 
   beforeEach(() => {
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsPackage = new AwsPackage(serverless, {});
-    serverless.config.servicePath = 'my-service';
     serverless.service = {
       provider: {
-        compiledCloudFormationTemplate: 'compiled content',
+        compiledCloudFormationTemplate: {
+          foo: 'bar',
+        },
       },
     };
-    getCompiledTemplateFileNameStub = sinon
-      .stub(awsPackage.provider.naming, 'getCompiledTemplateFileName')
-      .returns('compiled.json');
-    writeFileSyncStub = sinon
-      .stub(awsPackage.serverless.utils, 'writeFileSync').returns();
+    const tmpDirPath = testUtils.getTmpDirPath();
+    serverlessDirPath = path.join(tmpDirPath, '.serverless');
+    fse.mkdirsSync(serverlessDirPath);
+    awsPackage.serverless.config.servicePath = tmpDirPath;
   });
 
-  afterEach(() => {
-    awsPackage.provider.naming.getCompiledTemplateFileName.restore();
-    awsPackage.serverless.utils.writeFileSync.restore();
-  });
+  it('should write the compiled templates to disk', () => awsPackage
+    .saveCompiledTemplate().then(() => {
+      const compiledTemplateFileName = awsPackage.provider.naming.getCompiledTemplateFileName();
+      const alternativeTemplateFileName = 'compiled-cloudformation-template.json';
+      const file1Content = fse
+        .readJsonSync(path.join(serverlessDirPath, compiledTemplateFileName));
+      const file2Content = fse
+        .readJsonSync(path.join(serverlessDirPath, alternativeTemplateFileName));
+      const expectedContent = awsPackage.serverless.service.provider.compiledCloudFormationTemplate;
 
-  it('should write the compiled template to disk', () => {
-    const filePath = path.join(
-      awsPackage.serverless.config.servicePath,
-      '.serverless',
-      'compiled.json'
-    );
-
-    return awsPackage.saveCompiledTemplate().then(() => {
-      expect(getCompiledTemplateFileNameStub.calledOnce).to.equal(true);
-      expect(writeFileSyncStub.calledWithExactly(filePath, 'compiled content')).to.equal(true);
-    });
-  });
+      expect(file1Content).to.deep.equal(expectedContent);
+      expect(file2Content).to.deep.equal(expectedContent);
+    })
+  );
 });

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -73,8 +73,9 @@ module.exports = {
 
     _.forEach(functionResourceLogicalIds, (funcLogicalId, index) => {
       const stackObj = {
-        stackTemplate: {},
-        stackResource: {},
+        stackTemplate: {}, // the complete stack with all it's resources
+        stackResource: {}, // the stack resource which will be used in the parent stack
+        externalDeps: [], // logical ids of external deps (e.g. in the parent stack)
       };
 
       const lambdaLogicalIdRegex = this.provider.naming.getLambdaLogicalIdRegex();
@@ -93,8 +94,8 @@ module.exports = {
       const logGroupLogicalId = `${normalizedFuncName}${logGroupLogicalIdSuffix}`;
       newStackTemplate.Resources[logGroupLogicalId] = cfTemplate.Resources[logGroupLogicalId];
       // add all the dependant resources
-      const depResources = depGraph.dependantsOf(funcLogicalId);
-      _.forEach(depResources, (depLogicalId) => {
+      const dependantResources = depGraph.dependantsOf(funcLogicalId);
+      _.forEach(dependantResources, (depLogicalId) => {
         newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
       });
 
@@ -122,6 +123,12 @@ module.exports = {
       };
 
       stackObj.stackResource = newStackResourceObj;
+
+      // figure out external deps (e.g. resources from the parent stack)
+      const dependentResources = depGraph.dependenciesOf(funcLogicalId);
+      const nestedStackResources = Object.keys(newStackTemplate.Resources);
+      const externalDeps = _.difference(dependentResources, nestedStackResources);
+      stackObj.externalDeps = externalDeps;
 
       this.serverless.service.provider.nestedStacks.push(stackObj);
     });

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -105,6 +105,49 @@ module.exports = {
         }
       });
 
+      // NOTE: special case here...
+      // we copy over the roleLogicalId and modify it to be function specific
+      const roleLogicalId = this.provider.naming.getRoleLogicalId();
+      const roleResource = _.cloneDeep(cfTemplate.Resources[roleLogicalId]);
+      // update the RoleName so that it won't clash
+      const roleNameArray = roleResource.Properties.RoleName['Fn::Join'][1];
+      const lastPartOfRoleName = roleNameArray.pop();
+      const updatedLastPart = `${lastPartOfRoleName}-nested-stack-${index + 1}`;
+      roleNameArray[roleNameArray.length - 1] = updatedLastPart;
+      // remove all references to other functions
+      const funcNameInResourceRegex = new RegExp(`${normalizedFuncName}:*`, 'i');
+      const statements = roleResource.Properties.Policies[0].PolicyDocument.Statement;
+      statements.forEach((statement) => {
+        const updatedStatement = statement;
+        const updatedResources = statement.Resource.filter((resource) => {
+          const matchingResource = resource['Fn::Sub'].match(funcNameInResourceRegex);
+          if (matchingResource) return resource;
+          return null;
+        });
+        const funcResource = updatedResources[0];
+        updatedStatement.Resource = [];
+        updatedStatement.Resource.push(funcResource);
+      });
+      roleResource.Properties.Policies[0].PolicyDocument.Statement = statements;
+
+      newStackTemplate.Resources[roleLogicalId] = roleResource;
+
+      // figure out external deps (e.g. resources from the parent stack)
+      const dependentResources = depGraph.dependenciesOf(funcLogicalId);
+      const nestedStackResources = Object.keys(newStackTemplate.Resources);
+      let externalDeps = _.difference(dependentResources, nestedStackResources);
+      // remove the roleLogicalId since we already moved it over previously
+      externalDeps = externalDeps.filter((dep) => dep !== roleLogicalId);
+      stackObj.externalDeps = externalDeps;
+
+      // add external deps as a typed parameter
+      _.forEach(externalDeps, (depLogicalId) => {
+        newStackTemplate.Parameters[depLogicalId] = {
+          // TODO add support for other types
+          Type: 'String',
+        };
+      });
+
       stackObj.stackTemplate = newStackTemplate;
 
       // create the (nested) stack resource
@@ -126,17 +169,20 @@ module.exports = {
       newStackResource.Description = description;
       newStackResource.Properties.TemplateURL = templateURL;
 
+      // add external deps as ref parameters
+      _.forEach(externalDeps, (dep) => {
+        const depLogicalId = dep;
+        // TODO replace intrinsic functions such as Fn::GetAtt with Ref
+        newStackResource.Properties.Parameters[depLogicalId] = {
+          Ref: depLogicalId,
+        };
+      });
+
       const newStackResourceObj = {
         [resourceLogicalId]: newStackResource,
       };
 
       stackObj.stackResource = newStackResourceObj;
-
-      // figure out external deps (e.g. resources from the parent stack)
-      const dependentResources = depGraph.dependenciesOf(funcLogicalId);
-      const nestedStackResources = Object.keys(newStackTemplate.Resources);
-      const externalDeps = _.difference(dependentResources, nestedStackResources);
-      stackObj.externalDeps = externalDeps;
 
       this.serverless.service.provider.nestedStacks.push(stackObj);
     });
@@ -197,6 +243,7 @@ module.exports = {
     return {
       AWSTemplateFormatVersion: '2010-09-09',
       Description: 'Stack template',
+      Parameters: {},
       Resources: {},
       Outputs: {},
     };
@@ -206,6 +253,7 @@ module.exports = {
     return {
       Type: 'AWS::CloudFormation::Stack',
       Properties: {
+        Parameters: {},
         TemplateURL: '',
       },
     };

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -85,7 +85,6 @@ module.exports = {
 
       // create the stack template (the template which contains the function and related resources)
       const newStackTemplate = this.cfStackTemplate();
-      const depResources = depGraph.dependantsOf(funcLogicalId);
       newStackTemplate.Description = description;
       // add the function
       newStackTemplate.Resources[funcLogicalId] = cfTemplate.Resources[funcLogicalId];
@@ -94,6 +93,7 @@ module.exports = {
       const logGroupLogicalId = `${normalizedFuncName}${logGroupLogicalIdSuffix}`;
       newStackTemplate.Resources[logGroupLogicalId] = cfTemplate.Resources[logGroupLogicalId];
       // add all the dependant resources
+      const depResources = depGraph.dependantsOf(funcLogicalId);
       _.forEach(depResources, (depLogicalId) => {
         newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
       });

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-use-before-define */
+
 const path = require('path');
 const _ = require('lodash');
 const BbPromise = require('bluebird');
@@ -63,63 +65,49 @@ module.exports = {
     const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
     const depGraph = this.serverless.service.provider.cloudFormationDependencyGraph;
 
-    const functionResourceLogicalIds = [];
+    const funcLogicalIds = this.getFuncLogicalIds(cfTemplate.Resources);
 
-    _.forEach(cfTemplate.Resources, (resource, logicalId) => {
-      if (resource.Type === 'AWS::Lambda::Function') {
-        functionResourceLogicalIds.push(logicalId);
-      }
-    });
+    const allResourcesToMigrate = this.getAllResourcesToMigrate(funcLogicalIds);
 
-    _.forEach(functionResourceLogicalIds, (funcLogicalId, index) => {
+    _.forEach(funcLogicalIds, (funcLogicalId, index) => {
       const stackObj = {
         stackTemplate: {}, // the complete stack with all it's resources
         stackResource: {}, // the stack resource which will be used in the parent stack
-        externalDeps: [], // logical ids of external deps (e.g. in the parent stack)
       };
-
-      const lambdaLogicalIdRegex = this.provider.naming.getLambdaLogicalIdRegex();
-      const normalizedFuncNameEnd = lambdaLogicalIdRegex.exec(funcLogicalId).index;
-      const normalizedFuncName = funcLogicalId.slice(0, normalizedFuncNameEnd);
 
       const description = `Stack for function "${funcLogicalId}" and its dependencies`;
 
       // create the stack template (the template which contains the function and related resources)
       const newStackTemplate = this.cfStackTemplate();
       newStackTemplate.Description = description;
-      // add the function
-      newStackTemplate.Resources[funcLogicalId] = cfTemplate.Resources[funcLogicalId];
-      // add the log group
-      const logGroupLogicalIdSuffix = this.provider.naming.getLogGroupLogicalIdSuffix();
-      const logGroupLogicalId = `${normalizedFuncName}${logGroupLogicalIdSuffix}`;
-      newStackTemplate.Resources[logGroupLogicalId] = cfTemplate.Resources[logGroupLogicalId];
-      // add all the other dependant resources and outputs
-      const dependantResources = depGraph.dependantsOf(funcLogicalId);
-      _.forEach(dependantResources, (dep) => {
-        const depLogicalId = dep;
-        const depData = depGraph.getNodeData(dep);
-        if (depData.type === 'resource') {
-          newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
-        } else {
-          newStackTemplate.Outputs[depLogicalId] = cfTemplate.Outputs[depLogicalId];
-        }
+
+      const resourcesToMigrate = this.getResourcesForNestedStack(funcLogicalId);
+      const outputsToMigrate = this.getOutputsForNestedStack(funcLogicalId);
+
+      _.forEach(resourcesToMigrate, (logicalId) => {
+        newStackTemplate.Resources[logicalId] = _.cloneDeep(cfTemplate.Resources[logicalId]);
       });
 
-      // figure out external deps (e.g. resources from the parent stack)
-      const dependentResources = depGraph.dependenciesOf(funcLogicalId);
-      const nestedStackResources = Object.keys(newStackTemplate.Resources);
-      const externalDeps = _.difference(dependentResources, nestedStackResources);
-      stackObj.externalDeps = externalDeps;
+      _.forEach(outputsToMigrate, (logicalId) => {
+        newStackTemplate.Outputs[logicalId] = _.cloneDeep(cfTemplate.Outputs[logicalId]);
+      });
+
+      // figure out all the dependencies in the nested stack (internal and external)
+      let allNestedStackDependencies = [];
+      resourcesToMigrate.forEach((res) => {
+        const deps = depGraph.dependenciesOf(res);
+        allNestedStackDependencies = _.union(allNestedStackDependencies, deps);
+      });
+
+      // filter out only the dependencies to the parent stack
+      const externalDeps = _.difference(allNestedStackDependencies, allResourcesToMigrate);
 
       const externalValuesToPass = [];
       traverse(newStackTemplate).forEach(function () {
         if (this.key === 'DependsOn') {
-          // remove DependsOn on external deps
-          const intersectingElements = _.intersection(externalDeps, this.node);
-          if (intersectingElements.length) {
-            const updatedArray = _.difference(this.node, intersectingElements);
-            this.update(updatedArray);
-          }
+          // only keep the dependencies on internal resources
+          const updatedDependsOn = _.intersection(this.node, resourcesToMigrate);
+          this.update(updatedDependsOn);
         } else if (this.key === 'Fn::GetAtt') {
           // transform Fn::GetAtt to Ref
           // this way we have only Ref in the nested stack
@@ -240,6 +228,77 @@ module.exports = {
     });
 
     return BbPromise.resolve();
+  },
+
+  // utils / functions
+  getFuncLogicalIds(cfResources) {
+    const functionResourceLogicalIds = [];
+    _.forEach(cfResources, (resource, logicalId) => {
+      if (resource.Type === 'AWS::Lambda::Function') {
+        functionResourceLogicalIds.push(logicalId);
+      }
+    });
+    return functionResourceLogicalIds;
+  },
+
+  getNormalizedFuncName(logicalId) {
+    const lambdaRegex = this.provider.naming.getLambdaLogicalIdRegex();
+    const normalizedFuncNameEnd = lambdaRegex.exec(logicalId).index;
+    return logicalId.slice(0, normalizedFuncNameEnd);
+  },
+
+  getResourcesForNestedStack(funcLogicalId) {
+    const depGraph = this.serverless.service.provider.cloudFormationDependencyGraph;
+    let resourceLogicalIds = [];
+    // add the function
+    resourceLogicalIds = _.union(resourceLogicalIds, [funcLogicalId]);
+    // add the log group
+    const normalizedFuncName = this.getNormalizedFuncName(funcLogicalId);
+    const logGroupLogicalIdSuffix = this.provider.naming.getLogGroupLogicalIdSuffix();
+    const logGroupLogicalId = `${normalizedFuncName}${logGroupLogicalIdSuffix}`;
+    resourceLogicalIds = _.union(resourceLogicalIds, [logGroupLogicalId]);
+    // add all the other dependant resources and outputs
+    const dependantResources = depGraph.dependantsOf(funcLogicalId);
+    _.forEach(dependantResources, (dep) => {
+      const depLogicalId = dep;
+      const depData = depGraph.getNodeData(dep);
+      if (depData.type === 'resource') {
+        resourceLogicalIds = _.union(resourceLogicalIds, [depLogicalId]);
+      }
+    });
+    return resourceLogicalIds;
+  },
+
+  getOutputsForNestedStack(funcLogicalId) {
+    const depGraph = this.serverless.service.provider.cloudFormationDependencyGraph;
+    let outputLogicalIds = [];
+    const dependantResources = depGraph.dependantsOf(funcLogicalId);
+    _.forEach(dependantResources, (dep) => {
+      const depLogicalId = dep;
+      const depData = depGraph.getNodeData(dep);
+      if (depData.type === 'output') {
+        outputLogicalIds = _.union(outputLogicalIds, [depLogicalId]);
+      }
+    });
+    return outputLogicalIds;
+  },
+
+  getAllResourcesToMigrate(funcLogicalIds) {
+    let resourceLogicalIds = [];
+    _.forEach(funcLogicalIds, (funcLogicalId) => {
+      const res = this.getResourcesForNestedStack(funcLogicalId);
+      resourceLogicalIds = _.union(resourceLogicalIds, res);
+    });
+    return resourceLogicalIds;
+  },
+
+  getAllOutputsToMigrate(funcLogicalIds) {
+    let outputLogicalIds = [];
+    _.forEach(funcLogicalIds, (funcLogicalId) => {
+      const res = this.getOutputsForNestedStack(funcLogicalId);
+      outputLogicalIds = _.union(outputLogicalIds, res);
+    });
+    return outputLogicalIds;
   },
 
   // CloudFormation templates

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -154,10 +154,9 @@ module.exports = {
       const newStackResource = this.cfStackResourceTemplate();
 
       const stackId = index + 1;
-      // TODO move these to provider.naming
-      const fileName = `cloudformation-template-nested-stack-${stackId}.json`;
-      const resourceLogicalId = `NestedStack${stackId}`;
-      const deploymentBucketName = '%DEPLOYMENT-BUCKET-NAME%';
+      const fileName = this.provider.naming.getCompiledNestedStackTemplateFileName(stackId);
+      const resourceLogicalId = this.provider.naming.getNestedStackLogicalId(stackId);
+      const deploymentBucketName = this.provider.naming.getDeploymentBucketNamePlaceholder();
       const templateURL = `https://s3.amazonaws.com/${
         deploymentBucketName
         }/${

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -105,40 +105,39 @@ module.exports = {
         }
       });
 
-      // NOTE: special case here...
-      // we copy over the roleLogicalId and modify it to be function specific
-      const roleLogicalId = this.provider.naming.getRoleLogicalId();
-      const roleResource = _.cloneDeep(cfTemplate.Resources[roleLogicalId]);
-      // update the RoleName so that it won't clash
-      const roleNameArray = roleResource.Properties.RoleName['Fn::Join'][1];
-      const lastPartOfRoleName = roleNameArray.pop();
-      const updatedLastPart = `${lastPartOfRoleName}-nested-stack-${index + 1}`;
-      roleNameArray[roleNameArray.length - 1] = updatedLastPart;
-      // remove all references to other functions
-      const funcNameInResourceRegex = new RegExp(`${normalizedFuncName}:*`, 'i');
-      const statements = roleResource.Properties.Policies[0].PolicyDocument.Statement;
-      statements.forEach((statement) => {
-        const updatedStatement = statement;
-        const updatedResources = statement.Resource.filter((resource) => {
-          const matchingResource = resource['Fn::Sub'].match(funcNameInResourceRegex);
-          if (matchingResource) return resource;
-          return null;
-        });
-        const funcResource = updatedResources[0];
-        updatedStatement.Resource = [];
-        updatedStatement.Resource.push(funcResource);
-      });
-      roleResource.Properties.Policies[0].PolicyDocument.Statement = statements;
-
-      newStackTemplate.Resources[roleLogicalId] = roleResource;
-
       // figure out external deps (e.g. resources from the parent stack)
       const dependentResources = depGraph.dependenciesOf(funcLogicalId);
       const nestedStackResources = Object.keys(newStackTemplate.Resources);
-      let externalDeps = _.difference(dependentResources, nestedStackResources);
-      // remove the roleLogicalId since we already moved it over previously
-      externalDeps = externalDeps.filter((dep) => dep !== roleLogicalId);
+      const externalDeps = _.difference(dependentResources, nestedStackResources);
       stackObj.externalDeps = externalDeps;
+
+      const externalValuesToPass = [];
+      traverse(newStackTemplate).forEach(function () {
+        if (this.key === 'DependsOn') {
+          // remove DependsOn on external deps
+          const intersectingElements = _.intersection(externalDeps, this.node);
+          if (intersectingElements.length) {
+            const updatedArray = _.difference(this.node, intersectingElements);
+            this.update(updatedArray);
+          }
+        } else if (this.key === 'Fn::GetAtt') {
+          // transform Fn::GetAtt to Ref
+          // this way we have only Ref in the nested stack
+          // we'll save the Fn::GetAtt value and pass it as a param from the parent stack
+          const intersectingElements = _.intersection(externalDeps, this.node);
+          if (intersectingElements.length) {
+            const parentNode = this.parent;
+            const logicalId = intersectingElements[0];
+            // add the Fn::GetAtt call to the array which will be used to pass it from the
+            // parent template down to the nested stack templates
+            const newFnGetAttResource = {};
+            newFnGetAttResource[logicalId] = parentNode.node;
+            externalValuesToPass.push(newFnGetAttResource);
+            // update it from Fn::GetAtt to Ref
+            parentNode.update({ Ref: intersectingElements[0] });
+          }
+        }
+      });
 
       // add external deps as a typed parameter
       _.forEach(externalDeps, (depLogicalId) => {
@@ -171,10 +170,16 @@ module.exports = {
       // add external deps as ref parameters
       _.forEach(externalDeps, (dep) => {
         const depLogicalId = dep;
-        // TODO replace intrinsic functions such as Fn::GetAtt with Ref
         newStackResource.Properties.Parameters[depLogicalId] = {
           Ref: depLogicalId,
         };
+      });
+
+      // iterate over array of external values to pass as params
+      // update the previously set params with the new intrinsic function
+      _.forEach(externalValuesToPass, (val) => {
+        const key = Object.keys(val)[0];
+        newStackResource.Properties.Parameters[key] = val[key];
       });
 
       const newStackResourceObj = {

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -105,10 +105,12 @@ module.exports = {
       const newStackResource = this.cfStackResourceTemplate();
 
       const stackId = index + 1;
+      // TODO move these to provider.naming
       const fileName = `cloudformation-template-nested-stack-${stackId}.json`;
-      const resourceLogicalId = `NestedStack${stackId}`; // TODO move this to provider.naming
+      const resourceLogicalId = `NestedStack${stackId}`;
+      const deploymentBucketName = '%DEPLOYMENT-BUCKET-NAME%';
       const templateURL = `https://s3.amazonaws.com/${
-        this.bucketName
+        deploymentBucketName
         }/${
           this.serverless.service.package.artifactDirectoryName
         }/${

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -173,8 +173,7 @@ module.exports = {
       });
 
       // add the stack Resources to parent stack
-      const logicalId = Object.keys(stackResource)[0];
-      cfTemplate.Resources[logicalId] = stackResource;
+      _.merge(cfTemplate.Resources, stackResource);
     });
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -37,7 +37,7 @@ module.exports = {
       const type = this.path[0] === 'Resources' ? 'resource' : 'output';
       const name = this.path[1];
       if ((type === 'resource' || type === 'output') && this.path.length === 2) {
-        graph.addNode(name);
+        graph.addNode(name, { type });
       }
 
       // create the dependencies
@@ -93,10 +93,16 @@ module.exports = {
       const logGroupLogicalIdSuffix = this.provider.naming.getLogGroupLogicalIdSuffix();
       const logGroupLogicalId = `${normalizedFuncName}${logGroupLogicalIdSuffix}`;
       newStackTemplate.Resources[logGroupLogicalId] = cfTemplate.Resources[logGroupLogicalId];
-      // add all the dependant resources
+      // add all the other dependant resources and outputs
       const dependantResources = depGraph.dependantsOf(funcLogicalId);
-      _.forEach(dependantResources, (depLogicalId) => {
-        newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
+      _.forEach(dependantResources, (dep) => {
+        const depLogicalId = dep;
+        const depData = depGraph.getNodeData(dep);
+        if (depData.type === 'resource') {
+          newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
+        } else {
+          newStackTemplate.Outputs[depLogicalId] = cfTemplate.Outputs[depLogicalId];
+        }
       });
 
       stackObj.stackTemplate = newStackTemplate;
@@ -167,11 +173,16 @@ module.exports = {
       const stackResource = nestedStack.stackResource;
       const stackTemplate = nestedStack.stackTemplate;
 
-      // remove resources from parent stack since they are alraedy in nested stack
+      // remove resources from parent stack since they've been moved to the nested stack
       const resourcesToRemove = stackTemplate.Resources;
-
       _.forEach(resourcesToRemove, (resource, logicalId) => {
         delete cfTemplate.Resources[logicalId];
+      });
+
+      // remove outputs from parent stack since they've been moved to the nested stack
+      const outputsToRemove = stackTemplate.Outputs;
+      _.forEach(outputsToRemove, (output, logicalId) => {
+        delete cfTemplate.Outputs[logicalId];
       });
 
       // add the stack Resources to parent stack

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const path = require('path');
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+const traverse = require('traverse');
+const DepGraph = require('dependency-graph').DepGraph;
+
+module.exports = {
+  splitStack() {
+    if (!this.serverless.service.provider.useStackSplitting) return BbPromise.resolve();
+
+    this.serverless.service.provider.cloudFormationDependencyGraph = null;
+    this.serverless.service.provider.nestedStacks = [];
+
+    return BbPromise.bind(this)
+      .then(this.createDependencyGraph)
+      .then(this.generateNestedStacks)
+      .then(this.writeStacksToDisk)
+      .then(this.updateCompiledCloudFormationTemplate);
+  },
+
+  createDependencyGraph() {
+    const items = this.serverless.service.provider.compiledCloudFormationTemplate;
+
+    const resources = items.Resources;
+    const resourcesLogicalIds = Object.keys(resources);
+    const outputs = items.Outputs;
+    const outputsLogicalIds = Object.keys(outputs);
+    const allLogicalIds = _.union(resourcesLogicalIds, outputsLogicalIds);
+
+    const graph = new DepGraph();
+
+    traverse(items).forEach(function (prop) {
+      // add all the resources and outputs to the graph
+      // note: this.path looks something like this --> ['Resources', 'ResourceLogicalId', ...]
+      const type = this.path[0] === 'Resources' ? 'resource' : 'output';
+      const name = this.path[1];
+      if ((type === 'resource' || type === 'output') && this.path.length === 2) {
+        graph.addNode(name);
+      }
+
+      // create the dependencies
+      // remove the first two items from this.path since they'll be something
+      // like ['Resources', 'ResourceLogicalId', ...] to filter out dependencies by key
+      const subPath = this.path.slice(2, this.path.length);
+      if (subPath.length && _.isString(prop)) {
+        if (allLogicalIds.includes(prop)) {
+          const dependantName = name;
+          const dependencyName = prop;
+
+          graph.addDependency(dependantName, dependencyName);
+        }
+      }
+    });
+
+    this.serverless.service.provider.cloudFormationDependencyGraph = graph;
+
+    return BbPromise.resolve();
+  },
+
+  generateNestedStacks() {
+    const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const depGraph = this.serverless.service.provider.cloudFormationDependencyGraph;
+
+    const functionResourceLogicalIds = [];
+
+    _.forEach(cfTemplate.Resources, (resource, logicalId) => {
+      if (resource.Type === 'AWS::Lambda::Function') {
+        functionResourceLogicalIds.push(logicalId);
+      }
+    });
+
+    _.forEach(functionResourceLogicalIds, (funcLogicalId, index) => {
+      const stackObj = {
+        stackTemplate: {},
+        stackResource: {},
+      };
+
+      const description = `Stack for function "${funcLogicalId}" and its dependencies`;
+
+      // create the stack template
+      const newStackTemplate = this.cfStackTemplate();
+      const depResources = depGraph.dependantsOf(funcLogicalId);
+
+      newStackTemplate.Description = description;
+      newStackTemplate.Resources[funcLogicalId] = cfTemplate.Resources[funcLogicalId];
+      _.forEach(depResources, (depLogicalId) => {
+        newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
+      });
+
+      stackObj.stackTemplate = newStackTemplate;
+
+      // create the (nested) stack resource
+      const newStackResource = this.cfStackResourceTemplate();
+
+      const stackId = index + 1;
+      const fileName = `cloudformation-template-nested-stack-${stackId}.json`;
+      const resourceLogicalId = `NestedStack${stackId}`; // TODO move this to provider.naming
+      const templateURL = `https://s3.amazonaws.com/${
+        this.bucketName
+        }/${
+          this.serverless.service.package.artifactDirectoryName
+        }/${
+          fileName
+        }`;
+
+      newStackResource.Description = description;
+      newStackResource.Properties.TemplateURL = templateURL;
+
+      const newStackResourceObj = {
+        [resourceLogicalId]: newStackResource,
+      };
+
+      stackObj.stackResource = newStackResourceObj;
+
+      this.serverless.service.provider.nestedStacks.push(stackObj);
+    });
+
+    return BbPromise.resolve();
+  },
+
+  writeStacksToDisk() {
+    const nestedStacks = this.serverless.service.provider.nestedStacks;
+
+    _.forEach(nestedStacks, (nestedStack) => {
+      const stackResource = nestedStack.stackResource;
+      const stackTemplate = nestedStack.stackTemplate;
+
+      const logicalId = Object.keys(stackResource)[0];
+      const fileName = stackResource[logicalId].Properties.TemplateURL.split('/').pop();
+      const destPath = path.join(
+        this.serverless.config.servicePath,
+        '.serverless',
+        fileName
+      );
+
+      this.serverless.utils.writeFileSync(destPath, stackTemplate);
+    });
+
+    return BbPromise.resolve();
+  },
+
+  updateCompiledCloudFormationTemplate() {
+    const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const nestedStacks = this.serverless.service.provider.nestedStacks;
+
+    _.forEach(nestedStacks, (nestedStack) => {
+      const stackResource = nestedStack.stackResource;
+      const stackTemplate = nestedStack.stackTemplate;
+
+      // remove resources from parent stack since they are alraedy in nested stack
+      const resourcesToRemove = stackTemplate.Resources;
+
+      _.forEach(resourcesToRemove, (resource, logicalId) => {
+        delete cfTemplate.Resources[logicalId];
+      });
+
+      // add the stack Resources to parent stack
+      const logicalId = Object.keys(stackResource)[0];
+      cfTemplate.Resources[logicalId] = stackResource;
+    });
+
+    return BbPromise.resolve();
+  },
+
+  // CloudFormation templates
+  cfStackTemplate() {
+    return {
+      AWSTemplateFormatVersion: '2010-09-09',
+      Description: 'Stack template',
+      Resources: {},
+      Outputs: {},
+    };
+  },
+
+  cfStackResourceTemplate() {
+    return {
+      Type: 'AWS::CloudFormation::Stack',
+      Properties: {
+        TemplateURL: '',
+      },
+    };
+  },
+};

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -77,14 +77,23 @@ module.exports = {
         stackResource: {},
       };
 
+      const lambdaLogicalIdRegex = this.provider.naming.getLambdaLogicalIdRegex();
+      const normalizedFuncNameEnd = lambdaLogicalIdRegex.exec(funcLogicalId).index;
+      const normalizedFuncName = funcLogicalId.slice(0, normalizedFuncNameEnd);
+
       const description = `Stack for function "${funcLogicalId}" and its dependencies`;
 
-      // create the stack template
+      // create the stack template (the template which contains the function and related resources)
       const newStackTemplate = this.cfStackTemplate();
       const depResources = depGraph.dependantsOf(funcLogicalId);
-
       newStackTemplate.Description = description;
+      // add the function
       newStackTemplate.Resources[funcLogicalId] = cfTemplate.Resources[funcLogicalId];
+      // add the log group
+      const logGroupLogicalIdSuffix = this.provider.naming.getLogGroupLogicalIdSuffix();
+      const logGroupLogicalId = `${normalizedFuncName}${logGroupLogicalIdSuffix}`;
+      newStackTemplate.Resources[logGroupLogicalId] = cfTemplate.Resources[logGroupLogicalId];
+      // add all the dependant resources
       _.forEach(depResources, (depLogicalId) => {
         newStackTemplate.Resources[depLogicalId] = cfTemplate.Resources[depLogicalId];
       });

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -161,6 +161,9 @@ module.exports = {
       newStackResource.Description = description;
       newStackResource.Properties.TemplateURL = templateURL;
 
+      // add DependsOn declarations to external dependencies
+      newStackResource.DependsOn = externalDeps;
+
       // add external deps as ref parameters
       _.forEach(externalDeps, (dep) => {
         const depLogicalId = dep;

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -55,7 +55,9 @@ module.exports = {
           const dependantName = name;
           const dependencyName = prop;
 
-          graph.addDependency(dependantName, dependencyName);
+          if (dependencyName !== dependantName) {
+            graph.addDependency(dependantName, dependencyName);
+          }
         }
       }
     });

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -33,7 +33,8 @@ module.exports = {
 
     const graph = new DepGraph();
 
-    traverse(items).forEach(function (prop) {
+    // add all nodes
+    traverse(items).forEach(function () {
       // add all the resources and outputs to the graph
       // note: this.path looks something like this --> ['Resources', 'ResourceLogicalId', ...]
       const type = this.path[0] === 'Resources' ? 'resource' : 'output';
@@ -41,8 +42,11 @@ module.exports = {
       if ((type === 'resource' || type === 'output') && this.path.length === 2) {
         graph.addNode(name, { type });
       }
+    });
 
-      // create the dependencies
+    // create the dependencies
+    traverse(items).forEach(function (prop) {
+      const name = this.path[1];
       // remove the first two items from this.path since they'll be something
       // like ['Resources', 'ResourceLogicalId', ...] to filter out dependencies by key
       const subPath = this.path.slice(2, this.path.length);

--- a/lib/plugins/aws/package/lib/splitStack.js
+++ b/lib/plugins/aws/package/lib/splitStack.js
@@ -51,7 +51,7 @@ module.exports = {
       // like ['Resources', 'ResourceLogicalId', ...] to filter out dependencies by key
       const subPath = this.path.slice(2, this.path.length);
       if (subPath.length && _.isString(prop)) {
-        if (allLogicalIds.includes(prop)) {
+        if (_.includes(allLogicalIds, prop)) {
           const dependantName = name;
           const dependencyName = prop;
 

--- a/lib/plugins/aws/package/lib/splitStack.test.js
+++ b/lib/plugins/aws/package/lib/splitStack.test.js
@@ -1,0 +1,384 @@
+'use strict';
+
+const path = require('path');
+const fse = require('fs-extra');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const testUtils = require('../../../../../tests/utils');
+const AwsPackage = require('../index');
+const Serverless = require('../../../../Serverless');
+const AwsProvider = require('../../provider/awsProvider');
+
+describe('splitStack', () => {
+  let serverless;
+  let awsPackage;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    awsPackage = new AwsPackage(serverless, {});
+    serverless.service = {
+      package: {
+        artifactDirectoryName: 'some-directory',
+      },
+      provider: {
+        /* eslint-disable max-len */
+        compiledCloudFormationTemplate: {
+          Resources: {
+            ServerlessDeploymentBucket: {
+              Type: 'AWS::S3::Bucket',
+            },
+            Func1LogGroup: {
+              Type: 'AWS::Logs::LogGroup',
+              Properties: { LogGroupName: '/aws/lambda/service-dev-hello' },
+            },
+            IamRoleLambdaExecution: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: ['lambda.amazonaws.com'] },
+                      Action: ['sts:AssumeRole'],
+                    },
+                  ],
+                },
+                Policies: [
+                  {
+                    PolicyName: {
+                      'Fn::Join': ['-', ['dev', 'service', 'lambda']],
+                    },
+                    PolicyDocument: {
+                      Version: '2012-10-17',
+                      Statement: [
+                        {
+                          Effect: 'Allow',
+                          Action: ['logs:CreateLogStream'],
+                          Resource: [{ 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/service-dev-func1:*' }],
+                        },
+                        {
+                          Effect: 'Allow',
+                          Action: ['logs:PutLogEvents'],
+                          Resource: [{ 'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/service-dev-func1:*:*' }],
+                        },
+                      ],
+                    },
+                  },
+                ],
+                Path: '/',
+                RoleName: { 'Fn::Join': ['-', ['service', 'dev', 'us-east-1', 'lambdaRole']] },
+              },
+            },
+            Func1LambdaFunction: {
+              Type: 'AWS::Lambda::Function',
+              Properties: {
+                Code: {
+                  S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+                  S3Key: 'serverless/service/dev/1494405999466-2017-05-10T08:46:39.466Z/service.zip',
+                },
+                FunctionName: 'service-dev-func1',
+                Handler: 'handler.func1',
+                MemorySize: 1024,
+                Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+                Runtime: 'nodejs6.10',
+                Timeout: 6,
+              },
+              DependsOn: ['Func1LogGroup', 'IamRoleLambdaExecution'],
+            },
+            Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI: {
+              Type: 'AWS::Lambda::Version',
+              DeletionPolicy: 'Retain',
+              Properties: {
+                FunctionName: {
+                  Ref: 'Func1LambdaFunction',
+                },
+                CodeSha256: 'N+W4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI=',
+              },
+            },
+            SNSTopicFoo: {
+              Type: 'AWS::SNS::Topic',
+              Properties: {
+                TopicName: 'foo',
+                DisplayName: '',
+                Subscription: [
+                  {
+                    Endpoint: { 'Fn::GetAtt': ['Func1LambdaFunction', 'Arn'] },
+                    Protocol: 'lambda',
+                  },
+                ],
+              },
+            },
+            Func1LambdaPermissionFooSNS: {
+              Type: 'AWS::Lambda::Permission',
+              Properties: {
+                FunctionName: {
+                  'Fn::GetAtt': ['Func1LambdaFunction', 'Arn'],
+                },
+                Action: 'lambda:InvokeFunction',
+                Principal: 'sns.amazonaws.com',
+                SourceArn: {
+                  'Fn::Join': ['', ['arn:aws:sns:', { Ref: 'AWS::Region' }, ':', { Ref: 'AWS::AccountId' }, ':', 'foo']],
+                },
+              },
+            },
+          },
+          Outputs: {
+            ServerlessDeploymentBucketName: {
+              Value: {
+                Ref: 'ServerlessDeploymentBucket',
+              },
+            },
+            Func1LambdaFunctionQualifiedArn: {
+              Description: 'Current Lambda function version',
+              Value: {
+                Ref: 'Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI',
+              },
+            },
+          },
+        },
+        /* eslint-enable max-len */
+        cloudFormationDependencyGraph: null,
+        nestedStacks: [],
+      },
+    };
+  });
+
+  describe('#splitStack()', () => {
+    let createDependencyGraphStub;
+    let generateNestedStacksStub;
+    let writeStacksToDiskStub;
+    let updateCompiledCloudFormationTemplateStub;
+
+    beforeEach(() => {
+      createDependencyGraphStub = sinon
+        .stub(awsPackage, 'createDependencyGraph').resolves();
+      generateNestedStacksStub = sinon
+        .stub(awsPackage, 'generateNestedStacks').resolves();
+      writeStacksToDiskStub = sinon
+        .stub(awsPackage, 'writeStacksToDisk').resolves();
+      updateCompiledCloudFormationTemplateStub = sinon
+        .stub(awsPackage, 'updateCompiledCloudFormationTemplate').resolves();
+    });
+
+    afterEach(() => {
+      awsPackage.createDependencyGraph.restore();
+      awsPackage.generateNestedStacks.restore();
+      awsPackage.writeStacksToDisk.restore();
+      awsPackage.updateCompiledCloudFormationTemplate.restore();
+    });
+
+    it('should resolve if useStackSplitting config variable is not set', () => awsPackage
+      .splitStack().then(() => {
+        expect(createDependencyGraphStub.calledOnce).to.equal(false);
+        expect(generateNestedStacksStub.calledOnce).to.equal(false);
+        expect(writeStacksToDiskStub.calledOnce).to.equal(false);
+        expect(updateCompiledCloudFormationTemplateStub.calledOnce).to.equal(false);
+      })
+    );
+
+    it('should run promise chain if useStackSplitting config variable is set', () => {
+      awsPackage.serverless.service.provider.useStackSplitting = true;
+
+      return awsPackage.splitStack().then(() => {
+        expect(createDependencyGraphStub.calledOnce).to.equal(true);
+        expect(generateNestedStacksStub.calledAfter(createDependencyGraphStub)).to.equal(true);
+        expect(writeStacksToDiskStub.calledAfter(generateNestedStacksStub)).to.equal(true);
+        expect(updateCompiledCloudFormationTemplateStub
+          .calledAfter(writeStacksToDiskStub)).to.equal(true);
+      });
+    });
+  });
+
+  describe('#createDependencyGraph()', () => {
+    it('should compute a valid dependency graph', () => {
+      const expectedDepGraph = {
+        nodes: {
+          ServerlessDeploymentBucket: { type: 'resource' },
+          Func1LogGroup: { type: 'resource' },
+          IamRoleLambdaExecution: { type: 'resource' },
+          Func1LambdaFunction: { type: 'resource' },
+          Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI: { type: 'resource' },
+          SNSTopicFoo: { type: 'resource' },
+          Func1LambdaPermissionFooSNS: { type: 'resource' },
+          ServerlessDeploymentBucketName: { type: 'output' },
+          Func1LambdaFunctionQualifiedArn: { type: 'output' },
+        },
+        outgoingEdges: {
+          ServerlessDeploymentBucket: [],
+          Func1LogGroup: [],
+          IamRoleLambdaExecution: [],
+          Func1LambdaFunction: [
+            'ServerlessDeploymentBucket',
+            'IamRoleLambdaExecution',
+            'Func1LogGroup',
+          ],
+          Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI: ['Func1LambdaFunction'],
+          SNSTopicFoo: ['Func1LambdaFunction'],
+          Func1LambdaPermissionFooSNS: ['Func1LambdaFunction'],
+          ServerlessDeploymentBucketName: ['ServerlessDeploymentBucket'],
+          Func1LambdaFunctionQualifiedArn: [
+            'Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI',
+          ],
+        },
+        incomingEdges: {
+          ServerlessDeploymentBucket: [
+            'Func1LambdaFunction',
+            'ServerlessDeploymentBucketName',
+          ],
+          Func1LogGroup: ['Func1LambdaFunction'],
+          IamRoleLambdaExecution: ['Func1LambdaFunction'],
+          Func1LambdaFunction: [
+            'Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI',
+            'SNSTopicFoo',
+            'Func1LambdaPermissionFooSNS',
+          ],
+          Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI: [
+            'Func1LambdaFunctionQualifiedArn',
+          ],
+          SNSTopicFoo: [],
+          Func1LambdaPermissionFooSNS: [],
+          ServerlessDeploymentBucketName: [],
+          Func1LambdaFunctionQualifiedArn: [],
+        },
+      };
+
+      return awsPackage.createDependencyGraph().then(() => {
+        const depGraph = awsPackage.serverless.service.provider.cloudFormationDependencyGraph;
+
+        expect(depGraph.nodes).to.deep.equal(expectedDepGraph.nodes);
+        expect(depGraph.outgoingEdges).to.deep.equal(expectedDepGraph.outgoingEdges);
+        expect(depGraph.incomingEdges).to.deep.equal(expectedDepGraph.incomingEdges);
+      });
+    });
+  });
+
+  describe('#generateNestedStacks()', () => {
+    beforeEach(() => {
+      awsPackage.createDependencyGraph();
+    });
+
+    it('should generate and append the resources for the nested stacks', () => awsPackage
+      .generateNestedStacks().then(() => {
+        const nestedStacks = awsPackage.serverless.service.provider.nestedStacks;
+
+        // stackTemplate
+        const stackTemplateParameters = {
+          ServerlessDeploymentBucket: {
+            Type: 'String',
+          },
+          IamRoleLambdaExecution: {
+            Type: 'String',
+          },
+        };
+        const stackTemplate = nestedStacks[0].stackTemplate;
+        expect(stackTemplate.Parameters).to.deep.equal(stackTemplateParameters);
+        expect(Object.keys(stackTemplate.Resources).length).to.equal(5);
+        expect(stackTemplate.Resources.Func1LambdaFunction).to.not.equal(undefined);
+        expect(stackTemplate.Resources.Func1LambdaFunction.Properties.Code.S3Bucket.Ref)
+          .to.equal('ServerlessDeploymentBucket');
+        expect(stackTemplate.Resources.Func1LambdaFunction.Properties.Role.Ref)
+          .to.equal('IamRoleLambdaExecution');
+        expect(stackTemplate.Resources.Func1LambdaFunction.DependsOn)
+          .to.deep.equal(['Func1LogGroup']);
+        expect(stackTemplate.Resources.Func1LogGroup).to.not.equal(undefined);
+        expect(stackTemplate.Resources.Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI)
+          .to.not.equal(undefined);
+        expect(stackTemplate.Resources.Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI
+          .Properties.FunctionName.Ref).to.equal('Func1LambdaFunction');
+        expect(stackTemplate.Resources.SNSTopicFoo).to.not.equal(undefined);
+        expect(stackTemplate.Resources.SNSTopicFoo.Properties.Subscription[0].Endpoint)
+          .to.deep.equal({ 'Fn::GetAtt': ['Func1LambdaFunction', 'Arn'] });
+        expect(stackTemplate.Resources.Func1LambdaPermissionFooSNS).to.not.equal(undefined);
+        expect(stackTemplate.Resources.Func1LambdaPermissionFooSNS.Properties.FunctionName)
+          .to.deep.equal({ 'Fn::GetAtt': ['Func1LambdaFunction', 'Arn'] });
+        expect(Object.keys(stackTemplate.Outputs).length).to.equal(1);
+        expect(stackTemplate.Outputs.Func1LambdaFunctionQualifiedArn).to.not.equal(undefined);
+        expect(stackTemplate.Outputs.Func1LambdaFunctionQualifiedArn.Value.Ref)
+          .to.equal('Func1LambdaVersionNW4EsouaYTwudLQRlbUl7fVQR6WAYwqCfytC6fDOtI');
+
+        // stackResource
+        const stackResourceParameters = {
+          ServerlessDeploymentBucket: {
+            Ref: 'ServerlessDeploymentBucket',
+          },
+          IamRoleLambdaExecution: {
+            'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
+          },
+        };
+        const statckResourceDependsOn = ['ServerlessDeploymentBucket', 'IamRoleLambdaExecution'];
+        const stackResource = nestedStacks[0].stackResource;
+        expect(Object.keys(stackResource).length).to.equal(1);
+        expect(stackResource.NestedStack1).to.not.equal(undefined);
+        expect(stackResource.NestedStack1.Properties.Parameters)
+          .to.deep.equal(stackResourceParameters);
+        expect(stackResource.NestedStack1.Properties.TemplateURL)
+          .to.match(/cloudformation-template-nested-stack-1\.json/);
+        expect(stackResource.NestedStack1.DependsOn).to.deep.equal(statckResourceDependsOn);
+      })
+    );
+  });
+
+  describe('#writeStacksToDisk()', () => {
+    beforeEach(() => {
+      awsPackage.createDependencyGraph();
+      awsPackage.generateNestedStacks();
+    });
+
+    it('should write the generated nested stack templates to disk', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const serverlessDirPath = path.join(tmpDirPath, '.serverless');
+      const nestedStackFile1 = 'cloudformation-template-nested-stack-1.json';
+      const nestedStackFile1Path = path.join(serverlessDirPath, nestedStackFile1);
+      fse.mkdirsSync(serverlessDirPath);
+      awsPackage.serverless.config.servicePath = tmpDirPath;
+
+      return awsPackage.writeStacksToDisk().then(() => {
+        const nestedStacks = awsPackage.serverless.service.provider.nestedStacks;
+        const nestedStackFile1Content = fse.readJsonSync(nestedStackFile1Path);
+
+        expect(nestedStackFile1Content).to.deep.equal(nestedStacks[0].stackTemplate);
+      });
+    });
+  });
+
+  describe('#updateCompiledCloudFormationTemplate()', () => {
+    beforeEach(() => {
+      awsPackage.createDependencyGraph();
+      awsPackage.generateNestedStacks();
+    });
+
+    it('should update the in-memory compiled CloudFormation template', () => awsPackage
+      .updateCompiledCloudFormationTemplate().then(() => {
+        const compiledCfTemplate = awsPackage.serverless.service
+          .provider.compiledCloudFormationTemplate;
+
+        const nestedStackParameters = {
+          ServerlessDeploymentBucket: {
+            Ref: 'ServerlessDeploymentBucket',
+          },
+          IamRoleLambdaExecution: {
+            'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
+          },
+        };
+
+        const nestedStackDependsOn = ['ServerlessDeploymentBucket', 'IamRoleLambdaExecution'];
+        expect(Object.keys(compiledCfTemplate.Resources).length).to.equal(3);
+        expect(compiledCfTemplate.Resources.ServerlessDeploymentBucket).to.not.equal(undefined);
+        expect(compiledCfTemplate.Resources.IamRoleLambdaExecution).to.not.equal(undefined);
+        expect(compiledCfTemplate.Resources.NestedStack1).to.not.equal(undefined);
+        expect(compiledCfTemplate.Resources.NestedStack1.Properties.Parameters)
+          .to.deep.equal(nestedStackParameters);
+        expect(compiledCfTemplate.Resources.NestedStack1.Properties.TemplateURL)
+          .to.match(/cloudformation-template-nested-stack-1\.json/);
+        expect(compiledCfTemplate.Resources.NestedStack1.DependsOn)
+          .to.deep.equal(nestedStackDependsOn);
+        expect(Object.keys(compiledCfTemplate.Outputs).length).to.equal(1);
+        expect(compiledCfTemplate.Outputs.ServerlessDeploymentBucketName).to.not.equal(undefined);
+        expect(compiledCfTemplate.Outputs.ServerlessDeploymentBucketName.Value.Ref)
+          .to.equal('ServerlessDeploymentBucket');
+      })
+    );
+  });
+});

--- a/lib/plugins/aws/package/lib/validateAgainstStackLimits.js
+++ b/lib/plugins/aws/package/lib/validateAgainstStackLimits.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+
+module.exports = {
+  validateAgainstStackLimits() {
+    const isStackSplittingUsed = this.serverless.service.provider.useStackSplitting;
+
+    if (!isStackSplittingUsed) {
+      // validate against http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+      const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+      const resources = cfTemplate.Resources;
+      const resourceCount = Object.keys(resources).length;
+      const maxResourceCount = 200;
+      const outputs = cfTemplate.Outputs;
+      const outputCount = Object.keys(outputs).length;
+      const maxOutputCount = 60;
+      const serviceName = this.serverless.service.service;
+
+      if (resourceCount >= maxResourceCount) {
+        const errorMessage = [
+          `The CloudFormation template of your service "${serviceName}"`,
+          ` currently uses "${resourceCount}" Resources.`,
+          ` The current Resource count limit is "${maxResourceCount}" according to AWS.`,
+          ' You can mitigate this problem by splitting up your stack into multiple stacks.',
+          ' Serverless can automate this process for you with the help of the "useStackSplitting"',
+          ' config (CAUTION: this is a one-way route since nested stacks are used in this case).',
+          ' However you can also use cross service communication to do this manually.',
+          ' Please check the docs for more info.',
+        ].join('');
+        return BbPromise.reject(errorMessage);
+      }
+
+      if (outputCount >= maxOutputCount) {
+        const errorMessage = [
+          `The CloudFormation template of your service "${serviceName}"`,
+          ` currently uses "${outputCount}" Outputs.`,
+          ` The current Output count limit is "${maxOutputCount}" according to AWS.`,
+          ' You can mitigate this problem by splitting up your stack into multiple stacks.',
+          ' Serverless can automate this process for you with the help of the "useStackSplitting"',
+          ' config (CAUTION: this is a one-way route since nested stacks are used in this case).',
+          ' However you can also use cross service communication to do this manually.',
+          ' Please check the docs for more info.',
+        ].join('');
+        return BbPromise.reject(errorMessage);
+      }
+    }
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/package/lib/validateAgainstStackLimits.test.js
+++ b/lib/plugins/aws/package/lib/validateAgainstStackLimits.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsPackage = require('../index');
+const Serverless = require('../../../../Serverless');
+const AwsProvider = require('../../provider/awsProvider');
+
+describe('validateAgainstStackLimits', () => {
+  let serverless;
+  let awsPackage;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    awsPackage = new AwsPackage(serverless, {});
+    serverless.service = {
+      service: 'my-service',
+      provider: {
+        compiledCloudFormationTemplate: {
+          Resources: {},
+          Outputs: {},
+        },
+      },
+    };
+  });
+
+  describe('#validateAgainstStackLimits()', () => {
+    it('should resolve if automatic stack splitting is used', () => {
+      awsPackage.serverless.service.provider.useStackSplitting = true;
+
+      return awsPackage.validateAgainstStackLimits();
+    });
+
+    it('should throw if resource count exceeds limit w/o using stack splitting', () => {
+      let mockResources = Array(200).fill(1, 0, 200);
+      mockResources = mockResources.map((res, index) => {
+        const mockResource = {
+          [index + 1]: {},
+        };
+        return mockResource;
+      });
+
+      awsPackage.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources = mockResources;
+
+      return awsPackage.validateAgainstStackLimits().catch((error) => {
+        expect(error).to.match(/The current Resource count limit/);
+      });
+    });
+
+    it('should throw if output count exceeds limit w/o using stack splitting', () => {
+      let mockOutputs = Array(60).fill(1, 0, 60);
+      mockOutputs = mockOutputs.map((res, index) => {
+        const mockOutput = {
+          [index + 1]: {},
+        };
+        return mockOutput;
+      });
+
+      awsPackage.serverless.service.provider
+        .compiledCloudFormationTemplate.Outputs = mockOutputs;
+
+      return awsPackage.validateAgainstStackLimits().catch((error) => {
+        expect(error).to.match(/The current Output count limit/);
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "bluebird": "^3.4.0",
     "chalk": "^1.1.1",
     "ci-info": "^1.0.0",
+    "dependency-graph": "^0.5.0",
     "download": "^5.0.2",
     "filesize": "^3.3.0",
     "fs-extra": "^0.26.7",

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
     "semver-regex": "^1.0.0",
     "shelljs": "^0.6.0",
     "tabtab": "^2.2.2",
+    "traverse": "^0.6.6",
     "uuid": "^2.0.2",
     "write-file-atomic": "^2.1.0"
-    "traverse": "^0.6.6",
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,5 +117,6 @@
     "tabtab": "^2.2.2",
     "uuid": "^2.0.2",
     "write-file-atomic": "^2.1.0"
+    "traverse": "^0.6.6",
   }
 }


### PR DESCRIPTION
## Todos

- [x] Print log message when resource count is nearly reached + add link do docs for stack splitting
- [x] Translate AWS error message ("Resource count is over 200") into useful error message + add link do docs for stack splitting
- [ ] Check if `params` need to be set for file uploads so that they're also using SSE if it's setup
- [x] Write tests
- [x] Write documentation
- [x] Manually test if this PR really solves the 200 resources / outputs limit 
- [x] Provide verification config / commands / resources
- [ ] Update the messages below

---

## What did you implement:

Closes #3411
Refs #3441 

Add function-based automatic stack splitting to avoid deploy failures when facing a high resources count.

## How did you implement it:

Serverless will analyze the compiled CloudFormation template to figure out the dependencies and build a dependency graph based upon this knowledge.

After that all the functions and their dependants will be moved into own nested stacks. Those stacks are written to disk. Furthermore the parent CloudFormation template will be updated so that the functions and the dependants are removed and replaced by references to the nested stack CloudFormation templates.

The user has to specifically opt-in for this feature via the `useStackSplitting: true` config.

## How can we verify it:

Create a service which looks like the following:

```yml
service: complex-service

provider:
  name: aws
  runtime: nodejs6.10
  useStackSplitting: true

functions:
  hello:
    handler: handler.hello
    events:
      - http: ANY hello
      - stream:
          type: dynamodb
          arn:
            Fn::GetAtt:
              - ResourcesDynamoDBStream
              - StreamArn
      - schedule: rate(2 hours)
  goodbye:
    handler: handler.goodbye
    events:
      - http:
          method: GET
          path: goodbye
          integration: LAMBDA
          cors: true
      - stream:
          type: kinesis
          arn:
            Fn::GetAtt:
              - ResourcesKinesisStream
              - Arn
      - sns:
          topicName: complex-sns-topic
          displayName: SNS topic for a complex event setup

resources:
  Resources:
    ResourcesKinesisStream:
      Type: AWS::Kinesis::Stream
      Properties:
        Name: ResourcesKinesisStream
        ShardCount: 1
    ResourcesDynamoDBStream:
      Type: AWS::DynamoDB::Table
      Properties:
        TableName: ResourcesDynamoDBStream
        AttributeDefinitions:
          - AttributeName: id
            AttributeType: S
        KeySchema:
          - AttributeName: id
            KeyType: HASH
        ProvisionedThroughput:
          ReadCapacityUnits: 1
          WriteCapacityUnits: 1
        StreamSpecification:
          StreamViewType: NEW_AND_OLD_IMAGES
```

Run `serverless package` and look into the `.serverless` directory to see all the resources.

Or run `serverless deploy` to deploy the stack.

---

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

/cc @brianneisler @eahefnawy @dougmoscrop 