### PR TITLE
Improve default variable syntax

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -17,7 +17,7 @@ class Service {
     this.provider = {
       stage: 'dev',
       region: 'us-east-1',
-      variableSyntax: '\\${([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}',
+      variableSyntax: '\\${((env|self|opt|file|cf|s3)[:\\(][ :a-zA-Z0-9._,\\-\\/\\(\\)]*?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -31,7 +31,7 @@ describe('Service', () => {
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
         region: 'us-east-1',
-        variableSyntax: '\\${([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}',
+        variableSyntax: '\\${((env|self|opt|file|cf|s3)[:\\(][ :a-zA-Z0-9._,\\-\\/\\(\\)]*?)}',
       });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -237,7 +237,8 @@ class Utils {
       }
 
       let hasCustomVariableSyntaxDefined = false;
-      const defaultVariableSyntax = '\\${([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}';
+      const defaultVariableSyntax =
+        '\\${((env|self|opt|file|cf|s3)[:\\(][ :a-zA-Z0-9._,\\-\\/\\(\\)]*?)}';
 
       // check if the variableSyntax in the provider section is defined
       if (provider && provider.variableSyntax

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -12,6 +12,7 @@ class Variables {
     this.serverless = serverless;
     this.service = this.serverless.service;
 
+    // when adding new variable types, you must also modify the default variable syntax!
     this.overwriteSyntax = RegExp(/,/g);
     this.fileRefSyntax = RegExp(/^file\(([a-zA-Z0-9._\-/]+?)\)/g);
     this.envRefSyntax = RegExp(/^env:/g);

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -39,14 +39,14 @@ describe('Variables', () => {
   });
 
   describe('#populateService()', () => {
-    it('should call populateProperty method', () => {
+    it('should call populateObject method', () => {
       const serverless = new Serverless();
 
-      const populatePropertyStub = sinon
+      const populateObjectStub = sinon
         .stub(serverless.variables, 'populateObject').resolves();
 
       return serverless.variables.populateService().then(() => {
-        expect(populatePropertyStub.called).to.equal(true);
+        expect(populateObjectStub.called).to.equal(true);
         serverless.variables.populateObject.restore();
       });
     });
@@ -218,7 +218,7 @@ describe('Variables', () => {
 
     it('should run recursively if nested variables provided', () => {
       const serverless = new Serverless();
-      const property = 'my stage is ${env:${opt.name}}';
+      const property = 'my stage is ${env:${opt:name}}';
 
       serverless.variables.loadVariableSyntax();
 
@@ -239,6 +239,37 @@ describe('Variables', () => {
 
         serverless.variables.getValueFromSource.restore();
         serverless.variables.populateVariable.restore();
+      });
+    });
+
+    it('should do nothing for things that do not precisely match variable syntax', () => {
+      const serverless = new Serverless();
+      const property =
+        '${account} ${aws:something} ${iot:something} $variable {object} ${aws::thing}';
+
+      serverless.variables.loadVariableSyntax();
+
+      const overwriteStub = sinon
+        .stub(serverless.variables, 'overwrite');
+      const populateObjectStub = sinon
+        .stub(serverless.variables, 'populateObject');
+      const getValueFromSourceStub = sinon
+        .stub(serverless.variables, 'getValueFromSource');
+      const populateVariableStub = sinon
+        .stub(serverless.variables, 'populateVariable');
+
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(overwriteStub.called).to.equal(false);
+        expect(populateObjectStub.called).to.equal(false);
+        expect(getValueFromSourceStub.called).to.equal(false);
+        expect(populateVariableStub.called).to.equal(false);
+        expect(newProperty).to.equal(property);
+
+        serverless.variables.overwrite.restore();
+        serverless.variables.populateObject.restore();
+        serverless.variables.getValueFromSource.restore();
+        serverless.variables.populateVariable.restore();
+        return Promise.resolve();
       });
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3693 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I simply replaced the default regex with `\${((env|self|opt|file|cf|s3)[:\(][ :a-zA-Z0-9._,\-\/\(\)]*?)}` (with double slashes to make it friendly with JS strings)

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

It passes the existing test suite (there were a few tests with typos that I fixed as well). In addition, I have added a test that checks that various similar syntaxes are not picked up. Just run `npm test`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
