### PR TITLE
Allow use of string as default values in variables

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -293,7 +293,7 @@ service: new-service
 provider:
   name: aws
   runtime: nodejs6.10
-  variableSyntax: "\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}" # notice the double quotes for yaml to ignore the escape characters!
+  variableSyntax: "\\${([ ~:a-zA-Z0-9._\'\",\\-\\/\\(\\)]+?)}" # notice the double quotes for yaml to ignore the escape characters!
 
 custom:
   myStage: ${{opt:stage}}

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -273,6 +273,7 @@ provider:
   stage: dev
 custom:
   myStage: ${opt:stage, self:provider.stage}
+  myRegion: ${opt:region, 'us-west-1'}
 
 functions:
   hello:

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -292,7 +292,7 @@ service: new-service
 provider:
   name: aws
   runtime: nodejs6.10
-  variableSyntax: "\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
+  variableSyntax: "\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}" # notice the double quotes for yaml to ignore the escape characters!
 
 custom:
   myStage: ${{opt:stage}}

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -16,7 +16,7 @@ class Service {
     this.provider = {
       stage: 'dev',
       region: 'us-east-1',
-      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'\",\\-\\/\\(\\)]+?)}',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -16,7 +16,7 @@ class Service {
     this.provider = {
       stage: 'dev',
       region: 'us-east-1',
-      variableSyntax: '\\${([ ~:a-zA-Z0-9._\',\\-\\/\\(\\)]+?)}',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'\",\\-\\/\\(\\)]+?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -16,7 +16,7 @@ class Service {
     this.provider = {
       stage: 'dev',
       region: 'us-east-1',
-      variableSyntax: '\\${([ ~:a-zA-Z0-9._,\\-\\/\\(\\)]+?)}',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._\',\\-\\/\\(\\)]+?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -31,7 +31,7 @@ describe('Service', () => {
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
         region: 'us-east-1',
-        variableSyntax: '\\${([ ~:a-zA-Z0-9._\',\\-\\/\\(\\)]+?)}',
+        variableSyntax: '\\${([ ~:a-zA-Z0-9._\'\",\\-\\/\\(\\)]+?)}',
       });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -131,7 +131,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -165,7 +165,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}'
+          '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -188,7 +188,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -221,7 +221,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}'
+          '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -244,7 +244,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -277,7 +277,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}'
+          '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -299,7 +299,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -712,7 +712,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
         },
         plugins: ['testPlugin'],
         functions: {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -131,7 +131,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -165,7 +165,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -188,7 +188,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -221,7 +221,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -244,7 +244,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -277,7 +277,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -299,7 +299,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -712,7 +712,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -31,7 +31,7 @@ describe('Service', () => {
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
         region: 'us-east-1',
-        variableSyntax: '\\${([ ~:a-zA-Z0-9._\'\",\\-\\/\\(\\)]+?)}',
+        variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
       });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -31,7 +31,7 @@ describe('Service', () => {
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
         region: 'us-east-1',
-        variableSyntax: '\\${([ ~:a-zA-Z0-9._,\\-\\/\\(\\)]+?)}',
+        variableSyntax: '\\${([ ~:a-zA-Z0-9._\',\\-\\/\\(\\)]+?)}',
       });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -256,7 +256,7 @@ class Utils {
       }
 
       let hasCustomVariableSyntaxDefined = false;
-      const defaultVariableSyntax = '\\${([ ~:a-zA-Z0-9._,\\-\\/\\(\\)]+?)}';
+      const defaultVariableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}';
 
       // check if the variableSyntax in the provider section is defined
       if (provider && provider.variableSyntax

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -20,7 +20,7 @@ class Variables {
     this.selfRefSyntax = RegExp(/^self:/g);
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
-    this.stringRefSynax = RegExp(/('|").+('|")/g);
+    this.stringRefSynax = RegExp(/('.*')|(".*")/g);
   }
 
   loadVariableSyntax() {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -20,6 +20,7 @@ class Variables {
     this.selfRefSyntax = RegExp(/^self:/g);
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
+    this.stringRefSynax = RegExp(/'.+'/g);
   }
 
   loadVariableSyntax() {
@@ -176,6 +177,8 @@ class Variables {
       return this.getValueFromCf(variableString);
     } else if (variableString.match(this.s3RefSyntax)) {
       return this.getValueFromS3(variableString);
+    } else if (variableString.match(this.stringRefSynax)) {
+      return this.getValueFromString(variableString);
     }
     const errorMessage = [
       `Invalid variable reference syntax for variable ${variableString}.`,
@@ -193,6 +196,11 @@ class Variables {
     } else {
       valueToPopulate = process.env;
     }
+    return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromString(variableString) {
+    const valueToPopulate = variableString.replace(/'/g, '');
     return BbPromise.resolve(valueToPopulate);
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -20,7 +20,7 @@ class Variables {
     this.selfRefSyntax = RegExp(/^self:/g);
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
-    this.stringRefSynax = RegExp(/'.+'/g);
+    this.stringRefSynax = RegExp(/('|").+('|")/g);
   }
 
   loadVariableSyntax() {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -56,7 +56,7 @@ describe('Variables', () => {
     it('should use variableSyntax', () => {
       const serverless = new Serverless();
 
-      const variableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}';
+      const variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
       const fooValue = '${clientId()}';
       const barValue = 'test';
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -33,7 +33,7 @@ describe('Variables', () => {
     it('should set variableSyntax', () => {
       const serverless = new Serverless();
 
-      serverless.service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}';
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
 
       serverless.variables.loadVariableSyntax();
       expect(serverless.variables.variableSyntax).to.be.a('RegExp');

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -56,7 +56,7 @@ describe('Variables', () => {
     it('should use variableSyntax', () => {
       const serverless = new Serverless();
 
-      const variableSyntax = '\\${{([ :a-zA-Z0-9._\',\\-\\/\\(\\)]+?)}}';
+      const variableSyntax = '\\${{([ :a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
       const fooValue = '${clientId()}';
       const barValue = 'test';
 
@@ -157,9 +157,31 @@ describe('Variables', () => {
       });
     });
 
-    it('should allow a string if overwrite syntax provided', () => {
+    it('should allow a single-quoted string if overwrite syntax provided', () => {
       const serverless = new Serverless();
       const property = "my stage is ${opt:stage, 'prod'}";
+
+      serverless.variables.loadVariableSyntax();
+
+      const overwriteStub = sinon
+        .stub(serverless.variables, 'overwrite').resolves('\'prod\'');
+      const populateVariableStub = sinon
+        .stub(serverless.variables, 'populateVariable').resolves('my stage is prod');
+
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(overwriteStub.called).to.equal(true);
+        expect(populateVariableStub.called).to.equal(true);
+        expect(newProperty).to.equal('my stage is prod');
+
+        serverless.variables.overwrite.restore();
+        serverless.variables.populateVariable.restore();
+        return BbPromise.resolve();
+      });
+    });
+
+    it('should allow a double-quoted string if overwrite syntax provided', () => {
+      const serverless = new Serverless();
+      const property = 'my stage is ${opt:stage, "prod"}';
 
       serverless.variables.loadVariableSyntax();
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -56,7 +56,7 @@ describe('Variables', () => {
     it('should use variableSyntax', () => {
       const serverless = new Serverless();
 
-      const variableSyntax = '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}';
+      const variableSyntax = '\\${{([ :a-zA-Z0-9._\',\\-\\/\\(\\)]+?)}}';
       const fooValue = '${clientId()}';
       const barValue = 'test';
 
@@ -150,6 +150,28 @@ describe('Variables', () => {
         expect(overwriteStub.called).to.equal(true);
         expect(populateVariableStub.called).to.equal(true);
         expect(newProperty).to.equal('my stage is dev');
+
+        serverless.variables.overwrite.restore();
+        serverless.variables.populateVariable.restore();
+        return BbPromise.resolve();
+      });
+    });
+
+    it('should allow a string if overwrite syntax provided', () => {
+      const serverless = new Serverless();
+      const property = "my stage is ${opt:stage, 'prod'}";
+
+      serverless.variables.loadVariableSyntax();
+
+      const overwriteStub = sinon
+        .stub(serverless.variables, 'overwrite').resolves('\'prod\'');
+      const populateVariableStub = sinon
+        .stub(serverless.variables, 'populateVariable').resolves('my stage is prod');
+
+      return serverless.variables.populateProperty(property).then(newProperty => {
+        expect(overwriteStub.called).to.equal(true);
+        expect(populateVariableStub.called).to.equal(true);
+        expect(newProperty).to.equal('my stage is prod');
 
         serverless.variables.overwrite.restore();
         serverless.variables.populateVariable.restore();

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -33,7 +33,7 @@ describe('Variables', () => {
     it('should set variableSyntax', () => {
       const serverless = new Serverless();
 
-      serverless.service.provider.variableSyntax = '\\${{([ :a-zA-Z0-9._,\\-\\/\\(\\)]+?)}}';
+      serverless.service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}';
 
       serverless.variables.loadVariableSyntax();
       expect(serverless.variables.variableSyntax).to.be.a('RegExp');
@@ -56,7 +56,7 @@ describe('Variables', () => {
     it('should use variableSyntax', () => {
       const serverless = new Serverless();
 
-      const variableSyntax = '\\${{([ :a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
+      const variableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}';
       const fooValue = '${clientId()}';
       const barValue = 'test';
 


### PR DESCRIPTION
## What did you implement:

Closes #4072


## How did you implement it:

- Changed the variable syntax to allow plain strings to be accepted as valid. 
- Changed the variable extractor to pull the quotes from strings and inject as a literal value.



## How can we verify it:

In a serverless.yml file, add a variable in the form:

```
${opt:blah, 'vtha'}
```

When no opt is passed, the literal value 'vtha' should be used. 

## Todos:

- [x ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
