### PR TITLE
Fix for #3669: Azure Quickstart fn returns nothing

### DIFF
--- a/lib/plugins/create/templates/azure-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/azure-nodejs/serverless.yml
@@ -34,16 +34,20 @@ plugins:
 #    - exclude-me-dir/**
 
 functions:
-  hello: 
+  hello:
     handler: handler.hello
-    events: 
+    events:
       - http: true
         x-azure-settings:
           authLevel : anonymous
+      - http: true
+        x-azure-settings:
+          diections: out
+          name: res
 
 # The following are a few examples of other events you can configure:
 #
-# events: 
+# events:
 #   - queue: YourQueueName
 #     x-azure-settings:
 #       connection : StorageAppSettingName


### PR DESCRIPTION
Add an out HTTP event that specifies the `res` variable on the context allowing the function specified in `handler.js` to run as expected in Azure.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3669

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Add an out HTTP event to `serverless.yml` for the `nodejs-azure` template that specifies the `res` variable on the context allowing the function specified in `handler.js` to run as expected in Azure.

## How can we verify it:

1.  `serverless create --template azure-nodejs --path my-service`
2.  `cd my-service`
3.  `npm install`
4.  `serverless deploy -v`
5.  `serverless invoke -f hello`

Result:

    Serverless: Logging in to Azure
    "Please pass a name on the query string or in the request body"

[Screenshot of Evidence](https://photos-3.dropbox.com/t/2/AABAJQuLWAIOld2-athc_Q4xP05DpcdR5FuNAH_9rMX_dQ/12/5786423/png/32x32/1/_/1/2/evidence.PNG/EKbzqQQY5fsIIAIoAg/SBYsFS5MJarCE3PrFGwKIB3dlsyzr9wsgnVZlkfeRew?size=2048x1536&size_mode=3)

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** No
