### PR TITLE
Use naming.getStackName method instead of hardcoding.

### DIFF
--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -5,7 +5,7 @@ const BbPromise = require('bluebird');
 module.exports = {
   remove() {
     this.serverless.cli.log('Removing Stack...');
-    const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+    const stackName = this.provider.naming.getStackName();
     const params = {
       StackName: stackName,
     };


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Removes the hardcoding of the stack name generation in remove stack class.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Used the getStackname from the naming lib.

## How can we verify it:

Remove a deployed service. and it works.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
