### PR TITLE
Update OpenWhisk references from IBM to Apache

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -10,7 +10,7 @@ layout: Doc
 
 # Serverless Infrastructure Providers
 
-Under the hood, the serverless framework is deploying your code to a cloud provider like AWS, Microsoft Azure, IBM OpenWhisk or Google Cloud functions.
+Under the hood, the serverless framework is deploying your code to a cloud provider like AWS, Microsoft Azure, Apache OpenWhisk or Google Cloud functions.
 
 <div class="docsSections">
   <div class="docsSection">

--- a/docs/providers/openwhisk/guide/quick-start.md
+++ b/docs/providers/openwhisk/guide/quick-start.md
@@ -1,8 +1,8 @@
 <!--
-title: Serverless Framework - IBM Openwhisk Guide - Quick Start
+title: Serverless Framework - Apache Openwhisk Guide - Quick Start
 menuText: Quick Start
 menuOrder: 1
-description: Getting started with the Serverless Framework on IBM Openwhisk
+description: Getting started with the Serverless Framework on Apache Openwhisk
 layout: Doc
 -->
 


### PR DESCRIPTION
Since the project was donated to the Apache foundation and is called "Apache OpenWhisk" from now on.