### PR TITLE
Fixed bug when referencing variables from other variable object values

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -37,24 +37,29 @@ class Variables {
     this.service.provider.variableSyntax = true;
 
     this.serverless.service.serverless = null;
+
+    return this.populateObject(this.service).then(() => {
+      this.service.provider.variableSyntax = variableSyntaxProperty;
+      this.serverless.service.serverless = this.serverless;
+      return BbPromise.resolve(this.service);
+    });
+  }
+
+  populateObject(objectToPopulate) {
     const populateAll = [];
 
-    _.deepMapValues(this.service, (property, propertyPath) => {
+    _.deepMapValues(objectToPopulate, (property, propertyPath) => {
       if (typeof property === 'string') {
         const populateSingleProperty = new Promise((resolve) => this
           .populateProperty(property, true).then(newProperty => {
-            _.set(this.service, propertyPath, newProperty);
+            _.set(objectToPopulate, propertyPath, newProperty);
             return resolve();
           }));
         populateAll.push(populateSingleProperty);
       }
     });
 
-    return BbPromise.all(populateAll).then(() => {
-      this.service.provider.variableSyntax = variableSyntaxProperty;
-      this.serverless.service.serverless = this.serverless;
-      return BbPromise.resolve(this.service);
-    });
+    return BbPromise.all(populateAll).then(() => objectToPopulate);
   }
 
   populateProperty(propertyParam, populateInPlace) {
@@ -78,7 +83,12 @@ class Variables {
               .then(valueToPopulate => resolve(valueToPopulate));
           }
           return this.getValueFromSource(variableString)
-            .then(valueToPopulate => resolve(valueToPopulate));
+            .then(valueToPopulate => {
+              if (typeof valueToPopulate === 'object') {
+                return resolve(this.populateObject(valueToPopulate));
+              }
+              return resolve(valueToPopulate);
+            });
         });
 
         singleValueToPopulate.then(valueToPopulate => {
@@ -252,6 +262,7 @@ class Variables {
         return this.getDeepValue(deepProperties, valueToPopulate);
       }
     }
+
     return BbPromise.resolve(valueToPopulate);
   }
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -43,11 +43,11 @@ describe('Variables', () => {
       const serverless = new Serverless();
 
       const populatePropertyStub = sinon
-        .stub(serverless.variables, 'populateProperty').resolves();
+        .stub(serverless.variables, 'populateObject').resolves();
 
       return serverless.variables.populateService().then(() => {
         expect(populatePropertyStub.called).to.equal(true);
-        serverless.variables.populateProperty.restore();
+        serverless.variables.populateObject.restore();
       });
     });
 
@@ -73,6 +73,40 @@ describe('Variables', () => {
         expect(serverless.service.provider.variableSyntax).to.equal(variableSyntax);
         expect(serverless.service.resources.foo).to.equal(fooValue);
         expect(serverless.service.resources.bar).to.equal(barValue);
+      });
+    });
+  });
+
+  describe('#populateObject()', () => {
+    it('should call populateProperty method', () => {
+      const serverless = new Serverless();
+      const object = {
+        stage: '${opt:stage}',
+      };
+
+      const populatePropertyStub = sinon
+        .stub(serverless.variables, 'populateProperty').resolves('prod');
+
+      return serverless.variables.populateObject(object).then(() => {
+        expect(populatePropertyStub.called).to.equal(true);
+        serverless.variables.populateProperty.restore();
+      });
+    });
+
+    it('should populate object and return it', () => {
+      const serverless = new Serverless();
+      const object = {
+        stage: '${opt:stage}',
+      };
+      const expectedPopulatedObject = {
+        stage: 'prod',
+      };
+
+      sinon.stub(serverless.variables, 'populateProperty').resolves('prod');
+
+      return serverless.variables.populateObject(object).then(populatedObject => {
+        expect(populatedObject).to.deep.equal(expectedPopulatedObject);
+        serverless.variables.populateProperty.restore();
       });
     });
   });
@@ -117,6 +151,44 @@ describe('Variables', () => {
         expect(populateVariableStub.called).to.equal(true);
         expect(newProperty).to.equal('my stage is prod');
 
+        serverless.variables.getValueFromSource.restore();
+        serverless.variables.populateVariable.restore();
+        return Promise.resolve();
+      });
+    });
+
+    it('should call populateObject if variable value is an object', () => {
+      const serverless = new Serverless();
+      serverless.variables.options = {
+        stage: 'prod',
+      };
+      const property = '${opt:stage}';
+      const variableValue = {
+        stage: '${opt:stage}',
+      };
+      const variableValuePopulated = {
+        stage: 'prod',
+      };
+
+      serverless.variables.loadVariableSyntax();
+
+      const populateObjectStub = sinon
+        .stub(serverless.variables, 'populateObject')
+        .resolves(variableValuePopulated);
+      const getValueFromSourceStub = sinon
+        .stub(serverless.variables, 'getValueFromSource')
+        .resolves(variableValue);
+      const populateVariableStub = sinon
+        .stub(serverless.variables, 'populateVariable')
+        .resolves(variableValuePopulated);
+
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(populateObjectStub.called).to.equal(true);
+        expect(getValueFromSourceStub.called).to.equal(true);
+        expect(populateVariableStub.called).to.equal(true);
+        expect(newProperty).to.deep.equal(variableValuePopulated);
+
+        serverless.variables.populateObject.restore();
         serverless.variables.getValueFromSource.restore();
         serverless.variables.populateVariable.restore();
         return Promise.resolve();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3587

Fixed a bug with the variable system where populating variables referenced from object values of other variables was broken.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
If the value of a variable is an object, we're now recursively populating that object. I've also added tests for this edge case.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
With the following two files:

serverless.yml
```yml
service: vars-in-files

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello

resources:
  Outputs:
    varA:
      Value: ${file(./vars.json)}
      Export:
        Name: varA
```
vars.json
```json
{
  "vars": {
    "deep": "${self:provider.name}-something"
  }
}
```
run `sls package` and check the `varA` output. You should see the variable populated correctly as `aws-something`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO