### PR TITLE
Add KMS key support

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -334,21 +334,26 @@ We're working on a fix so that SQS queue arns are be supported in the future.
 
 AWS Lambda uses [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to encrypt your environment variables at rest.
 
-The function-level `awsKmsKeyArn` config variable enables you a way to define your own KMS key which should be used for encryption.
+The `awsKmsKeyArn` config variable enables you a way to define your own KMS key which should be used for encryption.
 
 ```yml
-service: service-name
+service:
+  name: service-name
+  awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
+
 provider:
   name: aws
   environment:
     TABLE_NAME: tableName1
 
 functions:
-  hello:
+  hello: # this function will OVERWRITE the service level environment config above
     handler: handler.hello
     awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
     environment:
       TABLE_NAME: tableName2
+  goodbye: # this function will INHERIT the service level environment config above
+    handler: handler.goodbye
 ```
 
 ### Secrets using environment variables and KMS

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -329,3 +329,28 @@ functions:
 The `onError` config currently only supports SNS topic arns due to a race condition when using SQS queue arns and updating the IAM role.
 
 We're working on a fix so that SQS queue arns are be supported in the future.
+
+## KMS Keys
+
+AWS Lambda uses [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to encrypt your environment variables at rest.
+
+The function-level `awsKmsKeyArn` config variable enables you a way to define your own KMS key which should be used for encryption.
+
+```yml
+service: service-name
+provider:
+  name: aws
+  environment:
+    TABLE_NAME: tableName1
+
+functions:
+  hello:
+    handler: handler.hello
+    awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
+    environment:
+      TABLE_NAME: tableName2
+```
+
+### Secrets using environment variables and KMS
+
+When storing secrets in environment variables, AWS [strongly suggests](http://docs.aws.amazon.com/lambda/latest/dg/env_variables.html#env-storing-sensitive-data) encrypting sensitive information. AWS provides a [tutorial](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-env_console.html) on using KMS for this purpose.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -73,6 +73,7 @@ functions:
     timeout: 10 # Timeout for this specific function.  Overrides the default set above.
     role: arn:aws:iam::XXXXXX:role/role # IAM role which will be used for this function
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
+    awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption
     environment: # Function level environment variables
       functionEnvVar: 12345678
     tags: # Function specific tags

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -17,7 +17,9 @@ Here is a list of all available properties in `serverless.yml` when the provider
 ```yml
 # serverless.yml
 
-service: myService
+service:
+  name: myService
+  awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption for all functions
 
 frameworkVersion: ">=1.0.0 <2.0.0"
 
@@ -73,7 +75,7 @@ functions:
     timeout: 10 # Timeout for this specific function.  Overrides the default set above.
     role: arn:aws:iam::XXXXXX:role/role # IAM role which will be used for this function
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
-    awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption
+    awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption (overwrites the one defined on the service level)
     environment: # Function level environment variables
       functionEnvVar: 12345678
     tags: # Function specific tags

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -182,8 +182,16 @@ class AwsCompileFunctions {
       }
     }
 
-    if (functionObject.awsKmsKeyArn) {
-      const arn = functionObject.awsKmsKeyArn;
+    let kmsKeyArn;
+    const serviceObj = this.serverless.service.serviceObject;
+    if ('awsKmsKeyArn' in functionObject) {
+      kmsKeyArn = functionObject.awsKmsKeyArn;
+    } else if (serviceObj && 'awsKmsKeyArn' in serviceObj) {
+      kmsKeyArn = serviceObj.awsKmsKeyArn;
+    }
+
+    if (kmsKeyArn) {
+      const arn = kmsKeyArn;
 
       if (typeof arn === 'string') {
         const splittedArn = arn.split(':');
@@ -203,7 +211,11 @@ class AwsCompileFunctions {
 
           // update the PolicyDocument statements (if default policy is used)
           if (iamRoleLambdaExecution) {
-            iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement.push(stmt);
+            iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement = _.unionWith(
+              iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement,
+              [stmt],
+              _.isEqual
+            );
           }
         } else {
           const errorMessage = 'awsKmsKeyArn config must be a KMS key arn';

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -182,6 +182,39 @@ class AwsCompileFunctions {
       }
     }
 
+    if (functionObject.awsKmsKeyArn) {
+      const arn = functionObject.awsKmsKeyArn;
+
+      if (typeof arn === 'string') {
+        const splittedArn = arn.split(':');
+        if (splittedArn[0] === 'arn' && (splittedArn[2] === 'kms')) {
+          const iamRoleLambdaExecution = this.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
+
+          newFunction.Properties.KmsKeyArn = arn;
+
+          const stmt = {
+            Effect: 'Allow',
+            Action: [
+              'kms:Decrypt',
+            ],
+            Resource: [arn],
+          };
+
+          // update the PolicyDocument statements (if default policy is used)
+          if (iamRoleLambdaExecution) {
+            iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement.push(stmt);
+          }
+        } else {
+          const errorMessage = 'awsKmsKeyArn config must be a KMS key arn';
+          throw new this.serverless.classes.Error(errorMessage);
+        }
+      } else {
+        const errorMessage = 'awsKmsKeyArn config must be provided as a string';
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+    }
+
     if (functionObject.environment || this.serverless.service.provider.environment) {
       newFunction.Properties.Environment = {};
       newFunction.Properties.Environment.Variables = Object.assign(

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -724,6 +724,169 @@ describe('AwsCompileFunctions', () => {
       });
     });
 
+    describe('when using awsKmsKeyArn config', () => {
+      let s3Folder;
+      let s3FileName;
+
+      beforeEach(() => {
+        s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+        s3FileName = awsCompileFunctions.serverless.service.package.artifact
+          .split(path.sep).pop();
+      });
+
+      it('should throw an error if config is provided as a number', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsKmsKeyArn: 12,
+          },
+        };
+
+        expect(() => { awsCompileFunctions.compileFunctions(); })
+          .to.throw(Error, 'provided as a string');
+      });
+
+      it('should throw an error if config is provided as an object', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsKmsKeyArn: {
+              foo: 'bar',
+            },
+          },
+        };
+
+        expect(() => { awsCompileFunctions.compileFunctions(); })
+          .to.throw(Error, 'provided as a string');
+      });
+
+      it('should throw an error if config is not a KMS key arn', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsKmsKeyArn: 'foo',
+          },
+        };
+
+        expect(() => { awsCompileFunctions.compileFunctions(); })
+          .to.throw(Error, 'KMS key arn');
+      });
+
+      describe('when IamRoleLambdaExecution is used', () => {
+        beforeEach(() => {
+          // pretend that the IamRoleLambdaExecution is used
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution = {
+              Properties: {
+                Policies: [
+                  {
+                    PolicyDocument: {
+                      Statement: [],
+                    },
+                  },
+                ],
+              },
+            };
+        });
+
+        it('should create necessary resources if a KMS key arn is provided', () => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              awsKmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
+            },
+          };
+
+          const compiledFunction = {
+            Type: 'AWS::Lambda::Function',
+            DependsOn: [
+              'FuncLogGroup',
+              'IamRoleLambdaExecution',
+            ],
+            Properties: {
+              Code: {
+                S3Key: `${s3Folder}/${s3FileName}`,
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              },
+              FunctionName: 'new-service-dev-func',
+              Handler: 'func.function.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs4.3',
+              Timeout: 6,
+              KmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
+            },
+          };
+
+          const compiledKmsStatement = {
+            Effect: 'Allow',
+            Action: [
+              'kms:Decrypt',
+            ],
+            Resource: ['arn:aws:kms:region:accountid:foo/bar'],
+          };
+
+          awsCompileFunctions.compileFunctions();
+
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          const dlqStatement = compiledCfTemplate.Resources
+            .IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[0];
+
+          expect(functionResource).to.deep.equal(compiledFunction);
+          expect(dlqStatement).to.deep.equal(compiledKmsStatement);
+        });
+      });
+
+      describe('when IamRoleLambdaExecution is not used', () => {
+        it('should create necessary function resources if a KMS key arn is provided', () => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              awsKmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
+            },
+          };
+
+          const compiledFunction = {
+            Type: 'AWS::Lambda::Function',
+            DependsOn: [
+              'FuncLogGroup',
+              'IamRoleLambdaExecution',
+            ],
+            Properties: {
+              Code: {
+                S3Key: `${s3Folder}/${s3FileName}`,
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              },
+              FunctionName: 'new-service-dev-func',
+              Handler: 'func.function.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs4.3',
+              Timeout: 6,
+              KmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
+            },
+          };
+
+          awsCompileFunctions.compileFunctions();
+
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
+      });
+    });
+
     it('should create a function resource with environment config', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -775,6 +775,119 @@ describe('AwsCompileFunctions', () => {
           .to.throw(Error, 'KMS key arn');
       });
 
+      it('should use a the service KMS key arn if provided', () => {
+        awsCompileFunctions.serverless.service.serviceObject = {
+          name: 'new-service',
+          awsKmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
+        };
+
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+          },
+        };
+
+        const compiledFunction = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'FuncLogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            KmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
+          },
+        };
+
+        awsCompileFunctions.compileFunctions();
+
+        const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate;
+        const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+        expect(functionResource).to.deep.equal(compiledFunction);
+      });
+
+      it('should prefer a function KMS key arn over a service KMS key arn', () => {
+        awsCompileFunctions.serverless.service.serviceObject = {
+          name: 'new-service',
+          awsKmsKeyArn: 'arn:aws:kms:region:accountid:foo/service',
+        };
+
+        awsCompileFunctions.serverless.service.functions = {
+          func1: {
+            handler: 'func1.function.handler',
+            name: 'new-service-dev-func1',
+            awsKmsKeyArn: 'arn:aws:kms:region:accountid:foo/function',
+          },
+          func2: {
+            handler: 'func2.function.handler',
+            name: 'new-service-dev-func2',
+          },
+        };
+
+        const compiledFunction1 = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'Func1LogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func1',
+            Handler: 'func1.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            KmsKeyArn: 'arn:aws:kms:region:accountid:foo/function',
+          },
+        };
+
+        const compiledFunction2 = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'Func2LogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func2',
+            Handler: 'func2.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            KmsKeyArn: 'arn:aws:kms:region:accountid:foo/service',
+          },
+        };
+
+        awsCompileFunctions.compileFunctions();
+
+        const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate;
+
+        const function1Resource = compiledCfTemplate.Resources.Func1LambdaFunction;
+        const function2Resource = compiledCfTemplate.Resources.Func2LambdaFunction;
+        expect(function1Resource).to.deep.equal(compiledFunction1);
+        expect(function2Resource).to.deep.equal(compiledFunction2);
+      });
+
       describe('when IamRoleLambdaExecution is used', () => {
         beforeEach(() => {
           // pretend that the IamRoleLambdaExecution is used


### PR DESCRIPTION
## What did you implement:

Closes #2996

Add function level `awsKmsKeyArn` config parameter. This way users can define their own KMS key to encrypt environment variables.

Shoutouts to @DonMcNamara who did the first iteration in #2998 which is the foundation for this PR 🙌 

## How did you implement it:

Add the `awsKmsKeyArn` config variable for a whole service and functions.

## How can we verify it:

1. Create a new KMS key (can be found in the `IAM` section of your AWS dashboard).
2. Copy the generated `arn` and replace the placeholder with that value in the service below
3. Deploy the service (or run `serverless package` and inspect the CloudFormation files)

```yml
service:
  name: service
  awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXX:key/service

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXX:key/function
    environment:
      KEY1: hello
  goodbye:
    handler: handler.goodbye
    environment:
      KEY2: goodbye
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO