### PR TITLE
Add shared API Gateway support

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -46,6 +46,7 @@ class Variables {
 
   populateObject(objectToPopulate) {
     const populateAll = [];
+    // TODO replace the usage of this method with traverse() from utils
     const deepMapValues = (object, callback, propertyPath) => {
       const deepMapValuesIteratee =
         (value, key) => deepMapValues(value, callback, propertyPath ? propertyPath

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -16,6 +16,7 @@ const compilePermissions = require('./lib/permissions');
 const getMethodAuthorization = require('./lib/method/authorization');
 const getMethodIntegration = require('./lib/method/integration');
 const getMethodResponses = require('./lib/method/responses');
+const mergeSharedApiGateway = require('./lib/mergeSharedApiGateway');
 
 class AwsCompileApigEvents {
   constructor(serverless, options) {
@@ -38,7 +39,8 @@ class AwsCompileApigEvents {
       compilePermissions,
       getMethodAuthorization,
       getMethodIntegration,
-      getMethodResponses
+      getMethodResponses,
+      mergeSharedApiGateway
     );
 
     this.hooks = {
@@ -60,6 +62,17 @@ class AwsCompileApigEvents {
           .then(this.compileUsagePlan)
           .then(this.compileUsagePlanKeys)
           .then(this.compilePermissions);
+      },
+
+      'after:package:compileEvents': () => {
+        this.validated = this.validate();
+
+        if (this.validated.events.length === 0) {
+          return BbPromise.resolve();
+        }
+
+        return BbPromise.bind(this)
+          .then(this.mergeSharedApiGateway);
       },
 
       // TODO should be removed once AWS fixes the removal via CloudFormation

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/mergeSharedApiGateway.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/mergeSharedApiGateway.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+const traverse = require('../../../../../../../utils/traverse');
+
+module.exports = {
+  mergeSharedApiGateway() {
+    const restApiId = this.serverless.service.provider.apiGatewayRestApiId;
+
+    if (!restApiId) {
+      return BbPromise.resolve();
+    }
+
+    return BbPromise.bind(this)
+      .then(this.replaceUsages)
+      .then(this.removeOldRestApiResource);
+  },
+
+  replaceUsages() {
+    const restApiId = this.serverless.service.provider.apiGatewayRestApiId;
+    let cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const restApiLogicalId = this.provider.naming.getRestApiLogicalId();
+    const newRestApiLogicalId = this.provider.findAllCfReferences(restApiId)[0].ref;
+
+    traverse(cfTemplate, (property, propertyPath) => {
+      // replace usage of old AWS::ApiGateway::RestApi resource
+      if (property === restApiLogicalId) {
+        const updatedCfTemplate = _.set(cfTemplate, propertyPath, newRestApiLogicalId);
+        cfTemplate = updatedCfTemplate;
+      }
+      // replace usage of RootResourceId
+      if (property === 'RootResourceId') {
+        const pathToRestApiName = propertyPath;
+        pathToRestApiName[pathToRestApiName.length - 1] = 0;
+        const updatedCfTemplate = _.set(cfTemplate, pathToRestApiName, newRestApiLogicalId);
+
+        cfTemplate = updatedCfTemplate;
+      }
+    });
+  },
+
+  removeOldRestApiResource() {
+    const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const restApiLogicalId = this.provider.naming.getRestApiLogicalId();
+
+    if (cfTemplate.Resources[restApiLogicalId]) {
+      delete cfTemplate.Resources[restApiLogicalId];
+    }
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-param-reassign */
+
 const AWS = require('aws-sdk');
 const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
@@ -255,6 +257,35 @@ class AwsProvider {
   getAccountId() {
     return this.request('STS', 'getCallerIdentity', {})
       .then((result) => result.Account);
+  }
+
+  findAllCfReferences(root) {
+    const resourceRefs = [];
+    const stack = [{ parent: null, value: root, path: '' }];
+
+    while (!_.isEmpty(stack)) {
+      const property = stack.pop();
+
+      _.forOwn(property.value, (value, key) => {
+        if (key === 'Ref') {
+          resourceRefs.push({ ref: value, path: property.path });
+        } else if (key === 'Fn::GetAtt') {
+          resourceRefs.push({ ref: value[0], path: property.path });
+        } else if (key === 'Fn::ImportValue') {
+          resourceRefs.push({ ref: key, path: property.path });
+        } else if (_.isObject(value)) {
+          if (_.isArray(property.value)) {
+            key = `[${key}]`;
+          } else if (_.isEmpty(property.path)) {
+            key = `${key}`;
+          } else {
+            key = `.${key}`;
+          }
+          stack.push({ parent: property, value, path: `${property.path}${key}` });
+        }
+      });
+    }
+    return resourceRefs;
   }
 }
 

--- a/lib/utils/traverse.js
+++ b/lib/utils/traverse.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const _ = require('lodash');
+
+function traverse(object, callback, propertyPath) {
+  const traverseIteratee =
+    (value, key) => traverse(value, callback, propertyPath ? propertyPath
+      .concat(key) : [key]);
+  if (_.isArray(object)) {
+    return _.map(object, traverseIteratee);
+  } else if (_.isObject(object) &&
+    !_.isDate(object) &&
+    !_.isRegExp(object) &&
+    !_.isFunction(object)) {
+    return _.extend({}, object, _.mapValues(object, traverseIteratee));
+  }
+  return callback(object, propertyPath);
+}
+
+module.exports = traverse;


### PR DESCRIPTION
## What did you implement:

Add support for a shared API Gateway REST API.

Closes #3078 
Refs #3212 --> (we need to update all the other parts where the global arn parser should be used)

## How did you implement it:

Add a transformation step after compiling the API Gateway resources which replaces all the `AWS::ApiGateway::RestApi` references with the ones defined in the `service.awsApiGatewayRestApiId` config.

This also implements the global `arn` parser (code is stolen from the `alias-plugin` by @HyperBrain 
😬 🙏 ) to get the `ref` to the new `AWS::ApiGateway::RestApi` resource.

Still a WIP PR though!

## How can we verify it:

Use this `serverless.yml` file and enter `serverless package`. After that you should inspect the generated CloudFormation template to see that all the old `AWS::ApiGateway::RestApi` references are replaced with the new ones.

```yml
service:
  name: test-service

provider:
  name: aws
  runtime: nodejs6.10
  apiGatewayRestApiId:
    Ref: MySharedApiGatewayRestApi

functions:
  hello:
    handler: handler.hello
    events:
      - http: GET hello

resources:
  Resources:
    MySharedApiGatewayRestApi:
      Type: AWS::ApiGateway::RestApi
      Properties:
        Name: dev-my-shared-api-gateway
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO