### PR TITLE
Fix #3792: Resolve tabtab/src/cli.js path when installing locally

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,7 +5,6 @@
 
 const Serverless = require('../lib/Serverless');
 const execSync = require('child_process').execSync;
-const path = require('path');
 
 try {
   const serverless = new Serverless();

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,6 +5,8 @@
 
 const Serverless = require('../lib/Serverless');
 const execSync = require('child_process').execSync;
+const path = require('path');
+const fileExistsSync = require('../lib/utils/fs/fileExistsSync');
 
 try {
   const serverless = new Serverless();
@@ -20,13 +22,17 @@ try {
 
 function setupAutocomplete() {
   return new Promise((resolve, reject) => {
+    let tabtabPath = './node_modules/tabtab';
+    if (!fileExistsSync(path.join(__dirname, '..', 'node_modules', 'tabtab', 'src', 'cli.js'))) {
+      tabtabPath = '../tabtab';
+    }
     try {
-      execSync('node ./node_modules/tabtab/src/cli.js install --name serverless --auto');
-      execSync('node ./node_modules/tabtab/src/cli.js install --name sls --auto');
+      execSync(`node ${tabtabPath}/src/cli.js install --name serverless --auto`);
+      execSync(`node ${tabtabPath}/src/cli.js install --name sls --auto`);
       return resolve();
     } catch (error) {
-      execSync('node ./node_modules/tabtab/src/cli.js install --name serverless --stdout');
-      execSync('node ./node_modules/tabtab/src/cli.js install --name sls --stdout');
+      execSync(`node ${tabtabPath}/src/cli.js install --name serverless --stdout`);
+      execSync(`node ${tabtabPath}/src/cli.js install --name sls --stdout`);
       console.log('Could not auto-install serverless autocomplete script.');
       console.log('Please copy / paste the script above into your shell.');
       return reject(error);

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,7 +6,6 @@
 const Serverless = require('../lib/Serverless');
 const execSync = require('child_process').execSync;
 const path = require('path');
-const fileExistsSync = require('../lib/utils/fs/fileExistsSync');
 
 try {
   const serverless = new Serverless();
@@ -22,10 +21,7 @@ try {
 
 function setupAutocomplete() {
   return new Promise((resolve, reject) => {
-    let tabtabPath = './node_modules/tabtab';
-    if (!fileExistsSync(path.join(__dirname, '..', 'node_modules', 'tabtab', 'src', 'cli.js'))) {
-      tabtabPath = '../tabtab';
-    }
+    const tabtabPath = require.resolve('tabtab').replace(/\/index.js$/, '');
     try {
       execSync(`node ${tabtabPath}/src/cli.js install --name serverless --auto`);
       execSync(`node ${tabtabPath}/src/cli.js install --name sls --auto`);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3792 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Check `tabtab` path using `fileExistsSync` before exec.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

- Create directory with `mkdir sls-project && cd sls-project`
- Run `npm init`
- Run `npm install k1LoW/serverless#get-installed-path --save` , and you will see no error like #3792 

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
