### PR TITLE
Script command to run bare tests (without coverage overhead)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "sls": "./bin/serverless"
   },
   "scripts": {
+    "test-bare": "env FORCE_COLOR=0 node_modules/mocha/bin/_mocha \"!(node_modules)/**/*.test.js\" --require=sinon-bluebird -R spec --recursive --no-exit",
     "test": "env FORCE_COLOR=0 istanbul cover -x \"**/*.test.js\" node_modules/mocha/bin/_mocha \"!(node_modules)/**/*.test.js\" -- --require=sinon-bluebird -R spec --recursive",
     "lint": "eslint . --cache",
     "docs": "node scripts/generate-readme.js",


### PR DESCRIPTION

## What did you implement:

It'll be great to have a _test_ command, that runs tests directly without _coverage_ overhead.

Main problem with _coverage_ wrap is that it manipulates source code, so eventually exposed error stacks do not relate to code as in codebase, which makes errors harder to investigate

## How did you implement it:

Here I propose least invasive way, as I just configured aside `test-bare` script.

However in my eyes following two approaches could be better:

1. Make `test` a plain test command, but introduce `coverage` script, which will do what `test` does now. CI configuration will have to be updated

2. To not repeat mocha arguments setup in two scripts (certainly a mainance issue). Introduce a js program (e.g. in `bin/test`) that invokes mocha programmaticaly with exactly this setup, and then configure scripts as follows:
- `bare-test`: `node bin/test`
- `test`: `istanbul cover -x \"**/*.test.js\"  bin/test`

Let me know.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
