### PR TITLE
Adding Cognito User Pool Trigger documentation link

### DIFF
--- a/docs/providers/aws/events/cognito-user-pool.md
+++ b/docs/providers/aws/events/cognito-user-pool.md
@@ -14,7 +14,8 @@ layout: Doc
 
 ## Valid Triggers
 
-Serverless supports all Cognito User Pool Triggers as specified [here][aws-triggers-list].
+Serverless supports all Cognito User Pool Triggers as specified [here][aws-triggers-list]. Use [this guide][aws-triggers-guide] to understand
+the event objects that will be passed to your function.
 
 ## Simple event definition
 
@@ -112,4 +113,6 @@ resources:
       Type: AWS::Cognito::UserPool
 ```
 
-[aws-triggers-list]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html
+[aws-triggers-guide]: http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html
+[aws-triggers-list]:
+https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html

--- a/docs/providers/aws/events/cognito-user-pool.md
+++ b/docs/providers/aws/events/cognito-user-pool.md
@@ -112,4 +112,4 @@ resources:
       Type: AWS::Cognito::UserPool
 ```
 
-[aws-triggers-list]: http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-syntax-shared
+[aws-triggers-list]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The docs link to Cognito User Pool Triggers AWS documentation is only a guide on the incoming events and doesn't contain the actual trigger names. I added a link to the CloudFormation documentation that does contain those triggers. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
