### PR TITLE
Improve error message when indentation for http event is wrong

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -150,7 +150,7 @@ module.exports = {
   },
 
   getHttpPath(http, functionName) {
-    if (typeof http.path === 'string') {
+    if (http && typeof http.path === 'string') {
       return http.path.replace(/^\//, '').replace(/\/$/, '');
     }
     const errorMessage = [

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -158,6 +158,7 @@ module.exports = {
       ' for http event in serverless.yml.',
       ' If you define an http event, make sure you pass a valid value for it,',
       ' either as string syntax, or object syntax.',
+      ' Please check the indentation of your config values if you use the object syntax.',
       ' Please check the docs for more options.',
     ].join('');
     throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -61,6 +61,23 @@ describe('#validate()', () => {
     expect(() => awsCompileApigEvents.validate()).to.throw(Error);
   });
 
+  it('should throw a helpful error if http event type object doesn\'t have a path property', () => {
+    /**
+     * This can happen with surprising subtle syntax error such as when path is not indented under http in the yml
+     */
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: null
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.validate()).to.throw(/Missing or invalid "path" property in function "first"/);
+  });  
+
   it('should validate the http events "path" property', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -63,20 +63,22 @@ describe('#validate()', () => {
 
   it('should throw a helpful error if http event type object doesn\'t have a path property', () => {
     /**
-     * This can happen with surprising subtle syntax error such as when path is not indented under http in the yml
+     * This can happen with surprising subtle syntax error such as when path is not
+     * indented under http in yml.
      */
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [
           {
-            http: null
+            http: null,
           },
         ],
       },
     };
 
-    expect(() => awsCompileApigEvents.validate()).to.throw(/Missing or invalid "path" property in function "first"/);
-  });  
+    expect(() => awsCompileApigEvents.validate()).to
+      .throw(/invalid "path" property in function "first"/);
+  });
 
   it('should validate the http events "path" property', () => {
     awsCompileApigEvents.serverless.service.functions = {


### PR DESCRIPTION
## What did you implement:

Closes #3845


## How did you implement it:
Trivial

## How can we verify it:
Added test


## Todos:

- [x] Write tests
- [x] Write documentation - n/a
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources - n/a
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
