### PR TITLE
Fix incorrect command for looking up service principal

### DIFF
--- a/docs/providers/azure/guide/quickstart.md
+++ b/docs/providers/azure/guide/quickstart.md
@@ -70,7 +70,7 @@ We'll set up an Azure Subscription and our service principal. You can learn more
     azure ad sp create -n <name> -p <password>
     ```
 
-    This should return an object which has the `servicePrincipalNames` property on it. Save one of the names in the array and the password you provided for later. If you need to look up your service principal later, you can use `azure ad sp -c <name>` where `<name>` is the name provided originally. Note that the `<name>` you provided is not the name you'll provide later, it is a name in the `servicePrincipalNames` array.
+    This should return an object which has the `servicePrincipalNames` property on it. Save one of the names in the array and the password you provided for later. If you need to look up your service principal later, you can use `azure ad sp show -c <name>` where `<name>` is the name provided originally. Note that the `<name>` you provided is not the name you'll provide later, it is a name in the `servicePrincipalNames` array.
 
     Then grant the SP contributor access with the ObjectId
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes an incorrect command for verifying service principal

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Corrected command in markdown

## How can we verify it:

run command on own azure subscription with valid service principal name

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->



## Todos:

- [ n/a ] Write tests
- [ X ] Write documentation
- [ n/a ] Fix linting errors
- [ n/a ] Make sure code coverage hasn't dropped
- [ n/a ] Provide verification config / commands / resources
- [ n/a ] Enable "Allow edits from maintainers" for this PR
- [ n/a ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
