### PR TITLE
Reverse version sorting for "sls deploy list functions"

### DIFF
--- a/lib/plugins/aws/deployList/index.js
+++ b/lib/plugins/aws/deployList/index.js
@@ -92,22 +92,32 @@ class AwsDeployList {
     }).then((result) => _.map(result, (item) => item.Configuration));
   }
 
+  getFunctionPaginatedVersions(params, totalVersions) {
+    return this.provider.request('Lambda',
+      'listVersionsByFunction',
+      params,
+      this.options.stage,
+      this.options.region)
+      .then((response) => {
+        const Versions = (totalVersions || []).concat(response.Versions);
+        if (response.NextMarker) {
+          return this.getFunctionPaginatedVersions(
+            Object.assign({}, params, { Marker: response.NextMarker }), Versions);
+        }
+
+        return Promise.resolve({ Versions });
+      });
+  }
+
   getFunctionVersions(funcs) {
     const requestPromises = [];
 
     funcs.forEach((func) => {
       const params = {
         FunctionName: func.FunctionName,
-        MaxItems: 5,
       };
 
-      const request = this.provider.request('Lambda',
-        'listVersionsByFunction',
-        params,
-        this.options.stage,
-        this.options.region);
-
-      requestPromises.push(request);
+      requestPromises.push(this.getFunctionPaginatedVersions(params));
     });
 
     return BbPromise.all(requestPromises);
@@ -125,7 +135,8 @@ class AwsDeployList {
       name = name.replace(`${this.options.stage}-`, '');
 
       message += `${name}: `;
-      const versions = func.Versions.map((funcEntry) => funcEntry.Version).reverse();
+      const versions = func.Versions.map((funcEntry) => funcEntry.Version)
+        .slice(Math.max(0, func.Versions.length - 5));
 
       message += versions.join(', ');
       this.serverless.cli.log(message);

--- a/lib/plugins/aws/deployList/index.test.js
+++ b/lib/plugins/aws/deployList/index.test.js
@@ -163,6 +163,47 @@ describe('AwsDeployList', () => {
     });
   });
 
+  describe('#getFunctionPaginatedVersions()', () => {
+    beforeEach(() => {
+      sinon
+        .stub(awsDeployList.provider, 'request')
+        .onFirstCall()
+        .resolves({
+          Versions: [
+            { FunctionName: 'listDeployments-dev-func', Version: '1' },
+          ],
+          NextMarker: '123',
+        })
+        .onSecondCall()
+        .resolves({
+          Versions: [
+            { FunctionName: 'listDeployments-dev-func', Version: '2' },
+          ],
+        });
+    });
+
+    afterEach(() => {
+      awsDeployList.provider.request.restore();
+    });
+
+    it('should return the versions for the provided function when response is paginated', () => {
+      const params = {
+        FunctionName: 'listDeployments-dev-func',
+      };
+
+      return awsDeployList.getFunctionPaginatedVersions(params).then((result) => {
+        const expectedResult = {
+          Versions: [
+            { FunctionName: 'listDeployments-dev-func', Version: '1' },
+            { FunctionName: 'listDeployments-dev-func', Version: '2' },
+          ],
+        };
+
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+  });
+
   describe('#getFunctionVersions()', () => {
     let listVersionsByFunctionStub;
 
@@ -210,13 +251,17 @@ describe('AwsDeployList', () => {
     const funcs = [
       {
         Versions: [
-          { FunctionName: 'listDeployments-dev-func-1', Version: '$LATEST' },
+          { FunctionName: 'listDeployments-dev-func-1', Version: '1337' },
         ],
       },
       {
         Versions: [
-          { FunctionName: 'listDeployments-dev-func-2', Version: '$LATEST' },
-          { FunctionName: 'listDeployments-dev-func-2', Version: '4711' },
+          { FunctionName: 'listDeployments-dev-func-2', Version: '2' },
+          { FunctionName: 'listDeployments-dev-func-2', Version: '3' },
+          { FunctionName: 'listDeployments-dev-func-2', Version: '4' },
+          { FunctionName: 'listDeployments-dev-func-2', Version: '5' },
+          { FunctionName: 'listDeployments-dev-func-2', Version: '6' },
+          { FunctionName: 'listDeployments-dev-func-2', Version: '7' },
         ],
       },
     ];
@@ -229,9 +274,8 @@ describe('AwsDeployList', () => {
           .to.be.equal(true);
         expect(log.calledWithExactly('-------------')).to.be.equal(true);
 
-        expect(log.calledWithExactly('func-1: $LATEST')).to.be.equal(true);
-        expect(log.calledWithExactly('func-2: 4711, $LATEST')).to.be.equal(true);
-      });
+        expect(log.calledWithExactly('func-1: 1337')).to.be.equal(true);
+        expect(log.calledWithExactly('func-2: 3, 4, 5, 6, 7')).to.be.equal(true);      });
     });
   });
 });

--- a/lib/plugins/aws/deployList/index.test.js
+++ b/lib/plugins/aws/deployList/index.test.js
@@ -275,7 +275,8 @@ describe('AwsDeployList', () => {
         expect(log.calledWithExactly('-------------')).to.be.equal(true);
 
         expect(log.calledWithExactly('func-1: 1337')).to.be.equal(true);
-        expect(log.calledWithExactly('func-2: 3, 4, 5, 6, 7')).to.be.equal(true);      });
+        expect(log.calledWithExactly('func-2: 3, 4, 5, 6, 7')).to.be.equal(true);
+      });
     });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/3917,
Replaces https://github.com/serverless/serverless/pull/3957 

## How did you implement it:

I've removed `MaxItems` parameter from `deployList.listVersionsByFunction` and changed sorting in `displayFunctions` function.

## How can we verify it:

serverless.yml
```
service: domain-manager

frameworkVersion: "<=1.17.0"

provider:
  name: aws
  runtime: nodejs6.10
  stage: dev
  region: us-east-1
  iamRoleStatements:
    - Effect: "Allow"
      Action:
        - "route53:*"
      Resource: "*"

functions:
  list-zos:
    handler: zones.listt
  get-zone:
    handler: zones.get
  create-zone:
    handler: zones.create
  delete-zone:
    handler: zones.delete

  list-records:
    handler: records.list
  create-record:
    handler: records.upsert
  update-record:
    handler: records.upsert
  delete-record:
    handler: records.delete
```

And deploy 6 times:
```
for i in {1..6}
do
   sls deploy
done

sls deploy list functions
```

Will now produce: 
```
Serverless: Listing functions and their last 5 versions:
Serverless: -------------
Serverless: delete-zone: 2, 3, 4, 5, 6
Serverless: list-zones: 2, 3, 4, 5, 6
Serverless: update-record: 2, 3, 4, 5, 6
Serverless: create-record: 2, 3, 4, 5, 6
Serverless: get-zone: 2, 3, 4, 5, 6
Serverless: list-records: 2, 3, 4, 5, 6
Serverless: create-zone: 2, 3, 4, 5, 6
Serverless: delete-record: 2, 3, 4, 5, 6
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO