### PR TITLE
Add --context and --contextPath to `invoke local` cmd

### DIFF
--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -24,6 +24,8 @@ serverless invoke local --function functionName
 - `--path` or `-p` The path to a json file holding input data to be passed to the invoked function as the `event`. This path is relative to the root directory of the service.
 - `--data` or `-d` String data to be passed as an event to your function. Keep in mind that if you pass both `--path` and `--data`, the data included in the `--path` file will overwrite the data you passed with the `--data` flag.
 - `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
+- `--contextPath` or `-x`, The path to a json file holding input context to be passed to the invoked function. This path is relative to the root directory of the service.
+- `--context` or `-c`, String data to be passed as a context to your function. Same like with `--data`, context included in `--contextPath` will overwrite the context you passed with `--context` flag.
 
 ## Environment
 
@@ -52,6 +54,13 @@ serverless invoke local --function functionName --data "hello world"
 serverless invoke local --function functionName --data '{"a":"bar"}'
 ```
 
+### Local function invocation with custom context
+
+```bash
+serverless invoke local --function functionName --context "hello world"
+```
+
+
 ### Local function invocation with data from standard input
 
 ```bash
@@ -76,6 +85,12 @@ This example will pass the json data in the `lib/data.json` file (relative to th
   //  etc. //
 }
 ```
+
+### Local function invocation with context passing
+```bash
+serverless invoke local --function functionName --contextPath lib/context.json
+```
+This example will pass the json context in the `lib/context.json` file (relative to the root of the service) while invoking the specified/deployed function.
 
 ### Limitations
 

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -25,6 +25,22 @@ class AwsInvokeLocal {
     };
   }
 
+  validateFile(filePath, key) {
+    const absolutePath = path.isAbsolute(filePath) ?
+      filePath :
+      path.join(this.serverless.config.servicePath, filePath);
+    if (!this.serverless.utils.fileExistsSync(absolutePath)) {
+      throw new this.serverless.classes.Error('The file you provided does not exist.');
+    }
+
+    if (absolutePath.endsWith('.js')) {
+      // to support js - export as an input data
+      this.options[key] = require(absolutePath); // eslint-disable-line global-require
+    } else {
+      this.options[key] = this.serverless.utils.readFileSync(absolutePath);
+    }
+  }
+
   extendedValidate() {
     this.validate();
 
@@ -33,23 +49,14 @@ class AwsInvokeLocal {
     this.options.data = this.options.data || '';
 
     return new BbPromise(resolve => {
+      if (this.options.contextPath) {
+        this.validateFile(this.options.contextPath, 'context');
+      }
+
       if (this.options.data) {
         resolve();
       } else if (this.options.path) {
-        const absolutePath = path.isAbsolute(this.options.path) ?
-          this.options.path :
-          path.join(this.serverless.config.servicePath, this.options.path);
-        if (!this.serverless.utils.fileExistsSync(absolutePath)) {
-          throw new this.serverless.classes.Error('The file you provided does not exist.');
-        }
-        //
-
-        if (absolutePath.endsWith('.js')) {
-          // to support js - export as an input data
-          this.options.data = require(absolutePath); // eslint-disable-line global-require
-        } else {
-          this.options.data = this.serverless.utils.readFileSync(absolutePath);
-        }
+        this.validateFile(this.options.path, 'data');
 
         resolve();
       } else {
@@ -67,6 +74,7 @@ class AwsInvokeLocal {
       try {
         if (!this.options.raw) {
           this.options.data = JSON.parse(this.options.data);
+          this.options.context = JSON.parse(this.options.context);
         }
       } catch (exception) {
         // do nothing if it's a simple string or object already
@@ -115,7 +123,8 @@ class AwsInvokeLocal {
       return this.invokeLocalNodeJs(
         handlerPath,
         handlerName,
-        this.options.data);
+        this.options.data,
+        this.options.context);
     }
 
     if (runtime === 'python2.7' || runtime === 'python3.6') {
@@ -123,29 +132,36 @@ class AwsInvokeLocal {
         process.platform === 'win32' ? 'python.exe' : runtime,
         handlerPath,
         handlerName,
-        this.options.data);
+        this.options.data,
+        this.options.context);
     }
 
     throw new this.serverless.classes
       .Error('You can only invoke Node.js & Python functions locally.');
   }
 
-  invokeLocalPython(runtime, handlerPath, handlerName, event) {
+  invokeLocalPython(runtime, handlerPath, handlerName, event, context) {
+    const input = JSON.stringify({
+      event: event || {},
+      context,
+    });
+
     if (process.env.VIRTUAL_ENV) {
       process.env.PATH = `${process.env.VIRTUAL_ENV}/bin:${process.env.PATH}`;
     }
+
     return new BbPromise(resolve => {
       const python = spawn(runtime,
         [path.join(__dirname, 'invoke.py'), handlerPath, handlerName], { env: process.env });
       python.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       python.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
-      python.stdin.write(JSON.stringify(event || {}));
+      python.stdin.write(input);
       python.stdin.end();
       python.on('close', () => resolve());
     });
   }
 
-  invokeLocalNodeJs(handlerPath, handlerName, event) {
+  invokeLocalNodeJs(handlerPath, handlerName, event, customContext) {
     let lambda;
 
     try {
@@ -202,7 +218,7 @@ class AwsInvokeLocal {
 
 
     const startTime = new Date();
-    const context = {
+    let context = {
       awsRequestId: 'id',
       invokeid: 'id',
       logGroupName: this.provider.naming.getLogGroupName(this.options.functionObj.name),
@@ -226,6 +242,10 @@ class AwsInvokeLocal {
         return (new Date()).valueOf() - startTime.valueOf();
       },
     };
+
+    if (customContext) {
+      context = customContext;
+    }
 
     return lambda(event, context, callback);
   }

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -122,10 +122,10 @@ describe('AwsInvokeLocal', () => {
       };
       serverless.utils.writeFileSync(path
         .join(serverless.config.servicePath, 'data.json'), JSON.stringify(data));
-      awsInvokeLocal.options.path = 'data.json';
+      awsInvokeLocal.options.contextPath = 'data.json';
 
       return awsInvokeLocal.extendedValidate().then(() => {
-        expect(awsInvokeLocal.options.data).to.deep.equal(data);
+        expect(awsInvokeLocal.options.context).to.deep.equal(data);
       });
     });
 
@@ -139,6 +139,7 @@ describe('AwsInvokeLocal', () => {
       const dataFile = path.join(serverless.config.servicePath, 'data.json');
       serverless.utils.writeFileSync(dataFile, JSON.stringify(data));
       awsInvokeLocal.options.path = dataFile;
+      awsInvokeLocal.options.contextPath = false;
 
       return awsInvokeLocal.extendedValidate().then(() => {
         expect(awsInvokeLocal.options.data).to.deep.equal(data);
@@ -320,6 +321,21 @@ describe('AwsInvokeLocal', () => {
             'handler',
             'hello',
             {}
+          )).to.be.equal(true);
+          awsInvokeLocal.invokeLocalNodeJs.restore();
+        });
+    });
+
+    it('should call invokeLocalNodeJs with custom context if provided', () => {
+      awsInvokeLocal.options.context = 'custom context';
+      awsInvokeLocal.invokeLocal()
+        .then(() => {
+          expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
+          expect(invokeLocalNodeJsStub.calledWithExactly(
+            'handler',
+            'hello',
+            {},
+            'custom context'
           )).to.be.equal(true);
           awsInvokeLocal.invokeLocalNodeJs.restore();
         });

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -306,7 +306,8 @@ describe('AwsInvokeLocal', () => {
         expect(invokeLocalNodeJsStub.calledWithExactly(
           'handler',
           'hello',
-          {}
+          {},
+          undefined
         )).to.be.equal(true);
         awsInvokeLocal.invokeLocalNodeJs.restore();
       })

--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -54,6 +54,9 @@ if __name__ == '__main__':
     module = import_module(args.handler_path.replace('/', '.'))
     handler = getattr(module, args.handler_name)
 
-    event = json.load(sys.stdin)
-    result = handler(event, FakeLambdaContext())
+    input = json.load(sys.stdin)
+    context = FakeLambdaContext()
+    if 'context' in input:
+        context = input['context']
+        result = handler(input['event'], context)
     sys.stdout.write(json.dumps(result, indent=4))

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -41,7 +41,7 @@ class Invoke {
             shortcut: 'l',
           },
           data: {
-            usage: 'input data',
+            usage: 'Input data',
             shortcut: 'd',
           },
           raw: {
@@ -72,6 +72,14 @@ class Invoke {
               },
               raw: {
                 usage: 'Flag to pass input data as a raw string',
+              },
+              context: {
+                usage: 'Context of the service',
+                shortcut: 'c',
+              },
+              contextPath: {
+                usage: 'Path to JSON or YAML file holding context data',
+                shortcut: 'x',
               },
             },
           },


### PR DESCRIPTION
## What did you implement:

Closes #4031

Adds `--context` and `--contextPath` flags to `invoke local` command.

## How did you implement it:

Because validation mechanism is the same for `path` and for `contextPath`, I've extracted a `validateFile` function to avoid redundancy. When it comes to python, custom context is sent using stdin.

## How can we verify it:

`serverless.yml`
```
service: invokelocal

provider:
  name: aws
  runtime: nodejs6.10
  stage: dev
  region: us-east-1

functions:
  func:
    handler: handler.index
```

`handler.js`
```js
'use strict';

module.exports.index = (event, context, callback) => {
  console.log(context);

  const response = {
    statusCode: 200,
    body: JSON.stringify({
      context,
    }),
  };

  callback(null, response);
};
```
`serverless invoke local -f func -c '{"data":1}'`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
