### PR TITLE
Adding note to deploy function documentation

### DIFF
--- a/docs/providers/aws/cli-reference/deploy-function.md
+++ b/docs/providers/aws/cli-reference/deploy-function.md
@@ -18,6 +18,11 @@ The `sls deploy function` command deploys an individual function without AWS Clo
 serverless deploy function -f functionName
 ```
 
+**Note:** Because this command is only deploying the function code, function
+properties such as environment variables and events will **not** be deployed.
+Those properties are deployed via CloudFormation, which does not execute with
+this command.
+
 ## Options
 - `--function` or `-f` The name of the function which should be deployed
 - `--stage` or `-s` The stage in your service that you want to deploy to.

--- a/docs/providers/azure/cli-reference/deploy-function.md
+++ b/docs/providers/azure/cli-reference/deploy-function.md
@@ -20,5 +20,8 @@ is a much faster way of deploying changes in code.
 serverless deploy function -f functionName
 ```
 
+**Note:** Because this command is only deploying the function code, function
+properties such as environment variables and events will **not** be deployed.
+
 ## Options
 - `--function` or `-f` The name of the function which should be deployed

--- a/docs/providers/openwhisk/cli-reference/deploy-function.md
+++ b/docs/providers/openwhisk/cli-reference/deploy-function.md
@@ -18,5 +18,8 @@ The `sls deploy function` command deploys an individual function.  This command 
 serverless deploy function -f functionName
 ```
 
+**Note:** Because this command is only deploying the function code, function
+properties such as environment variables and events will **not** be deployed.
+
 ## Options
 - `--function` or `-f` The name of the function which should be deployed


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Addresses #3542. The issue opener suggested adding a note about the side-effects of the `deploy function` command. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added documentation to aws, azure, and openwhisk sections. GCP appears to have not implemented the `deploy function` command.

I use serverless exclusively with aws, so someone may want to validate whether the note is applicable to azure and openwhisk as well.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
