### PR TITLE
Add detailed lifecycle events to info plugin

### DIFF
--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -319,3 +319,24 @@ module.exports = MyPlugin;
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.
+
+### Extending the `info` command
+
+The `info` command which is used to display information about the deployment has detailed `lifecycleEvents` you can hook into to add and display custom information.
+
+Here's an example overview of the info lifecycle events the AWS implementation exposes:
+
+```
+-> info:info
+  -> aws:info:validate
+  -> aws:info:gatherData
+  -> aws:info:displayServiceInfo
+  -> aws:info:displayApiKeys
+  -> aws:info:displayEndpoints
+  -> aws:info:displayFunctions
+  -> aws:info:displayStackOutputs
+```
+
+Here you could e.g. hook into `after:aws:info:gatherData` and implement your own data collection and display it to the user.
+
+**Note:** Every provider implements its own `info` plugin so you might want to take a look into the `lifecycleEvents` the provider `info` plugin exposes.

--- a/docs/providers/azure/guide/plugins.md
+++ b/docs/providers/azure/guide/plugins.md
@@ -319,3 +319,24 @@ module.exports = MyPlugin;
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.
+
+### Extending the `info` command
+
+The `info` command which is used to display information about the deployment has detailed `lifecycleEvents` you can hook into to add and display custom information.
+
+Here's an example overview of the info lifecycle events the AWS implementation exposes:
+
+```
+-> info:info
+  -> aws:info:validate
+  -> aws:info:gatherData
+  -> aws:info:displayServiceInfo
+  -> aws:info:displayApiKeys
+  -> aws:info:displayEndpoints
+  -> aws:info:displayFunctions
+  -> aws:info:displayStackOutputs
+```
+
+Here you could e.g. hook into `after:aws:info:gatherData` and implement your own data collection and display it to the user.
+
+**Note:** Every provider implements its own `info` plugin so you might want to take a look into the `lifecycleEvents` the provider `info` plugin exposes.

--- a/docs/providers/openwhisk/guide/plugins.md
+++ b/docs/providers/openwhisk/guide/plugins.md
@@ -319,3 +319,24 @@ module.exports = MyPlugin;
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.
+
+### Extending the `info` command
+
+The `info` command which is used to display information about the deployment has detailed `lifecycleEvents` you can hook into to add and display custom information.
+
+Here's an example overview of the info lifecycle events the AWS implementation exposes:
+
+```
+-> info:info
+  -> aws:info:validate
+  -> aws:info:gatherData
+  -> aws:info:displayServiceInfo
+  -> aws:info:displayApiKeys
+  -> aws:info:displayEndpoints
+  -> aws:info:displayFunctions
+  -> aws:info:displayStackOutputs
+```
+
+Here you could e.g. hook into `after:aws:info:gatherData` and implement your own data collection and display it to the user.
+
+**Note:** Every provider implements its own `info` plugin so you might want to take a look into the `lifecycleEvents` the provider `info` plugin exposes.

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -19,7 +19,7 @@ module.exports = {
 
   displayApiKeys() {
     const info = this.gatheredData.info;
-    let apiKeysMessage = `\n${chalk.yellow('api keys:')}`;
+    let apiKeysMessage = `${chalk.yellow('api keys:')}`;
 
     if (info.apiKeys && info.apiKeys.length > 0) {
       info.apiKeys.forEach((apiKeyInfo) => {
@@ -35,7 +35,7 @@ module.exports = {
 
   displayEndpoints() {
     const info = this.gatheredData.info;
-    let endpointsMessage = `\n${chalk.yellow('endpoints:')}`;
+    let endpointsMessage = `${chalk.yellow('endpoints:')}`;
 
     if (info.endpoint) {
       _.forEach(this.serverless.service.functions, (functionObject) => {
@@ -66,7 +66,7 @@ module.exports = {
 
   displayFunctions() {
     const info = this.gatheredData.info;
-    let functionsMessage = `\n${chalk.yellow('functions:')}`;
+    let functionsMessage = `${chalk.yellow('functions:')}`;
 
     if (info.functions && info.functions.length > 0) {
       info.functions.forEach((f) => {
@@ -83,7 +83,7 @@ module.exports = {
   displayStackOutputs() {
     let message = '';
     if (this.options.verbose) {
-      message = `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
+      message = `${chalk.yellow.underline('\nStack Outputs\n')}`;
       _.forEach(this.gatheredData.outputs, (output) => {
         message += `${chalk.yellow(output.OutputKey)}: ${output.OutputValue}\n`;
       });

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -4,17 +4,21 @@ const chalk = require('chalk');
 const _ = require('lodash');
 
 module.exports = {
-  display() {
+  displayServiceInfo() {
     const info = this.gatheredData.info;
 
     let message = '';
-
     message += `${chalk.yellow.underline('Service Information')}\n`;
     message += `${chalk.yellow('service:')} ${info.service}\n`;
     message += `${chalk.yellow('stage:')} ${info.stage}\n`;
     message += `${chalk.yellow('region:')} ${info.region}`;
 
-    // Display API Keys
+    this.serverless.cli.consoleLog(message);
+    return message;
+  },
+
+  displayApiKeys() {
+    const info = this.gatheredData.info;
     let apiKeysMessage = `\n${chalk.yellow('api keys:')}`;
 
     if (info.apiKeys && info.apiKeys.length > 0) {
@@ -25,9 +29,12 @@ module.exports = {
       apiKeysMessage += '\n  None';
     }
 
-    message += apiKeysMessage;
+    this.serverless.cli.consoleLog(apiKeysMessage);
+    return apiKeysMessage;
+  },
 
-    // Display Endpoints
+  displayEndpoints() {
+    const info = this.gatheredData.info;
     let endpointsMessage = `\n${chalk.yellow('endpoints:')}`;
 
     if (info.endpoint) {
@@ -53,9 +60,12 @@ module.exports = {
       endpointsMessage += '\n  None';
     }
 
-    message += endpointsMessage;
+    this.serverless.cli.consoleLog(endpointsMessage);
+    return endpointsMessage;
+  },
 
-    // Display function information
+  displayFunctions() {
+    const info = this.gatheredData.info;
     let functionsMessage = `\n${chalk.yellow('functions:')}`;
 
     if (info.functions && info.functions.length > 0) {
@@ -66,17 +76,21 @@ module.exports = {
       functionsMessage += '\n  None';
     }
 
-    message += functionsMessage;
+    this.serverless.cli.consoleLog(functionsMessage);
+    return functionsMessage;
+  },
 
-    // when verbose info is requested, add the stack outputs to the output
+  displayStackOutputs() {
+    let message = '';
     if (this.options.verbose) {
-      message += `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
+      message = `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
       _.forEach(this.gatheredData.outputs, (output) => {
         message += `${chalk.yellow(output.OutputKey)}: ${output.OutputValue}\n`;
       });
+
+      this.serverless.cli.consoleLog(message);
     }
 
-    this.serverless.cli.consoleLog(message);
     return message;
   },
 };

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -58,7 +58,7 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `\n${chalk.yellow('api keys:')}`;
+    expectedMessage += `${chalk.yellow('api keys:')}`;
     expectedMessage += '\n  keyOne: 1234';
 
     const message = awsInfo.displayApiKeys();
@@ -67,7 +67,7 @@ describe('#display()', () => {
 
     delete awsInfo.gatheredData.info.apiKeys;
     const missingMessage = awsInfo.displayApiKeys();
-    expectedMessage = `\n${chalk.yellow('api keys:')}`;
+    expectedMessage = `${chalk.yellow('api keys:')}`;
     expectedMessage += '\n  None';
     expect(missingMessage).to.equal(expectedMessage);
   });
@@ -122,7 +122,7 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `\n${chalk.yellow('endpoints:')}`;
+    expectedMessage += `${chalk.yellow('endpoints:')}`;
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev';
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both';
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both/add';
@@ -135,7 +135,7 @@ describe('#display()', () => {
 
     delete awsInfo.gatheredData.info.endpoint;
     const missingMessage = awsInfo.displayEndpoints();
-    expectedMessage = `\n${chalk.yellow('endpoints:')}`;
+    expectedMessage = `${chalk.yellow('endpoints:')}`;
     expectedMessage += '\n  None';
     expect(missingMessage).to.equal(expectedMessage);
   });
@@ -158,7 +158,7 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `\n${chalk.yellow('functions:')}`;
+    expectedMessage += `${chalk.yellow('functions:')}`;
     expectedMessage += '\n  function1: my-first-dev-function1';
     expectedMessage += '\n  function2: my-first-dev-function2';
     expectedMessage += '\n  function3: my-first-dev-function3';
@@ -169,7 +169,7 @@ describe('#display()', () => {
 
     delete awsInfo.gatheredData.info.functions;
     const missingMessage = awsInfo.displayFunctions();
-    expectedMessage = `\n${chalk.yellow('functions:')}`;
+    expectedMessage = `${chalk.yellow('functions:')}`;
     expectedMessage += '\n  None';
     expect(missingMessage).to.equal(expectedMessage);
   });
@@ -192,7 +192,7 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
+    expectedMessage += `${chalk.yellow.underline('\nStack Outputs\n')}`;
     expectedMessage += `${chalk.yellow('Function1FunctionArn')}: ${'arn:function1'}\n`;
     expectedMessage += `${chalk.yellow('Function2FunctionArn')}: ${'arn:function2'}\n`;
 

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -47,14 +47,8 @@ describe('#display()', () => {
     expectedMessage += `${chalk.yellow('service:')} my-first\n`;
     expectedMessage += `${chalk.yellow('stage:')} dev\n`;
     expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
-    expectedMessage += `\n${chalk.yellow('api keys:')}`;
-    expectedMessage += '\n  None';
-    expectedMessage += `\n${chalk.yellow('endpoints:')}`;
-    expectedMessage += '\n  None';
-    expectedMessage += `\n${chalk.yellow('functions:')}`;
-    expectedMessage += '\n  None';
 
-    const message = awsInfo.display();
+    const message = awsInfo.displayServiceInfo();
     expect(consoleLogStub.calledOnce).to.equal(true);
     expect(message).to.equal(expectedMessage);
   });
@@ -64,20 +58,18 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
-    expectedMessage += `${chalk.yellow('service:')} my-first\n`;
-    expectedMessage += `${chalk.yellow('stage:')} dev\n`;
-    expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
     expectedMessage += `\n${chalk.yellow('api keys:')}`;
     expectedMessage += '\n  keyOne: 1234';
-    expectedMessage += `\n${chalk.yellow('endpoints:')}`;
-    expectedMessage += '\n  None';
-    expectedMessage += `\n${chalk.yellow('functions:')}`;
-    expectedMessage += '\n  None';
 
-    const message = awsInfo.display();
+    const message = awsInfo.displayApiKeys();
     expect(consoleLogStub.calledOnce).to.equal(true);
     expect(message).to.equal(expectedMessage);
+
+    delete awsInfo.gatheredData.info.apiKeys;
+    const missingMessage = awsInfo.displayApiKeys();
+    expectedMessage = `\n${chalk.yellow('api keys:')}`;
+    expectedMessage += '\n  None';
+    expect(missingMessage).to.equal(expectedMessage);
   });
 
   it('should display endpoints if given', () => {
@@ -130,24 +122,22 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
-    expectedMessage += `${chalk.yellow('service:')} my-first\n`;
-    expectedMessage += `${chalk.yellow('stage:')} dev\n`;
-    expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
-    expectedMessage += `\n${chalk.yellow('api keys:')}`;
-    expectedMessage += '\n  None';
     expectedMessage += `\n${chalk.yellow('endpoints:')}`;
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev';
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both';
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/both/add';
     expectedMessage += '\n  POST - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/e';
     expectedMessage += '\n  GET - ab12cd34ef.execute-api.us-east-1.amazonaws.com/dev/function1';
-    expectedMessage += `\n${chalk.yellow('functions:')}`;
-    expectedMessage += '\n  None';
 
-    const message = awsInfo.display();
+    const message = awsInfo.displayEndpoints();
     expect(consoleLogStub.calledOnce).to.equal(true);
     expect(message).to.equal(expectedMessage);
+
+    delete awsInfo.gatheredData.info.endpoint;
+    const missingMessage = awsInfo.displayEndpoints();
+    expectedMessage = `\n${chalk.yellow('endpoints:')}`;
+    expectedMessage += '\n  None';
+    expect(missingMessage).to.equal(expectedMessage);
   });
 
   it('should display functions if given', () => {
@@ -168,22 +158,20 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
-    expectedMessage += `${chalk.yellow('service:')} my-first\n`;
-    expectedMessage += `${chalk.yellow('stage:')} dev\n`;
-    expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
-    expectedMessage += `\n${chalk.yellow('api keys:')}`;
-    expectedMessage += '\n  None';
-    expectedMessage += `\n${chalk.yellow('endpoints:')}`;
-    expectedMessage += '\n  None';
     expectedMessage += `\n${chalk.yellow('functions:')}`;
     expectedMessage += '\n  function1: my-first-dev-function1';
     expectedMessage += '\n  function2: my-first-dev-function2';
     expectedMessage += '\n  function3: my-first-dev-function3';
 
-    const message = awsInfo.display();
+    const message = awsInfo.displayFunctions();
     expect(consoleLogStub.calledOnce).to.equal(true);
     expect(message).to.equal(expectedMessage);
+
+    delete awsInfo.gatheredData.info.functions;
+    const missingMessage = awsInfo.displayFunctions();
+    expectedMessage = `\n${chalk.yellow('functions:')}`;
+    expectedMessage += '\n  None';
+    expect(missingMessage).to.equal(expectedMessage);
   });
 
   it('should display CloudFormation outputs when verbose output is requested', () => {
@@ -204,22 +192,16 @@ describe('#display()', () => {
 
     let expectedMessage = '';
 
-    expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
-    expectedMessage += `${chalk.yellow('service:')} my-first\n`;
-    expectedMessage += `${chalk.yellow('stage:')} dev\n`;
-    expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
-    expectedMessage += `\n${chalk.yellow('api keys:')}`;
-    expectedMessage += '\n  None';
-    expectedMessage += `\n${chalk.yellow('endpoints:')}`;
-    expectedMessage += '\n  None';
-    expectedMessage += `\n${chalk.yellow('functions:')}`;
-    expectedMessage += '\n  None';
     expectedMessage += `${chalk.yellow.underline('\n\nStack Outputs\n')}`;
     expectedMessage += `${chalk.yellow('Function1FunctionArn')}: ${'arn:function1'}\n`;
     expectedMessage += `${chalk.yellow('Function2FunctionArn')}: ${'arn:function2'}\n`;
 
-    const message = awsInfo.display();
+    const message = awsInfo.displayStackOutputs();
     expect(consoleLogStub.calledOnce).to.equal(true);
     expect(message).to.equal(expectedMessage);
+
+    awsInfo.options.verbose = false;
+    const nonVerboseMessage = awsInfo.displayStackOutputs();
+    expect(nonVerboseMessage).to.equal('');
   });
 });

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -19,18 +19,51 @@ class AwsInfo {
       display
     );
 
-    this.hooks = {
-      'info:info': () => BbPromise.bind(this)
-        .then(this.validate)
-        .then(this.getStackInfo)
-        .then(this.getApiKeyValues)
-        .then(this.display),
+    this.commands = {
+      aws: {
+        type: 'entrypoint',
+        commands: {
+          info: {
+            lifecycleEvents: [
+              'validate',
+              'gatherData',
+              'displayServiceInfo',
+              'displayApiKeys',
+              'displayEndpoints',
+              'displayFunctions',
+              'displayStackOutputs',
+            ],
+          },
+        },
+      },
+    };
 
-      'deploy:deploy': () => BbPromise.bind(this)
-        .then(this.validate)
+    this.hooks = {
+      'info:info': () => this.serverless.pluginManager.spawn('aws:info'),
+
+      'deploy:deploy': () => this.serverless.pluginManager.spawn('aws:info'),
+
+      'aws:info:validate': () => BbPromise.bind(this)
+        .then(this.validate),
+
+      'aws:info:gatherData': () => BbPromise.bind(this)
         .then(this.getStackInfo)
-        .then(this.getApiKeyValues)
-        .then(this.display),
+        .then(this.getApiKeyValues),
+
+      'aws:info:displayServiceInfo': () => BbPromise.bind(this)
+        .then(this.displayServiceInfo),
+
+      'aws:info:displayApiKeys': () => BbPromise.bind(this)
+        .then(this.displayApiKeys),
+
+      'aws:info:displayEndpoints': () => BbPromise.bind(this)
+        .then(this.displayEndpoints),
+
+      'aws:info:displayFunctions': () => BbPromise.bind(this)
+        .then(this.displayFunctions),
+
+      'aws:info:displayStackOutputs': () => BbPromise.bind(this)
+        .then(this.displayStackOutputs),
     };
   }
 }

--- a/lib/plugins/aws/info/index.test.js
+++ b/lib/plugins/aws/info/index.test.js
@@ -12,7 +12,11 @@ describe('AwsInfo', () => {
   let validateStub;
   let getStackInfoStub;
   let getApiKeyValuesStub;
-  let displayStub;
+  let displayServiceInfoStub;
+  let displayApiKeysStub;
+  let displayEndpointsStub;
+  let displayFunctionsStub;
+  let displayStackOutputsStub;
 
   beforeEach(() => {
     serverless = new Serverless();
@@ -22,21 +26,36 @@ describe('AwsInfo', () => {
       region: 'us-east-1',
     };
     awsInfo = new AwsInfo(serverless, options);
+    // Load commands and hooks into pluginManager
+    serverless.pluginManager.loadCommands(awsInfo);
+    serverless.pluginManager.loadHooks(awsInfo);
     validateStub = sinon
       .stub(awsInfo, 'validate').resolves();
     getStackInfoStub = sinon
       .stub(awsInfo, 'getStackInfo').resolves();
     getApiKeyValuesStub = sinon
       .stub(awsInfo, 'getApiKeyValues').resolves();
-    displayStub = sinon
-      .stub(awsInfo, 'display').resolves();
+    displayServiceInfoStub = sinon
+      .stub(awsInfo, 'displayServiceInfo').resolves();
+    displayApiKeysStub = sinon
+      .stub(awsInfo, 'displayApiKeys').resolves();
+    displayEndpointsStub = sinon
+      .stub(awsInfo, 'displayEndpoints').resolves();
+    displayFunctionsStub = sinon
+      .stub(awsInfo, 'displayFunctions').resolves();
+    displayStackOutputsStub = sinon
+      .stub(awsInfo, 'displayStackOutputs').resolves();
   });
 
   afterEach(() => {
     awsInfo.validate.restore();
     awsInfo.getStackInfo.restore();
     awsInfo.getApiKeyValues.restore();
-    awsInfo.display.restore();
+    awsInfo.displayServiceInfo.restore();
+    awsInfo.displayApiKeys.restore();
+    awsInfo.displayEndpoints.restore();
+    awsInfo.displayFunctions.restore();
+    awsInfo.displayStackOutputs.restore();
   });
 
   describe('#constructor()', () => {
@@ -55,7 +74,11 @@ describe('AwsInfo', () => {
       awsInfo.hooks['info:info']().then(() => {
         expect(validateStub.calledOnce).to.equal(true);
         expect(getStackInfoStub.calledAfter(validateStub)).to.equal(true);
-        expect(displayStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+        expect(displayServiceInfoStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+        expect(displayApiKeysStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+        expect(displayEndpointsStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+        expect(displayFunctionsStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+        expect(displayStackOutputsStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
       })
     );
 
@@ -64,7 +87,11 @@ describe('AwsInfo', () => {
         awsInfo.hooks['deploy:deploy']().then(() => {
           expect(validateStub.calledOnce).to.equal(true);
           expect(getStackInfoStub.calledAfter(validateStub)).to.equal(true);
-          expect(displayStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+          expect(displayServiceInfoStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+          expect(displayApiKeysStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+          expect(displayEndpointsStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+          expect(displayFunctionsStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
+          expect(displayStackOutputsStub.calledAfter(getApiKeyValuesStub)).to.equal(true);
         })
       );
     });


### PR DESCRIPTION
## What did you implement:

Closes #3502 

The info plugin (AWS) now exposes more detailed lifecycle events that can be used by plugins to integrate their output into the info sections, instead of putting everything after the standard info plugin.
Until now it was only possible to hook `after:info:info`.

#### The new lifecycle looks as follows:
```
-> info:info
  -> aws:info:validate
  -> aws:info:gatherData
  -> aws:info:displayServiceInfo
  -> aws:info:displayApiKeys
  -> aws:info:displayEndpoints
  -> aws:info:displayFunctions
  -> aws:info:displayStackOutputs
```

Plugins now can hook `after:aws:info:gatherData` to implement their own data collection and then output their information next to the section they want by hooking one or more of the `after:aws:info:displayXXXX` hooks.

#### Example:

A plugin that adds some information to the endpoints section (maybe because it adds endpoint relevant resources), would hook `aws:info:displayEndpoints` and print its information right after the standard endpoints information.

An advanced usecase would even be to overwrite `aws:info:displayEndpoints` to replace the standard output completely (_not recommended_).

## How did you implement it:

Added internal lifecycle and use **pluginManager.spawn()** to spawn the internal `aws:info` entrypoint. Split the old display() function into parts that handle each section.

## How can we verify it:

Non-breaking tests: Run `serverless info` with any plugin activated -> The output should be exactly the same as before.

Write a plugin that hooks one of the new lifecycle events. It should be triggered accordingly.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
