### PR TITLE
Added support for cross service communication via CloudFormation outputs

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -16,10 +16,13 @@ The Serverless framework provides a powerful variable system which allows you to
 
 - Reference & load variables from environment variables
 - Reference & load variables from CLI options
+- Reference & load variables from CloudFormation stack outputs
 - Recursively reference properties of any type from the same `serverless.yml` file
 - Recursively reference properties of any type from other YAML/JSON files
+- Recursively reference properties exported from JS files, synchronously or asynchronously
 - Recursively nest variable references within each other for ultimate flexibility
 - Combine multiple variable references to overwrite each other
+- Define your own variable syntax if it conflicts with CF syntax
 
 **Note:** You can only use variables in `serverless.yml` property **values**, not property keys. So you can't use variables to generate dynamic logical IDs in the custom resources section for example.
 
@@ -91,6 +94,21 @@ functions:
 ```
 
 In the above example, you're dynamically adding a prefix to the function names by referencing the `stage` option that you pass in the CLI when you run `serverless deploy --stage dev`. So when you deploy, the function name will always include the stage you're deploying to.
+
+## Reference CloudFormation Outputs
+You can reference CloudFormation stack output values as the source of your variables to use in your service with the `cf:stackName.outputKey` syntax. For example:
+```yml
+service: new-service
+provider: aws
+functions:
+  hello:
+      name: ${cf:another-service-dev.functionPrefix}-hello
+      handler: handler.hello
+  world:
+      name: ${cf:another-stack.functionPrefix}-world
+      handler: handler.world
+```
+In that case, the framework will fetch the values of those `functionPrefix` outputs from the provided stack names and populate your variables. There are many use cases for this functionality and it allows your service to communicate with other services/stacks.
 
 ## Reference Variables in Other Files
 To reference variables in other YAML or JSON files, use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. This functionality is recursive, so you can go as deep in that file as you want. Here's an example:
@@ -232,6 +250,22 @@ functions:
 What this says is to use the `stage` CLI option if it exists, if not, use the default stage (which lives in `provider.stage`). So during development you can safely deploy with `serverless deploy`, but during production you can do `serverless deploy --stage production` and the stage will be picked up for you without having to make any changes to `serverless.yml`.
 
 You can have as many variable references as you want, from any source you want, and each of them can be of different type and different name.
+
+## Using Custom Variable Syntax
+In some cases, the `${xxx}` variable syntax conflicts with some CloudFormation functionality. In that case you can provide a custom syntax to overwrite our default `${xxx}` syntax by setting the `provider.variableSyntax` property to the desired regex:
+
+```yml
+service: new-service
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  variableSyntax: "\\${{([\\s\\S]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
+
+custom:
+  myStage: ${{opt:stage}}
+```
+In this example, we're overwriting the default regex for our variable syntax. So whenever you define variables, you now need to use `${{}}` instead of `${}` (double curly brackets).
 
 ## Migrating serverless.env.yml
 Previously we used the `serverless.env.yml` file to track Serverless Variables. It was a completely different system with different concepts. To migrate your variables from `serverless.env.yml`, you'll need to decide where you want to store your variables.

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -19,6 +19,7 @@ class Variables {
     this.envRefSyntax = RegExp(/^env:/g);
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
+    this.cfRefSyntax = RegExp(/^cf:/g);
   }
 
   loadVariableSyntax() {
@@ -150,6 +151,8 @@ class Variables {
       return this.getValueFromSelf(variableString);
     } else if (variableString.match(this.fileRefSyntax)) {
       return this.getValueFromFile(variableString);
+    } else if (variableString.match(this.cfRefSyntax)) {
+      return this.getValueFromCf(variableString);
     }
     const errorMessage = [
       `Invalid variable reference syntax for variable ${variableString}.`,
@@ -250,6 +253,23 @@ class Variables {
       }
     }
     return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromCf(variableString) {
+    const variableStringWithoutSource = variableString.split(':')[1].split('.');
+    const stackName = variableStringWithoutSource[0];
+    const outputLogicalId = variableStringWithoutSource[1];
+    return this.serverless.getProvider('aws')
+      .request('CloudFormation',
+        'describeStacks',
+        { StackName: stackName },
+        this.options.stage,
+        this.options.region)
+      .then(result => {
+        const outputs = result.Stacks[0].Outputs;
+        const output = outputs.find(x => x.OutputKey === outputLogicalId);
+        return output.OutputValue;
+      });
   }
 
   getDeepValue(deepProperties, valueToPopulate) {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -10,6 +10,7 @@ const Serverless = require('../../lib/Serverless');
 const sinon = require('sinon');
 const testUtils = require('../../tests/utils');
 const slsError = require('./Error');
+const AwsProvider = require('../plugins/aws/provider/awsProvider');
 
 describe('Variables', () => {
   describe('#constructor()', () => {
@@ -557,6 +558,45 @@ describe('Variables', () => {
 
       expect(() => serverless.variables
         .getValueFromFile('file(./config.yml).testObj.sub')).to.throw(Error);
+    });
+  });
+
+  describe('#getValueFromCf()', () => {
+    it('should get variable from CloudFormation', () => {
+      const serverless = new Serverless();
+      const options = {
+        stage: 'prod',
+        region: 'us-west-2',
+      };
+      const awsProvider = new AwsProvider(serverless, options);
+      serverless.setProvider('aws', awsProvider);
+      serverless.variables.options = options;
+      const awsResponseMock = {
+        Stacks: [{
+          Outputs: [{
+            OutputKey: 'MockExport',
+            OutputValue: 'MockValue',
+          }],
+        }],
+      };
+
+      const cfStub = sinon.stub(serverless.getProvider('aws'), 'request')
+        .resolves(awsResponseMock);
+      return serverless.variables.getValueFromCf('cf:some-stack.MockExport')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.be.equal('MockValue');
+          expect(cfStub.calledOnce).to.be.equal(true);
+          expect(cfStub.calledWithExactly(
+            'CloudFormation',
+            'describeStacks',
+            {
+              StackName: 'some-stack',
+            },
+            serverless.variables.options.stage,
+            serverless.variables.options.region
+          )).to.be.equal(true);
+          serverless.getProvider('aws').request.restore();
+        });
     });
   });
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -336,6 +336,19 @@ describe('Variables', () => {
         });
     });
 
+    it('should call getValueFromCf if referencing CloudFormation Outputs', () => {
+      const serverless = new Serverless();
+      const getValueFromCfStub = sinon
+        .stub(serverless.variables, 'getValueFromCf').resolves('variableValue');
+      return serverless.variables.getValueFromSource('cf:test-stack.testOutput')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('variableValue');
+          expect(getValueFromCfStub.called).to.equal(true);
+          expect(getValueFromCfStub.calledWith('cf:test-stack.testOutput')).to.equal(true);
+          serverless.variables.getValueFromCf.restore();
+        });
+    });
+
     it('should throw error if referencing an invalid source', () => {
       const serverless = new Serverless();
       expect(() => serverless.variables.getValueFromSource('weird:source'))


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3442

This PR adds support for cross service/stack communication by utilising CloudFormation outputs as a new source for the variable system => `${cf:stackName.outputKey}`
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Added a new CloudFormation source to the variable system that allows you reference any output values in any stack you specify. This way a user can define CF outputs in one service, and reference them in another.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
You'll need two services to test communication:
```yml
service: service-a

provider:
  name: aws
  memorySize: 512

functions:
  hello:
      handler: handler.hello

resources:
  Outputs:
    memorySize:
      Value: ${self:provider.memorySize}
      Export:
        Name: memorySize
```

```yml
service: service-b

provider:
  name: aws
  memorySize: ${cf:service-a-dev.memorySize}

functions:
  hello:
      handler: handler.hello
```
deploy `service-a` then `service-b`, you'll notice that the memory size of the hello function in `service-b` is now set to 512 instead of the default 1024, following `service-a` config.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
