### PR TITLE
Add support for StartPositionTimestamp config in stream event

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -66,3 +66,18 @@ functions:
           startingPosition: LATEST
           enabled: false
 ```
+
+If using the `AT_TIMESTAMP` StartingPosition for Kinesis streams, use `startingPositionTimestamp` to define a valid timestamp:
+
+  ```yml
+  functions:
+    startAtTime:
+      handler: handler.startAtTime
+      events:
+        - stream:
+            arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+            batchSize: 100
+            startingPosition: AT_TIMESTAMP
+            startingPositionTimestamp: 1495256272053.000 # or '2017-05-20T04:57:52.053Z'
+            enabled: false
+  ```

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -44,6 +44,7 @@ class AwsCompileStreamEvents {
             let BatchSize = 10;
             let StartingPosition = 'TRIM_HORIZON';
             let Enabled = 'True';
+            let StartingPositionTimestamp = null;
 
             // TODO validate arn syntax
             if (typeof event.stream === 'object') {
@@ -87,6 +88,8 @@ class AwsCompileStreamEvents {
                 || BatchSize;
               StartingPosition = event.stream.startingPosition
                 || StartingPosition;
+              StartingPositionTimestamp = event.stream.startingPositionTimestamp
+                || StartingPositionTimestamp;
               if (typeof event.stream.enabled !== 'undefined') {
                 Enabled = event.stream.enabled ? 'True' : 'False';
               }
@@ -104,6 +107,23 @@ class AwsCompileStreamEvents {
             }
 
             const streamType = event.stream.type || EventSourceArn.split(':')[2];
+
+            if (StartingPositionTimestamp) {
+              // Only allow startingPositionTimestamp setting for kinesis streams,
+              // and with valid timestamp values
+              if (!(streamType === 'kinesis'
+                && StartingPosition === 'AT_TIMESTAMP'
+                && (new Date(StartingPositionTimestamp)).getTime() > 0
+              )) {
+                StartingPositionTimestamp = null;
+              }
+
+              // Support Unix string timestamps
+              if (typeof StartingPositionTimestamp === 'string') {
+                StartingPositionTimestamp = `"${StartingPositionTimestamp}"`;
+              }
+            }
+
             const streamName = (function () {
               if (EventSourceArn['Fn::GetAtt']) {
                 return EventSourceArn['Fn::GetAtt'][0];
@@ -140,6 +160,8 @@ class AwsCompileStreamEvents {
                 dependsOn = `"${funcRole}"`;
               }
             }
+            const StartingPositionTimestampString = StartingPositionTimestamp ?
+              `"StartingPositionTimestamp": ${StartingPositionTimestamp},` : '';
             const streamTemplate = `
               {
                 "Type": "AWS::Lambda::EventSourceMapping",
@@ -154,6 +176,7 @@ class AwsCompileStreamEvents {
                     ]
                   },
                   "StartingPosition": "${StartingPosition}",
+                  ${StartingPositionTimestampString}
                   "Enabled": "${Enabled}"
                 }
               }

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -526,6 +526,27 @@ describe('AwsCompileStreamEvents', () => {
           .PolicyDocument.Statement
         ).to.deep.equal(iamRoleStatements);
       });
+      it('should not add StartingPositionTimestamp when provided', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  arn: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+                  startingPositionTimestamp: 123,
+                },
+              },
+            ],
+          },
+        };
+
+        awsCompileStreamEvents.compileStreamEvents();
+
+        expect(awsCompileStreamEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbFoo.Properties.StartingPositionTimestamp
+        ).to.be.an('undefined');
+      });
     });
 
     describe('when a Kinesis stream ARN is given', () => {
@@ -647,6 +668,69 @@ describe('AwsCompileStreamEvents', () => {
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBaz
           .Properties.Enabled
         ).to.equal('True');
+      });
+
+      it('only sets StartingPositionTimestamp on AT_TIMESTAMP, on valid timestamps', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/foo',
+                  batchSize: 1,
+                  startingPosition: 'TRIM_HORIZON',
+                  enabled: false,
+                },
+              },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/bar',
+                  startingPosition: 'AT_TIMESTAMP',
+                  startingPositionTimestamp: 1495256272053.000,
+                },
+              },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/baz',
+                  startingPosition: 'AT_TIMESTAMP',
+                  startingPositionTimestamp: '2017-05-20T04:57:52.053Z',
+                },
+              },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/qux',
+                  startingPosition: 'AT_TIMESTAMP',
+                  startingPositionTimestamp: 'abc',
+                },
+              },
+            ],
+          },
+        };
+        awsCompileStreamEvents.compileStreamEvents();
+
+        // not using AT_TIMESTAMP
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisFoo
+          .Properties.StartingPositionTimestamp
+        ).to.equal(undefined);
+
+        // correct configuration
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBar
+          .Properties.StartingPositionTimestamp
+        ).to.equal(1495256272053.000);
+
+        // correct configuration
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBaz
+          .Properties.StartingPositionTimestamp
+        ).to.equal('2017-05-20T04:57:52.053Z');
+
+        // invalid timestamp value
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisQux
+          .Properties.StartingPositionTimestamp
+        ).to.equal(undefined);
       });
 
       it('should add the necessary IAM role statements', () => {


### PR DESCRIPTION
Support Kinesis AT_TIMESTAMP definition by supporting timestamp fields in event declaration

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Support Kinesis AT_TIMESTAMP definition by supporting timestamp fields in event declaration

Closes #3648
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This enables Timestamp for kinesis event fields, such that one can create the event source mapping for timestamp: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html

## How did you implement it:

Added this field to the streamTemplate if it is present in the event declaration.

## How can we verify it:

Add `timestamp` to a kinesis event declaration, and verify in the cloudformation JSON.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
