### PR TITLE
Add note to change directory into service prior to deployment

### DIFF
--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -160,7 +160,13 @@ Create this file and add event data so you can invoke your function with the dat
 
 When you deploy a Service, all of the Functions, Events and Resources in your `serverless.yml` are translated to an AWS CloudFormation template and deployed as a single CloudFormation stack.
 
-To deploy a service, use the `deploy` command:
+To deploy a service, first 'cd' into the relevant service directory:
+
+```bash
+cd myService
+```
+
+Then use the `deploy` command:
 
 ```bash
 serverless deploy

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -160,10 +160,10 @@ Create this file and add event data so you can invoke your function with the dat
 
 When you deploy a Service, all of the Functions, Events and Resources in your `serverless.yml` are translated to an AWS CloudFormation template and deployed as a single CloudFormation stack.
 
-To deploy a service, first 'cd' into the relevant service directory:
+To deploy a service, first `cd` into the relevant service directory:
 
 ```bash
-cd myService
+cd my-service
 ```
 
 Then use the `deploy` command:

--- a/docs/providers/azure/guide/services.md
+++ b/docs/providers/azure/guide/services.md
@@ -115,7 +115,13 @@ When you deploy a Service, all of the Functions, and Events in your
 `serverless.yml` are translated into calls to the platform API to dynamically
 define those resources.
 
-To deploy a service, use the `deploy` command:
+To deploy a service, first `cd` into the relevant service directory:
+
+```bash
+cd my-service
+```
+
+Then use the `deploy` command:
 
 ```bash
 serverless deploy

--- a/docs/providers/google/guide/services.md
+++ b/docs/providers/google/guide/services.md
@@ -100,7 +100,13 @@ The `index.js` file contains your exported functions.
 
 When you deploy a Service, all of the Functions, and Events in your `serverless.yml` are translated into calls to the Google Cloud API to dynamically define those resources.
 
-To deploy a service, use the `deploy` command:
+To deploy a service, first `cd` into the relevant service directory:
+
+```bash
+cd my-service
+```
+
+Then use the `deploy` command:
 
 ```bash
 serverless deploy

--- a/docs/providers/openwhisk/guide/services.md
+++ b/docs/providers/openwhisk/guide/services.md
@@ -107,7 +107,13 @@ Create this file and add event data so you can invoke your function with the dat
 
 When you deploy a Service, all of the Functions, Events and Resources in your `serverless.yml` are translated into calls to the platform API to dynamically define those resources.
 
-To deploy a service, use the `deploy` command:
+To deploy a service, first `cd` into the relevant service directory:
+
+```bash
+cd my-service
+```
+
+Then use the `deploy` command:
 
 ```bash
 serverless deploy


### PR DESCRIPTION
Be sure to 'cd' into the relevant service directory before running the 'deploy' command, otherwise you'll likely see the following error message: "Avoid the following error: "This command can only be run inside a service directory".

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
