### PR TITLE
More Background on Dead Letter Queues

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -303,15 +303,17 @@ provider:
 
 These versions are not cleaned up by serverless, so make sure you use a plugin or other tool to prune sufficiently old versions. The framework can't clean up versions because it doesn't have information about whether older versions are invoked or not. This feature adds to the number of total stack outputs and resources because a function version is a separate resource from the function it refers to.
 
-## DeadLetterConfig
+## Dead Letter Queue (DLQ)
 
-You can setup `DeadLetterConfig` with the help of a SNS topic and the `onError` config parameter.
+When AWS lambda functions fail, they are [retried](http://docs.aws.amazon.com/lambda/latest/dg/retries-on-errors.html). If the retries also fail, AWS has a feature to send information about the failed request to a SNS topic or SNS queue, called the [Dead Letter Queue](http://docs.aws.amazon.com/lambda/latest/dg/dlq.html), which you can use to track and diagnose and react to lambda failures.
 
-The SNS topic needs to be created beforehand and provided as an `arn` on the function level.
+You can setup a dead letter queue for your serverless functions with the help of a SNS topic and the `onError` config parameter.
 
 **Note:** You can only provide one `onError` config per function.
 
 ### DLQ with SNS
+
+The SNS topic needs to be created beforehand and provided as an `arn` on the function level.
 
 ```yml
 service: service
@@ -328,7 +330,7 @@ functions:
 
 ### DLQ with SQS
 
-The `onError` config currently only supports SNS topic arns due to a race condition when using SQS queue arns and updating the IAM role.
+Although Dead Letter Queues support both SNS topics and SQUS queues, the `onError` config currently only supports SNS topic arns due to a race condition when using SQS queue arns and updating the IAM role.
 
 We're working on a fix so that SQS queue arns will be supported in the future.
 


### PR DESCRIPTION
Adding a bit more background information and links on dead letter queues,
since some users of the Serverless framework won't be versed on every
detail of AWS lambda functions.

## What did you implement:
Additional documentation surrounding dead letter queues.

## How did you implement it:
An additional paragraph of introductory text, and a little 'refactoring' of what was already there.

## How can we verify it:
Read the revised text.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
