### PR TITLE
Add support for a publish flag

### DIFF
--- a/lib/plugins/platform/platform.js
+++ b/lib/plugins/platform/platform.js
@@ -13,6 +13,7 @@ const chalk = require('chalk');
 const configUtils = require('../../utils/config');
 const functionInfoUtils = require('../../utils/functionInfoUtils');
 const createApolloClient = require('../../utils/createApolloClient');
+const selectServicePublish = require('../../utils/selectors/selectServicePublish');
 
 // NOTE Needed for apollo to work
 global.fetch = fetch;
@@ -105,7 +106,8 @@ class Platform {
 
   publishService() {
     const authToken = this.getAuthToken();
-    if (!authToken) {
+    const publishFlag = selectServicePublish(this.serverless.service);
+    if (!authToken || !publishFlag) {
       // NOTE publishService is an opt-in feature and no warning is needed
       return BbPromise.resolve();
     }

--- a/lib/plugins/platform/platform.test.js
+++ b/lib/plugins/platform/platform.test.js
@@ -147,5 +147,20 @@ describe('Platform', () => {
         expect(console.log.calledWithExactly(url)).to.be.equal(true);
       });
     });
+
+    it('should skip publishing if user opted out via "publish" config', () => {
+      platform.serverless.service.service = 'new-service-2';
+      platform.serverless.service.serviceObject = {
+        name: 'new-service-2',
+        publish: false,
+      };
+
+      return platform.publishService().then(() => {
+        expect(getAuthTokenStub.calledOnce).to.be.equal(true);
+        expect(getAccountIdStub.calledOnce).to.be.equal(false);
+        expect(endpointsRequestStub.calledOnce).to.be.equal(false);
+        expect(publishServiceRequestStub.calledOnce).to.be.equal(false);
+      });
+    });
   });
 });

--- a/lib/utils/selectors/selectServicePublish.js
+++ b/lib/utils/selectors/selectServicePublish.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const _ = require('lodash');
+
+const selectServicePublish = (service) => _.get(service, 'serviceObject.publish', true);
+
+module.exports = selectServicePublish;

--- a/lib/utils/selectors/selectServicePublish.test.js
+++ b/lib/utils/selectors/selectServicePublish.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const expect = require('chai').expect;
+const selectServicePublish = require('./selectServicePublish');
+
+describe('#selectServicePublish()', () => {
+  it('should return the publish value of the service object', () => {
+    const service = {
+      serviceObject: {
+        publish: true,
+      },
+    };
+
+    const result = selectServicePublish(service);
+
+    expect(result).to.equal(true);
+  });
+});


### PR DESCRIPTION
## What did you implement:
This PR adds support for a publish flag so that you can disable publishing to the platform during deploy on a service by service basis.

## How did you implement it:

Added support for the flag at the `service` level
```yaml
service:
  name: my-service
  publish: false  #defaults to true
```

## How can we verify it:

- login to platform
- deploy a service
- service should successfully publish to platform
- set `service.publish` to `false`
- deploy again
- service should skip publishing to platform

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO