### PR TITLE
Add platform gate to sls run/emit

### DIFF
--- a/lib/plugins/emit/index.js
+++ b/lib/plugins/emit/index.js
@@ -122,8 +122,8 @@ class Emit {
   emitEvent() {
     const authToken = getAuthToken();
     if (!authToken) {
-      throw new this.serverless.classes
-        .Error('Must be logged in to use this command. Please run `sls login`.');
+      return BbPromise.reject(new this.serverless.classes
+        .Error('Must be logged in to use this command. Please run `sls login`.'));
     }
 
     userStats.track('service_emitted');

--- a/lib/plugins/emit/index.js
+++ b/lib/plugins/emit/index.js
@@ -123,7 +123,7 @@ class Emit {
     const authToken = getAuthToken();
     if (!authToken) {
       return BbPromise.reject(new this.serverless.classes
-        .Error('Must be logged in to use this command. Please run `serverless login`.'));
+        .Error('Must be logged in to use this command. Please run "serverless login".'));
     }
 
     userStats.track('service_emitted');

--- a/lib/plugins/emit/index.js
+++ b/lib/plugins/emit/index.js
@@ -123,7 +123,7 @@ class Emit {
     const authToken = getAuthToken();
     if (!authToken) {
       return BbPromise.reject(new this.serverless.classes
-        .Error('Must be logged in to use this command. Please run `sls login`.'));
+        .Error('Must be logged in to use this command. Please run `serverless login`.'));
     }
 
     userStats.track('service_emitted');

--- a/lib/plugins/emit/index.js
+++ b/lib/plugins/emit/index.js
@@ -5,6 +5,7 @@ const BbPromise = require('bluebird');
 const fdk = require('@serverless/fdk');
 const path = require('path');
 const stdin = require('get-stdin');
+const getAuthToken = require('../../utils/getAuthToken');
 const userStats = require('../../utils/userStats');
 const chalk = require('chalk');
 
@@ -61,7 +62,10 @@ class Emit {
 
     this.hooks = {
       'emit:emit': () =>
-        BbPromise.bind(this).then(this.retrieveData).then(this.parseData).then(this.emitEvent),
+        BbPromise.bind(this)
+          .then(this.retrieveData)
+          .then(this.parseData)
+          .then(this.emitEvent),
     };
   }
 
@@ -116,6 +120,12 @@ class Emit {
   }
 
   emitEvent() {
+    const authToken = getAuthToken();
+    if (!authToken) {
+      throw new this.serverless.classes
+        .Error('Must be logged in to use this command. Please run `sls login`.');
+    }
+
     userStats.track('service_emitted');
     const url = this.options.url || 'http://localhost:4000';
     const eventGateway = fdk.eventGateway({

--- a/lib/plugins/emit/index.test.js
+++ b/lib/plugins/emit/index.test.js
@@ -13,27 +13,25 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 describe('Emit', () => {
-  let emit;
-  let serverless;
-  let emitEventStub;
-  let logStub;
-
-  beforeEach(() => {
-    serverless = new Serverless();
-    serverless.cli = new CLI(serverless);
-    emitEventStub = sinon.stub().resolves();
-    const Emit = proxyquire('./index', {
-      '@serverless/fdk': {
-        eventGateway: () => ({
-          emit: emitEventStub,
-        }),
-      },
-    });
-    emit = new Emit(serverless);
-    logStub = sinon.stub(emit.serverless.cli, 'consoleLog');
-  });
-
   describe('#constructor()', () => {
+    let emit;
+    let serverless;
+    let emitEventStub;
+
+    beforeEach(() => {
+      serverless = new Serverless();
+      serverless.cli = new CLI(serverless);
+      emitEventStub = sinon.stub().resolves();
+      const Emit = proxyquire('./index', {
+        '@serverless/fdk': {
+          eventGateway: () => ({
+            emit: emitEventStub,
+          }),
+        },
+      });
+      emit = new Emit(serverless);
+    });
+
     it('should have commands', () => expect(emit.commands).to.be.not.empty);
     it('should have hooks', () => expect(emit.hooks).to.be.not.empty);
 
@@ -52,6 +50,24 @@ describe('Emit', () => {
   });
 
   describe('#retrieveData()', () => {
+    let emit;
+    let serverless;
+    let emitEventStub;
+
+    beforeEach(() => {
+      serverless = new Serverless();
+      serverless.cli = new CLI(serverless);
+      emitEventStub = sinon.stub().resolves();
+      const Emit = proxyquire('./index', {
+        '@serverless/fdk': {
+          eventGateway: () => ({
+            emit: emitEventStub,
+          }),
+        },
+      });
+      emit = new Emit(serverless);
+    });
+
     it('should use the data args if provided over path', () => {
       emit.options.path = '/some/path';
       emit.options.data = '{"key": "value"}';
@@ -129,7 +145,27 @@ describe('Emit', () => {
     });
   });
 
-  describe('#emitEvent()', () => {
+  describe('#emitEvent() - logged in', () => {
+    let emit;
+    let serverless;
+    let emitEventStub;
+    let logStub;
+
+    beforeEach(() => {
+      serverless = new Serverless();
+      serverless.cli = new CLI(serverless);
+      emitEventStub = sinon.stub().resolves();
+      const Emit = proxyquire('./index', {
+        '@serverless/fdk': {
+          eventGateway: () => ({
+            emit: emitEventStub,
+          }),
+        },
+        '../../utils/getAuthToken': () => 'abc123',
+      });
+      emit = new Emit(serverless);
+      logStub = sinon.stub(emit.serverless.cli, 'consoleLog');
+    });
     it('should emit an event using the name args', () => {
       emit.options.name = 'userCreated';
       emit.data = { key: 'value' };
@@ -164,6 +200,38 @@ describe('Emit', () => {
         expect(logStub.getCall(0).args[0]).to.equal(
           // eslint-disable-next-line max-len
           ' Serverless       Emitted the event userCreated as datatype text/plain:\n                    "This is a message"'
+        );
+      });
+    });
+  });
+
+  describe('#emitEvent() - logged out', () => {
+    let emit;
+    let serverless;
+    let emitEventStub;
+
+    beforeEach(() => {
+      serverless = new Serverless();
+      serverless.cli = new CLI(serverless);
+      emitEventStub = sinon.stub().resolves();
+      const Emit = proxyquire('./index', {
+        '@serverless/fdk': {
+          eventGateway: () => ({
+            emit: emitEventStub,
+          }),
+        },
+        '../../utils/getAuthToken': () => null,
+      });
+      emit = new Emit(serverless);
+    });
+
+    it('should throw an Error of not logged in', () => {
+      emit.options.name = 'userCreated';
+      emit.data = { key: 'value' };
+      return emit.emitEvent().catch(err => {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.equal(
+          'Must be logged in to use this command. Please run `sls login`.'
         );
       });
     });

--- a/lib/plugins/emit/index.test.js
+++ b/lib/plugins/emit/index.test.js
@@ -231,7 +231,7 @@ describe('Emit', () => {
       return emit.emitEvent().catch(err => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal(
-          'Must be logged in to use this command. Please run `serverless login`.'
+          'Must be logged in to use this command. Please run "serverless login".'
         );
       });
     });

--- a/lib/plugins/emit/index.test.js
+++ b/lib/plugins/emit/index.test.js
@@ -231,7 +231,7 @@ describe('Emit', () => {
       return emit.emitEvent().catch(err => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal(
-          'Must be logged in to use this command. Please run `sls login`.'
+          'Must be logged in to use this command. Please run `serverless login`.'
         );
       });
     });

--- a/lib/plugins/platform/platform.js
+++ b/lib/plugins/platform/platform.js
@@ -10,9 +10,9 @@ const BbPromise = require('bluebird');
 const fsExtra = require('../../utils/fs/fse');
 const fetch = require('node-fetch');
 const chalk = require('chalk');
-const configUtils = require('../../utils/config');
 const functionInfoUtils = require('../../utils/functionInfoUtils');
 const createApolloClient = require('../../utils/createApolloClient');
+const getAuthToken = require('../../utils/getAuthToken');
 const selectServicePublish = require('../../utils/selectors/selectServicePublish');
 
 // NOTE Needed for apollo to work
@@ -91,17 +91,7 @@ class Platform {
   }
 
   getAuthToken() {
-    if (process.env.SERVERLESS_TOKEN) {
-      return process.env.SERVERLESS_TOKEN;
-    }
-
-    const userConfig = configUtils.getConfig();
-    const currentId = userConfig.userId;
-    const globalConfig = configUtils.getGlobalConfig();
-    if (globalConfig.users && globalConfig.users[currentId] && globalConfig.users[currentId].auth) {
-      return globalConfig.users[currentId].auth.id_token;
-    }
-    return null;
+    return getAuthToken();
   }
 
   publishService() {

--- a/lib/plugins/run/index.js
+++ b/lib/plugins/run/index.js
@@ -70,7 +70,7 @@ class Run {
     const authToken = getAuthToken();
     if (!authToken) {
       throw new this.serverless.classes
-        .Error('Must be logged in to use this command. Please run `sls login`.');
+        .Error('Must be logged in to use this command. Please run `serverless login`.');
     }
 
     let functionsDeployed = false;

--- a/lib/plugins/run/index.js
+++ b/lib/plugins/run/index.js
@@ -20,6 +20,8 @@ const registerFunctionsToEventGateway = require('./utils/registerFunctionsToEven
 const manageLocalEmulator = require('./utils/manageLocalEmulator');
 const manageEventGateway = require('./utils/manageEventGateway');
 
+const getAuthToken = require('../../utils/getAuthToken');
+
 class Run {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -64,6 +66,12 @@ class Run {
   run() {
     const EVENT_GATEWAY_VERSION = '0.5.14';
     const LOCAL_EMULATOR_VERSION = '0.1.18';
+
+    const authToken = getAuthToken();
+    if (!authToken) {
+      throw new this.serverless.classes
+        .Error('Must be logged in to use this command. Please run `sls login`.');
+    }
 
     let functionsDeployed = false;
     let functionsRegistered = false;

--- a/lib/plugins/run/index.js
+++ b/lib/plugins/run/index.js
@@ -70,7 +70,7 @@ class Run {
     const authToken = getAuthToken();
     if (!authToken) {
       throw new this.serverless.classes
-        .Error('Must be logged in to use this command. Please run `serverless login`.');
+        .Error('Must be logged in to use this command. Please run "serverless login".');
     }
 
     let functionsDeployed = false;

--- a/lib/utils/getAuthToken.js
+++ b/lib/utils/getAuthToken.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const configUtils = require('./config');
+
+function getAuthToken() {
+  if (process.env.SERVERLESS_TOKEN) {
+    return process.env.SERVERLESS_TOKEN;
+  }
+
+  const userConfig = configUtils.getConfig();
+  const currentId = userConfig.userId;
+  const globalConfig = configUtils.getGlobalConfig();
+  if (globalConfig.users && globalConfig.users[currentId] && globalConfig.users[currentId].auth) {
+    return globalConfig.users[currentId].auth.id_token;
+  }
+  return null;
+}
+
+module.exports = getAuthToken;


### PR DESCRIPTION
## What did you implement:

This PR gates the `sls run` and `sls emit` commands behind `sls login`.


## How did you implement it:

Throw an error if no auth token is detected when running either command.


## How can we verify it:

- Ensure you are logged out of platform.
- run `sls emit -n abc123 -d"{}"`
- framework should throw an error asking user to run `sls login`
- run `sls run` (needs to be run inside of a service project folder)
- framework should throw an error asking user to run `sls login`

- login to platform with `sls login`
- run `sls emit -n abc123 -d"{}"`
- command should run successfully (will probably indicate that event could not be emitted since gateway is not running)
- run `sls run` (needs to be run inside of a service project folder)
- command should run successfully 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
