### PR TITLE
Improve deprecated hook message

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -143,7 +143,8 @@ class PluginManager {
       if (_.has(this.deprecatedEvents, baseEvent)) {
         const redirectedEvent = this.deprecatedEvents[baseEvent];
         if (process.env.SLS_DEBUG) {
-          this.serverless.cli.log(`WARNING: Plugin ${pluginName} uses deprecated hook ${event}, use ${redirectedEvent} hook instead`);
+          this.serverless.cli.log(`WARNING: Plugin ${pluginName} uses deprecated hook ${event},
+                     use ${redirectedEvent} hook instead`);
         }
         if (redirectedEvent) {
           target = _.replace(event, baseEvent, redirectedEvent);

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -141,10 +141,10 @@ class PluginManager {
       let target = event;
       const baseEvent = _.replace(event, /^(?:after:|before:)/, '');
       if (_.has(this.deprecatedEvents, baseEvent)) {
-        if (process.env.SLS_DEBUG) {
-          this.serverless.cli.log(`WARNING: Plugin ${pluginName} uses deprecated hook ${event}`);
-        }
         const redirectedEvent = this.deprecatedEvents[baseEvent];
+        if (process.env.SLS_DEBUG) {
+          this.serverless.cli.log(`WARNING: Plugin ${pluginName} uses deprecated hook ${event}, use ${redirectedEvent} hook instead`);
+        }
         if (redirectedEvent) {
           target = _.replace(event, baseEvent, redirectedEvent);
         }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4010 

<!--
Briefly describe the feature if no issue exists for this PR
-->

A little PR to improve the deprecated hook message (show to the user which hook should be used instead of the deprecated one)

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
I changed the `WARNING` message
Old: 
![Image of the old view](https://i.gyazo.com/e01c033814ba70a98121eadcea28de92.png)

New:
![Image of new view](https://i.gyazo.com/2bd21037b99fc0ca1e568a7a26479b07.png)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
