### PR TITLE
Kubeless template for python and nodejs

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -18,10 +18,12 @@ const validTemplates = [
   'aws-csharp',
   'aws-fsharp',
   'azure-nodejs',
+  'google-nodejs',
+  'kubeless-python',
+  'kubeless-nodejs',
   'openwhisk-nodejs',
   'openwhisk-python',
   'openwhisk-swift',
-  'google-nodejs',
   'plugin',
 
   // this template is used to streamline the onboarding process

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -387,6 +387,38 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "kubeless-python" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'kubeless-python';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'package.json')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.py')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+      });
+    });
+
+    it('should generate scaffolding for "kubeless-nodejs" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'kubeless-nodejs';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'package.json')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.js')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+      });
+    });
+
     it('should generate scaffolding for "plugin" template', () => {
       process.chdir(tmpDir);
       create.options.template = 'plugin';

--- a/lib/plugins/create/templates/kubeless-nodejs/gitignore
+++ b/lib/plugins/create/templates/kubeless-nodejs/gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/kubeless-nodejs/handler.js
+++ b/lib/plugins/create/templates/kubeless-nodejs/handler.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = {
+  capitalize(req, res) {
+    let body = [];
+    req.on('error', (err) => {
+      console.error(err);
+    }).on('data', (chunk) => {
+      body.push(chunk);
+    }).on('end', () => {
+      body = Buffer.concat(body).toString();
+      res.end(_.capitalize(body));
+    });
+  },
+};

--- a/lib/plugins/create/templates/kubeless-nodejs/package.json
+++ b/lib/plugins/create/templates/kubeless-nodejs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "kubeless-nodejs",
+  "version": "1.0.0",
+  "description": "Example function for serverless kubeless",
+  "dependencies": {
+    "serverless-kubeless": "^0.1.3",
+    "lodash": "^4.1.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "serverless",
+    "kubeless"
+  ],
+  "author": "The Kubeless Authors",
+  "license": "Apache-2.0"
+}

--- a/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
@@ -1,0 +1,27 @@
+# Welcome to Serverless!
+#
+# For full config options, check the kubeless plugin docs:
+#    https://github.com/serverless/serverless-kubeless
+#
+# For documentation on kubeless itself:
+#    http://kubeless.io
+
+# Update the service name below with your own service name
+service: capitalize
+
+# Please ensure the serverless-kubeless provider plugin is installed globally.
+# $ npm install -g serverless-kubeless
+#
+# ...before installing project dependencies to register this provider.
+# $ npm install
+
+provider:
+  name: kubeless
+  runtime: nodejs6.10
+
+plugins:
+  - serverless-kubeless
+
+functions:
+  capitalize:
+    handler: handler.capitalize

--- a/lib/plugins/create/templates/kubeless-python/gitignore
+++ b/lib/plugins/create/templates/kubeless-python/gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/kubeless-python/handler.py
+++ b/lib/plugins/create/templates/kubeless-python/handler.py
@@ -1,0 +1,14 @@
+import json
+
+def hello(request):
+    body = {
+        "message": "Go Serverless v1.0! Your function executed successfully!",
+        "input": request.json
+    }
+
+    response = {
+        "statusCode": 200,
+        "body": json.dumps(body)
+    }
+
+    return response

--- a/lib/plugins/create/templates/kubeless-python/package.json
+++ b/lib/plugins/create/templates/kubeless-python/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "kubeless-python",
+  "version": "1.0.0",
+  "description": "Sample Kubeless Python serverless framework service.",
+  "dependencies": {
+    "serverless-kubeless": "^0.1.3"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "serverless",
+    "kubeless"
+  ],
+  "author": "The Kubeless Authors",
+  "license": "Apache-2.0"
+}

--- a/lib/plugins/create/templates/kubeless-python/serverless.yml
+++ b/lib/plugins/create/templates/kubeless-python/serverless.yml
@@ -1,0 +1,27 @@
+# Welcome to Serverless!
+#
+# For full config options, check the kubeless plugin docs:
+#    https://github.com/serverless/serverless-kubeless
+#
+# For documentation on kubeless itself:
+#    http://kubeless.io
+
+# Update the service name below with your own service name
+service: hello-world
+
+# Please ensure the serverless-kubeless provider plugin is installed globally.
+# $ npm install -g serverless-kubeless
+#
+# ...before installing project dependencies to register this provider.
+# $ npm install
+
+provider:
+  name: kubeless
+  runtime: python2.7
+
+plugins:
+  - serverless-kubeless
+
+functions:
+  hello:
+    handler: handler.hello


### PR DESCRIPTION
## What did you implement:

Closes #3969

template creation for kubeless provider

## How did you implement it:

add templates in `lib/plugins/create/templates/kubeless-python`
and `lib/plugins/create/templates/kubeless-nodejs`

modified:

`lib/plugins/create/create.js`
`lib/plugins/create/create.test.js`

Plus the removal of the provider validation in:

https://github.com/serverless/serverless/pull/3941

## How can we verify it:

Install the PR and try:

```
serverless create --template kubeless-nodejs --path sebgoa
Serverless: Generating boilerplate...
Serverless: Generating boilerplate in "/Users/sebgoa/Desktop/foobar/sebgoa"
 _______                             __
|   _   .-----.----.--.--.-----.----|  .-----.-----.-----.
|   |___|  -__|   _|  |  |  -__|   _|  |  -__|__ --|__ --|
|____   |_____|__|  \___/|_____|__| |__|_____|_____|_____|
|   |   |             The Serverless Application Framework
|       |                           serverless.com, v1.17.0
 -------'

Serverless: Successfully generated boilerplate for template: "kubeless-nodejs"
```

or

```
serverless create --template kubeless-python --path foobar
```

## Todos:

- [ ] Write tests
- [ ] Write documentation

***Is this ready for review?:*** YES

But this also include the change pending in https://github.com/serverless/serverless/pull/3941

And let me know when you are ready to merge, as we will increment the plugin version number in the PR before merge.

***Is it a breaking change?:*** NO
