### PR TITLE
Allow service to be specified as object in serverless.yml

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -162,6 +162,10 @@ class Service {
     return this.serviceObject.name;
   }
 
+  getServiceObject() {
+    return this.serviceObject;
+  }
+
   getAllFunctions() {
     return Object.keys(this.functions);
   }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -13,6 +13,7 @@ class Service {
 
     // Default properties
     this.service = null;
+    this.serviceObject = null;
     this.provider = {
       stage: 'dev',
       region: 'us-east-1',
@@ -64,6 +65,9 @@ class Service {
         if (!serverlessFile.service) {
           throw new ServerlessError('"service" property is missing in serverless.yml');
         }
+        if (_.isObject(serverlessFile.service) && !serverlessFile.service.name) {
+          throw new ServerlessError('"service" is missing the "name" property in serverless.yml');
+        }
         if (!serverlessFile.provider) {
           throw new ServerlessError('"provider" property is missing in serverless.yml');
         }
@@ -91,7 +95,13 @@ class Service {
           , {});
         }
 
-        that.service = serverlessFile.service;
+        if (_.isObject(serverlessFile.service)) {
+          that.serviceObject = serverlessFile.service;
+          that.service = serverlessFile.service.name;
+        } else {
+          that.serviceObject = { name: serverlessFile.service };
+          that.service = serverlessFile.service;
+        }
         that.custom = serverlessFile.custom;
         that.plugins = serverlessFile.plugins;
         that.resources = serverlessFile.resources;
@@ -146,6 +156,10 @@ class Service {
 
   update(data) {
     return _.merge(this, data);
+  }
+
+  getServiceName() {
+    return this.serviceObject.name;
   }
 
   getAllFunctions() {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const YAML = require('js-yaml');
+const _ = require('lodash');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const Service = require('../../lib/classes/Service');
@@ -22,6 +23,7 @@ describe('Service', () => {
       const serviceInstance = new Service(serverless);
 
       expect(serviceInstance.service).to.be.equal(null);
+      expect(serviceInstance.serviceObject).to.be.equal(null);
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
         region: 'us-east-1',
@@ -196,6 +198,52 @@ describe('Service', () => {
       return serviceInstance.load().then(() => {
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
+      });
+    });
+
+    it('should fail when the service name is missing', () => {
+      const SUtils = new Utils();
+      const serverlessYaml = {
+        service: {},
+        provider: 'aws',
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yaml'),
+        YAML.dump(serverlessYaml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load().then(() => {
+        // if we reach this, then no error was thrown as expected
+        // so make assertion fail intentionally to let us know something is wrong
+        expect(1).to.equal(2);
+      }).catch(e => {
+        expect(e.name).to.be.equal('ServerlessError');
+      });
+    });
+
+    it('should support service objects', () => {
+      const SUtils = new Utils();
+      const serverlessYaml = {
+        service: {
+          name: 'my-service',
+          foo: 'bar',
+        },
+        provider: 'aws',
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yaml'),
+        YAML.dump(serverlessYaml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return serviceInstance.load().then(() => {
+        // if we reach this, then no error was thrown as expected
+        // so make assertion fail intentionally to let us know something is wrong
+        expect(serviceInstance.service).to.equal('my-service');
+        expect(serviceInstance.serviceObject).to.deep.equal(serverlessYaml.service);
       });
     });
 
@@ -523,6 +571,37 @@ describe('Service', () => {
       const newData = { service: 'newName' };
       const updatedInstance = serviceInstance.update(newData);
       expect(updatedInstance.service).to.be.equal('newName');
+    });
+  });
+
+  describe('#getServiceName()', () => {
+    it('should return the service name', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+      serviceInstance.serviceObject = {
+        name: 'my-service',
+      };
+
+      const serviceName = serviceInstance.getServiceName();
+
+      expect(serviceName).to.equal('my-service');
+    });
+  });
+
+  describe('#getServiceObject()', () => {
+    it('should return the service object with all properties', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+      const testObject = {
+        name: 'my-service',
+        foo: 'bar',
+      };
+      // Use a clone here to check for implicit reference errors
+      serviceInstance.serviceObject = _.cloneDeep(testObject);
+
+      const serviceObject = serviceInstance.getServiceObject();
+
+      expect(serviceObject).to.deep.equal(testObject);
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #3513 

## How did you implement it:

If the parser encounters an object typed service property it sets `service.service` to the service name (retrieved from `service.name`). This is done for compatibility reasons because lots of plugins (core and 3rd party) use `service.service` directly to get the service name.
The object is stored into the service as `service.serviceObject` and all of its properties can be accessed with `service.serviceObject.XXXXX`. 

In case the service property is a string, `service.service` is set to this and `service.serviceObject` is `{ name: XXXX }`.

Additionally I added a `service.getServiceName()` method to provide an option for plugins to become more robust against changes in the serverless object structure and `service.getServiceObject()` that returns the object or objectified service definition.

## How can we verify it:

Declare your service as object in the serverless.yml:
```
service:
  name: my-service
  foo: 1
  bar: doesnt-matter
```

Compatibility checks can be made with any existing serverless.yml that sets the property as string.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
