### PR TITLE
Fix updateAutocompleteCacheFile() bug caused by empty commands object

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -319,6 +319,9 @@ class PluginManager {
       if (!command.options) {
         command.options = {};
       }
+      if (!command.commands) {
+        command.commands = {};
+      }
       cacheFile.commands[commandName] = Object.keys(command.options)
         .map(option => `--${option}`)
         .concat(Object.keys(command.commands));

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const PluginManager = require('../../lib/classes/PluginManager');
+let PluginManager = require('../../lib/classes/PluginManager');
 const Serverless = require('../../lib/Serverless');
 const CLI = require('../../lib/classes/CLI');
 const Create = require('../../lib/plugins/create/create');
@@ -461,19 +461,27 @@ describe('PluginManager', () => {
   });
 
   describe('#updateAutocompleteCacheFile()', () => {
-    it('should update autocomplete cache file', () => {
-      const writeFileStub = sinon.stub().resolves();
-      const ModifiedPluginManager = proxyquire('./PluginManager.js', {
+    let writeFileStub;
+    let cacheFilePath;
+    let getCommandsStub;
+
+    beforeEach(() => {
+      writeFileStub = sinon.stub().resolves();
+      PluginManager = proxyquire('./PluginManager.js', {
         '../utils/fs/writeFile': writeFileStub,
       });
-
-      pluginManager = new ModifiedPluginManager(serverless);
-
-      pluginManager.serverless.config = {
-        servicePath: 'somePath',
-      };
+      pluginManager = new PluginManager(serverless);
+      pluginManager.serverless.config = { servicePath: 'somePath' };
       const servicePath = pluginManager.serverless.config.servicePath;
-      const cacheFilePath = getCacheFilePath(servicePath);
+      cacheFilePath = getCacheFilePath(servicePath);
+      getCommandsStub = sinon.stub(pluginManager, 'getCommands');
+    });
+
+    afterEach(() => {
+      pluginManager.getCommands.restore();
+    });
+
+    it('should update autocomplete cache file', () => {
       const commandsMock = {
         deploy: {
           options: {
@@ -491,12 +499,14 @@ describe('PluginManager', () => {
             local: {},
           },
         },
+        remove: {},
       };
       const expectedCommands = {
         deploy: ['--stage', 'function'],
         invoke: ['--region', 'local'],
+        remove: [],
       };
-      const getCommandsStub = sinon.stub(pluginManager, 'getCommands').returns(commandsMock);
+      getCommandsStub.returns(commandsMock);
 
       return pluginManager.updateAutocompleteCacheFile().then(() => {
         expect(getCommandsStub.calledOnce).to.equal(true);
@@ -504,8 +514,6 @@ describe('PluginManager', () => {
         expect(writeFileStub.getCall(0).args[0]).to.equal(cacheFilePath);
         expect(writeFileStub.getCall(0).args[1].commands).to.deep.equal(expectedCommands);
         expect(typeof writeFileStub.getCall(0).args[1].validationHash).to.equal('string');
-
-        pluginManager.getCommands.restore();
       });
     });
   });


### PR DESCRIPTION
Closes #3780 

To verify run `serverless --help`.