### PR TITLE
Add aws-profile option support

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -128,6 +128,14 @@ Now you can switch per project (/ API) by executing once when you start your pro
 in the Terminal. Now everything is set to execute all the `serverless` CLI options like `sls deploy`.
 The AWS region setting is to prevent issues with specific services, so adapt if you need another default region.
 
+##### Using the `aws-profile` option
+
+You can always speficy the profile which should be used via the `aws-profile` option like this:
+
+```bash
+serverless deploy --aws-profile devProfile
+```
+
 #### Per Stage Profiles
 
 As an advanced use-case, you can deploy different stages to different accounts by using different profiles per stage. In order to use different profiles per stage, you must leverage [variables](https://serverless.com/framework/docs/providers/aws/guide/variables) and the provider profile setting.

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -178,9 +178,16 @@ class AwsProvider {
     const result = {};
     const stageUpper = this.getStage() ? this.getStage().toUpperCase() : null;
 
+    let profile;
+    if (this.options['aws-profile']) {
+      profile = this.options['aws-profile'];
+    } else if (this.serverless.service.provider.profile) {
+      profile = this.serverless.service.provider.profile;
+    }
+
     // add specified credentials, overriding with more specific declarations
     impl.addCredentials(result, this.serverless.service.provider.credentials); // config creds
-    impl.addProfileCredentials(result, this.serverless.service.provider.profile);
+    impl.addProfileCredentials(result, profile);
     impl.addEnvironmentCredentials(result, 'AWS'); // creds for all stages
     impl.addEnvironmentProfile(result, 'AWS');
     impl.addEnvironmentCredentials(result, `AWS_${stageUpper}`); // stage specific creds

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -251,6 +251,7 @@ describe('AwsProvider', () => {
     let originalProviderCredentials;
     let originalProviderProfile;
     let originalEnvironmentVariables;
+
     beforeEach(() => {
       originalProviderCredentials = serverless.service.provider.credentials;
       originalProviderProfile = serverless.service.provider.profile;
@@ -273,6 +274,7 @@ describe('AwsProvider', () => {
       );
       newAwsProvider = new AwsProviderProxyquired(serverless, newOptions);
     });
+
     afterEach(() => {
       replaceEnv(originalEnvironmentVariables);
       serverless.service.provider.profile = originalProviderProfile;
@@ -406,6 +408,13 @@ describe('AwsProvider', () => {
 
     it('should get credentials from environment declared stage-specific profile', () => {
       process.env.AWS_TESTSTAGE_PROFILE = 'notDefault';
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials.profile).to.equal('notDefault');
+    });
+
+    it('should get credentials when profile is provied via --aws-profile option', () => {
+      newAwsProvider.options['aws-profile'] = 'notDefault';
+
       const credentials = newAwsProvider.getCredentials();
       expect(credentials.credentials.profile).to.equal('notDefault');
     });


### PR DESCRIPTION
## What did you implement:

Closes #1787

Adds support for the `--aws-profile` option to provide the profile which should be used e.g. for deployments.

## How did you implement it:

Extended the `AwsProvider` plugin so that it supports the detection of the `aws-profile` option.

## How can we verify it:

Update your `~/.aws/credentials` file and move your current `default` profile under another name. Invalidate the `default` profile by specifying wrong keys (so that a normal `serverless deploy` will fail).

Run `serverless deploy --aws-profile <your-new-profile-name>`

**Note:** Remember to update the `credentials` file later on so that your `default` profile is restored.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO