### PR TITLE
Unsetting undefined property.

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -68,7 +68,7 @@ class Variables {
             if (newProperty === undefined) {
               return _.unset(objectToPopulate, propertyPath);
             }
-            return _.set(objectToPopulate, propertyPath, newProperty)
+            return _.set(objectToPopulate, propertyPath, newProperty);
           })
           .return();
         populateAll.push(populateSingleProperty);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -64,7 +64,12 @@ class Variables {
     deepMapValues(objectToPopulate, (property, propertyPath) => {
       if (typeof property === 'string') {
         const populateSingleProperty = this.populateProperty(property, true)
-          .then(newProperty => _.set(objectToPopulate, propertyPath, newProperty))
+          .then(newProperty => {
+            if (newProperty === undefined) {
+              return _.unset(objectToPopulate, propertyPath);
+            }
+            return _.set(objectToPopulate, propertyPath, newProperty)
+          })
           .return();
         populateAll.push(populateSingleProperty);
       }


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/3514

## How did you implement it:

Properties with an `undefined` value will be stringified to `"undefined"`. By unsetting the property it will be omitted thus the environment variable is actually `undefined` as expected.

## How can we verify it:

Add an environment variable setting as follows:

```
property:
   environment:
     TEST: ${env:Test} 
```

If you havn't specified the `Test` environment variable while deploying the code you will get an warning message like that:

```
A valid environment variable to satisfy the declaration
'env:TEST' could not be found.
```

but when running the deployed Lambda method it will become `process.env.TEST == "undefined"`.

## Todos:

- [ ] Write tests _(Not sure how, where to add this test best, looking for advice)_

~~[ ] Write documentation~~ _(Not applicable, imho. this fixes an unexpected edge case)_

- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
