### PR TITLE
Update AWS documentation to include an example of what an event contains

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -72,6 +72,69 @@ module.exports.hello = function(event, context, callback) {
 JSON.parse(event.body);
 ```
 
+### Example event
+
+```
+{
+    "resource": "/",
+    "path": "/",
+    "httpMethod": "POST",
+    "headers": {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB,en-US;q=0.8,en;q=0.6,zh-CN;q=0.4",
+        "cache-control": "max-age=0",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Viewer-Country": "GB",
+        "content-type": "application/x-www-form-urlencoded",
+        "Host": "j3ap25j034.execute-api.eu-west-2.amazonaws.com",
+        "origin": "https://j3ap25j034.execute-api.eu-west-2.amazonaws.com",
+        "Referer": "https://j3ap25j034.execute-api.eu-west-2.amazonaws.com/dev/",
+        "upgrade-insecure-requests": "1",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36",
+        "Via": "2.0 a3650115c5e21e2b5d133ce84464bea3.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Id": "0nDeiXnReyHYCkv8cc150MWCFCLFPbJoTs1mexDuKe2WJwK5ANgv2A==",
+        "X-Amzn-Trace-Id": "Root=1-597079de-75fec8453f6fd4812414a4cd",
+        "X-Forwarded-For": "50.129.117.14, 50.112.234.94",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "queryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "path": "/dev/",
+        "accountId": "125002137610",
+        "resourceId": "qdolsr1yhk",
+        "stage": "dev",
+        "requestId": "0f2431a2-6d2f-11e7-b799-5152aa497861",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "apiKey": "",
+            "sourceIp": "50.129.117.14",
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36",
+            "user": null
+        },
+        "resourcePath": "/",
+        "httpMethod": "POST",
+        "apiId": "j3azlsj0c4"
+    },
+    "body": "postcode=LS17FR",
+    "isBase64Encoded": false
+}
+```
+
 ### HTTP Endpoint with Extended Options
 
 Here we've defined an POST endpoint for the path `posts/create`.


### PR DESCRIPTION
## What did you implement:

Added example of what an event contains, because I couldn't find it in the documentation. 

## How did you implement it:

Trivial change, I deployed a function which included `console.log(JSON.stringify(event))`, obfuscated a few values and updated the file.

## How can we verify it:

As above, create a simple function which logs to CloudWatch.

## Todos:

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
