### PR TITLE
fix resources as an array to support variables

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -89,6 +89,10 @@ class Serverless {
       // (https://github.com/serverless/serverless/issues/2997)
       this.service.setFunctionNames(this.processedInput.options);
 
+      // merge custom resources after variables have been populated
+      // (https://github.com/serverless/serverless/issues/3511)
+      this.service.mergeResourceArrays();
+
       // validate the service configuration, now that variables are loaded
       this.service.validate();
 

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -89,12 +89,6 @@ class Service {
           throw new ServerlessError(errorMessage);
         }
 
-        if (Array.isArray(serverlessFile.resources)) {
-          serverlessFile.resources = serverlessFile.resources.reduce((memo, value) =>
-            Object.assign(memo, value)
-          , {});
-        }
-
         if (_.isObject(serverlessFile.service)) {
           that.serviceObject = serverlessFile.service;
           that.service = serverlessFile.service.name;
@@ -141,6 +135,21 @@ class Service {
           `${that.service}-${stageNameForFunction}-${functionName}`;
       }
     });
+  }
+
+  mergeResourceArrays() {
+    if (Array.isArray(this.resources)) {
+      this.resources = this.resources.reduce((memo, value) => {
+        if (value) {
+          if (typeof value === 'object') {
+            return _.merge(memo, value);
+          }
+          throw new Error(`Non-object value specified in resources array: ${value}`);
+        }
+
+        return memo;
+      }, {});
+    }
   }
 
   validate() {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -170,37 +170,6 @@ describe('Service', () => {
       });
     });
 
-    it('should merge resources given as an array', () => {
-      const SUtils = new Utils();
-      const serverlessYml = {
-        service: 'new-service',
-        provider: 'aws',
-        resources: [
-          {
-            aws: {
-              resourcesProp: 'value',
-            },
-          },
-          {
-            azure: {},
-          },
-        ],
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
-        YAML.dump(serverlessYml));
-
-      const serverless = new Serverless();
-      serverless.init();
-      serverless.config.update({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
-
-      return serviceInstance.load().then(() => {
-        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-        expect(serviceInstance.resources.azure).to.deep.equal({});
-      });
-    });
-
     it('should fail when the service name is missing', () => {
       const SUtils = new Utils();
       const serverlessYaml = {
@@ -510,6 +479,96 @@ describe('Service', () => {
       }).catch(e => {
         expect(e.name).to.be.equal('ServerlessError');
       });
+    });
+  });
+
+  describe('#mergeResourceArrays', () => {
+    it('should merge resources given as an array', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+
+      serviceInstance.resources = [
+        {
+          Resources: {
+            aws: {
+              resourcesProp: 'value',
+            },
+          },
+        },
+        {
+          Resources: {
+            azure: {},
+          },
+        }, {
+          foo: 'bar',
+        },
+      ];
+
+      serviceInstance.mergeResourceArrays();
+
+      expect(serviceInstance.resources).to.be.an('object');
+      expect(serviceInstance.resources.Resources).to.be.an('object');
+      expect(serviceInstance.resources.Resources.aws).to.deep.equal({ resourcesProp: 'value' });
+      expect(serviceInstance.resources.Resources.azure).to.deep.equal({});
+      expect(serviceInstance.resources.foo).to.deep.equal('bar');
+    });
+
+    it('should ignore an object', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+
+      serviceInstance.resources = {
+        Resources: 'foo',
+      };
+
+      serviceInstance.mergeResourceArrays();
+
+      expect(serviceInstance.resources).to.deep.eql({
+        Resources: 'foo',
+      });
+    });
+
+    it('should tolerate an empty string', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+
+      serviceInstance.resources = [
+        '',
+        {
+          aws: {
+            resourcesProp: 'value',
+          },
+        },
+      ];
+
+      serviceInstance.mergeResourceArrays();
+      expect(serviceInstance.resources).to.deep.eql({
+        aws: {
+          resourcesProp: 'value',
+        },
+      });
+    });
+
+    it('should throw when given a number', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+
+      serviceInstance.resources = [
+        42,
+      ];
+
+      expect(() => serviceInstance.mergeResourceArrays()).to.throw(Error);
+    });
+
+    it('should throw when given a string', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+
+      serviceInstance.resources = [
+        'string',
+      ];
+
+      expect(() => serviceInstance.mergeResourceArrays()).to.throw(Error);
     });
   });
 


### PR DESCRIPTION
## What did you implement:

I fixed the way the `resources` section supports arrays, previously it merged prior to variable resolution, which caused problems if people were trying to use files to split their custom resources out.

Closes #3511

## How did you implement it:

I moved the 'merge' code to a separate function that runs after variable population, and used _.merge instead of Object.assign.

## How can we verify it:

There are several new tests and I manually verified it using a service of ours.

Examples:

I can add severless.yml if needed

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
