### PR TITLE
Use chai as promised

### DIFF
--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -3,12 +3,16 @@
 const path = require('path');
 const YAML = require('js-yaml');
 const _ = require('lodash');
-const expect = require('chai').expect;
+const chai = require('chai');
 const sinon = require('sinon');
 const Service = require('../../lib/classes/Service');
 const Utils = require('../../lib/classes/Utils');
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('Service', () => {
   describe('#constructor()', () => {
@@ -115,7 +119,7 @@ describe('Service', () => {
       const serverless = new Serverless();
       const noService = new Service(serverless);
 
-      return noService.load();
+      return expect(noService.load()).to.eventually.resolve;
     });
 
     it('should load from filesystem', () => {
@@ -154,7 +158,8 @@ describe('Service', () => {
       serverless.config.update({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([\\s\\S]+?)}}');
@@ -170,7 +175,7 @@ describe('Service', () => {
       });
     });
 
-    it('should fail when the service name is missing', () => {
+    it('should reject when the service name is missing', () => {
       const SUtils = new Utils();
       const serverlessYaml = {
         service: {},
@@ -183,13 +188,8 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
-      }).catch(e => {
-        expect(e.name).to.be.equal('ServerlessError');
-      });
+      return expect(serviceInstance.load()).to.eventually.be
+        .rejectedWith('"service" is missing the "name" property in serverless.yml');
     });
 
     it('should support service objects', () => {
@@ -208,9 +208,8 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
         expect(serviceInstance.service).to.equal('my-service');
         expect(serviceInstance.serviceObject).to.deep.equal(serverlessYaml.service);
       });
@@ -234,7 +233,8 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
         serviceInstance.setFunctionNames();
         const expectedFunc = {
           functionA: {
@@ -266,7 +266,8 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
         serviceInstance.setFunctionNames();
         const expectedFunc = {
           functionA: {
@@ -296,7 +297,8 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load({ stage: 'dev' }).then(() => {
+      return expect(serviceInstance.load({ stage: 'dev' })).to.eventually.be.fulfilled
+      .then(() => {
         serviceInstance.setFunctionNames();
         const expectedFunc = {
           functionA: {
@@ -310,7 +312,7 @@ describe('Service', () => {
       });
     });
 
-    it('should throw error if service property is missing', () => {
+    it('should reject if service property is missing', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         provider: 'aws',
@@ -322,16 +324,11 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
-      }).catch(e => {
-        expect(e.name).to.be.equal('ServerlessError');
-      });
+      return expect(serviceInstance.load()).to.eventually.be
+        .rejectedWith('"service" property is missing in serverless.yml');
     });
 
-    it('should throw error if provider property is missing', () => {
+    it('should reject if provider property is missing', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'service-name',
@@ -343,16 +340,11 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
-      }).catch(e => {
-        expect(e.name).to.be.equal('ServerlessError');
-      });
+      return expect(serviceInstance.load()).to.eventually.be
+        .rejectedWith('"provider" property is missing in serverless.yml');
     });
 
-    it('should throw error if frameworkVersion is not satisfied', () => {
+    it('should reject if frameworkVersion is not satisfied', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'service-name',
@@ -368,13 +360,8 @@ describe('Service', () => {
       getVersion.returns('1.0.2');
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
-      }).catch(e => {
-        expect(e.name).to.be.equal('ServerlessError');
-      });
+      return expect(serviceInstance.load()).to.eventually.be
+        .rejectedWith(/version \(1\.0\.2\).*"frameworkVersion" \(=1\.0\.0\)/);
     });
 
     it('should pass if frameworkVersion is satisfied', () => {
@@ -393,13 +380,10 @@ describe('Service', () => {
       getVersion.returns('1.2.2');
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if this callbar is reached, then no error was thrown as expected
-        expect(1).to.equal(1);
-      });
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled;
     });
 
-    it('should not throw error if functions property is missing', () => {
+    it('should fulfill if functions property is missing', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'service-name',
@@ -412,8 +396,8 @@ describe('Service', () => {
       serverless.variables.service = serverless.service;
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
         // populate variables in service configuration
         serverless.variables.populateService();
 
@@ -421,13 +405,36 @@ describe('Service', () => {
         serviceInstance.validate();
 
         expect(serviceInstance.functions).to.deep.equal({});
-      }).catch(() => {
-        // make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
       });
     });
 
-    it('should throw error if a function\'s event is not an array or a variable', () => {
+    it('should reject if provider property is invalid', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: 'service-name',
+        provider: 'invalid',
+        functions: {},
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be
+        .rejectedWith('Provider "invalid" is not supported.');
+    });
+  });
+
+  describe('#validate()', () => {
+    let tmpDirPath;
+
+    beforeEach(() => {
+      tmpDirPath = testUtils.getTmpDirPath();
+    });
+
+    it('should throw if a function\'s event is not an array or a variable', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'service-name',
@@ -444,40 +451,11 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serverless.service = new Service(serverless);
 
-      return serverless.service.load().then(() => {
+      return expect(serverless.service.load()).to.eventually.be.fulfilled
+      .then(() => {
         // validate the service configuration, now that variables are loaded
-        try {
-          serverless.service.validate();
-
-          // if we reach this, then no error was thrown as expected
-          // so make assertion fail intentionally to let us know something is wrong
-          expect(1).to.equal(2);
-        } catch (e) {
-          expect(e.name).to.be.equal('ServerlessError');
-        }
-      });
-    });
-
-    it('should throw error if provider property is invalid', () => {
-      const SUtils = new Utils();
-      const serverlessYml = {
-        service: 'service-name',
-        provider: 'invalid',
-        functions: {},
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
-        YAML.dump(serverlessYml));
-
-      const serverless = new Serverless({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
-
-      return serviceInstance.load().then(() => {
-        // if we reach this, then no error was thrown as expected
-        // so make assertion fail intentionally to let us know something is wrong
-        expect(1).to.equal(2);
-      }).catch(e => {
-        expect(e.name).to.be.equal('ServerlessError');
+        expect(() => serverless.service.validate())
+          .to.throw('Events for "functionA" must be an array, not an string');
       });
     });
   });
@@ -616,7 +594,8 @@ describe('Service', () => {
       serverless.config.update({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return serviceInstance.load().then(() => {
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
         serviceInstance.setFunctionNames();
         expect(serviceInstance.functions.functionA.name).to.be.equal('new-service-dev-functionA');
       });
@@ -658,9 +637,7 @@ describe('Service', () => {
       // Use a clone here to check for implicit reference errors
       serviceInstance.serviceObject = _.cloneDeep(testObject);
 
-      const serviceObject = serviceInstance.getServiceObject();
-
-      expect(serviceObject).to.deep.equal(testObject);
+      expect(serviceInstance.getServiceObject()).to.deep.equal(testObject);
     });
   });
 

--- a/lib/classes/YamlParser.test.js
+++ b/lib/classes/YamlParser.test.js
@@ -4,11 +4,15 @@
  * Test: YamlParser Function Class
  */
 
-const expect = require('chai').expect;
+const chai = require('chai');
 const YAML = require('js-yaml');
 const path = require('path');
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 const serverless = new Serverless();
 
@@ -19,9 +23,8 @@ describe('YamlParser', () => {
 
       serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
 
-      return serverless.yamlParser.parse(tmpFilePath).then((obj) => {
-        expect(obj.foo).to.equal('bar');
-      });
+      return expect(serverless.yamlParser.parse(tmpFilePath))
+        .to.eventually.have.property('foo').to.equal('bar');
     });
 
     it('should parse a simple .yml file', () => {
@@ -29,9 +32,8 @@ describe('YamlParser', () => {
 
       serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
 
-      return serverless.yamlParser.parse(tmpFilePath).then((obj) => {
-        expect(obj.foo).to.equal('bar');
-      });
+      return expect(serverless.yamlParser.parse(tmpFilePath))
+        .to.eventually.have.property('foo').to.equal('bar');
     });
 
     it('should parse a .yml file with JSON-REF to YAML', () => {
@@ -47,9 +49,8 @@ describe('YamlParser', () => {
 
       serverless.utils.writeFileSync(path.join(tmpDirPath, 'test.yml'), testYml);
 
-      return serverless.yamlParser.parse(path.join(tmpDirPath, 'test.yml')).then((obj) => {
-        expect(obj.main.foo).to.equal('bar');
-      });
+      return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'test.yml')))
+        .to.eventually.have.deep.property('main.foo').to.equal('bar');
     });
 
     it('should parse a .yml file with JSON-REF to JSON', () => {
@@ -65,9 +66,8 @@ describe('YamlParser', () => {
 
       serverless.utils.writeFileSync(path.join(tmpDirPath, 'test.yml'), testYml);
 
-      return serverless.yamlParser.parse(path.join(tmpDirPath, 'test.yml')).then((obj) => {
-        expect(obj.main.foo).to.equal('bar');
-      });
+      return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'test.yml')))
+        .to.eventually.have.deep.property('main.foo').to.equal('bar');
     });
 
     it('should parse a .yml file with recursive JSON-REF', () => {
@@ -91,9 +91,8 @@ describe('YamlParser', () => {
 
       serverless.utils.writeFileSync(path.join(tmpDirPath, 'one.yml'), oneYml);
 
-      return serverless.yamlParser.parse(path.join(tmpDirPath, 'one.yml')).then((obj) => {
-        expect(obj.one.two.foo).to.equal('bar');
-      });
+      return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'one.yml')))
+        .to.eventually.have.deep.property('one.two.foo').to.equal('bar');
     });
   });
 });

--- a/lib/plugins/deploy/deploy.test.js
+++ b/lib/plugins/deploy/deploy.test.js
@@ -1,9 +1,14 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
+const BbPromise = require('bluebird');
 const Deploy = require('./deploy');
 const Serverless = require('../../Serverless');
 const sinon = require('sinon');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('Deploy', () => {
   let deploy;
@@ -43,27 +48,30 @@ describe('Deploy', () => {
       deploy.options.package = false;
       deploy.serverless.service.package.path = 'some_path';
 
-      return deploy.hooks['before:deploy:deploy']().then(() => {
-        expect(spawnPackageStub.called).to.equal(false);
-      });
+      return BbPromise.join(
+        expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled,
+        expect(spawnPackageStub).to.be.not.called
+      );
     });
 
     it('should resolve if the service package path is set', () => {
       deploy.options.package = 'some_path';
       deploy.serverless.service.package.path = false;
 
-      return deploy.hooks['before:deploy:deploy']().then(() => {
-        expect(spawnPackageStub.called).to.equal(false);
-      });
+      return BbPromise.join(
+        expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled,
+        expect(spawnPackageStub).to.be.not.called
+      );
     });
 
     it('should use the default packaging mechanism if no packaging config is provided', () => {
       deploy.options.package = false;
       deploy.serverless.service.package.path = false;
 
-      return deploy.hooks['before:deploy:deploy']().then(() => {
-        expect(spawnPackageStub.calledOnce).to.equal(true);
-      });
+      return BbPromise.join(
+        expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled,
+        expect(spawnPackageStub).to.be.calledOnce
+      );
     });
   });
 });

--- a/lib/plugins/deploy/deploy.test.js
+++ b/lib/plugins/deploy/deploy.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const BbPromise = require('bluebird');
 const Deploy = require('./deploy');
 const Serverless = require('../../Serverless');
 const sinon = require('sinon');
@@ -48,30 +47,24 @@ describe('Deploy', () => {
       deploy.options.package = false;
       deploy.serverless.service.package.path = 'some_path';
 
-      return BbPromise.join(
-        expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled,
-        expect(spawnPackageStub).to.be.not.called
-      );
+      return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled
+      .then(() => expect(spawnPackageStub).to.be.not.called);
     });
 
     it('should resolve if the service package path is set', () => {
       deploy.options.package = 'some_path';
       deploy.serverless.service.package.path = false;
 
-      return BbPromise.join(
-        expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled,
-        expect(spawnPackageStub).to.be.not.called
-      );
+      return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled
+      .then(() => expect(spawnPackageStub).to.be.not.called);
     });
 
     it('should use the default packaging mechanism if no packaging config is provided', () => {
       deploy.options.package = false;
       deploy.serverless.service.package.path = false;
 
-      return BbPromise.join(
-        expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled,
-        expect(spawnPackageStub).to.be.calledOnce
-      );
+      return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled
+      .then(() => expect(spawnPackageStub).to.be.calledOnce);
     });
   });
 });

--- a/lib/plugins/deploy/deploy.test.js
+++ b/lib/plugins/deploy/deploy.test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
 describe('Deploy', () => {

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -1,9 +1,14 @@
 'use strict';
 
-const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const chai = require('chai');
 const sinon = require('sinon');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('#packageService()', () => {
   let serverless;
@@ -108,9 +113,8 @@ describe('#packageService()', () => {
       const packageAllStub = sinon
         .stub(packagePlugin, 'packageAll').resolves();
 
-      return packagePlugin.packageService().then(() => {
-        expect(packageAllStub.calledOnce).to.be.equal(true);
-      });
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => expect(packageAllStub).to.be.calledOnce);
     });
 
     it('should package functions individually', () => {
@@ -127,9 +131,8 @@ describe('#packageService()', () => {
       const packageFunctionStub = sinon
         .stub(packagePlugin, 'packageFunction').resolves((func) => func.name);
 
-      return packagePlugin.packageService().then(() => {
-        expect(packageFunctionStub.calledTwice).to.be.equal(true);
-      });
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => expect(packageFunctionStub).to.be.calledTwice);
     });
 
     it('should package single function individually', () => {
@@ -150,88 +153,102 @@ describe('#packageService()', () => {
       const packageAllStub = sinon
         .stub(packagePlugin, 'packageAll').resolves((func) => func.name);
 
-      return packagePlugin.packageService().then(() => {
-        expect(packageFunctionStub.calledOnce).to.be.equal(true);
-        expect(packageAllStub.calledOnce).to.be.equal(true);
-      });
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => BbPromise.join(
+        expect(packageFunctionStub).to.be.calledOnce,
+        expect(packageAllStub).to.be.calledOnce
+      ));
     });
   });
 
   describe('#packageAll()', () => {
+    const exclude = ['test-exclude'];
+    const include = ['test-include'];
+    const artifactFilePath = '/some/fake/path/test-artifact.zip';
+    let getExcludesStub;
+    let getIncludesStub;
+    let zipDirectoryStub;
+
+    beforeEach(() => {
+      getExcludesStub = sinon
+        .stub(packagePlugin, 'getExcludes').returns(exclude);
+      getIncludesStub = sinon
+        .stub(packagePlugin, 'getIncludes').returns(include);
+      zipDirectoryStub = sinon
+        .stub(packagePlugin, 'zipDirectory').resolves(artifactFilePath);
+    });
+
+    afterEach(() => {
+      packagePlugin.getExcludes.restore();
+      packagePlugin.getIncludes.restore();
+      packagePlugin.zipDirectory.restore();
+    });
+
     it('should call zipService with settings', () => {
       const servicePath = 'test';
-      const exclude = ['test-exclude'];
-      const include = ['test-include'];
       const zipFileName = `${serverless.service.service}.zip`;
-      const artifactFilePath = '/some/fake/path/test-artifact.zip';
 
       serverless.config.servicePath = servicePath;
 
-      const getExcludesStub = sinon
-        .stub(packagePlugin, 'getExcludes').returns(exclude);
-      const getIncludesStub = sinon
-        .stub(packagePlugin, 'getIncludes').returns(include);
-
-      const zipDirectoryStub = sinon
-        .stub(packagePlugin, 'zipDirectory').resolves(artifactFilePath);
-
-      return packagePlugin.packageAll().then(() => {
-        expect(getExcludesStub.calledOnce).to.be.equal(true);
-        expect(getIncludesStub.calledOnce).to.be.equal(true);
-
-        expect(zipDirectoryStub.calledOnce).to.be.equal(true);
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => BbPromise.all([
+        expect(getExcludesStub).to.be.calledOnce,
+        expect(getIncludesStub).to.be.calledOnce,
+        expect(zipDirectoryStub).to.be.calledOnce,
         expect(zipDirectoryStub.calledWithExactly(
           exclude,
           include,
           zipFileName
-        )).to.be.equal(true);
-
-        packagePlugin.getExcludes.restore();
-        packagePlugin.getIncludes.restore();
-        packagePlugin.zipDirectory.restore();
-      });
+        )).to.be.true,
+      ]));
     });
   });
 
   describe('#packageFunction()', () => {
+    const exclude = ['test-exclude'];
+    const include = ['test-include'];
+    const artifactFilePath = '/some/fake/path/test-artifact.zip';
+    let getExcludesStub;
+    let getIncludesStub;
+    let zipDirectoryStub;
+
+    beforeEach(() => {
+      getExcludesStub = sinon
+        .stub(packagePlugin, 'getExcludes').returns(exclude);
+      getIncludesStub = sinon
+        .stub(packagePlugin, 'getIncludes').returns(include);
+      zipDirectoryStub = sinon
+        .stub(packagePlugin, 'zipDirectory').resolves(artifactFilePath);
+    });
+
+    afterEach(() => {
+      packagePlugin.getExcludes.restore();
+      packagePlugin.getIncludes.restore();
+      packagePlugin.zipDirectory.restore();
+    });
+
     it('should call zipService with settings', () => {
       const servicePath = 'test';
       const funcName = 'test-func';
 
-      const exclude = ['test-exclude'];
-      const include = ['test-include'];
       const zipFileName = 'test-func.zip';
-      const artifactFilePath = '/some/fake/path/test-artifact.zip';
 
       serverless.config.servicePath = servicePath;
       serverless.service.functions = {};
       serverless.service.functions[funcName] = { name: `test-proj-${funcName}` };
 
-      const getExcludesStub = sinon
-        .stub(packagePlugin, 'getExcludes').returns(exclude);
-      const getIncludesStub = sinon
-        .stub(packagePlugin, 'getIncludes').returns(include);
+      return expect(packagePlugin.packageFunction(funcName)).to.eventually.equal(artifactFilePath)
+      .then(() => BbPromise.all([
+        expect(getExcludesStub.calledOnce).to.be.true,
+        expect(getIncludesStub.calledOnce).to.be.true,
 
-      const zipDirectoryStub = sinon
-        .stub(packagePlugin, 'zipDirectory').resolves(artifactFilePath);
-
-      return packagePlugin.packageFunction(funcName).then((filePath) => {
-        expect(getExcludesStub.calledOnce).to.be.equal(true);
-        expect(getIncludesStub.calledOnce).to.be.equal(true);
-
-        expect(zipDirectoryStub.calledOnce).to.be.equal(true);
+        expect(zipDirectoryStub.calledOnce).to.be.true,
         expect(zipDirectoryStub.calledWithExactly(
           exclude,
           include,
           zipFileName
-        )).to.be.equal(true);
-
-        expect(filePath).to.be.equal(artifactFilePath);
-
-        packagePlugin.getExcludes.restore();
-        packagePlugin.getIncludes.restore();
-        packagePlugin.zipDirectory.restore();
-      });
+        )).to.be.true,
+      ]));
     });
   });
 });

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -8,6 +8,7 @@ const Serverless = require('../../../Serverless');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
 describe('#packageService()', () => {
@@ -195,11 +196,11 @@ describe('#packageService()', () => {
         expect(getExcludesStub).to.be.calledOnce,
         expect(getIncludesStub).to.be.calledOnce,
         expect(zipDirectoryStub).to.be.calledOnce,
-        expect(zipDirectoryStub.calledWithExactly(
+        expect(zipDirectoryStub).to.have.been.calledWithExactly(
           exclude,
           include,
           zipFileName
-        )).to.be.true,
+        ),
       ]));
     });
   });
@@ -239,15 +240,15 @@ describe('#packageService()', () => {
 
       return expect(packagePlugin.packageFunction(funcName)).to.eventually.equal(artifactFilePath)
       .then(() => BbPromise.all([
-        expect(getExcludesStub.calledOnce).to.be.true,
-        expect(getIncludesStub.calledOnce).to.be.true,
+        expect(getExcludesStub).to.be.calledOnce,
+        expect(getIncludesStub).to.be.calledOnce,
 
-        expect(zipDirectoryStub.calledOnce).to.be.true,
-        expect(zipDirectoryStub.calledWithExactly(
+        expect(zipDirectoryStub).to.be.calledOnce,
+        expect(zipDirectoryStub).to.have.been.calledWithExactly(
           exclude,
           include,
           zipFileName
-        )).to.be.true,
+        ),
       ]));
     });
   });

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -9,6 +9,10 @@ const _ = require('lodash');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
 const testUtils = require('../../../../tests/utils');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('#zipService()', () => {
   let serverless;
@@ -97,49 +101,51 @@ describe('#zipService()', () => {
     const include = [];
     const zipFileName = getTestArtifactFileName('whole-service');
 
-    return packageService
-      .zipDirectory(exclude, include, zipFileName).then((artifact) => {
-        const data = fs.readFileSync(artifact);
+    return expect(packageService.zipDirectory(exclude, include, zipFileName))
+      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
+    .then(artifact => {
+      const data = fs.readFileSync(artifact);
+      return expect(zip.loadAsync(data)).to.be.fulfilled;
+    })
+    .then(unzippedData => {
+      const unzippedFileData = unzippedData.files;
 
-        return zip.loadAsync(data);
-      }).then(unzippedData => {
-        const unzippedFileData = unzippedData.files;
+      expect(Object.keys(unzippedFileData)
+       .filter(file => !unzippedFileData[file].dir))
+       .to.be.lengthOf(13);
 
-        expect(Object.keys(unzippedFileData)
-         .filter(file => !unzippedFileData[file].dir).length).to.equal(13);
+      // root directory
+      expect(unzippedFileData['event.json'].name)
+        .to.equal('event.json');
+      expect(unzippedFileData['handler.js'].name)
+        .to.equal('handler.js');
+      expect(unzippedFileData['file-1'].name)
+        .to.equal('file-1');
+      expect(unzippedFileData['file-2'].name)
+        .to.equal('file-2');
 
-        // root directory
-        expect(unzippedFileData['event.json'].name)
-          .to.equal('event.json');
-        expect(unzippedFileData['handler.js'].name)
-          .to.equal('handler.js');
-        expect(unzippedFileData['file-1'].name)
-          .to.equal('file-1');
-        expect(unzippedFileData['file-2'].name)
-          .to.equal('file-2');
+      // bin directory
+      expect(unzippedFileData['bin/binary-777'].name)
+        .to.equal('bin/binary-777');
+      expect(unzippedFileData['bin/binary-444'].name)
+        .to.equal('bin/binary-444');
 
-        // bin directory
-        expect(unzippedFileData['bin/binary-777'].name)
-          .to.equal('bin/binary-777');
-        expect(unzippedFileData['bin/binary-444'].name)
-          .to.equal('bin/binary-444');
+      // lib directory
+      expect(unzippedFileData['lib/file-1.js'].name)
+        .to.equal('lib/file-1.js');
+      expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+        .to.equal('lib/directory-1/file-1.js');
 
-        // lib directory
-        expect(unzippedFileData['lib/file-1.js'].name)
-          .to.equal('lib/file-1.js');
-        expect(unzippedFileData['lib/directory-1/file-1.js'].name)
-          .to.equal('lib/directory-1/file-1.js');
-
-        // node_modules directory
-        expect(unzippedFileData['node_modules/directory-1/file-1'].name)
-          .to.equal('node_modules/directory-1/file-1');
-        expect(unzippedFileData['node_modules/directory-1/file-2'].name)
-          .to.equal('node_modules/directory-1/file-2');
-        expect(unzippedFileData['node_modules/directory-2/file-1'].name)
-          .to.equal('node_modules/directory-2/file-1');
-        expect(unzippedFileData['node_modules/directory-2/file-2'].name)
-          .to.equal('node_modules/directory-2/file-2');
-      });
+      // node_modules directory
+      expect(unzippedFileData['node_modules/directory-1/file-1'].name)
+        .to.equal('node_modules/directory-1/file-1');
+      expect(unzippedFileData['node_modules/directory-1/file-2'].name)
+        .to.equal('node_modules/directory-1/file-2');
+      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+        .to.equal('node_modules/directory-2/file-1');
+      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+        .to.equal('node_modules/directory-2/file-2');
+    });
   });
 
   it('should keep file permissions', () => {
@@ -147,27 +153,28 @@ describe('#zipService()', () => {
     const include = [];
     const zipFileName = getTestArtifactFileName('file-permissions');
 
-    return packageService.zipDirectory(exclude, include, zipFileName)
-      .then((artifact) => {
-        const data = fs.readFileSync(artifact);
-        return zip.loadAsync(data);
-      }).then(unzippedData => {
-        const unzippedFileData = unzippedData.files;
+    return expect(packageService.zipDirectory(exclude, include, zipFileName))
+      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
+    .then(artifact => {
+      const data = fs.readFileSync(artifact);
+      return expect(zip.loadAsync(data)).to.be.fulfilled;
+    }).then(unzippedData => {
+      const unzippedFileData = unzippedData.files;
 
-        if (os.platform() === 'win32') {
-          // chmod does not work right on windows. this is better than nothing?
-          expect(unzippedFileData['bin/binary-777'].unixPermissions)
-            .to.not.equal(unzippedFileData['bin/binary-444'].unixPermissions);
-        } else {
-          // binary file is set with chmod of 777
-          expect(unzippedFileData['bin/binary-777'].unixPermissions)
-            .to.equal(Math.pow(2, 15) + 777);
+      if (os.platform() === 'win32') {
+        // chmod does not work right on windows. this is better than nothing?
+        expect(unzippedFileData['bin/binary-777'].unixPermissions)
+          .to.not.equal(unzippedFileData['bin/binary-444'].unixPermissions);
+      } else {
+        // binary file is set with chmod of 777
+        expect(unzippedFileData['bin/binary-777'].unixPermissions)
+          .to.equal(Math.pow(2, 15) + 777);
 
-          // read only file is set with chmod of 444
-          expect(unzippedFileData['bin/binary-444'].unixPermissions)
-            .to.equal(Math.pow(2, 15) + 444);
-        }
-      });
+        // read only file is set with chmod of 444
+        expect(unzippedFileData['bin/binary-444'].unixPermissions)
+          .to.equal(Math.pow(2, 15) + 444);
+      }
+    });
   });
 
   it('should exclude with globs', () => {
@@ -180,16 +187,17 @@ describe('#zipService()', () => {
 
     const zipFileName = getTestArtifactFileName('exclude-with-globs');
 
-    return packageService.zipDirectory(exclude, include, zipFileName)
-    .then((artifact) => {
+    return expect(packageService.zipDirectory(exclude, include, zipFileName))
+      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
+    .then(artifact => {
       const data = fs.readFileSync(artifact);
-
-      return zip.loadAsync(data);
+      return expect(zip.loadAsync(data)).to.be.fulfilled;
     }).then(unzippedData => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir).length).to.equal(8);
+        .filter(file => !unzippedFileData[file].dir))
+        .to.be.lengthOf(8);
 
       // root directory
       expect(unzippedFileData['handler.js'].name)
@@ -226,16 +234,17 @@ describe('#zipService()', () => {
 
     const zipFileName = getTestArtifactFileName('re-include-with-globs');
 
-    return packageService.zipDirectory(exclude, include, zipFileName)
-    .then((artifact) => {
+    return expect(packageService.zipDirectory(exclude, include, zipFileName))
+      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
+    .then(artifact => {
       const data = fs.readFileSync(artifact);
-
-      return zip.loadAsync(data);
+      return expect(zip.loadAsync(data)).to.be.fulfilled;
     }).then(unzippedData => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir).length).to.equal(11);
+        .filter(file => !unzippedFileData[file].dir))
+        .to.be.lengthOf(11);
 
       // root directory
       expect(unzippedFileData['event.json'].name)
@@ -280,16 +289,17 @@ describe('#zipService()', () => {
 
     const zipFileName = getTestArtifactFileName('re-include-with-include');
 
-    return packageService.zipDirectory(exclude, include, zipFileName)
-    .then((artifact) => {
+    return expect(packageService.zipDirectory(exclude, include, zipFileName))
+      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
+    .then(artifact => {
       const data = fs.readFileSync(artifact);
-
-      return zip.loadAsync(data);
+      return expect(zip.loadAsync(data)).to.be.fulfilled;
     }).then(unzippedData => {
       const unzippedFileData = unzippedData.files;
 
       expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir).length).to.equal(11);
+        .filter(file => !unzippedFileData[file].dir))
+        .to.be.lengthOf(11);
 
       // root directory
       expect(unzippedFileData['event.json'].name)

--- a/lib/plugins/package/package.test.js
+++ b/lib/plugins/package/package.test.js
@@ -1,9 +1,14 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
+const BbPromise = require('bluebird');
 const Package = require('./package');
 const Serverless = require('../../../lib/Serverless');
 const sinon = require('sinon');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('Package', () => {
   let serverless;
@@ -55,10 +60,10 @@ describe('Package', () => {
       () => expect(pkg.hooks).to.have.property('package:function:package'));
 
     describe('package:createDeploymentArtifacts', () => {
-      it('should call packageService', () => pkg.hooks['package:createDeploymentArtifacts']()
-        .then(() => {
-          expect(packageServiceStub.calledOnce).to.equal(true);
-        })
+      it('should call packageService', () => BbPromise.join(
+          expect(pkg.hooks['package:createDeploymentArtifacts']()).to.be.fulfilled,
+          expect(packageServiceStub).to.be.calledOnce
+        )
       );
     });
 
@@ -66,22 +71,20 @@ describe('Package', () => {
       it('should call packageFunction', () => {
         pkg.options.function = 'myFunction';
 
-        return pkg.hooks['package:function:package']()
-        .then(() => {
-          expect(packageFunctionStub.calledOnce).to.equal(true);
-        });
+        return BbPromise.join(
+            expect(pkg.hooks['package:function:package']()).to.be.fulfilled,
+            expect(packageFunctionStub).to.be.calledOnce
+        );
       });
 
       it('should fail without function option', () => {
         pkg.options.function = false;
 
-        return pkg.hooks['package:function:package']()
-        .then(() => {
-          expect(packageFunctionStub.called).to.equal(false);
-        })
-        .catch(err => {
-          expect(err.message).to.equal('Function name must be set');
-        });
+        return BbPromise.join(
+          expect(pkg.hooks['package:function:package']())
+            .to.be.rejectedWith('Function name must be set'),
+          expect(packageFunctionStub).to.be.not.called
+        );
       });
     });
   });

--- a/lib/plugins/package/package.test.js
+++ b/lib/plugins/package/package.test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
 describe('Package', () => {

--- a/lib/plugins/package/package.test.js
+++ b/lib/plugins/package/package.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const BbPromise = require('bluebird');
 const Package = require('./package');
 const Serverless = require('../../../lib/Serverless');
 const sinon = require('sinon');
@@ -60,10 +59,9 @@ describe('Package', () => {
       () => expect(pkg.hooks).to.have.property('package:function:package'));
 
     describe('package:createDeploymentArtifacts', () => {
-      it('should call packageService', () => BbPromise.join(
-          expect(pkg.hooks['package:createDeploymentArtifacts']()).to.be.fulfilled,
-          expect(packageServiceStub).to.be.calledOnce
-        )
+      it('should call packageService', () =>
+        expect(pkg.hooks['package:createDeploymentArtifacts']()).to.be.fulfilled
+        .then(() => expect(packageServiceStub).to.be.calledOnce)
       );
     });
 
@@ -71,20 +69,16 @@ describe('Package', () => {
       it('should call packageFunction', () => {
         pkg.options.function = 'myFunction';
 
-        return BbPromise.join(
-            expect(pkg.hooks['package:function:package']()).to.be.fulfilled,
-            expect(packageFunctionStub).to.be.calledOnce
-        );
+        return expect(pkg.hooks['package:function:package']()).to.be.fulfilled
+        .then(() => expect(packageFunctionStub).to.be.calledOnce);
       });
 
       it('should fail without function option', () => {
         pkg.options.function = false;
 
-        return BbPromise.join(
-          expect(pkg.hooks['package:function:package']())
-            .to.be.rejectedWith('Function name must be set'),
-          expect(packageFunctionStub).to.be.not.called
-        );
+        return expect(pkg.hooks['package:function:package']())
+          .to.be.rejectedWith('Function name must be set')
+        .then(() => expect(packageFunctionStub).to.be.not.called);
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "mock-require": "^1.3.0",
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.5",
-    "sinon-bluebird": "^3.1.0"
+    "sinon-bluebird": "^3.1.0",
+    "sinon-chai": "^2.9.0"
   },
   "dependencies": {
     "archiver": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "coveralls": "^2.12.0",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",


### PR DESCRIPTION
## What did you implement:

Relates to #3529 

## How did you implement it:

Added `chai-as-promised` to devDependencies.

Updated some unit test files that expect promised results as reference.

## How can we verify it:

Run the unit tests. Check the coverage.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
