### PR TITLE
Skip packaging if artifact specified

### DIFF
--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -42,8 +42,14 @@ module.exports = {
       });
     } else if (!_.isEmpty(this.serverless.service.functions)) {
       // artifact file validation (single service artifact)
-      const artifactFileName = this.provider.naming.getServiceArtifactName();
-      const artifactFilePath = path.join(this.packagePath, artifactFileName);
+      let artifactFilePath;
+      let artifactFileName;
+      if (this.serverless.service.package.artifact) {
+        artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
+      } else {
+        artifactFileName = this.provider.naming.getServiceArtifactName();
+        artifactFilePath = path.join(this.packagePath, artifactFileName);
+      }
       if (!this.serverless.utils.fileExistsSync(artifactFilePath)) {
         throw new this.serverless.classes
           .Error(`No ${artifactFileName} file found in the package path you provided.`);

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -99,5 +99,30 @@ describe('extendedValidate', () => {
         awsDeploy.serverless.utils.readFileSync.restore();
       });
     });
+
+    it('should throw error if specified package artifact does not exist', () => {
+      const fileExistsSyncStub = sinon.stub(awsDeploy.serverless.utils, 'fileExistsSync');
+      fileExistsSyncStub.onCall(0).returns(true);
+      fileExistsSyncStub.onCall(1).returns(false);
+      sinon.stub(awsDeploy.serverless.utils, 'readFileSync').returns(stateFileMock);
+      awsDeploy.serverless.service.package.artifact = 'some/file.zip';
+      expect(() => awsDeploy.extendedValidate()).to.throw(Error);
+      delete awsDeploy.serverless.service.package.artifact;
+      awsDeploy.serverless.utils.fileExistsSync.restore();
+      awsDeploy.serverless.utils.readFileSync.restore();
+    });
+
+    it('should not throw error if specified package artifact exists', () => {
+      const fileExistsSyncStub = sinon.stub(awsDeploy.serverless.utils, 'fileExistsSync');
+      fileExistsSyncStub.onCall(0).returns(true);
+      fileExistsSyncStub.onCall(1).returns(true);
+      sinon.stub(awsDeploy.serverless.utils, 'readFileSync').returns(stateFileMock);
+      awsDeploy.serverless.service.package.artifact = 'some/file.zip';
+      return awsDeploy.extendedValidate().then(() => {
+        delete awsDeploy.serverless.service.package.artifact;
+        awsDeploy.serverless.utils.fileExistsSync.restore();
+        awsDeploy.serverless.utils.readFileSync.restore();
+      });
+    });
   });
 });

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -43,7 +43,7 @@ module.exports = {
     });
 
     return BbPromise.all(packagePromises).then(() => {
-      if (shouldPackageService) {
+      if (shouldPackageService && !this.serverless.service.package.artifact) {
         return this.packageAll();
       }
       return BbPromise.resolve();

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -160,6 +160,65 @@ describe('#packageService()', () => {
         expect(packageAllStub).to.be.calledOnce
       ));
     });
+
+    it('should not package functions if package artifact specified', () => {
+      serverless.service.package.artifact = 'some/file.zip';
+
+      const packageAllStub = sinon.stub(packagePlugin, 'packageAll').resolves();
+
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+        .then(() => expect(packageAllStub).to.not.be.called);
+    });
+
+    it('should package functions individually if package artifact specified', () => {
+      serverless.service.package.artifact = 'some/file.zip';
+      serverless.service.package.individually = true;
+      serverless.service.functions = {
+        'test-one': {
+          name: 'test-one',
+        },
+        'test-two': {
+          name: 'test-two',
+        },
+      };
+
+      const packageFunctionStub = sinon
+        .stub(packagePlugin, 'packageFunction').resolves((func) => func.name);
+      const packageAllStub = sinon
+        .stub(packagePlugin, 'packageAll').resolves((func) => func.name);
+
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => BbPromise.join(
+        expect(packageFunctionStub).to.be.calledTwice,
+        expect(packageAllStub).to.not.be.called
+      ));
+    });
+
+    it('should package single functions individually if package artifact specified', () => {
+      serverless.service.package.artifact = 'some/file.zip';
+      serverless.service.functions = {
+        'test-one': {
+          name: 'test-one',
+          package: {
+            individually: true,
+          },
+        },
+        'test-two': {
+          name: 'test-two',
+        },
+      };
+
+      const packageFunctionStub = sinon
+        .stub(packagePlugin, 'packageFunction').resolves((func) => func.name);
+      const packageAllStub = sinon
+        .stub(packagePlugin, 'packageAll').resolves((func) => func.name);
+
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => BbPromise.join(
+        expect(packageFunctionStub).to.be.calledOnce,
+        expect(packageAllStub).to.not.be.called
+      ));
+    });
   });
 
   describe('#packageAll()', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added checks to *not* build a package at all if package.artifact is specified. I believe this is how it worked before it didn't.

Closes #3684 maybe

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Everything was already being tracked correctly, I pretty much just changed the package service to skip the "build all" step if an artifact is given in the config.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

If you check out one of the integration tests that has a package artifact in the config, you can see that it currently zips up the entire app root, even though it may not use it as the deployed artifact. With these changes, that zip is no longer built.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO