### PR TITLE
Support Custom Authorizer Type (COGNITO_USER_POOLS) with authorizeId

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -13,6 +13,15 @@ module.exports = {
     }
 
     if (http.authorizer) {
+      if (http.authorizer.type && http.authorizer.authorizerId) {
+        return {
+          Properties: {
+            AuthorizationType: http.authorizer.type,
+            AuthorizerId: http.authorizer.authorizerId,
+          },
+        };
+      }
+
       const authorizerLogicalId = this.provider.naming
         .getAuthorizerLogicalId(http.authorizer.name);
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -314,6 +314,32 @@ describe('#compileMethods()', () => {
     });
   });
 
+  it('should set custom authorizer config with authorizeId', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          authorizer: {
+            type: 'COGNITO_USER_POOLS',
+            authorizerId: 'gy7lyj',
+          },
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.AuthorizationType
+      ).to.equal('COGNITO_USER_POOLS');
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.AuthorizerId
+      ).to.equal('gy7lyj');
+    });
+  });
+
   it('should set authorizer config if given as ARN string', () => {
     awsCompileApigEvents.validated.events = [
       {
@@ -322,6 +348,7 @@ describe('#compileMethods()', () => {
           authorizer: {
             name: 'Authorizer',
           },
+          integration: 'AWS',
           path: 'users/create',
           method: 'post',
         },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -227,6 +227,7 @@ module.exports = {
     let resultTtlInSeconds;
     let identityValidationExpression;
     let claims;
+    let authorizerId;
 
     if (typeof authorizer === 'string') {
       if (authorizer.toUpperCase() === 'AWS_IAM') {
@@ -239,7 +240,10 @@ module.exports = {
         name = this.provider.naming.extractAuthorizerNameFromArn(arn);
       }
     } else if (typeof authorizer === 'object') {
-      if (authorizer.type && authorizer.type.toUpperCase() === 'AWS_IAM') {
+      if (authorizer.type && authorizer.authorizerId) {
+        type = authorizer.type;
+        authorizerId = authorizer.authorizerId;
+      } else if (authorizer.type && authorizer.type.toUpperCase() === 'AWS_IAM') {
         type = 'AWS_IAM';
       } else if (authorizer.arn) {
         arn = authorizer.arn;
@@ -284,6 +288,7 @@ module.exports = {
       type,
       name,
       arn,
+      authorizerId,
       resultTtlInSeconds,
       identitySource,
       identityValidationExpression,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

Closes #4711 

## What did you implement:
AWS API Gateway allow only 1 Authorizer for 1 ARN. If serverless try to create new Authorizer, Cloudformation will alert:

> ServerlessError: An error occurred: ApiGatewayMethodUsersUseridGet - Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer..

Because each serverless.yml will create new REST API, so we don't meet this error. However, if serverless support Shared API #3934. This case will appear

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Support AuthorizationType and AuthorizeId reference

## How can we verify it:

```
functions:
   deleteUser:
     ...
    events:
      - http:
          path: /users/{userId}
          ...     
          authorizer:
            type: COGNITO_USER_POOLS
            authorizerId: { Ref: "NApiGatewayAuthorizer"}

resources:
  Resources:
    NApiGatewayAuthorizer: 
      Type: AWS::ApiGateway::Authorizer
      Properties: 
        AuthorizerResultTtlInSeconds: 300
        IdentitySource: method.request.header.Authorization
        Name: NCognito
        RestApiId: 
          Ref: abcxyz
        Type: COGNITO_USER_POOLS
        ProviderARNs: 
          - arn:aws:cognito-idp:${self:provider.region}:xxxxxx:userpool/abcdef 
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
