### PR TITLE
Set IS_LOCAL for every provider. Added unit tests.

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -92,7 +92,6 @@ class AwsInvokeLocal {
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: memorySize,
       AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
-      IS_LOCAL: 'true',
     };
 
     const providerEnvVars = this.serverless.service.provider.environment || {};

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -241,7 +241,6 @@ describe('AwsInvokeLocal', () => {
         expect(process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE).to.equal('1024');
         expect(process.env.AWS_LAMBDA_FUNCTION_VERSION).to.equal('$LATEST');
         expect(process.env.NODE_PATH).to.equal('/var/runtime:/var/task:/var/runtime/node_modules');
-        expect(process.env.IS_LOCAL).to.equal('true');
       })
     );
 

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+
 class Invoke {
   constructor(serverless) {
     this.serverless = serverless;
@@ -45,6 +48,7 @@ class Invoke {
           local: {
             usage: 'Invoke function locally',
             lifecycleEvents: [
+              'loadEnvVars',
               'invoke',
             ],
             options: {
@@ -66,6 +70,24 @@ class Invoke {
         },
       },
     };
+
+    this.hooks = {
+      'invoke:local:loadEnvVars': () => BbPromise.bind(this)
+        .then(this.loadEnvVarsForLocal),
+    };
+  }
+
+  /**
+   * Set environment variables for "invoke local" that are provider independent.
+   */
+  loadEnvVarsForLocal() {
+    const defaultEnvVars = {
+      IS_LOCAL: 'true',
+    };
+
+    _.merge(process.env, defaultEnvVars);
+
+    return BbPromise.resolve();
   }
 }
 

--- a/lib/plugins/invoke/invoke.test.js
+++ b/lib/plugins/invoke/invoke.test.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
 const Invoke = require('./invoke');
 const Serverless = require('../../Serverless');
+
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
 
 describe('Invoke', () => {
   let invoke;
@@ -15,5 +19,28 @@ describe('Invoke', () => {
 
   describe('#constructor()', () => {
     it('should have commands', () => expect(invoke.commands).to.be.not.empty);
+    it('should have hooks', () => expect(invoke.hooks).to.be.not.empty);
+  });
+
+  describe('#loadEnvVarsForLocal()', () => {
+    it('should set IS_LOCAL', () => {
+      delete process.env.IS_LOCAL;
+      return expect(invoke.loadEnvVarsForLocal()).to.be.fulfilled
+      .then(() => expect(process.env.IS_LOCAL).to.equal('true'));
+    });
+  });
+
+  describe('hooks', () => {
+    describe('invoke:local:loadEnvVars', () => {
+      it('should be an event', () => {
+        expect(invoke.commands.invoke.commands.local.lifecycleEvents).to.contain('loadEnvVars');
+      });
+
+      it('should set IS_LOCAL', () => {
+        delete process.env.IS_LOCAL;
+        return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled
+        .then(() => expect(process.env.IS_LOCAL).to.equal('true'));
+      });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #3652 

## How did you implement it:

Added an outer `loadEnvVars` event to `invoke:local` that is used to set provider independent environment variables on local invocations. Currently only `IS_LOCAL` is set there.

## How can we verify it:

Use a service configured for an arbitrary provider. Use `invoke local` to run any contained function locally and print the environment. It should contain the `IS_LOCAL` variable.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
