### PR TITLE
Fix tests setup - ensure errors are exposed

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+'use strict';
+
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
+if (!process.env.FORCE_COLOR) process.env.FORCE_COLOR = '0';
+
+if (process.argv.length <= 2) {
+  process.argv.push(
+    '!(node_modules)/**/*.test.js',
+    '--require=sinon-bluebird',
+    '-R',
+    'spec',
+    '--recursive',
+    '--no-exit'
+  );
+}
+
+require('mocha/bin/_mocha');

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -173,7 +173,7 @@ describe('Serverless', () => {
       const updateAutocompleteCacheFileStub = sinon
         .stub(serverless.pluginManager, 'updateAutocompleteCacheFile');
 
-      serverlessInstance.init().then(loadedService => {
+      return serverlessInstance.init().then(loadedService => {
         expect(loadedService.custom.variableRefs.testA)
           .to.deep.equal({ one: 1, two: 'two' });
         expect(loadedService.custom.variableRefs.testB).to.equal('dev');
@@ -193,8 +193,7 @@ describe('Serverless', () => {
     let populateServiceStub;
     let runStub;
 
-    beforeEach(() => {
-      serverless.init();
+    beforeEach(() => serverless.init().then(() => {
       serverless.processedInput = { commands: [], options: {} };
       // setup default stubs
       logStatStub = sinon
@@ -207,9 +206,10 @@ describe('Serverless', () => {
         .stub(serverless.variables, 'populateService').resolves();
       runStub = sinon
         .stub(serverless.pluginManager, 'run').resolves();
-    });
+    }));
 
     afterEach(() => {
+      if (!serverless.utils.logStat.restore) return;
       serverless.utils.logStat.restore();
       serverless.cli.displayHelp.restore();
       serverless.pluginManager.validateCommand.restore();

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -110,25 +110,42 @@ describe('Serverless', () => {
   });
 
   describe('#init()', () => {
-    it('should create a new CLI instance', () => {
-      serverless.init();
-      expect(serverless.cli).to.be.instanceof(CLI);
+    let loadAllPluginsStub;
+    let updateAutocompleteCacheFileStub;
+
+    beforeEach(() => {
+      loadAllPluginsStub = sinon
+        .stub(serverless.pluginManager, 'loadAllPlugins').returns();
+      updateAutocompleteCacheFileStub = sinon
+        .stub(serverless.pluginManager, 'updateAutocompleteCacheFile').resolves();
     });
+
+    afterEach(() => {
+      serverless.pluginManager.loadAllPlugins.restore();
+      serverless.pluginManager.updateAutocompleteCacheFile.restore();
+    });
+
+    it('should create a new CLI instance', () => serverless.init().then(() => {
+      expect(serverless.cli).to.be.instanceof(CLI);
+    }));
 
     it('should allow a custom CLI instance', () => {
       class CustomCLI extends CLI {}
       serverless.classes.CLI = CustomCLI;
-      serverless.init();
-      expect(serverless.cli).to.be.instanceof(CLI);
-      expect(serverless.cli.constructor.name).to.equal('CustomCLI');
+
+      return serverless.init().then(() => {
+        expect(serverless.cli).to.be.instanceof(CLI);
+        expect(serverless.cli.constructor.name).to.equal('CustomCLI');
+      });
     });
 
     // note: we just test that the processedInput variable is set (not the content of it)
     // the test for the correct input is done in the CLI class test file
-    it('should receive the processed input form the CLI instance', () => {
-      serverless.init();
-      expect(serverless.processedInput).to.not.deep.equal({});
-    });
+    it('should receive the processed input form the CLI instance', () => serverless.init()
+      .then(() => {
+        expect(serverless.processedInput).to.not.deep.equal({});
+      })
+    );
 
     it('should resolve after loading the service', () => {
       const SUtils = new Utils();
@@ -136,32 +153,12 @@ describe('Serverless', () => {
       const serverlessYml = {
         service: 'new-service',
         provider: 'aws',
-        custom: {
-          selfValues: {
-            obj: {
-              one: 1,
-              two: 'two',
-            },
-            dev: true,
-          },
-          variableRefs: {
-            testA: '${self:custom.selfValues.obj}',
-            testB: '${env:random_env, opt:stage}',
-            testC: 'number is ${env:random_env, opt:random_opt, self:custom.selfValues.obj.two}',
-            testD: '${self:custom.selfValues.${opt:stage}}',
-          },
-        },
+        custom: {},
         plugins: ['testPlugin'],
         functions: {
           functionA: {},
         },
-        resources: {
-          aws: {
-            resourcesProp: 'value',
-          },
-          azure: {},
-          google: {},
-        },
+        resources: {},
         package: {
           exclude: ['exclude-me'],
           include: ['include-me'],
@@ -172,24 +169,14 @@ describe('Serverless', () => {
       SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
         YAML.dump(serverlessYml));
 
-      const serverlessInstance = new Serverless();
-      serverlessInstance.config.update({ servicePath: tmpDirPath });
+      serverless.config.update({ servicePath: tmpDirPath });
       serverless.pluginManager.cliOptions = {
         stage: 'dev',
       };
 
-      const updateAutocompleteCacheFileStub = sinon
-        .stub(serverless.pluginManager, 'updateAutocompleteCacheFile');
-
-      return serverlessInstance.init().then(loadedService => {
-        expect(loadedService.custom.variableRefs.testA)
-          .to.deep.equal({ one: 1, two: 'two' });
-        expect(loadedService.custom.variableRefs.testB).to.equal('dev');
-        expect(loadedService.custom.variableRefs.testC).to.equal('number is two');
-        expect(loadedService.custom.variableRefs.testD).to.equal(true);
+      return serverless.init().then(() => {
+        expect(loadAllPluginsStub.calledOnce).to.equal(true);
         expect(updateAutocompleteCacheFileStub.calledOnce).to.equal(true);
-
-        serverless.pluginManager.updateAutocompleteCacheFile.restore();
       });
     });
   });
@@ -201,7 +188,8 @@ describe('Serverless', () => {
     let populateServiceStub;
     let runStub;
 
-    beforeEach(() => serverless.init().then(() => {
+    beforeEach(() => {
+      serverless.cli = new CLI(serverless);
       serverless.processedInput = { commands: [], options: {} };
       // setup default stubs
       logStatStub = sinon
@@ -214,10 +202,9 @@ describe('Serverless', () => {
         .stub(serverless.variables, 'populateService').resolves();
       runStub = sinon
         .stub(serverless.pluginManager, 'run').resolves();
-    }));
+    });
 
     afterEach(() => {
-      if (!serverless.utils.logStat.restore) return;
       serverless.utils.logStat.restore();
       serverless.cli.displayHelp.restore();
       serverless.pluginManager.validateCommand.restore();

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -156,27 +156,28 @@ describe('Service', () => {
         YAML.dump(serverlessYml));
 
       const serverless = new Serverless();
-      serverless.init();
-      serverless.config.update({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
+      return serverless.init().then(() => {
+        serverless.config.update({ servicePath: tmpDirPath });
+        serviceInstance = new Service(serverless);
 
-      return expect(serviceInstance.load()).to.eventually.be.fulfilled
-      .then(() => {
-        expect(serviceInstance.service).to.be.equal('new-service');
-        expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
-        );
-        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
-        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-        expect(serviceInstance.resources.azure).to.deep.equal({});
-        expect(serviceInstance.resources.google).to.deep.equal({});
-        expect(serviceInstance.package.exclude.length).to.equal(1);
-        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
-        expect(serviceInstance.package.include.length).to.equal(1);
-        expect(serviceInstance.package.include[0]).to.equal('include-me');
-        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
-        expect(serviceInstance.package.excludeDevDependencies).to.equal(false);
+        return expect(serviceInstance.load()).to.eventually.be.fulfilled
+        .then(() => {
+          expect(serviceInstance.service).to.be.equal('new-service');
+          expect(serviceInstance.provider.name).to.deep.equal('aws');
+          expect(serviceInstance.provider.variableSyntax).to.equal(
+            '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+          );
+          expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+          expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+          expect(serviceInstance.resources.azure).to.deep.equal({});
+          expect(serviceInstance.resources.google).to.deep.equal({});
+          expect(serviceInstance.package.exclude.length).to.equal(1);
+          expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+          expect(serviceInstance.package.include.length).to.equal(1);
+          expect(serviceInstance.package.include[0]).to.equal('include-me');
+          expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+          expect(serviceInstance.package.excludeDevDependencies).to.equal(false);
+        });
       });
     });
 
@@ -212,27 +213,28 @@ describe('Service', () => {
         YAML.dump(serverlessYml));
 
       const serverless = new Serverless();
-      serverless.init();
-      serverless.config.update({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
+      return serverless.init().then(() => {
+        serverless.config.update({ servicePath: tmpDirPath });
+        serviceInstance = new Service(serverless);
 
-      return expect(serviceInstance.load()).to.eventually.be.fulfilled
-      .then(() => {
-        expect(serviceInstance.service).to.be.equal('new-service');
-        expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
-        );
-        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
-        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-        expect(serviceInstance.resources.azure).to.deep.equal({});
-        expect(serviceInstance.resources.google).to.deep.equal({});
-        expect(serviceInstance.package.exclude.length).to.equal(1);
-        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
-        expect(serviceInstance.package.include.length).to.equal(1);
-        expect(serviceInstance.package.include[0]).to.equal('include-me');
-        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
-        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
+        return expect(serviceInstance.load()).to.eventually.be.fulfilled
+        .then(() => {
+          expect(serviceInstance.service).to.be.equal('new-service');
+          expect(serviceInstance.provider.name).to.deep.equal('aws');
+          expect(serviceInstance.provider.variableSyntax).to.equal(
+            '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+          );
+          expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+          expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+          expect(serviceInstance.resources.azure).to.deep.equal({});
+          expect(serviceInstance.resources.google).to.deep.equal({});
+          expect(serviceInstance.package.exclude.length).to.equal(1);
+          expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+          expect(serviceInstance.package.include.length).to.equal(1);
+          expect(serviceInstance.package.include[0]).to.equal('include-me');
+          expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+          expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
+        });
       });
     });
 
@@ -268,27 +270,28 @@ describe('Service', () => {
         JSON.stringify(serverlessJSON));
 
       const serverless = new Serverless();
-      serverless.init();
-      serverless.config.update({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
+      return serverless.init().then(() => {
+        serverless.config.update({ servicePath: tmpDirPath });
+        serviceInstance = new Service(serverless);
 
-      return expect(serviceInstance.load()).to.eventually.be.fulfilled
-      .then(() => {
-        expect(serviceInstance.service).to.be.equal('new-service');
-        expect(serviceInstance.provider.name).to.deep.equal('aws');
-        expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
-        );
-        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
-        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-        expect(serviceInstance.resources.azure).to.deep.equal({});
-        expect(serviceInstance.resources.google).to.deep.equal({});
-        expect(serviceInstance.package.exclude.length).to.equal(1);
-        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
-        expect(serviceInstance.package.include.length).to.equal(1);
-        expect(serviceInstance.package.include[0]).to.equal('include-me');
-        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
-        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
+        return expect(serviceInstance.load()).to.eventually.be.fulfilled
+        .then(() => {
+          expect(serviceInstance.service).to.be.equal('new-service');
+          expect(serviceInstance.provider.name).to.deep.equal('aws');
+          expect(serviceInstance.provider.variableSyntax).to.equal(
+            '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+          );
+          expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+          expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+          expect(serviceInstance.resources.azure).to.deep.equal({});
+          expect(serviceInstance.resources.google).to.deep.equal({});
+          expect(serviceInstance.package.exclude.length).to.equal(1);
+          expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+          expect(serviceInstance.package.include.length).to.equal(1);
+          expect(serviceInstance.package.include[0]).to.equal('include-me');
+          expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+          expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
+        });
       });
     });
 
@@ -328,14 +331,15 @@ describe('Service', () => {
         YAML.dump(serverlessJSON));
 
       const serverless = new Serverless();
-      serverless.init();
-      serverless.config.update({ servicePath: tmpDirPath });
-      serviceInstance = new Service(serverless);
+      return serverless.init().then(() => {
+        serverless.config.update({ servicePath: tmpDirPath });
+        serviceInstance = new Service(serverless);
 
-      return expect(serviceInstance.load()).to.eventually.be.fulfilled
-      .then(() => {
-        // YAML should have been loaded instead of JSON
-        expect(serviceInstance.service).to.be.equal('YAML service');
+        return expect(serviceInstance.load()).to.eventually.be.fulfilled
+        .then(() => {
+          // YAML should have been loaded instead of JSON
+          expect(serviceInstance.service).to.be.equal('YAML service');
+        });
       });
     });
 

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -156,28 +156,25 @@ describe('Service', () => {
         YAML.dump(serverlessYml));
 
       const serverless = new Serverless();
-      return serverless.init().then(() => {
-        serverless.config.update({ servicePath: tmpDirPath });
-        serviceInstance = new Service(serverless);
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
 
-        return expect(serviceInstance.load()).to.eventually.be.fulfilled
-        .then(() => {
-          expect(serviceInstance.service).to.be.equal('new-service');
-          expect(serviceInstance.provider.name).to.deep.equal('aws');
-          expect(serviceInstance.provider.variableSyntax).to.equal(
-            '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
-          );
-          expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
-          expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-          expect(serviceInstance.resources.azure).to.deep.equal({});
-          expect(serviceInstance.resources.google).to.deep.equal({});
-          expect(serviceInstance.package.exclude.length).to.equal(1);
-          expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
-          expect(serviceInstance.package.include.length).to.equal(1);
-          expect(serviceInstance.package.include[0]).to.equal('include-me');
-          expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
-          expect(serviceInstance.package.excludeDevDependencies).to.equal(false);
-        });
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled.then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+        );
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(false);
       });
     });
 
@@ -213,28 +210,25 @@ describe('Service', () => {
         YAML.dump(serverlessYml));
 
       const serverless = new Serverless();
-      return serverless.init().then(() => {
-        serverless.config.update({ servicePath: tmpDirPath });
-        serviceInstance = new Service(serverless);
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
 
-        return expect(serviceInstance.load()).to.eventually.be.fulfilled
-        .then(() => {
-          expect(serviceInstance.service).to.be.equal('new-service');
-          expect(serviceInstance.provider.name).to.deep.equal('aws');
-          expect(serviceInstance.provider.variableSyntax).to.equal(
-            '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
-          );
-          expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
-          expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-          expect(serviceInstance.resources.azure).to.deep.equal({});
-          expect(serviceInstance.resources.google).to.deep.equal({});
-          expect(serviceInstance.package.exclude.length).to.equal(1);
-          expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
-          expect(serviceInstance.package.include.length).to.equal(1);
-          expect(serviceInstance.package.include[0]).to.equal('include-me');
-          expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
-          expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
-        });
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled.then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+        );
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
       });
     });
 
@@ -270,28 +264,26 @@ describe('Service', () => {
         JSON.stringify(serverlessJSON));
 
       const serverless = new Serverless();
-      return serverless.init().then(() => {
-        serverless.config.update({ servicePath: tmpDirPath });
-        serviceInstance = new Service(serverless);
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
 
-        return expect(serviceInstance.load()).to.eventually.be.fulfilled
-        .then(() => {
-          expect(serviceInstance.service).to.be.equal('new-service');
-          expect(serviceInstance.provider.name).to.deep.equal('aws');
-          expect(serviceInstance.provider.variableSyntax).to.equal(
-            '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
-          );
-          expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
-          expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
-          expect(serviceInstance.resources.azure).to.deep.equal({});
-          expect(serviceInstance.resources.google).to.deep.equal({});
-          expect(serviceInstance.package.exclude.length).to.equal(1);
-          expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
-          expect(serviceInstance.package.include.length).to.equal(1);
-          expect(serviceInstance.package.include[0]).to.equal('include-me');
-          expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
-          expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
-        });
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+        );
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
       });
     });
 
@@ -331,15 +323,13 @@ describe('Service', () => {
         YAML.dump(serverlessJSON));
 
       const serverless = new Serverless();
-      return serverless.init().then(() => {
-        serverless.config.update({ servicePath: tmpDirPath });
-        serviceInstance = new Service(serverless);
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
 
-        return expect(serviceInstance.load()).to.eventually.be.fulfilled
-        .then(() => {
-          // YAML should have been loaded instead of JSON
-          expect(serviceInstance.service).to.be.equal('YAML service');
-        });
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        // YAML should have been loaded instead of JSON
+        expect(serviceInstance.service).to.be.equal('YAML service');
       });
     });
 
@@ -740,12 +730,10 @@ describe('Service', () => {
         YAML.dump(serverlessYml));
 
       const serverless = new Serverless();
-      serverless.init();
       serverless.config.update({ servicePath: tmpDirPath });
       serviceInstance = new Service(serverless);
 
-      return expect(serviceInstance.load()).to.eventually.be.fulfilled
-      .then(() => {
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled.then(() => {
         serviceInstance.setFunctionNames();
         expect(serviceInstance.functions.functionA.name).to.be.equal('new-service-dev-functionA');
       });

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -21,7 +21,7 @@ describe('Utils', () => {
   beforeEach(() => {
     serverless = new Serverless();
     utils = new Utils(serverless);
-    serverless.init();
+    return serverless.init();
   });
 
   describe('#dirExistsSync()', () => {
@@ -305,18 +305,17 @@ describe('Utils', () => {
     let getConfigStub;
     let trackStub;
 
-    beforeEach(() => {
-      serverless.init();
-
+    beforeEach(() => serverless.init().then(() => {
       // set the properties for the processed inputs
       serverless.processedInput.commands = [];
       serverless.processedInput.options = {};
 
       trackStub = sinon.stub(segment, 'track');
       getConfigStub = sinon.stub(configUtils, 'getConfig');
-    });
+    }));
 
     afterEach(() => {
+      if (!segment.track.restore) return;
       segment.track.restore();
       configUtils.getConfig.restore();
     });

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -304,17 +304,18 @@ describe('Utils', () => {
     let getConfigStub;
     let trackStub;
 
-    beforeEach(() => serverless.init().then(() => {
-      // set the properties for the processed inputs
-      serverless.processedInput.commands = [];
-      serverless.processedInput.options = {};
+    beforeEach(() => {
+      // mock properties for processed inputs
+      serverless.processedInput = {
+        commands: [],
+        options: {},
+      };
 
       trackStub = sinon.stub(segment, 'track');
       getConfigStub = sinon.stub(configUtils, 'getConfig');
-    }));
+    });
 
     afterEach(() => {
-      if (!segment.track.restore) return;
       segment.track.restore();
       configUtils.getConfig.restore();
     });

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -21,7 +21,6 @@ describe('Utils', () => {
   beforeEach(() => {
     serverless = new Serverless();
     utils = new Utils(serverless);
-    return serverless.init();
   });
 
   describe('#dirExistsSync()', () => {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -342,9 +342,11 @@ describe('AwsInvokeLocal', () => {
     it('should call invokeLocalPython when python2.7 runtime is set', () => {
       awsInvokeLocal.options.functionObj.runtime = 'python2.7';
       return awsInvokeLocal.invokeLocal().then(() => {
+        // NOTE: this is important so that tests on Windows won't fail
+        const runtime = process.platform === 'win32' ? 'python.exe' : 'python2.7';
         expect(invokeLocalPythonStub.calledOnce).to.be.equal(true);
         expect(invokeLocalPythonStub.calledWithExactly(
-          'python2.7',
+          runtime,
           'handler',
           'hello',
           {},

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -422,7 +422,7 @@ describe('AwsInvokeLocal', () => {
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withRemainingTime');
 
         const remainingTimes = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
-        expect(remainingTimes.start).to.eql(5000);
+        expect(remainingTimes.start).to.match(/\d+/);
       });
 
       it('should never become negative', () => {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -296,8 +296,8 @@ describe('AwsInvokeLocal', () => {
     });
 
     afterEach(() => {
-      invokeLocalNodeJsStub.restore();
-      invokeLocalPythonStub.restore();
+      awsInvokeLocal.invokeLocalNodeJs.restore();
+      awsInvokeLocal.invokeLocalPython.restore();
     });
 
     it('should call invokeLocalNodeJs when no runtime is set', () => awsInvokeLocal.invokeLocal()
@@ -309,22 +309,20 @@ describe('AwsInvokeLocal', () => {
           {},
           undefined
         )).to.be.equal(true);
-        awsInvokeLocal.invokeLocalNodeJs.restore();
       })
     );
 
     it('should call invokeLocalNodeJs for any node.js runtime version', () => {
       awsInvokeLocal.options.functionObj.runtime = 'nodejs6.10';
-      return awsInvokeLocal.invokeLocal()
-        .then(() => {
-          expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
-          expect(invokeLocalNodeJsStub.calledWithExactly(
-            'handler',
-            'hello',
-            {}
-          )).to.be.equal(true);
-          awsInvokeLocal.invokeLocalNodeJs.restore();
-        });
+      return awsInvokeLocal.invokeLocal().then(() => {
+        expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
+        expect(invokeLocalNodeJsStub.calledWithExactly(
+          'handler',
+          'hello',
+          {},
+          undefined
+        )).to.be.equal(true);
+      });
     });
 
     it('should call invokeLocalNodeJs with custom context if provided', () => {
@@ -338,24 +336,22 @@ describe('AwsInvokeLocal', () => {
             {},
             'custom context'
           )).to.be.equal(true);
-          awsInvokeLocal.invokeLocalNodeJs.restore();
         });
     });
 
     it('should call invokeLocalPython when python2.7 runtime is set', () => {
       awsInvokeLocal.options.functionObj.runtime = 'python2.7';
-      return awsInvokeLocal.invokeLocal()
-        .then(() => {
-          expect(invokeLocalPythonStub.calledOnce).to.be.equal(true);
-          expect(invokeLocalPythonStub.calledWithExactly(
-            'python2.7',
-            'handler',
-            'hello',
-            {}
-          )).to.be.equal(true);
-          awsInvokeLocal.invokeLocalPython.restore();
-          delete awsInvokeLocal.options.functionObj.runtime;
-        });
+      return awsInvokeLocal.invokeLocal().then(() => {
+        expect(invokeLocalPythonStub.calledOnce).to.be.equal(true);
+        expect(invokeLocalPythonStub.calledWithExactly(
+          'python2.7',
+          'handler',
+          'hello',
+          {},
+          undefined
+        )).to.be.equal(true);
+        delete awsInvokeLocal.options.functionObj.runtime;
+      });
     });
 
     it('throw error when using runtime other than Node.js or Python', () => {

--- a/lib/utils/fs/writeFile.test.js
+++ b/lib/utils/fs/writeFile.test.js
@@ -16,7 +16,7 @@ describe('#writeFile()', function () {
   this.timeout(0);
   beforeEach(() => {
     serverless = new Serverless();
-    serverless.init();
+    return serverless.init();
   });
 
   it('should write a .json file asynchronously', () => {

--- a/lib/utils/fs/writeFile.test.js
+++ b/lib/utils/fs/writeFile.test.js
@@ -14,9 +14,9 @@ const expect = require('chai').expect;
 describe('#writeFile()', function () {
   let serverless;
   this.timeout(0);
+
   beforeEach(() => {
     serverless = new Serverless();
-    return serverless.init();
   });
 
   it('should write a .json file asynchronously', () => {

--- a/lib/utils/fs/writeFileSync.test.js
+++ b/lib/utils/fs/writeFileSync.test.js
@@ -11,7 +11,6 @@ describe('#writeFileSync()', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
-    return serverless.init();
   });
 
   it('should write a .json file synchronously', () => {

--- a/lib/utils/fs/writeFileSync.test.js
+++ b/lib/utils/fs/writeFileSync.test.js
@@ -11,7 +11,7 @@ describe('#writeFileSync()', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
-    serverless.init();
+    return serverless.init();
   });
 
   it('should write a .json file synchronously', () => {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "sls": "./bin/serverless"
   },
   "scripts": {
-    "test-bare": "env FORCE_COLOR=0 node_modules/mocha/bin/_mocha \"!(node_modules)/**/*.test.js\" --require=sinon-bluebird -R spec --recursive --no-exit",
-    "test": "env FORCE_COLOR=0 istanbul cover -x \"**/*.test.js\" node_modules/mocha/bin/_mocha \"!(node_modules)/**/*.test.js\" -- --require=sinon-bluebird -R spec --recursive",
+    "test-bare": "node bin/test",
+    "test": "istanbul cover -x \"**/*.test.js\" bin/test",
     "lint": "eslint . --cache",
     "docs": "node scripts/generate-readme.js",
     "simple-integration-test": "jest --maxWorkers=5 simple-suite",


### PR DESCRIPTION
## What did you implement:

There are errors in tests which are not properly exposed, additionally due to that, some configured tests are not invoked at all.

Issue lies in not handled rejected promises, their errors are exposed only via _UnhandledRejection_ warnings which can be seen through the tests output, but which do not force tests to fail as expected.

I didn't fix code corresponding to broken tests, I thought it's better (more efficient) if it's looked after by its authors. __Due to that CI crashes, it's expected__

## How did you implement it:

In tests I ensured that those rejected promises are returned to mocha functions, therefore exposed as expected.

Still, more future proof solution would be to add following code to some init test script:

```javascript
process.on('unhandledRejection', err => {
  throw err;
});
```

This will ensure that all currently (and those introduced in future) broken tests  will fail same way as they do after this PR is applied.

This approach was also scheduled to be default in Node.js -> https://github.com/nodejs/node/pull/12010
If you agree on that solution I may add it instead of patching individual tests, just let me know where's the best place.

## How can we verify it:

Run tests

## Todos:

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
