### PR TITLE
Add opt-out config for dev dependency exclusion

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -136,3 +136,10 @@ functions:
 Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
 
 This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.
+
+You can opt-out of automatic dev dependency exclusion by setting the `excludeDevDependencies` package config to `false`:
+
+```yml
+package:
+  excludeDevDependencies: false
+```

--- a/docs/providers/azure/guide/packaging.md
+++ b/docs/providers/azure/guide/packaging.md
@@ -157,3 +157,10 @@ functions:
 Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
 
 This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.
+
+You can opt-out of automatic dev dependency exclusion by setting the `excludeDevDependencies` package config to `false`:
+
+```yml
+package:
+  excludeDevDependencies: false
+```

--- a/docs/providers/google/guide/packaging.md
+++ b/docs/providers/google/guide/packaging.md
@@ -129,3 +129,10 @@ functions:
 Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
 
 This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.
+
+You can opt-out of automatic dev dependency exclusion by setting the `excludeDevDependencies` package config to `false`:
+
+```yml
+package:
+  excludeDevDependencies: false
+```

--- a/docs/providers/openwhisk/guide/packaging.md
+++ b/docs/providers/openwhisk/guide/packaging.md
@@ -123,3 +123,10 @@ functions:
 Serverless will auto-detect and exclude development dependencies based on the runtime your service is using.
 
 This ensures that only the production relevant packages and modules are included in your zip file. Doing this drastically reduces the overall size of the deployment package which will be uploaded to the cloud provider.
+
+You can opt-out of automatic dev dependency exclusion by setting the `excludeDevDependencies` package config to `false`:
+
+```yml
+package:
+  excludeDevDependencies: false
+```

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -125,6 +125,7 @@ class Service {
           that.package.artifact = serverlessFile.package.artifact;
           that.package.exclude = serverlessFile.package.exclude;
           that.package.include = serverlessFile.package.include;
+          that.package.excludeDevDependencies = serverlessFile.package.excludeDevDependencies;
         }
 
         return this;

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -80,6 +80,7 @@ describe('Service', () => {
       expect(serviceInstance.package.include.length).to.equal(1);
       expect(serviceInstance.package.include[0]).to.equal('include-me');
       expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+      expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
     });
 
     it('should support string based provider config', () => {
@@ -147,6 +148,7 @@ describe('Service', () => {
           exclude: ['exclude-me'],
           include: ['include-me'],
           artifact: 'some/path/foo.zip',
+          excludeDevDependencies: false,
         },
       };
 
@@ -172,6 +174,7 @@ describe('Service', () => {
         expect(serviceInstance.package.include.length).to.equal(1);
         expect(serviceInstance.package.include[0]).to.equal('include-me');
         expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(false);
       });
     });
 
@@ -225,6 +228,7 @@ describe('Service', () => {
         expect(serviceInstance.package.include.length).to.equal(1);
         expect(serviceInstance.package.include[0]).to.equal('include-me');
         expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
       });
     });
 
@@ -278,6 +282,7 @@ describe('Service', () => {
         expect(serviceInstance.package.include.length).to.equal(1);
         expect(serviceInstance.package.include[0]).to.equal('include-me');
         expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
       });
     });
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -27,10 +27,18 @@ module.exports = {
 
   excludeDevDependencies(params) {
     const servicePath = this.serverless.config.servicePath;
-    const exAndInNode = excludeNodeDevDependencies(servicePath);
 
-    params.exclude = _.union(params.exclude, exAndInNode.exclude);
-    params.include = _.union(params.include, exAndInNode.include);
+    let excludeDevDependencies = this.serverless.service.package.excludeDevDependencies;
+    if (excludeDevDependencies === undefined || excludeDevDependencies === null) {
+      excludeDevDependencies = true;
+    }
+
+    if (excludeDevDependencies) {
+      const exAndInNode = excludeNodeDevDependencies(servicePath);
+
+      params.exclude = _.union(params.exclude, exAndInNode.exclude);
+      params.include = _.union(params.include, exAndInNode.include);
+    }
 
     return BbPromise.resolve(params);
   },

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -68,6 +68,15 @@ describe('zipService', () => {
   });
 
   describe('#excludeDevDependencies()', () => {
+    it('should resolve when opted out of dev dependency exclusion', () => {
+      packagePlugin.serverless.service.package.excludeDevDependencies = false;
+
+      return expect(packagePlugin.excludeDevDependencies(params)).to.be
+        .fulfilled.then((updatedParams) => {
+          expect(updatedParams).to.deep.equal(params);
+        });
+    });
+
     describe('when dealing with Node.js runtimes', () => {
       let globbySyncStub;
       let processChdirStub;


### PR DESCRIPTION
## What did you implement:

Refs #3827
Refs #3874
Refs #3869

Add the `excludeDevDependencies` config variable to the `global` package level.

This config variable defaults to `true`.

## How did you implement it:

Added the config variable and added a check in the `excludeDevDependencies()` function.

## How can we verify it:

Use the following `package.json` file:

```json
{
  "name": "test-service",
  "version": "1.0.0",
  "main": "handler.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "node-fetch": "^1.7.1"
  },
  "devDependencies": {
    "ava": "^0.19.1",
    "babel-cli": "^6.24.1",
    "babel-core": "^6.25.0",
    "babel-preset-es2015": "^6.24.1",
    "browserify": "^14.4.0",
    "express": "^4.15.3",
    "jest": "^20.0.4",
    "mocha": "^3.4.2",
    "react": "^15.6.1",
    "react-native": "^0.45.1",
    "webpack": "^3.0.0"
  },
  "description": ""
}
```

Install the dependencies via `npm install`.

Run `serverless package`. After that run `ls -lh <path-to-service-zip>`. The size should be pretty small.

Add the following to your `serverless.yml` file:

```yml
package:
  excludeDevDependencies: false
```

Run `serverless package`. After that run `ls -lh <path-to-service-zip>`. The size should be pretty big.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO