### PR TITLE
Revert #3903

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -146,22 +146,11 @@ class AwsProvider {
         f()
           .then(resolve)
           .catch((e) => {
-            const err = e;
-            if (err.statusCode === 429) {
+            if (e.statusCode === 429) {
               that.serverless.cli.log("'Too many requests' received, sleeping 5 seconds");
               setTimeout(doCall, 5000);
             } else {
-              if (err.message.match(/(.+security token.+is )+(invalid)*|(expired)*/)) {
-                const errorMessage = [
-                  'The AWS security token included in the request is invalid / expired.\n',
-                  '  Please re-authenticate if you\'re using MFA.\n',
-                  '  Or check your ~./aws/credentials file and verify your keys are correct.\n',
-                  '  More information on setting up credentials',
-                  ` can be found here: ${chalk.green('https://git.io/vXsdd')}.`,
-                ].join('');
-                err.message = errorMessage;
-              }
-              reject(new this.serverless.classes.Error(err.message, err.statusCode));
+              reject(e);
             }
           });
       };

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -3,7 +3,6 @@
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const chalk = require('chalk');
 
 const AwsProvider = require('./awsProvider');
 const Serverless = require('../../../Serverless');
@@ -213,43 +212,6 @@ describe('AwsProvider', () => {
       awsProvider.request('S3', 'error', {})
         .then(() => done('Should not succeed'))
         .catch(() => done());
-    });
-
-    it('should ask to re-authenticate MFA or check if AWS credentials are valid', (done) => {
-      const error = {
-        statusCode: 403,
-        message: 'The security token included in the request is invalid',
-      };
-      class FakeS3 {
-        constructor(credentials) {
-          this.credentials = credentials;
-        }
-
-        error() {
-          return {
-            send(cb) {
-              cb(error);
-            },
-          };
-        }
-      }
-      awsProvider.sdk = {
-        S3: FakeS3,
-      };
-      awsProvider.request('S3', 'error', {})
-        .then(() => done('Should not succeed'))
-        .catch((err) => {
-          const errorMessage = [
-            'The AWS security token included in the request is invalid / expired.\n',
-            '  Please re-authenticate if you\'re using MFA.\n',
-            '  Or check your ~./aws/credentials file and verify your keys are correct.\n',
-            '  More information on setting up credentials',
-            ` can be found here: ${chalk.green('https://git.io/vXsdd')}.`,
-          ].join('');
-          expect(err.message).to.equal(errorMessage);
-          done();
-        })
-        .catch(done);
     });
 
     it('should return ref to docs for missing credentials', (done) => {


### PR DESCRIPTION
Reverts #3903 cause it's preventing users to deploy new services because it catches the "stack does not exist" error, which we've been ignoring and updating instead.