### PR TITLE
Add new syntax to specify arn for sns event

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -50,6 +50,15 @@ functions:
       - sns: arn:xxx
 ```
 
+```yml
+functions:
+  dispatcher:
+    handler: dispatcher.dispatch
+    events:
+      - sns:
+          arn: arn:xxx
+```
+
 Or with intrinsic CloudFormation function like `Fn::Join` or `Fn::GetAtt`.
 
 ```yml

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -32,6 +32,10 @@ class AwsCompileSNSEvents {
                   if (event.sns.topicName && typeof event.sns.topicName === 'string') {
                     topicArn = event.sns.arn;
                     topicName = event.sns.topicName;
+                  } else if (event.sns.arn.indexOf('arn:') === 0) {
+                    topicArn = event.sns.arn;
+                    const splitArn = topicArn.split(':');
+                    topicName = splitArn[splitArn.length - 1];
                   } else {
                     const errorMessage = [
                       'Missing or invalid topicName property for sns event',

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -134,7 +134,7 @@ describe('AwsCompileSNSEvents', () => {
       ).to.deep.equal({});
     });
 
-    it('should not create SNS topic when arn is given', () => {
+    it('should create SNS topic when arn is given', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
@@ -158,23 +158,33 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should raise an error when only arn is present', () => {
+    it('should create SNS topic when only arn is present', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
             {
               sns: {
-                arn: 'arn:aws:sns:region:accountid:bar',
+                arn: 'arn:aws:sns:region:accountid:foo',
               },
             },
           ],
         },
       };
 
-      expect(() => { awsCompileSNSEvents.compileSNSEvents(); }).to.throw(Error);
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(Object.keys(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources)
+      ).to.have.length(2);
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionFoo.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionFooSNS.Type
+      ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should not create SNS topic when arn is provided', () => {
+    it('should create SNS topic when arn is provided', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -134,7 +134,7 @@ describe('AwsCompileSNSEvents', () => {
       ).to.deep.equal({});
     });
 
-    it('should create SNS topic when arn is given', () => {
+    it('should create SNS topic when arn is given as a string', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
@@ -158,7 +158,7 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should create SNS topic when only arn is present', () => {
+    it('should create SNS topic when only arn is given as an object property', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
@@ -184,7 +184,7 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
-    it('should create SNS topic when arn is provided', () => {
+    it('should create SNS topic when arn and topicName are given as object properties', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Closes #3473 

Allowed the following syntax
```yml
events:
  - sns:
      arn: arn:xxx
```

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Added the condition that allowed the above syntax.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Please write the above in serverless.yml. Then run `sls deploy`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
