### PR TITLE
Fix #3175: Remove deprecated SError reference

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -46,9 +46,6 @@ module.exports.ServerlessError = class ServerlessError extends Error {
   }
 };
 
-// Deprecated - use ServerlessError instead
-module.exports.SError = module.exports.ServerlessError;
-
 module.exports.logError = (e) => {
   try {
     const errorType = e.name.replace(/([A-Z])/g, ' $1');


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3175

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Follow-up from https://github.com/serverless/serverless/commit/ffd6152de0d1b38368b3ec954c822e6778c4eb65, removed unnecessary exported `SError`.  I did a search through your other repos to make sure nothing else referenced the old `SError` and didn't find anything.

## How can we verify it:

All tests passing with `SError` removed.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
