### PR TITLE
Moving rollback function documentation after rollback in menu

### DIFF
--- a/docs/providers/aws/cli-reference/remove.md
+++ b/docs/providers/aws/cli-reference/remove.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Remove
 menuText: remove
-menuOrder: 14
+menuOrder: 15
 description: Remove a deployed Service and all of its AWS Lambda Functions, Events and Resources
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/rollback-function.md
+++ b/docs/providers/aws/cli-reference/rollback-function.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Rollback Function CLI Command
 menuText: rollback function
-menuOrder: 16
+menuOrder: 14
 description: Rollback a function to a specific version
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/slstats.md
+++ b/docs/providers/aws/cli-reference/slstats.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Serverless Stats
 menuText: serverless stats
-menuOrder: 15
+menuOrder: 16
 description: Enables or disables Serverless Statistic logging within the Serverless Framework.
 layout: Doc
 -->


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Moved the `rollback function` documentation entry after the `rollback` entry in the side menu. I thought this would make it easier to find, as `rollback function` was added to the end of the menu and people may miss it.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
