### PR TITLE
Added support for Promises in the variable system

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -164,6 +164,25 @@ module.exports.schedule = () => {
    };
 }
 ```
+If your use case requires handling with dynamic/async data sources (ie. DynamoDB, API calls...etc), you can also return a promise that would be resolved as the value of the variable:
+
+# serverless.yml
+service: new-service
+provider: aws
+functions:
+  scheduledFunction:
+      handler: handler.scheduledFunction
+      events:
+        - schedule: ${file(./myCustomFile.js):promised}
+```
+
+```js
+// myCustomFile.js
+module.exports.promised = () => {
+   // Async code that fetches the rate config...
+   return Promise.resolve('rate(10 minutes)');
+}
+```
 
 ## Multiple Configuration Files
 

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -164,7 +164,7 @@ module.exports.schedule = () => {
    };
 }
 ```
-If your use case requires handling with dynamic/async data sources (ie. DynamoDB, API calls...etc), you can also return a promise that would be resolved as the value of the variable:
+If your use case requires handling with dynamic/async data sources (ie. DynamoDB, API calls...etc), you can also return a Promise that would be resolved as the value of the variable:
 
 # serverless.yml
 service: new-service

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -84,17 +84,17 @@ class Serverless {
 
     // populate variables after --help, otherwise help may fail to print
     // (https://github.com/serverless/serverless/issues/2041)
-    this.variables.populateService(this.pluginManager.cliOptions);
+    return this.variables.populateService(this.pluginManager.cliOptions).then(() => {
+      // populate function names after variables are loaded in case functions were externalized
+      // (https://github.com/serverless/serverless/issues/2997)
+      this.service.setFunctionNames(this.processedInput.options);
 
-    // populate function names after variables are loaded in case functions were externalized
-    // (https://github.com/serverless/serverless/issues/2997)
-    this.service.setFunctionNames(this.processedInput.options);
+      // validate the service configuration, now that variables are loaded
+      this.service.validate();
 
-    // validate the service configuration, now that variables are loaded
-    this.service.validate();
-
-    // trigger the plugin lifecycle when there's something which should be processed
-    return this.pluginManager.run(this.processedInput.commands);
+      // trigger the plugin lifecycle when there's something which should be processed
+      return this.pluginManager.run(this.processedInput.commands);
+    });
   }
 
   setProvider(name, provider) {

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -198,7 +198,7 @@ describe('Serverless', () => {
       validateCommandStub = sinon
         .stub(serverless.pluginManager, 'validateCommand').returns();
       populateServiceStub = sinon
-        .stub(serverless.variables, 'populateService').returns();
+        .stub(serverless.variables, 'populateService').resolves();
       runStub = sinon
         .stub(serverless.pluginManager, 'run').resolves();
     });
@@ -221,6 +221,7 @@ describe('Serverless', () => {
         expect(validateCommandStub.calledOnce).to.equal(true);
         expect(populateServiceStub.calledOnce).to.equal(true);
         expect(runStub.calledOnce).to.equal(true);
+        return BbPromise.resolve();
       });
     });
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const path = require('path');
 const replaceall = require('replaceall');
 const logWarning = require('./Error').logWarning;
+const BbPromise = require('bluebird');
 
 _.mixin(require('lodash-deep'));
 
@@ -48,10 +49,10 @@ class Variables {
       }
     });
 
-    return Promise.all(populateAll).then(() => {
+    return BbPromise.all(populateAll).then(() => {
       this.service.provider.variableSyntax = variableSyntaxProperty;
       this.serverless.service.serverless = this.serverless;
-      return this.service;
+      return BbPromise.resolve(this.service);
     });
   }
 
@@ -84,21 +85,21 @@ class Variables {
           return this.populateVariable(property, matchedString, valueToPopulate)
             .then(newProperty => {
               property = newProperty;
-              return Promise.resolve(property);
+              return BbPromise.resolve(property);
             });
         });
 
         allValuesToPopulate.push(singleValueToPopulate);
       });
-      return Promise.all(allValuesToPopulate).then(() => {
+      return BbPromise.all(allValuesToPopulate).then(() => {
         if (property !== this.service) {
           return this.populateProperty(property);
         }
-        return Promise.resolve(property);
+        return BbPromise.resolve(property);
       });
     }
     // return property;
-    return Promise.resolve(property);
+    return BbPromise.resolve(property);
   }
 
   populateVariable(propertyParam, matchedString, valueToPopulate) {
@@ -118,11 +119,11 @@ class Variables {
           throw new this.serverless.classes
             .Error(errorMessage);
         }
-        return Promise.resolve(property);
+        return BbPromise.resolve(property);
       }
       property = valueToPopulate;
     }
-    return Promise.resolve(property);
+    return BbPromise.resolve(property);
   }
 
   overwrite(variableStringsString) {
@@ -130,13 +131,13 @@ class Variables {
     const variableStringsArray = variableStringsString.split(',');
     const allValuesFromSource = variableStringsArray
       .map(variableString => this.getValueFromSource(variableString));
-    return Promise.all(allValuesFromSource).then(valuesFromSources => {
+    return BbPromise.all(allValuesFromSource).then(valuesFromSources => {
       valuesFromSources.find(valueFromSource => {
         finalValue = valueFromSource;
         return (finalValue !== null && typeof finalValue !== 'undefined') &&
           !(typeof finalValue === 'object' && _.isEmpty(finalValue));
       });
-      return Promise.resolve(finalValue);
+      return BbPromise.resolve(finalValue);
     });
   }
 
@@ -166,7 +167,7 @@ class Variables {
     } else {
       valueToPopulate = process.env;
     }
-    return Promise.resolve(valueToPopulate);
+    return BbPromise.resolve(valueToPopulate);
   }
 
   getValueFromOptions(variableString) {
@@ -177,7 +178,7 @@ class Variables {
     } else {
       valueToPopulate = this.options;
     }
-    return Promise.resolve(valueToPopulate);
+    return BbPromise.resolve(valueToPopulate);
   }
 
   getValueFromSelf(variableString) {
@@ -197,7 +198,7 @@ class Variables {
 
     // Validate file exists
     if (!this.serverless.utils.fileExistsSync(referencedFileFullPath)) {
-      return Promise.resolve(undefined);
+      return BbPromise.resolve(undefined);
     }
 
     let valueToPopulate;
@@ -209,7 +210,7 @@ class Variables {
       jsModule = jsModule.split('.')[0];
       valueToPopulate = jsFile[jsModule]();
 
-      return Promise.resolve(valueToPopulate).then(valueToPopulateResolved => {
+      return BbPromise.resolve(valueToPopulate).then(valueToPopulateResolved => {
         let deepProperties = variableString.replace(matchedFileRefString, '');
         deepProperties = deepProperties.slice(1).split('.');
         deepProperties.splice(0, 1);
@@ -224,7 +225,7 @@ class Variables {
               throw new this.serverless.classes
                 .Error(errorMessage);
             }
-            return Promise.resolve(deepValueToPopulateResolved);
+            return BbPromise.resolve(deepValueToPopulateResolved);
           });
       });
     }
@@ -248,23 +249,23 @@ class Variables {
         return this.getDeepValue(deepProperties, valueToPopulate);
       }
     }
-    return Promise.resolve(valueToPopulate);
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  getDeepValue(deepProperties, valueToPopulateParam) {
-    let valueToPopulate = valueToPopulateParam;
-    deepProperties.forEach(subProperty => {
-      if (typeof valueToPopulate === 'undefined') {
-        valueToPopulate = {};
-      } else if (subProperty !== '' || '' in valueToPopulate) {
-        valueToPopulate = valueToPopulate[subProperty];
+  getDeepValue(deepProperties, valueToPopulate) {
+    return BbPromise.reduce(deepProperties, (computedValueToPopulateParam, subProperty) => {
+      let computedValueToPopulate = computedValueToPopulateParam;
+      if (typeof computedValueToPopulate === 'undefined') {
+        computedValueToPopulate = {};
+      } else if (subProperty !== '' || '' in computedValueToPopulate) {
+        computedValueToPopulate = computedValueToPopulate[subProperty];
       }
-      if (typeof valueToPopulate === 'string' && valueToPopulate.match(this.variableSyntax)) {
-        return this.populateProperty(valueToPopulate);
+      if (typeof computedValueToPopulate === 'string' &&
+        computedValueToPopulate.match(this.variableSyntax)) {
+        return this.populateProperty(computedValueToPopulate);
       }
-      return Promise.resolve(valueToPopulate);
-    });
-    return Promise.resolve(valueToPopulate);
+      return BbPromise.resolve(computedValueToPopulate);
+    }, valueToPopulate);
   }
 
   warnIfNotFound(variableString, valueToPopulate) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -51,7 +51,6 @@ class Variables {
     return Promise.all(populateAll).then(() => {
       this.service.provider.variableSyntax = variableSyntaxProperty;
       this.serverless.service.serverless = this.serverless;
-      console.log(this.service)
       return this.service;
     });
   }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -2,9 +2,10 @@
 
 const _ = require('lodash');
 const path = require('path');
-const traverse = require('traverse');
 const replaceall = require('replaceall');
 const logWarning = require('./Error').logWarning;
+
+_.mixin(require('lodash-deep'));
 
 class Variables {
 
@@ -24,7 +25,6 @@ class Variables {
   }
 
   populateService(processedOptions) {
-    const that = this;
     this.options = processedOptions || {};
 
     this.loadVariableSyntax();
@@ -34,22 +34,26 @@ class Variables {
     // temporally remove variable syntax from service otherwise it'll match
     this.service.provider.variableSyntax = true;
 
-    /*
-     * we can't use an arrow function in this case cause that would
-     * change the lexical scoping required by the traverse module
-     */
-    traverse(this.service).forEach(function (propertyParam) {
-      const t = this;
-      let property = propertyParam;
+    this.serverless.service.serverless = null;
+    const promises = [];
 
+    _.deepMapValues(this.service, (property, propertyPath) => {
       if (typeof property === 'string') {
-        property = that.populateProperty(property, true);
-        t.update(property);
+        const newPromise = new Promise((resolve) => this
+          .populateProperty(property, true).then(newProperty => {
+            _.set(this.service, propertyPath, newProperty);
+            return resolve();
+          }));
+        promises.push(newPromise);
       }
     });
 
-    this.service.provider.variableSyntax = variableSyntaxProperty;
-    return this.service;
+    return Promise.all(promises).then(() => {
+      this.service.provider.variableSyntax = variableSyntaxProperty;
+      this.serverless.service.serverless = this.serverless;
+      console.log(this.service)
+      return this.service;
+    });
   }
 
   populateProperty(propertyParam, populateInPlace) {
@@ -59,29 +63,43 @@ class Variables {
     } else {
       property = _.cloneDeep(propertyParam);
     }
-    let valueToPopulate;
+    const promises = [];
+
     if (typeof property === 'string' && property.match(this.variableSyntax)) {
       property.match(this.variableSyntax).forEach((matchedString) => {
         const variableString = matchedString
           .replace(this.variableSyntax, (match, varName) => varName.trim())
           .replace(/\s/g, '');
 
-        if (variableString.match(this.overwriteSyntax)) {
-          valueToPopulate = this.overwrite(variableString);
-        } else {
-          valueToPopulate = this.getValueFromSource(variableString);
-        }
+        const newPromise = new Promise((resolve) => {
+          if (variableString.match(this.overwriteSyntax)) {
+            return this.overwrite(variableString)
+              .then(valueToPopulate => resolve(valueToPopulate));
+          }
+          return this.getValueFromSource(variableString)
+            .then(valueToPopulate => resolve(valueToPopulate));
+        });
 
-        this.warnIfNotFound(variableString, valueToPopulate);
+        newPromise.then(valueToPopulate => {
+          this.warnIfNotFound(variableString, valueToPopulate);
+          return this.populateVariable(property, matchedString, valueToPopulate)
+            .then(newProperty => {
+              property = newProperty;
+              return Promise.resolve(property);
+            });
+        });
 
-        property = this.populateVariable(property, matchedString, valueToPopulate);
+        promises.push(newPromise);
       });
-      if (property !== this.service) {
-        property = this.populateProperty(property);
-      }
-      return property;
+      return Promise.all(promises).then(() => {
+        if (property !== this.service) {
+          return this.populateProperty(property);
+        }
+        return Promise.resolve(property);
+      });
     }
-    return property;
+    // return property;
+    return Promise.resolve(property);
   }
 
   populateVariable(propertyParam, matchedString, valueToPopulate) {
@@ -101,44 +119,44 @@ class Variables {
           throw new this.serverless.classes
             .Error(errorMessage);
         }
-        return property;
+        return Promise.resolve(property);
       }
       property = valueToPopulate;
     }
-    return property;
+    return Promise.resolve(property);
   }
 
   overwrite(variableStringsString) {
     let finalValue;
     const variableStringsArray = variableStringsString.split(',');
-    variableStringsArray.find(variableString => {
-      finalValue = this.getValueFromSource(variableString);
-      return (finalValue !== null && typeof finalValue !== 'undefined') &&
-        !(typeof finalValue === 'object' && _.isEmpty(finalValue));
+    const promises = variableStringsArray
+      .map(variableString => this.getValueFromSource(variableString));
+    return Promise.all(promises).then(valuesFromSources => {
+      valuesFromSources.find(valueFromSource => {
+        finalValue = valueFromSource;
+        return (finalValue !== null && typeof finalValue !== 'undefined') &&
+          !(typeof finalValue === 'object' && _.isEmpty(finalValue));
+      });
+      return Promise.resolve(finalValue);
     });
-
-    return finalValue;
   }
 
   getValueFromSource(variableString) {
-    let valueToPopulate;
     if (variableString.match(this.envRefSyntax)) {
-      valueToPopulate = this.getValueFromEnv(variableString);
+      return this.getValueFromEnv(variableString);
     } else if (variableString.match(this.optRefSyntax)) {
-      valueToPopulate = this.getValueFromOptions(variableString);
+      return this.getValueFromOptions(variableString);
     } else if (variableString.match(this.selfRefSyntax)) {
-      valueToPopulate = this.getValueFromSelf(variableString);
+      return this.getValueFromSelf(variableString);
     } else if (variableString.match(this.fileRefSyntax)) {
-      valueToPopulate = this.getValueFromFile(variableString);
-    } else {
-      const errorMessage = [
-        `Invalid variable reference syntax for variable ${variableString}.`,
-        ' You can only reference env vars, options, & files.',
-        ' You can check our docs for more info.',
-      ].join('');
-      throw new this.serverless.classes.Error(errorMessage);
+      return this.getValueFromFile(variableString);
     }
-    return valueToPopulate;
+    const errorMessage = [
+      `Invalid variable reference syntax for variable ${variableString}.`,
+      ' You can only reference env vars, options, & files.',
+      ' You can check our docs for more info.',
+    ].join('');
+    throw new this.serverless.classes.Error(errorMessage);
   }
 
   getValueFromEnv(variableString) {
@@ -149,7 +167,7 @@ class Variables {
     } else {
       valueToPopulate = process.env;
     }
-    return valueToPopulate;
+    return Promise.resolve(valueToPopulate);
   }
 
   getValueFromOptions(variableString) {
@@ -160,14 +178,13 @@ class Variables {
     } else {
       valueToPopulate = this.options;
     }
-    return valueToPopulate;
+    return Promise.resolve(valueToPopulate);
   }
 
   getValueFromSelf(variableString) {
-    let valueToPopulate = this.service;
+    const valueToPopulate = this.service;
     const deepProperties = variableString.split(':')[1].split('.');
-    valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
-    return valueToPopulate;
+    return this.getDeepValue(deepProperties, valueToPopulate);
   }
 
   getValueFromFile(variableString) {
@@ -181,7 +198,7 @@ class Variables {
 
     // Validate file exists
     if (!this.serverless.utils.fileExistsSync(referencedFileFullPath)) {
-      return undefined;
+      return Promise.resolve(undefined);
     }
 
     let valueToPopulate;
@@ -192,20 +209,25 @@ class Variables {
       let jsModule = variableString.split(':')[1];
       jsModule = jsModule.split('.')[0];
       valueToPopulate = jsFile[jsModule]();
-      let deepProperties = variableString.replace(matchedFileRefString, '');
-      deepProperties = deepProperties.slice(1).split('.');
-      deepProperties.splice(0, 1);
-      valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
 
-      if (typeof valueToPopulate === 'undefined') {
-        const errorMessage = [
-          'Invalid variable syntax when referencing',
-          ` file "${referencedFileRelativePath}".`,
-          ' Check if your javascript is returning the correct data.',
-        ].join('');
-        throw new this.serverless.classes
-          .Error(errorMessage);
-      }
+      return Promise.resolve(valueToPopulate).then(valueToPopulateResolved => {
+        let deepProperties = variableString.replace(matchedFileRefString, '');
+        deepProperties = deepProperties.slice(1).split('.');
+        deepProperties.splice(0, 1);
+        return this.getDeepValue(deepProperties, valueToPopulateResolved)
+          .then(deepValueToPopulateResolved => {
+            if (typeof deepValueToPopulateResolved === 'undefined') {
+              const errorMessage = [
+                'Invalid variable syntax when referencing',
+                ` file "${referencedFileRelativePath}".`,
+                ' Check if your javascript is returning the correct data.',
+              ].join('');
+              throw new this.serverless.classes
+                .Error(errorMessage);
+            }
+            return Promise.resolve(deepValueToPopulateResolved);
+          });
+      });
     }
 
     // Process everything except JS
@@ -224,10 +246,10 @@ class Variables {
             .Error(errorMessage);
         }
         deepProperties = deepProperties.slice(1).split('.');
-        valueToPopulate = this.getDeepValue(deepProperties, valueToPopulate);
+        return this.getDeepValue(deepProperties, valueToPopulate);
       }
     }
-    return valueToPopulate;
+    return Promise.resolve(valueToPopulate);
   }
 
   getDeepValue(deepProperties, valueToPopulateParam) {
@@ -239,10 +261,11 @@ class Variables {
         valueToPopulate = valueToPopulate[subProperty];
       }
       if (typeof valueToPopulate === 'string' && valueToPopulate.match(this.variableSyntax)) {
-        valueToPopulate = this.populateProperty(valueToPopulate);
+        return this.populateProperty(valueToPopulate);
       }
+      return Promise.resolve(valueToPopulate);
     });
-    return valueToPopulate;
+    return Promise.resolve(valueToPopulate);
   }
 
   warnIfNotFound(variableString, valueToPopulate) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -35,20 +35,20 @@ class Variables {
     this.service.provider.variableSyntax = true;
 
     this.serverless.service.serverless = null;
-    const promises = [];
+    const populateAll = [];
 
     _.deepMapValues(this.service, (property, propertyPath) => {
       if (typeof property === 'string') {
-        const newPromise = new Promise((resolve) => this
+        const populateSingleProperty = new Promise((resolve) => this
           .populateProperty(property, true).then(newProperty => {
             _.set(this.service, propertyPath, newProperty);
             return resolve();
           }));
-        promises.push(newPromise);
+        populateAll.push(populateSingleProperty);
       }
     });
 
-    return Promise.all(promises).then(() => {
+    return Promise.all(populateAll).then(() => {
       this.service.provider.variableSyntax = variableSyntaxProperty;
       this.serverless.service.serverless = this.serverless;
       console.log(this.service)
@@ -63,7 +63,7 @@ class Variables {
     } else {
       property = _.cloneDeep(propertyParam);
     }
-    const promises = [];
+    const allValuesToPopulate = [];
 
     if (typeof property === 'string' && property.match(this.variableSyntax)) {
       property.match(this.variableSyntax).forEach((matchedString) => {
@@ -71,7 +71,7 @@ class Variables {
           .replace(this.variableSyntax, (match, varName) => varName.trim())
           .replace(/\s/g, '');
 
-        const newPromise = new Promise((resolve) => {
+        const singleValueToPopulate = new Promise((resolve) => {
           if (variableString.match(this.overwriteSyntax)) {
             return this.overwrite(variableString)
               .then(valueToPopulate => resolve(valueToPopulate));
@@ -80,7 +80,7 @@ class Variables {
             .then(valueToPopulate => resolve(valueToPopulate));
         });
 
-        newPromise.then(valueToPopulate => {
+        singleValueToPopulate.then(valueToPopulate => {
           this.warnIfNotFound(variableString, valueToPopulate);
           return this.populateVariable(property, matchedString, valueToPopulate)
             .then(newProperty => {
@@ -89,9 +89,9 @@ class Variables {
             });
         });
 
-        promises.push(newPromise);
+        allValuesToPopulate.push(singleValueToPopulate);
       });
-      return Promise.all(promises).then(() => {
+      return Promise.all(allValuesToPopulate).then(() => {
         if (property !== this.service) {
           return this.populateProperty(property);
         }
@@ -129,9 +129,9 @@ class Variables {
   overwrite(variableStringsString) {
     let finalValue;
     const variableStringsArray = variableStringsString.split(',');
-    const promises = variableStringsArray
+    const allValuesFromSource = variableStringsArray
       .map(variableString => this.getValueFromSource(variableString));
-    return Promise.all(promises).then(valuesFromSources => {
+    return Promise.all(allValuesFromSource).then(valuesFromSources => {
       valuesFromSources.find(valueFromSource => {
         finalValue = valueFromSource;
         return (finalValue !== null && typeof finalValue !== 'undefined') &&

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -42,7 +42,7 @@ describe('Variables', () => {
       const serverless = new Serverless();
 
       const populatePropertyStub = sinon
-        .stub(serverless.variables, 'populateProperty').returns(Promise.resolve());
+        .stub(serverless.variables, 'populateProperty').resolves();
 
       return serverless.variables.populateService().then(() => {
         expect(populatePropertyStub.called).to.equal(true);
@@ -84,9 +84,9 @@ describe('Variables', () => {
       serverless.variables.loadVariableSyntax();
 
       const overwriteStub = sinon
-        .stub(serverless.variables, 'overwrite').returns(Promise.resolve('dev'));
+        .stub(serverless.variables, 'overwrite').resolves('dev');
       const populateVariableStub = sinon
-        .stub(serverless.variables, 'populateVariable').returns(Promise.resolve('my stage is dev'));
+        .stub(serverless.variables, 'populateVariable').resolves('my stage is dev');
 
       return serverless.variables.populateProperty(property).then(newProperty => {
         expect(overwriteStub.called).to.equal(true);
@@ -95,6 +95,7 @@ describe('Variables', () => {
 
         serverless.variables.overwrite.restore();
         serverless.variables.populateVariable.restore();
+        return Promise.resolve();
       });
     });
 
@@ -105,10 +106,10 @@ describe('Variables', () => {
       serverless.variables.loadVariableSyntax();
 
       const getValueFromSourceStub = sinon
-        .stub(serverless.variables, 'getValueFromSource').returns(Promise.resolve('prod'));
+        .stub(serverless.variables, 'getValueFromSource').resolves('prod');
       const populateVariableStub = sinon
         .stub(serverless.variables, 'populateVariable')
-        .returns(Promise.resolve('my stage is prod'));
+        .resolves('my stage is prod');
 
       return serverless.variables.populateProperty(property).then(newProperty => {
         expect(getValueFromSourceStub.called).to.equal(true);
@@ -117,6 +118,7 @@ describe('Variables', () => {
 
         serverless.variables.getValueFromSource.restore();
         serverless.variables.populateVariable.restore();
+        return Promise.resolve();
       });
     });
 
@@ -131,10 +133,10 @@ describe('Variables', () => {
       const populateVariableStub = sinon
         .stub(serverless.variables, 'populateVariable');
 
-      getValueFromSourceStub.onCall(0).returns(Promise.resolve('stage'));
-      getValueFromSourceStub.onCall(1).returns(Promise.resolve('dev'));
-      populateVariableStub.onCall(0).returns(Promise.resolve('my stage is ${env:stage}'));
-      populateVariableStub.onCall(1).returns(Promise.resolve('my stage is dev'));
+      getValueFromSourceStub.onCall(0).resolves('stage');
+      getValueFromSourceStub.onCall(1).resolves('dev');
+      populateVariableStub.onCall(0).resolves('my stage is ${env:stage}');
+      populateVariableStub.onCall(1).resolves('my stage is dev');
 
       return serverless.variables.populateProperty(property).then(newProperty => {
         expect(getValueFromSourceStub.callCount).to.equal(2);
@@ -201,9 +203,9 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(Promise.resolve(undefined));
-      getValueFromSourceStub.onCall(1).returns(Promise.resolve(null));
-      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue'));
+      getValueFromSourceStub.onCall(0).resolves(undefined);
+      getValueFromSourceStub.onCall(1).resolves(null);
+      getValueFromSourceStub.onCall(2).resolves('variableValue');
 
       return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
         .then(valueToPopulate => {
@@ -218,8 +220,8 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(Promise.resolve({}));
-      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
+      getValueFromSourceStub.onCall(0).resolves({});
+      getValueFromSourceStub.onCall(1).resolves('variableValue');
 
       return serverless.variables.overwrite('opt:stage,env:stage').then(valueToPopulate => {
         expect(valueToPopulate).to.equal('variableValue');
@@ -233,9 +235,9 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(Promise.resolve(0));
-      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
-      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue2'));
+      getValueFromSourceStub.onCall(0).resolves(0);
+      getValueFromSourceStub.onCall(1).resolves('variableValue');
+      getValueFromSourceStub.onCall(2).resolves('variableValue2');
       return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
         .then(valueToPopulate => {
           expect(valueToPopulate).to.equal(0);
@@ -248,9 +250,9 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(Promise.resolve(false));
-      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
-      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue2'));
+      getValueFromSourceStub.onCall(0).resolves(false);
+      getValueFromSourceStub.onCall(1).resolves('variableValue');
+      getValueFromSourceStub.onCall(2).resolves('variableValue2');
 
       return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
         .then(valueToPopulate => {
@@ -264,9 +266,9 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(Promise.resolve(undefined));
-      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
-      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue2'));
+      getValueFromSourceStub.onCall(0).resolves(undefined);
+      getValueFromSourceStub.onCall(1).resolves('variableValue');
+      getValueFromSourceStub.onCall(2).resolves('variableValue2');
 
       return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
         .then(valueToPopulate => {
@@ -280,7 +282,7 @@ describe('Variables', () => {
     it('should call getValueFromEnv if referencing env var', () => {
       const serverless = new Serverless();
       const getValueFromEnvStub = sinon
-        .stub(serverless.variables, 'getValueFromEnv').returns(Promise.resolve('variableValue'));
+        .stub(serverless.variables, 'getValueFromEnv').resolves('variableValue');
       return serverless.variables.getValueFromSource('env:TEST_VAR')
         .then(valueToPopulate => {
           expect(valueToPopulate).to.equal('variableValue');
@@ -294,7 +296,7 @@ describe('Variables', () => {
       const serverless = new Serverless();
       const getValueFromOptionsStub = sinon
         .stub(serverless.variables, 'getValueFromOptions')
-        .returns(Promise.resolve('variableValue'));
+        .resolves('variableValue');
 
       return serverless.variables.getValueFromSource('opt:stage')
         .then(valueToPopulate => {
@@ -308,7 +310,7 @@ describe('Variables', () => {
     it('should call getValueFromSelf if referencing from self', () => {
       const serverless = new Serverless();
       const getValueFromSelfStub = sinon
-        .stub(serverless.variables, 'getValueFromSelf').returns(Promise.resolve('variableValue'));
+        .stub(serverless.variables, 'getValueFromSelf').resolves('variableValue');
 
       return serverless.variables.getValueFromSource('self:provider')
         .then(valueToPopulate => {
@@ -322,7 +324,7 @@ describe('Variables', () => {
     it('should call getValueFromFile if referencing from another file', () => {
       const serverless = new Serverless();
       const getValueFromFileStub = sinon
-        .stub(serverless.variables, 'getValueFromFile').returns(Promise.resolve('variableValue'));
+        .stub(serverless.variables, 'getValueFromFile').resolves('variableValue');
 
       return serverless.variables.getValueFromSource('file(./config.yml)')
         .then(valueToPopulate => {
@@ -603,13 +605,13 @@ describe('Variables', () => {
       serverless.variables.service = {
         service: 'testService',
         custom: {
+          anotherVar: '${self:custom.var}',
           subProperty: {
             deep: '${self:custom.anotherVar.veryDeep}',
           },
           var: {
             veryDeep: 'someValue',
           },
-          anotherVar: '${self:custom.var}',
         },
         provider: serverless.service.provider,
       };

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -42,12 +42,12 @@ describe('Variables', () => {
       const serverless = new Serverless();
 
       const populatePropertyStub = sinon
-        .stub(serverless.variables, 'populateProperty');
+        .stub(serverless.variables, 'populateProperty').returns(Promise.resolve());
 
-      serverless.variables.populateService();
-      expect(populatePropertyStub.called).to.equal(true);
-
-      serverless.variables.populateProperty.restore();
+      return serverless.variables.populateService().then(() => {
+        expect(populatePropertyStub.called).to.equal(true);
+        serverless.variables.populateProperty.restore();
+      });
     });
 
     it('should use variableSyntax', () => {
@@ -68,10 +68,11 @@ describe('Variables', () => {
         bar: '${{self:custom.var}}',
       };
 
-      serverless.variables.populateService();
-      expect(serverless.service.provider.variableSyntax).to.equal(variableSyntax);
-      expect(serverless.service.resources.foo).to.equal(fooValue);
-      expect(serverless.service.resources.bar).to.equal(barValue);
+      return serverless.variables.populateService().then(() => {
+        expect(serverless.service.provider.variableSyntax).to.equal(variableSyntax);
+        expect(serverless.service.resources.foo).to.equal(fooValue);
+        expect(serverless.service.resources.bar).to.equal(barValue);
+      });
     });
   });
 
@@ -83,18 +84,18 @@ describe('Variables', () => {
       serverless.variables.loadVariableSyntax();
 
       const overwriteStub = sinon
-        .stub(serverless.variables, 'overwrite').returns('dev');
+        .stub(serverless.variables, 'overwrite').returns(Promise.resolve('dev'));
       const populateVariableStub = sinon
-        .stub(serverless.variables, 'populateVariable').returns('my stage is dev');
+        .stub(serverless.variables, 'populateVariable').returns(Promise.resolve('my stage is dev'));
 
-      const newProperty = serverless.variables
-        .populateProperty(property);
-      expect(overwriteStub.called).to.equal(true);
-      expect(populateVariableStub.called).to.equal(true);
-      expect(newProperty).to.equal('my stage is dev');
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(overwriteStub.called).to.equal(true);
+        expect(populateVariableStub.called).to.equal(true);
+        expect(newProperty).to.equal('my stage is dev');
 
-      serverless.variables.overwrite.restore();
-      serverless.variables.populateVariable.restore();
+        serverless.variables.overwrite.restore();
+        serverless.variables.populateVariable.restore();
+      });
     });
 
     it('should call getValueFromSource if no overwrite syntax provided', () => {
@@ -104,18 +105,19 @@ describe('Variables', () => {
       serverless.variables.loadVariableSyntax();
 
       const getValueFromSourceStub = sinon
-        .stub(serverless.variables, 'getValueFromSource').returns('prod');
+        .stub(serverless.variables, 'getValueFromSource').returns(Promise.resolve('prod'));
       const populateVariableStub = sinon
-        .stub(serverless.variables, 'populateVariable').returns('my stage is prod');
+        .stub(serverless.variables, 'populateVariable')
+        .returns(Promise.resolve('my stage is prod'));
 
-      const newProperty = serverless.variables
-        .populateProperty(property);
-      expect(getValueFromSourceStub.called).to.equal(true);
-      expect(populateVariableStub.called).to.equal(true);
-      expect(newProperty).to.equal('my stage is prod');
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(getValueFromSourceStub.called).to.equal(true);
+        expect(populateVariableStub.called).to.equal(true);
+        expect(newProperty).to.equal('my stage is prod');
 
-      serverless.variables.getValueFromSource.restore();
-      serverless.variables.populateVariable.restore();
+        serverless.variables.getValueFromSource.restore();
+        serverless.variables.populateVariable.restore();
+      });
     });
 
     it('should run recursively if nested variables provided', () => {
@@ -129,19 +131,19 @@ describe('Variables', () => {
       const populateVariableStub = sinon
         .stub(serverless.variables, 'populateVariable');
 
-      getValueFromSourceStub.onCall(0).returns('stage');
-      getValueFromSourceStub.onCall(1).returns('dev');
-      populateVariableStub.onCall(0).returns('my stage is ${env:stage}');
-      populateVariableStub.onCall(1).returns('my stage is dev');
+      getValueFromSourceStub.onCall(0).returns(Promise.resolve('stage'));
+      getValueFromSourceStub.onCall(1).returns(Promise.resolve('dev'));
+      populateVariableStub.onCall(0).returns(Promise.resolve('my stage is ${env:stage}'));
+      populateVariableStub.onCall(1).returns(Promise.resolve('my stage is dev'));
 
-      const newProperty = serverless.variables
-        .populateProperty(property);
-      expect(getValueFromSourceStub.callCount).to.equal(2);
-      expect(populateVariableStub.callCount).to.equal(2);
-      expect(newProperty).to.equal('my stage is dev');
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(getValueFromSourceStub.callCount).to.equal(2);
+        expect(populateVariableStub.callCount).to.equal(2);
+        expect(newProperty).to.equal('my stage is dev');
 
-      serverless.variables.getValueFromSource.restore();
-      serverless.variables.populateVariable.restore();
+        serverless.variables.getValueFromSource.restore();
+        serverless.variables.populateVariable.restore();
+      });
     });
   });
 
@@ -152,9 +154,10 @@ describe('Variables', () => {
       const matchedString = '${opt:stage}';
       const property = 'my stage is ${opt:stage}';
 
-      const newProperty = serverless.variables
-        .populateVariable(property, matchedString, valueToPopulate);
-      expect(newProperty).to.equal('my stage is dev');
+      return serverless.variables.populateVariable(property, matchedString, valueToPopulate)
+        .then(newProperty => {
+          expect(newProperty).to.equal('my stage is dev');
+        });
     });
 
     it('should populate number variables as sub string', () => {
@@ -163,9 +166,10 @@ describe('Variables', () => {
       const matchedString = '${opt:number}';
       const property = 'your account number is ${opt:number}';
 
-      const newProperty = serverless.variables
-        .populateVariable(property, matchedString, valueToPopulate);
-      expect(newProperty).to.equal('your account number is 5');
+      return serverless.variables.populateVariable(property, matchedString, valueToPopulate)
+        .then(newProperty => {
+          expect(newProperty).to.equal('your account number is 5');
+        });
     });
 
     it('should populate non string variables', () => {
@@ -174,9 +178,10 @@ describe('Variables', () => {
       const matchedString = '${opt:number}';
       const property = '${opt:number}';
 
-      const newProperty = serverless.variables
-        .populateVariable(property, matchedString, valueToPopulate);
-      expect(newProperty).to.equal(5);
+      return serverless.variables.populateVariable(property, matchedString, valueToPopulate)
+        .then(newProperty => {
+          expect(newProperty).to.equal(5);
+        });
     });
 
     it('should throw error if populating non string or non number variable as sub string', () => {
@@ -196,15 +201,16 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(undefined);
-      getValueFromSourceStub.onCall(1).returns(null);
-      getValueFromSourceStub.onCall(2).returns('variableValue');
+      getValueFromSourceStub.onCall(0).returns(Promise.resolve(undefined));
+      getValueFromSourceStub.onCall(1).returns(Promise.resolve(null));
+      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue'));
 
-      const valueToPopulate = serverless.variables
-        .overwrite('opt:stage,env:stage,self:provider.stage');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromSourceStub.callCount).to.equal(3);
-      serverless.variables.getValueFromSource.restore();
+      return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          expect(getValueFromSourceStub.callCount).to.equal(3);
+          serverless.variables.getValueFromSource.restore();
+        });
     });
 
     it('should overwrite empty object values', () => {
@@ -212,14 +218,14 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns({});
-      getValueFromSourceStub.onCall(1).returns('variableValue');
+      getValueFromSourceStub.onCall(0).returns(Promise.resolve({}));
+      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
 
-      const valueToPopulate = serverless.variables
-        .overwrite('opt:stage,env:stage');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromSourceStub.callCount).to.equal(2);
-      serverless.variables.getValueFromSource.restore();
+      return serverless.variables.overwrite('opt:stage,env:stage').then(valueToPopulate => {
+        expect(valueToPopulate).to.equal('variableValue');
+        expect(getValueFromSourceStub.callCount).to.equal(2);
+        serverless.variables.getValueFromSource.restore();
+      });
     });
 
     it('should not overwrite 0 values', () => {
@@ -227,15 +233,14 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(0);
-      getValueFromSourceStub.onCall(1).returns('variableValue');
-      getValueFromSourceStub.onCall(2).returns('variableValue2');
-
-      const valueToPopulate = serverless.variables
-        .overwrite('opt:stage,env:stage,self:provider.stage');
-      expect(valueToPopulate).to.equal(0);
-      expect(getValueFromSourceStub.callCount).to.equal(1);
-      serverless.variables.getValueFromSource.restore();
+      getValueFromSourceStub.onCall(0).returns(Promise.resolve(0));
+      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
+      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue2'));
+      return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal(0);
+          serverless.variables.getValueFromSource.restore();
+        });
     });
 
     it('should not overwrite false values', () => {
@@ -243,15 +248,15 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(false);
-      getValueFromSourceStub.onCall(1).returns('variableValue');
-      getValueFromSourceStub.onCall(2).returns('variableValue2');
+      getValueFromSourceStub.onCall(0).returns(Promise.resolve(false));
+      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
+      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue2'));
 
-      const valueToPopulate = serverless.variables
-        .overwrite('opt:stage,env:stage,self:provider.stage');
-      expect(valueToPopulate).to.equal(false);
-      expect(getValueFromSourceStub.callCount).to.equal(1);
-      serverless.variables.getValueFromSource.restore();
+      return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal(false);
+          serverless.variables.getValueFromSource.restore();
+        });
     });
 
     it('should skip getting values once a value has been found', () => {
@@ -259,15 +264,15 @@ describe('Variables', () => {
       const getValueFromSourceStub = sinon
         .stub(serverless.variables, 'getValueFromSource');
 
-      getValueFromSourceStub.onCall(0).returns(undefined);
-      getValueFromSourceStub.onCall(1).returns('variableValue');
-      getValueFromSourceStub.onCall(2).returns('variableValue2');
+      getValueFromSourceStub.onCall(0).returns(Promise.resolve(undefined));
+      getValueFromSourceStub.onCall(1).returns(Promise.resolve('variableValue'));
+      getValueFromSourceStub.onCall(2).returns(Promise.resolve('variableValue2'));
 
-      const valueToPopulate = serverless.variables
-        .overwrite('opt:stage,env:stage,self:provider.stage');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromSourceStub.callCount).to.equal(2);
-      serverless.variables.getValueFromSource.restore();
+      return serverless.variables.overwrite('opt:stage,env:stage,self:provider.stage')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          serverless.variables.getValueFromSource.restore();
+        });
     });
   });
 
@@ -275,49 +280,57 @@ describe('Variables', () => {
     it('should call getValueFromEnv if referencing env var', () => {
       const serverless = new Serverless();
       const getValueFromEnvStub = sinon
-        .stub(serverless.variables, 'getValueFromEnv').returns('variableValue');
-
-      const valueToPopulate = serverless.variables.getValueFromSource('env:TEST_VAR');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromEnvStub.called).to.equal(true);
-      expect(getValueFromEnvStub.calledWith('env:TEST_VAR')).to.equal(true);
-      serverless.variables.getValueFromEnv.restore();
+        .stub(serverless.variables, 'getValueFromEnv').returns(Promise.resolve('variableValue'));
+      return serverless.variables.getValueFromSource('env:TEST_VAR')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          expect(getValueFromEnvStub.called).to.equal(true);
+          expect(getValueFromEnvStub.calledWith('env:TEST_VAR')).to.equal(true);
+          serverless.variables.getValueFromEnv.restore();
+        });
     });
 
     it('should call getValueFromOptions if referencing an option', () => {
       const serverless = new Serverless();
       const getValueFromOptionsStub = sinon
-        .stub(serverless.variables, 'getValueFromOptions').returns('variableValue');
+        .stub(serverless.variables, 'getValueFromOptions')
+        .returns(Promise.resolve('variableValue'));
 
-      const valueToPopulate = serverless.variables.getValueFromSource('opt:stage');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromOptionsStub.called).to.equal(true);
-      expect(getValueFromOptionsStub.calledWith('opt:stage')).to.equal(true);
-      serverless.variables.getValueFromOptions.restore();
+      return serverless.variables.getValueFromSource('opt:stage')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          expect(getValueFromOptionsStub.called).to.equal(true);
+          expect(getValueFromOptionsStub.calledWith('opt:stage')).to.equal(true);
+          serverless.variables.getValueFromOptions.restore();
+        });
     });
 
     it('should call getValueFromSelf if referencing from self', () => {
       const serverless = new Serverless();
       const getValueFromSelfStub = sinon
-        .stub(serverless.variables, 'getValueFromSelf').returns('variableValue');
+        .stub(serverless.variables, 'getValueFromSelf').returns(Promise.resolve('variableValue'));
 
-      const valueToPopulate = serverless.variables.getValueFromSource('self:provider');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromSelfStub.called).to.equal(true);
-      expect(getValueFromSelfStub.calledWith('self:provider')).to.equal(true);
-      serverless.variables.getValueFromSelf.restore();
+      return serverless.variables.getValueFromSource('self:provider')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          expect(getValueFromSelfStub.called).to.equal(true);
+          expect(getValueFromSelfStub.calledWith('self:provider')).to.equal(true);
+          serverless.variables.getValueFromSelf.restore();
+        });
     });
 
     it('should call getValueFromFile if referencing from another file', () => {
       const serverless = new Serverless();
       const getValueFromFileStub = sinon
-        .stub(serverless.variables, 'getValueFromFile').returns('variableValue');
+        .stub(serverless.variables, 'getValueFromFile').returns(Promise.resolve('variableValue'));
 
-      const valueToPopulate = serverless.variables.getValueFromSource('file(./config.yml)');
-      expect(valueToPopulate).to.equal('variableValue');
-      expect(getValueFromFileStub.called).to.equal(true);
-      expect(getValueFromFileStub.calledWith('file(./config.yml)')).to.equal(true);
-      serverless.variables.getValueFromFile.restore();
+      return serverless.variables.getValueFromSource('file(./config.yml)')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          expect(getValueFromFileStub.called).to.equal(true);
+          expect(getValueFromFileStub.calledWith('file(./config.yml)')).to.equal(true);
+          serverless.variables.getValueFromFile.restore();
+        });
     });
 
     it('should throw error if referencing an invalid source', () => {
@@ -331,17 +344,19 @@ describe('Variables', () => {
     it('should get variable from environment variables', () => {
       const serverless = new Serverless();
       process.env.TEST_VAR = 'someValue';
-      const valueToPopulate = serverless.variables.getValueFromEnv('env:TEST_VAR');
-      expect(valueToPopulate).to.be.equal('someValue');
-      delete process.env.TEST_VAR;
+      return serverless.variables.getValueFromEnv('env:TEST_VAR').then(valueToPopulate => {
+        expect(valueToPopulate).to.be.equal('someValue');
+        delete process.env.TEST_VAR;
+      });
     });
 
     it('should allow top-level references to the environment variables hive', () => {
       const serverless = new Serverless();
       process.env.TEST_VAR = 'someValue';
-      const valueToPopulate = serverless.variables.getValueFromEnv('env:').TEST_VAR;
-      expect(valueToPopulate).to.be.equal('someValue');
-      delete process.env.TEST_VAR;
+      return serverless.variables.getValueFromEnv('env:').then(valueToPopulate => {
+        expect(valueToPopulate.TEST_VAR).to.be.equal('someValue');
+        delete process.env.TEST_VAR;
+      });
     });
   });
 
@@ -351,8 +366,9 @@ describe('Variables', () => {
       serverless.variables.options = {
         stage: 'prod',
       };
-      const valueToPopulate = serverless.variables.getValueFromOptions('opt:stage');
-      expect(valueToPopulate).to.be.equal('prod');
+      return serverless.variables.getValueFromOptions('opt:stage').then(valueToPopulate => {
+        expect(valueToPopulate).to.be.equal('prod');
+      });
     });
 
     it('should allow top-level references to the options hive', () => {
@@ -360,8 +376,9 @@ describe('Variables', () => {
       serverless.variables.options = {
         stage: 'prod',
       };
-      const valueToPopulate = serverless.variables.getValueFromOptions('opt:').stage;
-      expect(valueToPopulate).to.be.equal('prod');
+      return serverless.variables.getValueFromOptions('opt:').then(valueToPopulate => {
+        expect(valueToPopulate.stage).to.be.equal('prod');
+      });
     });
   });
 
@@ -372,11 +389,10 @@ describe('Variables', () => {
         service: 'testService',
         provider: serverless.service.provider,
       };
-
       serverless.variables.loadVariableSyntax();
-
-      const valueToPopulate = serverless.variables.getValueFromSelf('self:service');
-      expect(valueToPopulate).to.be.equal('testService');
+      return serverless.variables.getValueFromSelf('self:service').then(valueToPopulate => {
+        expect(valueToPopulate).to.be.equal('testService');
+      });
     });
 
     it('should handle self-references to the root of the serverless.yml file', () => {
@@ -389,8 +405,9 @@ describe('Variables', () => {
 
       serverless.variables.loadVariableSyntax();
 
-      const valueToPopulate = serverless.variables.getValueFromSelf('self:').provider;
-      expect(valueToPopulate).to.be.equal('testProvider');
+      return serverless.variables.getValueFromSelf('self:').then(valueToPopulate => {
+        expect(valueToPopulate.provider).to.be.equal('testProvider');
+      });
     });
   });
 
@@ -413,8 +430,9 @@ describe('Variables', () => {
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const valueToPopulate = serverless.variables.getValueFromFile('file(./config.yml)');
-      expect(valueToPopulate).to.deep.equal(configYml);
+      return serverless.variables.getValueFromFile('file(./config.yml)').then(valueToPopulate => {
+        expect(valueToPopulate).to.deep.equal(configYml);
+      });
     });
 
     it('should get undefined if non existing file and the second argument is true', () => {
@@ -423,8 +441,9 @@ describe('Variables', () => {
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const valueToPopulate = serverless.variables.getValueFromFile('file(./config.yml)');
-      expect(valueToPopulate).to.be.equal(undefined);
+      return serverless.variables.getValueFromFile('file(./config.yml)').then(valueToPopulate => {
+        expect(valueToPopulate).to.be.equal(undefined);
+      });
     });
 
     it('should populate non json/yml files', () => {
@@ -437,8 +456,9 @@ describe('Variables', () => {
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const valueToPopulate = serverless.variables.getValueFromFile('file(./someFile)');
-      expect(valueToPopulate).to.equal('hello world');
+      return serverless.variables.getValueFromFile('file(./someFile)').then(valueToPopulate => {
+        expect(valueToPopulate).to.equal('hello world');
+      });
     });
 
     it('should trim trailing whitespace and new line character', () => {
@@ -451,8 +471,9 @@ describe('Variables', () => {
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const valueToPopulate = serverless.variables.getValueFromFile('file(./someFile)');
-      expect(valueToPopulate).to.equal('hello world');
+      return serverless.variables.getValueFromFile('file(./someFile)').then(valueToPopulate => {
+        expect(valueToPopulate).to.equal('hello world');
+      });
     });
 
     it('should populate from another file when variable is of any type', () => {
@@ -473,9 +494,10 @@ describe('Variables', () => {
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const valueToPopulate = serverless.variables
-        .getValueFromFile('file(./config.yml):testObj.sub');
-      expect(valueToPopulate).to.equal(2);
+      return serverless.variables.getValueFromFile('file(./config.yml):testObj.sub')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal(2);
+        });
     });
 
     it('should populate from a javascript file', () => {
@@ -488,9 +510,10 @@ describe('Variables', () => {
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const valueToPopulate = serverless.variables
-        .getValueFromFile('file(./hello.js):hello');
-      expect(valueToPopulate).to.equal('hello world');
+      return serverless.variables.getValueFromFile('file(./hello.js):hello')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('hello world');
+        });
     });
 
     it('should populate deep object from a javascript file', () => {
@@ -506,9 +529,10 @@ describe('Variables', () => {
       serverless.config.update({ servicePath: tmpDirPath });
       serverless.variables.loadVariableSyntax();
 
-      const valueToPopulate = serverless.variables
-        .getValueFromFile('file(./hello.js):hello.one.two.three');
-      expect(valueToPopulate).to.equal('hello world');
+      return serverless.variables.getValueFromFile('file(./hello.js):hello.one.two.three')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('hello world');
+        });
     });
 
     it('should throw error if not using ":" syntax', () => {
@@ -549,9 +573,10 @@ describe('Variables', () => {
 
       serverless.variables.loadVariableSyntax();
 
-      const valueToPopulate = serverless.variables
-        .getDeepValue(['custom', 'subProperty', 'deep'], valueToPopulateMock);
-      expect(valueToPopulate).to.be.equal('deepValue');
+      return serverless.variables.getDeepValue(['custom', 'subProperty', 'deep'],
+        valueToPopulateMock).then(valueToPopulate => {
+          expect(valueToPopulate).to.be.equal('deepValue');
+        });
     });
 
     it('should not throw error if referencing invalid properties', () => {
@@ -566,9 +591,10 @@ describe('Variables', () => {
 
       serverless.variables.loadVariableSyntax();
 
-      const valueToPopulate = serverless.variables
-        .getDeepValue(['custom', 'subProperty', 'deep', 'deeper'], valueToPopulateMock);
-      expect(valueToPopulate).to.deep.equal({});
+      return serverless.variables.getDeepValue(['custom', 'subProperty', 'deep', 'deeper'],
+        valueToPopulateMock).then(valueToPopulate => {
+          expect(valueToPopulate).to.deep.equal({});
+        });
     });
 
     it('should get deep values with variable references', () => {
@@ -590,9 +616,10 @@ describe('Variables', () => {
 
       serverless.variables.loadVariableSyntax();
 
-      const valueToPopulate = serverless.variables
-        .getDeepValue(['custom', 'subProperty', 'deep'], serverless.variables.service);
-      expect(valueToPopulate).to.be.equal('someValue');
+      return serverless.variables.getDeepValue(['custom', 'subProperty', 'deep'],
+        serverless.variables.service).then(valueToPopulate => {
+          expect(valueToPopulate).to.be.equal('someValue');
+        });
     });
   });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -464,6 +464,11 @@
       "from": "lodash@>=4.13.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
     },
+    "lodash-deep": {
+      "version": "2.0.0",
+      "from": "lodash-deep@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-2.0.0.tgz"
+    },
     "lowercase-keys": {
       "version": "1.0.0",
       "from": "lowercase-keys@>=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "js-yaml": "^3.6.1",
     "json-refs": "^2.1.5",
     "lodash": "^4.13.1",
+    "lodash-deep": "^2.0.0",
     "minimist": "^1.2.0",
     "moment": "^2.13.0",
     "node-fetch": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "semver": "^5.0.3",
     "semver-regex": "^1.0.0",
     "shelljs": "^0.6.0",
-    "traverse": "^0.6.6",
     "uuid": "^2.0.2"
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Closes #3073

Added support for async sources in the variable system, beginning with the `file` source. Your JS files can now perform async operations and return a promise that would be resolved by the variable system.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Previously, the variable system was completely sync, so I had to control the flow of the entire system and it's methods and make it promise-ready. All methods now return a promise to assure everything is running in the correct flow.

I've also ditched the `traverse` module since it doesn't work smoothly with promises and instead I'm using a lodash based implementation for object traversal and updates.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
I've tested 17 different cases for the variable systems that covers pretty much everything the variables system can do, **including the new promises in files support**. Here's the config I used, but feel free to get crazy creative:

```yml
# serverless.yml

service: serverless-async-vars

provider:
  name: aws
  runtime: nodejs6.10

custom:
  data: # some data to reference
    zero: 0
    nooo: false
  varA: ${env:TESTING} # env vars
  varB: ${opt:stage} # opts vars
  varC: ${self:provider.name} # self vars
  varD: ${env:TESTING}-${opt:stage} # two vars in a string
  varE: ${opt:${env:TESTING}hoo} # nested vars
  varF: ${opt:region, opt:stage} # overwrite functionality
  varG: ${file(./vars.js):hello} # JS file running sync
  varH: ${file(./vars.js):promised} # JS file running async/promised NEW!!!
  varI: ${file(./vars.json):hoo.hoo2} # deep JSON file
  varJ: ${file(./vars.yml):hee.hee2} # deep YAML file
  varK: my stage is ${opt:stage} # vars sub string
  varL: your account number is ${opt:number} # number vars as sub string
  varM: ${opt:number} # preserving data type
  varN: ${self:plugins, self:package, self:service} # multiple overwrites when empty object and undefined
  varO: ${self:custom.data.zero, self:service} # shouldn't overwrite 0 values
  varP: ${self:custom.data.nooo, self:service} # shouldn't overwrite false values
  varQ: ${self:} # referencing the entire config file

functions:
  hello:
    handler: handler.hello
```
You'll need the `TESTING` env var to be set, and also the following vars files in your service root dir:
vars.js
```js
module.exports.hello = () => {
  // Sync code
  return {nested: 'world'};
}

module.exports.promised = () => {
  // Async code
  return Promise.resolve('world');
}
```
vars.yml
```yml
hee:
  hee2: haa
```
vars.json
```json
{
  "hoo": {
    "hoo2": "hum"
  }
}
```
You'll need to run the following command against this service for full test coverage:

```
sls package --stage dev --yahoo hi --region us-east-1 --number 1234
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO