### PR TITLE
bump event-gateway version to 0.5.15

### DIFF
--- a/lib/plugins/run/index.js
+++ b/lib/plugins/run/index.js
@@ -64,7 +64,7 @@ class Run {
   }
 
   run() {
-    const EVENT_GATEWAY_VERSION = '0.5.14';
+    const EVENT_GATEWAY_VERSION = '0.5.15';
     const LOCAL_EMULATOR_VERSION = '0.1.18';
 
     const authToken = getAuthToken();


### PR DESCRIPTION
## What did you implement:

Bump the version of the event-gateway to 0.5.15

## How can we verify it:

run `sls run` in a test service. Make sure that http paths with leading slashes and without both work. 

```
/my-path
my-path
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
