### PR TITLE
Allow use of Ref and Fn::ImportValue in OnError

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -325,7 +325,7 @@ provider:
 functions:
   hello:
     handler: handler.hello
-    onError: arn:aws:sns:us-east-1:XXXXXX:test
+    onError: arn:aws:sns:us-east-1:XXXXXX:test # Ref and Fn::ImportValue are supported as well
 ```
 
 ### DLQ with SQS

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -101,7 +101,7 @@ functions:
     runtime: nodejs6.10 # Runtime for this specific function. Overrides the default which is set on the provider level
     timeout: 10 # Timeout for this specific function.  Overrides the default set above.
     role: arn:aws:iam::XXXXXX:role/role # IAM role which will be used for this function
-    onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn which will be used for the DeadLetterConfig
+    onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic arn (Ref and Fn::ImportValue are supported as well) which will be used for the DeadLetterConfig
     awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption (overwrites the one defined on the service level)
     environment: # Function level environment variables
       functionEnvVar: 12345678

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -176,6 +176,10 @@ class AwsCompileFunctions {
           const errorMessage = 'onError config must be a SNS topic arn or SQS queue arn';
           throw new this.serverless.classes.Error(errorMessage);
         }
+      } else if (this.arnIsRefOrImport(arn)) {
+        newFunction.Properties.DeadLetterConfig = {
+          TargetArn: arn,
+        };
       } else {
         const errorMessage = 'onError config must be provided as a string';
         throw new this.serverless.classes.Error(errorMessage);
@@ -326,6 +330,11 @@ class AwsCompileFunctions {
   }
 
   // helper functions
+  arnIsRefOrImport(arn) {
+    return typeof arn === 'object' &&
+           _.some(_.keys(arn), (k) => _.includes(['Ref', 'Fn::ImportValue'], k));
+  }
+
   cfLambdaFunctionTemplate() {
     return {
       Type: 'AWS::Lambda::Function',

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -176,12 +176,15 @@ class AwsCompileFunctions {
           const errorMessage = 'onError config must be a SNS topic arn or SQS queue arn';
           throw new this.serverless.classes.Error(errorMessage);
         }
-      } else if (this.arnIsRefOrImport(arn)) {
+      } else if (this.isArnRefOrImportValue(arn)) {
         newFunction.Properties.DeadLetterConfig = {
           TargetArn: arn,
         };
       } else {
-        const errorMessage = 'onError config must be provided as a string';
+        const errorMessage = [
+          'onError config must be provided as an arn string,',
+          ' Ref or Fn::ImportValue',
+        ].join('');
         throw new this.serverless.classes.Error(errorMessage);
       }
     }
@@ -330,9 +333,9 @@ class AwsCompileFunctions {
   }
 
   // helper functions
-  arnIsRefOrImport(arn) {
+  isArnRefOrImportValue(arn) {
     return typeof arn === 'object' &&
-           _.some(_.keys(arn), (k) => _.includes(['Ref', 'Fn::ImportValue'], k));
+      _.some(_.keys(arn), (k) => _.includes(['Ref', 'Fn::ImportValue'], k));
   }
 
   cfLambdaFunctionTemplate() {

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -55,6 +55,15 @@ describe('AwsCompileFunctions', () => {
       expect(awsCompileFunctions.provider).to.be.instanceof(AwsProvider));
   });
 
+  describe('arnIsRefOrImport', () => {
+    it('should accept a Ref', () =>
+      expect(awsCompileFunctions.arnIsRefOrImport({ Ref: 'DLQ' })).to.eq(true));
+    it('should accept a Fn::ImportValue', () =>
+      expect(awsCompileFunctions.arnIsRefOrImport({ 'Fn::ImportValue': 'DLQ' })).to.eq(true));
+    it('should reject other objects', () =>
+      expect(awsCompileFunctions.arnIsRefOrImport({ Blah: 'vtha' })).to.eq(false));
+  });
+
   describe('#compileFunctions()', () => {
     it('should use service artifact if not individually', () => {
       awsCompileFunctions.serverless.service.package.individually = false;
@@ -664,7 +673,53 @@ describe('AwsCompileFunctions', () => {
           expect(() => { awsCompileFunctions.compileFunctions(); })
             .to.throw(Error, 'only supports SNS');
         });
+
+        it('should create necessary resources if a REF is provided to a DLQ', () => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              onError: {
+                Ref: 'DLQ',
+              },
+            },
+          };
+
+          const compiledFunction = {
+            Type: 'AWS::Lambda::Function',
+            DependsOn: [
+              'FuncLogGroup',
+              'IamRoleLambdaExecution',
+            ],
+            Properties: {
+              Code: {
+                S3Key: `${s3Folder}/${s3FileName}`,
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              },
+              FunctionName: 'new-service-dev-func',
+              Handler: 'func.function.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs4.3',
+              Timeout: 6,
+              DeadLetterConfig: {
+                TargetArn: {
+                  Ref: 'DLQ',
+                },
+              },
+            },
+          };
+
+          awsCompileFunctions.compileFunctions();
+
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
       });
+
 
       describe('when IamRoleLambdaExecution is not used', () => {
         it('should create necessary function resources if a SNS arn is provided', () => {

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -55,13 +55,14 @@ describe('AwsCompileFunctions', () => {
       expect(awsCompileFunctions.provider).to.be.instanceof(AwsProvider));
   });
 
-  describe('arnIsRefOrImport', () => {
+  describe('#isArnRefOrImportValue()', () => {
     it('should accept a Ref', () =>
-      expect(awsCompileFunctions.arnIsRefOrImport({ Ref: 'DLQ' })).to.eq(true));
+      expect(awsCompileFunctions.isArnRefOrImportValue({ Ref: 'DLQ' })).to.equal(true));
     it('should accept a Fn::ImportValue', () =>
-      expect(awsCompileFunctions.arnIsRefOrImport({ 'Fn::ImportValue': 'DLQ' })).to.eq(true));
+      expect(awsCompileFunctions.isArnRefOrImportValue({ 'Fn::ImportValue': 'DLQ' }))
+        .to.equal(true));
     it('should reject other objects', () =>
-      expect(awsCompileFunctions.arnIsRefOrImport({ Blah: 'vtha' })).to.eq(false));
+      expect(awsCompileFunctions.isArnRefOrImportValue({ Blah: 'vtha' })).to.equal(false));
   });
 
   describe('#compileFunctions()', () => {
@@ -674,7 +675,7 @@ describe('AwsCompileFunctions', () => {
             .to.throw(Error, 'only supports SNS');
         });
 
-        it('should create necessary resources if a REF is provided to a DLQ', () => {
+        it('should create necessary resources if a Ref is provided', () => {
           awsCompileFunctions.serverless.service.functions = {
             func: {
               handler: 'func.function.handler',
@@ -718,8 +719,52 @@ describe('AwsCompileFunctions', () => {
           const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
           expect(functionResource).to.deep.equal(compiledFunction);
         });
-      });
 
+        it('should create necessary resources if a Fn::ImportValue is provided', () => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              onError: {
+                'Fn::ImportValue': 'DLQ',
+              },
+            },
+          };
+
+          const compiledFunction = {
+            Type: 'AWS::Lambda::Function',
+            DependsOn: [
+              'FuncLogGroup',
+              'IamRoleLambdaExecution',
+            ],
+            Properties: {
+              Code: {
+                S3Key: `${s3Folder}/${s3FileName}`,
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              },
+              FunctionName: 'new-service-dev-func',
+              Handler: 'func.function.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs4.3',
+              Timeout: 6,
+              DeadLetterConfig: {
+                TargetArn: {
+                  'Fn::ImportValue': 'DLQ',
+                },
+              },
+            },
+          };
+
+          awsCompileFunctions.compileFunctions();
+
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
+      });
 
       describe('when IamRoleLambdaExecution is not used', () => {
         it('should create necessary function resources if a SNS arn is provided', () => {


### PR DESCRIPTION
## What did you implement:

Closes #4094

## How did you implement it:

Allows the use of an object in function onError, if that object is either a Ref or Fn::ImportValue.


## How can we verify it:

Create a function with a Ref instead of arn string in onerror:

```
  fn:
    handler: handler.main
    onError: 
       Ref: DeadLetterQueue  
```

The generated CFN script should allow this value. 

### NOTE
The current system will amend the default IAM role to provide access when using an SNS arn.

I have made no assumption here, if using a ref you will currently need to manage the permissions manually.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
