### PR TITLE
Using Fn:ImportValue for role should create empty DependsOn for strea…

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -136,6 +136,11 @@ class AwsCompileStreamEvents {
                 funcRole['Fn::GetAtt'][1] === 'Arn'
               ) {
                 dependsOn = `"${funcRole['Fn::GetAtt'][0]}"`;
+              } else if ( // otherwise, check if we have an import
+                typeof funcRole === 'object' &&
+                'Fn::ImportValue' in funcRole
+              ) {
+                dependsOn = '[]';
               } else if (typeof funcRole === 'string') {
                 dependsOn = `"${funcRole}"`;
               }

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -217,6 +217,31 @@ describe('AwsCompileStreamEvents', () => {
       ).to.equal(null);
     });
 
+    it('should not throw error if IAM role is imported', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          role: { 'Fn::ImportValue': 'ExportedRoleId' },
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamRoleLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamRoleLambdaExecution = null;
+
+      expect(() => { awsCompileStreamEvents.compileStreamEvents(); }).to.not.throw(Error);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn.length).to.equal(0);
+      expect(awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.IamRoleLambdaExecution).to.equal(null);
+    });
+
+
     it('should not throw error if custom IAM role reference is set in provider', () => {
       const roleLogicalId = 'RoleLogicalId';
       awsCompileStreamEvents.serverless.service.functions = {


### PR DESCRIPTION
## What did you implement:

Closes #4083


## How did you implement it:

Add test for use of Fn:ImportValue in a function role, and set DependsOn to be an empty array in that case. 

## How can we verify it:

Please see the bug report for examples of config. 
It should be possible to use Fn:ImportValue for a role when using a kinesis event.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
