### PR TITLE
Fix #3698: Throw error if an individual package is empty

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -42,7 +42,7 @@ module.exports = {
     });
 
     if (files.length === 0) {
-      const err = new this.serverless.classes.Error('No file matched by your include/exclude patterns');
+      const err = new this.serverless.classes.Error('No file matches include/exclude patterns');
       return new BbPromise((resolve, reject) => {
         reject(err);
       });

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -42,7 +42,8 @@ module.exports = {
     });
 
     if (files.length === 0) {
-      const error = new this.serverless.classes.Error('No file matches include/exclude patterns');
+      const error = new this.serverless
+        .classes.Error('No file matches include / exclude patterns');
       return BbPromise.reject(error);
     }
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -42,10 +42,8 @@ module.exports = {
     });
 
     if (files.length === 0) {
-      const err = new this.serverless.classes.Error('No file matches include/exclude patterns');
-      return new BbPromise((resolve, reject) => {
-        reject(err);
-      });
+      const error = new this.serverless.classes.Error('No file matches include/exclude patterns');
+      return BbPromise.reject(error);
     }
 
     output.on('open', () => {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -34,15 +34,22 @@ module.exports = {
 
     const output = fs.createWriteStream(artifactFilePath);
 
+    const files = globby.sync(patterns, {
+      cwd: this.serverless.config.servicePath,
+      dot: true,
+      silent: true,
+      follow: true,
+    });
+
+    if (files.length === 0) {
+      const err = new this.serverless.classes.Error('No file matched by your include/exclude patterns');
+      return new BbPromise((resolve, reject) => {
+        reject(err);
+      });
+    }
+
     output.on('open', () => {
       zip.pipe(output);
-
-      const files = globby.sync(patterns, {
-        cwd: this.serverless.config.servicePath,
-        dot: true,
-        silent: true,
-        follow: true,
-      });
 
       files.forEach((filePath) => {
         const fullPath = path.resolve(

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -332,15 +332,13 @@ describe('#zipService()', () => {
     });
   });
 
-  it('should explode when no file is matched', () => {
-    const exclude = [
-      '**/**',
-    ];
+  it('should throw an error when no file are matched', () => {
+    const exclude = ['**/**'];
     const include = [];
 
     const zipFileName = getTestArtifactFileName('empty');
 
     return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.be.rejectedWith(ServerlessError);
+      .to.be.rejectedWith(ServerlessError, 'file matches include/exclude');
   });
 });

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -8,6 +8,7 @@ const JsZip = require('jszip');
 const _ = require('lodash');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
+const ServerlessError = require('../../../classes/Error').ServerlessError;
 const testUtils = require('../../../../tests/utils');
 
 // Configure chai
@@ -329,5 +330,17 @@ describe('#zipService()', () => {
       expect(unzippedFileData['node_modules/directory-2/file-2'].name)
         .to.equal('node_modules/directory-2/file-2');
     });
+  });
+
+  it('should explode when no file is matched', () => {
+    const exclude = [
+      '**/**'
+    ];
+    const include = [];
+
+    const zipFileName = getTestArtifactFileName('empty');
+
+    return expect(packageService.zipDirectory(exclude, include, zipFileName))
+      .to.be.rejectedWith(ServerlessError);
   });
 });

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -339,6 +339,6 @@ describe('#zipService()', () => {
     const zipFileName = getTestArtifactFileName('empty');
 
     return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.be.rejectedWith(ServerlessError, 'file matches include/exclude');
+      .to.be.rejectedWith(ServerlessError, 'file matches include / exclude');
   });
 });

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -334,7 +334,7 @@ describe('#zipService()', () => {
 
   it('should explode when no file is matched', () => {
     const exclude = [
-      '**/**'
+      '**/**',
     ];
     const include = [];
 


### PR DESCRIPTION
## What did you implement:

Closes #3698 

## How did you implement it:

I have updated the `zipService` by adding a simple check to verify that at least one file is matched by the _include/exclude_ patterns. If no files are matched, a `ServerlessError` is thrown.

## How can we verify it:

I've added only one simple test.

You can run it individually: 

```
node_modules/mocha/bin/_mocha lib/plugins/package/lib/zipService.test.js
```

## Todos:

- [X] Write tests
- [ ] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
