### PR TITLE
#3495 Add AWS X-Ray support

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -22,7 +22,8 @@ All of the Lambda functions in your serverless service can be found in `serverle
 # serverless.yml
 service:
   name: myService
-  awsTracingConfigMode: Active # optional, can be 'Active' or 'PassThrough'
+  awsTracingConfig:
+    mode: Active # optional, can be 'Active' or 'PassThrough'
 
 provider:
   name: aws
@@ -39,7 +40,8 @@ functions:
     runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, in MB, default is 1024
     timeout: 10 # optional, in seconds, default is 6
-    awsTracingConfigMode: PassThrough # optional overwrite, can be 'Active' or 'PassThrough'
+    awsTracingConfig
+      mode: PassThrough # optional overwrite, can be 'Active' or 'PassThrough'
 ```
 
 The `handler` property points to the file and module containing the code you want to run in your function.
@@ -367,12 +369,13 @@ When storing secrets in environment variables, AWS [strongly suggests](http://do
 
 ## AWS X-Ray Tracing
 
-You can enable [AWS X-Ray Tracing](http://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) on your Lambda functions through the optional `awsTracingConfigMode` config variable:
+You can enable [AWS X-Ray Tracing](http://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) on your Lambda functions through the optional `awsTracingConfig` config variable in conjucntion with the `mode` property:
 
 ```yml
 service:
   name: myService
-  awsTracingConfigMode: Active
+  awsTracingConfig:
+    mode: Active
 ```
 
 You can also set this variable on a per-function basis. This will override the service level setting if it is present:
@@ -381,8 +384,10 @@ You can also set this variable on a per-function basis. This will override the s
 functions:
   hello:
     handler: handler.hello
-    awsTracingConfigMode: Active
+    awsTracingConfig:
+      mode: Active
   goodbye:
     handler: handler.goodbye
-    awsTracingConfigMode: PassThrough
+    awsTracingConfig:
+      mode: PassThrough
 ```

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -40,7 +40,7 @@ functions:
     runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, in MB, default is 1024
     timeout: 10 # optional, in seconds, default is 6
-    awsTracingConfig
+    awsTracingConfig:
       mode: PassThrough # optional overwrite, can be 'Active' or 'PassThrough'
 ```
 

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -20,7 +20,9 @@ All of the Lambda functions in your serverless service can be found in `serverle
 
 ```yml
 # serverless.yml
-service: myService
+service:
+  name: myService
+  awsTracingConfigMode: Active # optional, can be 'Active' or 'PassThrough'
 
 provider:
   name: aws
@@ -28,7 +30,6 @@ provider:
   memorySize: 512 # optional, default is 1024
   timeout: 10 # optional, default is 6
   versionFunctions: false # optional, default is true
-  tracingConfigMode: Active # optional, can be 'Active' or 'PassThrough'
 
 functions:
   hello:
@@ -38,7 +39,7 @@ functions:
     runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, default is 1024
     timeout: 10 # optional, default is 6
-    tracingConfigMode: PassThrough # optional overwrite, can be 'Active' or 'PassThrough'
+    awsTracingConfigMode: PassThrough # optional overwrite, can be 'Active' or 'PassThrough'
 ```
 
 The `handler` property points to the file and module containing the code you want to run in your function.
@@ -366,23 +367,22 @@ When storing secrets in environment variables, AWS [strongly suggests](http://do
 
 ## AWS X-Ray Tracing
 
-You can enable [AWS X-Ray Tracing](http://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) on your Lambda functions through the `tracingConfigMode` config variable:
+You can enable [AWS X-Ray Tracing](http://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) on your Lambda functions through the optional `awsTracingConfigMode` config variable:
 
 ```yml
-provider:
-  name: aws
-  runtime: nodejs6.10
-    tracingConfigMode: Active
+service:
+  name: myService
+  awsTracingConfigMode: Active
 ```
 
-You can also set this variable on a per-function basis:
+You can also set this variable on a per-function basis. This will override the service level setting if it is present:
 
 ```yml
 functions:
   hello:
     handler: handler.hello
-    tracingConfigMode: Active
+    awsTracingConfigMode: Active
   goodbye:
     handler: handler.goodbye
-    tracingConfigMode: PassThrough
+    awsTracingConfigMode: PassThrough
 ```

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -28,6 +28,7 @@ provider:
   memorySize: 512 # optional, default is 1024
   timeout: 10 # optional, default is 6
   versionFunctions: false # optional, default is true
+  tracingConfigMode: Active # optional, can be 'Active' or 'PassThrough'
 
 functions:
   hello:
@@ -37,6 +38,7 @@ functions:
     runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, default is 1024
     timeout: 10 # optional, default is 6
+    tracingConfigMode: PassThrough # optional overwrite, can be 'Active' or 'PassThrough'
 ```
 
 The `handler` property points to the file and module containing the code you want to run in your function.
@@ -361,3 +363,26 @@ functions:
 ### Secrets using environment variables and KMS
 
 When storing secrets in environment variables, AWS [strongly suggests](http://docs.aws.amazon.com/lambda/latest/dg/env_variables.html#env-storing-sensitive-data) encrypting sensitive information. AWS provides a [tutorial](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-env_console.html) on using KMS for this purpose.
+
+## AWS X-Ray Tracing
+
+You can enable [AWS X-Ray Tracing](http://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) on your Lambda functions through the `tracingConfigMode` config variable:
+
+```yml
+provider:
+  name: aws
+  runtime: nodejs6.10
+    tracingConfigMode: Active
+```
+
+You can also set this variable on a per-function basis:
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    tracingConfigMode: Active
+  goodbye:
+    handler: handler.goodbye
+    tracingConfigMode: PassThrough
+```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -20,6 +20,7 @@ Here is a list of all available properties in `serverless.yml` when the provider
 service:
   name: myService
   awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption for all functions
+  awsTracingConfigMode: Active # optional, can be 'Active' or 'PassThrough'
 
 frameworkVersion: ">=1.0.0 <2.0.0"
 
@@ -76,6 +77,7 @@ functions:
     role: arn:aws:iam::XXXXXX:role/role # IAM role which will be used for this function
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
     awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption (overwrites the one defined on the service level)
+    awsTracingConfigMode: Active # optional, can be 'Active' or 'PassThrough (overwrites the one defined on the service level)'
     environment: # Function level environment variables
       functionEnvVar: 12345678
     tags: # Function specific tags

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -20,7 +20,8 @@ Here is a list of all available properties in `serverless.yml` when the provider
 service:
   name: myService
   awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption for all functions
-  awsTracingConfigMode: Active # optional, can be 'Active' or 'PassThrough'
+  awsTracingConfig:
+    mode: Active # optional, can be 'Active' or 'PassThrough'
 
 frameworkVersion: ">=1.0.0 <2.0.0"
 
@@ -77,7 +78,8 @@ functions:
     role: arn:aws:iam::XXXXXX:role/role # IAM role which will be used for this function
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
     awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption (overwrites the one defined on the service level)
-    awsTracingConfigMode: Active # optional, can be 'Active' or 'PassThrough (overwrites the one defined on the service level)'
+    awsTracingConfig:
+      mode: Active # optional, can be 'Active' or 'PassThrough (overwrites the one defined on the service level)'
     environment: # Function level environment variables
       functionEnvVar: 12345678
     tags: # Function specific tags

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -118,8 +118,9 @@ class AwsCompileFunctions {
     const Runtime = functionObject.runtime
       || this.serverless.service.provider.runtime
       || 'nodejs4.3';
-    const TracingConfigMode = functionObject.tracingConfigMode
-      || this.serverless.service.provider.tracingConfigMode;
+    const TracingConfigMode = functionObject.awsTracingConfigMode
+      || (this.serverless.service.serviceObject
+          && this.serverless.service.serviceObject.awsTracingConfigMode);
 
     newFunction.Properties.Handler = Handler;
     newFunction.Properties.FunctionName = FunctionName;

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -118,20 +118,12 @@ class AwsCompileFunctions {
     const Runtime = functionObject.runtime
       || this.serverless.service.provider.runtime
       || 'nodejs4.3';
-    const TracingConfigMode = functionObject.awsTracingConfigMode
-      || (this.serverless.service.serviceObject
-          && this.serverless.service.serviceObject.awsTracingConfigMode);
 
     newFunction.Properties.Handler = Handler;
     newFunction.Properties.FunctionName = FunctionName;
     newFunction.Properties.MemorySize = MemorySize;
     newFunction.Properties.Timeout = Timeout;
     newFunction.Properties.Runtime = Runtime;
-    if (TracingConfigMode) {
-      newFunction.Properties.TracingConfig = {
-        Mode: TracingConfigMode,
-      };
-    }
 
     if (functionObject.description) {
       newFunction.Properties.Description = functionObject.description;
@@ -190,8 +182,9 @@ class AwsCompileFunctions {
       }
     }
 
-    let kmsKeyArn;
     const serviceObj = this.serverless.service.serviceObject;
+
+    let kmsKeyArn;
     if ('awsKmsKeyArn' in functionObject) {
       kmsKeyArn = functionObject.awsKmsKeyArn;
     } else if (serviceObj && 'awsKmsKeyArn' in serviceObj) {
@@ -231,6 +224,45 @@ class AwsCompileFunctions {
         }
       } else {
         const errorMessage = 'awsKmsKeyArn config must be provided as a string';
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+    }
+
+    let tracingConfig;
+    if ('awsTracingConfig' in functionObject) {
+      tracingConfig = functionObject.awsTracingConfig;
+    } else if (serviceObj && 'awsTracingConfig' in serviceObj) {
+      tracingConfig = serviceObj.awsTracingConfig;
+    }
+
+    if (tracingConfig) {
+      if (tracingConfig.mode && typeof tracingConfig.mode === 'string') {
+        const iamRoleLambdaExecution = this.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
+
+        newFunction.Properties.TracingConfig = {
+          Mode: tracingConfig.mode,
+        };
+
+        const stmt = {
+          Effect: 'Allow',
+          Action: [
+            'xray:PutTraceSegments',
+            'xray:PutTelemetryRecords',
+          ],
+          Resource: ['*'],
+        };
+
+        // update the PolicyDocument statements (if default policy is used)
+        if (iamRoleLambdaExecution) {
+          iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement = _.unionWith(
+            iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement,
+            [stmt],
+            _.isEqual
+          );
+        }
+      } else {
+        const errorMessage = 'awsTracingConfig must provide a "mode" property as a string';
         throw new this.serverless.classes.Error(errorMessage);
       }
     }

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -118,12 +118,19 @@ class AwsCompileFunctions {
     const Runtime = functionObject.runtime
       || this.serverless.service.provider.runtime
       || 'nodejs4.3';
+    const TracingConfigMode = functionObject.tracingConfigMode
+      || this.serverless.service.provider.tracingConfigMode;
 
     newFunction.Properties.Handler = Handler;
     newFunction.Properties.FunctionName = FunctionName;
     newFunction.Properties.MemorySize = MemorySize;
     newFunction.Properties.Timeout = Timeout;
     newFunction.Properties.Runtime = Runtime;
+    if (TracingConfigMode) {
+      newFunction.Properties.TracingConfig = {
+        Mode: TracingConfigMode,
+      };
+    }
 
     if (functionObject.description) {
       newFunction.Properties.Description = functionObject.description;

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1023,7 +1023,7 @@ describe('AwsCompileFunctions', () => {
           .to.throw(Error, 'property as a string');
       });
 
-      it('should throw an error if "mode" config is not a string', () => {
+      it('should throw an error if "mode" config paramter is not a string', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -1038,7 +1038,7 @@ describe('AwsCompileFunctions', () => {
           .to.throw(Error, 'property as a string');
       });
 
-      it('should use a the service wide awsTracingConfig "mode" if provided', () => {
+      it('should use a the service wide awsTracingConfig config if provided', () => {
         awsCompileFunctions.serverless.service.serviceObject = {
           name: 'new-service',
           awsTracingConfig: {
@@ -1084,7 +1084,7 @@ describe('AwsCompileFunctions', () => {
         expect(functionResource).to.deep.equal(compiledFunction);
       });
 
-      it('should prefer a function awsTracingConfig "mode" over a service "mode"', () => {
+      it('should prefer a function awsTracingConfig config over a service config', () => {
         awsCompileFunctions.serverless.service.serviceObject = {
           name: 'new-service',
           awsTracingConfig: {
@@ -1180,7 +1180,7 @@ describe('AwsCompileFunctions', () => {
             };
         });
 
-        it('should create necessary resources if a awsTracingConfig "mode" is provided', () => {
+        it('should create necessary resources if a awsTracingConfig config is provided', () => {
           awsCompileFunctions.serverless.service.functions = {
             func: {
               handler: 'func.function.handler',
@@ -1238,7 +1238,7 @@ describe('AwsCompileFunctions', () => {
       });
 
       describe('when IamRoleLambdaExecution is not used', () => {
-        it('should create necessary resources if a awsTracingConfig "mode" is provided', () => {
+        it('should create necessary resources if a awsTracingConfig config is provided', () => {
           awsCompileFunctions.serverless.service.functions = {
             func: {
               handler: 'func.function.handler',

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1254,7 +1254,7 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compiledFunction);
     });
 
-    it('should create a function resource with xray tracing enabled at the function level overwriting the provder level', () => {
+    it('should overwre the xray tracing provder level config', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
         .split(path.sep).pop();

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1254,7 +1254,7 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compiledFunction);
     });
 
-    it('should overwre the xray tracing provder level config', () => {
+    it('should overwrite the xray tracing provder level config', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
         .split(path.sep).pop();

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1149,12 +1149,15 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compiledFunction);
     });
 
-    it('should create a function resource with xray tracing enabled at the provider level', () => {
+    it('should create a function resource with xray tracing enabled at the service level', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
         .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.serviceObject = {
+        name: 'new-service',
+        awsTracingConfigMode: 'Active',
+      };
 
-      awsCompileFunctions.serverless.service.provider.tracingConfigMode = 'Active';
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -1210,7 +1213,7 @@ describe('AwsCompileFunctions', () => {
         func: {
           handler: 'func.function.handler',
           name: 'new-service-dev-func',
-          tracingConfigMode: 'Active',
+          awsTracingConfigMode: 'Active',
         },
       };
 
@@ -1254,16 +1257,19 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compiledFunction);
     });
 
-    it('should overwrite the xray tracing provder level config', () => {
+    it('should overwrite the xray tracing service level config', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
         .split(path.sep).pop();
-      awsCompileFunctions.serverless.service.provider.tracingConfigMode = 'PassThrough';
+      awsCompileFunctions.serverless.service.serviceObject = {
+        name: 'new-service',
+        awsTracingConfigMode: 'PassThrough',
+      };
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
           name: 'new-service-dev-func',
-          tracingConfigMode: 'Active',
+          awsTracingConfigMode: 'Active',
         },
       };
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1000,6 +1000,290 @@ describe('AwsCompileFunctions', () => {
       });
     });
 
+    describe('when using awsTracingConfig config', () => {
+      let s3Folder;
+      let s3FileName;
+
+      beforeEach(() => {
+        s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+        s3FileName = awsCompileFunctions.serverless.service.package.artifact
+          .split(path.sep).pop();
+      });
+
+      it('should throw an error if "mode" config parameter is not provided', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsTracingConfig: 'Active',
+          },
+        };
+
+        expect(() => { awsCompileFunctions.compileFunctions(); })
+          .to.throw(Error, 'property as a string');
+      });
+
+      it('should throw an error if "mode" config is not a string', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsTracingConfig: {
+              mode: 123,
+            },
+          },
+        };
+
+        expect(() => { awsCompileFunctions.compileFunctions(); })
+          .to.throw(Error, 'property as a string');
+      });
+
+      it('should use a the service wide awsTracingConfig "mode" if provided', () => {
+        awsCompileFunctions.serverless.service.serviceObject = {
+          name: 'new-service',
+          awsTracingConfig: {
+            mode: 'Active',
+          },
+        };
+
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+          },
+        };
+
+        const compiledFunction = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'FuncLogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            TracingConfig: {
+              Mode: 'Active',
+            },
+          },
+        };
+
+        awsCompileFunctions.compileFunctions();
+
+        const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate;
+        const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+        expect(functionResource).to.deep.equal(compiledFunction);
+      });
+
+      it('should prefer a function awsTracingConfig "mode" over a service "mode"', () => {
+        awsCompileFunctions.serverless.service.serviceObject = {
+          name: 'new-service',
+          awsTracingConfig: {
+            mode: 'Active',
+          },
+        };
+
+        awsCompileFunctions.serverless.service.functions = {
+          func1: {
+            handler: 'func1.function.handler',
+            name: 'new-service-dev-func1',
+            awsTracingConfig: {
+              mode: 'PassThrough',
+            },
+          },
+          func2: {
+            handler: 'func2.function.handler',
+            name: 'new-service-dev-func2',
+          },
+        };
+
+        const compiledFunction1 = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'Func1LogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func1',
+            Handler: 'func1.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            TracingConfig: {
+              Mode: 'PassThrough',
+            },
+          },
+        };
+
+        const compiledFunction2 = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'Func2LogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func2',
+            Handler: 'func2.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs4.3',
+            Timeout: 6,
+            TracingConfig: {
+              Mode: 'Active',
+            },
+          },
+        };
+
+        awsCompileFunctions.compileFunctions();
+
+        const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate;
+
+        const function1Resource = compiledCfTemplate.Resources.Func1LambdaFunction;
+        const function2Resource = compiledCfTemplate.Resources.Func2LambdaFunction;
+        expect(function1Resource).to.deep.equal(compiledFunction1);
+        expect(function2Resource).to.deep.equal(compiledFunction2);
+      });
+
+      describe('when IamRoleLambdaExecution is used', () => {
+        beforeEach(() => {
+          // pretend that the IamRoleLambdaExecution is used
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution = {
+              Properties: {
+                Policies: [
+                  {
+                    PolicyDocument: {
+                      Statement: [],
+                    },
+                  },
+                ],
+              },
+            };
+        });
+
+        it('should create necessary resources if a awsTracingConfig "mode" is provided', () => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              awsTracingConfig: {
+                mode: 'Active',
+              },
+            },
+          };
+
+          const compiledFunction = {
+            Type: 'AWS::Lambda::Function',
+            DependsOn: [
+              'FuncLogGroup',
+              'IamRoleLambdaExecution',
+            ],
+            Properties: {
+              Code: {
+                S3Key: `${s3Folder}/${s3FileName}`,
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              },
+              FunctionName: 'new-service-dev-func',
+              Handler: 'func.function.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs4.3',
+              Timeout: 6,
+              TracingConfig: {
+                Mode: 'Active',
+              },
+            },
+          };
+
+          const compiledXrayStatement = {
+            Effect: 'Allow',
+            Action: [
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+            ],
+            Resource: ['*'],
+          };
+
+          awsCompileFunctions.compileFunctions();
+
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          const xrayStatement = compiledCfTemplate.Resources
+            .IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[0];
+
+          expect(functionResource).to.deep.equal(compiledFunction);
+          expect(xrayStatement).to.deep.equal(compiledXrayStatement);
+        });
+      });
+
+      describe('when IamRoleLambdaExecution is not used', () => {
+        it('should create necessary resources if a awsTracingConfig "mode" is provided', () => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              awsTracingConfig: {
+                mode: 'Active',
+              },
+            },
+          };
+
+          const compiledFunction = {
+            Type: 'AWS::Lambda::Function',
+            DependsOn: [
+              'FuncLogGroup',
+              'IamRoleLambdaExecution',
+            ],
+            Properties: {
+              Code: {
+                S3Key: `${s3Folder}/${s3FileName}`,
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              },
+              FunctionName: 'new-service-dev-func',
+              Handler: 'func.function.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs4.3',
+              Timeout: 6,
+              TracingConfig: {
+                Mode: 'Active',
+              },
+            },
+          };
+
+          awsCompileFunctions.compileFunctions();
+
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
+      });
+    });
+
     it('should create a function resource with environment config', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
@@ -1137,170 +1421,6 @@ describe('AwsCompileFunctions', () => {
             Variables: {
               providerTest1: 'providerTest1',
             },
-          },
-        },
-      };
-
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
-    });
-
-    it('should create a function resource with xray tracing enabled at the service level', () => {
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep).pop();
-      awsCompileFunctions.serverless.service.serviceObject = {
-        name: 'new-service',
-        awsTracingConfigMode: 'Active',
-      };
-
-      awsCompileFunctions.serverless.service.functions = {
-        func: {
-          handler: 'func.function.handler',
-          name: 'new-service-dev-func',
-        },
-      };
-
-      awsCompileFunctions.serverless.service.provider.environment = {
-        providerTest1: 'providerTest1',
-      };
-
-      const compiledFunction = {
-        Type: 'AWS::Lambda::Function',
-        DependsOn: [
-          'FuncLogGroup',
-          'IamRoleLambdaExecution',
-        ],
-        Properties: {
-          Code: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 6,
-          Environment: {
-            Variables: {
-              providerTest1: 'providerTest1',
-            },
-          },
-          TracingConfig: {
-            Mode: 'Active',
-          },
-        },
-      };
-
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
-    });
-
-    it('should create a function resource with xray tracing enabled at the function level', () => {
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep).pop();
-      awsCompileFunctions.serverless.service.functions = {
-        func: {
-          handler: 'func.function.handler',
-          name: 'new-service-dev-func',
-          awsTracingConfigMode: 'Active',
-        },
-      };
-
-      awsCompileFunctions.serverless.service.provider.environment = {
-        providerTest1: 'providerTest1',
-      };
-
-      const compiledFunction = {
-        Type: 'AWS::Lambda::Function',
-        DependsOn: [
-          'FuncLogGroup',
-          'IamRoleLambdaExecution',
-        ],
-        Properties: {
-          Code: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 6,
-          Environment: {
-            Variables: {
-              providerTest1: 'providerTest1',
-            },
-          },
-          TracingConfig: {
-            Mode: 'Active',
-          },
-        },
-      };
-
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
-    });
-
-    it('should overwrite the xray tracing service level config', () => {
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep).pop();
-      awsCompileFunctions.serverless.service.serviceObject = {
-        name: 'new-service',
-        awsTracingConfigMode: 'PassThrough',
-      };
-      awsCompileFunctions.serverless.service.functions = {
-        func: {
-          handler: 'func.function.handler',
-          name: 'new-service-dev-func',
-          awsTracingConfigMode: 'Active',
-        },
-      };
-
-      awsCompileFunctions.serverless.service.provider.environment = {
-        providerTest1: 'providerTest1',
-      };
-
-      const compiledFunction = {
-        Type: 'AWS::Lambda::Function',
-        DependsOn: [
-          'FuncLogGroup',
-          'IamRoleLambdaExecution',
-        ],
-        Properties: {
-          Code: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 6,
-          Environment: {
-            Variables: {
-              providerTest1: 'providerTest1',
-            },
-          },
-          TracingConfig: {
-            Mode: 'Active',
           },
         },
       };

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1149,6 +1149,164 @@ describe('AwsCompileFunctions', () => {
       ).to.deep.equal(compiledFunction);
     });
 
+    it('should create a function resource with xray tracing enabled at the provider level', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+
+      awsCompileFunctions.serverless.service.provider.tracingConfigMode = 'Active';
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+        },
+      };
+
+      awsCompileFunctions.serverless.service.provider.environment = {
+        providerTest1: 'providerTest1',
+      };
+
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Environment: {
+            Variables: {
+              providerTest1: 'providerTest1',
+            },
+          },
+          TracingConfig: {
+            Mode: 'Active',
+          },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+      ).to.deep.equal(compiledFunction);
+    });
+
+    it('should create a function resource with xray tracing enabled at the function level', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          tracingConfigMode: 'Active',
+        },
+      };
+
+      awsCompileFunctions.serverless.service.provider.environment = {
+        providerTest1: 'providerTest1',
+      };
+
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Environment: {
+            Variables: {
+              providerTest1: 'providerTest1',
+            },
+          },
+          TracingConfig: {
+            Mode: 'Active',
+          },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+      ).to.deep.equal(compiledFunction);
+    });
+
+    it('should create a function resource with xray tracing enabled at the function level overwriting the provder level', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.provider.tracingConfigMode = 'PassThrough';
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          tracingConfigMode: 'Active',
+        },
+      };
+
+      awsCompileFunctions.serverless.service.provider.environment = {
+        providerTest1: 'providerTest1',
+      };
+
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Environment: {
+            Variables: {
+              providerTest1: 'providerTest1',
+            },
+          },
+          TracingConfig: {
+            Mode: 'Active',
+          },
+        },
+      };
+
+      awsCompileFunctions.compileFunctions();
+
+      expect(
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+      ).to.deep.equal(compiledFunction);
+    });
+
     it('should overwrite a provider level environment config when function config is given', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact

--- a/tests/integration/aws/general/xray-tracing/service/handler.js
+++ b/tests/integration/aws/general/xray-tracing/service/handler.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/tests/integration/aws/general/xray-tracing/service/serverless.yml
+++ b/tests/integration/aws/general/xray-tracing/service/serverless.yml
@@ -1,6 +1,7 @@
 service:
   name: aws-nodejs
-  awsTracingConfigMode: Active
+  awsTracingConfig:
+    mode: Active
 
 provider:
   name: aws

--- a/tests/integration/aws/general/xray-tracing/service/serverless.yml
+++ b/tests/integration/aws/general/xray-tracing/service/serverless.yml
@@ -1,0 +1,10 @@
+service: aws-nodejs # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  tracingConfigMode: Active
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/integration/aws/general/xray-tracing/service/serverless.yml
+++ b/tests/integration/aws/general/xray-tracing/service/serverless.yml
@@ -1,9 +1,10 @@
-service: aws-nodejs # NOTE: update this with your service name
+service:
+  name: aws-nodejs
+  awsTracingConfigMode: Active
 
 provider:
   name: aws
   runtime: nodejs6.10
-  tracingConfigMode: Active
 
 functions:
   hello:

--- a/tests/integration/aws/general/xray-tracing/tests.js
+++ b/tests/integration/aws/general/xray-tracing/tests.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const path = require('path');
+const expect = require('chai').expect;
+const AWS = require('aws-sdk');
+const BbPromise = require('bluebird');
+
+const Utils = require('../../../../utils/index');
+
+const Lambda = new AWS.Lambda({ region: 'us-east-1' });
+BbPromise.promisifyAll(Lambda, { suffix: 'Promised' });
+
+describe('AWS - General: Xray tracing test', () => {
+  let stackName;
+
+  beforeAll(() => {
+    stackName = Utils.createTestService('aws-nodejs', path.join(__dirname, 'service'));
+    Utils.deployService();
+  });
+
+  it('should enable active X-Ray tracing', () => {
+    const helloFunctionName = `${stackName}-hello`;
+    return Lambda.getFunctionPromised({ FunctionName: helloFunctionName })
+      .then(data => {
+        const tracingConfig = data.Configuration.TracingConfig;
+        expect(tracingConfig).to.not.be.undefined;
+        expect(tracingConfig.Mode).to.equal('Active')
+      });
+  });
+
+  afterAll(() => {
+    Utils.removeService();
+  });
+});

--- a/tests/integration/aws/general/xray-tracing/tests.js
+++ b/tests/integration/aws/general/xray-tracing/tests.js
@@ -23,8 +23,8 @@ describe('AWS - General: Xray tracing test', () => {
     return Lambda.getFunctionPromised({ FunctionName: helloFunctionName })
       .then(data => {
         const tracingConfig = data.Configuration.TracingConfig;
-        expect(tracingConfig).to.not.be.undefined;
-        expect(tracingConfig.Mode).to.equal('Active')
+        expect(tracingConfig).to.be.an('object');
+        expect(tracingConfig.Mode).to.equal('Active');
       });
   });
 


### PR DESCRIPTION
## Todos

- [ ] Move property from `service` back to `provider` and remove the `aws` prefix? (what about the definition on a `function` level?)

## What did you implement:

Closes #3495 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added optional configuration variable that pushes the new [AWS X-Ray Lambda configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-tracingconfig.html) into the cloudformation template

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Try deploying a serverless app with tracing config mode set to `Active`:

```yml
# serverless.yml
service:
  name: my-service
  awsTracingConfig:
    mode: Active
```

After deploying the app, all relevant Lambda functions should have "Enable active tracing" cheked in the AWS console:

![image](https://user-images.githubusercontent.com/6636911/26857848-0e152530-4b71-11e7-92b5-f101c6a2b98c.png)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
