### PR TITLE
Add checks for HTTP Authorizers

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -206,12 +206,16 @@ class Utils {
                 if (event.http.authorizer.type === 'AWS_IAM') {
                   hasIAMAuthorizer = true;
                 }
-                // If we don't have an ARN, it refers to a different Lambda function in the same service serving as an authorizer
+                // If we don't have an ARN, it refers to a different Lambda function in the same
+                // service serving as an authorizer
                 // If we do have an ARN, we'll check if it's a Lambda ARN
-                if ((event.http.authorizer.type !== 'AWS_IAM' && (!event.http.authorizer.arn || event.http.authorizer.arn.includes('arn:aws:lambda')) )) {
+                if (event.http.authorizer.type !== 'AWS_IAM'
+                   && (!event.http.authorizer.arn
+                   || event.http.authorizer.arn.includes('arn:aws:lambda'))) {
                   hasCustomAuthorizer = true;
                 }
-                if ((event.http.authorizer.arn && event.http.authorizer.arn.includes('arn:aws:cognito-idp'))) {
+                if (event.http.authorizer.arn
+                   && event.http.authorizer.arn.includes('arn:aws:cognito-idp')) {
                   hasCognitoAuthorizer = true;
                 }
               }

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -203,15 +203,23 @@ class Utils {
 
               // For HTTP events, see what authorizer types are enabled
               if (event.http && event.http.authorizer) {
-                if (event.http.authorizer.type === 'AWS_IAM') {
+                if ((typeof event.http.authorizer === 'string'
+                    && event.http.authorizer.toUpperCase() === 'AWS_IAM')
+                   || (event.http.authorizer.type
+                       && event.http.authorizer.type.toUpperCase() === 'AWS_IAM')) {
                   hasIAMAuthorizer = true;
                 }
-                // If we don't have an ARN, it refers to a different Lambda function in the same
-                // service serving as an authorizer
-                // If we do have an ARN, we'll check if it's a Lambda ARN
-                if (event.http.authorizer.type !== 'AWS_IAM'
-                   && (!event.http.authorizer.arn
-                   || event.http.authorizer.arn.includes('arn:aws:lambda'))) {
+                // There are three ways a user can specify a Custom authorizer:
+                // 1) By listing the name of a function in the same service OR a function ARN for
+                //    the authorizer property.
+                // 2) By listing the name of a function in the same service for the name property
+                //    in the authorizer object.
+                // 3) By listing a function's ARN in the arn property of the authorizer object.
+                if ((typeof event.http.authorizer === 'string'
+                    && event.http.authorizer.toUpperCase() !== 'AWS_IAM')
+                   || event.http.authorizer.name
+                   || (event.http.authorizer.arn
+                       && event.http.authorizer.arn.includes('arn:aws:lambda'))) {
                   hasCustomAuthorizer = true;
                 }
                 if (event.http.authorizer.arn

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -216,14 +216,17 @@ class Utils {
                 //    in the authorizer object.
                 // 3) By listing a function's ARN in the arn property of the authorizer object.
                 if ((typeof event.http.authorizer === 'string'
-                    && event.http.authorizer.toUpperCase() !== 'AWS_IAM')
+                    && event.http.authorizer.toUpperCase() !== 'AWS_IAM'
+                    && !event.http.authorizer.includes('arn:aws:cognito-idp'))
                    || event.http.authorizer.name
                    || (event.http.authorizer.arn
                        && event.http.authorizer.arn.includes('arn:aws:lambda'))) {
                   hasCustomAuthorizer = true;
                 }
-                if (event.http.authorizer.arn
-                   && event.http.authorizer.arn.includes('arn:aws:cognito-idp')) {
+                if ((typeof event.http.authorizer === 'string'
+                    && event.http.authorizer.includes('arn:aws:cognito-idp'))
+                   || (event.http.authorizer.arn
+                   && event.http.authorizer.arn.includes('arn:aws:cognito-idp'))) {
                   hasCognitoAuthorizer = true;
                 }
               }

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -179,6 +179,9 @@ class Utils {
       // event related information retrieval
       const numberOfEventsPerType = [];
       const eventNamesPerFunction = [];
+      let hasIAMAuthorizer = false;
+      let hasCustomAuthorizer = false;
+      let hasCognitoAuthorizer = false;
       if (numberOfFunctions) {
         _.forEach(functions, (func) => {
           if (func.events) {
@@ -196,6 +199,21 @@ class Utils {
                   name,
                   count: 1,
                 });
+              }
+
+              // For HTTP events, see what authorizer types are enabled
+              if (event.http && event.http.authorizer) {
+                if (event.http.authorizer.type === 'AWS_IAM') {
+                  hasIAMAuthorizer = true;
+                }
+                // If we don't have an ARN, it refers to a different Lambda function in the same service serving as an authorizer
+                // If we do have an ARN, we'll check if it's a Lambda ARN
+                if ((event.http.authorizer.type !== 'AWS_IAM' && (!event.http.authorizer.arn || event.http.authorizer.arn.includes('arn:aws:lambda')) )) {
+                  hasCustomAuthorizer = true;
+                }
+                if ((event.http.authorizer.arn && event.http.authorizer.arn.includes('arn:aws:cognito-idp'))) {
+                  hasCognitoAuthorizer = true;
+                }
               }
             });
 
@@ -253,6 +271,9 @@ class Utils {
             numberOfEvents: numberOfEventsPerType.length,
             numberOfEventsPerType,
             eventNamesPerFunction,
+            hasIAMAuthorizer,
+            hasCustomAuthorizer,
+            hasCognitoAuthorizer,
           },
           general: {
             userId,

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -286,9 +286,6 @@ class Utils {
             numberOfEvents: numberOfEventsPerType.length,
             numberOfEventsPerType,
             eventNamesPerFunction,
-            hasIAMAuthorizer,
-            hasCustomAuthorizer,
-            hasCognitoAuthorizer,
           },
           general: {
             userId,
@@ -309,6 +306,14 @@ class Utils {
       if (config.userId && data.properties && data.properties.general) {
         // add platformId to segment call
         data.properties.general.platformId = config.userId;
+      }
+
+      if (provider && provider.name && provider.name.toUpperCase() === 'AWS' && data.properties) {
+        data.properties.aws = {
+          hasIAMAuthorizer,
+          hasCustomAuthorizer,
+          hasCognitoAuthorizer,
+        };
       }
 
       return resolve(data);

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -389,10 +389,10 @@ describe('Utils', () => {
                 path: 'foo',
                 method: 'GET',
                 authorizer: {
-                  type: 'AWS_IAM'
-                }
+                  type: 'AWS_IAM',
+                },
               },
-            }
+            },
           ],
         },
       };
@@ -422,10 +422,10 @@ describe('Utils', () => {
                 path: 'foo',
                 method: 'GET',
                 authorizer: {
-                  name: 'authFunc'
-                }
+                  name: 'authFunc',
+                },
               },
-            }
+            },
           ],
         },
       };
@@ -455,10 +455,10 @@ describe('Utils', () => {
                 path: 'foo',
                 method: 'GET',
                 authorizer: {
-                  arn: 'arn:aws:lambda:us-east-1:123456789012:function:authFunc'
-                }
+                  arn: 'arn:aws:lambda:us-east-1:123456789012:function:authFunc',
+                },
               },
-            }
+            },
           ],
         },
       };
@@ -488,10 +488,10 @@ describe('Utils', () => {
                 path: 'foo',
                 method: 'GET',
                 authorizer: {
-                  arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ'
-                }
+                  arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+                },
               },
-            }
+            },
           ],
         },
       };
@@ -531,8 +531,8 @@ describe('Utils', () => {
                   path: 'foo',
                   method: 'GET',
                   authorizer: {
-                    type: 'AWS_IAM'
-                  }
+                    type: 'AWS_IAM',
+                  },
                 },
               },
               {

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -381,17 +381,22 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: 'aws_Iam',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: 'aws_Iam',
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 
@@ -400,9 +405,9 @@ describe('Utils', () => {
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(true);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(false);
       });
     });
 
@@ -412,30 +417,36 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: {
-                  type: 'AWS_IAM',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: {
+                    type: 'AWS_IAM',
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
       };
+
 
       return utils.logStat(serverless).then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(true);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(false);
       });
     });
 
@@ -445,17 +456,22 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: 'authorizerFunc',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: 'authorizerFunc',
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 
@@ -464,9 +480,9 @@ describe('Utils', () => {
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(true);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(false);
       });
     });
 
@@ -476,19 +492,24 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: {
-                  name: 'authFunc',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: {
+                    name: 'authFunc',
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 
@@ -497,9 +518,9 @@ describe('Utils', () => {
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(true);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(false);
       });
     });
 
@@ -509,19 +530,24 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: {
-                  arn: 'arn:aws:lambda:us-east-1:123456789012:function:authFunc',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: {
+                    arn: 'arn:aws:lambda:us-east-1:123456789012:function:authFunc',
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 
@@ -530,9 +556,9 @@ describe('Utils', () => {
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(true);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(false);
       });
     });
 
@@ -542,17 +568,22 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 
@@ -561,9 +592,9 @@ describe('Utils', () => {
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(true);
       });
     });
 
@@ -573,19 +604,24 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      serverless.service.functions = {
-        functionOne: {
-          events: [
-            {
-              http: {
-                path: 'foo',
-                method: 'GET',
-                authorizer: {
-                  arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+      serverless.service = {
+        provider: {
+          name: 'aws',
+        },
+        functions: {
+          functionOne: {
+            events: [
+              {
+                http: {
+                  path: 'foo',
+                  method: 'GET',
+                  authorizer: {
+                    arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 
@@ -594,9 +630,30 @@ describe('Utils', () => {
         expect(trackStub.calledOnce).to.equal(true);
 
         const data = trackStub.args[0][0];
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(true);
+      });
+    });
+
+    it('should not include an aws object for non-AWS providers', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service = {
+        provider: {
+          name: 'google',
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.aws).to.equal(undefined);
       });
     });
 
@@ -695,9 +752,10 @@ describe('Utils', () => {
         expect(data.properties.events.eventNamesPerFunction[0][1]).to.equal('s3');
         expect(data.properties.events.eventNamesPerFunction[1][0]).to.equal('http');
         expect(data.properties.events.eventNamesPerFunction[1][1]).to.equal('sns');
-        expect(data.properties.events.hasIAMAuthorizer).to.equal(true);
-        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
-        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+        // aws property
+        expect(data.properties.aws.hasIAMAuthorizer).to.equal(true);
+        expect(data.properties.aws.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.aws.hasCognitoAuthorizer).to.equal(false);
         // general property
         expect(data.properties.general.userId.length).to.be.at.least(1);
         expect(data.properties.general.timestamp).to.match(/[0-9]+/);

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -375,7 +375,38 @@ describe('Utils', () => {
       });
     });
 
-    it('should be able to detect IAM Authorizers', () => {
+    it('should be able to detect IAM Authorizers using the authorizer string format', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: 'aws_Iam',
+              },
+            },
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(true);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+      });
+    });
+
+    it('should be able to detect IAM Authorizers using the type property', () => {
       getConfigStub.returns({
         trackingDisabled: false,
         frameworkId: '1234wasd',
@@ -408,7 +439,38 @@ describe('Utils', () => {
       });
     });
 
-    it('should be able to detect named Custom Authorizers', () => {
+    it('should be able to detect named Custom Authorizers using the authorizer string format', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: 'authorizerFunc',
+              },
+            },
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(true);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+      });
+    });
+
+    it('should be able to detect named Custom Authorizers using the name property', () => {
       getConfigStub.returns({
         trackingDisabled: false,
         frameworkId: '1234wasd',

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -536,7 +536,38 @@ describe('Utils', () => {
       });
     });
 
-    it('should be able to detect Cognito Authorizers', () => {
+    it('should be able to detect Cognito Authorizers using the authorizer string format', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+              },
+            },
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(true);
+      });
+    });
+
+    it('should be able to detect Cognito Authorizers using the arn format', () => {
       getConfigStub.returns({
         trackingDisabled: false,
         frameworkId: '1234wasd',

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -375,6 +375,138 @@ describe('Utils', () => {
       });
     });
 
+    it('should be able to detect IAM Authorizers', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: {
+                  type: 'AWS_IAM'
+                }
+              },
+            }
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(true);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+      });
+    });
+
+    it('should be able to detect named Custom Authorizers', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: {
+                  name: 'authFunc'
+                }
+              },
+            }
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(true);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+      });
+    });
+
+    it('should be able to detect Custom Authorizers with ARNs', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: {
+                  arn: 'arn:aws:lambda:us-east-1:123456789012:function:authFunc'
+                }
+              },
+            }
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(true);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
+      });
+    });
+
+    it('should be able to detect Cognito Authorizers', () => {
+      getConfigStub.returns({
+        trackingDisabled: false,
+        frameworkId: '1234wasd',
+      });
+
+      serverless.service.functions = {
+        functionOne: {
+          events: [
+            {
+              http: {
+                path: 'foo',
+                method: 'GET',
+                authorizer: {
+                  arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ'
+                }
+              },
+            }
+          ],
+        },
+      };
+
+      return utils.logStat(serverless).then(() => {
+        expect(getConfigStub.calledOnce).to.equal(true);
+        expect(trackStub.calledOnce).to.equal(true);
+
+        const data = trackStub.args[0][0];
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(true);
+      });
+    });
+
     it('should send the gathered information', () => {
       getConfigStub.returns({
         trackingDisabled: false,
@@ -398,6 +530,9 @@ describe('Utils', () => {
                 http: {
                   path: 'foo',
                   method: 'GET',
+                  authorizer: {
+                    type: 'AWS_IAM'
+                  }
                 },
               },
               {
@@ -467,6 +602,9 @@ describe('Utils', () => {
         expect(data.properties.events.eventNamesPerFunction[0][1]).to.equal('s3');
         expect(data.properties.events.eventNamesPerFunction[1][0]).to.equal('http');
         expect(data.properties.events.eventNamesPerFunction[1][1]).to.equal('sns');
+        expect(data.properties.events.hasIAMAuthorizer).to.equal(true);
+        expect(data.properties.events.hasCustomAuthorizer).to.equal(false);
+        expect(data.properties.events.hasCognitoAuthorizer).to.equal(false);
         // general property
         expect(data.properties.general.userId.length).to.be.at.least(1);
         expect(data.properties.general.timestamp).to.match(/[0-9]+/);

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -439,7 +439,7 @@ describe('Utils', () => {
       });
     });
 
-    it('should be able to detect named Custom Authorizers using the authorizer string format', () => {
+    it('should be able to detect named Custom Authorizers using authorizer string format', () => {
       getConfigStub.returns({
         trackingDisabled: false,
         frameworkId: '1234wasd',


### PR DESCRIPTION
## What did you implement:

Adds checks for what types of authorizers (IAM, Cognito, or custom Lambda functions) users are using for API Gateway events. Helps us to set priorities for most commonly-used features.

## How did you implement it:

While iterating over each event on a function, it adds additional checks if it's an HTTP event and if it has an `authorizer`. If so, it sets a service-wide flag on the type of authorizer(s) used.

## How can we verify it:

Add an authorizer to an HTTP event in your `serverless.yml`. Make sure it's logged correctly.

One thing I wasn't sure of was whether the `logStat()` method has access to the raw values from `serverless.yml`, or if it's already gone through validation and standardization, e.g. [here](https://github.com/serverless/serverless/blob/6a9e99656d3288fc797cbf9dcf7003b7b23e4413/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js#L192), in the `getAuthorizer()` function. My assumption was the latter, so I'd need to make some changes if that's not the case.

## Todos:

- [X] Write tests
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
