### PR TITLE
Fix getFileContent encoding

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -101,7 +101,7 @@ module.exports = {
   },
 
   getFileContent(fullPath) {
-    return fs.readFileAsync(fullPath, 'utf8');
+    return fs.readFileAsync(fullPath);
   },
 };
 

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -68,6 +68,27 @@ describe('zipService', () => {
     });
   });
 
+  describe('#getFileContent()', () => {
+    let servicePath;
+
+    beforeEach(() => {
+      servicePath = serverless.config.servicePath;
+      fs.mkdirSync(servicePath);
+    });
+
+    it('should keep the file content as is', () => {
+      const buf = new Buffer([10, 20, 30, 40, 50]);
+      const filePath = path.join(servicePath, 'bin-file');
+
+      fs.writeFileSync(filePath, buf);
+
+      return expect(packagePlugin.getFileContent(filePath)).to.be.fulfilled
+        .then((result) => {
+          expect(result).to.deep.equal(buf);
+        });
+    });
+  });
+
   describe('#excludeDevDependencies()', () => {
     it('should resolve when opted out of dev dependency exclusion', () => {
       packagePlugin.serverless.service.package.excludeDevDependencies = false;


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4182

This line: https://github.com/serverless/serverless/pull/3924/files#diff-0e8817ce3b2d950d2b8d0e47f9fccb2eR107 changed encoding from `null` (default for `fs.readFileSync` according to the [docs](https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options)) to `utf8`. 

## How can we verify it:

```bash
npm install deasync --save
```

```js
require('deasync'); // or any other module that consists of executable binaries or has "weird" characters
```

Deploy & invoke, there should be no errors.

OR
```
git checkout f0b1474f1e49d69c39e27e3c8def929569e20bed # Before PR changing encoding
serverless package

# Check random executable size from node_modules

git pull https://github.com/RafalWilinski/serverless master
serverless package

# Check executable size, should be the same
```


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO