### PR TITLE
Document that variable refs aren't resolved at plugin constructor exe…

### DIFF
--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -316,6 +316,12 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
+**Note:**
+[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
+in the `serverless` instance are not resolved before a Plugin's constructor is
+called, so if you need these, make sure to wait to access those from
+[#hooks](hooks into lifecycle events).
+
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.

--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -316,11 +316,7 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-**Note:**
-[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
-in the `serverless` instance are not resolved before a Plugin's constructor is
-called, so if you need these, make sure to wait to access those from
-[#hooks](hooks into lifecycle events).
+**Note:** [Variable references](./variables.md#reference-properties-in-serverlessyml) in the `serverless` instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your [hooks](#hooks).
 
 ### Command Naming
 

--- a/docs/providers/azure/guide/plugins.md
+++ b/docs/providers/azure/guide/plugins.md
@@ -347,11 +347,7 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-**Note:**
-[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
-in the `serverless` instance are not resolved before a Plugin's constructor is
-called, so if you need these, make sure to wait to access those from
-[#hooks](hooks into lifecycle events).
+**Note:** [Variable references](./variables.md#reference-properties-in-serverlessyml) in the `serverless` instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your [hooks](#hooks).
 
 ### Command Naming
 

--- a/docs/providers/azure/guide/plugins.md
+++ b/docs/providers/azure/guide/plugins.md
@@ -347,6 +347,12 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
+**Note:**
+[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
+in the `serverless` instance are not resolved before a Plugin's constructor is
+called, so if you need these, make sure to wait to access those from
+[#hooks](hooks into lifecycle events).
+
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify

--- a/docs/providers/google/guide/plugins.md
+++ b/docs/providers/google/guide/plugins.md
@@ -315,6 +315,12 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
+**Note:**
+[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
+in the `serverless` instance are not resolved before a Plugin's constructor is
+called, so if you need these, make sure to wait to access those from
+[#hooks](hooks into lifecycle events).
+
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.

--- a/docs/providers/google/guide/plugins.md
+++ b/docs/providers/google/guide/plugins.md
@@ -315,11 +315,7 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-**Note:**
-[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
-in the `serverless` instance are not resolved before a Plugin's constructor is
-called, so if you need these, make sure to wait to access those from
-[#hooks](hooks into lifecycle events).
+**Note:** [Variable references](./variables.md#reference-properties-in-serverlessyml) in the `serverless` instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your [hooks](#hooks).
 
 ### Command Naming
 

--- a/docs/providers/openwhisk/guide/plugins.md
+++ b/docs/providers/openwhisk/guide/plugins.md
@@ -316,6 +316,12 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
+**Note:**
+[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
+in the `serverless` instance are not resolved before a Plugin's constructor is
+called, so if you need these, make sure to wait to access those from
+[#hooks](hooks into lifecycle events).
+
 ### Command Naming
 
 Command names need to be unique. If we load two commands and both want to specify the same command (e.g. we have an integrated command `deploy` and an external command also wants to use `deploy`) the Serverless CLI will print an error and exit. If you want to have your own `deploy` command you need to name it something different like `myCompanyDeploy` so they don't clash with existing plugins.

--- a/docs/providers/openwhisk/guide/plugins.md
+++ b/docs/providers/openwhisk/guide/plugins.md
@@ -316,11 +316,7 @@ class MyPlugin {
 module.exports = MyPlugin;
 ```
 
-**Note:**
-[Variable references](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-properties-in-serverlessyml)
-in the `serverless` instance are not resolved before a Plugin's constructor is
-called, so if you need these, make sure to wait to access those from
-[#hooks](hooks into lifecycle events).
+**Note:** [Variable references](./variables.md#reference-properties-in-serverlessyml) in the `serverless` instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your [hooks](#hooks).
 
 ### Command Naming
 


### PR DESCRIPTION
…cution time

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Documented some plugin API behavior that surprised me (it changed in v1.13 IIRC) and [another user](http://forum.serverless.com/t/serverless-plugin-resolving-variable-references/2233)

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
I wrote some docs.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
n/a?

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
