### PR TITLE
Upload function artifacts with limited concurrency

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -83,7 +83,7 @@ module.exports = {
     let shouldUploadService = false;
     this.serverless.cli.log('Uploading artifacts...');
     const functionNames = this.serverless.service.getAllFunctions();
-    const uploadPromises = functionNames.map(name => {
+    return BbPromise.map(functionNames, (name) => {
       const functionArtifactFileName = this.provider.naming.getFunctionArtifactName(name);
       const functionObject = this.serverless.service.getFunction(name);
       functionObject.package = functionObject.package || {};
@@ -100,9 +100,7 @@ module.exports = {
         return BbPromise.resolve();
       }
       return this.uploadZipFile(artifactFilePath);
-    });
-
-    return BbPromise.all(uploadPromises).then(() => {
+    }, { concurrency: 3 }).then(() => {
       if (shouldUploadService) {
         const artifactFileName = this.provider.naming.getServiceArtifactName();
         const artifactFilePath = path.join(this.packagePath, artifactFileName);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Addresses #3871 

<!--
Briefly describe the feature if no issue exists for this PR
-->

Per @HyperBrain's suggestion on #3871, this limits concurrency when uploading function artifacts.

## How did you implement it:

The change is pretty small and I think it's clear from the code.

## How can we verify it:

On one level, you could monitor uploads while deploying a service to verify the concurrency.  A better way would be to time the uploads for large service with many large functions and see how this affects things.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
