### PR TITLE
Display stack name in info output

### DIFF
--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -11,7 +11,8 @@ module.exports = {
     message += `${chalk.yellow.underline('Service Information')}\n`;
     message += `${chalk.yellow('service:')} ${info.service}\n`;
     message += `${chalk.yellow('stage:')} ${info.stage}\n`;
-    message += `${chalk.yellow('region:')} ${info.region}`;
+    message += `${chalk.yellow('region:')} ${info.region}\n`;
+    message += `${chalk.yellow('stack:')} ${info.stack}`;
 
     this.serverless.cli.consoleLog(message);
     return message;

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -28,6 +28,7 @@ describe('#display()', () => {
         service: 'my-first',
         stage: 'dev',
         region: 'eu-west-1',
+        stack: 'my-first-dev',
         endpoint: null,
         functions: [],
         apiKeys: [],
@@ -46,7 +47,8 @@ describe('#display()', () => {
     expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
     expectedMessage += `${chalk.yellow('service:')} my-first\n`;
     expectedMessage += `${chalk.yellow('stage:')} dev\n`;
-    expectedMessage += `${chalk.yellow('region:')} eu-west-1`;
+    expectedMessage += `${chalk.yellow('region:')} eu-west-1\n`;
+    expectedMessage += `${chalk.yellow('stack:')} my-first-dev`;
 
     const message = awsInfo.displayServiceInfo();
     expect(consoleLogStub.calledOnce).to.equal(true);

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -12,6 +12,7 @@ module.exports = {
         service: this.serverless.service.service,
         stage: this.options.stage,
         region: this.options.region,
+        stack: this.provider.naming.getStackName(this.options.stage),
       },
       outputs: [],
     };

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -86,6 +86,7 @@ describe('#getStackInfo()', () => {
         service: 'my-service',
         stage: 'dev',
         region: 'us-east-1',
+        stack: 'my-service-dev',
       },
       outputs: [
         {
@@ -134,6 +135,7 @@ describe('#getStackInfo()', () => {
         service: 'my-service',
         stage: 'dev',
         region: 'us-east-1',
+        stack: 'my-service-dev',
       },
       outputs: [],
     };


### PR DESCRIPTION
## What did you implement:

Closes #4078

## How did you implement it:

simply adds the stack name to the info output.
stack name is assumed to be `${service}-${stage}`

## How can we verify it:

Run `sls info`

![screenshot 2017-08-15 09 17 01](https://user-images.githubusercontent.com/28390/29295935-93bd4172-819a-11e7-85ac-1136aae401f1.png)


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
