### PR TITLE
Remove provider name validation

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -92,16 +92,6 @@ class Service {
           };
         }
 
-        const providers = ['aws', 'azure', 'google', 'openwhisk'];
-        if (providers.indexOf(serverlessFile.provider.name) === -1) {
-          const errorMessage = [
-            `Provider "${serverlessFile.provider.name}" is not supported.`,
-            ` Valid values for provider are: ${providers.join(', ')}.`,
-            ` Please provide one of those values to the "provider" property in ${serviceFilename}`,
-          ].join('');
-          throw new ServerlessError(errorMessage);
-        }
-
         if (_.isObject(serverlessFile.service)) {
           that.serviceObject = serverlessFile.service;
           that.service = serverlessFile.service.name;

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -571,24 +571,6 @@ describe('Service', () => {
         expect(serviceInstance.functions).to.deep.equal({});
       });
     });
-
-    it('should reject if provider property is invalid', () => {
-      const SUtils = new Utils();
-      const serverlessYml = {
-        service: 'service-name',
-        provider: 'invalid',
-        functions: {},
-      };
-
-      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
-        YAML.dump(serverlessYml));
-
-      const serverless = new Serverless({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
-
-      return expect(serviceInstance.load()).to.eventually.be
-        .rejectedWith('Provider "invalid" is not supported.');
-    });
   });
 
   describe('#validate()', () => {


### PR DESCRIPTION
## What did you implement:

Closes #3611

Removes the provider name validation to make it possible to support other 3rd party provider plugins.

## How did you implement it:

Removed the check if for the `provider` name.

## How can we verify it:

Run the tests / create a new service.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO