### PR TITLE
Allow aws credentials update

### DIFF
--- a/docs/providers/aws/cli-reference/config-credentials.md
+++ b/docs/providers/aws/cli-reference/config-credentials.md
@@ -22,6 +22,7 @@ serverless config credentials --provider provider --key key --secret secret
 - `--key` or `-k` The `aws_access_key_id`. **Required**.
 - `--secret` or `-s` The `aws_secret_access_key`. **Required**.
 - `--profile` or `-n` The name of the profile which should be created.
+- `--overwrite` or `-o` Overwrite the profile if it exists.
 
 ## Provided lifecycle events
 
@@ -44,3 +45,12 @@ serverless config credentials --provider aws --key 1234 --secret 5678 --profile 
 ```
 
 This example create and configure a `custom-profile` profile with the `aws_access_key_id` of `1234` and the `aws_secret_access_key` of `5678`.
+
+### Update an existing profile
+
+```bash
+serverless config credentials --provider aws --key 1234 --secret 5678 --profile custom-profile --overwrite
+```
+
+This example overwrite `custom-profile` profile with the `aws_access_key_id` of `1234` and the `aws_secret_access_key` of `5678`.
+If the profile do not exist, it will be added anyway.

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -38,13 +38,22 @@ class AwsConfigCredentials {
               },
               overwrite: {
                 usage: 'Overwrite the existing profile configuration in the credentials file',
-                shortcut: 'o'
+                shortcut: 'o',
               },
             },
           },
         },
       },
     };
+
+    if (!os.homedir()) {
+      throw new this.serverless.classes
+        .Error('Can\'t find home directory on your local file system.');
+    }
+
+    this.credentialsFilePath = path.join(os.homedir(), '.aws', 'credentials');
+    // Create the credentials file alongside the .aws directory if it's not yet present
+    fse.ensureFileSync(this.credentialsFilePath);
 
     this.hooks = {
       'config:credentials:config': () => BbPromise.bind(this)
@@ -68,96 +77,89 @@ class AwsConfigCredentials {
     }
 
     this.serverless.cli.log('Setting up AWS...');
-    this.serverless.cli.log('Saving your AWS profile in "~/.aws/credentials"...');
 
-    if (!os.homedir()) {
-      throw new this.serverless.classes
-        .Error('Can\'t find home directory on your local file system.');
-    }
+    this.credentials = this.getCredentials();
 
-    // check if ~/.aws/credentials exists
-    const configDir = path.join(os.homedir(), '.aws');
-    const credsPath = path.join(configDir, 'credentials');
-
-    // create the credentials file alongside the .aws directory if it's not yet present
-    fse.ensureFileSync(credsPath);
-
-    // check if credentials files contains anything
-    const credsFile = this.serverless.utils.readFileSync(credsPath);
+    // Get the profile start line and end line numbers inside the credentials array
+    const profileBoundaries = this.getProfileBoundaries();
 
     // Check if the profile exists
-    if (credsFile.length && credsFile.indexOf(`[${this.options.profile}]`) > -1) {
-
-      // Update the profile if the overwrite flag was set
-      if (this.options.overwrite) {
-        this.updateProfile(credsPath, credsFile);
-      } else {
+    const isNewProfile = profileBoundaries.start === -1;
+    if (isNewProfile) {
+      this.addProfile();
+    } else {
+      // Only update the profile if the overwrite flag was set
+      if (!this.options.overwrite) {
         this.serverless.cli.log(
-          `Failed! ~/.aws/credentials exists and already has a "${this.options.profile}" profile.
-          If you would like to overwrite the profile, use the overwrite flag ("-o" or "--overwrite")`);
+          `Failed! ~/.aws/credentials already has a "${this.options.profile}" profile.
+          Use the overwrite flag ("-o" or "--overwrite") to force the update`);
         return BbPromise.resolve();
       }
 
-    } else {
-      // if not, add the profile
-      this.addProfile(credsPath);
+      this.updateProfile(profileBoundaries);
     }
 
-    this.serverless.cli.log(
-      `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);
-
+    this.saveCredentialsFile();
     return BbPromise.resolve();
   }
 
-  addProfile(credsPath) {
-
-    let profileDefinition = `[${this.options.profile}]\n`;
-    profileDefinition += `aws_access_key_id=${this.options.key}\n`;
-    profileDefinition += `aws_secret_access_key=${this.options.secret}\n`;
-
-    this.serverless.utils.appendFileSync(credsPath, profileDefinition);
+  getCredentials() {
+    // Get the credentials file lines
+    const credentialsFileContent = this.serverless.utils.readFileSync(this.credentialsFilePath);
+    return credentialsFileContent ? credentialsFileContent.split('\n') : [];
   }
 
-  updateProfile(credsPath, credsFile) {
+  addProfile() {
+    this.credentials.push(`[${this.options.profile}]`,
+      `aws_access_key_id = ${this.options.key}`,
+      `aws_secret_access_key = ${this.options.secret}`);
+  }
 
-    const credsLines = _.split(credsFile, '\n');
-    const sectionBoundries = this.getSectionBoundaries(credsLines);
+  updateProfile(profileBoundries) {
+    let currentLine = profileBoundries.start;
+    let endLine = profileBoundries.end;
 
-    if ( sectionBoundries.start === -1 ) {
-      throw new this.serverless.classes
-        .Error('Can\'t find profile to update.');
-    }
-
-    // Remove existing 'aws_access_key_id' and 'aws_secret_access_key' from the section
-    let lineNumber = sectionBoundries.start;
-    while (lineNumber < sectionBoundries.end) {
+    // Remove existing 'aws_access_key_id' and 'aws_secret_access_key' properties
+    while (currentLine < endLine) {
+      const line = this.credentials[currentLine];
       if (
-        credsLines[lineNumber].indexOf('aws_access_key_id') > -1 ||
-        credsLines[lineNumber].indexOf('aws_secret_access_key') > -1) {
-          credsLines.splice(lineNumber, 1);
-          sectionBoundries.end--;
+        line.indexOf('aws_access_key_id') > -1 ||
+        line.indexOf('aws_secret_access_key') > -1
+      ) {
+        this.credentials.splice(currentLine, 1);
+        endLine--;
       } else {
-        lineNumber++;
+        currentLine++;
       }
     }
 
     // Add the key and the secret to the beginning of the section
-    credsLines.splice(sectionBoundries.start + 1, 0, `aws_secret_access_key = ${this.options.secret}`);
-    credsLines.splice(sectionBoundries.start + 1, 0, `aws_access_key_id = ${this.options.key}`);
+    const keyLine = `aws_access_key_id = ${this.options.key}`;
+    const secretLine = `aws_secret_access_key = ${this.options.secret}`;
 
-    // Generate the file content and add a line break at the end
-    let updatedCredsFile = _.join(credsLines, '\n') + '\n';
-
-    this.serverless.utils.writeFileSync(credsPath, updatedCredsFile);
+    this.credentials.splice(profileBoundries.start + 1, 0, secretLine);
+    this.credentials.splice(profileBoundries.start + 1, 0, keyLine);
   }
 
-  getSectionBoundaries(credsLines) {
+  saveCredentialsFile() {
+    // Generate the file content and add a line break at the end
+    const updatedCredsFileContent = `${this.credentials.join('\n')}\n`;
 
+    this.serverless.cli.log('Saving your AWS profile in "~/.aws/credentials"...');
+
+    this.serverless.utils.writeFileSync(this.credentialsFilePath, updatedCredsFileContent);
+
+    this.serverless.cli.log(
+      `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);
+  }
+
+  getProfileBoundaries() {
     // Get the line number of the aws profile definition, defaults to -1
-    const start = _.findIndex(credsLines, line => line === `[${this.options.profile}]`);
+    const start = this.credentials.indexOf(`[${this.options.profile}]`);
 
-    // Get the number of the following aws profile definition, defaults to the file rows number
-    const end = _.findIndex(credsLines, line => /\[[^\]]+\]/.test(line), start + 1) + 1 || credsLines.length;
+    const nextProfile = _.findIndex(this.credentials, line => /\[[^\]]+\]/.test(line), start + 1);
+    // Get the line number of the next aws profile definition, defaults to the file lines number
+    const end = nextProfile + 1 || this.credentials.length;
 
     return { start, end };
   }

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -147,7 +147,7 @@ class AwsConfigCredentials {
 
     this.serverless.cli.log('Saving your AWS profile in "~/.aws/credentials"...');
 
-    this.serverless.utils.writeFileSync(this.credentialsFilePath, updatedCredsFileContent);
+    this.serverless.utils.writeFile(this.credentialsFilePath, updatedCredsFileContent);
 
     this.serverless.cli.log(
       `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -79,28 +79,29 @@ class AwsConfigCredentials {
     const configDir = path.join(os.homedir(), '.aws');
     const credsPath = path.join(configDir, 'credentials');
 
-    if (this.serverless.utils.fileExistsSync(credsPath)) {
-      // check if credentials files contains anything
-      const credsFile = this.serverless.utils.readFileSync(credsPath);
+    // create the credentials file alongside the .aws directory if it's not yet present
+    fse.ensureFileSync(credsPath);
 
-      // if credentials file exists w/ profile, exit
-      if (credsFile.length && credsFile.indexOf(`[${this.options.profile}]`) > -1) {
+    // check if credentials files contains anything
+    const credsFile = this.serverless.utils.readFileSync(credsPath);
+
+    // Check if the profile exists
+    if (credsFile.length && credsFile.indexOf(`[${this.options.profile}]`) > -1) {
+
+      // Update the profile if the overwrite flag was set
+      if (this.options.overwrite) {
+        this.updateProfile(credsPath, credsFile);
+      } else {
         this.serverless.cli.log(
-          `Failed! ~/.aws/credentials exists and already has a "${this.options.profile}" profile.`);
+          `Failed! ~/.aws/credentials exists and already has a "${this.options.profile}" profile.
+          If you would like to overwrite the profile, use the overwrite flag ("-o" or "--overwrite")`);
         return BbPromise.resolve();
       }
-    } else {
-      // create the credentials file alongside the .aws directory if it's not yet present
-      fse.ensureFileSync(credsPath);
-    }
 
-    // write credentials file with 'default' profile
-    this.serverless.utils.appendFileSync(
-      credsPath,
-      `[${this.options.profile}]
-aws_access_key_id=${this.options.key}
-aws_secret_access_key=${this.options.secret}
-`); // Keep line break at the end. Otherwise will break AWS CLI.
+    } else {
+      // if not, add the profile
+      this.addProfile(credsPath);
+    }
 
     this.serverless.cli.log(
       `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -35,6 +35,10 @@ class AwsConfigCredentials {
                 usage: 'Name of the profile you wish to create. Defaults to "default"',
                 shortcut: 'n',
               },
+              overwrite: {
+                usage: 'Overwrite the existing profile configuration in the credentials file',
+                shortcut: 'o'
+              },
             },
           },
         },

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -99,8 +99,7 @@ class AwsConfigCredentials {
       this.updateProfile(profileBoundaries);
     }
 
-    this.saveCredentialsFile();
-    return BbPromise.resolve();
+    return this.saveCredentialsFile();
   }
 
   getCredentials() {
@@ -147,10 +146,11 @@ class AwsConfigCredentials {
 
     this.serverless.cli.log('Saving your AWS profile in "~/.aws/credentials"...');
 
-    this.serverless.utils.writeFile(this.credentialsFilePath, updatedCredsFileContent);
-
-    this.serverless.cli.log(
-      `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);
+    return this.serverless.utils.writeFile(this.credentialsFilePath, updatedCredsFileContent)
+      .then(() => {
+        this.serverless.cli.log(
+          `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);
+      });
   }
 
   getProfileBoundaries() {

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const path = require('path');
 const fse = require('fs-extra');
 const os = require('os');
+const _ = require('lodash');
 
 class AwsConfigCredentials {
   constructor(serverless, options) {
@@ -106,6 +107,60 @@ aws_secret_access_key=${this.options.secret}
 
     return BbPromise.resolve();
   }
+
+  addProfile(credsPath) {
+
+    let profileDefinition = `[${this.options.profile}]\n`;
+    profileDefinition += `aws_access_key_id=${this.options.key}\n`;
+    profileDefinition += `aws_secret_access_key=${this.options.secret}\n`;
+
+    this.serverless.utils.appendFileSync(credsPath, profileDefinition);
+  }
+
+  updateProfile(credsPath, credsFile) {
+
+    const credsLines = _.split(credsFile, '\n');
+    const sectionBoundries = this.getSectionBoundaries(credsLines);
+
+    if ( sectionBoundries.start === -1 ) {
+      throw new this.serverless.classes
+        .Error('Can\'t find profile to update.');
+    }
+
+    // Remove existing 'aws_access_key_id' and 'aws_secret_access_key' from the section
+    let lineNumber = sectionBoundries.start;
+    while (lineNumber < sectionBoundries.end) {
+      if (
+        credsLines[lineNumber].indexOf('aws_access_key_id') > -1 ||
+        credsLines[lineNumber].indexOf('aws_secret_access_key') > -1) {
+          credsLines.splice(lineNumber, 1);
+          sectionBoundries.end--;
+      } else {
+        lineNumber++;
+      }
+    }
+
+    // Add the key and the secret to the beginning of the section
+    credsLines.splice(sectionBoundries.start + 1, 0, `aws_secret_access_key = ${this.options.secret}`);
+    credsLines.splice(sectionBoundries.start + 1, 0, `aws_access_key_id = ${this.options.key}`);
+
+    // Generate the file content and add a line break at the end
+    let updatedCredsFile = _.join(credsLines, '\n') + '\n';
+
+    this.serverless.utils.writeFileSync(credsPath, updatedCredsFile);
+  }
+
+  getSectionBoundaries(credsLines) {
+
+    // Get the line number of the aws profile definition, defaults to -1
+    const start = _.findIndex(credsLines, line => line === `[${this.options.profile}]`);
+
+    // Get the number of the following aws profile definition, defaults to the file rows number
+    const end = _.findIndex(credsLines, line => /\[[^\]]+\]/.test(line), start + 1) + 1 || credsLines.length;
+
+    return { start, end };
+  }
+
 }
 
 module.exports = AwsConfigCredentials;

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -12,9 +12,24 @@ const Serverless = require('../../../Serverless');
 
 describe('AwsConfigCredentials', () => {
   let awsConfigCredentials;
+  let credentialsFileContent;
+  let credentialsFilePath;
   let serverless;
+  let sandbox;
+  let tmpDirPath;
 
   beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    tmpDirPath = testUtils.getTmpDirPath();
+    credentialsFilePath = path.join(tmpDirPath, '.aws', 'credentials');
+    credentialsFileContent = '[my-profile]\n';
+    credentialsFileContent += 'aws_access_key_id = my-old-profile-key\n';
+    credentialsFileContent += 'aws_secret_access_key = my-old-profile-secret\n';
+
+    // stub homedir handler to return the tmpDirPath
+    sandbox.stub(os, 'homedir').returns(tmpDirPath);
+
     serverless = new Serverless();
     serverless.init();
     const options = {
@@ -23,6 +38,10 @@ describe('AwsConfigCredentials', () => {
       secret: 'some-secret',
     };
     awsConfigCredentials = new AwsConfigCredentials(serverless, options);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   describe('#constructor()', () => {
@@ -66,29 +85,24 @@ describe('AwsConfigCredentials', () => {
         awsConfigCredentials.configureCredentials.restore();
       });
     });
+
+    it('should throw an error if the home directory was not found', () => {
+      os.homedir.returns(null);
+      expect(() => new AwsConfigCredentials(serverless, {})).to.throw(Error);
+    });
+
+    it('should create the .aws/credentials file if not yet present', () => {
+      // remove the .aws directory which was created in the before hook of the test
+      const awsDirectoryPath = path.join(tmpDirPath, '.aws');
+      fse.removeSync(awsDirectoryPath);
+
+      awsConfigCredentials = new AwsConfigCredentials(serverless, {});
+      const isCredentialsFilePresent = fs.existsSync(path.join(awsDirectoryPath, 'credentials'));
+      expect(isCredentialsFilePresent).to.equal(true);
+    });
   });
 
   describe('#configureCredentials()', () => {
-    let homeDir;
-    let tmpDirPath;
-    let credentialsFilePath;
-
-    beforeEach(() => {
-      // create a new tmpDir for the homeDir path
-      tmpDirPath = testUtils.getTmpDirPath();
-      fse.mkdirsSync(tmpDirPath);
-
-      // create the .aws/credetials directory and file
-      credentialsFilePath = path.join(tmpDirPath, '.aws', 'credentials');
-      fse.ensureFileSync(credentialsFilePath);
-
-      // save the homeDir so that we can reset this later on
-      homeDir = os.homedir();
-      process.env.HOME = tmpDirPath;
-      process.env.HOMEPATH = tmpDirPath;
-      process.env.USERPROFILE = tmpDirPath;
-    });
-
     it('should lowercase the provider option', () => {
       awsConfigCredentials.options.provider = 'SOMEPROVIDER';
 
@@ -117,85 +131,69 @@ describe('AwsConfigCredentials', () => {
     });
 
     it('should not update the profile if the overwrite flag is not set', () => {
-      let credentialsFile = '[my-profile]\n';
-      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
-      credentialsFile += 'aws_secret_access_key = my-old-profile-secret\n';
-
       awsConfigCredentials.options.profile = 'my-profile';
       awsConfigCredentials.options.key = 'my-new-profile-key';
       awsConfigCredentials.options.secret = 'my-new-profile-secret';
 
-      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+      fse.outputFileSync(credentialsFilePath, credentialsFileContent);
 
       return awsConfigCredentials.configureCredentials();
     });
 
     it('should update the profile', () => {
-
-      let credentialsFile = '[my-profile]\n';
-      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
-      credentialsFile += 'aws_secret_access_key = my-old-profile-secret\n';
-
       awsConfigCredentials.options.profile = 'my-profile';
       awsConfigCredentials.options.key = 'my-new-profile-key';
       awsConfigCredentials.options.secret = 'my-new-profile-secret';
       awsConfigCredentials.options.overwrite = true;
 
-      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+      fse.outputFileSync(credentialsFilePath, credentialsFileContent);
 
       return awsConfigCredentials.configureCredentials().then(() => {
-        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
-        const lineByLineContent = credentialsFileContent.split('\n');
+        const UpdatedCredentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = UpdatedCredentialsFileContent.split('\n');
 
         expect(lineByLineContent[0]).to.equal('[my-profile]');
         expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-new-profile-key');
         expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-new-profile-secret');
-
       });
     });
 
     it('should not alter other profiles when updating a profile', () => {
-
-      let credentialsFile = '[my-profile]\n';
-      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
-      credentialsFile += 'aws_secret_access_key = my-old-profile-secret\n';
-      credentialsFile += '[my-other-profile]\n';
-      credentialsFile += 'aws_secret_access_key = my-other-profile-secret\n';
-
       awsConfigCredentials.options.profile = 'my-profile';
       awsConfigCredentials.options.key = 'my-new-profile-key';
       awsConfigCredentials.options.secret = 'my-new-profile-secret';
       awsConfigCredentials.options.overwrite = true;
 
-      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+      credentialsFileContent += '[my-other-profile]\n';
+      credentialsFileContent += 'aws_secret_access_key = my-other-profile-secret\n';
+
+      fse.outputFileSync(credentialsFilePath, credentialsFileContent);
 
       return awsConfigCredentials.configureCredentials().then(() => {
-        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
-        const lineByLineContent = credentialsFileContent.split('\n');
+        const UpdatedCredentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = UpdatedCredentialsFileContent.split('\n');
 
         expect(lineByLineContent[0]).to.equal('[my-profile]');
         expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-new-profile-key');
         expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-new-profile-secret');
         expect(lineByLineContent[4]).to.equal('aws_secret_access_key = my-other-profile-secret');
-
       });
     });
 
     it('should add the missing credentials to the updated profile', () => {
-
-      let credentialsFile = '[my-profile]\n';
-      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
+      credentialsFileContent = '[my-profile]\n';
+      credentialsFileContent += 'aws_secret_access_key = my-profile-secret\n';
 
       awsConfigCredentials.options.profile = 'my-profile';
       awsConfigCredentials.options.key = 'my-new-profile-key';
       awsConfigCredentials.options.secret = 'my-new-profile-secret';
       awsConfigCredentials.options.overwrite = true;
 
-      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+      fse.outputFileSync(credentialsFilePath, credentialsFileContent);
 
       return awsConfigCredentials.configureCredentials().then(() => {
-        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
-        const lineByLineContent = credentialsFileContent.split('\n');
+        const UpdatedCredentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = UpdatedCredentialsFileContent.split('\n');
 
         expect(lineByLineContent[0]).to.equal('[my-profile]');
         expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-new-profile-key');
@@ -209,32 +207,13 @@ describe('AwsConfigCredentials', () => {
       awsConfigCredentials.options.secret = 'my-profile-secret';
 
       return awsConfigCredentials.configureCredentials().then(() => {
-        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
-        const lineByLineContent = credentialsFileContent.split('\n');
+        const UpdatedCredentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = UpdatedCredentialsFileContent.split('\n');
 
         expect(lineByLineContent[0]).to.equal('[my-profile]');
-        expect(lineByLineContent[1]).to.equal('aws_access_key_id=my-profile-key');
-        expect(lineByLineContent[2]).to.equal('aws_secret_access_key=my-profile-secret');
+        expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-profile-key');
+        expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-profile-secret');
       });
-    });
-
-    it('should create the .aws/credentials file if not yet present', () => {
-      // remove the .aws directory which was created in the before hook of the test
-      const awsDirectoryPath = path.join(tmpDirPath, '.aws');
-      fse.removeSync(awsDirectoryPath);
-
-      return awsConfigCredentials.configureCredentials().then(() => {
-        const isCredentialsFilePresent = fs.existsSync(path.join(awsDirectoryPath, 'credentials'));
-
-        expect(isCredentialsFilePresent).to.equal(true);
-      });
-    });
-
-    afterEach(() => {
-      // recover the homeDir
-      process.env.HOME = homeDir;
-      process.env.HOMEPATH = homeDir;
-      process.env.USERPROFILE = homeDir;
     });
   });
 });

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -116,11 +116,91 @@ describe('AwsConfigCredentials', () => {
       expect(() => awsConfigCredentials.configureCredentials()).to.throw(Error);
     });
 
-    it('should resolve if profile is already given in credentials file', (done) => {
-      awsConfigCredentials.options.profile = 'my-profile';
-      serverless.utils.appendFileSync(credentialsFilePath, '[my-profile]');
+    it('should not update the profile if the overwrite flag is not set', () => {
+      let credentialsFile = '[my-profile]\n';
+      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
+      credentialsFile += 'aws_secret_access_key = my-old-profile-secret\n';
 
-      awsConfigCredentials.configureCredentials().then(() => done());
+      awsConfigCredentials.options.profile = 'my-profile';
+      awsConfigCredentials.options.key = 'my-new-profile-key';
+      awsConfigCredentials.options.secret = 'my-new-profile-secret';
+
+      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+
+      return awsConfigCredentials.configureCredentials();
+    });
+
+    it('should update the profile', () => {
+
+      let credentialsFile = '[my-profile]\n';
+      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
+      credentialsFile += 'aws_secret_access_key = my-old-profile-secret\n';
+
+      awsConfigCredentials.options.profile = 'my-profile';
+      awsConfigCredentials.options.key = 'my-new-profile-key';
+      awsConfigCredentials.options.secret = 'my-new-profile-secret';
+      awsConfigCredentials.options.overwrite = true;
+
+      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+
+      return awsConfigCredentials.configureCredentials().then(() => {
+        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = credentialsFileContent.split('\n');
+
+        expect(lineByLineContent[0]).to.equal('[my-profile]');
+        expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-new-profile-key');
+        expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-new-profile-secret');
+
+      });
+    });
+
+    it('should not alter other profiles when updating a profile', () => {
+
+      let credentialsFile = '[my-profile]\n';
+      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
+      credentialsFile += 'aws_secret_access_key = my-old-profile-secret\n';
+      credentialsFile += '[my-other-profile]\n';
+      credentialsFile += 'aws_secret_access_key = my-other-profile-secret\n';
+
+      awsConfigCredentials.options.profile = 'my-profile';
+      awsConfigCredentials.options.key = 'my-new-profile-key';
+      awsConfigCredentials.options.secret = 'my-new-profile-secret';
+      awsConfigCredentials.options.overwrite = true;
+
+      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+
+      return awsConfigCredentials.configureCredentials().then(() => {
+        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = credentialsFileContent.split('\n');
+
+        expect(lineByLineContent[0]).to.equal('[my-profile]');
+        expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-new-profile-key');
+        expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-new-profile-secret');
+        expect(lineByLineContent[4]).to.equal('aws_secret_access_key = my-other-profile-secret');
+
+      });
+    });
+
+    it('should add the missing credentials to the updated profile', () => {
+
+      let credentialsFile = '[my-profile]\n';
+      credentialsFile += 'aws_access_key_id = my-old-profile-key\n';
+
+      awsConfigCredentials.options.profile = 'my-profile';
+      awsConfigCredentials.options.key = 'my-new-profile-key';
+      awsConfigCredentials.options.secret = 'my-new-profile-secret';
+      awsConfigCredentials.options.overwrite = true;
+
+      serverless.utils.appendFileSync(credentialsFilePath, credentialsFile);
+
+      return awsConfigCredentials.configureCredentials().then(() => {
+        const credentialsFileContent = fs.readFileSync(credentialsFilePath).toString();
+        const lineByLineContent = credentialsFileContent.split('\n');
+
+        expect(lineByLineContent[0]).to.equal('[my-profile]');
+        expect(lineByLineContent[1]).to.equal('aws_access_key_id = my-new-profile-key');
+        expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-new-profile-secret');
+      });
     });
 
     it('should append the profile to the credentials file', () => {

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -216,4 +216,61 @@ describe('AwsConfigCredentials', () => {
       });
     });
   });
+
+  describe('#getCredentials()', () => {
+    it('should load credentials file and return the credentials lines', () => {
+      fse.outputFileSync(credentialsFilePath, credentialsFileContent);
+      const credentials = awsConfigCredentials.getCredentials();
+
+      expect(credentials[0]).to.equal('[my-profile]');
+      expect(credentials[1]).to.equal('aws_access_key_id = my-old-profile-key');
+    });
+
+    it('should return an empty array if the file is empty', () => {
+      const credentials = awsConfigCredentials.getCredentials();
+
+      expect(credentials.length).to.equal(0);
+    });
+  });
+
+  describe('#getProfileBoundaries()', () => {
+    it('should return the start and end numbers of the profile', () => {
+      awsConfigCredentials.options.profile = 'my-profile';
+      awsConfigCredentials.credentials = [
+        '[my-profile]',
+        'aws_access_key_id = my-other-profile-key',
+      ];
+
+      const profileBoundaries = awsConfigCredentials.getProfileBoundaries();
+
+      expect(profileBoundaries.start).to.equal(0);
+      expect(profileBoundaries.end).to.equal(2);
+    });
+
+    it('should set the start property to -1 if the profile was not found', () => {
+      awsConfigCredentials.options.profile = 'my-not-yet-saved-profile';
+      awsConfigCredentials.credentials = [
+        '[my-profile]',
+        'aws_access_key_id = my-other-profile-key',
+      ];
+
+      const profileBoundaries = awsConfigCredentials.getProfileBoundaries();
+
+      expect(profileBoundaries.start).to.equal(-1);
+    });
+
+    it('should set the end to the credentials lentgh if no other profile was found', () => {
+      awsConfigCredentials.options.profile = 'my-profile';
+      awsConfigCredentials.credentials = [
+        '[my-profile]',
+        'aws_access_key_id = my-other-profile-key',
+        '# a comment',
+        'aws_secret_access_key = my-profile-secret',
+      ];
+
+      const profileBoundaries = awsConfigCredentials.getProfileBoundaries();
+
+      expect(profileBoundaries.end).to.equal(4);
+    });
+  });
 });


### PR DESCRIPTION
## What did you implement:
Added support for profile update when using the `serverless config credentials` command
Closes #3809 

## How did you implement it:
This was implemented by scanning the credentials file and locating the given profile section and then replacing the key and secret lines. I tried to adapt the logic of the [aws-cli config writer](https://github.com/aws/aws-cli/blob/e2295b022db35eea9fec7e6c5540d06dbd6e588b/awscli/customizations/configure/writer.py)
The **AwsConfigCredentials** was refactored to apply more the *DRY* and *OO* patterns.

## How can we verify it:
Use this command:
```bash
serverless config credentials --provider aws --key 1234 --secret 5678 --profile custom-profile --overwrite
```
Try the following:
- use the overwrite flag to update an existing profile.
- do not use the overwrite flag to update an existing profile => This should Fail.
- use the overwrite flag with a non-existing profile. => This should add the profile anyway.
- update an already existing profile with comments and other values inside the profile definition.
- update the first/last profile in the credential file.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
