### PR TITLE
Update example custom variable syntax to work with loading files

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -292,7 +292,7 @@ service: new-service
 provider:
   name: aws
   runtime: nodejs6.10
-  variableSyntax: "\\${{([\\s\\S]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
+  variableSyntax: "\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
 
 custom:
   myStage: ${{opt:stage}}

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -164,7 +164,9 @@ describe('Service', () => {
       .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}'
+        );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
@@ -218,7 +220,9 @@ describe('Service', () => {
       .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}'
+        );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
@@ -272,7 +276,9 @@ describe('Service', () => {
       .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}'
+        );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -131,7 +131,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([\\s\\S]+?)}}',
+          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -164,7 +164,7 @@ describe('Service', () => {
       .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([\\s\\S]+?)}}');
+        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}');
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
@@ -186,7 +186,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([\\s\\S]+?)}}',
+          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -218,7 +218,7 @@ describe('Service', () => {
       .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([\\s\\S]+?)}}');
+        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}');
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
@@ -240,7 +240,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([\\s\\S]+?)}}',
+          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -272,7 +272,7 @@ describe('Service', () => {
       .then(() => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([\\s\\S]+?)}}');
+        expect(serviceInstance.provider.variableSyntax).to.equal('\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}');
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
         expect(serviceInstance.resources.azure).to.deep.equal({});
@@ -293,7 +293,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([\\s\\S]+?)}}',
+          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -724,7 +724,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([\\s\\S]+?)}}',
+          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -32,7 +32,7 @@ describe('Variables', () => {
     it('should set variableSyntax', () => {
       const serverless = new Serverless();
 
-      serverless.service.provider.variableSyntax = '\\${{([\\s\\S]+?)}}';
+      serverless.service.provider.variableSyntax = '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}';
 
       serverless.variables.loadVariableSyntax();
       expect(serverless.variables.variableSyntax).to.be.a('RegExp');
@@ -55,7 +55,7 @@ describe('Variables', () => {
     it('should use variableSyntax', () => {
       const serverless = new Serverless();
 
-      const variableSyntax = '\\${{([\\s\\S]+?)}}';
+      const variableSyntax = '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}';
       const fooValue = '${clientId()}';
       const barValue = 'test';
 


### PR DESCRIPTION
## What did you implement:

Updated the documentation and tests to use a valid custom variable syntax. The existing example did not work when doing, for example:

```yaml
custom:
  foo: ${{file(config/${{opt:stage, self:provider.stage}}.js):vars}}
```

## How did you implement it:

Used the default variable syntax string and modified it to match the existing custom syntax example of `${{…}}`.

## How can we verify it:

Compare the custom example in the documentation against the default variable syntax.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
