### PR TITLE
Set read/write owner permissions when .aws/credentials file is created

### DIFF
--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const constants = require('constants');
 const path = require('path');
+const fs = require('fs');
 const fse = require('fs-extra');
 const os = require('os');
 const _ = require('lodash');
@@ -148,6 +150,15 @@ class AwsConfigCredentials {
 
     return this.serverless.utils.writeFile(this.credentialsFilePath, updatedCredsFileContent)
       .then(() => {
+        // set file permissions to only readable/writable by owner (equivalent to 'chmod 600')
+        // Note: `chmod` doesn't behave as intended on Windows, so skip if we're on Windows.
+        if (os.platform() !== 'win32') {
+          fs.chmodSync(
+            this.credentialsFilePath,
+            (fs.constants || constants).S_IRUSR | (fs.constants || constants).S_IWUSR
+          );
+        }
+
         this.serverless.cli.log(
           `Success! Your AWS access keys were stored under the "${this.options.profile}" profile.`);
       });

--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
+const constants = require('constants');
 const fs = require('fs');
 const fse = require('fs-extra');
 const os = require('os');
@@ -215,6 +216,21 @@ describe('AwsConfigCredentials', () => {
         expect(lineByLineContent[2]).to.equal('aws_secret_access_key = my-profile-secret');
       });
     });
+
+    if (os.platform() !== 'win32') {
+      it('should set the permissions of the credentials file to be owner-only read/write', () =>
+        awsConfigCredentials.configureCredentials().then(() => {
+          const fileMode = fs.statSync(credentialsFilePath).mode;
+          const filePermissions = fileMode & ~(fs.constants || constants).S_IFMT;
+
+          const readableByOwnerPermission = (fs.constants || constants).S_IRUSR;
+          const writableByOwnerPermission = (fs.constants || constants).S_IWUSR;
+          const expectedFilePermissions = readableByOwnerPermission | writableByOwnerPermission;
+
+          expect(filePermissions).to.equal(expectedFilePermissions);
+        })
+      );
+    }
   });
 
   describe('#getCredentials()', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #2970

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Immediately after the `.aws/credentials` file is created, use the Node.js file system module to set the file permissions to be owner readable/writable. This changes the file permissions from `644` to `600` This is recommended in an AWS Security Blog [post](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/).

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. Remove existing `credentials` file: 
   ```shell
   rm ~/.aws/credentials
   ```

2. Use CLI to create new `credentials` file: 
    ```shell
    serverless config credentials --provider aws --key 1234 --secret 5678
    ```

3. Show new file permissions:
    ```shell
    ls -l ~/.aws/credentials | awk '{print $1}'  
    ```

4. Output should be the symbolic value `-rw-------`, which corresponds to the octal value of `0600`.


## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
