### PR TITLE
kubeless quick fix for wrong runtime version in nodejs template

### DIFF
--- a/lib/plugins/create/templates/kubeless-nodejs/package.json
+++ b/lib/plugins/create/templates/kubeless-nodejs/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.1.3",
+    "serverless-kubeless": "^0.1.8",
     "lodash": "^4.1.0"
   },
   "devDependencies": {},

--- a/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
@@ -17,7 +17,7 @@ service: capitalize
 
 provider:
   name: kubeless
-  runtime: nodejs6.10
+  runtime: nodejs6
 
 plugins:
   - serverless-kubeless

--- a/lib/plugins/create/templates/kubeless-python/package.json
+++ b/lib/plugins/create/templates/kubeless-python/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sample Kubeless Python serverless framework service.",
   "dependencies": {
-    "serverless-kubeless": "^0.1.3"
+    "serverless-kubeless": "^0.1.8"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## What did you implement:

Not a feature, a quick fix for a wrong runtime version in the kubeless nodejs template

## How did you implement it:

trivial change from `nodejs6.10` to `nodejs6`

Also updated the default plugin version in the meantime.

## How can we verify it:

```
sls create --template kubeless-python --path foobar
cd foobar
sls deploy
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
