### PR TITLE
Exclude Node.js dev dependencies in .zip file

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -130,3 +130,9 @@ functions:
     package:
       individually: true
 ```
+
+### Development dependencies
+
+Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
+
+This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.

--- a/docs/providers/azure/guide/packaging.md
+++ b/docs/providers/azure/guide/packaging.md
@@ -151,3 +151,9 @@ functions:
     package:
       individually: true
 ```
+
+### Development dependencies
+
+Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
+
+This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.

--- a/docs/providers/google/guide/packaging.md
+++ b/docs/providers/google/guide/packaging.md
@@ -123,3 +123,9 @@ functions:
     package:
       individually: true
 ```
+
+### Development dependencies
+
+Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
+
+This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.

--- a/docs/providers/openwhisk/guide/packaging.md
+++ b/docs/providers/openwhisk/guide/packaging.md
@@ -117,3 +117,9 @@ functions:
       exclude:
         - some-file.js
 ```
+
+### Development dependencies
+
+Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
+
+This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -55,7 +55,7 @@ module.exports = {
     const include = this.getIncludes();
     const zipFileName = `${this.serverless.service.service}.zip`;
 
-    return this.zipDirectory(exclude, include, zipFileName).then(filePath => {
+    return this.zipService(exclude, include, zipFileName).then(filePath => {
       // only set the default artifact for backward-compatibility
       // when no explicit artifact is defined
       if (!this.serverless.service.package.artifact) {
@@ -74,7 +74,7 @@ module.exports = {
     const include = this.getIncludes(funcPackageConfig.include);
     const zipFileName = `${functionName}.zip`;
 
-    return this.zipDirectory(exclude, include, zipFileName).then(artifactPath => {
+    return this.zipService(exclude, include, zipFileName).then(artifactPath => {
       functionObject.artifact = artifactPath;
       return artifactPath;
     });

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -168,21 +168,21 @@ describe('#packageService()', () => {
     const artifactFilePath = '/some/fake/path/test-artifact.zip';
     let getExcludesStub;
     let getIncludesStub;
-    let zipDirectoryStub;
+    let zipServiceStub;
 
     beforeEach(() => {
       getExcludesStub = sinon
         .stub(packagePlugin, 'getExcludes').returns(exclude);
       getIncludesStub = sinon
         .stub(packagePlugin, 'getIncludes').returns(include);
-      zipDirectoryStub = sinon
-        .stub(packagePlugin, 'zipDirectory').resolves(artifactFilePath);
+      zipServiceStub = sinon
+        .stub(packagePlugin, 'zipService').resolves(artifactFilePath);
     });
 
     afterEach(() => {
       packagePlugin.getExcludes.restore();
       packagePlugin.getIncludes.restore();
-      packagePlugin.zipDirectory.restore();
+      packagePlugin.zipService.restore();
     });
 
     it('should call zipService with settings', () => {
@@ -195,8 +195,8 @@ describe('#packageService()', () => {
       .then(() => BbPromise.all([
         expect(getExcludesStub).to.be.calledOnce,
         expect(getIncludesStub).to.be.calledOnce,
-        expect(zipDirectoryStub).to.be.calledOnce,
-        expect(zipDirectoryStub).to.have.been.calledWithExactly(
+        expect(zipServiceStub).to.be.calledOnce,
+        expect(zipServiceStub).to.have.been.calledWithExactly(
           exclude,
           include,
           zipFileName
@@ -211,21 +211,21 @@ describe('#packageService()', () => {
     const artifactFilePath = '/some/fake/path/test-artifact.zip';
     let getExcludesStub;
     let getIncludesStub;
-    let zipDirectoryStub;
+    let zipServiceStub;
 
     beforeEach(() => {
       getExcludesStub = sinon
         .stub(packagePlugin, 'getExcludes').returns(exclude);
       getIncludesStub = sinon
         .stub(packagePlugin, 'getIncludes').returns(include);
-      zipDirectoryStub = sinon
-        .stub(packagePlugin, 'zipDirectory').resolves(artifactFilePath);
+      zipServiceStub = sinon
+        .stub(packagePlugin, 'zipService').resolves(artifactFilePath);
     });
 
     afterEach(() => {
       packagePlugin.getExcludes.restore();
       packagePlugin.getIncludes.restore();
-      packagePlugin.zipDirectory.restore();
+      packagePlugin.zipService.restore();
     });
 
     it('should call zipService with settings', () => {
@@ -243,8 +243,8 @@ describe('#packageService()', () => {
         expect(getExcludesStub).to.be.calledOnce,
         expect(getIncludesStub).to.be.calledOnce,
 
-        expect(zipDirectoryStub).to.be.calledOnce,
-        expect(zipDirectoryStub).to.have.been.calledWithExactly(
+        expect(zipServiceStub).to.be.calledOnce,
+        expect(zipServiceStub).to.have.been.calledWithExactly(
           exclude,
           include,
           zipFileName

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -10,7 +10,6 @@ const path = require('path');
 const fs = require('fs');
 const globby = require('globby');
 const _ = require('lodash');
-const walkDirSync = require('../../../utils/fs/walkDirSync');
 
 module.exports = {
   zipService(exclude, include, zipFileName) {
@@ -111,19 +110,27 @@ function excludeNodeDevDependencies(servicePath) {
   let include = [];
 
   try {
-    const filePathsInServiceDir = walkDirSync(servicePath);
-
-    // filter out non node_modules file paths
-    const packageJsonFilePaths = _.filter(filePathsInServiceDir, (filePath) => {
-      const isNodeModule = !!filePath.match(/node_modules/);
-      const hasPackageJson = !!filePath.match(/package\.json/);
-
-      return !isNodeModule && hasPackageJson;
+    const packageJsonFilePaths = globby.sync([
+      '**/package.json',
+      // TODO add glob for node_modules filtering
+    ], {
+      cwd: servicePath,
+      dot: true,
+      silent: true,
+      follow: true,
+      nosort: true,
     });
 
-    _.forEach(packageJsonFilePaths, (packageJsonFilePath) => {
+    // filter out non node_modules file paths
+    const relevantFilePaths = _.filter(packageJsonFilePaths, (filePath) => {
+      const isNodeModulesDir = !!filePath.match(/node_modules/);
+      return !isNodeModulesDir;
+    });
+
+    _.forEach(relevantFilePaths, (relevantFilePath) => {
       // the path where the package.json file lives
-      const rootDirPath = packageJsonFilePath.replace(path.join(path.sep, 'package.json'), '');
+      const fullPath = path.join(servicePath, relevantFilePath);
+      const rootDirPath = fullPath.replace(path.join(path.sep, 'package.json'), '');
 
       process.chdir(rootDirPath);
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -1,16 +1,45 @@
 'use strict';
 
+/* eslint-disable no-use-before-define */
+/* eslint-disable no-param-reassign */
+
+const childProcess = require('child_process');
 const archiver = require('archiver');
 const BbPromise = require('bluebird');
 const path = require('path');
 const fs = require('fs');
 const globby = require('globby');
+const _ = require('lodash');
+const walkDirSync = require('../../../utils/fs/walkDirSync');
 
 module.exports = {
-  zipDirectory(exclude, include, zipFileName) {
+  zipService(exclude, include, zipFileName) {
+    const params = {
+      exclude,
+      include,
+      zipFileName,
+    };
+
+    return BbPromise.bind(this)
+      .then(() => BbPromise.resolve(params))
+      .then(this.excludeDevDependencies)
+      .then(this.zip);
+  },
+
+  excludeDevDependencies(params) {
+    const servicePath = this.serverless.config.servicePath;
+    const exAndInNode = excludeNodeDevDependencies(servicePath);
+
+    params.exclude = _.union(params.exclude, exAndInNode.exclude);
+    params.include = _.union(params.include, exAndInNode.include);
+
+    return BbPromise.resolve(params);
+  },
+
+  zip(params) {
     const patterns = ['**'];
 
-    exclude.forEach((pattern) => {
+    params.exclude.forEach((pattern) => {
       if (pattern.charAt(0) !== '!') {
         patterns.push(`!${pattern}`);
       } else {
@@ -20,7 +49,7 @@ module.exports = {
 
     // push the include globs to the end of the array
     // (files and folders will be re-added again even if they were excluded beforehand)
-    include.forEach((pattern) => {
+    params.include.forEach((pattern) => {
       patterns.push(pattern);
     });
 
@@ -28,7 +57,7 @@ module.exports = {
     // Create artifact in temp path and move it to the package path (if any) later
     const artifactFilePath = path.join(this.serverless.config.servicePath,
       '.serverless',
-      zipFileName
+      params.zipFileName
     );
     this.serverless.utils.writeFileDir(artifactFilePath);
 
@@ -75,3 +104,63 @@ module.exports = {
     });
   },
 };
+
+function excludeNodeDevDependencies(servicePath) {
+  const cwd = process.cwd();
+  let exclude = [];
+  let include = [];
+
+  try {
+    const filePathsInServiceDir = walkDirSync(servicePath);
+
+    // filter out non node_modules file paths
+    const packageJsonFilePaths = _.filter(filePathsInServiceDir, (filePath) => {
+      const isNodeModule = !!filePath.match(/node_modules/);
+      const hasPackageJson = !!filePath.match(/package\.json/);
+
+      return !isNodeModule && hasPackageJson;
+    });
+
+    _.forEach(packageJsonFilePaths, (packageJsonFilePath) => {
+      // the path where the package.json file lives
+      const rootDirPath = packageJsonFilePath.replace(path.join(path.sep, 'package.json'), '');
+
+      process.chdir(rootDirPath);
+
+      // TODO replace with package-manager independent directory traversal?!
+      const prodDependencies = childProcess
+        .execSync('npm ls --prod=true --parseable=true --silent')
+        .toString().trim();
+
+      const prodDependencyPaths = prodDependencies.match(/(node_modules\/.*)/g);
+
+      let pathToDep = '';
+      // if the package.json file is not in the root of the service path
+      if (rootDirPath !== servicePath) {
+        // the path without the servicePath prepended
+        const relativeFilePath = rootDirPath.replace(path.join(servicePath, path.sep), '');
+        pathToDep = relativeFilePath ? `${relativeFilePath}/` : '';
+      }
+
+      const includePatterns = _.map(prodDependencyPaths, (depPath) =>
+        `${pathToDep}${depPath}/**`);
+
+      if (includePatterns.length) {
+        // at first exclude the whole node_modules directory
+        // after that re-include the production relevant modules
+        exclude = _.union(exclude, [`${pathToDep}node_modules/**`]);
+        include = _.union(include, includePatterns);
+      }
+    });
+  } catch (e) {
+    // npm is not installed
+  } finally {
+    // make sure to always chdir back to the cwd, no matter what
+    process.chdir(cwd);
+  }
+
+  return {
+    exclude,
+    include,
+  };
+}

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -7,10 +7,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const JsZip = require('jszip');
+const globby = require('globby');
 const _ = require('lodash');
 const childProcess = require('child_process');
 const sinon = require('sinon');
-const proxyquire = require('proxyquire');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
 const testUtils = require('../../../../tests/utils');
@@ -69,43 +69,40 @@ describe('zipService', () => {
 
   describe('#excludeDevDependencies()', () => {
     describe('when dealing with Node.js runtimes', () => {
-      let walkDirSyncStub;
+      let globbySyncStub;
       let processChdirStub;
       let execSyncStub;
 
       beforeEach(() => {
-        walkDirSyncStub = sinon.stub();
+        globbySyncStub = sinon.stub(globby, 'sync');
         processChdirStub = sinon.stub(process, 'chdir').returns();
         execSyncStub = sinon.stub(childProcess, 'execSync');
-        const zipService = proxyquire('./zipService.js', {
-          '../../../utils/fs/walkDirSync': walkDirSyncStub,
-        });
-        Object.assign(
-          packagePlugin,
-          zipService
-        );
       });
 
       afterEach(() => {
-        childProcess.execSync.restore();
         process.chdir.restore();
+        globby.sync.restore();
+        childProcess.execSync.restore();
       });
 
       it('should do nothing if no packages are used', () => {
-        const filePaths = [
-          path.join(packagePlugin.serverless.config.servicePath, 'serverless.yml'),
-          path.join(packagePlugin.serverless.config.servicePath, 'handler.js'),
-        ];
+        const filePaths = [];
 
-        walkDirSyncStub.returns(filePaths);
+        globbySyncStub.returns(filePaths);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
-            expect(walkDirSyncStub).to.have.been.calledOnce;
+            expect(globbySyncStub).to.have.been.calledOnce;
             expect(processChdirStub).to.have.been.calledOnce;
             expect(execSyncStub).to.not.have.been.called;
-            expect(walkDirSyncStub).to.have.been
-              .calledWithExactly(packagePlugin.serverless.config.servicePath);
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
             expect(updatedParams.exclude).to
               .deep.equal([]);
             expect(updatedParams.include).to
@@ -115,22 +112,24 @@ describe('zipService', () => {
       });
 
       it('should exclude dev dependencies in the services root directory', () => {
-        const filePaths = [
-          path.join(packagePlugin.serverless.config.servicePath, 'package.json'),
-          path.join(packagePlugin.serverless.config.servicePath, 'serverless.yml'),
-          path.join(packagePlugin.serverless.config.servicePath, 'handler.js'),
-        ];
+        const filePaths = ['package.json', 'node_modules'];
 
-        walkDirSyncStub.returns(filePaths);
+        globbySyncStub.returns(filePaths);
         execSyncStub.returns('node_modules/module-1\nnode_modules/module-2');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
-            expect(walkDirSyncStub).to.have.been.calledOnce;
+            expect(globbySyncStub).to.have.been.calledOnce;
             expect(processChdirStub).to.have.been.calledTwice;
             expect(execSyncStub).to.have.been.calledOnce;
-            expect(walkDirSyncStub).to.have.been
-              .calledWithExactly(packagePlugin.serverless.config.servicePath);
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
             expect(execSyncStub).to.have.been
               .calledWithExactly('npm ls --prod=true --parseable=true --silent');
             expect(updatedParams.exclude).to
@@ -144,22 +143,16 @@ describe('zipService', () => {
       it('should exclude dev dependencies in deeply nested services directories', () => {
         const filePaths = [
           // root of the service
-          path.join(packagePlugin.serverless.config.servicePath, 'package.json'),
-          path.join(packagePlugin.serverless.config.servicePath, 'serverless.yml'),
-          path.join(packagePlugin.serverless.config.servicePath, 'handler.js'),
+          'package.json', 'node_modules',
           // nested-dir
-          path.join(packagePlugin.serverless.config.servicePath, '1st',
-            'package.json'),
-          path.join(packagePlugin.serverless.config.servicePath, '1st',
-            'some-random-file'),
+          path.join('1st', 'package.json'),
+          path.join('1st', 'node_modules'),
           // nested-dir which is nested
-          path.join(packagePlugin.serverless.config.servicePath, '1st',
-            '2nd', 'package.json'),
-          path.join(packagePlugin.serverless.config.servicePath, '1st',
-            '2nd', 'some-random-file'),
+          path.join('1st', '2nd', 'package.json'),
+          path.join('1st', '2nd', 'node_modules'),
         ];
 
-        walkDirSyncStub.returns(filePaths);
+        globbySyncStub.returns(filePaths);
         execSyncStub.onCall(0).returns('node_modules/module-1\nnode_modules/module-2');
         execSyncStub.onCall(1)
           .returns('1st/node_modules/module-1\n1st/node_modules/module-2');
@@ -168,11 +161,17 @@ describe('zipService', () => {
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
-            expect(walkDirSyncStub).to.have.been.calledOnce;
+            expect(globbySyncStub).to.have.been.calledOnce;
             expect(processChdirStub.callCount).to.equal(4);
             expect(execSyncStub.callCount).to.equal(3);
-            expect(walkDirSyncStub).to.have.been
-              .calledWithExactly(packagePlugin.serverless.config.servicePath);
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
             expect(execSyncStub).to.have.been
               .calledWithExactly('npm ls --prod=true --parseable=true --silent');
             expect(updatedParams.exclude).to

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -1,344 +1,503 @@
 'use strict';
 
+/* eslint-disable no-unused-expressions */
+
 const chai = require('chai');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const JsZip = require('jszip');
 const _ = require('lodash');
+const childProcess = require('child_process');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
-const ServerlessError = require('../../../classes/Error').ServerlessError;
 const testUtils = require('../../../../tests/utils');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
-describe('#zipService()', () => {
+describe('zipService', () => {
+  let tmpDirPath;
   let serverless;
-  let packageService;
-  let zip;
-
-  const testDirectory = {
-    // root
-    '.': {
-      'event.json': 'some content',
-      'handler.js': 'some content',
-      'file-1': 'some content',
-      'file-2': 'some content',
-    },
-    // bin
-    bin: {
-      'binary-777': {
-        content: 'some content',
-        permissions: 777,
-      },
-      'binary-444': {
-        content: 'some content',
-        permissions: 444,
-      },
-    },
-    // lib
-    lib: {
-      'file-1.js': 'some content',
-    },
-    'lib/directory-1': {
-      'file-1.js': 'some content',
-    },
-    // node_modules
-    'node_modules/directory-1': {
-      'file-1': 'some content',
-      'file-2': 'some content',
-    },
-    'node_modules/directory-2': {
-      'file-1': 'some content',
-      'file-2': 'some content',
-    },
-  };
-
-  function getTestArtifactFileName(testName) {
-    return `test-${testName}-${(new Date()).getTime().toString()}.zip`;
-  }
+  let packagePlugin;
+  let params;
 
   beforeEach(() => {
+    tmpDirPath = testUtils.getTmpDirPath();
     serverless = new Serverless();
-    zip = new JsZip();
-    packageService = new Package(serverless, {});
-    packageService.serverless.cli = new serverless.classes.CLI();
+    serverless.service.service = 'first-service';
+    serverless.config.servicePath = tmpDirPath;
+    packagePlugin = new Package(serverless, {});
+    packagePlugin.serverless.cli = new serverless.classes.CLI();
+    params = {
+      include: [],
+      exclude: [],
+      zipFileName: 'my-service.zip',
+    };
+  });
 
-    // create a mock service in a temporary directory
-    const tmpDirPath = testUtils.getTmpDirPath();
+  describe('#zipService()', () => {
+    let excludeDevDependenciesStub;
+    let zipStub;
 
-    Object.keys(testDirectory).forEach(dirName => {
-      const dirPath = path.join(tmpDirPath, dirName);
-      const files = testDirectory[dirName];
+    beforeEach(() => {
+      excludeDevDependenciesStub = sinon.stub(packagePlugin, 'excludeDevDependencies').resolves();
+      zipStub = sinon.stub(packagePlugin, 'zip').resolves();
+    });
 
-      Object.keys(files).forEach(fileName => {
-        const filePath = path.join(dirPath, fileName);
-        const fileValue = files[fileName];
-        const file = _.isObject(fileValue) ? fileValue : { content: fileValue };
+    afterEach(() => {
+      packagePlugin.excludeDevDependencies.restore();
+      packagePlugin.zip.restore();
+    });
 
-        if (!file.content) {
-          throw new Error('File content is required');
-        }
+    it('should run promise chain in order', () => {
+      const exclude = params.exclude;
+      const include = params.include;
+      const zipFileName = params.zipFileName;
 
-        serverless.utils.writeFileSync(filePath, file.content);
+      return expect(packagePlugin.zipService(exclude, include, zipFileName)).to.be
+        .fulfilled.then(() => {
+          expect(excludeDevDependenciesStub).to.have.been.calledOnce;
+          expect(zipStub).to.have.been.calledOnce;
+        });
+    });
+  });
 
-        if (file.permissions) {
-          fs.chmodSync(filePath, file.permissions);
+  describe('#excludeDevDependencies()', () => {
+    describe('when dealing with Node.js runtimes', () => {
+      let walkDirSyncStub;
+      let processChdirStub;
+      let execSyncStub;
+
+      beforeEach(() => {
+        walkDirSyncStub = sinon.stub();
+        processChdirStub = sinon.stub(process, 'chdir').returns();
+        execSyncStub = sinon.stub(childProcess, 'execSync');
+        const zipService = proxyquire('./zipService.js', {
+          '../../../utils/fs/walkDirSync': walkDirSyncStub,
+        });
+        Object.assign(
+          packagePlugin,
+          zipService
+        );
+      });
+
+      afterEach(() => {
+        childProcess.execSync.restore();
+        process.chdir.restore();
+      });
+
+      it('should do nothing if no packages are used', () => {
+        const filePaths = [
+          path.join(packagePlugin.serverless.config.servicePath, 'serverless.yml'),
+          path.join(packagePlugin.serverless.config.servicePath, 'handler.js'),
+        ];
+
+        walkDirSyncStub.returns(filePaths);
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(walkDirSyncStub).to.have.been.calledOnce;
+            expect(processChdirStub).to.have.been.calledOnce;
+            expect(execSyncStub).to.not.have.been.called;
+            expect(walkDirSyncStub).to.have.been
+              .calledWithExactly(packagePlugin.serverless.config.servicePath);
+            expect(updatedParams.exclude).to
+              .deep.equal([]);
+            expect(updatedParams.include).to
+              .deep.equal([]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should exclude dev dependencies in the services root directory', () => {
+        const filePaths = [
+          path.join(packagePlugin.serverless.config.servicePath, 'package.json'),
+          path.join(packagePlugin.serverless.config.servicePath, 'serverless.yml'),
+          path.join(packagePlugin.serverless.config.servicePath, 'handler.js'),
+        ];
+
+        walkDirSyncStub.returns(filePaths);
+        execSyncStub.returns('node_modules/module-1\nnode_modules/module-2');
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(walkDirSyncStub).to.have.been.calledOnce;
+            expect(processChdirStub).to.have.been.calledTwice;
+            expect(execSyncStub).to.have.been.calledOnce;
+            expect(walkDirSyncStub).to.have.been
+              .calledWithExactly(packagePlugin.serverless.config.servicePath);
+            expect(execSyncStub).to.have.been
+              .calledWithExactly('npm ls --prod=true --parseable=true --silent');
+            expect(updatedParams.exclude).to
+              .deep.equal(['node_modules/**']);
+            expect(updatedParams.include).to
+              .deep.equal(['node_modules/module-1/**', 'node_modules/module-2/**']);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should exclude dev dependencies in deeply nested services directories', () => {
+        const filePaths = [
+          // root of the service
+          path.join(packagePlugin.serverless.config.servicePath, 'package.json'),
+          path.join(packagePlugin.serverless.config.servicePath, 'serverless.yml'),
+          path.join(packagePlugin.serverless.config.servicePath, 'handler.js'),
+          // nested-dir
+          path.join(packagePlugin.serverless.config.servicePath, '1st',
+            'package.json'),
+          path.join(packagePlugin.serverless.config.servicePath, '1st',
+            'some-random-file'),
+          // nested-dir which is nested
+          path.join(packagePlugin.serverless.config.servicePath, '1st',
+            '2nd', 'package.json'),
+          path.join(packagePlugin.serverless.config.servicePath, '1st',
+            '2nd', 'some-random-file'),
+        ];
+
+        walkDirSyncStub.returns(filePaths);
+        execSyncStub.onCall(0).returns('node_modules/module-1\nnode_modules/module-2');
+        execSyncStub.onCall(1)
+          .returns('1st/node_modules/module-1\n1st/node_modules/module-2');
+        execSyncStub.onCall(2)
+          .returns('1st/2nd/node_modules/module-1\n1st/2nd/node_modules/module-2');
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(walkDirSyncStub).to.have.been.calledOnce;
+            expect(processChdirStub.callCount).to.equal(4);
+            expect(execSyncStub.callCount).to.equal(3);
+            expect(walkDirSyncStub).to.have.been
+              .calledWithExactly(packagePlugin.serverless.config.servicePath);
+            expect(execSyncStub).to.have.been
+              .calledWithExactly('npm ls --prod=true --parseable=true --silent');
+            expect(updatedParams.exclude).to
+              .deep.equal([
+                'node_modules/**',
+                '1st/node_modules/**',
+                '1st/2nd/node_modules/**',
+              ]);
+            expect(updatedParams.include).to
+              .deep.equal([
+                'node_modules/module-1/**',
+                'node_modules/module-2/**',
+                '1st/node_modules/module-1/**',
+                '1st/node_modules/module-2/**',
+                '1st/2nd/node_modules/module-1/**',
+                '1st/2nd/node_modules/module-2/**',
+              ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+    });
+  });
+
+  describe('#zip()', () => {
+    let zip;
+
+    const testDirectory = {
+      // root
+      '.': {
+        'event.json': 'some content',
+        'handler.js': 'some content',
+        'file-1': 'some content',
+        'file-2': 'some content',
+      },
+      // bin
+      bin: {
+        'binary-777': {
+          content: 'some content',
+          permissions: 777,
+        },
+        'binary-444': {
+          content: 'some content',
+          permissions: 444,
+        },
+      },
+      // lib
+      lib: {
+        'file-1.js': 'some content',
+      },
+      'lib/directory-1': {
+        'file-1.js': 'some content',
+      },
+      // node_modules
+      'node_modules/directory-1': {
+        'file-1': 'some content',
+        'file-2': 'some content',
+      },
+      'node_modules/directory-2': {
+        'file-1': 'some content',
+        'file-2': 'some content',
+      },
+    };
+
+    function getTestArtifactFileName(testName) {
+      return `test-${testName}-${(new Date()).getTime().toString()}.zip`;
+    }
+
+    beforeEach(() => {
+      zip = new JsZip();
+
+      Object.keys(testDirectory).forEach(dirName => {
+        const dirPath = path.join(tmpDirPath, dirName);
+        const files = testDirectory[dirName];
+
+        Object.keys(files).forEach(fileName => {
+          const filePath = path.join(dirPath, fileName);
+          const fileValue = files[fileName];
+          const file = _.isObject(fileValue) ? fileValue : { content: fileValue };
+
+          if (!file.content) {
+            throw new Error('File content is required');
+          }
+
+          serverless.utils.writeFileSync(filePath, file.content);
+
+          if (file.permissions) {
+            fs.chmodSync(filePath, file.permissions);
+          }
+        });
+      });
+    });
+
+    it('should zip a whole service (without include / exclude usage)', () => {
+      params.zipFileName = getTestArtifactFileName('whole-service');
+
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+      .then(artifact => {
+        const data = fs.readFileSync(artifact);
+        return expect(zip.loadAsync(data)).to.be.fulfilled;
+      })
+      .then(unzippedData => {
+        const unzippedFileData = unzippedData.files;
+
+        expect(Object.keys(unzippedFileData)
+         .filter(file => !unzippedFileData[file].dir))
+         .to.be.lengthOf(13);
+
+        // root directory
+        expect(unzippedFileData['event.json'].name)
+          .to.equal('event.json');
+        expect(unzippedFileData['handler.js'].name)
+          .to.equal('handler.js');
+        expect(unzippedFileData['file-1'].name)
+          .to.equal('file-1');
+        expect(unzippedFileData['file-2'].name)
+          .to.equal('file-2');
+
+        // bin directory
+        expect(unzippedFileData['bin/binary-777'].name)
+          .to.equal('bin/binary-777');
+        expect(unzippedFileData['bin/binary-444'].name)
+          .to.equal('bin/binary-444');
+
+        // lib directory
+        expect(unzippedFileData['lib/file-1.js'].name)
+          .to.equal('lib/file-1.js');
+        expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+          .to.equal('lib/directory-1/file-1.js');
+
+        // node_modules directory
+        expect(unzippedFileData['node_modules/directory-1/file-1'].name)
+          .to.equal('node_modules/directory-1/file-1');
+        expect(unzippedFileData['node_modules/directory-1/file-2'].name)
+          .to.equal('node_modules/directory-1/file-2');
+        expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+          .to.equal('node_modules/directory-2/file-1');
+        expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+          .to.equal('node_modules/directory-2/file-2');
+      });
+    });
+
+    it('should keep file permissions', () => {
+      params.zipFileName = getTestArtifactFileName('file-permissions');
+
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+      .then(artifact => {
+        const data = fs.readFileSync(artifact);
+        return expect(zip.loadAsync(data)).to.be.fulfilled;
+      }).then(unzippedData => {
+        const unzippedFileData = unzippedData.files;
+
+        if (os.platform() === 'win32') {
+          // chmod does not work right on windows. this is better than nothing?
+          expect(unzippedFileData['bin/binary-777'].unixPermissions)
+            .to.not.equal(unzippedFileData['bin/binary-444'].unixPermissions);
+        } else {
+          // binary file is set with chmod of 777
+          expect(unzippedFileData['bin/binary-777'].unixPermissions)
+            .to.equal(Math.pow(2, 15) + 777);
+
+          // read only file is set with chmod of 444
+          expect(unzippedFileData['bin/binary-444'].unixPermissions)
+            .to.equal(Math.pow(2, 15) + 444);
         }
       });
     });
-    // set the service name
-    serverless.service.service = 'first-service';
 
-    // set the servicePath
-    serverless.config.servicePath = tmpDirPath;
-  });
+    it('should exclude with globs', () => {
+      params.zipFileName = getTestArtifactFileName('exclude-with-globs');
+      params.exclude = [
+        'event.json',
+        'lib/**',
+        'node_modules/directory-1/**',
+      ];
 
-  it('should zip a whole service (without include / exclude usage)', () => {
-    const exclude = [];
-    const include = [];
-    const zipFileName = getTestArtifactFileName('whole-service');
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+      .then(artifact => {
+        const data = fs.readFileSync(artifact);
+        return expect(zip.loadAsync(data)).to.be.fulfilled;
+      }).then(unzippedData => {
+        const unzippedFileData = unzippedData.files;
 
-    return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
-    .then(artifact => {
-      const data = fs.readFileSync(artifact);
-      return expect(zip.loadAsync(data)).to.be.fulfilled;
-    })
-    .then(unzippedData => {
-      const unzippedFileData = unzippedData.files;
+        expect(Object.keys(unzippedFileData)
+          .filter(file => !unzippedFileData[file].dir))
+          .to.be.lengthOf(8);
 
-      expect(Object.keys(unzippedFileData)
-       .filter(file => !unzippedFileData[file].dir))
-       .to.be.lengthOf(13);
+        // root directory
+        expect(unzippedFileData['handler.js'].name)
+          .to.equal('handler.js');
+        expect(unzippedFileData['file-1'].name)
+          .to.equal('file-1');
+        expect(unzippedFileData['file-2'].name)
+          .to.equal('file-2');
 
-      // root directory
-      expect(unzippedFileData['event.json'].name)
-        .to.equal('event.json');
-      expect(unzippedFileData['handler.js'].name)
-        .to.equal('handler.js');
-      expect(unzippedFileData['file-1'].name)
-        .to.equal('file-1');
-      expect(unzippedFileData['file-2'].name)
-        .to.equal('file-2');
+        // bin directory
+        expect(unzippedFileData['bin/binary-777'].name)
+          .to.equal('bin/binary-777');
+        expect(unzippedFileData['bin/binary-444'].name)
+          .to.equal('bin/binary-444');
 
-      // bin directory
-      expect(unzippedFileData['bin/binary-777'].name)
-        .to.equal('bin/binary-777');
-      expect(unzippedFileData['bin/binary-444'].name)
-        .to.equal('bin/binary-444');
-
-      // lib directory
-      expect(unzippedFileData['lib/file-1.js'].name)
-        .to.equal('lib/file-1.js');
-      expect(unzippedFileData['lib/directory-1/file-1.js'].name)
-        .to.equal('lib/directory-1/file-1.js');
-
-      // node_modules directory
-      expect(unzippedFileData['node_modules/directory-1/file-1'].name)
-        .to.equal('node_modules/directory-1/file-1');
-      expect(unzippedFileData['node_modules/directory-1/file-2'].name)
-        .to.equal('node_modules/directory-1/file-2');
-      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
-        .to.equal('node_modules/directory-2/file-1');
-      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
-        .to.equal('node_modules/directory-2/file-2');
+        // node_modules directory
+        expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+          .to.equal('node_modules/directory-2/file-1');
+        expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+          .to.equal('node_modules/directory-2/file-2');
+      });
     });
-  });
 
-  it('should keep file permissions', () => {
-    const exclude = [];
-    const include = [];
-    const zipFileName = getTestArtifactFileName('file-permissions');
+    it('should re-include files using ! glob pattern', () => {
+      params.zipFileName = getTestArtifactFileName('re-include-with-globs');
+      params.exclude = [
+        'event.json',
+        'lib/**',
+        'node_modules/directory-1/**',
 
-    return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
-    .then(artifact => {
-      const data = fs.readFileSync(artifact);
-      return expect(zip.loadAsync(data)).to.be.fulfilled;
-    }).then(unzippedData => {
-      const unzippedFileData = unzippedData.files;
+        '!event.json', // re-include
+        '!lib/**', // re-include
+      ];
 
-      if (os.platform() === 'win32') {
-        // chmod does not work right on windows. this is better than nothing?
-        expect(unzippedFileData['bin/binary-777'].unixPermissions)
-          .to.not.equal(unzippedFileData['bin/binary-444'].unixPermissions);
-      } else {
-        // binary file is set with chmod of 777
-        expect(unzippedFileData['bin/binary-777'].unixPermissions)
-          .to.equal(Math.pow(2, 15) + 777);
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+      .then(artifact => {
+        const data = fs.readFileSync(artifact);
+        return expect(zip.loadAsync(data)).to.be.fulfilled;
+      }).then(unzippedData => {
+        const unzippedFileData = unzippedData.files;
 
-        // read only file is set with chmod of 444
-        expect(unzippedFileData['bin/binary-444'].unixPermissions)
-          .to.equal(Math.pow(2, 15) + 444);
-      }
+        expect(Object.keys(unzippedFileData)
+          .filter(file => !unzippedFileData[file].dir))
+          .to.be.lengthOf(11);
+
+        // root directory
+        expect(unzippedFileData['event.json'].name)
+          .to.equal('event.json');
+        expect(unzippedFileData['handler.js'].name)
+          .to.equal('handler.js');
+        expect(unzippedFileData['file-1'].name)
+          .to.equal('file-1');
+        expect(unzippedFileData['file-2'].name)
+          .to.equal('file-2');
+
+        // bin directory
+        expect(unzippedFileData['bin/binary-777'].name)
+          .to.equal('bin/binary-777');
+        expect(unzippedFileData['bin/binary-444'].name)
+          .to.equal('bin/binary-444');
+
+        // lib directory
+        expect(unzippedFileData['lib/file-1.js'].name)
+          .to.equal('lib/file-1.js');
+        expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+          .to.equal('lib/directory-1/file-1.js');
+
+        // node_modules directory
+        expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+          .to.equal('node_modules/directory-2/file-1');
+        expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+          .to.equal('node_modules/directory-2/file-2');
+      });
     });
-  });
 
-  it('should exclude with globs', () => {
-    const exclude = [
-      'event.json',
-      'lib/**',
-      'node_modules/directory-1/**',
-    ];
-    const include = [];
+    it('should re-include files using include config', () => {
+      params.zipFileName = getTestArtifactFileName('re-include-with-include');
+      params.exclude = [
+        'event.json',
+        'lib/**',
+        'node_modules/directory-1/**',
+      ];
+      params.include = [
+        'event.json',
+        'lib/**',
+      ];
 
-    const zipFileName = getTestArtifactFileName('exclude-with-globs');
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+      .then(artifact => {
+        const data = fs.readFileSync(artifact);
+        return expect(zip.loadAsync(data)).to.be.fulfilled;
+      }).then(unzippedData => {
+        const unzippedFileData = unzippedData.files;
 
-    return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
-    .then(artifact => {
-      const data = fs.readFileSync(artifact);
-      return expect(zip.loadAsync(data)).to.be.fulfilled;
-    }).then(unzippedData => {
-      const unzippedFileData = unzippedData.files;
+        expect(Object.keys(unzippedFileData)
+          .filter(file => !unzippedFileData[file].dir))
+          .to.be.lengthOf(11);
 
-      expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir))
-        .to.be.lengthOf(8);
+        // root directory
+        expect(unzippedFileData['event.json'].name)
+          .to.equal('event.json');
+        expect(unzippedFileData['handler.js'].name)
+          .to.equal('handler.js');
+        expect(unzippedFileData['file-1'].name)
+          .to.equal('file-1');
+        expect(unzippedFileData['file-2'].name)
+          .to.equal('file-2');
 
-      // root directory
-      expect(unzippedFileData['handler.js'].name)
-        .to.equal('handler.js');
-      expect(unzippedFileData['file-1'].name)
-        .to.equal('file-1');
-      expect(unzippedFileData['file-2'].name)
-        .to.equal('file-2');
+        // bin directory
+        expect(unzippedFileData['bin/binary-777'].name)
+          .to.equal('bin/binary-777');
+        expect(unzippedFileData['bin/binary-444'].name)
+          .to.equal('bin/binary-444');
 
-      // bin directory
-      expect(unzippedFileData['bin/binary-777'].name)
-        .to.equal('bin/binary-777');
-      expect(unzippedFileData['bin/binary-444'].name)
-        .to.equal('bin/binary-444');
+        // lib directory
+        expect(unzippedFileData['lib/file-1.js'].name)
+          .to.equal('lib/file-1.js');
+        expect(unzippedFileData['lib/directory-1/file-1.js'].name)
+          .to.equal('lib/directory-1/file-1.js');
 
-      // node_modules directory
-      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
-        .to.equal('node_modules/directory-2/file-1');
-      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
-        .to.equal('node_modules/directory-2/file-2');
+        // node_modules directory
+        expect(unzippedFileData['node_modules/directory-2/file-1'].name)
+          .to.equal('node_modules/directory-2/file-1');
+        expect(unzippedFileData['node_modules/directory-2/file-2'].name)
+          .to.equal('node_modules/directory-2/file-2');
+      });
     });
-  });
 
-  it('should re-include files using ! glob pattern', () => {
-    const exclude = [
-      'event.json',
-      'lib/**',
-      'node_modules/directory-1/**',
+    it('should throw an error if no files are matched', () => {
+      params.exclude = ['**/**'];
+      params.include = [];
+      params.zipFileName = getTestArtifactFileName('empty');
 
-      '!event.json', // re-include
-      '!lib/**', // re-include
-    ];
-    const include = [];
-
-    const zipFileName = getTestArtifactFileName('re-include-with-globs');
-
-    return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
-    .then(artifact => {
-      const data = fs.readFileSync(artifact);
-      return expect(zip.loadAsync(data)).to.be.fulfilled;
-    }).then(unzippedData => {
-      const unzippedFileData = unzippedData.files;
-
-      expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir))
-        .to.be.lengthOf(11);
-
-      // root directory
-      expect(unzippedFileData['event.json'].name)
-        .to.equal('event.json');
-      expect(unzippedFileData['handler.js'].name)
-        .to.equal('handler.js');
-      expect(unzippedFileData['file-1'].name)
-        .to.equal('file-1');
-      expect(unzippedFileData['file-2'].name)
-        .to.equal('file-2');
-
-      // bin directory
-      expect(unzippedFileData['bin/binary-777'].name)
-        .to.equal('bin/binary-777');
-      expect(unzippedFileData['bin/binary-444'].name)
-        .to.equal('bin/binary-444');
-
-      // lib directory
-      expect(unzippedFileData['lib/file-1.js'].name)
-        .to.equal('lib/file-1.js');
-      expect(unzippedFileData['lib/directory-1/file-1.js'].name)
-        .to.equal('lib/directory-1/file-1.js');
-
-      // node_modules directory
-      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
-        .to.equal('node_modules/directory-2/file-1');
-      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
-        .to.equal('node_modules/directory-2/file-2');
+      return expect(packagePlugin.zip(params)).to.be
+        .rejectedWith(Error, 'file matches include / exclude');
     });
-  });
-
-  it('should re-include files using include config', () => {
-    const exclude = [
-      'event.json',
-      'lib/**',
-      'node_modules/directory-1/**',
-    ];
-    const include = [
-      'event.json',
-      'lib/**',
-    ];
-
-    const zipFileName = getTestArtifactFileName('re-include-with-include');
-
-    return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.eventually.be.equal(path.join(serverless.config.servicePath, '.serverless', zipFileName))
-    .then(artifact => {
-      const data = fs.readFileSync(artifact);
-      return expect(zip.loadAsync(data)).to.be.fulfilled;
-    }).then(unzippedData => {
-      const unzippedFileData = unzippedData.files;
-
-      expect(Object.keys(unzippedFileData)
-        .filter(file => !unzippedFileData[file].dir))
-        .to.be.lengthOf(11);
-
-      // root directory
-      expect(unzippedFileData['event.json'].name)
-        .to.equal('event.json');
-      expect(unzippedFileData['handler.js'].name)
-        .to.equal('handler.js');
-      expect(unzippedFileData['file-1'].name)
-        .to.equal('file-1');
-      expect(unzippedFileData['file-2'].name)
-        .to.equal('file-2');
-
-      // bin directory
-      expect(unzippedFileData['bin/binary-777'].name)
-        .to.equal('bin/binary-777');
-      expect(unzippedFileData['bin/binary-444'].name)
-        .to.equal('bin/binary-444');
-
-      // lib directory
-      expect(unzippedFileData['lib/file-1.js'].name)
-        .to.equal('lib/file-1.js');
-      expect(unzippedFileData['lib/directory-1/file-1.js'].name)
-        .to.equal('lib/directory-1/file-1.js');
-
-      // node_modules directory
-      expect(unzippedFileData['node_modules/directory-2/file-1'].name)
-        .to.equal('node_modules/directory-2/file-1');
-      expect(unzippedFileData['node_modules/directory-2/file-2'].name)
-        .to.equal('node_modules/directory-2/file-2');
-    });
-  });
-
-  it('should throw an error when no file are matched', () => {
-    const exclude = ['**/**'];
-    const include = [];
-
-    const zipFileName = getTestArtifactFileName('empty');
-
-    return expect(packageService.zipDirectory(exclude, include, zipFileName))
-      .to.be.rejectedWith(ServerlessError, 'file matches include / exclude');
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #2709

Exclude the `dev` node_modules when zipping to decrease the bundle size.

## How did you implement it:

Get a list of the production node_modules. Add the `node_modules/**` glob to the `exclude` and re-include the production `node_modules` via corresponding `<package-name>/**` globs in the `include` glob.

## How can we verify it:

Create a service and do a `npm init`.

Run `npm install --save node-fetch` and `npm install --save-dev jest`.

Run `serverless package` and inspect the zip file. It should only include the dependencies necessary for the `node-fetch` module (and not the ones for `jest`).

**Note:** please use nested directories with dependencies as well. Those should also only include the dev dependencies after packaging.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO