### PR TITLE
Rethrow original plugin error in debug mode. Added unit tests.

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -71,6 +71,11 @@ class PluginManager {
 
         this.addPlugin(Plugin);
       } catch (error) {
+        // Rethrow the original error in case we're in debug mode.
+        if (process.env.SLS_DEBUG) {
+          throw error;
+        }
+
         const errorMessage = [
           `Serverless plugin "${plugin}" not found.`,
           ' Make sure it\'s installed and listed in the "plugins" section',

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -6,6 +6,7 @@ const Serverless = require('../../lib/Serverless');
 const CLI = require('../../lib/classes/CLI');
 const Create = require('../../lib/plugins/create/create');
 
+const _ = require('lodash');
 const path = require('path');
 const fs = require('fs');
 const fse = require('fs-extra');
@@ -25,6 +26,12 @@ describe('PluginManager', () => {
   class ServicePluginMock1 {}
 
   class ServicePluginMock2 {}
+
+  class BrokenPluginMock {
+    constructor() {
+      throw new Error('Broken plugin');
+    }
+  }
 
   class Provider1PluginMock {
     constructor() {
@@ -528,6 +535,7 @@ describe('PluginManager', () => {
   describe('#loadPlugins()', () => {
     beforeEach(() => {
       mockRequire('ServicePluginMock1', ServicePluginMock1);
+      mockRequire('BrokenPluginMock', BrokenPluginMock);
     });
 
     it('should throw an error when trying to load unknown plugin', () => {
@@ -547,6 +555,26 @@ describe('PluginManager', () => {
 
       expect(pluginManager.plugins).to.contain(servicePluginMock1);
       expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+
+    it('should throw an error when trying to load a broken plugin (without SLS_DEBUG)', () => {
+      const servicePlugins = ['BrokenPluginMock'];
+
+      expect(() => pluginManager.loadPlugins(servicePlugins))
+        .to.throw(serverless.classes.Error);
+    });
+
+    it('should forward any errors when trying to load a broken plugin (with SLS_DEBUG)', () => {
+      const servicePlugins = ['BrokenPluginMock'];
+
+      return BbPromise.try(() => {
+        _.set(process.env, 'SLS_DEBUG', '*');
+        expect(() => pluginManager.loadPlugins(servicePlugins))
+          .to.throw(/Broken plugin/);
+      })
+      .finally(() => {
+        _.unset(process.env, 'SLS_DEBUG');
+      });
     });
 
     afterEach(() => {


### PR DESCRIPTION
## What did you implement:

Closes #4090 

## How did you implement it:

If `SLS_DEBUG` is set, the original exception is rethrown for crashes in plugins. This allows plugin authors to debug their plugins properly within the context of the Serverless framework.

The check is added in the loadPlugins() where any exceptions that occur during plugin loading and initialization are catched.

## How can we verify it:

Add a plugin to any project that either cannot load the plugin files (syntax error) or that throws during initialization (constructor).

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
