### PR TITLE
Throw an Error when requested Cloudformation variable does not exist

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -294,9 +294,9 @@ class Variables {
 
         if (output === undefined) {
           const errorMessage = [
-            'Trying to request a non exported variable from Cloudformation.',
+            'Trying to request a non exported variable from CloudFormation.',
             ` Stack name: "${stackName}"`,
-            ` Requested variable: "${outputLogicalId}"`,
+            ` Requested variable: "${outputLogicalId}".`,
           ].join('');
           throw new this.serverless.classes
             .Error(errorMessage);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -291,6 +291,17 @@ class Variables {
       .then(result => {
         const outputs = result.Stacks[0].Outputs;
         const output = outputs.find(x => x.OutputKey === outputLogicalId);
+
+        if (undefined === output) {
+          const errorMessage = [
+            'Trying to request a non variable from Cloudformation.',
+            ` Stack name: "${stackName}"`,
+            ` Requested variable: "${outputLogicalId}"`,
+          ].join('');
+          throw new this.serverless.classes
+            .Error(errorMessage);
+        }
+
         return output.OutputValue;
       });
   }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -292,9 +292,9 @@ class Variables {
         const outputs = result.Stacks[0].Outputs;
         const output = outputs.find(x => x.OutputKey === outputLogicalId);
 
-        if (undefined === output) {
+        if (output === undefined) {
           const errorMessage = [
-            'Trying to request a non variable from Cloudformation.',
+            'Trying to request a non exported variable from Cloudformation.',
             ` Stack name: "${stackName}"`,
             ` Requested variable: "${outputLogicalId}"`,
           ].join('');

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -755,7 +755,7 @@ describe('Variables', () => {
           )).to.be.equal(true);
           serverless.getProvider('aws').request.restore();
           expect(error).to.be.an.instanceof(Error);
-          expect(error.message).to.match(/to request a non exported variable from Cloudformation/);
+          expect(error.message).to.match(/to request a non exported variable from CloudFormation/);
         });
     });
   });

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -755,6 +755,7 @@ describe('Variables', () => {
           )).to.be.equal(true);
           serverless.getProvider('aws').request.restore();
           expect(error).to.be.an.instanceof(Error);
+          expect(error.message).to.match(/to request a non exported variable from Cloudformation/);
         });
     });
   });

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -718,6 +718,45 @@ describe('Variables', () => {
           serverless.getProvider('aws').request.restore();
         });
     });
+
+    it('should throw an error when variable from CloudFormation does not exist', () => {
+      const serverless = new Serverless();
+      const options = {
+        stage: 'prod',
+        region: 'us-west-2',
+      };
+      const awsProvider = new AwsProvider(serverless, options);
+      serverless.setProvider('aws', awsProvider);
+      serverless.variables.options = options;
+      const awsResponseMock = {
+        Stacks: [{
+          Outputs: [{
+            OutputKey: 'MockExport',
+            OutputValue: 'MockValue',
+          }],
+        }],
+      };
+
+      const cfStub = sinon.stub(serverless.getProvider('aws'), 'request')
+        .resolves(awsResponseMock);
+
+      return serverless.variables.getValueFromCf('cf:some-stack.DoestNotExist')
+        .then()
+        .catch(error => {
+          expect(cfStub.calledOnce).to.be.equal(true);
+          expect(cfStub.calledWithExactly(
+            'CloudFormation',
+            'describeStacks',
+            {
+              StackName: 'some-stack',
+            },
+            serverless.variables.options.stage,
+            serverless.variables.options.region
+          )).to.be.equal(true);
+          serverless.getProvider('aws').request.restore();
+          expect(error).to.be.an.instanceof(Error);
+        });
+    });
   });
 
   describe('#getValueFromS3()', () => {


### PR DESCRIPTION
## What did you implement:

A better error information when requesting a Cloudformation variable that does not exist. The previous one was:

> Cannot read property 'OutputValue' of undefined

## How did you implement it:

When the variable isn't found, instead of assuming it always existing, I checked if the value is undefined and throw an error in that case.

## How can we verify it:

Defining a non-existant variable in a `serverless.yml` file, like `${cf:my-stack.IDoReallyNotExist}` and run serverless.

It should throw:

```
jeremy@schiaparelli:~/$ serverless deploy --stage staging --verbose
 
  Serverless Error ---------------------------------------
 
     Trying to request a non variable from Cloudformation.
     Stack name: "my-stack" Requested variable: "IDoReallyNotExist"
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Forums:        forum.serverless.com
     Chat:          gitter.im/serverless/serverless
 
  Your Environment Information -----------------------------
     OS:                 linux
     Node Version:       6.3.0
     Serverless Version: 1.13.2
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
