### PR TITLE
Also set region env vars from config, not just CLI, for invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -84,8 +84,8 @@ class AwsInvokeLocal {
       LD_LIBRARY_PATH: '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib', // eslint-disable-line max-len
       LAMBDA_TASK_ROOT: '/var/task',
       LAMBDA_RUNTIME_DIR: '/var/runtime',
-      AWS_REGION: this.options.region,
-      AWS_DEFAULT_REGION: this.options.region,
+      AWS_REGION: this.options.region || _.get(this.serverless, 'service.provider.region'),
+      AWS_DEFAULT_REGION: this.options.region || _.get(this.serverless, 'service.provider.region'),
       AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
       AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',
       AWS_LAMBDA_FUNCTION_NAME: lambdaName,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Avoids setting `AWS_REGION` and `AWS_DEFAULT_REGION` to `undefined` when the it should come from the config.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
just grab it from the config  and use it instead if `options.region` is falsey.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
run a lamba with `sls invoke local` that returns `process.env.AWS_REGION`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
