### PR TITLE
Add Description to CloudWatch events

### DIFF
--- a/docs/providers/aws/events/cloudwatch-event.md
+++ b/docs/providers/aws/events/cloudwatch-event.md
@@ -90,3 +90,24 @@ functions:
                 - pending
           inputPath: '$.stageVariables'
 ```
+
+## Specify Input or Inputpath
+
+You can specify CloudWatch Event description
+
+```yml
+functions:
+  myCloudWatch:
+    handler: myCloudWatch.handler
+    events:
+      - cloudwatchEvent:
+          description: 'CloudWatch Event triggered on EC2 Instance pending state'
+          event:
+            source:
+              - "aws.ec2"
+            detail-type:
+              - "EC2 Instance State-change Notification"
+            detail:
+              state:
+                - pending
+```

--- a/docs/providers/aws/events/cloudwatch-event.md
+++ b/docs/providers/aws/events/cloudwatch-event.md
@@ -91,9 +91,9 @@ functions:
           inputPath: '$.stageVariables'
 ```
 
-## Specify Description
+## Specifying a Description
 
-You can specify CloudWatch Event description
+You can also specify a CloudWatch Event description.
 
 ```yml
 functions:

--- a/docs/providers/aws/events/cloudwatch-event.md
+++ b/docs/providers/aws/events/cloudwatch-event.md
@@ -91,7 +91,7 @@ functions:
           inputPath: '$.stageVariables'
 ```
 
-## Specify Input or Inputpath
+## Specify Description
 
 You can specify CloudWatch Event description
 

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
@@ -25,6 +25,7 @@ class AwsCompileCloudWatchEventEvents {
             let State;
             let Input;
             let InputPath;
+            let Description;
 
             if (typeof event.cloudwatchEvent === 'object') {
               if (!event.cloudwatchEvent.event) {
@@ -43,6 +44,7 @@ class AwsCompileCloudWatchEventEvents {
               }
               Input = event.cloudwatchEvent.input;
               InputPath = event.cloudwatchEvent.inputPath;
+              Description = event.cloudwatchEvent.description;
 
               if (Input && InputPath) {
                 const errorMessage = [
@@ -84,6 +86,7 @@ class AwsCompileCloudWatchEventEvents {
                 "Properties": {
                   "EventPattern": ${EventPattern.replace(/\\n|\\r/g, '')},
                   "State": "${State}",
+                  ${Description ? `"Description": "${Description}",` : ''}
                   "Targets": [{
                     ${Input ? `"Input": "${Input.replace(/\\n|\\r/g, '')}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath.replace(/\r?\n/g, '')}",` : ''}

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
@@ -218,6 +218,34 @@ describe('awsCompileCloudWatchEventEvents', () => {
       ).to.equal('{"key":"value"}');
     });
 
+    it('should respect description variable', () => {
+      awsCompileCloudWatchEventEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cloudwatchEvent: {
+                event: {
+                  source: ['aws.ec2'],
+                  'detail-type': ['EC2 Instance State-change Notification'],
+                  detail: { state: ['pending'] },
+                },
+                enabled: false,
+                input: '{"key":"value"}',
+                description: 'test description',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileCloudWatchEventEvents.compileCloudWatchEventEvents();
+
+      expect(awsCompileCloudWatchEventEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.Description
+      ).to.equal('test description');
+    });
+
     it('should respect input variable as an object', () => {
       awsCompileCloudWatchEventEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/3498

## How can we verify it:

```yml
service: aws-kotlin-jvm-maven 

provider:
  name: aws
  runtime: java8

package:
  artifact: target/hello-dev.jar

functions:
  hello:
    handler: com.serverless.Handler
    events:
      - cloudwatchEvent:
          description: 'desc2'
          event:
            source:
              - "aws.ec2"
            detail-type:
              - "EC2 Instance State-change Notification"
            resources:
              - arn:aws:ec2:us-east-1:123456789012:instance/i-12345678
            detail:
              state:
                - pending

```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
