### PR TITLE
Only re-deploy when code or service updated

### DIFF
--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -24,6 +24,8 @@ serverless deploy
 
 Use this method when you have updated your Function, Event or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to Amazon Web Services.
 
+**Note:** You can always enforce a deployment using the `--force` option.
+
 ### How It Works
 
 The Serverless Framework translates all syntax in `serverless.yml` to a single AWS CloudFormation template.  By depending on CloudFormation for deployments, users of the Serverless Framework get the safety and reliability of CloudFormation.
@@ -75,6 +77,8 @@ This deployment method does not touch your AWS CloudFormation Stack.  Instead, i
 ```bash
 serverless deploy function --function myFunction
 ```
+
+**Note:** You can always enforce a deployment using the `--force` option.
 
 ### How It Works
 

--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -31,6 +31,8 @@ The Serverless Framework translates all syntax in `serverless.yml` to a single A
 * An AWS CloudFormation template is created from your `serverless.yml`.
 * If a Stack has not yet been created, then it is created with no resources except for an S3 Bucket, which will store zip files of your Function code.
 * The code of your Functions is then packaged into zip files.
+* Serverless fetches the hashes for all files of the previous deployment (if any) and compares them against the hashes of the local files.
+* Serverless terminates the deployment process if all file hashes are the same.
 * Zip files of your Functions' code are uploaded to your Code S3 Bucket.
 * Any IAM Roles, Functions, Events and Resources are added to the AWS CloudFormation template.
 * The CloudFormation Stack is updated with the new CloudFormation template.
@@ -77,6 +79,8 @@ serverless deploy function --function myFunction
 ### How It Works
 
 * The Framework packages up the targeted AWS Lambda Function into a zip file.
+* The Framework fetches the hash of the already uploaded function .zip file and compares it to the local .zip file hash.
+* The Framework terminates if both hashes are the same.
 * That zip file is uploaded to your S3 bucket using the same name as the previous function, which the CloudFormation stack is pointing to.
 
 ### Tips

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -10,9 +10,10 @@
 
 const BbPromise = require('bluebird');
 const extendedValidate = require('./lib/extendedValidate');
+const setBucketName = require('../lib/setBucketName');
+const checkForChanges = require('./lib/checkForChanges');
 const monitorStack = require('../lib/monitorStack');
 const createStack = require('./lib/createStack');
-const setBucketName = require('../lib/setBucketName');
 const cleanupS3Bucket = require('./lib/cleanupS3Bucket');
 const uploadArtifacts = require('./lib/uploadArtifacts');
 const validateTemplate = require('./lib/validateTemplate');
@@ -34,6 +35,7 @@ class AwsDeploy {
       extendedValidate,
       createStack,
       setBucketName,
+      checkForChanges,
       cleanupS3Bucket,
       uploadArtifacts,
       validateTemplate,
@@ -51,6 +53,7 @@ class AwsDeploy {
               deploy: {
                 lifecycleEvents: [
                   'createStack',
+                  'checkForChanges',
                   'uploadArtifacts',
                   'validateTemplate',
                   'updateStack',
@@ -94,20 +97,38 @@ class AwsDeploy {
       'aws:deploy:deploy:createStack': () => BbPromise.bind(this)
         .then(this.createStack),
 
-      'aws:deploy:deploy:uploadArtifacts': () => BbPromise.bind(this)
+      'aws:deploy:deploy:checkForChanges': () => BbPromise.bind(this)
         .then(this.setBucketName)
-        .then(this.uploadArtifacts),
+        .then(this.checkForChanges),
+
+      'aws:deploy:deploy:uploadArtifacts': () => BbPromise.bind(this)
+        .then(() => {
+          if (this.serverless.service.provider.shouldNotDeploy) {
+            return BbPromise.resolve();
+          }
+          return BbPromise.bind(this).then(this.uploadArtifacts);
+        }),
 
       'aws:deploy:deploy:validateTemplate': () => BbPromise.bind(this)
-        .then(this.validateTemplate),
+        .then(() => {
+          if (this.serverless.service.provider.shouldNotDeploy) {
+            return BbPromise.resolve();
+          }
+          return BbPromise.bind(this).then(this.validateTemplate);
+        }),
 
       'aws:deploy:deploy:updateStack': () => BbPromise.bind(this)
-        .then(this.updateStack),
+        .then(() => {
+          if (this.serverless.service.provider.shouldNotDeploy) {
+            return BbPromise.resolve();
+          }
+          return BbPromise.bind(this).then(this.updateStack);
+        }),
 
       // Deploy finalize inner lifecycle
       'aws:deploy:finalize:cleanup': () => BbPromise.bind(this)
         .then(() => {
-          if (this.options.noDeploy) {
+          if (this.options.noDeploy || this.serverless.service.provider.shouldNotDeploy) {
             return BbPromise.resolve();
           }
           return this.cleanupS3Bucket();

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -84,9 +84,7 @@ describe('AwsDeploy', () => {
     let spawnStub;
     let createStackStub;
     let setBucketNameStub;
-    let uploadArtifactsStub;
-    let validateTemplateStub;
-    let updateStackStub;
+    let checkForChangesStub;
 
     beforeEach(() => {
       spawnStub = sinon
@@ -95,21 +93,15 @@ describe('AwsDeploy', () => {
         .stub(awsDeploy, 'createStack').resolves();
       setBucketNameStub = sinon
         .stub(awsDeploy, 'setBucketName').resolves();
-      uploadArtifactsStub = sinon
-        .stub(awsDeploy, 'uploadArtifacts').resolves();
-      validateTemplateStub = sinon
-        .stub(awsDeploy, 'validateTemplate').resolves();
-      updateStackStub = sinon
-        .stub(awsDeploy, 'updateStack').resolves();
+      checkForChangesStub = sinon
+        .stub(awsDeploy, 'checkForChanges').resolves();
     });
 
     afterEach(() => {
       serverless.pluginManager.spawn.restore();
       awsDeploy.createStack.restore();
       awsDeploy.setBucketName.restore();
-      awsDeploy.uploadArtifacts.restore();
-      awsDeploy.validateTemplate.restore();
-      awsDeploy.updateStack.restore();
+      awsDeploy.checkForChanges.restore();
     });
 
     describe('"before:deploy:deploy" hook', () => {
@@ -193,24 +185,96 @@ describe('AwsDeploy', () => {
       })
     );
 
-    it('should run "aws:deploy:deploy:uploadArtifacts" hook', () => awsDeploy
-      .hooks['aws:deploy:deploy:uploadArtifacts']().then(() => {
+    it('should run "aws:deploy:deploy:checkForChanges" hook', () => awsDeploy
+      .hooks['aws:deploy:deploy:checkForChanges']().then(() => {
         expect(setBucketNameStub.calledOnce).to.equal(true);
-        expect(uploadArtifactsStub.calledAfter(setBucketNameStub)).to.equal(true);
+        expect(checkForChangesStub.calledAfter(setBucketNameStub)).to.equal(true);
       })
     );
 
-    it('should run "aws:deploy:deploy:validateTemplate" hook', () => expect(awsDeploy
-      .hooks['aws:deploy:deploy:validateTemplate']()).to.be.fulfilled.then(() => {
-        expect(validateTemplateStub).to.have.been.calledOnce;
-      })
-    );
+    describe('"aws:deploy:deploy:uploadArtifacts" hook', () => {
+      let uploadArtifactsStub;
 
-    it('should run "aws:deploy:deploy:updateStack" hook', () => awsDeploy
-      .hooks['aws:deploy:deploy:updateStack']().then(() => {
-        expect(updateStackStub.calledOnce).to.equal(true);
-      })
-    );
+      beforeEach(() => {
+        uploadArtifactsStub = sinon
+          .stub(awsDeploy, 'uploadArtifacts').resolves();
+      });
+
+      afterEach(() => {
+        awsDeploy.uploadArtifacts.restore();
+      });
+
+      it('should upload the artifacts if a deployment is necessary', () => expect(awsDeploy
+        .hooks['aws:deploy:deploy:uploadArtifacts']()).to.be.fulfilled.then(() => {
+          expect(uploadArtifactsStub).to.have.been.calledOnce;
+        })
+      );
+
+      it('should resolve if no deployment is necessary', () => {
+        awsDeploy.serverless.service.provider.shouldNotDeploy = true;
+
+        return expect(awsDeploy
+          .hooks['aws:deploy:deploy:uploadArtifacts']()).to.be.fulfilled.then(() => {
+            expect(uploadArtifactsStub).to.not.have.been.called;
+          });
+      });
+    });
+
+    describe('"aws:deploy:deploy:validateTemplate" hook', () => {
+      let validateTemplateStub;
+
+      beforeEach(() => {
+        validateTemplateStub = sinon
+          .stub(awsDeploy, 'validateTemplate').resolves();
+      });
+
+      afterEach(() => {
+        awsDeploy.validateTemplate.restore();
+      });
+
+      it('should validate the template if a deployment is necessary', () => expect(awsDeploy
+        .hooks['aws:deploy:deploy:validateTemplate']()).to.be.fulfilled.then(() => {
+          expect(validateTemplateStub).to.have.been.calledOnce;
+        })
+      );
+
+      it('should resolve if no deployment is necessary', () => {
+        awsDeploy.serverless.service.provider.shouldNotDeploy = true;
+
+        return expect(awsDeploy
+          .hooks['aws:deploy:deploy:validateTemplate']()).to.be.fulfilled.then(() => {
+            expect(validateTemplateStub).to.not.have.been.called;
+          });
+      });
+    });
+
+    describe('"aws:deploy:deploy:updateStack" hook', () => {
+      let updateStackStub;
+
+      beforeEach(() => {
+        updateStackStub = sinon
+          .stub(awsDeploy, 'updateStack').resolves();
+      });
+
+      afterEach(() => {
+        awsDeploy.updateStack.restore();
+      });
+
+      it('should update the stack if a deployment is necessary', () => expect(awsDeploy
+        .hooks['aws:deploy:deploy:updateStack']()).to.be.fulfilled.then(() => {
+          expect(updateStackStub).to.have.been.calledOnce;
+        })
+      );
+
+      it('should resolve if no deployment is necessary', () => {
+        awsDeploy.serverless.service.provider.shouldNotDeploy = true;
+
+        return expect(awsDeploy
+          .hooks['aws:deploy:deploy:updateStack']()).to.be.fulfilled.then(() => {
+            expect(updateStackStub).to.not.have.been.called;
+          });
+      });
+    });
 
     describe('"aws:deploy:finalize:cleanup" hook', () => {
       let cleanupS3BucketStub;
@@ -256,6 +320,15 @@ describe('AwsDeploy', () => {
           expect(cleanupS3BucketStub.calledOnce).to.equal(true);
           expect(spawnAwsCommonCleanupTempDirStub.calledAfter(cleanupS3BucketStub))
             .to.equal(true);
+        });
+      });
+
+      it('should not cleanup if a deployment was not necessary', () => {
+        awsDeploy.serverless.service.provider.shouldNotDeploy = true;
+
+        return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
+          expect(cleanupS3BucketStub.called).to.equal(false);
+          expect(spawnAwsCommonCleanupTempDirStub.called).to.equal(false);
         });
       });
     });

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -101,8 +101,8 @@ module.exports = {
         return crypto.createHash('sha256').update(zipFile).digest('base64');
       });
 
-      zipFileHashes.push(localCfHash);
       const localHashes = zipFileHashes;
+      localHashes.push(localCfHash);
 
       if (_.isEqual(remoteHashes.sort(), localHashes.sort())) {
         this.serverless.service.provider.shouldNotDeploy = true;

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -101,14 +101,10 @@ module.exports = {
         return crypto.createHash('sha256').update(zipFile).digest('base64');
       });
 
-      const localHashes = _.union(zipFileHashes, [localCfHash]);
+      zipFileHashes.push(localCfHash);
+      const localHashes = zipFileHashes;
 
-      // figure out which hashes are remotely and locally available
-      const intersection = _.intersection(remoteHashes, localHashes);
-
-      const remoteHashCount = remoteHashes.length;
-      const localHashCount = localHashes.length;
-      if ((remoteHashCount === localHashCount) && (intersection.length === localHashCount)) {
+      if (_.isEqual(remoteHashes.sort(), localHashes.sort())) {
         this.serverless.service.provider.shouldNotDeploy = true;
 
         const message = [

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const globby = require('globby');
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+const normalizeFiles = require('../../lib/normalizeFiles');
+
+module.exports = {
+  checkForChanges() {
+    this.serverless.service.provider.shouldNotDeploy = false;
+
+    return BbPromise.bind(this)
+      .then(this.getMostRecentObjects)
+      .then(this.getObjectMetadata)
+      .then(this.checkIfDeploymentIsNecessary);
+  },
+
+  getMostRecentObjects() {
+    const service = this.serverless.service.service;
+
+    const params = {
+      Bucket: this.bucketName,
+      Prefix: `serverless/${service}/${this.options.stage}`,
+    };
+
+    return this.provider.request('S3',
+      'listObjectsV2',
+      params,
+      this.options.stage,
+      this.options.region
+    ).then((result) => {
+      if (result && result.Contents && result.Contents.length) {
+        const objects = result.Contents;
+
+        const ordered = _.orderBy(objects, ['Key'], ['desc']);
+
+        const firstKey = ordered[0].Key;
+        const directory = firstKey.substring(0, firstKey.lastIndexOf('/'));
+
+        const mostRecentObjects = ordered.filter((obj) => {
+          const objKey = obj.Key;
+          const objDirectory = objKey.substring(0, objKey.lastIndexOf('/'));
+
+          return directory === objDirectory;
+        });
+
+        return BbPromise.resolve(mostRecentObjects);
+      }
+
+      return BbPromise.resolve([]);
+    });
+  },
+
+  getObjectMetadata(objects) {
+    if (objects && objects.length) {
+      const headObjectObjects = objects
+        .map((obj) => this.provider.request('S3',
+          'headObject',
+          {
+            Bucket: this.bucketName,
+            Key: obj.Key,
+          },
+          this.options.stage,
+          this.options.region
+        ));
+
+      return BbPromise.all(headObjectObjects)
+        .then((result) => result);
+    }
+
+    return BbPromise.resolve([]);
+  },
+
+  checkIfDeploymentIsNecessary(objects) {
+    if (objects && objects.length) {
+      const remoteHashes = objects.map((object) => object.Metadata.filesha256 || '');
+
+      const serverlessDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+
+      // create a hash of the CloudFormation body
+      const compiledCfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+      const normCfTemplate = normalizeFiles.normalizeCloudFormationTemplate(compiledCfTemplate);
+      const localCfHash = crypto
+        .createHash('sha256')
+        .update(JSON.stringify(normCfTemplate))
+        .digest('base64');
+
+      // create hashes for all the zip files
+      const zipFiles = globby.sync(['**.zip'], { cwd: serverlessDirPath, dot: true, silent: true });
+      const zipFilePaths = zipFiles.map((zipFile) => path.join(serverlessDirPath, zipFile));
+      const zipFileHashes = zipFilePaths.map((zipFilePath) => {
+        // TODO refactor to be async (use util function to compute checksum async)
+        const zipFile = fs.readFileSync(zipFilePath);
+        return crypto.createHash('sha256').update(zipFile).digest('base64');
+      });
+
+      const localHashes = _.union(zipFileHashes, [localCfHash]);
+
+      // check the local hashes against the remote hashes
+      const pendingFiles = _.difference(remoteHashes, localHashes);
+
+      if (!pendingFiles.length) {
+        this.serverless.service.provider.shouldNotDeploy = true;
+
+        const message = [
+          'Service files not changed. Skipping deployment...',
+        ].join('');
+        this.serverless.cli.log(message);
+      }
+    }
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -99,10 +99,12 @@ module.exports = {
 
       const localHashes = _.union(zipFileHashes, [localCfHash]);
 
-      // check the local hashes against the remote hashes
-      const pendingFiles = _.difference(remoteHashes, localHashes);
+      // figure out which hashes are remotely and locally available
+      const intersection = _.intersection(remoteHashes, localHashes);
 
-      if (!pendingFiles.length) {
+      const remoteHashCount = remoteHashes.length;
+      const localHashCount = localHashes.length;
+      if ((remoteHashCount === localHashCount) && (intersection.length === localHashCount)) {
         this.serverless.service.provider.shouldNotDeploy = true;
 
         const message = [

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -12,6 +12,10 @@ module.exports = {
   checkForChanges() {
     this.serverless.service.provider.shouldNotDeploy = false;
 
+    if (this.options.force) {
+      return BbPromise.resolve();
+    }
+
     return BbPromise.bind(this)
       .then(this.getMostRecentObjects)
       .then(this.getObjectMetadata)

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -392,7 +392,7 @@ describe('checkForChanges', () => {
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
           expect(globbySyncStub).to.have.been.calledOnce;
           expect(readFileSyncStub).to.have.been.calledTwice;
-          //expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+          expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
           );

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -375,6 +375,45 @@ describe('checkForChanges', () => {
         });
     });
 
+    it('should not set a flag if remote and local hashes are the same but are duplicated', () => {
+      globbySyncStub.returns(['func1.zip', 'func2.zip']);
+      cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-cf-template');
+      // happens when package.individually is used
+      cryptoStub.createHash().update().digest.onCall(1).returns('remote-hash-zip-file-1');
+      cryptoStub.createHash().update().digest.onCall(2).returns('remote-hash-zip-file-1');
+
+      const input = [
+        { Metadata: { filesha256: 'remote-hash-cf-template' } },
+        { Metadata: { filesha256: 'remote-hash-zip-file-1' } },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input))
+        .to.be.fulfilled.then(() => {
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+          expect(globbySyncStub).to.have.been.calledOnce;
+          expect(readFileSyncStub).to.have.been.calledTwice;
+          //expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+            awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          );
+          expect(globbySyncStub).to.have.been.calledWithExactly(
+            ['**.zip'],
+            {
+              cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+              dot: true,
+              silent: true,
+            }
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/func1.zip'
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/func2.zip'
+          );
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
+        });
+    });
+
     it('should set a flag if the remote and local hashes are equal', () => {
       globbySyncStub.returns(['my-service.zip']);
       cryptoStub.createHash().update().digest.onCall(0).returns('hash-cf-template');
@@ -404,6 +443,46 @@ describe('checkForChanges', () => {
           );
           expect(readFileSyncStub).to.have.been.calledWithExactly(
             'my-service/.serverless/my-service.zip'
+          );
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
+        });
+    });
+
+    it('should set a flag if the remote and local hashes are duplicated and equal', () => {
+      globbySyncStub.returns(['func1.zip', 'func2.zip']);
+      cryptoStub.createHash().update().digest.onCall(0).returns('hash-cf-template');
+      // happens when package.individually is used
+      cryptoStub.createHash().update().digest.onCall(1).returns('hash-zip-file-1');
+      cryptoStub.createHash().update().digest.onCall(2).returns('hash-zip-file-1');
+
+      const input = [
+        { Metadata: { filesha256: 'hash-cf-template' } },
+        { Metadata: { filesha256: 'hash-zip-file-1' } },
+        { Metadata: { filesha256: 'hash-zip-file-1' } },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input))
+        .to.be.fulfilled.then(() => {
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+          expect(globbySyncStub).to.have.been.calledOnce;
+          expect(readFileSyncStub).to.have.been.calledTwice;
+          expect(awsDeploy.serverless.cli.log).to.have.been.calledOnce;
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+            awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          );
+          expect(globbySyncStub).to.have.been.calledWithExactly(
+            ['**.zip'],
+            {
+              cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+              dot: true,
+              silent: true,
+            }
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/func1.zip'
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/func2.zip'
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
         });

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -79,8 +79,23 @@ describe('checkForChanges', () => {
         expect(getMostRecentObjectsStub).to.have.been.calledOnce;
         expect(getObjectMetadataStub).to.have.been.calledAfter(getMostRecentObjectsStub);
         expect(checkIfDeploymentIsNecessaryStub).to.have.been.calledAfter(getObjectMetadataStub);
+
+        expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(false);
       })
     );
+
+    it('should resolve if the "force" option is used', () => {
+      awsDeploy.options.force = true;
+
+      return expect(awsDeploy.checkForChanges())
+        .to.be.fulfilled.then(() => {
+          expect(getMostRecentObjectsStub).to.not.have.been.called;
+          expect(getObjectMetadataStub).to.not.have.been.called;
+          expect(checkIfDeploymentIsNecessaryStub).to.not.have.been.called;
+
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(false);
+        });
+    });
   });
 
   describe('#getMostRecentObjects()', () => {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -1,0 +1,397 @@
+'use strict';
+
+/* eslint-disable no-unused-expressions */
+
+const fs = require('fs');
+const path = require('path');
+const globby = require('globby');
+const sinon = require('sinon');
+const chai = require('chai');
+const proxyquire = require('proxyquire');
+const normalizeFiles = require('../../lib/normalizeFiles');
+const AwsProvider = require('../../provider/awsProvider');
+const AwsDeploy = require('../index');
+const Serverless = require('../../../../Serverless');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+const expect = require('chai').expect;
+
+describe('checkForChanges', () => {
+  let serverless;
+  let awsDeploy;
+  let s3Key;
+  let cryptoStub;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.config.servicePath = 'my-service';
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.service = 'my-service';
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.bucketName = 'deployment-bucket';
+    awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {
+      foo: 'bar',
+    };
+    s3Key = `serverless/${serverless.service.service}/${options.stage}`;
+    awsDeploy.serverless.cli = { log: sinon.spy() };
+    cryptoStub = {
+      createHash: function () { return this; }, // eslint-disable-line
+      update: function () { return this; }, // eslint-disable-line
+      digest: sinon.stub(),
+    };
+    const checkForChanges = proxyquire('./checkForChanges.js', {
+      crypto: cryptoStub,
+    });
+    Object.assign(
+      awsDeploy,
+      checkForChanges
+    );
+  });
+
+  describe('#checkForChanges()', () => {
+    let getMostRecentObjectsStub;
+    let getObjectMetadataStub;
+    let checkIfDeploymentIsNecessaryStub;
+
+    beforeEach(() => {
+      getMostRecentObjectsStub = sinon
+        .stub(awsDeploy, 'getMostRecentObjects').resolves();
+      getObjectMetadataStub = sinon
+        .stub(awsDeploy, 'getObjectMetadata').resolves();
+      checkIfDeploymentIsNecessaryStub = sinon
+        .stub(awsDeploy, 'checkIfDeploymentIsNecessary').resolves();
+    });
+
+    afterEach(() => {
+      awsDeploy.getMostRecentObjects.restore();
+      awsDeploy.getObjectMetadata.restore();
+      awsDeploy.checkIfDeploymentIsNecessary.restore();
+    });
+
+    it('should run promise chain in order', () => expect(awsDeploy.checkForChanges())
+      .to.be.fulfilled.then(() => {
+        expect(getMostRecentObjectsStub).to.have.been.calledOnce;
+        expect(getObjectMetadataStub).to.have.been.calledAfter(getMostRecentObjectsStub);
+        expect(checkIfDeploymentIsNecessaryStub).to.have.been.calledAfter(getObjectMetadataStub);
+      })
+    );
+  });
+
+  describe('#getMostRecentObjects()', () => {
+    let listObjectsV2Stub;
+
+    beforeEach(() => {
+      listObjectsV2Stub = sinon
+        .stub(awsDeploy.provider, 'request');
+    });
+
+    afterEach(() => {
+      awsDeploy.provider.request.restore();
+    });
+
+    it('should resolve if no result is returned', () => {
+      listObjectsV2Stub.resolves();
+
+      return expect(awsDeploy.getMostRecentObjects()).to.be.fulfilled.then((result) => {
+        expect(listObjectsV2Stub).to.have.been.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: 'serverless/my-service/dev',
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+        expect(result).to.deep.equal([]);
+      });
+    });
+
+    it('should resolve if result array is empty', () => {
+      const serviceObjects = {
+        Contents: [],
+      };
+
+      listObjectsV2Stub.resolves(serviceObjects);
+
+      return expect(awsDeploy.getMostRecentObjects()).to.be.fulfilled.then((result) => {
+        expect(listObjectsV2Stub).to.have.been.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: 'serverless/my-service/dev',
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+        expect(result).to.deep.equal([]);
+      });
+    });
+
+    it('should resolve with the most recently deployed objects', () => {
+      const serviceObjects = {
+        Contents: [
+          { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
+          { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
+          { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip` },
+          { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json` },
+        ],
+      };
+
+      listObjectsV2Stub.resolves(serviceObjects);
+
+      return expect(awsDeploy.getMostRecentObjects()).to.be.fulfilled.then((result) => {
+        expect(listObjectsV2Stub).to.have.been.calledWithExactly(
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: 'serverless/my-service/dev',
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+        expect(result).to.deep.equal([
+          { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
+          { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
+        ]);
+      });
+    });
+  });
+
+  describe('#getObjectMetadata()', () => {
+    let headObjectStub;
+
+    beforeEach(() => {
+      headObjectStub = sinon
+        .stub(awsDeploy.provider, 'request').resolves();
+    });
+
+    afterEach(() => {
+      awsDeploy.provider.request.restore();
+    });
+
+    it('should resolve if no input is provided', () => expect(awsDeploy.getObjectMetadata())
+      .to.be.fulfilled.then((result) => {
+        expect(headObjectStub).to.not.have.been.called;
+        expect(result).to.deep.equal([]);
+      })
+    );
+
+    it('should resolve if no objects are provided as input', () => {
+      const input = [];
+
+      return expect(awsDeploy.getObjectMetadata(input)).to.be.fulfilled.then((result) => {
+        expect(headObjectStub).to.not.have.been.called;
+        expect(result).to.deep.equal([]);
+      });
+    });
+
+    it('should request the object detailed information', () => {
+      const input = [
+        { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
+        { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
+        { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip` },
+        { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json` },
+      ];
+
+      return expect(awsDeploy.getObjectMetadata(input)).to.be.fulfilled.then(() => {
+        expect(headObjectStub.callCount).to.equal(4);
+        expect(headObjectStub).to.have.been.calledWithExactly(
+          'S3',
+          'headObject',
+          {
+            Bucket: awsDeploy.bucketName,
+            Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+        expect(headObjectStub).to.have.been.calledWithExactly(
+          'S3',
+          'headObject',
+          {
+            Bucket: awsDeploy.bucketName,
+            Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+        expect(headObjectStub).to.have.been.calledWithExactly(
+          'S3',
+          'headObject',
+          {
+            Bucket: awsDeploy.bucketName,
+            Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+        expect(headObjectStub).to.have.been.calledWithExactly(
+          'S3',
+          'headObject',
+          {
+            Bucket: awsDeploy.bucketName,
+            Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json`,
+          },
+          awsDeploy.options.stage,
+          awsDeploy.options.region
+        );
+      });
+    });
+  });
+
+  describe('#checkIfDeploymentIsNecessary()', () => {
+    let normalizeCloudFormationTemplateStub;
+    let globbySyncStub;
+    let readFileSyncStub;
+
+    beforeEach(() => {
+      normalizeCloudFormationTemplateStub = sinon
+        .stub(normalizeFiles, 'normalizeCloudFormationTemplate')
+        .returns();
+      globbySyncStub = sinon
+        .stub(globby, 'sync');
+      readFileSyncStub = sinon
+        .stub(fs, 'readFileSync')
+        .returns();
+    });
+
+    afterEach(() => {
+      normalizeFiles.normalizeCloudFormationTemplate.restore();
+      globby.sync.restore();
+      fs.readFileSync.restore();
+    });
+
+    it('should resolve if no input is provided', () => expect(awsDeploy
+      .checkIfDeploymentIsNecessary()).to.be.fulfilled.then(() => {
+        expect(normalizeCloudFormationTemplateStub).to.not.have.been.called;
+        expect(globbySyncStub).to.not.have.been.called;
+        expect(readFileSyncStub).to.not.have.been.called;
+        expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+      })
+    );
+
+    it('should resolve if no objects are provided as input', () => {
+      const input = [];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input))
+        .to.be.fulfilled.then(() => {
+          expect(normalizeCloudFormationTemplateStub).to.not.have.been.called;
+          expect(globbySyncStub).to.not.have.been.called;
+          expect(readFileSyncStub).to.not.have.been.called;
+          expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+        });
+    });
+
+    it('should not set a flag if there are more remote hashes', () => {
+      globbySyncStub.returns(['my-service.zip']);
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-cf-template');
+      cryptoStub.createHash().update().digest.onCall(1).returns('local-hash-zip-file-1');
+
+      const input = [
+        { Metadata: { filesha256: 'remote-hash-cf-template' } },
+        { Metadata: { filesha256: 'remote-hash-zip-file-1' } },
+        { Metadata: { /* no filesha256 available */ } }, // will be translated to ''
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input))
+        .to.be.fulfilled.then(() => {
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+          expect(globbySyncStub).to.have.been.calledOnce;
+          expect(readFileSyncStub).to.have.been.calledOnce;
+          expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+            awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          );
+          expect(globbySyncStub).to.have.been.calledWithExactly(
+            ['**.zip'],
+            {
+              cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+              dot: true,
+              silent: true,
+            }
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/my-service.zip'
+          );
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
+        });
+    });
+
+    it('should not set a flag if remote and local hashes are different', () => {
+      globbySyncStub.returns(['my-service.zip']);
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-cf-template');
+      cryptoStub.createHash().update().digest.onCall(1).returns('local-hash-zip-file-1');
+
+      const input = [
+        { Metadata: { filesha256: 'remote-hash-cf-template' } },
+        { Metadata: { filesha256: 'remote-hash-zip-file-1' } },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input))
+        .to.be.fulfilled.then(() => {
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+          expect(globbySyncStub).to.have.been.calledOnce;
+          expect(readFileSyncStub).to.have.been.calledOnce;
+          expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+            awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          );
+          expect(globbySyncStub).to.have.been.calledWithExactly(
+            ['**.zip'],
+            {
+              cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+              dot: true,
+              silent: true,
+            }
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/my-service.zip'
+          );
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
+        });
+    });
+
+    it('should set a flag if the remote and local hashes are equal', () => {
+      globbySyncStub.returns(['my-service.zip']);
+      cryptoStub.createHash().update().digest.onCall(0).returns('hash-cf-template');
+      cryptoStub.createHash().update().digest.onCall(1).returns('hash-zip-file-1');
+
+      const input = [
+        { Metadata: { filesha256: 'hash-cf-template' } },
+        { Metadata: { filesha256: 'hash-zip-file-1' } },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input))
+        .to.be.fulfilled.then(() => {
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+          expect(globbySyncStub).to.have.been.calledOnce;
+          expect(readFileSyncStub).to.have.been.calledOnce;
+          expect(awsDeploy.serverless.cli.log).to.have.been.calledOnce;
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+            awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          );
+          expect(globbySyncStub).to.have.been.calledWithExactly(
+            ['**.zip'],
+            {
+              cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+              dot: true,
+              silent: true,
+            }
+          );
+          expect(readFileSyncStub).to.have.been.calledWithExactly(
+            'my-service/.serverless/my-service.zip'
+          );
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
+        });
+    });
+  });
+});

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -3,22 +3,39 @@
 /* eslint-disable no-use-before-define */
 
 const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
 const BbPromise = require('bluebird');
 const filesize = require('filesize');
-const path = require('path');
+const normalizeFiles = require('../../lib/normalizeFiles');
 
 module.exports = {
+  uploadArtifacts() {
+    return BbPromise.bind(this)
+      .then(this.uploadCloudFormationFile)
+      .then(this.uploadFunctions);
+  },
+
   uploadCloudFormationFile() {
     this.serverless.cli.log('Uploading CloudFormation file to S3...');
 
     const compiledTemplateFileName = 'compiled-cloudformation-template.json';
 
-    const body = JSON.stringify(this.serverless.service.provider.compiledCloudFormationTemplate);
+    const compiledCfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const normCfTemplate = normalizeFiles.normalizeCloudFormationTemplate(compiledCfTemplate);
+    const fileHash = crypto
+      .createHash('sha256')
+      .update(JSON.stringify(normCfTemplate))
+      .digest('base64');
+
     let params = {
       Bucket: this.bucketName,
       Key: `${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
-      Body: body,
+      Body: JSON.stringify(compiledCfTemplate),
       ContentType: 'application/json',
+      Metadata: {
+        filesha256: fileHash,
+      },
     };
 
     const deploymentBucketObject = this.serverless.service.provider.deploymentBucketObject;
@@ -36,11 +53,18 @@ module.exports = {
   uploadZipFile(artifactFilePath) {
     const fileName = artifactFilePath.split(path.sep).pop();
 
+    // TODO refactor to be async (use util function to compute checksum async)
+    const data = fs.readFileSync(artifactFilePath);
+    const fileHash = crypto.createHash('sha256').update(data).digest('base64');
+
     let params = {
       Bucket: this.bucketName,
       Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
       Body: fs.createReadStream(artifactFilePath),
       ContentType: 'application/zip',
+      Metadata: {
+        filesha256: fileHash,
+      },
     };
 
     const deploymentBucketObject = this.serverless.service.provider.deploymentBucketObject;
@@ -88,12 +112,6 @@ module.exports = {
       }
       return BbPromise.resolve();
     });
-  },
-
-  uploadArtifacts() {
-    return BbPromise.bind(this)
-      .then(this.uploadCloudFormationFile)
-      .then(this.uploadFunctions);
   },
 };
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -1,17 +1,20 @@
 'use strict';
 
 const sinon = require('sinon');
+const fs = require('fs');
 const path = require('path');
 const expect = require('chai').expect;
+const proxyquire = require('proxyquire');
+const normalizeFiles = require('../../lib/normalizeFiles');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 const testUtils = require('../../../../../tests/utils');
-const fs = require('fs');
 
 describe('uploadArtifacts', () => {
   let serverless;
   let awsDeploy;
+  let cryptoStub;
 
   beforeEach(() => {
     serverless = new Serverless();
@@ -29,19 +32,66 @@ describe('uploadArtifacts', () => {
         handler: 'foo',
       },
     };
-
+    awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {
+      foo: 'bar',
+    };
     awsDeploy.serverless.cli = new serverless.classes.CLI();
+    cryptoStub = {
+      createHash: function () { return this; }, // eslint-disable-line
+      update: function () { return this; }, // eslint-disable-line
+      digest: sinon.stub(),
+    };
+    const uploadArtifacts = proxyquire('./uploadArtifacts.js', {
+      crypto: cryptoStub,
+    });
+    Object.assign(
+      awsDeploy,
+      uploadArtifacts
+    );
+  });
+
+  describe('#uploadArtifacts()', () => {
+    it('should run promise chain in order', () => {
+      const uploadCloudFormationFileStub = sinon
+        .stub(awsDeploy, 'uploadCloudFormationFile').resolves();
+      const uploadFunctionsStub = sinon
+        .stub(awsDeploy, 'uploadFunctions').resolves();
+
+      return awsDeploy.uploadArtifacts().then(() => {
+        expect(uploadCloudFormationFileStub.calledOnce)
+          .to.be.equal(true);
+        expect(uploadFunctionsStub.calledAfter(uploadCloudFormationFileStub)).to.be.equal(true);
+
+        awsDeploy.uploadCloudFormationFile.restore();
+        awsDeploy.uploadFunctions.restore();
+      });
+    });
   });
 
   describe('#uploadCloudFormationFile()', () => {
-    it('should upload the CloudFormation file to the S3 bucket', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+    let normalizeCloudFormationTemplateStub;
+    let putObjectStub;
 
-      const putObjectStub = sinon
-        .stub(awsDeploy.provider, 'request').resolves();
+    beforeEach(() => {
+      normalizeCloudFormationTemplateStub = sinon
+        .stub(normalizeFiles, 'normalizeCloudFormationTemplate')
+        .returns();
+      putObjectStub = sinon
+        .stub(awsDeploy.provider, 'request')
+        .resolves();
+    });
+
+    afterEach(() => {
+      normalizeFiles.normalizeCloudFormationTemplate.restore();
+      awsDeploy.provider.request.restore();
+    });
+
+    it('should upload the CloudFormation file to the S3 bucket', () => {
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-cf-template');
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
-        expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(normalizeCloudFormationTemplateStub.calledOnce).to.equal(true);
+        expect(putObjectStub.calledOnce).to.equal(true);
         expect(putObjectStub.calledWithExactly(
           'S3',
           'putObject',
@@ -49,27 +99,28 @@ describe('uploadArtifacts', () => {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package
               .artifactDirectoryName}/compiled-cloudformation-template.json`,
-            Body: JSON.stringify(awsDeploy.serverless.service.provider
-              .compiledCloudFormationTemplate),
+            Body: JSON.stringify({ foo: 'bar' }),
             ContentType: 'application/json',
+            Metadata: {
+              filesha256: 'local-hash-cf-template',
+            },
           },
           awsDeploy.options.stage,
           awsDeploy.options.region
         )).to.be.equal(true);
-        awsDeploy.provider.request.restore();
+        expect(normalizeCloudFormationTemplateStub.calledWithExactly({ foo: 'bar' }))
+          .to.equal(true);
       });
     });
 
-    it('should upload to a bucket with server side encryption bucket policy', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = { key: 'value' };
+    it('should upload the CloudFormation file to a bucket with SSE bucket policy', () => {
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-cf-template');
       awsDeploy.serverless.service.provider.deploymentBucketObject = {
         serverSideEncryption: 'AES256',
       };
 
-      const putObjectStub = sinon
-        .stub(awsDeploy.provider, 'request').resolves();
-
       return awsDeploy.uploadCloudFormationFile().then(() => {
+        expect(normalizeCloudFormationTemplateStub.calledOnce).to.equal(true);
         expect(putObjectStub.calledOnce).to.be.equal(true);
         expect(putObjectStub.calledWithExactly(
           'S3',
@@ -78,36 +129,54 @@ describe('uploadArtifacts', () => {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package
               .artifactDirectoryName}/compiled-cloudformation-template.json`,
-            Body: JSON.stringify(awsDeploy.serverless.service.provider
-              .compiledCloudFormationTemplate),
+            Body: JSON.stringify({ foo: 'bar' }),
             ContentType: 'application/json',
             ServerSideEncryption: 'AES256',
+            Metadata: {
+              filesha256: 'local-hash-cf-template',
+            },
           },
           awsDeploy.options.stage,
           awsDeploy.options.region
         )).to.be.equal(true);
-
-        awsDeploy.provider.request.restore();
+        expect(normalizeCloudFormationTemplateStub.calledWithExactly({ foo: 'bar' }))
+          .to.equal(true);
       });
     });
   });
 
   describe('#uploadZipFile()', () => {
+    let readFileSyncStub;
+    let putObjectStub;
+
+    beforeEach(() => {
+      readFileSyncStub = sinon
+        .stub(fs, 'readFileSync')
+        .returns();
+      putObjectStub = sinon
+        .stub(awsDeploy.provider, 'request')
+        .resolves();
+    });
+
+    afterEach(() => {
+      fs.readFileSync.restore();
+      awsDeploy.provider.request.restore();
+    });
+
     it('should throw for null artifact paths', () => {
-      sinon.stub(awsDeploy.provider, 'request').resolves();
       expect(() => awsDeploy.uploadZipFile(null)).to.throw(Error);
     });
 
     it('should upload the .zip file to the S3 bucket', () => {
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-zip-file');
+
       const tmpDirPath = testUtils.getTmpDirPath();
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
-      const putObjectStub = sinon
-        .stub(awsDeploy.provider, 'request').resolves();
-
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(readFileSyncStub.calledOnce).to.equal(true);
         expect(putObjectStub.calledWithExactly(
           'S3',
           'putObject',
@@ -116,26 +185,30 @@ describe('uploadArtifacts', () => {
             Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/artifact.zip`,
             Body: sinon.match.object.and(sinon.match.has('path', artifactFilePath)),
             ContentType: 'application/zip',
+            Metadata: {
+              filesha256: 'local-hash-zip-file',
+            },
           },
           awsDeploy.options.stage,
           awsDeploy.options.region
         )).to.be.equal(true);
-        awsDeploy.provider.request.restore();
+        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
       });
     });
 
-    it('should upload to a bucket with server side encryption bucket policy', () => {
+    it('should upload the .zip file to a bucket with SSE bucket policy', () => {
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-zip-file');
+
       const tmpDirPath = testUtils.getTmpDirPath();
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
       awsDeploy.serverless.service.provider.deploymentBucketObject = {
         serverSideEncryption: 'AES256',
       };
-      const putObjectStub = sinon
-        .stub(awsDeploy.provider, 'request').resolves();
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
         expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(readFileSyncStub.calledOnce).to.equal(true);
         expect(putObjectStub.calledWithExactly(
           'S3',
           'putObject',
@@ -145,11 +218,14 @@ describe('uploadArtifacts', () => {
             Body: sinon.match.object.and(sinon.match.has('path', artifactFilePath)),
             ContentType: 'application/zip',
             ServerSideEncryption: 'AES256',
+            Metadata: {
+              filesha256: 'local-hash-zip-file',
+            },
           },
           awsDeploy.options.stage,
           awsDeploy.options.region
         )).to.be.equal(true);
-        awsDeploy.provider.request.restore();
+        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
       });
     });
   });
@@ -243,24 +319,6 @@ describe('uploadArtifacts', () => {
 
         fs.statSync.restore();
         awsDeploy.uploadZipFile.restore();
-      });
-    });
-  });
-
-  describe('#uploadArtifacts()', () => {
-    it('should run promise chain in order', () => {
-      const uploadCloudFormationFileStub = sinon
-        .stub(awsDeploy, 'uploadCloudFormationFile').resolves();
-      const uploadFunctionsStub = sinon
-        .stub(awsDeploy, 'uploadFunctions').resolves();
-
-      return awsDeploy.uploadArtifacts().then(() => {
-        expect(uploadCloudFormationFileStub.calledOnce)
-          .to.be.equal(true);
-        expect(uploadFunctionsStub.calledAfter(uploadCloudFormationFileStub)).to.be.equal(true);
-
-        awsDeploy.uploadCloudFormationFile.restore();
-        awsDeploy.uploadFunctions.restore();
       });
     });
   });

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -17,7 +17,7 @@ class AwsDeployFunction {
     this.provider = this.serverless.getProvider('aws');
 
     // used to store data received via AWS SDK
-    this.remoteFunctionData = null;
+    this.serverless.service.provider.remoteFunctionData = null;
 
     Object.assign(this, validate);
 
@@ -51,7 +51,7 @@ class AwsDeployFunction {
       this.options.stage, this.options.region
     )
     .then((result) => {
-      this.remoteFunctionData = result;
+      this.serverless.service.provider.remoteFunctionData = result;
       return result;
     })
     .catch(() => {
@@ -71,7 +71,7 @@ class AwsDeployFunction {
     const artifactFilePath = path.join(this.packagePath, artifactFileName);
     const data = fs.readFileSync(artifactFilePath);
 
-    const remoteHash = this.remoteFunctionData.Configuration.CodeSha256;
+    const remoteHash = this.serverless.service.provider.remoteFunctionData.Configuration.CodeSha256;
     const localHash = crypto.createHash('sha256').update(data).digest('base64');
 
     if (remoteHash === localHash) {

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -74,7 +74,7 @@ class AwsDeployFunction {
     const remoteHash = this.serverless.service.provider.remoteFunctionData.Configuration.CodeSha256;
     const localHash = crypto.createHash('sha256').update(data).digest('base64');
 
-    if (remoteHash === localHash) {
+    if (remoteHash === localHash && !this.options.force) {
       this.serverless.cli.log('Code not changed. Skipping function deployment.');
       return BbPromise.resolve();
     }

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -75,7 +75,7 @@ class AwsDeployFunction {
     const localHash = crypto.createHash('sha256').update(data).digest('base64');
 
     if (remoteHash === localHash) {
-      this.serverless.cli.log('Function not deployed since code was not changed.');
+      this.serverless.cli.log('Code not changed. Skipping function deployment.');
       return BbPromise.resolve();
     }
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 const validate = require('../lib/validate');
@@ -15,12 +16,14 @@ class AwsDeployFunction {
       path.join(this.serverless.config.servicePath || '.', '.serverless');
     this.provider = this.serverless.getProvider('aws');
 
+    // used to store data received via AWS SDK
+    this.remoteFunctionData = null;
+
     Object.assign(this, validate);
 
     this.hooks = {
       'deploy:function:initialize': () => BbPromise.bind(this)
         .then(this.validate)
-        .then(this.logStatus)
         .then(this.checkIfFunctionExists),
 
       'deploy:function:packageFunction': () => this.serverless.pluginManager
@@ -32,11 +35,6 @@ class AwsDeployFunction {
     };
   }
 
-  logStatus() {
-    this.serverless.cli.log(`Deploying function: ${this.options.function}...`);
-    return BbPromise.resolve();
-  }
-
   checkIfFunctionExists() {
     // check if the function exists in the service
     this.options.functionObj = this.serverless.service.getFunction(this.options.function);
@@ -46,23 +44,25 @@ class AwsDeployFunction {
       FunctionName: this.options.functionObj.name,
     };
 
-    this.provider.request(
+    return this.provider.request(
       'Lambda',
       'getFunction',
       params,
       this.options.stage, this.options.region
-    ).catch(() => {
+    )
+    .then((result) => {
+      this.remoteFunctionData = result;
+      return result;
+    })
+    .catch(() => {
       const errorMessage = [
         `The function "${this.options.function}" you want to update is not yet deployed.`,
         ' Please run "serverless deploy" to deploy your service.',
         ' After that you can redeploy your services functions with the',
         ' "serverless deploy function" command.',
       ].join('');
-      throw new this.serverless.classes
-        .Error(errorMessage);
+      throw new this.serverless.classes.Error(errorMessage);
     });
-
-    return BbPromise.resolve();
   }
 
   deployFunction() {
@@ -71,18 +71,24 @@ class AwsDeployFunction {
     const artifactFilePath = path.join(this.packagePath, artifactFileName);
     const data = fs.readFileSync(artifactFilePath);
 
+    const remoteHash = this.remoteFunctionData.Configuration.CodeSha256;
+    const localHash = crypto.createHash('sha256').update(data).digest('base64');
+
+    if (remoteHash === localHash) {
+      this.serverless.cli.log('Function not deployed since code was not changed.');
+      return BbPromise.resolve();
+    }
+
     const params = {
       FunctionName: this.options.functionObj.name,
       ZipFile: data,
     };
 
-    // Get function stats
     const stats = fs.statSync(artifactFilePath);
     this.serverless.cli.log(
       `Uploading function: ${this.options.function} (${filesize(stats.size)})...`
     );
 
-    // Perform upload
     return this.provider.request(
       'Lambda',
       'updateFunctionCode',

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -172,6 +172,29 @@ describe('AwsDeployFunction', () => {
       });
     });
 
+    it('should deploy the function if the hashes are same but the "force" option is used', () => {
+      awsDeployFunction.options.force = true;
+      cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-zip-file');
+
+      return awsDeployFunction.deployFunction().then(() => {
+        const data = fs.readFileSync(artifactFilePath);
+
+        expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
+        expect(readFileSyncStub.called).to.equal(true);
+        expect(updateFunctionCodeStub.calledWithExactly(
+          'Lambda',
+          'updateFunctionCode',
+          {
+            FunctionName: 'first',
+            ZipFile: data,
+          },
+          awsDeployFunction.options.stage,
+          awsDeployFunction.options.region
+        )).to.be.equal(true);
+        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
+      });
+    });
+
     it('should resolve if the hashes are the same', () => {
       cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-zip-file');
 

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -4,14 +4,16 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs');
+const proxyquire = require('proxyquire');
 const AwsProvider = require('../provider/awsProvider');
-const AwsDeployFunction = require('./index');
 const Serverless = require('../../../Serverless');
 const testUtils = require('../../../../tests/utils');
 
 describe('AwsDeployFunction', () => {
+  let AwsDeployFunction;
   let serverless;
   let awsDeployFunction;
+  let cryptoStub;
 
   beforeEach(() => {
     serverless = new Serverless();
@@ -44,6 +46,14 @@ describe('AwsDeployFunction', () => {
     };
     serverless.init();
     serverless.setProvider('aws', new AwsProvider(serverless));
+    cryptoStub = {
+      createHash: function () { return this; }, // eslint-disable-line
+      update: function () { return this; }, // eslint-disable-line
+      digest: sinon.stub(),
+    };
+    AwsDeployFunction = proxyquire('./index.js', {
+      crypto: cryptoStub,
+    });
     awsDeployFunction = new AwsDeployFunction(serverless, options);
   });
 
@@ -61,15 +71,24 @@ describe('AwsDeployFunction', () => {
   });
 
   describe('#checkIfFunctionExists()', () => {
+    let getFunctionStub;
+
+    beforeEach(() => {
+      getFunctionStub = sinon
+        .stub(awsDeployFunction.provider, 'request')
+        .resolves({ func: { name: 'first' } });
+    });
+
+    afterEach(() => {
+      awsDeployFunction.provider.request.restore();
+    });
+
     it('it should throw error if function is not provided', () => {
       serverless.service.functions = null;
       expect(() => awsDeployFunction.checkIfFunctionExists()).to.throw(Error);
     });
 
-    it('should check if the function is deployed', () => {
-      const getFunctionStub = sinon
-        .stub(awsDeployFunction.provider, 'request').resolves();
-
+    it('should check if the function is deployed and save the result', () => {
       awsDeployFunction.serverless.service.functions = {
         first: {
           name: 'first',
@@ -88,30 +107,57 @@ describe('AwsDeployFunction', () => {
           awsDeployFunction.options.stage,
           awsDeployFunction.options.region
         )).to.be.equal(true);
-        awsDeployFunction.provider.request.restore();
+        expect(awsDeployFunction.remoteFunctionData).to.deep.equal({
+          func: {
+            name: 'first',
+          },
+        });
       });
     });
   });
 
   describe('#deployFunction()', () => {
     let artifactFilePath;
+    let updateFunctionCodeStub;
+    let statSyncStub;
+    let readFileSyncStub;
 
     beforeEach(() => {
       // write a file to disc to simulate that the deployment artifact exists
       awsDeployFunction.packagePath = testUtils.getTmpDirPath();
       artifactFilePath = path.join(awsDeployFunction.packagePath, 'first.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'first.zip file content');
+      updateFunctionCodeStub = sinon
+        .stub(awsDeployFunction.provider, 'request')
+        .resolves();
+      statSyncStub = sinon
+        .stub(fs, 'statSync')
+        .returns({ size: 1024 });
+      sinon.spy(awsDeployFunction.serverless.cli, 'log');
+      readFileSyncStub = sinon
+        .stub(fs, 'readFileSync')
+        .returns();
+      awsDeployFunction.remoteFunctionData = {
+        Configuration: {
+          CodeSha256: 'remote-hash-zip-file',
+        },
+      };
     });
 
-    it('should deploy the function', () => {
-      // deploy the function artifact not the service artifact
-      const updateFunctionCodeStub = sinon
-        .stub(awsDeployFunction.provider, 'request').resolves();
+    afterEach(() => {
+      awsDeployFunction.provider.request.restore();
+      fs.statSync.restore();
+      fs.readFileSync.restore();
+    });
+
+    it('should deploy the function if the hashes are different', () => {
+      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-zip-file');
 
       return awsDeployFunction.deployFunction().then(() => {
         const data = fs.readFileSync(artifactFilePath);
 
         expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
+        expect(readFileSyncStub.called).to.equal(true);
         expect(updateFunctionCodeStub.calledWithExactly(
           'Lambda',
           'updateFunctionCode',
@@ -122,21 +168,34 @@ describe('AwsDeployFunction', () => {
           awsDeployFunction.options.stage,
           awsDeployFunction.options.region
         )).to.be.equal(true);
-        awsDeployFunction.provider.request.restore();
+        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
+      });
+    });
+
+    it('should resolve if the hashes are the same', () => {
+      cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-zip-file');
+
+      return awsDeployFunction.deployFunction().then(() => {
+        const expected = 'Function not deployed since code was not changed.';
+
+        expect(updateFunctionCodeStub.calledOnce).to.be.equal(false);
+        expect(readFileSyncStub.calledOnce).to.equal(true);
+        expect(awsDeployFunction.serverless.cli.log.calledWithExactly(expected)).to.equal(true);
+        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
       });
     });
 
     it('should log artifact size', () => {
-      sinon.stub(fs, 'statSync').returns({ size: 1024 });
-      sinon.stub(awsDeployFunction.provider, 'request').resolves();
-      sinon.spy(awsDeployFunction.serverless.cli, 'log');
+      // awnY7Oi280gp5kTCloXzsqJCO4J766x6hATWqQsN/uM= <-- hash of the local zip file
+      readFileSyncStub.returns(new Buffer('my-service.zip content'));
 
       return awsDeployFunction.deployFunction().then(() => {
         const expected = 'Uploading function: first (1 KB)...';
-        expect(awsDeployFunction.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);
 
-        awsDeployFunction.provider.request.restore();
-        fs.statSync.restore();
+        expect(readFileSyncStub.calledOnce).to.equal(true);
+        expect(statSyncStub.calledOnce).to.equal(true);
+        expect(awsDeployFunction.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);
+        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
       });
     });
   });

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -107,7 +107,7 @@ describe('AwsDeployFunction', () => {
           awsDeployFunction.options.stage,
           awsDeployFunction.options.region
         )).to.be.equal(true);
-        expect(awsDeployFunction.remoteFunctionData).to.deep.equal({
+        expect(awsDeployFunction.serverless.service.provider.remoteFunctionData).to.deep.equal({
           func: {
             name: 'first',
           },
@@ -137,7 +137,7 @@ describe('AwsDeployFunction', () => {
       readFileSyncStub = sinon
         .stub(fs, 'readFileSync')
         .returns();
-      awsDeployFunction.remoteFunctionData = {
+      awsDeployFunction.serverless.service.provider.remoteFunctionData = {
         Configuration: {
           CodeSha256: 'remote-hash-zip-file',
         },

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -176,7 +176,7 @@ describe('AwsDeployFunction', () => {
       cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-zip-file');
 
       return awsDeployFunction.deployFunction().then(() => {
-        const expected = 'Function not deployed since code was not changed.';
+        const expected = 'Code not changed. Skipping function deployment.';
 
         expect(updateFunctionCodeStub.calledOnce).to.be.equal(false);
         expect(readFileSyncStub.calledOnce).to.equal(true);

--- a/lib/plugins/aws/lib/normalizeFiles.js
+++ b/lib/plugins/aws/lib/normalizeFiles.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = {
+  normalizeCloudFormationTemplate(template) {
+    const normalizedTemplate = _.cloneDeep(template);
+
+    // reset all the S3Keys for AWS::Lambda::Function resources
+    _.forEach(normalizedTemplate.Resources, (value) => {
+      if (value.Type && value.Type === 'AWS::Lambda::Function') {
+        const newVal = value;
+        newVal.Properties.Code.S3Key = '';
+      }
+    });
+
+    return normalizedTemplate;
+  },
+};

--- a/lib/plugins/aws/lib/normalizeFiles.test.js
+++ b/lib/plugins/aws/lib/normalizeFiles.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const expect = require('chai').expect;
+const normalizeFiles = require('./normalizeFiles');
+
+describe('normalizeFiles', () => {
+  describe('#normalizeCloudFormationTemplate()', () => {
+    it('should reset the S3 code keys for Lambda functions', () => {
+      const input = {
+        Resources: {
+          MyLambdaFunction: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {
+              Code: {
+                S3Key: 'some-s3-key-for-the-code',
+              },
+            },
+          },
+        },
+      };
+
+      const result = normalizeFiles.normalizeCloudFormationTemplate(input);
+
+      expect(result).to.deep.equal({
+        Resources: {
+          MyLambdaFunction: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {
+              Code: {
+                S3Key: '',
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should keep other resources untouched', () => {
+      const input = {
+        Resources: {
+          MyOtherResource: {
+            Type: 'AWS::XXX::XXX',
+          },
+        },
+      };
+
+      const result = normalizeFiles.normalizeCloudFormationTemplate(input);
+
+      expect(result).to.deep.equal({
+        Resources: {
+          MyOtherResource: {
+            Type: 'AWS::XXX::XXX',
+          },
+        },
+      });
+    });
+  });
+});

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -44,6 +44,9 @@ class Deploy {
             usage: 'Show all stack events during deployment',
             shortcut: 'v',
           },
+          force: {
+            usage: 'Forces a deployment to take place',
+          },
         },
         commands: {
           function: {
@@ -66,6 +69,9 @@ class Deploy {
               region: {
                 usage: 'Region of the function',
                 shortcut: 'r',
+              },
+              force: {
+                usage: 'Forces a deployment to take place',
               },
             },
           },

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -90,6 +90,7 @@ module.exports = {
           zip.append(fs.readFileSync(fullPath), {
             name: filePath,
             mode: stats.mode,
+            date: new Date(0), // necessary to get the same hash when zipping the same content
           });
         }
       });


### PR DESCRIPTION
## What did you implement:

Closes #2710

Checks if the function code or service configuration has changed and only deploys if that's the case.

## How did you implement it:

Add a `sha256` based hash comparison for the files in question (e.g. the `.zip` or `CloudFormation` files). Only deploy when the hashes are different.

This PR introduces a new AWS related lifecycle event (`checkForChanges`) and sets a globally available flag (`this.serverless.service.provider.shouldNotDeploy`) so that others can use the result of the check as well. Thanks for pointing that out @HyperBrain 👍 

## How can we verify it:

Use the following service:

```yml
service:
  name: my-service

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
  goodbye:
    handler: handler.goodbye
```

1. Run `serverless deploy` to deploy everything.
2. Run `serverless deploy function -f hello` --> Console will tell you that nothing was deployed because the code was not changed.
3. Update `hello` function code
4. Run `serverless deploy function -f hello` --> New function code will be uploaded
5. Run `serverless deploy`
6. Run `serverless deploy` (yes, a second time) --> Nothing will be updated since nothing changed
7. Change the `hello` function code
8. Run `serverless deploy` --> Deployment should be triggerend since the function code changed
9. Run `serverless deploy` --> Nothing should change since nothing was updated
10. Change configuration by e.g. adding a new function
11. Run `serverless deploy` --> Deployment should succeed

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO