### PR TITLE
Handle Export errors when deleting CF stack

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -74,7 +74,9 @@ module.exports = {
                     }
                     // Keep track of first failed event
                     if (eventStatus
-                      && eventStatus.endsWith('FAILED') && stackLatestError === null) {
+                      && (eventStatus.endsWith('FAILED')
+                      || eventStatus === 'UPDATE_ROLLBACK_IN_PROGRESS')
+                      && stackLatestError === null) {
                       stackLatestError = event;
                     }
                     // Log stack events
@@ -102,6 +104,8 @@ module.exports = {
                 || (stackStatus
                     && stackStatus.endsWith('ROLLBACK_COMPLETE')
                     && this.options.verbose)) {
+                  // empty console.log for a prettier output
+                  if (!this.options.verbose) this.serverless.cli.consoleLog('');
                   this.serverless.cli.log('Deployment failed!');
                   let errorMessage = 'An error occurred while provisioning your stack: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -646,5 +646,69 @@ describe('monitorStack', () => {
         awsPlugin.provider.request.restore();
       });
     });
+
+    it('should record an error and fail the update if stack status is UPDATE_ROLLBACK_IN_PROGRESS', () => {
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            LogicalResourceId: 'mocha',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateRollbackEvent = {
+        StackEvents: [
+          {
+            EventId: '1i2j3k4l',
+            LogicalResourceId: 'mocha',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
+            ResourceStatusReason: 'Export is in use',
+          },
+        ],
+      };
+      const updateRollbackCompleteEvent = {
+        StackEvents: [
+          {
+            EventId: '1m2n3o4p',
+            LogicalResourceId: 'mocha',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_ROLLBACK_COMPLETE',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).resolves(updateStartEvent);
+      describeStackEventsStub.onCall(1).resolves(updateRollbackEvent);
+      describeStackEventsStub.onCall(2).resolves(updateRollbackCompleteEvent);
+
+      return awsPlugin.monitorStack('update', cfDataMock, 10).catch((e) => {
+        let errorMessage = 'An error occurred while provisioning your stack: ';
+        errorMessage += 'mocha - Export is in use.';
+        expect(e.name).to.be.equal('ServerlessError');
+        expect(e.message).to.be.equal(errorMessage);
+        // callCount is 2 because Serverless will immediately exits and shows the error
+        expect(describeStackEventsStub.callCount).to.be.equal(2);
+        expect(describeStackEventsStub.calledWithExactly(
+          'CloudFormation',
+          'describeStackEvents',
+          {
+            StackName: cfDataMock.StackId,
+          },
+          awsPlugin.options.stage,
+          awsPlugin.options.region
+        )).to.be.equal(true);
+        awsPlugin.provider.request.restore();
+      });
+    });
   });
 });

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -647,7 +647,7 @@ describe('monitorStack', () => {
       });
     });
 
-    it('should record an error and fail the update if stack status is UPDATE_ROLLBACK_IN_PROGRESS', () => {
+    it('should record an error and fail if status is UPDATE_ROLLBACK_IN_PROGRESS', () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {
         StackId: 'new-service-dev',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When calling `remove` on a stack, if there was an Export being used by another stack, no '_FAILED' status would occur but an 'UPDATE_ROLLBACK_IN_PROGRESS' would immediately fire. Serverless was silently throwing with a 'Cannot read property 'LogicalResourceId' of null' message because the reason the rollback started wasn't capture as an error. This resolves this situation and fails with the correct error message.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Catches the 'UPDATE_ROLLBACK_IN_PROGRESS' state if there is no previous error. Basically, if an '_FAILED' comes first, the rollback event is ignored. If a rollback event happens when there's no previous failed event, it treats the rollback event as a failure.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create two stacks, one that depends on an export from the other. Try and remove the depended upon stack.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
