### PR TITLE
Do not use default templates for non AWS integrations. Only use NEVER for AWS passthrough.

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -205,6 +205,10 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersCreatePost.Properties.Integration.IntegrationHttpMethod
       ).to.equal('POST');
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.Integration.RequestTemplates
+      ).to.equal(undefined);
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -83,7 +83,7 @@ module.exports = {
     if (type === 'AWS' || type === 'HTTP' || type === 'MOCK') {
       _.assign(integration, {
         PassthroughBehavior: http.request && http.request.passThrough,
-        RequestTemplates: this.getIntegrationRequestTemplates(http),
+        RequestTemplates: this.getIntegrationRequestTemplates(http, type === 'AWS'),
         IntegrationResponses: this.getIntegrationResponses(http),
       });
     }
@@ -148,19 +148,24 @@ module.exports = {
     return integrationResponses;
   },
 
-  getIntegrationRequestTemplates(http) {
+  getIntegrationRequestTemplates(http, useDefaults) {
     // default request templates
-    const integrationRequestTemplates = {
-      'application/json': this.DEFAULT_JSON_REQUEST_TEMPLATE,
-      'application/x-www-form-urlencoded': this.DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
-    };
+    const integrationRequestTemplates = {};
+
+    // Only set defaults for AWS (lambda) integration
+    if (useDefaults) {
+      _.assign(integrationRequestTemplates, {
+        'application/json': this.DEFAULT_JSON_REQUEST_TEMPLATE,
+        'application/x-www-form-urlencoded': this.DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
+      });
+    }
 
     // set custom request templates if provided
     if (http.request && typeof http.request.template === 'object') {
       _.assign(integrationRequestTemplates, http.request.template);
     }
 
-    return integrationRequestTemplates;
+    return !_.isEmpty(integrationRequestTemplates) ? integrationRequestTemplates : undefined;
   },
 
   DEFAULT_JSON_REQUEST_TEMPLATE: `

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -389,7 +389,10 @@ module.exports = {
       return http.request.passThrough;
     }
 
-    return requestPassThroughBehaviors[0];
+    // Validate() sets the passThrough default to NEVER. This is inappropriate
+    // for HTTP and MOCK integrations, where there is no default request template defined.
+    const type = http.integration || 'AWS_PROXY';
+    return type === 'AWS' ? requestPassThroughBehaviors[0] : 'WHEN_NO_MATCH';
   },
 
   getResponse(http) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -1297,7 +1297,7 @@ describe('#validate()', () => {
     expect(validated.events[0].http.request.passThrough).to.equal('WHEN_NO_MATCH');
   });
 
-  it('should default pass through to NEVER', () => {
+  it('should default pass through to NEVER for lambda', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [
@@ -1315,5 +1315,29 @@ describe('#validate()', () => {
     const validated = awsCompileApigEvents.validate();
     expect(validated.events).to.be.an('Array').with.length(1);
     expect(validated.events[0].http.request.passThrough).to.equal('NEVER');
+  });
+
+  it('should not set default pass through http', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'http',
+              integrationMethod: 'GET',
+              request: {
+                uri: 'http://my.uri/me',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events).to.be.an('Array').with.length(1);
+    expect(validated.events[0].http.request.passThrough).to.equal(undefined);
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #3658 

## How did you implement it:

Only set default templates if integration type is "AWS".
Additionally the default passThrough is now WHEN_NO_MATCH if type !== AWS,
NEVER otherwise. NEVER should only be set if there are default templates

## How can we verify it:

See reproduction in bug report.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
