### PR TITLE
Remove entrypoint subcmds in generateCommandsHelp

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -155,7 +155,7 @@ class CLI {
       if (currentCmd.commands && cmd in currentCmd.commands) {
         return currentCmd.commands[cmd];
       }
-      return undefined;
+      return null;
     }, { commands: allCommands });
 
     // Throw error if command not found.

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -161,8 +161,8 @@ class CLI {
     // Throw error if command not found.
     if (!command) {
       const errorMessage = [
-        `Serverless command "${commandName}" not found`,
-        'Run "serverless help" for a list of all available commands.',
+        `Serverless command "${commandName}" not found.`,
+        ' Run "serverless help" for a list of all available commands.',
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -160,9 +160,10 @@ class CLI {
 
     // Throw error if command not found.
     if (!command) {
-      const errorMessage = `Serverless command "${commandName}" not found
-
-  Run "serverless help" for a list of all available commands.`;
+      const errorMessage = [
+        `Serverless command "${commandName}" not found`,
+        'Run "serverless help" for a list of all available commands.',
+      ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -149,6 +149,13 @@ class CLI {
     const command = this.serverless.pluginManager.getCommand(commandsArray);
     const commandName = commandsArray.join(' ');
 
+    // Remove entrypoint subcommands
+    _.forEach(command.commands, (details, cmd) => {
+      if (details.type === 'entrypoint') {
+        delete command.commands[cmd];
+      }
+    });
+
     // print the name of the plugin
     this.consoleLog(chalk.yellow.underline(`Plugin: ${command.pluginName}`));
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -146,15 +146,25 @@ class CLI {
   }
 
   generateCommandsHelp(commandsArray) {
-    const command = this.serverless.pluginManager.getCommand(commandsArray);
     const commandName = commandsArray.join(' ');
 
-    // Remove entrypoint subcommands
-    _.forEach(command.commands, (details, cmd) => {
-      if (details.type === 'entrypoint') {
-        delete command.commands[cmd];
+    // Get all the commands using getCommands() with filtered entrypoint
+    // commands and reduce to the required command.
+    const allCommands = this.serverless.pluginManager.getCommands();
+    const command = _.reduce(commandsArray, (currentCmd, cmd) => {
+      if (currentCmd.commands && cmd in currentCmd.commands) {
+        return currentCmd.commands[cmd];
       }
-    });
+      return undefined;
+    }, { commands: allCommands });
+
+    // Throw error if command not found.
+    if (!command) {
+      const errorMessage = `Serverless command "${commandName}" not found
+
+  Run "serverless help" for a list of all available commands.`;
+      throw new this.serverless.classes.Error(errorMessage);
+    }
 
     // print the name of the plugin
     this.consoleLog(chalk.yellow.underline(`Plugin: ${command.pluginName}`));

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -352,5 +352,17 @@ describe('CLI', () => {
         done();
       });
     });
+
+    it('should not print entrypoint subcommands in help', (done) => {
+      exec(`${this.serverlessExec} package --help`, (err, stdout) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(stdout).to.not.contain('package function');
+        done();
+      });
+    });
   });
 });

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -5,6 +5,7 @@
  */
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const CLI = require('../../lib/classes/CLI');
 const os = require('os');
 const fse = require('fs-extra');
@@ -273,6 +274,79 @@ describe('CLI', () => {
     });
   });
 
+  describe('#generateCommandsHelp()', () => {
+    let getCommandsStub;
+    let consoleLogStub;
+    let displayCommandUsageStub;
+    let displayCommandOptionsStub;
+
+    const commands = {
+      package: {
+        usage: 'Packages a Serverless service',
+        lifecycleEvents: ['cleanup', 'initialize'],
+        options: {},
+        key: 'package',
+        pluginName: 'Package',
+      },
+      deploy: {
+        usage: 'Deploy a Serverless service',
+        lifecycleEvents: ['cleanup', 'initialize'],
+        options: {},
+        key: 'deploy',
+        pluginName: 'Deploy',
+        commands: {},
+      },
+    };
+
+    beforeEach(() => {
+      cli = new CLI(serverless);
+      getCommandsStub = sinon.stub(cli.serverless.pluginManager, 'getCommands')
+        .returns(commands);
+      consoleLogStub = sinon.stub(cli, 'consoleLog').returns();
+      displayCommandUsageStub = sinon.stub(cli, 'displayCommandUsage').returns();
+      displayCommandOptionsStub = sinon.stub(cli, 'displayCommandOptions').returns();
+    });
+
+    afterEach(() => {
+      cli.serverless.pluginManager.getCommands.restore();
+      cli.consoleLog.restore();
+      cli.displayCommandUsage.restore();
+      cli.displayCommandOptions.restore();
+    });
+
+    it('should gather and generate the commands help info if the command can be found', () => {
+      const commandsArray = ['package'];
+      cli.inputArray = commandsArray;
+
+      cli.generateCommandsHelp(commandsArray);
+
+      expect(getCommandsStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.called).to.equal(true);
+      expect(displayCommandUsageStub.calledOnce).to.equal(true);
+      expect(displayCommandUsageStub.calledWithExactly(
+        commands.package,
+        'package'
+      )).to.equal(true);
+      expect(displayCommandOptionsStub.calledOnce).to.equal(true);
+      expect(displayCommandOptionsStub.calledWithExactly(
+        commands.package
+      )).to.equal(true);
+    });
+
+    it('should throw an error if the command could not be found', () => {
+      const commandsArray = ['invalid-command'];
+
+      cli.inputArray = commandsArray;
+
+      expect(() => { cli.generateCommandsHelp(commandsArray); })
+        .to.throw(Error, 'not found');
+      expect(getCommandsStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.called).to.equal(false);
+      expect(displayCommandUsageStub.calledOnce).to.equal(false);
+      expect(displayCommandOptionsStub.calledOnce).to.equal(false);
+    });
+  });
+
   describe('#processInput()', () => {
     it('should only return the commands when only commands are given', () => {
       cli = new CLI(serverless, ['deploy', 'functions']);
@@ -349,18 +423,6 @@ describe('CLI', () => {
 
         expect(stdout).to.contain('deploy');
         expect(stdout).to.contain('--stage');
-        done();
-      });
-    });
-
-    it('should not print entrypoint subcommands in help', (done) => {
-      exec(`${this.serverlessExec} package --help`, (err, stdout) => {
-        if (err) {
-          done(err);
-          return;
-        }
-
-        expect(stdout).to.not.contain('package function');
         done();
       });
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3847 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Added a loop to iterate through all the subcommands of the parent command and check for `type` of the command to be `entrypoint`. Subcommands with type `entrypoint` are deleted because they should be hidden.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
`sls package -h` results in:
```
Plugin: Package
package ....................... Packages a Serverless service
    --stage / -s ....................... Stage of the service
    --region / -r ...................... Region of the service
    --package / -p ..................... Output path for the package
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
