### PR TITLE
Supports SSM Parameters as serverless variable references

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -24,6 +24,7 @@ The Serverless framework provides a powerful variable system which allows you to
 - Combine multiple variable references to overwrite each other
 - Define your own variable syntax if it conflicts with CF syntax
 - Reference & load variables from S3
+- Reference & load variables from SSM
 
 **Note:** You can only use variables in `serverless.yml` property **values**, not property keys. So you can't use variables to generate dynamic logical IDs in the custom resources section for example.
 
@@ -124,7 +125,37 @@ functions:
 ```
 In the above example, the value for `myKey` in the `myBucket` S3 bucket will be looked up and used to populate the variable.
 
-## Reference Variables in other Files
+## Reference Variables using the SSM Parameter Store
+You can reference SSM Parameters as the source of your variables with the `ssm:/path/to/param` syntax. For example:
+
+```yml
+service: ${ssm:/path/to/service/id}-service
+provider:
+  name: aws
+functions:
+  hello:
+    name: ${ssm:/path/to/service/myParam}-hello
+    handler: handler.hello
+```
+
+In the above example, the value for the SSM Parameters will be looked up and used to populate the variables.
+
+You can also reference encrypted SSM Parameters, of type SecureString, using the extended syntax, `ssm:/path/to/secureparam~true`.
+
+```yml
+service: new-service
+provider: aws
+functions:
+  hello:
+    name: hello
+    handler: handler.hello
+custom:
+  supersecret: ${ssm:/path/to/secureparam~true}
+```
+
+In this example, the serverless variable will contain the decrypted value of the SecureString.
+
+## Reference Variables in Other Files
 You can reference variables in other YAML or JSON files.  To reference variables in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file. To reference variables in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly. Here's an example:
 
 ```yml

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -21,6 +21,7 @@ class Variables {
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
     this.stringRefSynax = RegExp(/('.*')|(".*")/g);
+    this.ssmRefSyntax = RegExp(/^ssm:([a-zA-Z0-9_.-/]+)[~]?(true|false)?/);
   }
 
   loadVariableSyntax() {
@@ -179,6 +180,8 @@ class Variables {
       return this.getValueFromS3(variableString);
     } else if (variableString.match(this.stringRefSynax)) {
       return this.getValueFromString(variableString);
+    } else if (variableString.match(this.ssmRefSyntax)) {
+      return this.getValueFromSsm(variableString);
     }
     const errorMessage = [
       `Invalid variable reference syntax for variable ${variableString}.`,
@@ -347,6 +350,28 @@ class Variables {
       this.options.region)
     .then(
       response => response.Body.toString(),
+      err => {
+        const errorMessage = `Error getting value for ${variableString}. ${err.message}`;
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+    );
+  }
+
+  getValueFromSsm(variableString) {
+    const groups = variableString.match(this.ssmRefSyntax);
+    const param = groups[1];
+    const decrypt = (groups[2] === 'true');
+    return this.serverless.getProvider('aws')
+    .request('SSM',
+      'getParameter',
+      {
+        Name: param,
+        WithDecryption: decrypt,
+      },
+      this.options.stage,
+      this.options.region)
+    .then(
+      response => response.Parameter.Value,
       err => {
         const errorMessage = `Error getting value for ${variableString}. ${err.message}`;
         throw new this.serverless.classes.Error(errorMessage);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -371,10 +371,13 @@ class Variables {
       this.options.stage,
       this.options.region)
     .then(
-      response => response.Parameter.Value,
+      response => BbPromise.resolve(response.Parameter.Value),
       err => {
-        const errorMessage = `Error getting value for ${variableString}. ${err.message}`;
-        throw new this.serverless.classes.Error(errorMessage);
+        const expectedErrorMessage = `Parameter ${param} not found.`;
+        if (err.message !== expectedErrorMessage) {
+          throw new this.serverless.classes.Error(err.message);
+        }
+        return BbPromise.resolve(undefined);
       }
     );
   }
@@ -410,6 +413,8 @@ class Variables {
         varType = 'service attribute';
       } else if (variableString.match(this.fileRefSyntax)) {
         varType = 'file';
+      } else if (variableString.match(this.ssmRefSyntax)) {
+        varType = 'SSM parameter';
       }
       logWarning(
         `A valid ${varType} to satisfy the declaration '${variableString}' could not be found.`

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -501,6 +501,19 @@ describe('Variables', () => {
       });
     });
 
+    it('should call getValueFromSsm if referencing variable in SSM', () => {
+      const serverless = new Serverless();
+      const getValueFromSsmStub = sinon
+      .stub(serverless.variables, 'getValueFromSsm').resolves('variableValue');
+      return serverless.variables.getValueFromSource('ssm:/test/path/to/param')
+      .then(valueToPopulate => {
+        expect(valueToPopulate).to.equal('variableValue');
+        expect(getValueFromSsmStub.called).to.equal(true);
+        expect(getValueFromSsmStub.calledWith('ssm:/test/path/to/param')).to.equal(true);
+        serverless.variables.getValueFromSsm.restore();
+      });
+    });
+
     it('should throw error if referencing an invalid source', () => {
       const serverless = new Serverless();
       expect(() => serverless.variables.getValueFromSource('weird:source'))
@@ -927,6 +940,156 @@ describe('Variables', () => {
       }, (err) => {
         expect(err.message).to.be.equal('Error getting value for s3:some.bucket/path/to/key. ' +
           'The specified bucket is not valid');
+      });
+    });
+  });
+
+  describe('#getValueFromSsm()', () => {
+    let serverless;
+    let awsProvider;
+
+    beforeEach(() => {
+      serverless = new Serverless();
+      const options = {
+        stage: 'prod',
+        region: 'us-west-2',
+      };
+      awsProvider = new AwsProvider(serverless, options);
+      serverless.setProvider('aws', awsProvider);
+      serverless.variables.options = options;
+    });
+
+    it('should get variable from Ssm using regular-style param', () => {
+      const awsResponseMock = {
+        Parameter: {
+          Value: 'MockValue',
+        },
+      };
+      const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
+
+      return serverless.variables.getValueFromSsm('ssm:param').then(value => {
+        expect(value).to.be.equal('MockValue');
+        expect(ssmStub.calledOnce).to.be.equal(true);
+        expect(ssmStub.calledWithExactly(
+          'SSM',
+          'getParameter',
+          {
+            Name: 'param',
+            WithDecryption: false,
+          },
+          serverless.variables.options.stage,
+          serverless.variables.options.region
+        )).to.be.equal(true);
+      });
+    });
+
+    it('should get variable from Ssm using path-style param', () => {
+      const awsResponseMock = {
+        Parameter: {
+          Value: 'MockValue',
+        },
+      };
+      const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
+
+      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param').then(value => {
+        expect(value).to.be.equal('MockValue');
+        expect(ssmStub.calledOnce).to.be.equal(true);
+        expect(ssmStub.calledWithExactly(
+          'SSM',
+          'getParameter',
+          {
+            Name: '/some/path/to/param',
+            WithDecryption: false,
+          },
+          serverless.variables.options.stage,
+          serverless.variables.options.region
+        )).to.be.equal(true);
+      });
+    });
+
+    it('should get encrypted variable from Ssm using extended syntax', () => {
+      const awsResponseMock = {
+        Parameter: {
+          Value: 'MockValue',
+        },
+      };
+      const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
+
+      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param~true').then(value => {
+        expect(value).to.be.equal('MockValue');
+        expect(ssmStub.calledOnce).to.be.equal(true);
+        expect(ssmStub.calledWithExactly(
+          'SSM',
+          'getParameter',
+          {
+            Name: '/some/path/to/param',
+            WithDecryption: true,
+          },
+          serverless.variables.options.stage,
+          serverless.variables.options.region
+        )).to.be.equal(true);
+      });
+    });
+
+    it('should get unencrypted variable from Ssm using extended syntax', () => {
+      const awsResponseMock = {
+        Parameter: {
+          Value: 'MockValue',
+        },
+      };
+      const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
+
+      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param~false').then(value => {
+        expect(value).to.be.equal('MockValue');
+        expect(ssmStub.calledOnce).to.be.equal(true);
+        expect(ssmStub.calledWithExactly(
+          'SSM',
+          'getParameter',
+          {
+            Name: '/some/path/to/param',
+            WithDecryption: false,
+          },
+          serverless.variables.options.stage,
+          serverless.variables.options.region
+        )).to.be.equal(true);
+      });
+    });
+
+    it('should ignore bad values for extended syntax', () => {
+      const awsResponseMock = {
+        Parameter: {
+          Value: 'MockValue',
+        },
+      };
+      const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
+
+      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param~badvalue')
+        .then(value => {
+          expect(value).to.be.equal('MockValue');
+          expect(ssmStub.calledOnce).to.be.equal(true);
+          expect(ssmStub.calledWithExactly(
+            'SSM',
+            'getParameter',
+            {
+              Name: '/some/path/to/param',
+              WithDecryption: false,
+            },
+            serverless.variables.options.stage,
+            serverless.variables.options.region
+          )).to.be.equal(true);
+        });
+    });
+
+
+    it('should throw error if error getting value from Ssm', () => {
+      const error = new Error('The specified SSM parameter is not valid');
+      sinon.stub(awsProvider, 'request').rejects(error);
+
+      return serverless.variables.getValueFromSsm('ssm:/some/path/to/invalidparam').then(() => {
+        throw new Error('Ssm parameter was invalid or unauthorized');
+      }, (err) => {
+        expect(err.message).to.be.equal('Error getting value for ssm:/some/path/to/invalidparam. ' +
+          'The specified SSM parameter is not valid');
       });
     });
   });

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1080,17 +1080,21 @@ describe('Variables', () => {
         });
     });
 
-
-    it('should throw error if error getting value from Ssm', () => {
-      const error = new Error('The specified SSM parameter is not valid');
+    it('should return undefined if SSM parameter does not exist', () => {
+      const param = 'ssm:/some/path/to/invalidparam';
+      const error = new Error(`Parameter ${param} not found.`);
       sinon.stub(awsProvider, 'request').rejects(error);
 
-      return serverless.variables.getValueFromSsm('ssm:/some/path/to/invalidparam').then(() => {
-        throw new Error('Ssm parameter was invalid or unauthorized');
-      }, (err) => {
-        expect(err.message).to.be.equal('Error getting value for ssm:/some/path/to/invalidparam. ' +
-          'The specified SSM parameter is not valid');
-      });
+      expect(() => serverless.variables.getValueFromSsm(param).to.be(undefined));
+    });
+
+    it('should throw exception if SSM request returns unexpected error', () => {
+      const param = 'ssm:/some/path/to/invalidparam';
+      const error = new Error(
+        'User: <arn> is not authorized to perform: ssm:GetParameter on resource: <arn>');
+      sinon.stub(awsProvider, 'request').rejects(error);
+
+      expect(() => serverless.variables.getValueFromSsm(param).to.throw(error));
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,9 +166,9 @@
       "dev": true
     },
     "apollo-client": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-1.9.1.tgz",
-      "integrity": "sha512-30e5851mju1mhJzfONvPg3fjYz7rUwjxNAuEIyhFrjWyUYWSBBOEC7+loGPCrj4I0nuTWcKe54rxqtjH8v5vcA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-1.9.2.tgz",
+      "integrity": "sha512-1ZAw2x6AYtGFRosO9sR37+g5bNvCIyyNZ781h9M4Tm/lm8ejzINapx+BH2hdHgMxaGPuPvFpWGuD3m+sTbmWPQ==",
       "requires": {
         "@types/graphql": "0.10.2",
         "apollo-link-core": "0.5.0",
@@ -302,7 +302,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.0"
+        "es-abstract": "1.8.1"
       }
     },
     "arrify": {
@@ -352,9 +352,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.102.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.102.0.tgz",
-      "integrity": "sha1-cOUqjv9j3kxo4dCMXDfbVWEyQ0A=",
+      "version": "2.107.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.107.0.tgz",
+      "integrity": "sha1-/jki58+Ppf04N0bzfjqTsN+1G0c=",
       "requires": {
         "buffer": "4.9.1",
         "crypto-browserify": "1.0.9",
@@ -368,15 +368,6 @@
         "xmlbuilder": "4.2.1"
       },
       "dependencies": {
-        "url": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          }
-        },
         "uuid": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
@@ -558,7 +549,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -571,7 +562,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
       }
     },
@@ -839,7 +830,7 @@
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.2.1"
+        "supports-color": "4.4.0"
       }
     },
     "check-error": {
@@ -1033,9 +1024,9 @@
       "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
     },
     "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
       "dev": true
     },
     "core-util-is": {
@@ -1131,7 +1122,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.29"
+        "es5-ext": "0.10.30"
       }
     },
     "damerau-levenshtein": {
@@ -1452,13 +1443,13 @@
       }
     },
     "es-abstract": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
-      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.1.tgz",
+      "integrity": "sha512-G6pkMLdmxF3dh4hbuYuQiku29rRqo9p5+iRf7mZTEELT/xZ/D9Vzg04ddlvzJuJuCmZp1WBbfbVLZEeygYNkpw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
@@ -1476,9 +1467,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.29",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
-      "integrity": "sha512-KXla9NXo5sdaEkGSmbFPYgjH6m75kxsthL6GDRSug/Y2OiMoYm0I9giL39j4cgmaFmAbkIFJ6gG+SGKnLSmOvA==",
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -1492,7 +1483,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
+        "es5-ext": "0.10.30",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1503,7 +1494,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1523,7 +1514,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1536,7 +1527,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29"
+        "es5-ext": "0.10.30"
       }
     },
     "es6-weak-map": {
@@ -1546,7 +1537,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -1614,7 +1605,7 @@
         "file-entry-cache": "2.0.0",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.1",
@@ -1857,7 +1848,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.29"
+        "es5-ext": "0.10.30"
       }
     },
     "events": {
@@ -2092,9 +2083,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
-      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -2133,9 +2124,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gauge": {
@@ -2209,7 +2200,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2320,7 +2311,7 @@
         "coffee-script": "1.12.7",
         "extend-shallow": "2.0.1",
         "js-yaml": "3.9.1",
-        "toml": "2.3.2"
+        "toml": "2.3.3"
       }
     },
     "growl": {
@@ -2409,7 +2400,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -2426,16 +2417,16 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-symbol-support-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz",
-      "integrity": "sha512-F1NtLDtW9NyUrS3faUcI1yVFHCTXyzPb1jfrZBQi5NHxFPlXxZnFLFGzfA2DsdmgCxv2MZ0+bfcgC4EZTmk4SQ=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
     },
     "has-to-string-tag-x": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz",
-      "integrity": "sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "1.4.0"
+        "has-symbol-support-x": "1.4.1"
       }
     },
     "has-unicode": {
@@ -2535,9 +2526,9 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "immediate": {
@@ -2976,9 +2967,9 @@
       }
     },
     "istanbul-api": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.12.tgz",
-      "integrity": "sha1-ktZ+nY+eqHNJpkpw3fWnqM35fyE=",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.13.tgz",
+      "integrity": "sha1-cZf2RBNgDr3+xjR6LcPU4D+X7Vo=",
       "dev": true,
       "requires": {
         "async": "2.5.0",
@@ -2988,7 +2979,7 @@
         "istanbul-lib-instrument": "1.7.5",
         "istanbul-lib-report": "1.1.1",
         "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.1",
+        "istanbul-reports": "1.1.2",
         "js-yaml": "3.9.1",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
@@ -3086,9 +3077,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-      "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
       "dev": true,
       "requires": {
         "handlebars": "4.0.10"
@@ -3099,7 +3090,7 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "1.4.0",
+        "has-to-string-tag-x": "1.4.1",
         "is-object": "1.0.1"
       }
     },
@@ -3125,7 +3116,7 @@
         "chalk": "1.1.3",
         "graceful-fs": "4.1.11",
         "is-ci": "1.0.10",
-        "istanbul-api": "1.1.12",
+        "istanbul-api": "1.1.13",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-instrument": "1.7.5",
         "jest-changed-files": "17.0.2",
@@ -3743,9 +3734,9 @@
       "dev": true
     },
     "jszip": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
-      "integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.4.tgz",
+      "integrity": "sha512-z6w8iYIxZ/fcgul0j/OerkYnkomH8BZigvzbxVmr2h5HkZUrPtk2kjYtLkqR9wwQxEP6ecKNoKLsbhd18jfnGA==",
       "dev": true,
       "requires": {
         "core-js": "2.3.0",
@@ -4155,9 +4146,9 @@
       "dev": true
     },
     "markdown-magic": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-0.1.17.tgz",
-      "integrity": "sha1-lj/jsNvoIF5ycJRJpErS9NsR/24=",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-0.1.18.tgz",
+      "integrity": "sha1-aalfD1Ekj5/ChO118kva2FpFzu4=",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
@@ -4310,13 +4301,13 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz",
+      "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ=="
     },
     "mime-db": {
       "version": "1.29.0",
@@ -4334,7 +4325,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -4610,7 +4601,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
         "object-keys": "1.0.11"
       }
     },
@@ -5150,13 +5141,12 @@
       "dev": true
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remarkable": {
@@ -5647,18 +5637,18 @@
         "cookiejar": "2.1.1",
         "debug": "2.6.8",
         "extend": "3.0.1",
-        "form-data": "2.2.0",
+        "form-data": "2.3.1",
         "formidable": "1.1.1",
         "methods": "1.1.2",
-        "mime": "1.3.6",
+        "mime": "1.4.0",
         "qs": "6.5.0",
         "readable-stream": "2.3.3"
       }
     },
     "supports-color": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-      "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -5864,9 +5854,9 @@
       }
     },
     "toml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.2.tgz",
-      "integrity": "sha1-Xt7VykKIeSSUn9BusOlVZWAB6DQ=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
       "dev": true
     },
     "tough-cookie": {
@@ -6031,6 +6021,15 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
           "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
         }
+      }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
       }
     },
     "url-parse": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "apollo-client": "^1.4.2",
     "archiver": "^1.1.0",
     "async": "^1.5.2",
-    "aws-sdk": "^2.7.13",
+    "aws-sdk": "^2.75.0",
     "bluebird": "^3.4.0",
     "chalk": "^2.0.0",
     "ci-info": "^1.0.0",


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Adds ability to specify SSM parameters as serverless variable references.

This is mostly intended to support discussion in #4053, so everyone can see what the code looks like.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

* Created a new regex to match `ssm:` variable references
* Created a new function that calls the SSM API to retrieve the parameter value

I cribbed a lot of the implementation from the already existing code for `s3:` variable references.

In order to support decryption of SecureString parameters, I selected the `~` as a delimiter between the parameter name and a true/false value that maps to the `WithDecryption` option of the SSM GetParameter API. I selected the `~` only because it is already allowed in the default variable regex, and because it is not allowed as a character in the SSM parameter name.

The AWS SDK needed to be updated to version 2.75.0 because that is when the GetParameter API was [added](https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#2750).

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Here are commands to put a parameter into SSM:
```
aws ssm put-parameter --name foo --value bar --type SecureString
aws ssm put-parameter --name bar --value foo --type String
aws ssm put-parameter --name /foo/bar --value bar --type SecureString
aws ssm put-parameter --name /bar/foo --value foo --type String
```

With a minimal serverless.yml file, you would then be able to reference the variables like so:

```
${ssm:foo}
${ssm:bar~true}
${ssm:/foo/bar}
${ssm:/bar/foo~true}
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
