### PR TITLE
Add check for unknown attributes

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -80,7 +80,11 @@ class Service {
         // check for non recognized attributes
         Object.keys(serverlessFile).forEach((key) => {
           if (this.allowedProperties.indexOf(key) === -1) {
-            throw new ServerlessError(`"${key}" is not recognized. If you are trying to use a custom attribute please use the "custom" object.`); // eslint-disable-line max-len
+            const errorMessage = [
+              `"${key}" is not recognized. If you are trying`,
+              ' to use a custom attribute please use the "custom" object.',
+            ].join('');
+            throw new ServerlessError(errorMessage);
           }
         });
 

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -10,6 +10,17 @@ class Service {
   constructor(serverless, data) {
     this.serverless = serverless;
 
+    this.allowedProperties = [
+      'service',
+      'provider',
+      'custom',
+      'plugins',
+      'functions',
+      'resources',
+      'package',
+      'frameworkVersion',
+    ];
+
     // Default properties
     this.service = null;
     this.serviceObject = null;
@@ -65,6 +76,18 @@ class Service {
       .parse(serviceFilePath)
       .then((serverlessFileParam) => {
         const serverlessFile = serverlessFileParam;
+
+        // check for non recognized attributes
+        Object.keys(serverlessFile).forEach((key) => {
+          if (this.allowedProperties.indexOf(key) === -1) {
+            const errorMessage = [
+              `"${key}" is not recognized.`,
+              ` If you are trying to use a custom attribute please use the "custom" object.`,
+            ].join('');
+            throw new ServerlessError(errorMessage);
+          }
+        });
+
         // basic service level validation
         const version = this.serverless.utils.getVersion();
         const ymlVersion = serverlessFile.frameworkVersion;

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -80,11 +80,7 @@ class Service {
         // check for non recognized attributes
         Object.keys(serverlessFile).forEach((key) => {
           if (this.allowedProperties.indexOf(key) === -1) {
-            const errorMessage = [
-              `"${key}" is not recognized.`,
-              ` If you are trying to use a custom attribute please use the "custom" object.`,
-            ].join('');
-            throw new ServerlessError(errorMessage);
+            throw new ServerlessError(`"${key}" is not recognized. If you are trying to use a custom attribute please use the "custom" object.`); // eslint-disable-line max-len
           }
         });
 

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -371,7 +371,7 @@ describe('Service', () => {
       serviceInstance = new Service(serverless);
 
       return expect(serviceInstance.load()).to.eventually.be
-        .rejectedWith('"nonExisting" is not recognized. If you are trying to use a custom attribute please use the "custom" object.');
+        .rejectedWith('"nonExisting" is not recognized. If you are trying to use a custom attribute please use the "custom" object.'); // eslint-disable-line max-len
     });
 
     it('should support service objects', () => {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -370,8 +370,12 @@ describe('Service', () => {
       const serverless = new Serverless({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
+      const expectedErrorText = [
+        '"nonExisting" is not recognized. If you are trying',
+        ' to use a custom attribute please use the "custom" object.',
+      ].join('');
       return expect(serviceInstance.load()).to.eventually.be
-        .rejectedWith('"nonExisting" is not recognized. If you are trying to use a custom attribute please use the "custom" object.'); // eslint-disable-line max-len
+        .rejectedWith(expectedErrorText);
     });
 
     it('should support service objects', () => {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -356,6 +356,24 @@ describe('Service', () => {
         .rejectedWith('"service" is missing the "name" property in');
     });
 
+    it('should reject when there is an unknown attribute', () => {
+      const SUtils = new Utils();
+      const serverlessYaml = {
+        service: 'name',
+        provider: 'aws',
+        nonExisting: 'undefined',
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yaml'),
+        YAML.dump(serverlessYaml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be
+        .rejectedWith('"nonExisting" is not recognized. If you are trying to use a custom attribute please use the "custom" object.');
+    });
+
     it('should support service objects', () => {
       const SUtils = new Utils();
       const serverlessYaml = {


### PR DESCRIPTION
## What did you implement:

Closes #3994

## How did you implement it:

Added a check against the known attributes and the current input.

## How can we verify it:

Add an unknown top level attribute in a serverless config and it will throw an error.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES (since some plugins using the root of the serverless file to add extra information)
