### PR TITLE
Support "Task timed out" warnings as HTTP 504-errors

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -29,7 +29,7 @@ const DEFAULT_STATUS_CODES = {
     pattern: '[\\s\\S]*\\[502\\][\\s\\S]*',
   },
   504: {
-    pattern: '([\\s\\S]*\\[504\\][\\s\\S]*)|(^\[Task timed out\].*)',
+    pattern: '([\\s\\S]*\\[504\\][\\s\\S]*)|(^[Task timed out].*)',
   },
 };
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -29,7 +29,7 @@ const DEFAULT_STATUS_CODES = {
     pattern: '[\\s\\S]*\\[502\\][\\s\\S]*',
   },
   504: {
-    pattern: '[\\s\\S]*\\[504\\][\\s\\S]*',
+    pattern: '([\s\S]*\[504\][\s\S]*)|(^[Task timed out].*)',
   },
 };
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -29,7 +29,7 @@ const DEFAULT_STATUS_CODES = {
     pattern: '[\\s\\S]*\\[502\\][\\s\\S]*',
   },
   504: {
-    pattern: '([\s\S]*\[504\][\s\S]*)|(^[Task timed out].*)',
+    pattern: '([\\s\\S]*\\[504\\][\\s\\S]*)|(^\[Task timed out\].*)',
   },
 };
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Currently if Lambda functions have a timeout then you will not see any errors in Cloudwatch, while the user gets a 200 http response code with `{ errorMessage: 'Task timed out in 10.0 s'}`. 

This change will show 5XX errors in Cloudwatch.

To support this I need to copy all the default patterns in `serverless.yml` per function, so therefore I think this need to be a default setting, while this is not caused by the Serverless(/our) code but by AWS Lambda itself.

## How did you implement it:

Support not only 504 errors caused by Serverless/our code, but also support AWS Lambda default errors like timeouts.

## How can we verify it:

Run it in a regex test tool, like https://regex101.com with 

```
Task timed out after 10.0s
[504] Error message...
```

If you change 504 in 502, you will see that the adapted regex is matching `Task timed out` and the previous default setting `[504]`.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
