### PR TITLE
making python templates pep8 compliant

### DIFF
--- a/lib/plugins/create/templates/aws-python/handler.py
+++ b/lib/plugins/create/templates/aws-python/handler.py
@@ -1,5 +1,6 @@
 import json
 
+
 def hello(event, context):
     body = {
         "message": "Go Serverless v1.0! Your function executed successfully!",
@@ -13,7 +14,8 @@ def hello(event, context):
 
     return response
 
-    # Use this code if you don't use the http event with the LAMBDA-PROXY integration
+    # Use this code if you don't use the http event with the LAMBDA-PROXY
+    # integration
     """
     return {
         "message": "Go Serverless v1.0! Your function executed successfully!",

--- a/lib/plugins/create/templates/aws-python3/handler.py
+++ b/lib/plugins/create/templates/aws-python3/handler.py
@@ -1,5 +1,6 @@
 import json
 
+
 def hello(event, context):
     body = {
         "message": "Go Serverless v1.0! Your function executed successfully!",
@@ -13,7 +14,8 @@ def hello(event, context):
 
     return response
 
-    # Use this code if you don't use the http event with the LAMBDA-PROXY integration
+    # Use this code if you don't use the http event with the LAMBDA-PROXY
+    # integration
     """
     return {
         "message": "Go Serverless v1.0! Your function executed successfully!",

--- a/lib/plugins/create/templates/kubeless-python/handler.py
+++ b/lib/plugins/create/templates/kubeless-python/handler.py
@@ -1,5 +1,6 @@
 import json
 
+
 def hello(request):
     body = {
         "message": "Go Serverless v1.0! Your function executed successfully!",

--- a/lib/plugins/create/templates/spotinst-python/handler.py
+++ b/lib/plugins/create/templates/spotinst-python/handler.py
@@ -1,7 +1,7 @@
+# Implement your function here.
+# The function will get the request as parameter.
+# The function should return an object
 
- # Implement your function here.
- # The function will get the request as parameter.
- # The function should return an object
 
 def main(args):
     queryparams = args.get("query", {})


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When using Serverless with python templates, templates created were not pep8 compliant.

> Surround top-level function and class definitions with two blank lines.

[source](https://www.python.org/dev/peps/pep-0008/#blank-lines)

## How did you implement it:

Checked code using pep8 CLI and added new lines where it was necessary.

## How can we verify it:

Install [pep8 cli](https://pypi.python.org/pypi/pep8), position your shell in project's root in current master branch and run:

`pep8 lib/plugins/create/`

In master you will get several errors, in my branch 0.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
