### PR TITLE
Add clarifications on the need for file suffix/extension when using variables from reference files

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -124,7 +124,7 @@ functions:
 ```
 In the above example, the value for `myKey` in the `myBucket` S3 bucket will be looked up and used to populate the variable.
 
-## Reference Variables in Other Files
+## Reference Variables in other Files
 You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
 
 ```yml
@@ -157,6 +157,7 @@ myevents:
 ```
 
 and for JSON:
+
 ```json
 {
   "myevents": [{
@@ -167,20 +168,22 @@ and for JSON:
 }
 ```
 
-In your serverless.yml, depending on the type of your source file, either have the following syntax for YAML
+In your `serverless.yml`, depending on the type of your source file, either have the following syntax for YAML:
+
 ```yml
 functions:
   hello:
-      handler: handler.hello
-      events: ${file(./myCustomFile.yml):myevents
+    handler: handler.hello
+    events: ${file(./myCustomFile.yml):myevents
 ```
 
 or for a JSON reference file use this sytax:
+
 ```yml
 functions:
   hello:
-      handler: handler.hello
-      events: ${file(./myCustomFile.json):myevents
+    handler: handler.hello
+    events: ${file(./myCustomFile.json):myevents
 ```
 
 ## Reference Variables in Javascript Files

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -123,6 +123,7 @@ functions:
       handler: handler.hello
 ```
 In the above example, the value for `myKey` in the `myBucket` S3 bucket will be looked up and used to populate the variable.
+
 ## Reference Variables in Other Files
 You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
 
@@ -181,7 +182,6 @@ functions:
       handler: handler.hello
       events: ${file(./myCustomFile.json):myevents
 ```
-
 
 ## Reference Variables in Javascript Files
 

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -124,7 +124,7 @@ functions:
 ```
 In the above example, the value for `myKey` in the `myBucket` S3 bucket will be looked up and used to populate the variable.
 ## Reference Variables in Other Files
-To reference variables in other YAML or JSON files, use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. This functionality is recursive, so you can go as deep in that file as you want. Here's an example:
+You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
 
 ```yml
 # myCustomFile.yml
@@ -147,7 +147,41 @@ functions:
         - schedule: ${self:custom.globalSchedule} # This would also work in this case
 ```
 
-In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `schedule` property. It's completely recursive and you can go as deep as you want.
+In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `schedule` property. It's completely recursive and you can go as deep as you want.  Additionally you can request properties that contain arrays from either YAML or JSON reference files.  Here's a YAML example for an events array:
+
+```yml
+myevents:
+  - schedule:
+     rate: rate(1 minute)
+```
+
+and for JSON:
+```json
+{
+  "myevents": [{
+    "schedule" : {
+      "rate" : "rate(1 minute)"
+    }
+  }]
+}
+```
+
+In your serverless.yml, depending on the type of your source file, either have the following syntax for YAML
+```yml
+functions:
+  hello:
+      handler: handler.hello
+      events: ${file(./myCustomFile.yml):myevents
+```
+
+or for a JSON reference file use this sytax:
+```yml
+functions:
+  hello:
+      handler: handler.hello
+      events: ${file(./myCustomFile.json):myevents
+```
+
 
 ## Reference Variables in Javascript Files
 

--- a/docs/providers/azure/guide/variables.md
+++ b/docs/providers/azure/guide/variables.md
@@ -27,6 +27,7 @@ able to do the following:
 not property keys. So you can't use variables to generate dynamic logical IDs in
 the custom resources section for example.
 
+
 ## Reference Properties In serverless.yml
 
 To self-reference properties in `serverless.yml`, use the `${self:someProperty}`
@@ -53,6 +54,65 @@ functions:
 In the above example you're setting a global schedule for all functions by
 referencing the `globalSchedule` property in the same `serverless.yml` file. This
 way, you can easily change the schedule for all functions whenever you like.
+
+## Reference Variables in Other Files
+You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
+
+```javascript
+// myCustomFile.yml
+cron: cron(0 * * * *)
+```
+
+```yml
+# serverless.yml
+service: new-service
+provider: azure
+
+custom: ${file(./myCustomFile.yml)} # You can reference the entire file
+
+functions:
+  hello:
+      handler: handler.hello
+      events:
+        - timer: ${file(./myCustomFile.yml):cron} # Or you can reference a specific property
+  world:
+      handler: handler.world
+      events:
+        - timer: ${self:custom.cron} # This would also work in this case
+```
+
+
+In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `cron` property. It's completely recursive and you can go as deep as you want.  Additionally you can request properties that contain arrays from either YAML or JSON reference files.  Here's a YAML example for an events array:
+
+```yml
+myevents:
+  - timer: cron(0 * * * *)
+```
+
+and for JSON:
+```json
+{
+  "myevents": [{
+    "timer" : "cron(0 * * * *)"
+  }]
+}
+```
+
+In your serverless.yml, depending on the type of your source file, either have the following syntax for YAML
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events: ${file(./myCustomFile.yml):myevents
+```
+
+or for a JSON reference file use this sytax:
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events: ${file(./myCustomFile.json):myevents
+```
 
 ## Reference Variables in JavaScript Files
 

--- a/docs/providers/azure/guide/variables.md
+++ b/docs/providers/azure/guide/variables.md
@@ -27,7 +27,6 @@ able to do the following:
 not property keys. So you can't use variables to generate dynamic logical IDs in
 the custom resources section for example.
 
-
 ## Reference Properties In serverless.yml
 
 To self-reference properties in `serverless.yml`, use the `${self:someProperty}`
@@ -42,24 +41,24 @@ custom:
 
 functions:
   hello:
-      handler: handler.hello
-      events:
-        - timer: ${self:custom.globalSchedule}
+    handler: handler.hello
+    events:
+      - timer: ${self:custom.globalSchedule}
   world:
-      handler: handler.world
-      events:
-        - timer: ${self:custom.globalSchedule}
+    handler: handler.world
+    events:
+      - timer: ${self:custom.globalSchedule}
 ```
 
 In the above example you're setting a global schedule for all functions by
 referencing the `globalSchedule` property in the same `serverless.yml` file. This
 way, you can easily change the schedule for all functions whenever you like.
 
-## Reference Variables in Other Files
+## Reference Variables in other Files
 You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
 
-```javascript
-// myCustomFile.yml
+```yml
+# myCustomFile.yml
 cron: cron(0 * * * *)
 ```
 
@@ -72,13 +71,13 @@ custom: ${file(./myCustomFile.yml)} # You can reference the entire file
 
 functions:
   hello:
-      handler: handler.hello
-      events:
-        - timer: ${file(./myCustomFile.yml):cron} # Or you can reference a specific property
+    handler: handler.hello
+    events:
+      - timer: ${file(./myCustomFile.yml):cron} # Or you can reference a specific property
   world:
-      handler: handler.world
-      events:
-        - timer: ${self:custom.cron} # This would also work in this case
+    handler: handler.world
+    events:
+      - timer: ${self:custom.cron} # This would also work in this case
 ```
 
 

--- a/docs/providers/google/guide/variables.md
+++ b/docs/providers/google/guide/variables.md
@@ -50,6 +50,72 @@ functions:
 
 In the above example you're setting a global event resource for all functions by referencing the `resource` property in the same `serverless.yml` file. This way, you can easily change the event resource for all functions whenever you like.
 
+## Reference Variables in Other Files
+You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
+
+```javascript
+// myCustomFile.yml
+topic: projects/*/topics/my-topic
+```
+
+```yml
+# serverless.yml
+service: new-service
+provider: google
+
+custom: ${file(./myCustomFile.yml)} # You can reference the entire file
+
+functions:
+  hello:
+    handler: pubSub.hello
+    events:
+      - event:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: ${file(./myCustomFile.yml):topic} # Or you can reference a specific property
+  world:
+      handler: pubSub.hello
+      events:
+          eventType: providers/cloud.pubsub/eventTypes/topics.publish
+          resource: ${self:custom.topic} # This would also work in this case
+```
+
+In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `topic` property. It's completely recursive and you can go as deep as you want.  Additionally you can request properties that contain arrays from either YAML or JSON reference files.  Here's a YAML example for an events array:
+
+```yml
+myevents:
+  - event:
+      eventType: providers/cloud.pubsub/eventTypes/topic.publish
+      resource: projects/*/topics/my-topic
+```
+
+and for JSON:
+```json
+{
+  "myevents": [{
+    "event" : {
+      "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
+      "resource" : "projects/*/topics/my-topic"
+    }
+  }]
+}
+```
+
+In your serverless.yml, depending on the type of your source file, either have the following syntax for YAML
+```yml
+functions:
+  hello:
+    handler: pubSub.hello
+    events: ${file(./myCustomFile.yml):myevents
+```
+
+or for a JSON reference file use this sytax:
+```yml
+functions:
+  hello:
+    handler: pubSub.hello
+    events: ${file(./myCustomFile.json):myevents
+```
+
 ## Reference Variables in JavaScript Files
 
 You can reference JavaScript files to add dynamic data into your variables.

--- a/docs/providers/google/guide/variables.md
+++ b/docs/providers/google/guide/variables.md
@@ -50,11 +50,11 @@ functions:
 
 In the above example you're setting a global event resource for all functions by referencing the `resource` property in the same `serverless.yml` file. This way, you can easily change the event resource for all functions whenever you like.
 
-## Reference Variables in Other Files
+## Reference Variables in other Files
 You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
 
-```javascript
-// myCustomFile.yml
+```yml
+# myCustomFile.yml
 topic: projects/*/topics/my-topic
 ```
 

--- a/docs/providers/openwhisk/guide/variables.md
+++ b/docs/providers/openwhisk/guide/variables.md
@@ -80,7 +80,7 @@ functions:
 In the above example, you're dynamically adding a prefix to the function names by referencing the `stage` option that you pass in the CLI when you run `serverless deploy --stage dev`. So when you deploy, the function name will always include the stage you're deploying to.
 
 ## Reference Variables in Other Files
-To reference variables in other YAML or JSON files, use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. This functionality is recursive, so you can go as deep in that file as you want. Here's an example:
+To reference variables in other YAML or JSON files, use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. Here's an example:
 
 ```yml
 # myCustomFile.yml
@@ -103,7 +103,37 @@ functions:
         - schedule: ${self:custom.globalSchedule} # This would also work in this case
 ```
 
-In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `schedule` property. It's completely recursive and you can go as deep as you want.
+In the above example, you're referencing the entire `myCustomFile.yml` file in the `custom` property. You need to pass the path relative to your service directory. You can also request specific properties in that file as shown in the `schedule` property. It's completely recursive and you can go as deep as you want.  Additionally you can request properties that contain arrays from either YAML or JSON reference files.  Here's a YAML example for an events array:
+
+```yml
+myevents:
+  - schedule: cron(0 * * * *)
+```
+
+and for JSON:
+```json
+{
+  "myevents": [{
+    "schedule" : "cron(0 * * * *)"
+  }]
+}
+```
+
+In your serverless.yml, depending on the type of your source file, either have the following syntax for YAML
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events: ${file(./myCustomFile.yml):myevents
+```
+
+or for a JSON reference file use this sytax:
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events: ${file(./myCustomFile.json):myevents
+```
 
 ## Reference Variables in Javascript Files
 

--- a/docs/providers/openwhisk/guide/variables.md
+++ b/docs/providers/openwhisk/guide/variables.md
@@ -79,7 +79,7 @@ functions:
 
 In the above example, you're dynamically adding a prefix to the function names by referencing the `stage` option that you pass in the CLI when you run `serverless deploy --stage dev`. So when you deploy, the function name will always include the stage you're deploying to.
 
-## Reference Variables in Other Files
+## Reference Variables in other Files
 To reference variables in other YAML or JSON files, use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. Here's an example:
 
 ```yml


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3379

Add clarifications on the need for file suffix/extension when using variables from reference files of type YAML or JSON.  Also mentioned it is possible to reference array variables and provided an example of that for both JSON and YAML.  This was under the heading "Reference Variables in Other Files" on the variables.md page for AWS

## How did you implement it:

Edited serverless/docs/providers/aws/guide/variable.md in a text editor.  Used http://dillinger.io/ to check formatting.

## How can we verify it:

Follow the examples provided in the updated section or proof read.  I'm unsure of another way.

## Todos:

None that I'm aware of.

***Is this ready for review?:Yes
***Is it a breaking change?:NO
