### PR TITLE
Optionally skip parsing input to JSON when using `invoke` and `invoke local`

### DIFF
--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -23,6 +23,7 @@ serverless invoke local --function functionName
 - `--function` or `-f` The name of the function in your service that you want to invoke locally. **Required**.
 - `--path` or `-p` The path to a json file holding input data to be passed to the invoked function as the `event`. This path is relative to the root directory of the service.
 - `--data` or `-d` String data to be passed as an event to your function. Keep in mind that if you pass both `--path` and `--data`, the data included in the `--path` file will overwrite the data you passed with the `--data` flag.
+- `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
 
 ## Environment
 

--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -23,6 +23,7 @@ serverless invoke [local] --function functionName
 - `--stage` or `-s` The stage in your service you want to invoke your function in.
 - `--region` or `-r` The region in your stage that you want to invoke your function in.
 - `--data` or `-d` String data to be passed as an event to your function. By default data is read from standard input.
+- `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
 - `--path` or `-p` The path to a json file with input data to be passed to the invoked function. This path is relative to the root directory of the service.
 - `--type` or `-t` The type of invocation. Either `RequestResponse`, `Event` or `DryRun`. Default is `RequestResponse`.
 - `--log` or `-l` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation. Default is `false`.
@@ -44,6 +45,7 @@ serverless invoke local --function functionName
 - `--path` or `-p` The path to a json file holding input data to be passed to the invoked function as the `event`. This path is relative to the
 root directory of the service.
 - `--data` or `-d` String data to be passed as an event to your function. Keep in mind that if you pass both `--path` and `--data`, the data included in the `--path` file will overwrite the data you passed with the `--data` flag.
+- `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
 
 ## Examples
 

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -55,7 +55,9 @@ class AwsInvoke {
       }
     }).then(() => {
       try {
-        this.options.data = JSON.parse(this.options.data);
+        if (!this.options.raw) {
+          this.options.data = JSON.parse(this.options.data);
+        }
       } catch (exception) {
         // do nothing if it's a simple string or object already
       }

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -105,6 +105,15 @@ describe('AwsInvoke', () => {
       });
     });
 
+    it('should skip parsing data if "raw" requested', () => {
+      awsInvoke.options.data = '{"key": "value"}';
+      awsInvoke.options.raw = true;
+
+      return awsInvoke.extendedValidate().then(() => {
+        expect(awsInvoke.options.data).to.deep.equal('{"key": "value"}');
+      });
+    });
+
     it('it should parse file if relative file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -65,7 +65,9 @@ class AwsInvokeLocal {
       }
     }).then(() => {
       try {
-        this.options.data = JSON.parse(this.options.data);
+        if (!this.options.raw) {
+          this.options.data = JSON.parse(this.options.data);
+        }
       } catch (exception) {
         // do nothing if it's a simple string or object already
       }

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -106,6 +106,15 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
+    it('should skip parsing data if "raw" requested', () => {
+      awsInvokeLocal.options.data = '{"key": "value"}';
+      awsInvokeLocal.options.raw = true;
+
+      return awsInvokeLocal.extendedValidate().then(() => {
+        expect(awsInvokeLocal.options.data).to.deep.equal('{"key": "value"}');
+      });
+    });
+
     it('it should parse file if relative file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -44,6 +44,10 @@ class Invoke {
             usage: 'input data',
             shortcut: 'd',
           },
+          raw: {
+            usage: 'Flag to pass input data as a raw string'
+          },
+
         },
         commands: {
           local: {
@@ -65,6 +69,9 @@ class Invoke {
               data: {
                 usage: 'input data',
                 shortcut: 'd',
+              },
+              raw: {
+                usage: 'Flag to pass input data as a raw string'
               },
             },
           },

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -45,7 +45,7 @@ class Invoke {
             shortcut: 'd',
           },
           raw: {
-            usage: 'Flag to pass input data as a raw string'
+            usage: 'Flag to pass input data as a raw string',
           },
 
         },
@@ -71,7 +71,7 @@ class Invoke {
                 shortcut: 'd',
               },
               raw: {
-                usage: 'Flag to pass input data as a raw string'
+                usage: 'Flag to pass input data as a raw string',
               },
             },
           },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

Please review and course-correct on parameter naming and defaults. See #3788. Thank you! 

## What did you implement:

Closes #3788 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Offer a `--raw` flag in CLI and skip JSON parsing if it is set.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Unittest should take enough care of it, but to test end-to-end, create a simple lambda function, call it as following and verify that `event` type is a string: 

```
sls invoke -f my_function -d '{"foo":"bar"}' --raw
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
