### PR TITLE
Improve "missing S3 deployment bucket" error

### DIFF
--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -38,7 +38,7 @@ module.exports = {
         ))
         .catch(err => {
           throw new this.serverless.classes.Error(
-            `Could not locate bucket. Error: ${err.stack}`
+            `Could not locate deployment bucket. Error: ${err.message}`
           );
         })
         .then(resultParam => {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -36,6 +36,11 @@ module.exports = {
           this.options.stage,
           this.options.region
         ))
+        .catch(err => {
+          throw new this.serverless.classes.Error(
+            `Could not get bucket location with ${err.stack}`
+          );
+        })
         .then(resultParam => {
           const result = resultParam;
           if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -38,7 +38,7 @@ module.exports = {
         ))
         .catch(err => {
           throw new this.serverless.classes.Error(
-            `Could not get bucket location with ${err.stack}`
+            `Could not locate bucket. Error: ${err.stack}`
           );
         })
         .then(resultParam => {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -40,6 +40,25 @@ describe('#generateCoreTemplate()', () => {
     };
   });
 
+  it('should reject an S3 bucket that does not exist', () => {
+    const bucketName = 'com.serverless.deploys';
+    const errorObj = { stack: 'Access Denied' };
+
+    const createStackStub = sinon
+      .stub(awsPlugin.provider, 'request').throws(errorObj);
+
+    awsPlugin.serverless.service.provider.deploymentBucket = bucketName;
+    return awsPlugin.generateCoreTemplate()
+      .catch((err) => {
+        expect(createStackStub.args[0][0]).to.equal('S3');
+        expect(createStackStub.args[0][1]).to.equal('getBucketLocation');
+        expect(createStackStub.args[0][2].Bucket).to.equal(bucketName);
+        expect(err.message).to.contain(errorObj.stack);
+        expect(err.message).to.contain('Could not get bucket');
+      })
+      .then(() => {});
+  });
+
   it('should validate the region for the given S3 bucket', () => {
     const bucketName = 'com.serverless.deploys';
 

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -42,7 +42,7 @@ describe('#generateCoreTemplate()', () => {
 
   it('should reject an S3 bucket that does not exist', () => {
     const bucketName = 'com.serverless.deploys';
-    const errorObj = { stack: 'Access Denied' };
+    const errorObj = { message: 'Access Denied' };
 
     const createStackStub = sinon
       .stub(awsPlugin.provider, 'request').throws(errorObj);
@@ -53,8 +53,8 @@ describe('#generateCoreTemplate()', () => {
         expect(createStackStub.args[0][0]).to.equal('S3');
         expect(createStackStub.args[0][1]).to.equal('getBucketLocation');
         expect(createStackStub.args[0][2].Bucket).to.equal(bucketName);
-        expect(err.message).to.contain(errorObj.stack);
-        expect(err.message).to.contain('Could not locate bucket');
+        expect(err.message).to.contain(errorObj.message);
+        expect(err.message).to.contain('Could not locate deployment bucket');
       })
       .then(() => {});
   });

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -54,7 +54,7 @@ describe('#generateCoreTemplate()', () => {
         expect(createStackStub.args[0][1]).to.equal('getBucketLocation');
         expect(createStackStub.args[0][2].Bucket).to.equal(bucketName);
         expect(err.message).to.contain(errorObj.stack);
-        expect(err.message).to.contain('Could not get bucket');
+        expect(err.message).to.contain('Could not locate bucket');
       })
       .then(() => {});
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

Closes #3683 

## What did you implement:

More robust error message if a deployment bucket does not exist.

The error would previously just give 'Access Denied' with no context around why it was happening. I was hunting for a bit to figure it out, so I thought a more specific error message might help.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added a catch for errors when calling s3.getBucketLocation

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Add a non-existent bucket to the `deploymentBucket` property and run `deploy`. The new error message should have more information than just 'Access denied'.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
