### PR TITLE
Adding Shared Gateway Issue Link

### DIFF
--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -37,7 +37,7 @@ comments/
 ```
 This makes sense since related functions usually use common infrastructure resources, and you want to keep those functions and resources together as a single unit of deployment, for better organization and separation of concerns.
 
-**Note:** Currently, every service will create a separate REST API on AWS API Gateway.  Due to a limitation with AWS API Gateway, you can only have a custom domain per one REST API.  If you plan on making a large REST API, please make note of this limitation.  Also, a fix is in the works and is a top priority.
+**Note:** Currently, every service will create a separate REST API on AWS API Gateway.  Due to a limitation with AWS API Gateway, you can only have a custom domain per one REST API.  If you plan on making a large REST API, please make note of this limitation.  Also, [a fix is in the works][https://github.com/serverless/serverless/issues/3078] and is a top priority.
 
 ## Creation
 


### PR DESCRIPTION
I hit this section in the documentation and immediately wanted to know more,
so after a little digging, I found the issue. It'd be easier for others if
the issue were linked directly until it's fixed.

## What did you implement:

Added a link to the issue referenced in the documentation.

## How did you implement it:

Added a Markdown Link to the issue.

## How can we verify it:

Look at the Markdown, or generate the HTML and open it in a browser.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO