### PR TITLE
Update docs to indicate you can use cognito pool authoriser and claim…

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -265,7 +265,12 @@ functions:
             arn: arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ
 ```
 
-By default the `sub` claim will be exposed in `events.cognitoPoolClaims`, you can add extra claims like so:
+If you are using the default `lambda-proxy` integration, your attributes will be
+exposed at `event.requestContext.authorizer.claims`.
+
+If you want control more control over which attributes are exposed as claims you
+can switch to `integration: lambda` and add the following configuration. The
+claims will be exposed at `events.cognitoPoolClaims`.
 
 ```yml
 functions:
@@ -282,8 +287,6 @@ functions:
               - email
               - nickname
 ```
-
-Note: Since claims must be explicitly listed to be exposed, you must use `integration: lambda` integration type to access any claims.
 
 ### Catching Exceptions In Your Lambda Function
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -247,7 +247,7 @@ module.exports = {
     if (integration === 'AWS_PROXY'
         && typeof arn === 'string' && arn.match(/^arn:aws:cognito-idp/) && authorizer.claims) {
       const errorMessage = [
-        'Cognito claims can\'t be retrieved when using lambda-proxy as the integration type',
+        'Cognito claims can only be filtered when using the lambda integration type',
       ];
       throw new this.serverless.classes.Error(errorMessage);
     }


### PR DESCRIPTION
…s with lambda-proxy

## What did you implement:

Improve the docs, to indicate that you can now get all the cognito user pool claims when using lambda proxy. Previously you couldn't get the claims that way. Well that's what I though when I implemented it anyway.

## How did you implement it:

Just documentation updates.

## How can we verify it:

You could take a look at https://github.com/johnf/serverless-cognito-demo

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
