### PR TITLE
Persist self references with "${self:}" and restore it correctly

### DIFF
--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const BbPromise = require('bluebird');
 const _ = require('lodash');
+const findReferences = require('../../utils/findReferences');
 
 module.exports = {
   extendedValidate() {
@@ -17,7 +18,11 @@ module.exports = {
     }
     const state = this.serverless
       .utils.readFileSync(serviceStateFilePath);
+    const selfReferences = findReferences(state.service, '${self:}');
+    _.forEach(selfReferences, ref => _.set(state.service, ref, this.serverless.service));
+
     _.assign(this.serverless.service, state.service);
+
     this.serverless.service.package.artifactDirectoryName = state.package.artifactDirectoryName;
     if (!_.isEmpty(state.package.artifact)) {
       this.serverless.service.package.artifact = path

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -3,39 +3,7 @@
 const BbPromise = require('bluebird');
 const path = require('path');
 const _ = require('lodash');
-
-/**
- * Find all self references within a given object.
- * The search is implemented non-recursive to prevent stackoverflows and will
- * do a complete deep search including arrays.
- * @param root {Object} Root object for search
- * @param self {Object} Object reference to be treated as self
- * @returns {Array<String>} Paths to all self references found within the object
- */
-function findSelfReferences(root, self) {
-  const resourcePaths = [];
-  const stack = [{ parent: null, value: root, path: '' }];
-
-  while (!_.isEmpty(stack)) {
-    const property = stack.pop();
-
-    _.forOwn(property.value, (value, key) => {
-      if (value === self) {
-        resourcePaths.push(`${property.path}.${key}`);
-      } else if (_.isObject(value)) {
-        let propKey;
-        if (_.isArray(property.value)) {
-          propKey = `[${key}]`;
-        } else {
-          propKey = _.isEmpty(property.path) ? `${key}` : `.${key}`;
-        }
-        stack.push({ parent: property, value, path: `${property.path}${propKey}` });
-      }
-    });
-  }
-
-  return resourcePaths;
-}
+const findReferences = require('../../utils/findReferences');
 
 module.exports = {
   saveServiceState() {
@@ -56,7 +24,7 @@ module.exports = {
     const strippedService = _.assign(
       {}, _.omit(this.serverless.service, ['serverless', 'package'])
     );
-    const selfReferences = findSelfReferences(strippedService, this.serverless.service);
+    const selfReferences = findReferences(strippedService, this.serverless.service);
     _.forEach(selfReferences, refPath => _.set(strippedService, refPath, '${self:}'));
 
     const state = {

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -4,6 +4,39 @@ const BbPromise = require('bluebird');
 const path = require('path');
 const _ = require('lodash');
 
+/**
+ * Find all self references within a given object.
+ * The search is implemented non-recursive to prevent stackoverflows and will
+ * do a complete deep search including arrays.
+ * @param root {Object} Root object for search
+ * @param self {Object} Object reference to be treated as self
+ * @returns {Array<String>} Paths to all self references found within the object
+ */
+function findSelfReferences(root, self) {
+  const resourcePaths = [];
+  const stack = [{ parent: null, value: root, path: '' }];
+
+  while (!_.isEmpty(stack)) {
+    const property = stack.pop();
+
+    _.forOwn(property.value, (value, key) => {
+      if (value === self) {
+        resourcePaths.push(`${property.path}.${key}`);
+      } else if (_.isObject(value)) {
+        let propKey;
+        if (_.isArray(property.value)) {
+          propKey = `[${key}]`;
+        } else {
+          propKey = _.isEmpty(property.path) ? `${key}` : `.${key}`;
+        }
+        stack.push({ parent: property, value, path: `${property.path}${propKey}` });
+      }
+    });
+  }
+
+  return resourcePaths;
+}
+
 module.exports = {
   saveServiceState() {
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
@@ -20,8 +53,14 @@ module.exports = {
       )
     );
 
+    const strippedService = _.assign(
+      {}, _.omit(this.serverless.service, ['serverless', 'package'])
+    );
+    const selfReferences = findSelfReferences(strippedService, this.serverless.service);
+    _.forEach(selfReferences, refPath => _.set(strippedService, refPath, '${self:}'));
+
     const state = {
-      service: _.assign({}, _.omit(this.serverless.service, ['serverless', 'package'])),
+      service: strippedService,
       package: {
         individually: this.serverless.service.package.individually,
         artifactDirectoryName: this.serverless.service.package.artifactDirectoryName,

--- a/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -66,4 +66,38 @@ describe('#saveServiceState()', () => {
         .to.equal(true);
     });
   });
+
+  it('should remove self references correctly', () => {
+    const filePath = path.join(
+      awsPackage.serverless.config.servicePath,
+      '.serverless',
+      'service-state.json'
+    );
+
+    serverless.service.custom = {
+      mySelfRef: serverless.service,
+    };
+
+    return awsPackage.saveServiceState().then(() => {
+      const expectedStateFileContent = {
+        service: {
+          provider: {
+            compiledCloudFormationTemplate: 'compiled content',
+          },
+          custom: {
+            mySelfRef: '${self:}',
+          },
+        },
+        package: {
+          individually: false,
+          artifactDirectoryName: 'artifact-directory',
+          artifact: 'service.zip',
+        },
+      };
+
+      expect(getServiceStateFileNameStub.calledOnce).to.equal(true);
+      expect(writeFileSyncStub.calledWithExactly(filePath, expectedStateFileContent))
+        .to.equal(true);
+    });
+  });
 });

--- a/lib/plugins/aws/utils/findReferences.js
+++ b/lib/plugins/aws/utils/findReferences.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const _ = require('lodash');
+
+/**
+ * Find all objects with a given value within a given root object.
+ * The search is implemented non-recursive to prevent stackoverflows and will
+ * do a complete deep search including arrays.
+ * @param root {Object} Root object for search
+ * @param value {Object} Value to search
+ * @returns {Array<String>} Paths to all self references found within the object
+ */
+function findReferences(root, value) {
+  const resourcePaths = [];
+  const stack = [{ parent: null, propValue: root, path: '' }];
+
+  while (!_.isEmpty(stack)) {
+    const property = stack.pop();
+
+    _.forOwn(property.propValue, (propValue, key) => {
+      if (propValue === value) {
+        resourcePaths.push(`${property.path}.${key}`);
+      } else if (_.isObject(propValue)) {
+        let propKey;
+        if (_.isArray(property.propValue)) {
+          propKey = `[${key}]`;
+        } else {
+          propKey = _.isEmpty(property.path) ? `${key}` : `.${key}`;
+        }
+        stack.push({ parent: property, propValue, path: `${property.path}${propKey}` });
+      }
+    });
+  }
+
+  return resourcePaths;
+}
+
+module.exports = findReferences;

--- a/lib/plugins/aws/utils/findReferences.js
+++ b/lib/plugins/aws/utils/findReferences.js
@@ -11,6 +11,7 @@ const _ = require('lodash');
  * @returns {Array<String>} Paths to all self references found within the object
  */
 function findReferences(root, value) {
+  const visitedObjects = [];
   const resourcePaths = [];
   const stack = [{ parent: null, propValue: root, path: '' }];
 
@@ -21,6 +22,11 @@ function findReferences(root, value) {
       if (propValue === value) {
         resourcePaths.push(`${property.path}.${key}`);
       } else if (_.isObject(propValue)) {
+        // Prevent circular references
+        if (_.includes(visitedObjects, propValue)) {
+          return;
+        }
+        visitedObjects.push(propValue);
         let propKey;
         if (_.isArray(property.propValue)) {
           propKey = `[${key}]`;

--- a/lib/plugins/aws/utils/findReferences.js
+++ b/lib/plugins/aws/utils/findReferences.js
@@ -13,27 +13,27 @@ const _ = require('lodash');
 function findReferences(root, value) {
   const visitedObjects = [];
   const resourcePaths = [];
-  const stack = [{ parent: null, propValue: root, path: '' }];
+  const stack = [{ propValue: root, path: '' }];
 
   while (!_.isEmpty(stack)) {
     const property = stack.pop();
 
     _.forOwn(property.propValue, (propValue, key) => {
+      let propKey;
+      if (_.isArray(property.propValue)) {
+        propKey = `[${key}]`;
+      } else {
+        propKey = _.isEmpty(property.path) ? `${key}` : `.${key}`;
+      }
       if (propValue === value) {
-        resourcePaths.push(`${property.path}.${key}`);
+        resourcePaths.push(`${property.path}${propKey}`);
       } else if (_.isObject(propValue)) {
         // Prevent circular references
         if (_.includes(visitedObjects, propValue)) {
           return;
         }
         visitedObjects.push(propValue);
-        let propKey;
-        if (_.isArray(property.propValue)) {
-          propKey = `[${key}]`;
-        } else {
-          propKey = _.isEmpty(property.path) ? `${key}` : `.${key}`;
-        }
-        stack.push({ parent: property, propValue, path: `${property.path}${propKey}` });
+        stack.push({ propValue, path: `${property.path}${propKey}` });
       }
     });
   }

--- a/lib/plugins/aws/utils/findReferences.test.js
+++ b/lib/plugins/aws/utils/findReferences.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const expect = require('chai').expect;
+const _ = require('lodash');
+const findReferences = require('./findReferences');
+
+describe('#findReferences()', () => {
+  it('should succeed on invalid input', () => {
+    const withoutArgs = findReferences();
+    const nullArgs = findReferences(null);
+
+    expect(withoutArgs).to.be.a('Array').to.have.lengthOf(0);
+    expect(nullArgs).to.be.a('Array').have.lengthOf(0);
+  });
+
+  it('should return paths', () => {
+    const testObject = {
+      prop1: 'test',
+      array1: [
+        {
+          prop1: 'hit',
+          prop2: 4,
+        },
+        'hit',
+        [
+          {
+            prop1: null,
+            prop2: 'hit',
+          },
+        ],
+      ],
+      prop2: {
+        prop1: 'foo',
+        prop2: {
+          prop1: 'hit',
+        },
+      },
+    };
+
+    const expectedResult = [
+      'array1[0].prop1',
+      'array1[1]',
+      'array1[2][0].prop2',
+      'prop2.prop2.prop1',
+    ];
+    const paths = findReferences(testObject, 'hit');
+
+    expect(paths).to.be.a('Array').to.have.lengthOf(4);
+    expect(_.every(paths, path => _.includes(expectedResult, path))).to.equal(true);
+  });
+
+  it('should not fail with circular references', () => {
+    const testObject = {
+      prop1: 'test',
+      array1: [
+        {
+          prop1: 'hit',
+          prop2: 4,
+        },
+        'hit',
+        [
+          {
+            prop1: null,
+            prop2: 'hit',
+          },
+        ],
+      ],
+      prop2: {
+        prop1: 'foo',
+        prop2: {
+          prop1: 'hit',
+        },
+      },
+    };
+    testObject.array1.push(testObject.prop2);
+
+    const expectedResult = [
+      'array1[0].prop1',
+      'array1[1]',
+      'array1[2][0].prop2',
+      'prop2.prop2.prop1',
+    ];
+    const paths = findReferences(testObject, 'hit');
+
+    expect(paths).to.be.a('Array').to.have.lengthOf(4);
+    expect(_.every(paths, path => _.includes(expectedResult, path))).to.equal(true);
+  });
+});


### PR DESCRIPTION
## What did you implement:

This is work-in-progress!

Closes #3509

Self references created with `${self:}` are now persisted as `${self:}` and will be restored properly on state restoration.

## How did you implement it:

In `saveServiceState()` a deep search for self references is done now (the FQ property paths are extracted) and all refs are replaced with "${self:}".

## How can we verify it:

Create a service that contains

```
...
custom:
  newService: ${self:}
  ...
```

Run a package and then a deploy.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
