### PR TITLE
Create separate quick start docs for the providers.

### DIFF
--- a/docs/providers/aws/guide/quick-start.md
+++ b/docs/providers/aws/guide/quick-start.md
@@ -1,0 +1,73 @@
+<!--
+title: Serverless Framework - AWS Lambda Guide - Quick Start
+menuText: Quick Start
+menuOrder: 1
+description: Getting started with the Serverless Framework on AWS Lambda
+layout: Doc
+-->
+
+# Quick Start
+
+## Pre-requisites
+
+1. Node.js `v6.5.0` or later.
+2. Serverless CLI `v1.9.0` or later. You can run 
+`npm install -g serverless` to install it.
+3. An AWS account. If you don't already have one, you can sign up for a [free trial](https://aws.amazon.com/s/dm/optimization/server-side-test/free-tier/free_np/) that includes 1 million free Lambda requests per month.
+4. **Set-up your [Provider Credentials](./credentials.md)**. [Watch the video on setting up credentials](https://www.youtube.com/watch?v=HSd9uYj2LJA)
+
+## Create a new service
+
+Create a new service using the Node.js template, specifying a unique name and an optional path for your service.
+
+```bash
+# Create a new Serverless Service/Project
+$ serverless create --template aws-nodejs --path my-service
+# Change into the newly created directory
+$ cd my-service
+# Install npm dependencies
+$ npm install
+```
+
+## Deploy, test and diagnose your service
+
+1. **Deploy the Service**
+
+  Use this when you have made changes to your Functions, Events or Resources in `serverless.yml` or you simply want to deploy all changes within your Service at the same time.
+  
+  ```bash
+  serverless deploy -v
+  ```
+
+2. **Deploy the Function**
+
+  Use this to quickly upload and overwrite your function code, allowing you to develop faster.
+  
+  ```bash
+  serverless deploy function -f hello
+  ```
+
+3. **Invoke the Function**
+
+  Invokes an Function and returns logs.
+  
+  ```bash
+  serverless invoke -f hello -l
+  ```
+
+4. **Fetch the Function Logs**
+
+  Open up a separate tab in your console and stream all logs for a specific Function using this command.
+  ```bash
+  serverless logs -f hello -t
+  ```
+
+## Cleanup
+
+If at any point, you no longer need your service, you can run the following command to remove the Functions, Events and Resources that were created, and ensure that you don't incur any unexpected charges.
+
+```bash
+serverless remove
+```
+
+Check out the [Serverless Framework Guide](./README.md) for more information.

--- a/docs/providers/azure/guide/quick-start.md
+++ b/docs/providers/azure/guide/quick-start.md
@@ -1,0 +1,98 @@
+<!--
+title: Serverless Framework - Azure Functions Guide - Quick Start
+menuText: Quick Start
+menuOrder: 1
+description: Getting started with the Serverless Framework on Azure Functions
+layout: Doc
+-->
+
+# Quick Start
+
+## Pre-requisites
+
+1. Node.js `v6.5.0` or later. *(this is the runtime version supported by Azure Functions)*
+2. Serverless CLI `v1.9.0` or later. You can run 
+`npm install -g serverless` to install it.
+3. An Azure account. If you don't already have one, you can sign up for a [free trial](https://azure.microsoft.com/en-us/free/) that includes $200 of free credit.
+4. **Set-up your [Provider Credentials](./credentials.md)**. 
+
+## Create a new service
+
+Create a new service using the Node.js template, specifying a unique name and an optional path for your service.
+
+```bash
+# Create a new Serverless Service/Project
+$ serverless create --template aws-nodejs --path my-service
+# Change into the newly created directory
+$ cd my-service
+# Install npm dependencies
+$ npm install
+```
+
+## Deploy, test and diagnose your service
+
+1. **Deploy the Service:**
+  
+  Deploy your new service to Azure! The first time you do this, you will be asked to authenticate with your Azure account, so the `serverless` CLI can manage Functions on your behalf. Simply follow the provided instructions, and the deployment will continue as soon as the authentication process is completed.
+
+  ```bash
+  serverless deploy -v
+  ```
+
+  > Note: Once you've authenticated, a new Azure "service principal" will be created, and used for subsequent deployments. This prevents you from needing to manually login again. See [below](#advanced-authentication) if you'd prefer to use a custom service principal instead.
+
+2. **Deploy the Function**
+
+  Use this to quickly upload and overwrite your function code,  allowing you to develop faster. If you're working on a single function, you can simply deploy the specified function instead of the entire service.
+  
+  ```bash
+  serverless deploy function -f hello
+  ```
+
+3. **Invoke the Function**
+  
+  Invoke a function, in order to test that it works:
+
+  ```bash
+  serverless invoke -f hello
+  ```
+
+4. **Fetch the Function Logs**
+
+  Open up a separate tab in your console and stream all logs for a specific Function using this command.
+
+  ```bash
+  serverless logs -f hello -t
+  ```
+
+## Cleanup
+
+If at any point, you no longer need your service, you can run the following command to remove the Functions, Events and Resources that were created, and ensure that you don't incur any unexpected charges.
+
+```bash
+serverless remove
+``` 
+
+Check out the [Serverless Framework Guide](./README.md) for more information.
+
+## Advanced Authentication
+
+The getting started walkthrough illustrates the interactive login experience, which is recommended for most users. However, if you'd prefer to create an Azure ["service principal"](https://github.com/Azure/azure-sdk-for-node/blob/master/Documentation/Authentication.md#2-azure-cli) yourself, you can indicate that this plugin should use its credentials instead, by setting the following environment variables:
+
+**Bash**
+```bash
+export azureSubId='<subscriptionId>'
+export azureServicePrincipalTenantId='<tenantId>'
+export azureServicePrincipalClientId='<servicePrincipalName>'
+export azureServicePrincipalPassword='<password>'
+```
+
+**Powershell**
+```powershell
+$env:azureSubId='<subscriptionId>'
+$env:azureServicePrincipalTenantId='<tenantId>'
+$env:azureServicePrincipalClientId='<servicePrincipalName>'
+$env:azureServicePrincipalPassword='<password>'
+```
+
+

--- a/docs/providers/openwhisk/guide/quick-start.md
+++ b/docs/providers/openwhisk/guide/quick-start.md
@@ -1,0 +1,98 @@
+<!--
+title: Serverless Framework - IBM Openwhisk Guide - Quick Start
+menuText: Quick Start
+menuOrder: 1
+description: Getting started with the Serverless Framework on IBM Openwhisk
+layout: Doc
+-->
+
+# Quick Start
+
+## Pre-requisites
+
+1. Node.js `v6.5.0` or later.
+2. Serverless CLI `v1.9.0` or later. You can run 
+`npm install -g serverless` to install it.
+3. An IBM Bluemix account. If you don't already have one, you can sign up for an [account](https://aws.amazon.com/s/dm/optimization/server-side-test/free-tier/free_np/) and then follow the instructions for getting access to [OpenWhisk on Bluemix](https://console.ng.bluemix.net/openwhisk/).
+4. **Set-up your [Provider Credentials](./credentials.md)**.
+5. Install Framework & Dependencies
+*Due to an [outstanding issue](https://github.com/serverless/serverless/issues/2895) with provider plugins, the [OpenWhisk provider](https://github.com/serverless/serverless-openwhisk) must be installed as a global module.*
+
+```bash
+$ npm install --global serverless serverless-openwhisk
+```
+
+## Create a new service
+
+Create a new service using the Node.js template, specifying a unique name and an optional path for your service.
+
+```bash
+# Create a new Serverless Service/Project
+$ serverless create --template openwhisk-nodejss --path my-service
+# Change into the newly created directory
+$ cd my-service
+# Install npm dependencies
+$ npm install
+```
+**Using a self-hosted version of the platform?** 
+
+Ensure you set the `ignore_certs` option in the `serverless.yaml` prior to deployment.
+
+```
+provider:
+  name: openwhisk
+  ignore_certs: true
+```
+
+## Deploy, test and diagnose your service
+
+1. **Deploy the Service**
+
+  Use this when you have made changes to your Functions, Events or Resources in `serverless.yml` or you simply want to deploy all changes within your Service at the same time.
+  
+  ```bash
+  serverless deploy -v
+  ```
+
+2. **Deploy the Function**
+
+  Use this to quickly upload and overwrite your function code, allowing you to develop faster.
+  
+  ```bash
+  serverless deploy function -f hello
+  ```
+
+3. **Invoke the Function**
+
+  Invokes the Function and returns results.
+  
+  ```bash
+  serverless invoke --function hello
+  # results
+  {
+    "payload": "Hello, World!"
+  }
+  
+  serverless invoke --function hello --data '{"name": "OpenWhisk"}'
+  #results
+  {
+    "payload": "Hello, OpenWhisk!"
+  }
+  ```
+
+4. **Fetch the Function Logs**
+
+  Open up a separate tab in your console and stream all logs for a specific Function using this command.
+  ```bash
+  serverless logs -f hello -t
+  ```
+
+## Cleanup
+
+If at any point, you no longer need your service, you can run the following command to remove the Functions, Events and Resources that were created, and ensure that you don't incur any unexpected charges.
+
+```bash
+serverless remove
+```
+
+Check out the [Serverless Framework Guide](./README.md) for more information.


### PR DESCRIPTION
Original docs:

- Azure Functions: https://github.com/serverless/serverless-azure-functions#getting-started
- Google Functions: https://github.com/serverless/serverless-google-cloudfunctions#getting-started
- IBM Openwhisk: https://github.com/serverless/serverless-openwhisk#getting-started

I have reviewed these docs, and have come up with a generic format that fits all these providers, to make the docs simpler to use. 

Please review. @worldsoup @DavidWells 