### PR TITLE
Change eventHub to serviceBus as event type

### DIFF
--- a/docs/providers/azure/events/servicebus.md
+++ b/docs/providers/azure/events/servicebus.md
@@ -29,7 +29,7 @@ functions:
   example:
     handler: handler.hello
     events:
-      - eventHub:
+      - serviceBus:
         x-azure-settings:
             name: item #<string>, default - "mySbMsg", specifies which name it's available on `context.bindings`
             queueName: hello #<string>, specifies the queue name to listen on
@@ -61,7 +61,7 @@ functions:
   example:
     handler: handler.hello
     events:
-      - eventHub:
+      - serviceBus:
         x-azure-settings:
             name: item #<string>, default - "mySbMsg", specifies which name it's available on `context.bindings` 
             topicName: "hello" #<string>, topic to listen on


### PR DESCRIPTION
- I think this should be `serviceBus` type instead of `eventHub`. Please let me know if this change is incorrect.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3750