### PR TITLE
Allow custom CLI class instances

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -49,7 +49,7 @@ class Serverless {
 
   init() {
     // create a new CLI instance
-    this.cli = new CLI(this);
+    this.cli = new this.classes.CLI(this);
 
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -115,6 +115,14 @@ describe('Serverless', () => {
       expect(serverless.cli).to.be.instanceof(CLI);
     });
 
+    it('should allow a custom CLI instance', () => {
+      class CustomCLI extends CLI {}
+      serverless.classes.CLI = CustomCLI;
+      serverless.init();
+      expect(serverless.cli).to.be.instanceof(CLI);
+      expect(serverless.cli.constructor.name).to.equal('CustomCLI');
+    });
+
     // note: we just test that the processedInput variable is set (not the content of it)
     // the test for the correct input is done in the CLI class test file
     it('should receive the processed input form the CLI instance', () => {


### PR DESCRIPTION
## What did you implement:

Goals:

An easier way to pass custom CLI arguments without messing with `process.argv` for version 1. 

Similar issues with a short description:

#1678 / #2444 Issue is open (discussion stage). Serverless response was that it is on roadmap for v2. No resolution for v1 users with multiple discussions with best way to hack around the issue.

#3895 Issue is open (status: help wanted). Suggestion was to add a configuration entry and pass it through. Serverless response was that it was on roadmap.

#2426 Closed. Serverless response was that discussions are ongoing for version 2 but nothing for version 1.

#3707 It could close this feature request?

## How did you implement it:

The error handling logic in Serverless references `new this.classes.Error()` so I applied the same logic to the `init()` method so that a custom CLI class can be used. This would allow customization of how the `process.argv` are processed by overwriting the method and allow capturing of output.

This one line change doesn't affect any existing method signatures or functionality as previous PRs. All other discussions and PRs were closed due to version 2 but I believe this would be a flexible way to gain some functionality with minimal code changes for those of us that will remain on version 1 for some time.

If this PR is closed, can we re-open a discussion on options for version 1?

## How can we verify it:

`npm run test`

Here is some code that demonstrates how to provide custom input array as well as capture the log output:

```
const serverless = new Serverless({});

const CLI = require('../lib/classes/CLI');

CLI.prototype.processInput = function() {
  return { commands: ['logs'], options: { help: true } };
};

CLI.prototype.consoleLog = function(message) {
  (this._internal = this._internal || []).push(message);
};

CLI.prototype.outputLog = function(message) {
  console.log(this._internal);
};

serverless.cli = CLI;

return serverless.init().then(() => serverless.run()).then(() => serverless.cli.outputLog());
```

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
