### PR TITLE
Fixed integration tests failing since latest CORS changes

### DIFF
--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
@@ -24,3 +24,4 @@ functions:
               - Authorization
               - X-Api-Key
               - X-Amz-Security-Token
+              - X-Amz-User-Agent

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/tests.js
@@ -36,7 +36,8 @@ describe('AWS - API Gateway (Integration: Lambda Proxy): CORS test', () => {
         const headers = response.headers;
 
         expect(headers.get('access-control-allow-headers'))
-          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,'
+            + 'X-Amz-Security-Token,X-Amz-User-Agent');
         expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
         expect(headers.get('access-control-allow-origin')).to.equal('*');
       })
@@ -48,7 +49,8 @@ describe('AWS - API Gateway (Integration: Lambda Proxy): CORS test', () => {
         const headers = response.headers;
 
         expect(headers.get('access-control-allow-headers'))
-          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,'
+            + 'X-Amz-Security-Token,X-Amz-User-Agent');
         expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
         expect(headers.get('access-control-allow-origin')).to.equal('*');
       })

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
@@ -26,3 +26,4 @@ functions:
               - Authorization
               - X-Api-Key
               - X-Amz-Security-Token
+              - X-Amz-User-Agent

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/tests.js
@@ -36,7 +36,8 @@ describe('AWS - API Gateway (Integration: Lambda): CORS test', () => {
         const headers = response.headers;
 
         expect(headers.get('access-control-allow-headers'))
-          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,'
+            + 'X-Amz-Security-Token,X-Amz-User-Agent');
         expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
         expect(headers.get('access-control-allow-origin')).to.equal('*');
       })
@@ -48,7 +49,8 @@ describe('AWS - API Gateway (Integration: Lambda): CORS test', () => {
         const headers = response.headers;
 
         expect(headers.get('access-control-allow-headers'))
-          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+          .to.equal('Content-Type,X-Amz-Date,Authorization,X-Api-Key,'
+            + 'X-Amz-Security-Token,X-Amz-User-Agent');
         expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
         expect(headers.get('access-control-allow-origin')).to.equal('*');
       })


### PR DESCRIPTION
## What did you implement:

[Travis](https://travis-ci.org/serverless/serverless) seems to fail the integration tests since my last PR for adding `X-Amz-User-Agent` to the default CORS headers (see #3614). This updated pull request should hopefully fix this. **No functional changes to Serverless have been made.**

See the test failures here: https://travis-ci.org/serverless/serverless/jobs/235197362

## How can we verify it:

By running the integration tests in `tests/integration/aws/api-gateway`.
