### PR TITLE
preserve context when executing exported function from .js file

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -252,7 +252,7 @@ class Variables {
             ' Check if your javascript is exporting a function that returns a value.',
           ].join(''));
       }
-      valueToPopulate = returnValueFunction();
+      valueToPopulate = returnValueFunction.call(jsFile);
 
       return BbPromise.resolve(valueToPopulate).then(valueToPopulateResolved => {
         let deepProperties = variableString.replace(matchedFileRefString, '');

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -683,7 +683,7 @@ describe('Variables', () => {
         });
     });
 
-    it('should thow if property exported by a javascript file is not a function', () => {
+    it('should throw if property exported by a javascript file is not a function', () => {
       const serverless = new Serverless();
       const SUtils = new Utils();
       const tmpDirPath = testUtils.getTmpDirPath();
@@ -704,6 +704,25 @@ describe('Variables', () => {
       const jsData = `module.exports.hello=function(){
         return {one:{two:{three: 'hello world'}}}
       };`;
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+
+      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.variables.loadVariableSyntax();
+
+      return serverless.variables.getValueFromFile('file(./hello.js):hello.one.two.three')
+        .then(valueToPopulate => {
+          expect(valueToPopulate).to.equal('hello world');
+        });
+    });
+
+    it('should preserve the exported function context when executing', () => {
+      const serverless = new Serverless();
+      const SUtils = new Utils();
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const jsData = `
+      module.exports.one = {two: {three: 'hello world'}}
+      module.exports.hello=function(){ return this; };`;
 
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3965 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Revised how the function exported from the .js variable file is executed by ensuring the fully required file is passed as the first argument of fn.call to maintain "this"
## How can we verify it:
An example project, [indieisaconcept/serverless-issue-3965](https://github.com/indieisaconcept/serverless-issue-3965) illustrates this issue and steps to reproduce.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
