### PR TITLE
Fix dev dependency exclusion bug

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-use-before-define */
 /* eslint-disable no-param-reassign */
+/* eslint-disable consistent-return */
 
 const childProcess = require('child_process');
 const archiver = require('archiver');
@@ -34,10 +35,14 @@ module.exports = {
     }
 
     if (excludeDevDependencies) {
-      const exAndInNode = excludeNodeDevDependencies(servicePath);
-
-      params.exclude = _.union(params.exclude, exAndInNode.exclude);
-      params.include = _.union(params.include, exAndInNode.include);
+      return BbPromise.bind(this)
+        .then(() => excludeNodeDevDependencies(servicePath))
+        .then((exAndInNode) => {
+          params.exclude = _.union(params.exclude, exAndInNode.exclude);
+          params.include = _.union(params.include, exAndInNode.include);
+          return params;
+        })
+        .catch(() => params);
     }
 
     return BbPromise.resolve(params);
@@ -114,9 +119,10 @@ module.exports = {
 };
 
 function excludeNodeDevDependencies(servicePath) {
-  const cwd = process.cwd();
-  let exclude = [];
-  let include = [];
+  const exAndIn = {
+    include: [],
+    exclude: [],
+  };
 
   try {
     const packageJsonFilePaths = globby.sync([
@@ -131,53 +137,62 @@ function excludeNodeDevDependencies(servicePath) {
     });
 
     // filter out non node_modules file paths
-    const relevantFilePaths = _.filter(packageJsonFilePaths, (filePath) => {
+    const packageJsonPaths = _.filter(packageJsonFilePaths, (filePath) => {
       const isNodeModulesDir = !!filePath.match(/node_modules/);
       return !isNodeModulesDir;
     });
 
-    _.forEach(relevantFilePaths, (relevantFilePath) => {
+    return BbPromise.map(packageJsonPaths, (packageJsonPath) => {
       // the path where the package.json file lives
-      const fullPath = path.join(servicePath, relevantFilePath);
-      const rootDirPath = fullPath.replace(path.join(path.sep, 'package.json'), '');
+      const fullPath = path.join(servicePath, packageJsonPath);
+      const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
 
-      process.chdir(rootDirPath);
+      const childProc = childProcess.spawn('npm',
+        ['ls', '--dev=true', '--parseable=true', '--silent'],
+        { cwd: dirWithPackageJson }
+      );
 
-      // TODO replace with package-manager independent directory traversal?!
-      const prodDependencies = childProcess
-        .execSync('npm ls --prod=true --parseable=true --silent')
-        .toString().trim();
+      let result = [];
 
+      return new BbPromise((resolve) => {
+        if (childProc.error) {
+          return resolve(result);
+        }
+
+        const chunks = [];
+
+        childProc.stdout.on('data', (chunk) => {
+          chunks.push(chunk);
+        });
+
+        childProc.stdout.on('end', () => {
+          result = Buffer.concat(chunks)
+            .toString()
+            .split('\n')
+            .filter((item) => item.length > 0);
+          return resolve(result);
+        });
+
+        childProc.stdout.on('error', () => resolve(result));
+      });
+    })
+    .then((results) => {
+      // turn the two result arrays into one
+      const result = [].concat.apply([], results); // eslint-disable-line
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
-      const prodDependencyPaths = prodDependencies.match(nodeModulesRegex);
 
-      let pathToDep = '';
-      // if the package.json file is not in the root of the service path
-      if (rootDirPath !== servicePath) {
-        // the path without the servicePath prepended
-        const relativeFilePath = rootDirPath.replace(path.join(servicePath, path.sep), '');
-        pathToDep = relativeFilePath ? `${relativeFilePath}/` : '';
+      if (result.length) {
+        const globs = result
+          .map((item) => item.replace(servicePath, ''))
+          .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
+          .map((item) => `${item.substring(1)}/**`);
+        exAndIn.exclude = globs;
       }
 
-      const includePatterns = _.map(prodDependencyPaths, (depPath) =>
-        `${pathToDep}${depPath}/**`);
-
-      if (includePatterns.length) {
-        // at first exclude the whole node_modules directory
-        // after that re-include the production relevant modules
-        exclude = _.union(exclude, [`${pathToDep}node_modules/**`]);
-        include = _.union(include, includePatterns);
-      }
-    });
+      return exAndIn;
+    })
+    .catch(() => exAndIn);
   } catch (e) {
-    // npm is not installed
-  } finally {
-    // make sure to always chdir back to the cwd, no matter what
-    process.chdir(cwd);
+    // fail silently
   }
-
-  return {
-    exclude,
-    include,
-  };
 }

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -4,11 +4,13 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable consistent-return */
 
-const childProcess = require('child_process');
-const archiver = require('archiver');
 const BbPromise = require('bluebird');
+const archiver = require('archiver');
+const os = require('os');
 const path = require('path');
-const fs = require('fs');
+const crypto = require('crypto');
+const fs = BbPromise.promisifyAll(require('fs'));
+const childProcess = BbPromise.promisifyAll(require('child_process'));
 const globby = require('globby');
 const _ = require('lodash');
 
@@ -124,6 +126,12 @@ function excludeNodeDevDependencies(servicePath) {
     exclude: [],
   };
 
+  // the file where we'll write the dependencies into
+  const nodeDevDepFile = path.join(
+    os.tmpdir(),
+    `node-dev-dependencies-${crypto.randomBytes(8).toString('hex')}`
+  );
+
   try {
     const packageJsonFilePaths = globby.sync([
       '**/package.json',
@@ -142,47 +150,24 @@ function excludeNodeDevDependencies(servicePath) {
       return !isNodeModulesDir;
     });
 
-    return BbPromise.map(packageJsonPaths, (packageJsonPath) => {
+    // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
+    return BbPromise.mapSeries(packageJsonPaths, (packageJsonPath) => {
       // the path where the package.json file lives
       const fullPath = path.join(servicePath, packageJsonPath);
       const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
 
-      const childProc = childProcess.spawn('npm',
-        ['ls', '--dev=true', '--parseable=true', '--silent'],
+      return childProcess.execAsync(
+        `npm ls --dev=true --parseable=true --silent >> ${nodeDevDepFile}`,
         { cwd: dirWithPackageJson }
       );
-
-      let result = [];
-
-      return new BbPromise((resolve) => {
-        if (childProc.error) {
-          return resolve(result);
-        }
-
-        const chunks = [];
-
-        childProc.stdout.on('data', (chunk) => {
-          chunks.push(chunk);
-        });
-
-        childProc.stdout.on('end', () => {
-          result = Buffer.concat(chunks)
-            .toString()
-            .split('\n')
-            .filter((item) => item.length > 0);
-          return resolve(result);
-        });
-
-        childProc.stdout.on('error', () => resolve(result));
-      });
     })
-    .then((results) => {
-      // turn the two result arrays into one
-      const result = [].concat.apply([], results); // eslint-disable-line
+    .then(() => fs.readFileAsync(nodeDevDepFile))
+    .then((fileContent) => {
+      const dependencies = fileContent.toString('utf8').split('\n');
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
-      if (result.length) {
-        const globs = result
+      if (dependencies.length) {
+        const globs = dependencies
           .map((item) => item.replace(servicePath, ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
           .map((item) => `${item.substring(1)}/**`);

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -163,10 +163,10 @@ function excludeNodeDevDependencies(servicePath) {
     })
     .then(() => fs.readFileAsync(nodeDevDepFile))
     .then((fileContent) => {
-      const dependencies = fileContent.toString('utf8').split('\n');
+      const dependencies = _.uniq(_.split(fileContent.toString('utf8'), '\n'));
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
-      if (dependencies.length) {
+      if (!_.isEmpty(dependencies)) {
         const globs = dependencies
           .map((item) => item.replace(servicePath, ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -1,8 +1,6 @@
 'use strict';
 
 /* eslint-disable no-use-before-define */
-/* eslint-disable no-param-reassign */
-/* eslint-disable consistent-return */
 
 const BbPromise = require('bluebird');
 const archiver = require('archiver');
@@ -40,8 +38,8 @@ module.exports = {
       return BbPromise.bind(this)
         .then(() => excludeNodeDevDependencies(servicePath))
         .then((exAndInNode) => {
-          params.exclude = _.union(params.exclude, exAndInNode.exclude);
-          params.include = _.union(params.include, exAndInNode.include);
+          params.exclude = _.union(params.exclude, exAndInNode.exclude); //eslint-disable-line
+          params.include = _.union(params.include, exAndInNode.include); //eslint-disable-line
           return params;
         })
         .catch(() => params);
@@ -120,6 +118,7 @@ module.exports = {
   },
 };
 
+// eslint-disable-next-line
 function excludeNodeDevDependencies(servicePath) {
   const exAndIn = {
     include: [],

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -149,6 +149,10 @@ function excludeNodeDevDependencies(servicePath) {
       return !isNodeModulesDir;
     });
 
+    if (_.isEmpty(packageJsonPaths)) {
+      return BbPromise.resolve(exAndIn);
+    }
+
     // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
     return BbPromise.mapSeries(packageJsonPaths, (packageJsonPath) => {
       // the path where the package.json file lives
@@ -164,14 +168,17 @@ function excludeNodeDevDependencies(servicePath) {
     })
     .then(() => fs.readFileAsync(nodeDevDepFile))
     .then((fileContent) => {
-      const dependencies = _.uniq(_.split(fileContent.toString('utf8'), '\n'));
+      const dependencies = _.filter(
+        (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
+        elem => elem.length > 0
+      );
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
       if (!_.isEmpty(dependencies)) {
         const globs = dependencies
-          .map((item) => item.replace(servicePath, ''))
+          .map((item) => item.replace(path.join(servicePath, path.sep), ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
-          .map((item) => `${item.substring(1)}/**`);
+          .map((item) => `${item}/**`);
         exAndIn.exclude = globs;
       }
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -155,10 +155,12 @@ function excludeNodeDevDependencies(servicePath) {
       const fullPath = path.join(servicePath, packageJsonPath);
       const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
 
+      // we added a catch which resolves so that npm commands with an exit code of 1
+      // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
       return childProcess.execAsync(
         `npm ls --dev=true --parseable=true --silent >> ${nodeDevDepFile}`,
         { cwd: dirWithPackageJson }
-      );
+      ).catch(() => BbPromise.resolve());
     })
     .then(() => fs.readFileAsync(nodeDevDepFile))
     .then((fileContent) => {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -168,7 +168,7 @@ function excludeNodeDevDependencies(servicePath) {
     })
     .then(() => fs.readFileAsync(nodeDevDepFile))
     .then((fileContent) => {
-      const dependencies = _.filter(
+      const dependencies = _.compact(
         (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
         elem => elem.length > 0
       );

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -3,13 +3,14 @@
 /* eslint-disable no-unused-expressions */
 
 const chai = require('chai');
-const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const JsZip = require('jszip');
 const globby = require('globby');
 const _ = require('lodash');
-const childProcess = require('child_process');
+const BbPromise = require('bluebird');
+const fs = BbPromise.promisifyAll(require('fs'));
+const childProcess = BbPromise.promisifyAll(require('child_process'));
 const sinon = require('sinon');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
@@ -34,8 +35,8 @@ describe('zipService', () => {
     packagePlugin = new Package(serverless, {});
     packagePlugin.serverless.cli = new serverless.classes.CLI();
     params = {
-      include: [],
-      exclude: [],
+      include: ['user-defined-include-me'],
+      exclude: ['user-defined-exclude-me'],
       zipFileName: 'my-service.zip',
     };
   });
@@ -79,19 +80,21 @@ describe('zipService', () => {
 
     describe('when dealing with Node.js runtimes', () => {
       let globbySyncStub;
-      let processChdirStub;
-      let execSyncStub;
+      let execAsyncStub;
+      let readFileAsyncStub;
+      let servicePath;
 
       beforeEach(() => {
+        servicePath = packagePlugin.serverless.config.servicePath;
         globbySyncStub = sinon.stub(globby, 'sync');
-        processChdirStub = sinon.stub(process, 'chdir').returns();
-        execSyncStub = sinon.stub(childProcess, 'execSync');
+        execAsyncStub = sinon.stub(childProcess, 'execAsync');
+        readFileAsyncStub = sinon.stub(fs, 'readFileAsync');
       });
 
       afterEach(() => {
-        process.chdir.restore();
         globby.sync.restore();
-        childProcess.execSync.restore();
+        childProcess.execAsync.restore();
+        fs.readFileAsync.restore();
       });
 
       it('should do nothing if no packages are used', () => {
@@ -102,8 +105,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(processChdirStub).to.have.been.calledOnce;
-            expect(execSyncStub).to.not.have.been.called;
+            expect(execAsyncStub).to.not.have.been.called;
+            expect(readFileAsyncStub).to.not.have.been.called;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -112,10 +115,152 @@ describe('zipService', () => {
                 follow: true,
                 nosort: true,
               });
-            expect(updatedParams.exclude).to
-              .deep.equal([]);
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should do nothing if no dependencies are found', () => {
+        const filePaths = ['package.json', 'node_modules'];
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.resolves();
+        const depPaths = '';
+        readFileAsyncStub.resolves(depPaths);
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledOnce;
+            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
+            expect(execAsyncStub.args[0][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should return excludes and includes if an error is thrown in the global scope', () => {
+        globbySyncStub.rejects();
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.not.have.been.called;
+            expect(readFileAsyncStub).to.not.have.been.called;
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should return excludes and includes if a Promise is rejected in the chain', () => {
+        const filePaths = ['package.json', 'node_modules'];
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.resolves();
+        readFileAsyncStub.rejects();
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledOnce;
+            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should fail silently and continue if "npm ls" call throws an error', () => {
+        const filePaths = [
+          // root of the service
+          'package.json', 'node_modules',
+          // nested-dir
+          // NOTE: reading the dependencies in this directory will fail in this tests
+          path.join('1st', 'package.json'),
+          path.join('1st', 'node_modules'),
+          // nested-dir which is nested
+          path.join('1st', '2nd', 'package.json'),
+          path.join('1st', '2nd', 'node_modules'),
+        ];
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.onCall(0).resolves();
+        execAsyncStub.onCall(1).rejects();
+        execAsyncStub.onCall(2).resolves();
+        const depPaths = [
+          `${servicePath}/node_modules/module-1`,
+          `${servicePath}/node_modules/module-2`,
+          `${servicePath}/1st/2nd/node_modules/module-1`,
+          `${servicePath}/1st/2nd/node_modules/module-2`,
+        ].join('\n');
+        readFileAsyncStub.resolves(depPaths);
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub.callCount).to.equal(3);
+            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
+            expect(execAsyncStub.args[0][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[1][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[1][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[2][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[2][1].cwd).to
+              .match(/.+/);
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+              'node_modules/module-1/**',
+              'node_modules/module-2/**',
+              '1st/2nd/node_modules/module-1/**',
+              '1st/2nd/node_modules/module-2/**',
+            ]);
             expect(updatedParams.include).to
-              .deep.equal([]);
+              .deep.equal([
+                'user-defined-include-me',
+              ]);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
           });
       });
@@ -124,13 +269,18 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
-        execSyncStub.returns('node_modules/module-1\nnode_modules/module-2');
+        execAsyncStub.resolves();
+        const depPaths = [
+          `${servicePath}/node_modules/module-1`,
+          `${servicePath}/node_modules/module-2`,
+        ].join('\n');
+        readFileAsyncStub.resolves(depPaths);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(processChdirStub).to.have.been.calledTwice;
-            expect(execSyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledOnce;
+            expect(readFileAsyncStub).to.have.been.calledOnce;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -139,12 +289,18 @@ describe('zipService', () => {
                 follow: true,
                 nosort: true,
               });
-            expect(execSyncStub).to.have.been
-              .calledWithExactly('npm ls --prod=true --parseable=true --silent');
-            expect(updatedParams.exclude).to
-              .deep.equal(['node_modules/**']);
-            expect(updatedParams.include).to
-              .deep.equal(['node_modules/module-1/**', 'node_modules/module-2/**']);
+            expect(execAsyncStub.args[0][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+              'node_modules/module-1/**',
+              'node_modules/module-2/**',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
           });
       });
@@ -162,17 +318,22 @@ describe('zipService', () => {
         ];
 
         globbySyncStub.returns(filePaths);
-        execSyncStub.onCall(0).returns('node_modules/module-1\nnode_modules/module-2');
-        execSyncStub.onCall(1)
-          .returns('1st/node_modules/module-1\n1st/node_modules/module-2');
-        execSyncStub.onCall(2)
-          .returns('1st/2nd/node_modules/module-1\n1st/2nd/node_modules/module-2');
+        execAsyncStub.resolves();
+        const depPaths = [
+          `${servicePath}/node_modules/module-1`,
+          `${servicePath}/node_modules/module-2`,
+          `${servicePath}/1st/node_modules/module-1`,
+          `${servicePath}/1st/node_modules/module-2`,
+          `${servicePath}/1st/2nd/node_modules/module-1`,
+          `${servicePath}/1st/2nd/node_modules/module-2`,
+        ].join('\n');
+        readFileAsyncStub.resolves(depPaths);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(processChdirStub.callCount).to.equal(4);
-            expect(execSyncStub.callCount).to.equal(3);
+            expect(execAsyncStub.callCount).to.equal(3);
+            expect(readFileAsyncStub).to.have.been.calledOnce;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -181,23 +342,30 @@ describe('zipService', () => {
                 follow: true,
                 nosort: true,
               });
-            expect(execSyncStub).to.have.been
-              .calledWithExactly('npm ls --prod=true --parseable=true --silent');
-            expect(updatedParams.exclude).to
-              .deep.equal([
-                'node_modules/**',
-                '1st/node_modules/**',
-                '1st/2nd/node_modules/**',
-              ]);
-            expect(updatedParams.include).to
-              .deep.equal([
-                'node_modules/module-1/**',
-                'node_modules/module-2/**',
-                '1st/node_modules/module-1/**',
-                '1st/node_modules/module-2/**',
-                '1st/2nd/node_modules/module-1/**',
-                '1st/2nd/node_modules/module-2/**',
-              ]);
+            expect(execAsyncStub.args[0][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[1][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[1][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[2][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[2][1].cwd).to
+              .match(/.+/);
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+              'node_modules/module-1/**',
+              'node_modules/module-2/**',
+              '1st/node_modules/module-1/**',
+              '1st/node_modules/module-2/**',
+              '1st/2nd/node_modules/module-1/**',
+              '1st/2nd/node_modules/module-2/**',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
           });
       });


### PR DESCRIPTION
## What did you implement:

Closes #3827
Closes #3874
Closes #3869

Fixes a bug where the dev dependency exclusion errors out due to a large number of dependencies (and string capacity limitations).

Also fixes the error where exclusion is not working anymore.

Speed is increased due to async operations ran concurrently.

## How did you implement it:

1. Switch from sync to async calls and compute them in a `Bluebird Promise.map`
2. Switched from `execSync` to `spawn` to get a stream (mitigates the buffer limit `execSync` introduces where the packages for exclusion are capped)
3. Switch from `npm ls --prod=true` to `npm ls --dev=true` so that we exclude only the `dev` dependencies rather than excluding all `node_modules` and then re-including the prod dependencies. This should avoid side-effects when the exclusion of dev dependencies fails.

## How can we verify it:

Take the steps described here: https://github.com/serverless/serverless/pull/3737#issue-233860537

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO