### PR TITLE
Avoid Referencing Providers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ to review a PR, the faster we can review and merge it.
 Examples:
 * serverless.yml - Fully functioning to easily deploy changes
 * Screenshots - Showing the difference between your output and the master
-* AWS CLI commands - To list AWS resources and show that the correct config is in place
+* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
 * Other - Anything else that comes to mind to help us evaluate
 -->
 

--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -62,7 +62,7 @@ This example will generate scaffolding for a service with `AWS` as a provider an
 will be generated in the current working directory.
 
 Your new service will have a default stage called `dev` and a default region inside that stage called `us-east-1`.
-The provider which is used for deployment later on is AWS (Amazon web services).
+The provider which is used for deployment later on is AWS (Amazon Web Services).
 
 ### Creating a named service in a (new) directory
 

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -16,7 +16,7 @@ The Serverless Framework needs access to your cloud provider's account so that i
 
 Here we'll provide setup instructions for different cloud provider accounts. Just pick the one for your provider and follow the steps to get everything in place for Serverless.
 
-At this time, the Serverless Framework supports only Amazon Web Services, but support for other providers is in the works.
+This guide is for the Amazon Web Services (AWS) provider, so we'll step through the process of setting up credential for AWS and using them with Serverless.
 
 [Watch the video on setting up credentials](https://www.youtube.com/watch?v=HSd9uYj2LJA)
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Minor changes to avoid referencing providers directly unless:
- it is part of a provider-specific section of the site
- it is a comprehensive list of providers in the few places where they should be listed
- it is an example to help provide context

Closes #3512 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Minor changes to documentation text only.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* AWS CLI commands - To list AWS resources and show that the correct config is in place
* Other - Anything else that comes to mind to help us evaluate
-->

Visual review will likely suffice.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
