### PR TITLE
trivial fix: removed an extra double quote

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -98,7 +98,7 @@ class AwsCompileFunctions {
 
     if (!functionObject.handler) {
       const errorMessage = [
-        `Missing "handler" property in function ""${functionName}".`,
+        `Missing "handler" property in function "${functionName}".`,
         ' Please make sure you point to the correct lambda handler.',
         ' For example: handler.hello.',
         ' Please check the docs for more info',


### PR DESCRIPTION
## What did you implement:

Fixed a typo in an error message.

## How did you implement it:

Removed the quote

## How can we verify it:

Check the diff

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
