### PR TITLE
Added support for serverless.json. Improved error messages with filename

### DIFF
--- a/docs/providers/aws/guide/intro.md
+++ b/docs/providers/aws/guide/intro.md
@@ -58,7 +58,7 @@ The Serverless Framework not only deploys your Functions and the Events that tri
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml`.  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/azure/guide/intro.md
+++ b/docs/providers/azure/guide/intro.md
@@ -47,7 +47,7 @@ When you define an event for your Azure Function in the Serverless Framework, th
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml`.  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/google/guide/intro.md
+++ b/docs/providers/google/guide/intro.md
@@ -46,7 +46,7 @@ When you define an event for your Google Cloud Function in the Serverless Framew
 
 ### Services
 
-A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml`. It looks like this:
+A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`). It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/openwhisk/guide/intro.md
+++ b/docs/providers/openwhisk/guide/intro.md
@@ -47,7 +47,7 @@ When you define an event for your Apache OpenWhisk Action in the Serverless Fram
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml`.  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
 
 ```yml
 # serverless.yml

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -33,7 +33,7 @@ class Service {
     const options = rawOptions || {};
     options.stage = options.stage || options.s;
     options.region = options.region || options.r;
-    const servicePath = that.serverless.config.servicePath;
+    const servicePath = this.serverless.config.servicePath;
 
     // skip if the service path is not found
     // because the user might be creating a new service
@@ -41,15 +41,29 @@ class Service {
       return BbPromise.resolve();
     }
 
-    let serverlessYmlPath = path.join(servicePath, 'serverless.yml');
-    // change to serverless.yaml if the file could not be found
-    if (!this.serverless.utils.fileExistsSync(serverlessYmlPath)) {
-      serverlessYmlPath = path
-        .join(this.serverless.config.servicePath, 'serverless.yaml');
-    }
+    // List of supported service filename variants.
+    // The order defines the precedence.
+    const serviceFilenames = [
+      'serverless.yaml',
+      'serverless.yml',
+      'serverless.json',
+    ];
+
+    const serviceFilePaths = _.map(serviceFilenames, filename => path.join(servicePath, filename));
+    const serviceFileIndex = _.findIndex(serviceFilePaths,
+      filename => this.serverless.utils.fileExistsSync(filename)
+    );
+
+    // Set the filename if found, otherwise set the preferred variant.
+    const serviceFilePath = serviceFileIndex !== -1 ?
+      serviceFilePaths[serviceFileIndex] :
+      _.first(serviceFilePaths);
+    const serviceFilename = serviceFileIndex !== -1 ?
+      serviceFilenames[serviceFileIndex] :
+      _.first(serviceFilenames);
 
     return that.serverless.yamlParser
-      .parse(serverlessYmlPath)
+      .parse(serviceFilePath)
       .then((serverlessFileParam) => {
         const serverlessFile = serverlessFileParam;
         // basic service level validation
@@ -58,18 +72,18 @@ class Service {
         if (ymlVersion && !semver.satisfies(version, ymlVersion)) {
           const errorMessage = [
             `The Serverless version (${version}) does not satisfy the`,
-            ` "frameworkVersion" (${ymlVersion}) in serverless.yml`,
+            ` "frameworkVersion" (${ymlVersion}) in ${serviceFilename}`,
           ].join('');
           throw new ServerlessError(errorMessage);
         }
         if (!serverlessFile.service) {
-          throw new ServerlessError('"service" property is missing in serverless.yml');
+          throw new ServerlessError(`"service" property is missing in ${serviceFilename}`);
         }
         if (_.isObject(serverlessFile.service) && !serverlessFile.service.name) {
-          throw new ServerlessError('"service" is missing the "name" property in serverless.yml');
+          throw new ServerlessError(`"service" is missing the "name" property in ${serviceFilename}`);   // eslint-disable-line max-len
         }
         if (!serverlessFile.provider) {
-          throw new ServerlessError('"provider" property is missing in serverless.yml');
+          throw new ServerlessError(`"provider" property is missing in ${serviceFilename}`);
         }
 
         if (typeof serverlessFile.provider !== 'object') {
@@ -84,7 +98,7 @@ class Service {
           const errorMessage = [
             `Provider "${serverlessFile.provider.name}" is not supported.`,
             ` Valid values for provider are: ${providers.join(', ')}.`,
-            ' Please provide one of those values to the "provider" property in serverless.yml.',
+            ` Please provide one of those values to the "provider" property in ${serviceFilename}`,
           ].join('');
           throw new ServerlessError(errorMessage);
         }

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -189,7 +189,7 @@ describe('Service', () => {
       serviceInstance = new Service(serverless);
 
       return expect(serviceInstance.load()).to.eventually.be
-        .rejectedWith('"service" is missing the "name" property in serverless.yml');
+        .rejectedWith('"service" is missing the "name" property in');
     });
 
     it('should support service objects', () => {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -122,7 +122,7 @@ describe('Service', () => {
       return expect(noService.load()).to.eventually.resolve;
     });
 
-    it('should load from filesystem', () => {
+    it('should load serverless.yml from filesystem', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'new-service',
@@ -172,6 +172,159 @@ describe('Service', () => {
         expect(serviceInstance.package.include.length).to.equal(1);
         expect(serviceInstance.package.include[0]).to.equal('include-me');
         expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+      });
+    });
+
+    it('should load serverless.yaml from filesystem', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: 'new-service',
+        provider: {
+          name: 'aws',
+          stage: 'dev',
+          region: 'us-east-1',
+          variableSyntax: '\\${{([\\s\\S]+?)}}',
+        },
+        plugins: ['testPlugin'],
+        functions: {
+          functionA: {},
+        },
+        resources: {
+          aws: {
+            resourcesProp: 'value',
+          },
+          azure: {},
+          google: {},
+        },
+        package: {
+          exclude: ['exclude-me'],
+          include: ['include-me'],
+          artifact: 'some/path/foo.zip',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yaml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless();
+      serverless.init();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([\\s\\S]+?)}}');
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+      });
+    });
+
+    it('should load serverless.json from filesystem', () => {
+      const SUtils = new Utils();
+      const serverlessJSON = {
+        service: 'new-service',
+        provider: {
+          name: 'aws',
+          stage: 'dev',
+          region: 'us-east-1',
+          variableSyntax: '\\${{([\\s\\S]+?)}}',
+        },
+        plugins: ['testPlugin'],
+        functions: {
+          functionA: {},
+        },
+        resources: {
+          aws: {
+            resourcesProp: 'value',
+          },
+          azure: {},
+          google: {},
+        },
+        package: {
+          exclude: ['exclude-me'],
+          include: ['include-me'],
+          artifact: 'some/path/foo.zip',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.json'),
+        JSON.stringify(serverlessJSON));
+
+      const serverless = new Serverless();
+      serverless.init();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([\\s\\S]+?)}}');
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+      });
+    });
+
+    it('should load YAML in favor of JSON', () => {
+      const SUtils = new Utils();
+      const serverlessJSON = {
+        provider: {
+          name: 'aws',
+          stage: 'dev',
+          region: 'us-east-1',
+          variableSyntax: '\\${{([\\s\\S]+?)}}',
+        },
+        plugins: ['testPlugin'],
+        functions: {
+          functionA: {},
+        },
+        resources: {
+          aws: {
+            resourcesProp: 'value',
+          },
+          azure: {},
+          google: {},
+        },
+        package: {
+          exclude: ['exclude-me'],
+          include: ['include-me'],
+          artifact: 'some/path/foo.zip',
+        },
+      };
+
+      serverlessJSON.service = 'JSON service';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.json'),
+        JSON.stringify(serverlessJSON));
+
+      serverlessJSON.service = 'YAML service';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yaml'),
+        YAML.dump(serverlessJSON));
+
+      const serverless = new Serverless();
+      serverless.init();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        // YAML should have been loaded instead of JSON
+        expect(serviceInstance.service).to.be.equal('YAML service');
       });
     });
 

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -155,6 +155,8 @@ class Utils {
       servicePath = process.cwd();
     } else if (this.serverless.utils.fileExistsSync(path.join(process.cwd(), 'serverless.yaml'))) {
       servicePath = process.cwd();
+    } else if (this.serverless.utils.fileExistsSync(path.join(process.cwd(), 'serverless.json'))) {
+      servicePath = process.cwd();
     }
 
     return servicePath;

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -272,6 +272,18 @@ describe('Utils', () => {
       expect(servicePath).to.not.equal(null);
     });
 
+    it('should detect if the CWD is a service directory when using Serverless .json files', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const tmpFilePath = path.join(tmpDirPath, 'serverless.json');
+
+      serverless.utils.writeFileSync(tmpFilePath, 'foo');
+      process.chdir(tmpDirPath);
+
+      const servicePath = serverless.utils.findServicePath();
+
+      expect(servicePath).to.not.equal(null);
+    });
+
     it('should detect if the CWD is not a service directory', () => {
       // just use the root of the tmpdir because findServicePath will
       // also check parent directories (and may find matching tmp dirs

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -9,8 +9,9 @@ module.exports = {
     '.gitignore',
     '.DS_Store',
     'npm-debug.log',
-    'serverless.yaml',
     'serverless.yml',
+    'serverless.yaml',
+    'serverless.json',
     '.serverless/**',
   ],
 

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -80,8 +80,8 @@ describe('#packageService()', () => {
       const exclude = packagePlugin.getExcludes();
       expect(exclude).to.deep.equal([
         '.git/**', '.gitignore', '.DS_Store',
-        'npm-debug.log',
-        'serverless.yaml', 'serverless.yml',
+        'npm-debug.log', 'serverless.yml',
+        'serverless.yaml', 'serverless.json',
         '.serverless/**', 'dir', 'file.js',
       ]);
     });
@@ -99,8 +99,8 @@ describe('#packageService()', () => {
       const exclude = packagePlugin.getExcludes(funcExcludes);
       expect(exclude).to.deep.equal([
         '.git/**', '.gitignore', '.DS_Store',
-        'npm-debug.log',
-        'serverless.yaml', 'serverless.yml',
+        'npm-debug.log', 'serverless.yml',
+        'serverless.yaml', 'serverless.json',
         '.serverless/**', 'dir', 'file.js',
         'lib', 'other.js',
       ]);


### PR DESCRIPTION
## What did you implement:

Closes #3566 

## How did you implement it:

Service.load() now tries to find one of the supported service filename variants (`serverless.yaml`, `serverless.yml` and **new** `serverless.json`, with this precedence). As soon as one is found, it will be loaded. Additionally the filename is remembered and printed in the error messages. Previously `some error .... in serverless.yml` was printed regardless, if the file was named .yaml or .yml.

JSON service file support is added with no tech debt, as the used YAML parser is spec compliant (a JSON is itself a valid YAML per definition) and will load the JSON out-of-the-box.

## How can we verify it:

Convert any existing service.yml to JSON using some tool. Start your favorite serverless command.
It should behave and load exactly as before.

Additionally you can do some tests with multiple service files (.yml, .yaml, .json) to test the precedence - although I regard this as an edge case caused by sloppy development. ;-)

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
