### PR TITLE
fixed unhandled rejection errors in Utils test

### DIFF
--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const os = require('os');
-const expect = require('chai').expect;
+const chai = require('chai');
 const sinon = require('sinon');
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
@@ -10,6 +10,8 @@ const configUtils = require('../utils/config');
 const serverlessVersion = require('../../package.json').version;
 const segment = require('../utils/segment');
 const proxyquire = require('proxyquire');
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('Utils', () => {
   let utils;
@@ -83,7 +85,7 @@ describe('Utils', () => {
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
-      return serverless.yamlParser.parse(tmpFilePath).then((obj) => {
+      return expect(serverless.yamlParser.parse(tmpFilePath)).to.be.fulfilled.then((obj) => {
         expect(obj.foo).to.equal('bar');
       });
     });
@@ -93,7 +95,7 @@ describe('Utils', () => {
 
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
-      return serverless.yamlParser.parse(tmpFilePath).then((obj) => {
+      return expect(serverless.yamlParser.parse(tmpFilePath)).to.be.fulfilled.then((obj) => {
         expect(obj.foo).to.equal('bar');
       });
     });
@@ -108,7 +110,8 @@ describe('Utils', () => {
       const tmpFilePath = testUtils.getTmpFilePath('anything.json');
 
       // note: use return when testing promises otherwise you'll have unhandled rejection errors
-      return serverless.utils.writeFile(tmpFilePath, { foo: 'bar' }).then(() => {
+      return expect(serverless.utils.writeFile(tmpFilePath, { foo: 'bar' }))
+      .to.be.fulfilled.then(() => {
         const obj = serverless.utils.readFileSync(tmpFilePath);
 
         expect(obj.foo).to.equal('bar');
@@ -178,7 +181,7 @@ describe('Utils', () => {
       serverless.utils.writeFileSync(tmpFilePath, { foo: 'bar' });
 
       // note: use return when testing promises otherwise you'll have unhandled rejection errors
-      return serverless.utils.readFile(tmpFilePath).then((obj) => {
+      return expect(serverless.utils.readFile(tmpFilePath)).to.be.fulfilled.then((obj) => {
         expect(obj.foo).to.equal('bar');
       });
     });
@@ -349,7 +352,7 @@ describe('Utils', () => {
       // help is a whitelisted option
       serverless.processedInput.options = options;
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(trackStub.calledOnce).to.equal(true);
         expect(getConfigStub.calledOnce).to.equal(true);
 
@@ -365,7 +368,7 @@ describe('Utils', () => {
         frameworkId: '1234wasd',
       });
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(isDockerContainerStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
@@ -403,7 +406,7 @@ describe('Utils', () => {
         },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -445,7 +448,7 @@ describe('Utils', () => {
       };
 
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -484,7 +487,7 @@ describe('Utils', () => {
         },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -525,7 +528,7 @@ describe('Utils', () => {
         },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -566,7 +569,7 @@ describe('Utils', () => {
         },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -605,7 +608,7 @@ describe('Utils', () => {
         },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -646,7 +649,7 @@ describe('Utils', () => {
         },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -667,12 +670,9 @@ describe('Utils', () => {
         provider: {
           name: 'google',
         },
-        package: {
-          path: 'foo',
-        },
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(getConfigStub.calledOnce).to.equal(true);
         expect(trackStub.calledOnce).to.equal(true);
 
@@ -735,7 +735,7 @@ describe('Utils', () => {
         package: {},
       };
 
-      return utils.logStat(serverless).then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
         expect(trackStub.calledOnce).to.equal(true);
         expect(getConfigStub.calledOnce).to.equal(true);
 

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -23,6 +23,9 @@ describe('Utils', () => {
       '../utils/isDockerContainer': isDockerContainerStub,
     });
     serverless = new Serverless();
+    serverless.service.package = {
+      path: 'foo',
+    };
     utils = new Utils(serverless);
     serverless.init();
   });
@@ -398,6 +401,9 @@ describe('Utils', () => {
             ],
           },
         },
+        package: {
+          path: 'foo',
+        },
       };
 
       return utils.logStat(serverless).then(() => {
@@ -436,6 +442,9 @@ describe('Utils', () => {
             ],
           },
         },
+        package: {
+          path: 'foo',
+        },
       };
 
 
@@ -472,6 +481,9 @@ describe('Utils', () => {
               },
             ],
           },
+        },
+        package: {
+          path: 'foo',
         },
       };
 
@@ -511,6 +523,9 @@ describe('Utils', () => {
             ],
           },
         },
+        package: {
+          path: 'foo',
+        },
       };
 
       return utils.logStat(serverless).then(() => {
@@ -549,6 +564,9 @@ describe('Utils', () => {
             ],
           },
         },
+        package: {
+          path: 'foo',
+        },
       };
 
       return utils.logStat(serverless).then(() => {
@@ -584,6 +602,9 @@ describe('Utils', () => {
               },
             ],
           },
+        },
+        package: {
+          path: 'foo',
         },
       };
 
@@ -623,6 +644,9 @@ describe('Utils', () => {
             ],
           },
         },
+        package: {
+          path: 'foo',
+        },
       };
 
       return utils.logStat(serverless).then(() => {
@@ -645,6 +669,9 @@ describe('Utils', () => {
       serverless.service = {
         provider: {
           name: 'google',
+        },
+        package: {
+          path: 'foo',
         },
       };
 

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -23,9 +23,6 @@ describe('Utils', () => {
       '../utils/isDockerContainer': isDockerContainerStub,
     });
     serverless = new Serverless();
-    serverless.service.package = {
-      path: 'foo',
-    };
     utils = new Utils(serverless);
     serverless.init();
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3920

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Added `pakage.path` element to `serverless.service` object, since errors that can not find the `path` element occurs.

Then, to standardize test code, updated to use chai-as-promised instead of chai.(This is not tha main purpose of this though)

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Please run `npm run test`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
