### PR TITLE
Display plugin commands alphabetically under help

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -179,7 +179,7 @@ class CLI {
         pluginCommands[pcmd.pluginName] = [pcmd];
       }
 
-      // Check for subcommands
+      // check for subcommands
       if ('commands' in cmd) {
         _.forEach(cmd.commands, (d) => {
           addToPluginCommands(d);

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -72,14 +72,14 @@ class CLI {
     return false;
   }
 
-  displayCommandUsage(commandObject, command, indents = 0) {
+  displayCommandUsage(commandObject, command, indents) {
     const dotsLength = 30;
 
     // check if command has lifecycleEvents (can be executed)
     if (commandObject.lifecycleEvents) {
       const usage = commandObject.usage;
       const dots = _.repeat('.', dotsLength - command.length);
-      const indent = _.repeat('  ', indents);
+      const indent = _.repeat('  ', indents || 0);
       this.consoleLog(`${indent}${chalk.yellow(command)} ${chalk.dim(dots)} ${usage}`);
     }
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -129,9 +129,19 @@ class CLI {
 
     this.consoleLog('');
 
-    _.forEach(this.loadedCommands, (details, command) => {
-      this.displayCommandUsage(details, command);
-    });
+    if (this.loadedCommands) {
+      const commandKeys = Object.keys(this.loadedCommands);
+      const sortedCommandKeys = _.sortBy(commandKeys);
+      const sortedCommands = _.fromPairs(
+        _.map(sortedCommandKeys, key => [key, this.loadedCommands[key]])
+      );
+
+      _.forEach(sortedCommands, (details, command) => {
+        this.displayCommandUsage(details, command);
+      });
+    } else {
+      this.consoleLog('No commands found');
+    }
 
     this.consoleLog('');
 
@@ -139,11 +149,7 @@ class CLI {
     this.consoleLog(chalk.yellow.underline('Plugins'));
 
     if (this.loadedPlugins.length) {
-      const sortedPlugins = _.sortBy(
-        this.loadedPlugins,
-        (plugin) => plugin.constructor.name
-      );
-
+      const sortedPlugins = _.sortBy(this.loadedPlugins, (plugin) => plugin.constructor.name);
       this.consoleLog(sortedPlugins.map((plugin) => plugin.constructor.name).join(', '));
     } else {
       this.consoleLog('No plugins added yet');
@@ -157,14 +163,14 @@ class CLI {
 
     let pluginCommands = {};
 
-    // Add commands to pluginCommands based on command's plugin
+    // add commands to pluginCommands based on command's plugin
     const addToPluginCommands = (cmd) => {
       const pcmd = _.clone(cmd);
 
-      // Remove subcommand from clone
+      // remove subcommand from clone
       delete pcmd.commands;
 
-      // Check if a plugin entry is alreay present in pluginCommands. Use the
+      // check if a plugin entry is alreay present in pluginCommands. Use the
       // existing one or create a new plugin entry.
       if (_.has(pluginCommands, pcmd.pluginName)) {
         pluginCommands[pcmd.pluginName] = pluginCommands[pcmd.pluginName].concat(pcmd);
@@ -180,19 +186,19 @@ class CLI {
       }
     };
 
-    // Fill up pluginCommands with commands in loadedCommands
+    // fill up pluginCommands with commands in loadedCommands
     _.forEach(this.loadedCommands, (details) => {
       addToPluginCommands(details);
     });
 
-    // Sort plugins alphabetically
+    // sort plugins alphabetically
     pluginCommands = _(pluginCommands).toPairs().sortBy(0).fromPairs()
       .value();
 
     _.forEach(pluginCommands, (details, plugin) => {
       this.consoleLog(plugin);
       _.forEach(details, (cmd) => {
-        // Display command usage with single(1) indent
+        // display command usage with single(1) indent
         this.displayCommandUsage(cmd, cmd.key.split(':').join(' '), 1);
       });
       this.consoleLog('');

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -125,8 +125,8 @@ class CLI {
     this.consoleLog(chalk.yellow.underline('Commands'));
     this.consoleLog(chalk.dim('* Serverless documentation: http://docs.serverless.com'));
     this.consoleLog(chalk.dim('* You can run commands with "serverless" or the shortcut "sls"'));
-    this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
     this.consoleLog(chalk.dim('* Pass "--verbose" to this command to get in-depth plugin info'));
+    this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
 
     this.consoleLog('');
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -126,6 +126,7 @@ class CLI {
     this.consoleLog(chalk.dim('* Serverless documentation: http://docs.serverless.com'));
     this.consoleLog(chalk.dim('* You can run commands with "serverless" or the shortcut "sls"'));
     this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
+    this.consoleLog(chalk.dim('* Pass "--verbose" to this command to get in-depth plugin info'));
 
     this.consoleLog('');
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -56,7 +56,11 @@ class CLI {
     if ((commands.length === 0) ||
         (commands.length === 0 && (options.help || options.h)) ||
         (commands.length === 1 && (commands.indexOf('help') > -1))) {
-      this.generateMainHelp();
+      if (options.plugins || options.p) {
+        this.generateCommandsByPluginHelp();
+      } else {
+        this.generateMainHelp();
+      }
       return true;
     }
 
@@ -143,6 +147,12 @@ class CLI {
     } else {
       this.consoleLog('No plugins added yet');
     }
+  }
+
+  generateCommandsByPluginHelp() {
+    this.consoleLog('');
+
+    this.consoleLog(chalk.yellow.underline('Commands by plugin'));
   }
 
   generateCommandsHelp(commandsArray) {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -72,18 +72,19 @@ class CLI {
     return false;
   }
 
-  displayCommandUsage(commandObject, command) {
+  displayCommandUsage(commandObject, command, indents = 0) {
     const dotsLength = 30;
 
     // check if command has lifecycleEvents (can be executed)
     if (commandObject.lifecycleEvents) {
       const usage = commandObject.usage;
       const dots = _.repeat('.', dotsLength - command.length);
-      this.consoleLog(`${chalk.yellow(command)} ${chalk.dim(dots)} ${usage}`);
+      const indent = _.repeat('  ', indents);
+      this.consoleLog(`${indent}${chalk.yellow(command)} ${chalk.dim(dots)} ${usage}`);
     }
 
     _.forEach(commandObject.commands, (subcommandObject, subcommand) => {
-      this.displayCommandUsage(subcommandObject, `${command} ${subcommand}`);
+      this.displayCommandUsage(subcommandObject, `${command} ${subcommand}`, indents);
     });
   }
 
@@ -153,6 +154,14 @@ class CLI {
     this.consoleLog('');
 
     this.consoleLog(chalk.yellow.underline('Commands by plugin'));
+
+    this.consoleLog('');
+
+    _.forEach(this.loadedCommands, (details, command) => {
+      this.consoleLog(details.pluginName);
+      this.displayCommandUsage(details, command, 1);
+      this.consoleLog('');
+    });
   }
 
   generateCommandsHelp(commandsArray) {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -157,9 +157,46 @@ class CLI {
 
     this.consoleLog('');
 
-    _.forEach(this.loadedCommands, (details, command) => {
-      this.consoleLog(details.pluginName);
-      this.displayCommandUsage(details, command, 1);
+    let pluginCommands = {};
+
+    // Add commands to pluginCommands based on command's plugin
+    const addToPluginCommands = (cmd) => {
+      const pcmd = _.clone(cmd);
+
+      // Remove subcommand from clone
+      delete pcmd.commands;
+
+      // Check if a plugin entry is alreay present in pluginCommands. Use the
+      // existing one or create a new plugin entry.
+      if (_.has(pluginCommands, pcmd.pluginName)) {
+        pluginCommands[pcmd.pluginName] = pluginCommands[pcmd.pluginName].concat(pcmd);
+      } else {
+        pluginCommands[pcmd.pluginName] = [pcmd];
+      }
+
+      // Check for subcommands
+      if ('commands' in cmd) {
+        _.forEach(cmd.commands, (d) => {
+          addToPluginCommands(d);
+        });
+      }
+    };
+
+    // Fill up pluginCommands with commands in loadedCommands
+    _.forEach(this.loadedCommands, (details) => {
+      addToPluginCommands(details);
+    });
+
+    // Sort plugins alphabetically
+    pluginCommands = _(pluginCommands).toPairs().sortBy(0).fromPairs()
+                      .value();
+
+    _.forEach(pluginCommands, (details, plugin) => {
+      this.consoleLog(plugin);
+      _.forEach(details, (cmd) => {
+        // Display command usage with single(1) indent
+        this.displayCommandUsage(cmd, cmd.key.split(':').join(' '), 1);
+      });
       this.consoleLog('');
     });
   }

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -56,8 +56,8 @@ class CLI {
     if ((commands.length === 0) ||
         (commands.length === 0 && (options.help || options.h)) ||
         (commands.length === 1 && (commands.indexOf('help') > -1))) {
-      if (options.plugins || options.p) {
-        this.generateCommandsByPluginHelp();
+      if (options.verbose || options.v) {
+        this.generateVerboseHelp();
       } else {
         this.generateMainHelp();
       }
@@ -150,11 +150,9 @@ class CLI {
     }
   }
 
-  generateCommandsByPluginHelp() {
+  generateVerboseHelp() {
     this.consoleLog('');
-
     this.consoleLog(chalk.yellow.underline('Commands by plugin'));
-
     this.consoleLog('');
 
     let pluginCommands = {};
@@ -189,7 +187,7 @@ class CLI {
 
     // Sort plugins alphabetically
     pluginCommands = _(pluginCommands).toPairs().sortBy(0).fromPairs()
-                      .value();
+      .value();
 
     _.forEach(pluginCommands, (details, plugin) => {
       this.consoleLog(plugin);

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -1,9 +1,5 @@
 'use strict';
 
-/**
- * Test: CLI Class
- */
-
 const expect = require('chai').expect;
 const CLI = require('../../lib/classes/CLI');
 const os = require('os');
@@ -353,8 +349,8 @@ describe('CLI', () => {
       });
     });
 
-    it('should print sorted plugin commands --help --plugins', (done) => {
-      exec(`${this.serverlessExec} --help --plugins`, (err, stdout) => {
+    it('should print help --verbose to stdout', (done) => {
+      exec(`${this.serverlessExec} help --verbose`, (err, stdout) => {
         if (err) {
           done(err);
           return;

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -352,5 +352,17 @@ describe('CLI', () => {
         done();
       });
     });
+
+    it('should print sorted plugin commands --help --plugins', (done) => {
+      exec(`${this.serverlessExec} --help --plugins`, (err, stdout) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(stdout).to.contain('Commands by plugin');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3784 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
This change adds a new option to `help` command, `--verbose`. `sls help --verbose` extracts the loaded commands and arranges them according to their plugin name and displays all the commands grouped under their plugin names.

Commit messages should be helpful enough to understand the incremental changes.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
![screen shot 2017-06-21 at 7 01 20 pm](https://user-images.githubusercontent.com/614105/27386693-37332e32-56b4-11e7-9115-a7d67bfe561a.png)


## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
