### PR TITLE
Filter nested entrypoints on getCommands(). Used by help.

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -173,9 +173,26 @@ class PluginManager {
   }
 
   getCommands() {
-    // Return filtered list of visible commands
-    const cmds = _.omitBy(this.commands, ['type', 'entrypoint']);
-    return cmds;
+    const result = {};
+
+    // Iterate through the commands and stop at entrypoints to include only public
+    // command throughout the hierarchy.
+    const stack = [{ commands: this.commands, target: result }];
+    while (!_.isEmpty(stack)) {
+      const currentCommands = stack.pop();
+      const commands = currentCommands.commands;
+      const target = currentCommands.target;
+      _.forOwn(commands, (command, name) => {
+        if (command.type !== 'entrypoint') {
+          _.set(target, name, _.omit(command, 'commands'));
+          if (_.some(command.commands, childCommand => childCommand.type !== 'entrypoint')) {
+            target[name].commands = {};
+            stack.push({ commands: command.commands, target: target[name].commands });
+          }
+        }
+      });
+    }
+    return result;
   }
 
   /**

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -240,6 +240,13 @@ describe('PluginManager', () => {
                 'event2',
               ],
             },
+            spawnep: {
+              type: 'entrypoint',
+              lifecycleEvents: [
+                'event1',
+                'event2',
+              ],
+            },
           },
         },
 
@@ -1067,6 +1074,21 @@ describe('PluginManager', () => {
             '>subInitialize>subFinalize>initialize>finalize>run>subEPInitialize>subEPFinalize'
           );
         });
+    });
+  });
+
+  describe('#getCommands()', () => {
+    it('should hide entrypoints on any level and only return commands', () => {
+      pluginManager.addPlugin(EntrypointPluginMock);
+
+      const commands = pluginManager.getCommands();
+      expect(commands).to.have.a.property('mycmd');
+      expect(commands).to.have.a.deep.property('mycmd.commands.mysubcmd');
+      expect(commands).to.have.a.deep.property('mycmd.commands.spawncmd');
+      // Check for omitted entrypoints
+      expect(commands).to.not.have.a.property('myep');
+      expect(commands).to.not.have.a.deep.property('myep.commands.mysubep');
+      expect(commands).to.not.have.a.deep.property('mycmd.commands.spawnep');
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #3501 

## How did you implement it:

getCommands() which is exclusively used by the help functionality now returns only publicly visible and executable commands. Entrypoint commands and hives under an entrypoint will be omitted in the list.

## How can we verify it:

run `serverless` and check if `package` is shown, but `package function` is hidden.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
