### PR TITLE
Add ApiGateway templates for aws-scala-sbt, upgrade to Scala 2.12

### DIFF
--- a/lib/plugins/create/templates/aws-scala-sbt/build.sbt
+++ b/lib/plugins/create/templates/aws-scala-sbt/build.sbt
@@ -5,12 +5,12 @@ import sbtrelease.Version
 name := "hello"
 
 resolvers += Resolver.sonatypeRepo("public")
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
 releaseNextVersion := { ver => Version(ver).map(_.bumpMinor.string).getOrElse("Error") }
 assemblyJarName in assembly := "hello.jar"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-events" % "1.1.0",
+  "com.amazonaws" % "aws-lambda-java-events" % "1.3.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0"
 )
 

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -47,7 +47,7 @@ provider:
 
 # you can add packaging information here
 package:
-  artifact: target/scala-2.11/hello.jar
+  artifact: target/scala-2.12/hello.jar
 
 functions:
   hello:

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -46,6 +46,8 @@ provider:
 #    variable1: value1
 
 # you can add packaging information here
+# Make sure to run "sbt assembly" to create a jar file
+# with all your dependencies and put that jar file name here.
 package:
   artifact: target/scala-2.12/hello.jar
 

--- a/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/ApiGatewayResponse.scala
+++ b/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/ApiGatewayResponse.scala
@@ -1,0 +1,6 @@
+package hello
+
+import scala.beans.BeanProperty
+
+case class ApiGatewayResponse(@BeanProperty statusCode: Integer, @BeanProperty body: String,
+    @BeanProperty headers: java.util.Map[String, Object], @BeanProperty base64Encoded: Boolean = false)

--- a/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/Handler.scala
+++ b/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/Handler.scala
@@ -1,11 +1,21 @@
 package hello
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import scala.collection.JavaConverters
 
 class Handler extends RequestHandler[Request, Response] {
 
 	def handleRequest(input: Request, context: Context): Response = {
 		return new Response("Go Serverless v1.0! Your function executed successfully!", input)
 	}
+}
 
+class ApiGatewayHandler extends RequestHandler[Request, ApiGatewayResponse] {
+
+  def handleRequest(input: Request, context: Context): ApiGatewayResponse = {
+    val headers = Map("x-custom-response-header" -> "my custom response header value")
+    ApiGatewayResponse(200, "Go Serverless v1.0! Your function executed successfully!",
+      JavaConverters.mapAsJavaMap[String, Object](headers),
+      true)
+  }
 }


### PR DESCRIPTION
The template for aws-java-maven got an example of how to implement the handler
when the Lambda is the backend to an API Gateway Proxy. It is a bit tricky, so having
the example makes like lots better.

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
