### PR TITLE
follow the serverless framework conventions for error handling

### DIFF
--- a/lib/plugins/platform/platform.js
+++ b/lib/plugins/platform/platform.js
@@ -158,22 +158,25 @@ class Platform {
         const readmePath = path.join(this.serverless.config.servicePath, 'README.md');
         const serviceDataWithReadme = addReadme(serviceData, readmePath);
 
-        return this.publishServiceRequest(serviceDataWithReadme, clientWithAuth)
-          .then(() => {
-            const username = jwtDecode(authToken).nickname;
-            const serviceName = this.serverless.service.service;
-            const url = `${config.PLATFORM_FRONTEND_BASE_URL}services/${username}/${serviceName}`;
-            this.serverless
-              .cli.log('Service successfully published! Your service details are available at:');
-            this.serverless
-              .cli.log(chalk.green(url));
-          })
-          .catch(error => {
-            this.serverless.cli.log(
-              "Couldn't publish this deploy information to the Serverless Platform due: \n",
-              error
-            );
-          });
+        return new BbPromise((resolve, reject) => {
+          this.publishServiceRequest(serviceDataWithReadme, clientWithAuth)
+            .then(() => {
+              const username = jwtDecode(authToken).nickname;
+              const serviceName = this.serverless.service.service;
+              const url = `${config.PLATFORM_FRONTEND_BASE_URL}services/${username}/${serviceName}`;
+              this.serverless.cli.log(
+                'Service successfully published! Your service details are available at:'
+              );
+              this.serverless.cli.log(chalk.green(url));
+              resolve();
+            })
+            .catch(error => {
+              this.serverless.cli.log(
+                "Couldn't publish this deploy information to the Serverless Platform."
+              );
+              reject(error);
+            });
+        });
       })
     );
   }


### PR DESCRIPTION
## What did you implement:

The platform code didn't properly follow the existing error handling patterns. In case of an error the code should reject the promise. This is done properly now while we explicitly make sure to inform the user what when wrong.

## How did you implement it:

I wrapped the existing code into a new promise that resolved once all steps success. The error in catch is not passed to log, but rather to reject. The stack trace can be shown using `SLS_DEBUG=*`

## How can we verify it:

Manipulate your id_token inside `.serverlessrc` e.g. add 12k random characters and deploy a test service. It should fail with the error: `Network error: Network request failed with status 413 - "Request Entity Too Large"`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
