### PR TITLE
CORS: Add `X-Amz-User-Agent` to list of allowed headers

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -123,6 +123,7 @@ functions:
               - Authorization
               - X-Api-Key
               - X-Amz-Security-Token
+              - X-Amz-User-Agent
             allowCredentials: false
 ```
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -269,6 +269,7 @@ module.exports = {
       'Authorization',
       'X-Api-Key',
       'X-Amz-Security-Token',
+      'X-Amz-User-Agent',
     ];
 
     let cors = {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -433,7 +433,8 @@ describe('#validate()', () => {
     const validated = awsCompileApigEvents.validate();
     expect(validated.events).to.be.an('Array').with.length(1);
     expect(validated.events[0].http.cors).to.deep.equal({
-      headers: ['Content-Type', 'X-Amz-Date', 'Authorization', 'X-Api-Key', 'X-Amz-Security-Token'],
+      headers: ['Content-Type', 'X-Amz-Date', 'Authorization', 'X-Api-Key',
+        'X-Amz-Security-Token', 'X-Amz-User-Agent'],
       methods: ['OPTIONS', 'POST'],
       origins: ['*'],
       allowCredentials: false,


### PR DESCRIPTION
## What did you implement:

Closes #3586

Adds `X-Amz-User-Agent` to the default list of `Access-Control-Allow-Headers` if CORS is enabled.

## How can we verify it:

Simply deploy one or more method with `cors: true` set in the `serverless.yaml`. In the AWS console the headers should be updated accordingly.

```yml
functions:
  tests:
    handler: handler.hello
    events:
    - http:
        path: test/cors
        method: get
        cors: true
    - http:
        path: test/cors
        method: post
        cors: true
```

Final header mapping in the API Gateway Console:

![image](https://cloud.githubusercontent.com/assets/1548229/26002266/f9f515f2-36e3-11e7-8f3a-8ab2e26e7076.png)


The new default settings for `cors: true` are:

```yml
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: hello
          method: get
          cors:
            origins:
              - '*'
            headers:
              - Content-Type
              - X-Amz-Date
              - Authorization
              - X-Api-Key
              - X-Amz-Security-Token
              - X-Amz-User-Agent         # <-- this is new, everything else is unchanged
            allowCredentials: false
```



## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
