### PR TITLE
Parse yaml without changing cwd

### DIFF
--- a/lib/classes/YamlParser.js
+++ b/lib/classes/YamlParser.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const path = require('path');
 const YAML = require('js-yaml');
-const resolve = require('json-refs').resolveRefs;
+const resolve = require('json-refs').resolveRefsAt;
 
 class YamlParser {
 
@@ -11,12 +10,6 @@ class YamlParser {
   }
 
   parse(yamlFilePath) {
-    let parentDir = yamlFilePath.split(path.sep);
-    parentDir.pop();
-    parentDir = parentDir.join('/');
-    process.chdir(parentDir);
-
-    const root = this.serverless.utils.readFileSync(yamlFilePath);
     const options = {
       filter: ['relative', 'remote'],
       loaderOptions: {
@@ -25,7 +18,7 @@ class YamlParser {
         },
       },
     };
-    return resolve(root, options).then((res) => (res.resolved));
+    return resolve(yamlFilePath, options).then((res) => (res.resolved));
   }
 }
 

--- a/lib/classes/YamlParser.js
+++ b/lib/classes/YamlParser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const YAML = require('js-yaml');
-const resolve = require('json-refs').resolveRefsAt;
+const jsonRefs = require('json-refs');
 
 class YamlParser {
 
@@ -18,7 +18,10 @@ class YamlParser {
         },
       },
     };
-    return resolve(yamlFilePath, options).then((res) => (res.resolved));
+    return jsonRefs.resolveRefsAt(yamlFilePath, options).then((res) => {
+      jsonRefs.clearCache();
+      return res.resolved;
+    });
   }
 }
 

--- a/lib/classes/YamlParser.js
+++ b/lib/classes/YamlParser.js
@@ -2,11 +2,17 @@
 
 const YAML = require('js-yaml');
 const jsonRefs = require('json-refs');
+const BbPromise = require('bluebird');
 
 class YamlParser {
 
   constructor(serverless) {
     this.serverless = serverless;
+    this.queue = BbPromise.resolve();
+  }
+
+  resolve(yamlFilePath, options) {
+    return jsonRefs.resolveRefsAt(yamlFilePath, options).then((res) => res.resolved);
   }
 
   parse(yamlFilePath) {
@@ -18,10 +24,9 @@ class YamlParser {
         },
       },
     };
-    return jsonRefs.resolveRefsAt(yamlFilePath, options).then((res) => {
-      jsonRefs.clearCache();
-      return res.resolved;
-    });
+    const queued = this.queue.then(() => this.resolve(yamlFilePath, options));
+    this.queue = queued.finally(() => jsonRefs.clearCache());
+    return queued;
   }
 }
 

--- a/lib/classes/YamlParser.test.js
+++ b/lib/classes/YamlParser.test.js
@@ -94,5 +94,30 @@ describe('YamlParser', () => {
       return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'one.yml')))
         .to.eventually.have.deep.property('one.two.foo').to.equal('bar');
     });
+
+    it('should parse a .yml file with references across folders', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+
+      serverless.utils.writeFileSync(path.join(tmpDirPath, 'a/x/y/three.yml'), { foo: 'bar' });
+
+      const twoYml = {
+        two: {
+          $ref: './x/y/three.yml',
+        },
+      };
+
+      serverless.utils.writeFileSync(path.join(tmpDirPath, 'a/two.yml'), twoYml);
+
+      const oneYml = {
+        one: {
+          $ref: '../../two.yml',
+        },
+      };
+
+      serverless.utils.writeFileSync(path.join(tmpDirPath, 'a/b/c/one.yml'), oneYml);
+
+      return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'a/b/c/one.yml')))
+        .to.eventually.have.deep.property('one.two.foo').to.equal('bar');
+    });
   });
 });

--- a/lib/classes/YamlParser.test.js
+++ b/lib/classes/YamlParser.test.js
@@ -153,5 +153,20 @@ describe('YamlParser', () => {
             .to.eventually.have.deep.property('main.foo').to.equal('baz');
         });
     });
+
+    it('should queue parsing to prevent cache races', () => {
+      const tmpFilePath = testUtils.getTmpFilePath('queued.yaml');
+
+      serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
+
+      const parse1 = serverless.yamlParser.parse(tmpFilePath);
+      const parse2 = serverless.yamlParser.parse(tmpFilePath);
+
+      return expect(parse1).to.eventually.have.deep.property('foo').to.equal('bar').then(() => {
+        expect(parse2.isFulfilled()).to.equal(false);
+        serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'baz' }));
+        return expect(parse2).to.eventually.have.deep.property('foo').to.equal('baz');
+      });
+    });
   });
 });

--- a/lib/classes/YamlParser.test.js
+++ b/lib/classes/YamlParser.test.js
@@ -132,5 +132,26 @@ describe('YamlParser', () => {
             .to.eventually.have.property('foo').to.equal('baz');
         });
     });
+
+    it('should not cache referenced file contents', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+
+      serverless.utils.writeFileSync(path.join(tmpDirPath, 'ref.yml'), { foo: 'bar' });
+
+      const testYml = {
+        main: {
+          $ref: './ref.yml',
+        },
+      };
+
+      serverless.utils.writeFileSync(path.join(tmpDirPath, 'test.yml'), testYml);
+
+      return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'test.yml')))
+        .to.eventually.have.deep.property('main.foo').to.equal('bar').then(() => {
+          serverless.utils.writeFileSync(path.join(tmpDirPath, 'ref.yml'), { foo: 'baz' });
+          return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'test.yml')))
+            .to.eventually.have.deep.property('main.foo').to.equal('baz');
+        });
+    });
   });
 });

--- a/lib/classes/YamlParser.test.js
+++ b/lib/classes/YamlParser.test.js
@@ -119,5 +119,18 @@ describe('YamlParser', () => {
       return expect(serverless.yamlParser.parse(path.join(tmpDirPath, 'a/b/c/one.yml')))
         .to.eventually.have.deep.property('one.two.foo').to.equal('bar');
     });
+
+    it('should not cache file contents', () => {
+      const tmpFilePath = testUtils.getTmpFilePath('simple.yaml');
+
+      serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
+
+      return expect(serverless.yamlParser.parse(tmpFilePath))
+        .to.eventually.have.property('foo').to.equal('bar').then(() => {
+          serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'baz' }));
+          return expect(serverless.yamlParser.parse(tmpFilePath))
+            .to.eventually.have.property('foo').to.equal('baz');
+        });
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Changed yaml parser to no longer change the current working directory.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

There's already a json-ref method that does it.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

The tests pass, and they parse yaml in directories other than the current.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
