### PR TITLE
Fix link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ Already using AWS or another cloud provider? Read on.
   </div>
   <div class="docsSection">
     <div class="docsSectionHeader">
-      <a href="./providers/kubeless/">
+      <a href="./providers/spotinst/">
         <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/spotinst-logos-black-small.png" width="250" draggable="false"/>
       </a>
     </div>


### PR DESCRIPTION
The "Spotinst image link" links to "spotinst" instead to "kubeless"

## What did you implement:

Closes #XXXXX

## How did you implement it:

Fix link 

## How can we verify it:

it's an error in the documentation

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
