### PR TITLE
Fix node_modules regex in excludeDevDependencies to be OS independent

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -139,7 +139,8 @@ function excludeNodeDevDependencies(servicePath) {
         .execSync('npm ls --prod=true --parseable=true --silent')
         .toString().trim();
 
-      const prodDependencyPaths = prodDependencies.match(/(node_modules\/.*)/g);
+      const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
+      const prodDependencyPaths = prodDependencies.match(nodeModulesRegex);
 
       let pathToDep = '';
       // if the package.json file is not in the root of the service path


### PR DESCRIPTION
## What did you implement:

Adds dev dependency exclusion support for Windows 😬 .

Thanks for bringing this up @HyperBrain 👍 

## How did you implement it:

Just updated the regex to use OS dependent path separators.

## How can we verify it:

Same steps you can finde in https://github.com/serverless/serverless/pull/3737

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO