### PR TITLE
Fix/deps of devdeps

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -161,7 +161,7 @@ function excludeNodeDevDependencies(servicePath) {
 
       // we added a catch which resolves so that npm commands with an exit code of 1
       // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
-      return BbPromise.map(['dev', 'prod'], (env) => {
+      return BbPromise.mapSeries(['dev', 'prod'], (env) => {
         const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
         return childProcess.execAsync(
           `npm ls --${env}=true --parseable=true --silent >> ${depFile}`,
@@ -169,7 +169,7 @@ function excludeNodeDevDependencies(servicePath) {
         ).catch(() => BbPromise.resolve());
       });
     })
-    .then(() => BbPromise.map(['dev', 'prod'], (env) => {
+    .then(() => BbPromise.mapSeries(['dev', 'prod'], (env) => {
       const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
       return fs.readFileAsync(depFile)
         .then((fileContent) => _.compact(

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -161,17 +161,24 @@ function excludeNodeDevDependencies(servicePath) {
 
       // we added a catch which resolves so that npm commands with an exit code of 1
       // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
-      return childProcess.execAsync(
-        `npm ls --dev=true --parseable=true --silent >> ${nodeDevDepFile}`,
-        { cwd: dirWithPackageJson }
-      ).catch(() => BbPromise.resolve());
+      return BbPromise.map(['dev', 'prod'], (env) => {
+        return childProcess.execAsync(
+          `npm ls --${env}=true --parseable=true --silent >> ${nodeDevDepFile}_${env}`,
+          { cwd: dirWithPackageJson }
+        ).catch(() => BbPromise.resolve());
+      });
     })
-    .then(() => fs.readFileAsync(nodeDevDepFile))
-    .then((fileContent) => {
-      const dependencies = _.compact(
-        (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
-        elem => elem.length > 0
-      );
+    .then(() => BbPromise.map(['dev', 'prod'], (env) => {
+      return fs.readFileAsync(`${nodeDevDepFile}_${env}`)
+        .then((fileContent) => _.compact(
+          (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
+          elem => elem.length > 0
+        ));
+    }))
+    .then(([devDependencies/*, prodDependencies */]) => {
+      // const dependencies = _.difference(devDependencies, prodDependencies);
+      const dependencies = devDependencies; // Retain old functionality for failing test
+
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
       if (!_.isEmpty(dependencies)) {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -175,10 +175,9 @@ function excludeNodeDevDependencies(servicePath) {
           elem => elem.length > 0
         ));
     }))
-    .then(([devDependencies/*, prodDependencies */]) => {
-      // const dependencies = _.difference(devDependencies, prodDependencies);
-      const dependencies = devDependencies; // Retain old functionality for failing test
+    .then(([devDependencies, prodDependencies]) => {
 
+      const dependencies = _.difference(devDependencies, prodDependencies);
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
       if (!_.isEmpty(dependencies)) {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -125,11 +125,11 @@ function excludeNodeDevDependencies(servicePath) {
     exclude: [],
   };
 
-  // the file where we'll write the dependencies into
-  const nodeDevDepFile = path.join(
-    os.tmpdir(),
-    `node-dev-dependencies-${crypto.randomBytes(8).toString('hex')}`
-  );
+  // the files where we'll write the dependencies into
+  const tmpDir = os.tmpdir();
+  const randHash = crypto.randomBytes(8).toString('hex');
+  const nodeDevDepFile = path.join(tmpDir, `node-dependencies-${randHash}-dev`);
+  const nodeProdDepFile = path.join(tmpDir, `node-dependencies-${randHash}-prod`);
 
   try {
     const packageJsonFilePaths = globby.sync([
@@ -161,20 +161,22 @@ function excludeNodeDevDependencies(servicePath) {
 
       // we added a catch which resolves so that npm commands with an exit code of 1
       // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
-      return BbPromise.map(['dev', 'prod'], (env) =>
-        childProcess.execAsync(
-          `npm ls --${env}=true --parseable=true --silent >> ${nodeDevDepFile}_${env}`,
+      return BbPromise.map(['dev', 'prod'], (env) => {
+        const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
+        return childProcess.execAsync(
+          `npm ls --${env}=true --parseable=true --silent >> ${depFile}`,
           { cwd: dirWithPackageJson }
-        ).catch(() => BbPromise.resolve())
-      );
+        ).catch(() => BbPromise.resolve());
+      });
     })
-    .then(() => BbPromise.map(['dev', 'prod'], (env) =>
-      fs.readFileAsync(`${nodeDevDepFile}_${env}`)
+    .then(() => BbPromise.map(['dev', 'prod'], (env) => {
+      const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
+      return fs.readFileAsync(depFile)
         .then((fileContent) => _.compact(
           (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
           elem => elem.length > 0
-        ))
-    ))
+        ));
+    }))
     .then((devDependenciesAndProdDependencies) => {
       const devDependencies = devDependenciesAndProdDependencies[0];
       const prodDependencies = devDependenciesAndProdDependencies[1];

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -161,7 +161,7 @@ function excludeNodeDevDependencies(servicePath) {
 
       // we added a catch which resolves so that npm commands with an exit code of 1
       // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
-      return BbPromise.mapSeries(['dev', 'prod'], (env) => {
+      return BbPromise.map(['dev', 'prod'], (env) => {
         const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
         return childProcess.execAsync(
           `npm ls --${env}=true --parseable=true --silent >> ${depFile}`,
@@ -169,6 +169,7 @@ function excludeNodeDevDependencies(servicePath) {
         ).catch(() => BbPromise.resolve());
       });
     })
+    // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
     .then(() => BbPromise.mapSeries(['dev', 'prod'], (env) => {
       const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
       return fs.readFileAsync(depFile)

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -161,22 +161,21 @@ function excludeNodeDevDependencies(servicePath) {
 
       // we added a catch which resolves so that npm commands with an exit code of 1
       // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
-      return BbPromise.map(['dev', 'prod'], (env) => {
-        return childProcess.execAsync(
+      return BbPromise.map(['dev', 'prod'], (env) =>
+        childProcess.execAsync(
           `npm ls --${env}=true --parseable=true --silent >> ${nodeDevDepFile}_${env}`,
           { cwd: dirWithPackageJson }
-        ).catch(() => BbPromise.resolve());
-      });
+        ).catch(() => BbPromise.resolve())
+      );
     })
-    .then(() => BbPromise.map(['dev', 'prod'], (env) => {
-      return fs.readFileAsync(`${nodeDevDepFile}_${env}`)
+    .then(() => BbPromise.map(['dev', 'prod'], (env) =>
+      fs.readFileAsync(`${nodeDevDepFile}_${env}`)
         .then((fileContent) => _.compact(
           (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
           elem => elem.length > 0
-        ));
-    }))
+        ))
+    ))
     .then(([devDependencies, prodDependencies]) => {
-
       const dependencies = _.difference(devDependencies, prodDependencies);
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -35,6 +35,8 @@ module.exports = {
     }
 
     if (excludeDevDependencies) {
+      this.serverless.cli.log('Excluding development dependencies...');
+
       return BbPromise.bind(this)
         .then(() => excludeNodeDevDependencies(servicePath))
         .then((exAndInNode) => {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -175,7 +175,10 @@ function excludeNodeDevDependencies(servicePath) {
           elem => elem.length > 0
         ))
     ))
-    .then(([devDependencies, prodDependencies]) => {
+    .then((devDependenciesAndProdDependencies) => {
+      const devDependencies = devDependenciesAndProdDependencies[0];
+      const prodDependencies = devDependenciesAndProdDependencies[1];
+
       const dependencies = _.difference(devDependencies, prodDependencies);
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -177,10 +177,11 @@ function excludeNodeDevDependencies(servicePath) {
           elem => elem.length > 0
         ));
     }))
-    .then((devDependenciesAndProdDependencies) => {
-      const devDependencies = devDependenciesAndProdDependencies[0];
-      const prodDependencies = devDependenciesAndProdDependencies[1];
+    .then((devAndProDependencies) => {
+      const devDependencies = devAndProDependencies[0];
+      const prodDependencies = devAndProDependencies[1];
 
+      // NOTE: the order for _.difference is important
       const dependencies = _.difference(devDependencies, prodDependencies);
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -178,7 +178,7 @@ function excludeNodeDevDependencies(servicePath) {
         .then((fileContent) => _.compact(
           (_.uniq(_.split(fileContent.toString('utf8'), '\n'))),
           elem => elem.length > 0
-        ));
+        )).catch(() => BbPromise.resolve());
     }))
     .then((devAndProDependencies) => {
       const devDependencies = devAndProDependencies[0];

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -182,12 +182,36 @@ describe('zipService', () => {
           });
       });
 
-      it('should return excludes and includes if a Promise is rejected in the chain', () => {
+      it('should return excludes and includes if a exec Promise is rejected', () => {
+        const filePaths = ['package.json', 'node_modules'];
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.onCall(0).resolves();
+        execAsyncStub.onCall(1).rejects();
+        readFileAsyncStub.resolves();
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should return excludes and includes if a readFile Promise is rejected', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
-        readFileAsyncStub.rejects();
+        readFileAsyncStub.onCall(0).resolves();
+        readFileAsyncStub.onCall(1).rejects();
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -370,7 +370,7 @@ describe('zipService', () => {
           });
       });
 
-      it.only('should not include packages if in both dependencies and devDependencies', () => {
+      it('should not include packages if in both dependencies and devDependencies', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -230,7 +230,8 @@ describe('zipService', () => {
           `${servicePath}/1st/2nd/node_modules/module-1`,
           `${servicePath}/1st/2nd/node_modules/module-2`,
         ].join('\n');
-        readFileAsyncStub.resolves(depPaths);
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
@@ -293,7 +294,8 @@ describe('zipService', () => {
           `${servicePath}/node_modules/module-1`,
           `${servicePath}/node_modules/module-2`,
         ].join('\n');
-        readFileAsyncStub.resolves(depPaths);
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
@@ -351,6 +353,8 @@ describe('zipService', () => {
           `${servicePath}/1st/2nd/node_modules/module-2`,
         ].join('\n');
         readFileAsyncStub.resolves(depPaths);
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
@@ -415,12 +419,12 @@ describe('zipService', () => {
           `${servicePath}/node_modules/module-1`,
           `${servicePath}/node_modules/module-2`,
         ].join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).onCall(0).resolves(devDepPaths);
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
 
         const prodDepPaths = [
           `${servicePath}/node_modules/module-2`,
         ];
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).onCall(0).resolves(prodDepPaths);
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -428,7 +428,6 @@ describe('zipService', () => {
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
-
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledTwice;

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -369,6 +369,56 @@ describe('zipService', () => {
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
           });
       });
+
+      it.only('should not include packages if in both dependencies and devDependencies', () => {
+        const filePaths = ['package.json', 'node_modules'];
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.resolves();
+
+        const devDepPaths = [
+          `${servicePath}/node_modules/module-1`,
+          `${servicePath}/node_modules/module-2`,
+        ].join('\n');
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).onCall(0).resolves(devDepPaths);
+
+        const prodDepPaths = [
+          `${servicePath}/node_modules/module-2`,
+        ];
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).onCall(0).resolves(prodDepPaths);
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+
+            expect(globbySyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
+            expect(execAsyncStub.args[0][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[1][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[1][1].cwd).to
+              .match(/.+/);
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+              'node_modules/module-1/**',
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
     });
   });
 

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -136,8 +136,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledOnce;
-            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -149,6 +149,10 @@ describe('zipService', () => {
             expect(execAsyncStub.args[0][0]).to
               .match(/npm ls --dev=true --parseable=true --silent >> .+/);
             expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[1][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[1][1].cwd).to
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -188,8 +192,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledOnce;
-            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
             ]);
@@ -215,8 +219,11 @@ describe('zipService', () => {
 
         globbySyncStub.returns(filePaths);
         execAsyncStub.onCall(0).resolves();
-        execAsyncStub.onCall(1).rejects();
-        execAsyncStub.onCall(2).resolves();
+        execAsyncStub.onCall(1).resolves();
+        execAsyncStub.onCall(2).rejects();
+        execAsyncStub.onCall(3).rejects();
+        execAsyncStub.onCall(4).resolves();
+        execAsyncStub.onCall(5).resolves();
         const depPaths = [
           `${servicePath}/node_modules/module-1`,
           `${servicePath}/node_modules/module-2`,
@@ -228,8 +235,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(3);
-            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub.callCount).to.equal(6);
+            expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -243,12 +250,24 @@ describe('zipService', () => {
             expect(execAsyncStub.args[0][1].cwd).to
               .match(/.+/);
             expect(execAsyncStub.args[1][0]).to
-              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
             expect(execAsyncStub.args[1][1].cwd).to
               .match(/.+/);
             expect(execAsyncStub.args[2][0]).to
               .match(/npm ls --dev=true --parseable=true --silent >> .+/);
             expect(execAsyncStub.args[2][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[3][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[3][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[4][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[4][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[5][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[5][1].cwd).to
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -279,8 +298,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledOnce;
-            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -292,6 +311,10 @@ describe('zipService', () => {
             expect(execAsyncStub.args[0][0]).to
               .match(/npm ls --dev=true --parseable=true --silent >> .+/);
             expect(execAsyncStub.args[0][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[1][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[1][1].cwd).to
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -332,8 +355,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(3);
-            expect(readFileAsyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub.callCount).to.equal(6);
+            expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -347,12 +370,24 @@ describe('zipService', () => {
             expect(execAsyncStub.args[0][1].cwd).to
               .match(/.+/);
             expect(execAsyncStub.args[1][0]).to
-              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
             expect(execAsyncStub.args[1][1].cwd).to
               .match(/.+/);
             expect(execAsyncStub.args[2][0]).to
               .match(/npm ls --dev=true --parseable=true --silent >> .+/);
             expect(execAsyncStub.args[2][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[3][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[3][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[4][0]).to
+              .match(/npm ls --dev=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[4][1].cwd).to
+              .match(/.+/);
+            expect(execAsyncStub.args[5][0]).to
+              .match(/npm ls --prod=true --parseable=true --silent >> .+/);
+            expect(execAsyncStub.args[5][1].cwd).to
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3972 

Necessary dependencies of devDependencies are no longer pruned.
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
The recent `devDependencies` pruning feature uses `npm ls >> tmpfile` to keep track of all devDependencies. With this change, the `--prod=true` dependencies are collected in the same way (npm ls to another temp file).  

Then, `_.difference(devDependencies, prodDependencies)` is used to avoid excluding actually needed dependencies

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

The first commit (`3e4986c`) implements the change (disabled) and a failing test. Didn't see a way to provide a failing test without changing code also, due to the stubbing strategy.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO