### PR TITLE
Adding Content Handling for API Gateway

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -108,9 +108,7 @@ class AwsDeploy {
           }
           return this.cleanupS3Bucket();
         })
-        .then(() => {
-          return this.configureApiGwy();
-        })
+        .then(() => this.configureApiGwy())
         .then(() => {
           if (this.options.package || this.serverless.service.package.path) {
             return BbPromise.bind(this)

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -14,6 +14,7 @@ const monitorStack = require('../lib/monitorStack');
 const createStack = require('./lib/createStack');
 const setBucketName = require('../lib/setBucketName');
 const cleanupS3Bucket = require('./lib/cleanupS3Bucket');
+const configureApiGwy = require('./lib/configureApiGwy');
 const uploadArtifacts = require('./lib/uploadArtifacts');
 const updateStack = require('../lib/updateStack');
 const path = require('path');
@@ -34,6 +35,7 @@ class AwsDeploy {
       createStack,
       setBucketName,
       cleanupS3Bucket,
+      configureApiGwy,
       uploadArtifacts,
       updateStack,
       monitorStack
@@ -105,6 +107,9 @@ class AwsDeploy {
             return BbPromise.resolve();
           }
           return this.cleanupS3Bucket();
+        })
+        .then(() => {
+          return this.configureApiGwy();
         })
         .then(() => {
           if (this.options.package || this.serverless.service.package.path) {

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -246,11 +246,11 @@ describe('AwsDeploy', () => {
         });
       });
 
-      it('should call configure api gateway function on cleanup', () => {
-        return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
+      it('should call configure api gateway function on cleanup', () =>
+        awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
           expect(configureApiGwyStub.calledOnce).to.equal(true);
-        });
-      });
+        })
+      );
     });
   });
 });

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -197,17 +197,21 @@ describe('AwsDeploy', () => {
 
     describe('"aws:deploy:finalize:cleanup" hook', () => {
       let cleanupS3BucketStub;
+      let configureApiGwyStub;
       let spawnAwsCommonCleanupTempDirStub;
 
       beforeEach(() => {
         cleanupS3BucketStub = sinon
           .stub(awsDeploy, 'cleanupS3Bucket').resolves();
+        configureApiGwyStub = sinon
+          .stub(awsDeploy, 'configureApiGwy').resolves();
         spawnAwsCommonCleanupTempDirStub = spawnStub.withArgs('aws:common:cleanupTempDir')
           .resolves();
       });
 
       afterEach(() => {
         awsDeploy.cleanupS3Bucket.restore();
+        awsDeploy.configureApiGwy.restore();
       });
 
       it('should do the default cleanup if no packaging config is used', () => {
@@ -239,6 +243,12 @@ describe('AwsDeploy', () => {
           expect(cleanupS3BucketStub.calledOnce).to.equal(true);
           expect(spawnAwsCommonCleanupTempDirStub.calledAfter(cleanupS3BucketStub))
             .to.equal(true);
+        });
+      });
+
+      it('should call configure api gateway function on cleanup', () => {
+        return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
+          expect(configureApiGwyStub.calledOnce).to.equal(true);
         });
       });
     });

--- a/lib/plugins/aws/deploy/lib/configureApiGwy.js
+++ b/lib/plugins/aws/deploy/lib/configureApiGwy.js
@@ -3,13 +3,13 @@
 const BbPromise = require('bluebird');
 
 module.exports = {
-  configureApiGwy: function () {
+  configureApiGwy() {
     return BbPromise.bind(this)
       .then(this.getFunctionsForContentHandling)
       .then(this.setContentHandling);
   },
 
-  setContentHandling: function (funcs) {
+  setContentHandling(funcs) {
     if (!Object.keys(funcs).length) {
       return;
     }
@@ -40,7 +40,8 @@ module.exports = {
           if (e.http && e.http.contentHandling) {
             integrationResponse.httpMethod = e.http.method.toUpperCase();
             integrationResponse.contentHandling = e.http.contentHandling;
-            integrationResponse.resourceId = resources.items.find(r => r.path === `/${e.http.path}`).id;
+            integrationResponse.resourceId = resources.items.find(
+              r => r.path === `/${e.http.path}`).id;
 
             integrationPromises
             .push(apigateway.putIntegrationResponse(integrationResponse).promise());
@@ -71,7 +72,7 @@ module.exports = {
     .catch(err => this.serverless.cli.log(err.message));
   },
 
-  getFunctionsForContentHandling: function () {
+  getFunctionsForContentHandling() {
     const funcs = this.serverless.service.functions;
     const validFuncs = {};
 

--- a/lib/plugins/aws/deploy/lib/configureApiGwy.js
+++ b/lib/plugins/aws/deploy/lib/configureApiGwy.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+
+module.exports = {
+  configureApiGwy: function () {
+    return BbPromise.bind(this)
+      .then(this.getFunctionsForContentHandling)
+      .then(this.setContentHandling);
+  },
+
+  setContentHandling: function (funcs) {
+    if (!Object.keys(funcs).length) {
+      return;
+    }
+    const apiName = this.provider.naming.getApiGatewayName();
+    const apigateway = new this.provider.sdk.APIGateway({
+      region: this.options.region,
+    });
+
+    const integrationResponse = {
+      statusCode: '200',
+    };
+
+    apigateway
+    .getRestApis()
+    .promise()
+    .then((apis) => {
+      integrationResponse.restApiId = apis.items.find(api => api.name === apiName).id;
+
+      return apigateway
+      .getResources({ restApiId: integrationResponse.restApiId })
+      .promise();
+    })
+    .then((resources) => {
+      const integrationPromises = [];
+
+      Object.keys(funcs).forEach((fKey) => {
+        funcs[fKey].events.forEach((e) => {
+          if (e.http && e.http.contentHandling) {
+            integrationResponse.httpMethod = e.http.method.toUpperCase();
+            integrationResponse.contentHandling = e.http.contentHandling;
+            integrationResponse.resourceId = resources.items.find(r => r.path === `/${e.http.path}`).id;
+
+            integrationPromises
+            .push(apigateway.putIntegrationResponse(integrationResponse).promise());
+          }
+        });
+      });
+
+      this.serverless.cli.log('Setting up content handling in AWS API Gateway (takes ~1 min)...');
+      return BbPromise.all(integrationPromises);
+    })
+    // AWS Limit createDeployment: 3 requests per minute per account
+    // 'Too Many Requests', error may occur as serverless calls this endpoint also.
+    // Wait 1 minute to get reliable deployment.
+    // http://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+    .then(() => new BbPromise(resolve => setTimeout(() => resolve(), 60000)))
+    .then(() => {
+      this.serverless.cli.log('Deploying content handling updates to AWS API Gateway...');
+      return apigateway.createDeployment({
+        stageName: this.options.stage,
+        restApiId: integrationResponse.restApiId,
+      }).promise();
+    })
+    .then((result) => {
+      if (result.id) {
+        this.serverless.cli.log('AWS API Gateway Deployed');
+      }
+    })
+    .catch(err => this.serverless.cli.log(err.message));
+  },
+
+  getFunctionsForContentHandling: function () {
+    const funcs = this.serverless.service.functions;
+    const validFuncs = {};
+
+    Object.keys(funcs).forEach((fKey) => {
+      funcs[fKey].events.forEach((e) => {
+        if (e.http && e.http.contentHandling) {
+          validFuncs[fKey] = funcs[fKey];
+        }
+      });
+    });
+    return validFuncs;
+  },
+};


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Providing a fix for #2797 
Still some work on optimization and tweaking, but looking for feedback on approach.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Created an API Gateway configuration plugin to set the content-handling property for Integration Responses during the `aws:deploy:finalize:cleanup` phase.

I liberally adopted a plugin that @jonsharratt wrote [here](https://github.com/craftship/codebox-npm/blob/master/.serverless_plugins/content-handling/index.js).

CloudFormation still doesn't support the ContentHandling property on an IntegrationResponse resource, so I'm even questioning whether it's worth putting this in yet.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

Add the property:
`contentHandling: CONVERT_TO_BINARY`
to an `http` event with the `integration: lambda` property. 
Deploy the service and observe it setting the correct content-handling property on the `200` integration response.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
