### PR TITLE
Limit upload concurrency (follow-up for #4035)

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -73,7 +73,7 @@ module.exports = {
     }
 
     return this.provider.request('S3',
-      'putObject',
+      'upload',
       params,
       this.options.stage,
       this.options.region);

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -83,7 +83,7 @@ module.exports = {
     let shouldUploadService = false;
     this.serverless.cli.log('Uploading artifacts...');
     const functionNames = this.serverless.service.getAllFunctions();
-    const uploadPromises = functionNames.map(name => {
+    return BbPromise.map(functionNames, (name) => {
       const functionArtifactFileName = this.provider.naming.getFunctionArtifactName(name);
       const functionObject = this.serverless.service.getFunction(name);
       functionObject.package = functionObject.package || {};
@@ -100,9 +100,7 @@ module.exports = {
         return BbPromise.resolve();
       }
       return this.uploadZipFile(artifactFilePath);
-    });
-
-    return BbPromise.all(uploadPromises).then(() => {
+    }, { concurrency: 3 }).then(() => {
       if (shouldUploadService) {
         const artifactFileName = this.provider.naming.getServiceArtifactName();
         const artifactFilePath = path.join(this.packagePath, artifactFileName);

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -44,7 +44,7 @@ module.exports = {
     }
 
     return this.provider.request('S3',
-      'putObject',
+      'upload',
       params,
       this.options.stage,
       this.options.region);

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -207,9 +207,9 @@ describe('uploadArtifacts', () => {
       };
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(uploadStub.calledOnce).to.be.equal(true);
         expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(putObjectStub.calledWithExactly(
+        expect(uploadStub.calledWithExactly(
           'S3',
           'upload',
           {

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -147,13 +147,13 @@ describe('uploadArtifacts', () => {
 
   describe('#uploadZipFile()', () => {
     let readFileSyncStub;
-    let putObjectStub;
+    let uploadStub;
 
     beforeEach(() => {
       readFileSyncStub = sinon
         .stub(fs, 'readFileSync')
         .returns();
-      putObjectStub = sinon
+      uploadStub = sinon
         .stub(awsDeploy.provider, 'request')
         .resolves();
     });
@@ -175,9 +175,9 @@ describe('uploadArtifacts', () => {
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(putObjectStub.calledOnce).to.be.equal(true);
+        expect(uploadStub.calledOnce).to.be.equal(true);
         expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(putObjectStub.calledWithExactly(
+        expect(uploadStub.calledWithExactly(
           'S3',
           'upload',
           {

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -70,13 +70,13 @@ describe('uploadArtifacts', () => {
 
   describe('#uploadCloudFormationFile()', () => {
     let normalizeCloudFormationTemplateStub;
-    let putObjectStub;
+    let uploadStub;
 
     beforeEach(() => {
       normalizeCloudFormationTemplateStub = sinon
         .stub(normalizeFiles, 'normalizeCloudFormationTemplate')
         .returns();
-      putObjectStub = sinon
+      uploadStub = sinon
         .stub(awsDeploy.provider, 'request')
         .resolves();
     });
@@ -91,10 +91,10 @@ describe('uploadArtifacts', () => {
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
         expect(normalizeCloudFormationTemplateStub.calledOnce).to.equal(true);
-        expect(putObjectStub.calledOnce).to.equal(true);
-        expect(putObjectStub.calledWithExactly(
+        expect(uploadStub.calledOnce).to.equal(true);
+        expect(uploadStub.calledWithExactly(
           'S3',
-          'putObject',
+          'upload',
           {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package
@@ -121,10 +121,10 @@ describe('uploadArtifacts', () => {
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
         expect(normalizeCloudFormationTemplateStub.calledOnce).to.equal(true);
-        expect(putObjectStub.calledOnce).to.be.equal(true);
-        expect(putObjectStub.calledWithExactly(
+        expect(uploadStub.calledOnce).to.be.equal(true);
+        expect(uploadStub.calledWithExactly(
           'S3',
-          'putObject',
+          'upload',
           {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -179,7 +179,7 @@ describe('uploadArtifacts', () => {
         expect(readFileSyncStub.calledOnce).to.equal(true);
         expect(putObjectStub.calledWithExactly(
           'S3',
-          'putObject',
+          'upload',
           {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/artifact.zip`,
@@ -211,7 +211,7 @@ describe('uploadArtifacts', () => {
         expect(readFileSyncStub.calledOnce).to.equal(true);
         expect(putObjectStub.calledWithExactly(
           'S3',
-          'putObject',
+          'upload',
           {
             Bucket: awsDeploy.bucketName,
             Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/artifact.zip`,


### PR DESCRIPTION
This is a direct follow-up to https://github.com/serverless/serverless/pull/4035 - please see conversation there.


# What did you implement:

Addresses #3871

Per @HyperBrain's suggestion on #3871, this limits concurrency when uploading function artifacts.

# How did you implement it:

Artifacts uploads are limited to 3 parallel threads and use AWS SDK's S3 `upload` method instead of `putObject` now. `upload` is designed for (large) file uploads with automatic retry, multi-part upload, etc.

# How can we verify it:

On one level, you could monitor uploads while deploying a service to verify the concurrency. A better way would be to time the uploads for large service with many large functions and see how this affects things.

# Todos:

* [ ] ~Write tests~
* [ ] ~Write documentation~
* [x] Fix linting errors
* [x] Make sure code coverage hasn't dropped
* [ ] ~Provide verification config / commands / resources~
* [x] Enable "Allow edits from maintainers" for this PR
* [x] Update the messages below

**Is this ready for review?**: YES
**Is it a breaking change?**: NO
