### PR TITLE
Fix tabtab paths in postinstall script

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 /* eslint-disable no-console */
 /* eslint-disable no-use-before-define */
 
@@ -20,14 +22,17 @@ try {
 
 function setupAutocomplete() {
   return new Promise((resolve, reject) => {
-    const tabtabPath = require.resolve('tabtab').replace(/\/index.js$/, '');
+    const indexRegex = new RegExp(path.join(path.sep, 'index.js'));
+    const tabtabPath = require.resolve('tabtab').replace(indexRegex, '');
+    const tabtabCliPath = path.join(tabtabPath, 'src', 'cli.js');
+
     try {
-      execSync(`node ${tabtabPath}/src/cli.js install --name serverless --auto`);
-      execSync(`node ${tabtabPath}/src/cli.js install --name sls --auto`);
+      execSync(`node ${tabtabCliPath} install --name serverless --auto`);
+      execSync(`node ${tabtabCliPath} install --name sls --auto`);
       return resolve();
     } catch (error) {
-      execSync(`node ${tabtabPath}/src/cli.js install --name serverless --stdout`);
-      execSync(`node ${tabtabPath}/src/cli.js install --name sls --stdout`);
+      execSync(`node ${tabtabCliPath} install --name serverless --stdout`);
+      execSync(`node ${tabtabCliPath} install --name sls --stdout`);
       console.log('Could not auto-install serverless autocomplete script.');
       console.log('Please copy / paste the script above into your shell.');
       return reject(error);


### PR DESCRIPTION
## What did you implement:

Refs #3798 and #3792

Make the path to the `tabtab` CLI script OS independent.

## How did you implement it:

Replace `/` with `path.sep` and `path.join()`.

## How can we verify it:

Install Serverless from this branch or run `node scripts/postinstall.js`.

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO