### PR TITLE
Ignore custom plugins in the project when uploading artifacts

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -13,6 +13,7 @@ module.exports = {
     'serverless.yaml',
     'serverless.json',
     '.serverless/**',
+    '.serverless_plugins/**',
   ],
 
   getIncludes(include) {

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -82,7 +82,8 @@ describe('#packageService()', () => {
         '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log', 'serverless.yml',
         'serverless.yaml', 'serverless.json',
-        '.serverless/**', 'dir', 'file.js',
+        '.serverless/**', '.serverless_plugins/**',
+        'dir', 'file.js',
       ]);
     });
 
@@ -101,8 +102,8 @@ describe('#packageService()', () => {
         '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log', 'serverless.yml',
         'serverless.yaml', 'serverless.json',
-        '.serverless/**', 'dir', 'file.js',
-        'lib', 'other.js',
+        '.serverless/**', '.serverless_plugins/**',
+        'dir', 'file.js', 'lib', 'other.js',
       ]);
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR
-->

When packaging a service, if you've implemented [custom plugins](https://serverlesscode.com/post/customizing-serverless-with-plugins/) within the project, they're uploaded along with your functions. Given that plugins by definition run on the deploying machine, they shouldn't be included. 

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Added `.serverless_plugins/**` to the default excludes.

## How can we verify it:

- Create a project with a custom plugin in `.serverless_plugins`
- Run `sls package`
- Run `unzip -l .serverless/[service_name].zip` and see that the plugin is included
- Run again with this patch, and see that it's excluded.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
