### PR TITLE
Add notificationArns AWS parameter to enable Cloudformation notifications

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -83,6 +83,8 @@ provider:
     subnetIds:
       - subnetId1
       - subnetId2
+  notificationArns: # List of existing Amazon SNS topics in the same region where notifications about stack events are sent.
+    - 'arn:aws:sns:us-east-1:XXXXXX:mytopic'
 
 package: # Optional deployment packaging configuration
   include: # Specify the directories and files which should be included in the deployment package

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -32,6 +32,10 @@ module.exports = {
       params.RoleARN = this.serverless.service.provider.cfnRole;
     }
 
+    if (this.serverless.service.provider.notificationArns) {
+      params.NotificationARNs = this.serverless.service.provider.notificationArns;
+    }
+
     return this.provider.request(
       'CloudFormation',
       'createStack',

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -71,6 +71,22 @@ describe('createStack', () => {
         awsDeploy.monitorStack.restore();
       });
     });
+
+    it('should use use notificationArns if it is specified', () => {
+      const mytopicArn = 'arn:aws:sns::123456789012:mytopic';
+      awsDeploy.serverless.service.provider.notificationArns = [mytopicArn];
+
+      const createStackStub = sinon
+        .stub(awsDeploy.provider, 'request').resolves();
+      sinon.stub(awsDeploy, 'monitorStack').resolves();
+
+      return awsDeploy.create().then(() => {
+        expect(createStackStub.args[0][2].NotificationARNs)
+          .to.deep.equal([mytopicArn]);
+        awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
+      });
+    });
   });
 
   describe('#createStack()', () => {

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -36,6 +36,10 @@ module.exports = {
       params.RoleARN = this.serverless.service.provider.cfnRole;
     }
 
+    if (this.serverless.service.provider.notificationArns) {
+      params.NotificationARNs = this.serverless.service.provider.notificationArns;
+    }
+
     return this.provider.request('CloudFormation',
       'createStack',
       params,
@@ -70,6 +74,10 @@ module.exports = {
 
     if (this.serverless.service.provider.cfnRole) {
       params.RoleARN = this.serverless.service.provider.cfnRole;
+    }
+
+    if (this.serverless.service.provider.notificationArns) {
+      params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
 
     // Policy must have at least one statement, otherwise no updates would be possible at all

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -94,6 +94,21 @@ describe('updateStack', () => {
         awsDeploy.monitorStack.restore();
       });
     });
+
+    it('should use use notificationArns if it is specified', () => {
+      const mytopicArn = 'arn:aws:sns::123456789012:mytopic';
+      awsDeploy.serverless.service.provider.notificationArns = [mytopicArn];
+
+      const createStackStub = sinon.stub(awsDeploy.provider, 'request').resolves();
+      sinon.stub(awsDeploy, 'monitorStack').resolves();
+
+      return awsDeploy.createFallback().then(() => {
+        expect(createStackStub.args[0][2].NotificationARNs)
+          .to.deep.equal([mytopicArn]);
+        awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
+      });
+    });
   });
 
   describe('#update()', () => {
@@ -170,6 +185,16 @@ describe('updateStack', () => {
       return awsDeploy.update().then(() => {
         expect(updateStackStub.args[0][2].RoleARN)
           .to.equal('arn:aws:iam::123456789012:role/myrole');
+      });
+    });
+
+    it('should use use notificationArns if it is specified', () => {
+      const mytopicArn = 'arn:aws:sns::123456789012:mytopic';
+      awsDeploy.serverless.service.provider.notificationArns = [mytopicArn];
+
+      return awsDeploy.update().then(() => {
+        expect(updateStackStub.args[0][2].NotificationARNs)
+          .to.deep.equal([mytopicArn]);
       });
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added a new AWS provider's property ``notificationArns`` to enable deploy events notification. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html#cfn-cloudformation-stack-notificationarns

Closes #3998

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Set the ``NotificationARNs`` parameter if the ``notificationArns`` provider property is set.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. Create a SNS topic and grab its ARN (i.e.: `arn:aws:sns:us-west-2:1234567890:mytopic`). Optionally you can set up a subscriber to read the messages from the topic and publish them somewhere (i.e. to a [slack channel](https://github.com/robbwagoner/aws-lambda-sns-to-slack)).
2. Add the `notificationArns` property to a `serverless.yml`:

```
provider:
  name: aws
  region: us-west-2
  ...
  notificationArns:
    - arn:aws:sns:us-west-2:1234567890:mytopic
```

3. Run `serverless deploy` and stack events will be sent to the SNS topic.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
