### PR TITLE
Ensure current documentation

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -86,7 +86,7 @@ resources:
     myDefaultRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /my/default/path
+        Path: /my/default/path/
         RoleName: MyDefaultRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
@@ -149,7 +149,7 @@ resources:
     myCustRole0:
       Type: AWS::IAM::Role
       Properties:
-        Path: /my/cust/path
+        Path: /my/cust/path/
         RoleName: MyCustRole0
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
@@ -180,7 +180,7 @@ resources:
     myCustRole1:
       Type: AWS::IAM::Role
       Properties:
-        Path: /my/cust/path
+        Path: /my/cust/path/
         RoleName: MyCustRole1
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
@@ -232,7 +232,7 @@ resources:
     myDefaultRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /my/default/path
+        Path: /my/default/path/
         RoleName: MyDefaultRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
@@ -264,7 +264,7 @@ resources:
     myCustRole0:
       Type: AWS::IAM::Role
       Properties:
-        Path: /my/cust/path
+        Path: /my/cust/path/
         RoleName: MyCustRole0
         AssumeRolePolicyDocument:
           Version: '2012-10-17'


### PR DESCRIPTION
Creating an IAM Role with a 'Path' that does not end with a '/' will
lead to:

The specified value for path is invalid. It must begin and end with /
and contain only alphanumeric characters and/or / characters..