### PR TITLE
Fix this.s3RefSyntax variable name typo

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -19,7 +19,7 @@ class Variables {
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
     this.cfRefSyntax = RegExp(/^cf:/g);
-    this.s3RefSynax = RegExp(/^s3:(.+?)\/(.+)$/);
+    this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
   }
 
   loadVariableSyntax() {
@@ -174,7 +174,7 @@ class Variables {
       return this.getValueFromFile(variableString);
     } else if (variableString.match(this.cfRefSyntax)) {
       return this.getValueFromCf(variableString);
-    } else if (variableString.match(this.s3RefSynax)) {
+    } else if (variableString.match(this.s3RefSyntax)) {
       return this.getValueFromS3(variableString);
     }
     const errorMessage = [
@@ -325,7 +325,7 @@ class Variables {
   }
 
   getValueFromS3(variableString) {
-    const groups = variableString.match(this.s3RefSynax);
+    const groups = variableString.match(this.s3RefSyntax);
     const bucket = groups[1];
     const key = groups[2];
     return this.serverless.getProvider('aws')


### PR DESCRIPTION
## What did you implement:

Fix a typo in `Variables.js` file.


## How can we verify it:

Nothing to verify.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
