### PR TITLE
Add Usage Plan to Amazon API Gateway

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -297,7 +297,8 @@ You can specify a list of API keys to be used by your service Rest API by adding
 `provider` object in `serverless.yml`. You'll also need to explicitly specify which endpoints are `private` and require
 one of the api keys to be included in the request by adding a `private` boolean property to the `http` event object you
 want to set as private. API Keys are created globally, so if you want to deploy your service to different stages make sure
-your API key contains a stage variable as defined below.
+your API key contains a stage variable as defined below. When using API keys, you can optionally define usage plan quota
+and throttle, using `usagePlan` object.
 
 Here's an example configuration for setting API keys for your service Rest API:
 
@@ -309,6 +310,14 @@ provider:
     - myFirstKey
     - ${opt:stage}-myFirstKey
     - ${env:MY_API_KEY} # you can hide it in a serverless variable
+  usagePlan:
+    quota:
+      limit: 5000
+      offset: 2
+      period: MONTH
+    throttle:
+      burstLimit: 200
+      rateLimit: 100
 functions:
   hello:
     events:

--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -80,6 +80,9 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 |ApiGateway::Authorizer | {normalizedFunctionName}ApiGatewayAuthorizer            | HelloApiGatewayAuthorizer     |
 |ApiGateway::Deployment | ApiGatewayDeployment{randomNumber}                      | ApiGatewayDeployment12356789  |
 |ApiGateway::ApiKey     | ApiGatewayApiKey{SequentialID}                          | ApiGatewayApiKey1             |
+|ApiGateway::UsagePlan  | ApiGatewayUsagePlan                          | ApiGatewayUsagePlan             |
+|ApiGateway::UsagePlanKey     | ApiGatewayUsagePlanKey{SequentialID}                          | ApiGatewayUsagePlanKey1             |
+|ApiGateway::Stage      | ApiGatewayStage                          | ApiGatewayStage             |
 |SNS::Topic             | SNSTopic{normalizedTopicName}                           | SNSTopicSometopic             |
 |SNS::Subscription      | {normalizedFunctionName}SnsSubscription{normalizedTopicName}   | HelloSnsSubscriptionSomeTopic             |
 |AWS::Lambda::EventSourceMapping | <ul><li>**DynamoDB:** {normalizedFunctionName}EventSourceMappingDynamodb{tableName}</li><li>**Kinesis:** {normalizedFunctionName}EventSourceMappingKinesis{streamName}</li></ul> | <ul><li>**DynamoDB:** HelloLambdaEventSourceMappingDynamodbUsers</li><li>**Kinesis:** HelloLambdaEventSourceMappingKinesisMystream</li></ul> |

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -41,6 +41,14 @@ provider:
     - myFirstKey
     - ${opt:stage}-myFirstKey
     - ${env:MY_API_KEY} # you can hide it in a serverless variable
+  usagePlan: # Optional usage plan configuration
+    quota:
+      limit: 5000
+      offset: 2
+      period: MONTH
+    throttle:
+      burstLimit: 200
+      rateLimit: 100
   stackTags: # Optional CF stack tags
     key: value
   iamRoleStatements: # IAM role statements so that services can be accessed in the AWS account

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -182,6 +182,12 @@ module.exports = {
   getApiKeyLogicalIdRegex() {
     return /^ApiGatewayApiKey/;
   },
+  getUsagePlanLogicalId() {
+    return 'UsagePlan';
+  },
+  getUsagePlanKeyLogicalId(usagePlanKeyNumber) {
+    return `UsagePlanKey${usagePlanKeyNumber}`;
+  },
 
   // S3
   getDeploymentBucketLogicalId() {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -183,10 +183,13 @@ module.exports = {
     return /^ApiGatewayApiKey/;
   },
   getUsagePlanLogicalId() {
-    return 'UsagePlan';
+    return 'ApiGatewayUsagePlan';
   },
   getUsagePlanKeyLogicalId(usagePlanKeyNumber) {
-    return `UsagePlanKey${usagePlanKeyNumber}`;
+    return `ApiGatewayUsagePlanKey${usagePlanKeyNumber}`;
+  },
+  getStageLogicalId() {
+    return 'ApiGatewayStage';
   },
 
   // S3

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -317,6 +317,26 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getUsagePlanLogicalId()', () => {
+    it('should return ApiGateway usage plan logical id', () => {
+      expect(sdk.naming.getUsagePlanLogicalId())
+        .to.equal('ApiGatewayUsagePlan');
+    });
+  });
+
+  describe('#getUsagePlanKeyLogicalId(keyIndex)', () => {
+    it('should produce the given index with ApiGatewayUsagePlanKey as a prefix', () => {
+      expect(sdk.naming.getUsagePlanKeyLogicalId(1)).to.equal('ApiGatewayUsagePlanKey1');
+    });
+  });
+
+  describe('#getStageLogicalId()', () => {
+    it('should return ApiGateway stage logical id', () => {
+      expect(sdk.naming.getStageLogicalId())
+        .to.equal('ApiGatewayStage');
+    });
+  });
+
   describe('#getDeploymentBucketLogicalId()', () => {
     it('should return "ServerlessDeploymentBucket"', () => {
       expect(sdk.naming.getDeploymentBucketLogicalId()).to.equal('ServerlessDeploymentBucket');

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -64,6 +64,16 @@ class AwsCompileApigEvents {
           .then(this.compileUsagePlanKeys)
           .then(this.compilePermissions);
       },
+
+      // TODO should be removed once AWS fixes the removal via CloudFormation
+      'before:remove:remove': () => {
+        const validate = require('../../../../lib/validate').validate; // eslint-disable-line
+        const disassociateUsagePlan = require('./lib/disassociateUsagePlan').disassociateUsagePlan; // eslint-disable-line
+
+        return BbPromise.bind(this)
+          .then(validate)
+          .then(disassociateUsagePlan);
+      },
     };
   }
 }

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -5,6 +5,7 @@ const BbPromise = require('bluebird');
 const validate = require('./lib/validate');
 const compileRestApi = require('./lib/restApi');
 const compileApiKeys = require('./lib/apiKeys');
+const compileStage = require('./lib/stage');
 const compileUsagePlan = require('./lib/usagePlan');
 const compileUsagePlanKeys = require('./lib/usagePlanKeys');
 const compileResources = require('./lib/resources');
@@ -35,6 +36,7 @@ class AwsCompileApigEvents {
       compileMethods,
       compileAuthorizers,
       compileDeployment,
+      compileStage,
       compilePermissions,
       getMethodAuthorization,
       getMethodIntegration,
@@ -56,6 +58,7 @@ class AwsCompileApigEvents {
           .then(this.compileMethods)
           .then(this.compileAuthorizers)
           .then(this.compileDeployment)
+          .then(this.compileStage)
           .then(this.compileApiKeys)
           .then(this.compileUsagePlan)
           .then(this.compileUsagePlanKeys)

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -5,6 +5,8 @@ const BbPromise = require('bluebird');
 const validate = require('./lib/validate');
 const compileRestApi = require('./lib/restApi');
 const compileApiKeys = require('./lib/apiKeys');
+const compileUsagePlan = require('./lib/usagePlan');
+const compileUsagePlanKeys = require('./lib/usagePlanKeys');
 const compileResources = require('./lib/resources');
 const compileCors = require('./lib/cors');
 const compileMethods = require('./lib/method/index');
@@ -26,6 +28,8 @@ class AwsCompileApigEvents {
       validate,
       compileRestApi,
       compileApiKeys,
+      compileUsagePlan,
+      compileUsagePlanKeys,
       compileResources,
       compileCors,
       compileMethods,
@@ -53,6 +57,8 @@ class AwsCompileApigEvents {
           .then(this.compileAuthorizers)
           .then(this.compileDeployment)
           .then(this.compileApiKeys)
+          .then(this.compileUsagePlan)
+          .then(this.compileUsagePlanKeys)
           .then(this.compilePermissions);
       },
     };

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -5,9 +5,12 @@ const sinon = require('sinon');
 const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileApigEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
+const validate = require('../../../../lib/validate');
+const disassociateUsagePlan = require('./lib/disassociateUsagePlan');
 
 describe('AwsCompileApigEvents', () => {
   let awsCompileApigEvents;
+
   beforeEach(() => {
     const serverless = new Serverless();
     serverless.service.environment = {
@@ -32,12 +35,51 @@ describe('AwsCompileApigEvents', () => {
   });
 
   describe('#constructor()', () => {
+    let compileRestApiStub;
+    let compileResourcesStub;
+    let compileMethodsStub;
+    let compileDeploymentStub;
+    let compileStageStub;
+    let compileUsagePlanStub;
+    let compilePermissionsStub;
+    let disassociateUsagePlanStub;
+
+    beforeEach(() => {
+      compileRestApiStub = sinon
+        .stub(awsCompileApigEvents, 'compileRestApi').resolves();
+      compileResourcesStub = sinon
+        .stub(awsCompileApigEvents, 'compileResources').resolves();
+      compileMethodsStub = sinon
+        .stub(awsCompileApigEvents, 'compileMethods').resolves();
+      compileDeploymentStub = sinon
+        .stub(awsCompileApigEvents, 'compileDeployment').resolves();
+      compileStageStub = sinon
+        .stub(awsCompileApigEvents, 'compileStage').resolves();
+      compileUsagePlanStub = sinon
+        .stub(awsCompileApigEvents, 'compileUsagePlan').resolves();
+      compilePermissionsStub = sinon
+        .stub(awsCompileApigEvents, 'compilePermissions').resolves();
+      disassociateUsagePlanStub = sinon
+        .stub(disassociateUsagePlan, 'disassociateUsagePlan').resolves();
+    });
+
+    afterEach(() => {
+      awsCompileApigEvents.compileRestApi.restore();
+      awsCompileApigEvents.compileResources.restore();
+      awsCompileApigEvents.compileMethods.restore();
+      awsCompileApigEvents.compileDeployment.restore();
+      awsCompileApigEvents.compileStage.restore();
+      awsCompileApigEvents.compileUsagePlan.restore();
+      awsCompileApigEvents.compilePermissions.restore();
+      disassociateUsagePlan.disassociateUsagePlan.restore();
+    });
+
     it('should have hooks', () => expect(awsCompileApigEvents.hooks).to.be.not.empty);
 
     it('should set the provider variable to be an instanceof AwsProvider', () =>
       expect(awsCompileApigEvents.provider).to.be.instanceof(AwsProvider));
 
-    it('should run promise chain in order', () => {
+    it('should run "package:compileEvents" promise chain in order', () => {
       const validateStub = sinon
         .stub(awsCompileApigEvents, 'validate').returns({
           events: [
@@ -50,20 +92,6 @@ describe('AwsCompileApigEvents', () => {
             },
           ],
         });
-      const compileRestApiStub = sinon
-        .stub(awsCompileApigEvents, 'compileRestApi').resolves();
-      const compileResourcesStub = sinon
-        .stub(awsCompileApigEvents, 'compileResources').resolves();
-      const compileMethodsStub = sinon
-        .stub(awsCompileApigEvents, 'compileMethods').resolves();
-      const compileDeploymentStub = sinon
-        .stub(awsCompileApigEvents, 'compileDeployment').resolves();
-      const compileStageStub = sinon
-        .stub(awsCompileApigEvents, 'compileStage').resolves();
-      const compileUsagePlanStub = sinon
-        .stub(awsCompileApigEvents, 'compileUsagePlan').resolves();
-      const compilePermissionsStub = sinon
-        .stub(awsCompileApigEvents, 'compilePermissions').resolves();
 
       return awsCompileApigEvents.hooks['package:compileEvents']().then(() => {
         expect(validateStub.calledOnce).to.be.equal(true);
@@ -76,13 +104,17 @@ describe('AwsCompileApigEvents', () => {
         expect(compilePermissionsStub.calledAfter(compileUsagePlanStub)).to.be.equal(true);
 
         awsCompileApigEvents.validate.restore();
-        awsCompileApigEvents.compileRestApi.restore();
-        awsCompileApigEvents.compileResources.restore();
-        awsCompileApigEvents.compileMethods.restore();
-        awsCompileApigEvents.compileDeployment.restore();
-        awsCompileApigEvents.compileStage.restore();
-        awsCompileApigEvents.compileUsagePlan.restore();
-        awsCompileApigEvents.compilePermissions.restore();
+      });
+    });
+
+    it('should run "before:remove:remove" promise chain in order', () => {
+      const validateStub = sinon.stub(validate, 'validate').returns();
+
+      return awsCompileApigEvents.hooks['before:remove:remove']().then(() => {
+        expect(validateStub.calledOnce).to.equal(true);
+        expect(disassociateUsagePlanStub.calledAfter(validateStub)).to.equal(true);
+
+        validate.validate.restore();
       });
     });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -58,6 +58,8 @@ describe('AwsCompileApigEvents', () => {
         .stub(awsCompileApigEvents, 'compileMethods').resolves();
       const compileDeploymentStub = sinon
         .stub(awsCompileApigEvents, 'compileDeployment').resolves();
+      const compileUsagePlanStub = sinon
+        .stub(awsCompileApigEvents, 'compileUsagePlan').resolves();
       const compilePermissionsStub = sinon
         .stub(awsCompileApigEvents, 'compilePermissions').resolves();
 
@@ -67,13 +69,15 @@ describe('AwsCompileApigEvents', () => {
         expect(compileResourcesStub.calledAfter(compileRestApiStub)).to.be.equal(true);
         expect(compileMethodsStub.calledAfter(compileResourcesStub)).to.be.equal(true);
         expect(compileDeploymentStub.calledAfter(compileMethodsStub)).to.be.equal(true);
-        expect(compilePermissionsStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compileUsagePlanStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compilePermissionsStub.calledAfter(compileUsagePlanStub)).to.be.equal(true);
 
         awsCompileApigEvents.validate.restore();
         awsCompileApigEvents.compileRestApi.restore();
         awsCompileApigEvents.compileResources.restore();
         awsCompileApigEvents.compileMethods.restore();
         awsCompileApigEvents.compileDeployment.restore();
+        awsCompileApigEvents.compileUsagePlan.restore();
         awsCompileApigEvents.compilePermissions.restore();
       });
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -58,6 +58,8 @@ describe('AwsCompileApigEvents', () => {
         .stub(awsCompileApigEvents, 'compileMethods').resolves();
       const compileDeploymentStub = sinon
         .stub(awsCompileApigEvents, 'compileDeployment').resolves();
+      const compileStageStub = sinon
+        .stub(awsCompileApigEvents, 'compileStage').resolves();
       const compileUsagePlanStub = sinon
         .stub(awsCompileApigEvents, 'compileUsagePlan').resolves();
       const compilePermissionsStub = sinon
@@ -69,7 +71,8 @@ describe('AwsCompileApigEvents', () => {
         expect(compileResourcesStub.calledAfter(compileRestApiStub)).to.be.equal(true);
         expect(compileMethodsStub.calledAfter(compileResourcesStub)).to.be.equal(true);
         expect(compileDeploymentStub.calledAfter(compileMethodsStub)).to.be.equal(true);
-        expect(compileUsagePlanStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compileStageStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
+        expect(compileUsagePlanStub.calledAfter(compileStageStub)).to.be.equal(true);
         expect(compilePermissionsStub.calledAfter(compileUsagePlanStub)).to.be.equal(true);
 
         awsCompileApigEvents.validate.restore();
@@ -77,6 +80,7 @@ describe('AwsCompileApigEvents', () => {
         awsCompileApigEvents.compileResources.restore();
         awsCompileApigEvents.compileMethods.restore();
         awsCompileApigEvents.compileDeployment.restore();
+        awsCompileApigEvents.compileStage.restore();
         awsCompileApigEvents.compileUsagePlan.restore();
         awsCompileApigEvents.compilePermissions.restore();
       });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -31,7 +31,7 @@ module.exports = {
                 StageName: this.options.stage,
               }],
             },
-            DependsOn: this.apiGatewayDeploymentLogicalId,
+            DependsOn: this.apiGatewayStageLogicalId,
           },
         });
       });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
@@ -28,6 +28,7 @@ describe('#compileApiKeys()', () => {
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
+    awsCompileApigEvents.apiGatewayStageLogicalId = 'ApiGatewayStage';
   });
 
   it('should compile api key resource', () =>
@@ -72,7 +73,7 @@ describe('#compileApiKeys()', () => {
           .Resources[
             awsCompileApigEvents.provider.naming.getApiKeyLogicalId(1)
           ].DependsOn
-      ).to.equal('ApiGatewayDeploymentTest');
+      ).to.equal('ApiGatewayStage');
     })
   );
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
@@ -13,7 +13,6 @@ module.exports = {
         Type: 'AWS::ApiGateway::Deployment',
         Properties: {
           RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
-          StageName: this.options.stage,
         },
         DependsOn: this.apiGatewayMethodLogicalIds,
       },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
@@ -39,7 +39,6 @@ describe('#compileDeployment()', () => {
         DependsOn: ['method-dependency1', 'method-dependency2'],
         Properties: {
           RestApiId: { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
-          StageName: 'dev',
         },
       });
     })

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+
+module.exports = {
+  disassociateUsagePlan() {
+    const apiKeys = this.serverless.service.provider.apiKeys;
+
+    if (apiKeys && apiKeys.length) {
+      this.serverless.cli.log('Removing usage plan association...');
+      const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+      return BbPromise.all([
+        this.provider.request('CloudFormation',
+          'describeStackResource',
+          {
+            StackName: stackName,
+            LogicalResourceId: this.provider.naming.getRestApiLogicalId(),
+          },
+          this.options.stage,
+          this.options.region),
+        this.provider.request('APIGateway',
+          'getUsagePlans', {},
+          this.options.stage,
+          this.options.region),
+      ]).then((data) => data[1].items.filter((item) =>
+          _.includes(item.apiStages
+            .map(apistage => apistage.apiId), data[0].StackResourceDetail.PhysicalResourceId)))
+        .then((items) => BbPromise.all(_.flattenDeep(items.map(item =>
+          item.apiStages.map(apiStage =>
+            this.provider.request('APIGateway',
+              'updateUsagePlan', {
+                usagePlanId: item.id,
+                patchOperations: [{
+                  op: 'remove',
+                  path: '/apiStages',
+                  value: `${apiStage.apiId}:${apiStage.stage}`,
+                }],
+              },
+              this.options.stage,
+              this.options.region))))));
+    }
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const Serverless = require('../../../../../../../Serverless');
+const AwsProvider = require('../../../../../provider/awsProvider');
+const disassociateUsagePlan = require('./disassociateUsagePlan');
+
+describe('#disassociateUsagePlan()', () => {
+  let serverless;
+  let options;
+  let awsProvider;
+  let providerRequestStub;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.service.service = 'my-service';
+    serverless.cli = {
+      log: sinon.spy(),
+    };
+    options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsProvider = new AwsProvider(serverless);
+    serverless.setProvider('aws', awsProvider);
+    providerRequestStub = sinon.stub(awsProvider, 'request');
+
+    disassociateUsagePlan.serverless = serverless;
+    disassociateUsagePlan.options = options;
+    disassociateUsagePlan.provider = awsProvider;
+
+    providerRequestStub.withArgs('CloudFormation', 'describeStackResource')
+      .resolves({ StackResourceDetail: { PhysicalResourceId: 'resource-id' } });
+    providerRequestStub.withArgs('APIGateway', 'getUsagePlans').resolves({
+      items: [{
+        apiStages: [
+          {
+            apiId: 'resource-id',
+            stage: 'dev',
+          },
+        ],
+        id: 'usage-plan-id',
+      },
+      {
+        apiStages: [
+          {
+            apiId: 'another-resource-id',
+            stage: 'dev',
+          },
+        ],
+        id: 'another-usage-plan-id',
+      }],
+    });
+    providerRequestStub.withArgs('APIGateway', 'updateUsagePlan').resolves();
+  });
+
+  afterEach(() => {
+    awsProvider.request.restore();
+  });
+
+  it('should remove association from the usage plan', () => {
+    disassociateUsagePlan.serverless.service.provider.apiKeys = ['apiKey1'];
+
+    return disassociateUsagePlan.disassociateUsagePlan().then(() => {
+      expect(providerRequestStub.callCount).to.be.equal(3);
+
+      expect(providerRequestStub.calledWithExactly(
+        'CloudFormation',
+        'describeStackResource',
+        {
+          StackName: `${serverless.service.service}-${options.stage}`,
+          LogicalResourceId: 'ApiGatewayRestApi',
+        },
+        options.stage,
+        options.region
+      )).to.be.equal(true);
+
+      expect(providerRequestStub.calledWithExactly(
+        'APIGateway',
+        'getUsagePlans',
+        {},
+        options.stage,
+        options.region
+      )).to.be.equal(true);
+
+      expect(providerRequestStub.calledWithExactly(
+        'APIGateway',
+        'updateUsagePlan',
+        {
+          usagePlanId: 'usage-plan-id',
+          patchOperations: [{
+            op: 'remove',
+            path: '/apiStages',
+            value: 'resource-id:dev',
+          }],
+        },
+        options.stage,
+        options.region
+      )).to.be.equal(true);
+    });
+  });
+
+  it('should resolve if no api keys are given', () => {
+    disassociateUsagePlan.serverless.service.provider.apiKeys = [];
+
+    return disassociateUsagePlan.disassociateUsagePlan().then(() => {
+      expect(providerRequestStub.callCount).to.be.equal(0);
+    });
+  });
+});

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  compileStage() {
+    this.apiGatewayStageLogicalId = this.provider.naming.getStageLogicalId();
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      [this.apiGatewayStageLogicalId]: {
+        Type: 'AWS::ApiGateway::Stage',
+        Properties: {
+          DeploymentId: {
+            Ref: this.apiGatewayDeploymentLogicalId,
+          },
+          RestApiId: {
+            Ref: this.apiGatewayRestApiLogicalId,
+          },
+          StageName: this.options.stage,
+        },
+      },
+    });
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileApigEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+const AwsProvider = require('../../../../../provider/awsProvider');
+
+describe('#compileStage()', () => {
+  let serverless;
+  let awsCompileApigEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.service = 'first-service';
+    serverless.service.provider = {
+      name: 'aws',
+      apiKeys: ['1234567890'],
+    };
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+      Outputs: {},
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
+  });
+
+  it('should compile stage resource', () =>
+    awsCompileApigEvents.compileStage().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getStageLogicalId()
+          ].Type
+      ).to.equal('AWS::ApiGateway::Stage');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getStageLogicalId()
+          ].Properties
+      ).to.deep.equal({
+        DeploymentId: {
+          Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId,
+        },
+        RestApiId: {
+          Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId,
+        },
+        StageName: 'dev',
+      });
+    })
+  );
+});

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  compileUsagePlan() {
+    this.apiGatewayUsagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
+
+    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      [this.apiGatewayUsagePlanLogicalId]: {
+        Type: 'AWS::ApiGateway::UsagePlan',
+        DependsOn: [this.apiGatewayDeploymentLogicalId],
+        Properties: {
+          ApiStages: [
+            {
+              ApiId: this.apiGatewayRestApiLogicalId,
+              Stage: this.options.stage,
+            },
+          ],
+          Description:
+            `Usage plan for ${this.serverless.service.service} ${this.options.stage} stage`,
+          UsagePlanName: `${this.serverless.service.service}-usage-plan`,
+        },
+      },
+    });
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -5,30 +5,28 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileUsagePlan() {
-    this.apiGatewayUsagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
-
-    _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
-      [this.apiGatewayUsagePlanLogicalId]: {
-        Type: 'AWS::ApiGateway::UsagePlan',
-        DependsOn: [
-          this.apiGatewayDeploymentLogicalId,
-        ],
-        Properties: {
-          ApiStages: [
-            {
-              ApiId: {
-                Ref: this.apiGatewayRestApiLogicalId,
+    if (this.serverless.service.provider.apiKeys) {
+      this.apiGatewayUsagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+        [this.apiGatewayUsagePlanLogicalId]: {
+          Type: 'AWS::ApiGateway::UsagePlan',
+          DependsOn: this.apiGatewayStageLogicalId,
+          Properties: {
+            ApiStages: [
+              {
+                ApiId: {
+                  Ref: this.apiGatewayRestApiLogicalId,
+                },
+                Stage: this.options.stage,
               },
-              Stage: this.options.stage,
-            },
-          ],
-          Description:
-            `Usage plan for ${this.serverless.service.service} ${this.options.stage} stage`,
-          UsagePlanName: `${this.serverless.service.service}-usage-plan`,
+            ],
+            Description:
+              `Usage plan for ${this.serverless.service.service} ${this.options.stage} stage`,
+            UsagePlanName: `${this.serverless.service.service}-${this.options.stage}`,
+          },
         },
-      },
-    });
-
+      });
+    }
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -10,11 +10,15 @@ module.exports = {
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.apiGatewayUsagePlanLogicalId]: {
         Type: 'AWS::ApiGateway::UsagePlan',
-        DependsOn: [this.apiGatewayDeploymentLogicalId],
+        DependsOn: [
+          this.apiGatewayDeploymentLogicalId,
+        ],
         Properties: {
           ApiStages: [
             {
-              ApiId: this.apiGatewayRestApiLogicalId,
+              ApiId: {
+                Ref: this.apiGatewayRestApiLogicalId,
+              },
               Stage: this.options.stage,
             },
           ],

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -26,6 +26,31 @@ module.exports = {
           },
         },
       });
+      if (_.has(this.serverless.service.provider, 'usagePlan.quota')
+        && this.serverless.service.provider.usagePlan.quota !== null) {
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          [this.apiGatewayUsagePlanLogicalId]: {
+            Properties: {
+              Quota: _.merge(
+                { Limit: this.serverless.service.provider.usagePlan.quota.limit },
+                { Offset: this.serverless.service.provider.usagePlan.quota.offset },
+                { Period: this.serverless.service.provider.usagePlan.quota.period }),
+            },
+          },
+        });
+      }
+      if (_.has(this.serverless.service.provider, 'usagePlan.throttle')
+        && this.serverless.service.provider.usagePlan.throttle !== null) {
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          [this.apiGatewayUsagePlanLogicalId]: {
+            Properties: {
+              Throttle: _.merge(
+                { BurstLimit: this.serverless.service.provider.usagePlan.throttle.burstLimit },
+                { RateLimit: this.serverless.service.provider.usagePlan.throttle.rateLimit }),
+            },
+          },
+        });
+      }
     }
     return BbPromise.resolve();
   },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileApigEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+const AwsProvider = require('../../../../../provider/awsProvider');
+
+describe('#compileUsagePlan()', () => {
+  let serverless;
+  let awsCompileApigEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.service = 'first-service';
+    serverless.service.provider = {
+      name: 'aws',
+      apiKeys: ['1234567890'],
+    };
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+      Outputs: {},
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
+  });
+
+  it('should compile usage plan resource', () =>
+    awsCompileApigEvents.compileUsagePlan().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Type
+      ).to.equal('AWS::ApiGateway::UsagePlan');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].DependsOn[0]
+      ).to.equal('ApiGatewayDeploymentTest');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.ApiStages[0].ApiId
+      ).to.equal('ApiGatewayRestApi');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.ApiStages[0].Stage
+      ).to.equal('dev');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.Description
+      ).to.equal('Usage plan for first-service dev stage');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.UsagePlanName
+      ).to.equal('first-service-usage-plan');
+    })
+  );
+});

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -50,7 +50,7 @@ describe('#compileUsagePlan()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
-          ].Properties.ApiStages[0].ApiId
+          ].Properties.ApiStages[0].ApiId.Ref
       ).to.equal('ApiGatewayRestApi');
 
       expect(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -16,6 +16,17 @@ describe('#compileUsagePlan()', () => {
     serverless.service.provider = {
       name: 'aws',
       apiKeys: ['1234567890'],
+      usagePlan: {
+        quota: {
+          limit: 500,
+          offset: 10,
+          period: 'MONTH',
+        },
+        throttle: {
+          burstLimit: 200,
+          rateLimit: 100,
+        },
+      },
     };
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
@@ -66,6 +77,27 @@ describe('#compileUsagePlan()', () => {
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
           ].Properties.Description
       ).to.equal('Usage plan for first-service dev stage');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.Quota
+      ).to.deep.equal({
+        Limit: 500,
+        Offset: 10,
+        Period: 'MONTH',
+      });
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.Throttle
+      ).to.deep.equal({
+        BurstLimit: 200,
+        RateLimit: 100,
+      });
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -27,7 +27,7 @@ describe('#compileUsagePlan()', () => {
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
-    awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
+    awsCompileApigEvents.apiGatewayStageLogicalId = 'ApiGatewayStage';
   });
 
   it('should compile usage plan resource', () =>
@@ -43,8 +43,8 @@ describe('#compileUsagePlan()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
-          ].DependsOn[0]
-      ).to.equal('ApiGatewayDeploymentTest');
+          ].DependsOn
+      ).to.equal('ApiGatewayStage');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -72,7 +72,7 @@ describe('#compileUsagePlan()', () => {
           .Resources[
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
           ].Properties.UsagePlanName
-      ).to.equal('first-service-usage-plan');
+      ).to.equal('first-service-dev');
     })
   );
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  compileUsagePlanKeys() {
+    if (this.serverless.service.provider.apiKeys) {
+      if (!Array.isArray(this.serverless.service.provider.apiKeys)) {
+        throw new this.serverless.classes.Error('apiKeys property must be an array');
+      }
+
+      _.forEach(this.serverless.service.provider.apiKeys, (apiKey, i) => {
+        const usagePlanKeyNumber = i + 1;
+
+        if (typeof apiKey !== 'string') {
+          throw new this.serverless.classes.Error('API Keys must be strings');
+        }
+
+        const usagePlanKeyLogicalId = this.provider.naming
+          .getUsagePlanKeyLogicalId(usagePlanKeyNumber);
+
+        const apiKeyLogicalId = this.provider.naming
+          .getApiKeyLogicalId(usagePlanKeyNumber);
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          [usagePlanKeyLogicalId]: {
+            Type: 'AWS::ApiGateway::UsagePlanKey',
+            Properties: {
+              KeyId: {
+                Ref: apiKeyLogicalId,
+              },
+              KeyType: 'API_KEY',
+              UsagePlanId: {
+                Ref: this.apiGatewayUsagePlanLogicalId,
+              },
+            },
+          },
+        });
+      });
+    }
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileApigEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+const AwsProvider = require('../../../../../provider/awsProvider');
+
+describe('#compileUsagePlanKeys()', () => {
+  let serverless;
+  let awsCompileApigEvents;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.service = 'first-service';
+    serverless.service.provider = {
+      name: 'aws',
+      apiKeys: ['1234567890'],
+    };
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+      Outputs: {},
+    };
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
+    awsCompileApigEvents.apiGatewayUsagePlanLogicalId = 'UsagePlan';
+  });
+
+  it('should compile usage plan key resource', () =>
+    awsCompileApigEvents.compileUsagePlanKeys().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanKeyLogicalId(1)
+          ].Type
+      ).to.equal('AWS::ApiGateway::UsagePlanKey');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanKeyLogicalId(1)
+          ].Properties.KeyId.Ref
+      ).to.equal('ApiGatewayApiKey1');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanKeyLogicalId(1)
+          ].Properties.KeyType
+      ).to.equal('API_KEY');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanKeyLogicalId(1)
+          ].Properties.UsagePlanId.Ref
+      ).to.equal('UsagePlan');
+    })
+  );
+
+  it('throw error if apiKey property is not an array', () => {
+    awsCompileApigEvents.serverless.service.provider.apiKeys = 2;
+    expect(() => awsCompileApigEvents.compileUsagePlanKeys()).to.throw(Error);
+  });
+
+  it('throw error if an apiKey is not a string', () => {
+    awsCompileApigEvents.serverless.service.provider.apiKeys = [2];
+    expect(() => awsCompileApigEvents.compileUsagePlanKeys()).to.throw(Error);
+  });
+});

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const _ = require('lodash');
 
 module.exports = {
   remove() {
@@ -27,46 +26,8 @@ module.exports = {
       .then(() => cfData);
   },
 
-  disassociateUsagePlan() {
-    if (this.serverless.service.provider.apiKeys) {
-      this.serverless.cli.log('Removing usage plan association...');
-      const stackName = `${this.serverless.service.service}-${this.options.stage}`;
-      return BbPromise.all([
-        this.provider.request('CloudFormation',
-          'describeStackResource',
-          {
-            StackName: stackName,
-            LogicalResourceId: this.provider.naming.getRestApiLogicalId(),
-          },
-          this.options.stage,
-          this.options.region),
-        this.provider.request('APIGateway',
-          'getUsagePlans', {},
-          this.options.stage,
-          this.options.region),
-      ]).then((data) => data[1].items.filter((item) =>
-          _.includes(item.apiStages
-            .map(apistage => apistage.apiId), data[0].StackResourceDetail.PhysicalResourceId)))
-        .then((items) => BbPromise.all(_.flattenDeep(items.map(item =>
-          item.apiStages.map(apiStage =>
-            this.provider.request('APIGateway',
-              'updateUsagePlan', {
-                usagePlanId: item.id,
-                patchOperations: [{
-                  op: 'remove',
-                  path: '/apiStages',
-                  value: `${apiStage.apiId}:${apiStage.stage}`,
-                }],
-              },
-              this.options.stage,
-              this.options.region))))));
-    }
-    return BbPromise.resolve();
-  },
-
   removeStack() {
     return BbPromise.bind(this)
-      .then(this.disassociateUsagePlan)
       .then(this.remove);
   },
 };

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -31,23 +31,22 @@ module.exports = {
     if (this.serverless.service.provider.apiKeys) {
       this.serverless.cli.log('Removing usage plan association...');
       const stackName = `${this.serverless.service.service}-${this.options.stage}`;
-      return this.provider.request('CloudFormation',
-        'describeStackResource',
-        {
-          StackName: stackName,
-          LogicalResourceId: this.provider.naming.getRestApiLogicalId(),
-        },
-        this.options.stage,
-        this.options.region)
-        .then((response) => response.StackResourceDetail.PhysicalResourceId)
-        .then(apiResourceId =>
-          this.provider.request('APIGateway',
-            'getUsagePlans', { limit: 0 },
-            this.options.stage,
-            this.options.region)
-            .then((response) =>
-              response.items.filter((item) =>
-                _.includes(item.apiStages.map(apistage => apistage.apiId), apiResourceId))))
+      return BbPromise.all([
+        this.provider.request('CloudFormation',
+          'describeStackResource',
+          {
+            StackName: stackName,
+            LogicalResourceId: this.provider.naming.getRestApiLogicalId(),
+          },
+          this.options.stage,
+          this.options.region),
+        this.provider.request('APIGateway',
+          'getUsagePlans', {},
+          this.options.stage,
+          this.options.region),
+      ]).then((data) => data[1].items.filter((item) =>
+          _.includes(item.apiStages
+            .map(apistage => apistage.apiId), data[0].StackResourceDetail.PhysicalResourceId)))
         .then((items) => BbPromise.all(_.flattenDeep(items.map(item =>
           item.apiStages.map(apiStage =>
             this.provider.request('APIGateway',

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 
 module.exports = {
   remove() {
@@ -26,8 +27,47 @@ module.exports = {
       .then(() => cfData);
   },
 
+  disassociateUsagePlan() {
+    if (this.serverless.service.provider.apiKeys) {
+      this.serverless.cli.log('Removing usage plan association...');
+      const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+      return this.provider.request('CloudFormation',
+        'describeStackResource',
+        {
+          StackName: stackName,
+          LogicalResourceId: this.provider.naming.getRestApiLogicalId(),
+        },
+        this.options.stage,
+        this.options.region)
+        .then((response) => response.StackResourceDetail.PhysicalResourceId)
+        .then(apiResourceId =>
+          this.provider.request('APIGateway',
+            'getUsagePlans', { limit: 0 },
+            this.options.stage,
+            this.options.region)
+            .then((response) =>
+              response.items.filter((item) =>
+                _.includes(item.apiStages.map(apistage => apistage.apiId), apiResourceId))))
+        .then((items) => BbPromise.all(_.flattenDeep(items.map(item =>
+          item.apiStages.map(apiStage =>
+            this.provider.request('APIGateway',
+              'updateUsagePlan', {
+                usagePlanId: item.id,
+                patchOperations: [{
+                  op: 'remove',
+                  path: '/apiStages',
+                  value: `${apiStage.apiId}:${apiStage.stage}`,
+                }],
+              },
+              this.options.stage,
+              this.options.region))))));
+    }
+    return BbPromise.resolve();
+  },
+
   removeStack() {
     return BbPromise.bind(this)
+      .then(this.disassociateUsagePlan)
       .then(this.remove);
   },
 };

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -9,6 +9,7 @@ const Serverless = require('../../../../Serverless');
 describe('removeStack', () => {
   const serverless = new Serverless();
   serverless.service.service = 'removeStack';
+  serverless.service.provider.apiKeys = ['api-key'];
   serverless.setProvider('aws', new AwsProvider(serverless));
 
   let awsRemove;
@@ -21,7 +22,32 @@ describe('removeStack', () => {
     };
     awsRemove = new AwsRemove(serverless, options);
     awsRemove.serverless.cli = new serverless.classes.CLI();
-    removeStackStub = sinon.stub(awsRemove.provider, 'request').resolves();
+    removeStackStub = sinon.stub(awsRemove.provider, 'request');
+    removeStackStub.withArgs('CloudFormation', 'deleteStack').resolves();
+    removeStackStub.withArgs('CloudFormation', 'describeStackResource')
+      .resolves({ StackResourceDetail: { PhysicalResourceId: 'resource-id' } });
+    removeStackStub.withArgs('APIGateway', 'getUsagePlans')
+      .resolves({
+        items: [{
+          apiStages: [
+            {
+              apiId: 'resource-id',
+              stage: 'dev',
+            },
+          ],
+          id: 'usage-plan-id',
+        },
+        {
+          apiStages: [
+            {
+              apiId: 'another-resource-id',
+              stage: 'dev',
+            },
+          ],
+          id: 'another-usage-plan-id',
+        }],
+      });
+    removeStackStub.withArgs('APIGateway', 'updateUsagePlan').resolves();
   });
 
   describe('#remove()', () => {
@@ -48,6 +74,49 @@ describe('removeStack', () => {
         awsRemove.provider.request.restore();
       });
     });
+  });
+
+  describe('#disassociateUsagePlan()', () => {
+    it('should remove association from the usage plan', () => awsRemove
+      .disassociateUsagePlan().then(() => {
+        expect(removeStackStub.callCount).to.be.equal(3);
+
+        expect(removeStackStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackResource',
+          {
+            StackName: `${serverless.service.service}-${awsRemove.options.stage}`,
+            LogicalResourceId: 'ApiGatewayRestApi',
+          },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
+
+        expect(removeStackStub.calledWithExactly(
+          'APIGateway',
+          'getUsagePlans',
+          { limit: 0 },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
+
+        expect(removeStackStub.calledWithExactly(
+          'APIGateway',
+          'updateUsagePlan',
+          {
+            usagePlanId: 'usage-plan-id',
+            patchOperations: [{
+              op: 'remove',
+              path: '/apiStages',
+              value: 'resource-id:dev',
+            }],
+          },
+          awsRemove.options.stage,
+          awsRemove.options.region
+        )).to.be.equal(true);
+
+        awsRemove.provider.request.restore();
+      }));
   });
 
   describe('#removeStack()', () => {

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -95,7 +95,7 @@ describe('removeStack', () => {
         expect(removeStackStub.calledWithExactly(
           'APIGateway',
           'getUsagePlans',
-          { limit: 0 },
+          {},
           awsRemove.options.stage,
           awsRemove.options.region
         )).to.be.equal(true);

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -9,7 +9,6 @@ const Serverless = require('../../../../Serverless');
 describe('removeStack', () => {
   const serverless = new Serverless();
   serverless.service.service = 'removeStack';
-  serverless.service.provider.apiKeys = ['api-key'];
   serverless.setProvider('aws', new AwsProvider(serverless));
 
   let awsRemove;
@@ -22,32 +21,7 @@ describe('removeStack', () => {
     };
     awsRemove = new AwsRemove(serverless, options);
     awsRemove.serverless.cli = new serverless.classes.CLI();
-    removeStackStub = sinon.stub(awsRemove.provider, 'request');
-    removeStackStub.withArgs('CloudFormation', 'deleteStack').resolves();
-    removeStackStub.withArgs('CloudFormation', 'describeStackResource')
-      .resolves({ StackResourceDetail: { PhysicalResourceId: 'resource-id' } });
-    removeStackStub.withArgs('APIGateway', 'getUsagePlans')
-      .resolves({
-        items: [{
-          apiStages: [
-            {
-              apiId: 'resource-id',
-              stage: 'dev',
-            },
-          ],
-          id: 'usage-plan-id',
-        },
-        {
-          apiStages: [
-            {
-              apiId: 'another-resource-id',
-              stage: 'dev',
-            },
-          ],
-          id: 'another-usage-plan-id',
-        }],
-      });
-    removeStackStub.withArgs('APIGateway', 'updateUsagePlan').resolves();
+    removeStackStub = sinon.stub(awsRemove.provider, 'request').resolves();
   });
 
   describe('#remove()', () => {
@@ -76,58 +50,12 @@ describe('removeStack', () => {
     });
   });
 
-  describe('#disassociateUsagePlan()', () => {
-    it('should remove association from the usage plan', () => awsRemove
-      .disassociateUsagePlan().then(() => {
-        expect(removeStackStub.callCount).to.be.equal(3);
-
-        expect(removeStackStub.calledWithExactly(
-          'CloudFormation',
-          'describeStackResource',
-          {
-            StackName: `${serverless.service.service}-${awsRemove.options.stage}`,
-            LogicalResourceId: 'ApiGatewayRestApi',
-          },
-          awsRemove.options.stage,
-          awsRemove.options.region
-        )).to.be.equal(true);
-
-        expect(removeStackStub.calledWithExactly(
-          'APIGateway',
-          'getUsagePlans',
-          {},
-          awsRemove.options.stage,
-          awsRemove.options.region
-        )).to.be.equal(true);
-
-        expect(removeStackStub.calledWithExactly(
-          'APIGateway',
-          'updateUsagePlan',
-          {
-            usagePlanId: 'usage-plan-id',
-            patchOperations: [{
-              op: 'remove',
-              path: '/apiStages',
-              value: 'resource-id:dev',
-            }],
-          },
-          awsRemove.options.stage,
-          awsRemove.options.region
-        )).to.be.equal(true);
-
-        awsRemove.provider.request.restore();
-      }));
-  });
-
   describe('#removeStack()', () => {
     it('should run promise chain in order', () => {
-      const disassociateUsagePlanStub = sinon
-        .stub(awsRemove, 'disassociateUsagePlan').resolves();
       const removeStub = sinon
         .stub(awsRemove, 'remove').resolves();
 
       return awsRemove.removeStack().then(() => {
-        expect(disassociateUsagePlanStub.calledOnce).to.be.equal(true);
         expect(removeStub.calledOnce).to.be.equal(true);
         awsRemove.remove.restore();
       });

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -52,10 +52,13 @@ describe('removeStack', () => {
 
   describe('#removeStack()', () => {
     it('should run promise chain in order', () => {
+      const disassociateUsagePlanStub = sinon
+        .stub(awsRemove, 'disassociateUsagePlan').resolves();
       const removeStub = sinon
         .stub(awsRemove, 'remove').resolves();
 
       return awsRemove.removeStack().then(() => {
+        expect(disassociateUsagePlanStub.calledOnce).to.be.equal(true);
         expect(removeStub.calledOnce).to.be.equal(true);
         awsRemove.remove.restore();
       });

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/tests.js
@@ -17,8 +17,7 @@ const APIG = new AWS.APIGateway({ region: 'us-east-1' });
 BbPromise.promisifyAll(CF, { suffix: 'Promised' });
 BbPromise.promisifyAll(APIG, { suffix: 'Promised' });
 
-// NOTE this test will be skipped for now as AWS has some inconsistencies with API key usage
-xdescribe('AWS - API Gateway (Integration: Lambda Proxy): API keys test', () => {
+describe('AWS - API Gateway (Integration: Lambda Proxy): API keys test', () => {
   let stackName;
   let endpoint;
   let apiKey;

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/tests.js
@@ -17,8 +17,7 @@ const APIG = new AWS.APIGateway({ region: 'us-east-1' });
 BbPromise.promisifyAll(CF, { suffix: 'Promised' });
 BbPromise.promisifyAll(APIG, { suffix: 'Promised' });
 
-// NOTE this test will be skipped for now as AWS has some inconsistencies with API key usage
-xdescribe('AWS - API Gateway (Integration: Lambda): API keys test', () => {
+describe('AWS - API Gateway (Integration: Lambda): API keys test', () => {
   let stackName;
   let endpoint;
   let apiKey;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This PR adds usage plan to Amazon API Gateway.

Closes #2450
Closes #2741

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
By adding `AWS::ApiGateway::UsagePlan` and `AWS::ApiGateway::UsagePlanKey` to Amazon API Gateway build flow.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create a service with API key(s) and verify that deployment creates usage plan and usage plan key(s) to CF stack and AWS.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
