### PR TITLE
Add aws-kotlin-jvm-maven template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
     image: java:8
     volumes:
       - ./tmp/serverless-integration-test-aws-java-gradle:/app
+  aws-kotlin-jvm-maven:
+    image: maven:3-jdk-8
+    volumes:
+      - ./tmp/serverless-integration-test-aws-kotlin-jvm-maven:/app
   aws-groovy-gradle:
     image: java:8
     volumes:

--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -45,6 +45,7 @@ Most commonly used templates:
 - aws-nodejs-ecma-script
 - aws-python
 - aws-python3
+- aws-kotlin-jvm-maven
 - aws-groovy-gradle
 - aws-java-maven
 - aws-java-gradle

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -55,6 +55,7 @@ Here are the available runtimes for AWS Lambda:
 * aws-nodejs-ecma-script
 * aws-python
 * aws-python3
+* aws-kotlin-jvm-maven
 * aws-groovy-gradle
 * aws-java-gradle
 * aws-java-maven

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -16,6 +16,7 @@ const validTemplates = [
   'aws-groovy-gradle',
   'aws-java-maven',
   'aws-java-gradle',
+  'aws-kotlin-jvm-maven',
   'aws-scala-sbt',
   'aws-csharp',
   'aws-fsharp',

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -207,6 +207,26 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "aws-kotlin-jvm-maven" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'aws-kotlin-jvm-maven';
+
+      return create.create().then(() => {
+        const dirContent = walkDirSync(tmpDir)
+          .map(elem => elem.replace(path.join(tmpDir, path.sep), ''));
+
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('pom.xml');
+        expect(dirContent).to.include(path.join('src', 'main', 'kotlin', 'com', 'serverless',
+          'Handler.kt'));
+        expect(dirContent).to.include(path.join('src', 'main', 'kotlin', 'com', 'serverless',
+          'ApiGatewayResponse.kt'));
+        expect(dirContent).to.include(path.join('src', 'main', 'kotlin', 'com', 'serverless',
+          'Response.kt'));
+        expect(dirContent).to.include(path.join('.gitignore'));
+      });
+    });
+
     it('should generate scaffolding for "aws-java-gradle" template', () => {
       process.chdir(tmpDir);
       create.options.template = 'aws-java-gradle';

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -223,6 +223,7 @@ describe('Create', () => {
           'ApiGatewayResponse.kt'));
         expect(dirContent).to.include(path.join('src', 'main', 'kotlin', 'com', 'serverless',
           'Response.kt'));
+        expect(dirContent).to.include(path.join('src', 'test', 'kotlin', '.gitkeep'));
         expect(dirContent).to.include(path.join('.gitignore'));
       });
     });

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/gitignore
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/gitignore
@@ -1,0 +1,14 @@
+*.class
+target
+/bin/
+/.settings/
+.project
+.classpath
+
+# Package Files
+*.jar
+*.war
+*.ear
+
+# Serverless directories
+.serverless

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
@@ -1,0 +1,108 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.serverless</groupId>
+    <artifactId>hello</artifactId>
+    <packaging>jar</packaging>
+    <version>dev</version>
+    <name>hello</name>
+
+    <properties>
+        <kotlin.version>1.1.4-3</kotlin.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-log4j</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <!--
+              Using the Apache Maven Shade plugin to package the jar
+
+              "This plugin provides the capability to package the artifact
+              in an uber-jar, including its dependencies and to shade - i.e. rename -
+              the packages of some of the dependencies."
+
+              Link: https://maven.apache.org/plugins/maven-shade-plugin/
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals> <goal>compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
@@ -1,0 +1,98 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: aws-kotlin-jvm-maven # NOTE: update this with your service name
+
+# You can pin your service to only deploy with a specific Serverless version
+# Check out our docs for more details
+# frameworkVersion: "=X.X.X"
+
+provider:
+  name: aws
+  runtime: java8
+
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
+
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "/*"
+
+# you can define service wide environment variables here
+#  environment:
+#    variable1: value1
+
+# you can add packaging information here
+package:
+  artifact: target/hello-dev.jar
+
+functions:
+  hello:
+    handler: com.serverless.Handler
+
+#    The following are a few example events you can configure
+#    NOTE: Please make sure to change your handler code to work with those events
+#    Check the event documentation for details
+#    events:
+#      - http:
+#          path: users/create
+#          method: get
+#      - s3: ${env:BUCKET}
+#      - schedule: rate(10 minutes)
+#      - sns: greeter-topic
+#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+#      - alexaSkill
+#      - iot:
+#          sql: "SELECT * FROM 'some_topic'"
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - "aws.ec2"
+#            detail-type:
+#              - "EC2 Instance State-change Notification"
+#            detail:
+#              state:
+#                - pending
+#      - cloudwatchLog: '/aws/lambda/hello'
+#      - cognitoUserPool:
+#          pool: MyUserPool
+#          trigger: PreSignUp
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+# you can add CloudFormation resource templates here
+#resources:
+#  Resources:
+#    NewResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: my-new-bucket
+#  Outputs:
+#     NewOutput:
+#       Description: "Description for the output"
+#       Value: "Some output value"

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/ApiGatewayResponse.kt
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/ApiGatewayResponse.kt
@@ -1,0 +1,56 @@
+package com.serverless
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.log4j.Logger
+import java.nio.charset.StandardCharsets
+import java.util.*
+
+class ApiGatewayResponse(
+        val statusCode: Int = 200,
+        var body: String? = null,
+        val headers: Map<String, String>? = Collections.emptyMap(),
+        val isBase64Encoded: Boolean = false
+) {
+    private constructor(builder: Builder) : this(
+            builder.statusCode,
+            builder.rawBody,
+            builder.headers,
+            builder.base64Encoded
+    )
+
+    companion object {
+        inline fun build(block: Builder.() -> Unit) = Builder().apply(block).build()
+    }
+
+    class Builder {
+        var LOG: Logger = Logger.getLogger(ApiGatewayResponse.Builder::class.java)
+        var objectMapper: ObjectMapper = ObjectMapper()
+
+        var statusCode: Int = 200
+        var rawBody: String? = null
+        var headers: Map<String, String>? = Collections.emptyMap()
+        var objectBody: Response? = null
+        var binaryBody: ByteArray? = null
+        var base64Encoded: Boolean = false
+
+        fun build(): ApiGatewayResponse {
+            var body: String? = null
+
+            if (rawBody != null) {
+                body = rawBody as String
+            }
+            else if (objectBody != null) {
+                try {
+                    body = objectMapper.writeValueAsString(objectBody)
+                } catch (e: JsonProcessingException) {
+                    LOG.error("failed to serialize object", e)
+                    throw RuntimeException(e)
+                }
+            } else if (binaryBody != null) {
+                body = String(Base64.getEncoder().encode(binaryBody), StandardCharsets.UTF_8)
+            }
+            return ApiGatewayResponse(statusCode, body, headers, base64Encoded)
+        }
+    }
+}

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/Handler.kt
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/Handler.kt
@@ -1,0 +1,24 @@
+package com.serverless
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.RequestHandler
+import org.apache.log4j.BasicConfigurator
+import org.apache.log4j.Logger
+import java.util.*
+
+class Handler:RequestHandler<Map<String, Any>, ApiGatewayResponse> {
+    override fun handleRequest(input:Map<String, Any>, context:Context):ApiGatewayResponse {
+        BasicConfigurator.configure()
+        LOG.info("received: " + input.keys.toString())
+
+        val responseBody = Response("Go Serverless v1.x! Your Kotlin function executed successfully!", input)
+        return ApiGatewayResponse.build {
+            statusCode = 200
+            objectBody = responseBody
+            headers = Collections.singletonMap<String, String>("X-Powered-By", "AWS Lambda & serverless")
+        }
+    }
+    companion object {
+        private val LOG = Logger.getLogger(Handler::class.java)
+    }
+}

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/Response.kt
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/Response.kt
@@ -1,0 +1,8 @@
+package com.serverless
+
+class Response(message:String, input:Map<String, Any>) {
+  val message: String = message
+    get
+  val input: Map<String, Any> = input
+    get
+}

--- a/tests/templates/test_all_templates
+++ b/tests/templates/test_all_templates
@@ -17,6 +17,7 @@ integration-test aws-scala-sbt sbt assembly
 integration-test aws-nodejs
 integration-test aws-python
 integration-test aws-python3
+integration-test aws-kotlin-jvm-maven
 integration-test aws-nodejs-typescript
 integration-test aws-nodejs-ecma-script
 integration-test google-nodejs


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/3883

Adds Kotlin template. It uses JVM and Maven under the hood. Support for gradle based is coming soon.

I'm also willing to investigate Kotlin -> JS compilation so it might run using `node6.10` runtime.

## How can we verify it:

`serverless create -t aws-kotlin-jvm-maven`
`serverless deploy`

It's also compatible with https://github.com/serverless/serverless/pull/4199 so you can use `invoke local` too.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO