### PR TITLE
Fix function retrieval for "deploy list functions" command

### DIFF
--- a/lib/plugins/aws/deployList/index.js
+++ b/lib/plugins/aws/deployList/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 const validate = require('../lib/validate');
 const findAndGroupDeployments = require('../utils/findAndGroupDeployments');
 const setBucketName = require('../lib/setBucketName');
@@ -76,24 +77,19 @@ class AwsDeployList {
   }
 
   getFunctions() {
-    const params = {
-      MaxItems: 200,
-    };
+    const funcs = this.serverless.service.getAllFunctionsNames();
 
-    return this.provider.request('Lambda',
-      'listFunctions',
-      params,
-      this.options.stage,
-      this.options.region)
-      .then((result) => {
-        const allFuncs = result.Functions;
+    return BbPromise.map(funcs, (funcName) => {
+      const params = {
+        FunctionName: funcName,
+      };
 
-        const serviceName = `${this.serverless.service.service}-${this.options.stage}`;
-        const regex = new RegExp(serviceName);
-        const serviceFuncs = allFuncs.filter((func) => func.FunctionName.match(regex));
-
-        return BbPromise.resolve(serviceFuncs);
-      });
+      return this.provider.request('Lambda',
+        'getFunction',
+        params,
+        this.options.stage,
+        this.options.region);
+    }).then((result) => _.map(result, (item) => item.Configuration));
   }
 
   getFunctionVersions(funcs) {

--- a/lib/plugins/aws/deployList/index.test.js
+++ b/lib/plugins/aws/deployList/index.test.js
@@ -125,39 +125,39 @@ describe('AwsDeployList', () => {
     let listFunctionsStub;
 
     beforeEach(() => {
-      listFunctionsStub = sinon
-        .stub(awsDeployList.provider, 'request')
-        .resolves({
-          Functions: [
-            { FunctionName: 'listDeployments-dev-func1' },
-            { FunctionName: 'listDeployments-dev-func2' },
-            { FunctionName: 'unrelatedService-dev-func3' },
-            { FunctionName: 'unrelatedService-dev-func4' },
-          ],
-        });
+      awsDeployList.serverless.service.functions = {
+        func1: {
+          name: 'listDeployments-dev-func1',
+        },
+        func2: {
+          name: 'listDeployments-dev-func2',
+        },
+      };
+      listFunctionsStub = sinon.stub(awsDeployList.provider, 'request');
+      listFunctionsStub.onCall(0).resolves({
+        Configuration: {
+          FunctionName: 'listDeployments-dev-func1',
+        },
+      });
+      listFunctionsStub.onCall(1).resolves({
+        Configuration: {
+          FunctionName: 'listDeployments-dev-func2',
+        },
+      });
     });
 
     afterEach(() => {
       awsDeployList.provider.request.restore();
     });
 
-    it('should get all functions and filter out the service related ones', () => {
+    it('should get all service related functions', () => {
       const expectedResult = [
         { FunctionName: 'listDeployments-dev-func1' },
         { FunctionName: 'listDeployments-dev-func2' },
       ];
 
       return awsDeployList.getFunctions().then((result) => {
-        expect(listFunctionsStub.calledOnce).to.equal(true);
-        expect(listFunctionsStub.calledWithExactly(
-          'Lambda',
-          'listFunctions',
-          {
-            MaxItems: 200,
-          },
-          awsDeployList.options.stage,
-          awsDeployList.options.region
-        )).to.equal(true);
+        expect(listFunctionsStub.callCount).to.equal(2);
         expect(result).to.deep.equal(expectedResult);
       });
     });


### PR DESCRIPTION
Fix retrieval when too many functions are deployed.