### PR TITLE
Fix s3 event race condition bug

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -137,7 +137,20 @@ class AwsCompileS3Events {
             LambdaConfigurations: bucketLambdaConfiguration,
           },
         },
+        DependsOn: [],
       };
+
+      // create the DependsOn properties for the buckets permissions (which are created later on)
+      const dependsOnToCreate = s3EnabledFunctions
+        .filter(func => func.bucketName === bucketName);
+
+      _.forEach(dependsOnToCreate, (item) => {
+        const lambdaPermissionLogicalId = this.provider.naming
+          .getLambdaS3PermissionLogicalId(item.functionName,
+            item.bucketName);
+
+        bucketTemplate.DependsOn.push(lambdaPermissionLogicalId);
+      });
 
       const bucketLogicalId = this.provider.naming
         .getBucketLogicalId(bucketName);

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -163,6 +163,44 @@ describe('AwsCompileS3Events', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should add the permission resource logical id to the buckets DependsOn array', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: 'first-function-bucket-one',
+            },
+            {
+              s3: {
+                bucket: 'first-function-bucket-two',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileS3Events.compileS3Events();
+
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.S3BucketFirstfunctionbucketone.Type
+      ).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.S3BucketFirstfunctionbuckettwo.Type
+      ).to.equal('AWS::S3::Bucket');
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstLambdaPermissionFirstfunctionbucketoneS3.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstLambdaPermissionFirstfunctionbuckettwoS3.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.S3BucketFirstfunctionbucketone.DependsOn
+      ).to.deep.equal(['FirstLambdaPermissionFirstfunctionbucketoneS3']);
+      expect(awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.S3BucketFirstfunctionbuckettwo.DependsOn
+      ).to.deep.equal(['FirstLambdaPermissionFirstfunctionbuckettwoS3']);
+    });
+
     it('should not create corresponding resources when S3 events are not given', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {


### PR DESCRIPTION
## What did you implement:

Closes #3038

Fixes the race condition bug where S3 events randomly fail while deploying the service.

## How did you implement it:

Added a `DependsOn` declaration which contains the buckets permission. This ensures that the permission is in place before the bucket is created.

## How can we verify it:

Just deploy a service like the following:

```yml
service: service

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    events:
      - s3: some.random.bucket.name
```

or run the S3 (complex) integration tests. They should stop failing now.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO