### PR TITLE
Add infinite stack trace limit for Errors

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -6,6 +6,8 @@ const autocomplete = require('../lib/utils/autocomplete');
 const BbPromise = require('bluebird');
 const logError = require('../lib/classes/Error').logError;
 
+Error.stackTraceLimit = Infinity;
+
 BbPromise.config({
   longStackTraces: true,
 });


### PR DESCRIPTION
## What did you implement:

Closes #3579

Please test if this does the trick. Not entirely sure how to test this now since everything is Promise based and Bluebird kicks in automatically.