### PR TITLE
Removes escaping of double-quotes around string value

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -203,7 +203,7 @@ class Variables {
   }
 
   getValueFromString(variableString) {
-    const valueToPopulate = variableString.replace(/'/g, '');
+    const valueToPopulate = variableString.replace(/^['"]|['"]$/g, '');
     return BbPromise.resolve(valueToPopulate);
   }
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -160,21 +160,15 @@ describe('Variables', () => {
     it('should allow a single-quoted string if overwrite syntax provided', () => {
       const serverless = new Serverless();
       const property = "my stage is ${opt:stage, 'prod'}";
+      serverless.variables.options = {
+        stage: undefined,
+      };
 
       serverless.variables.loadVariableSyntax();
 
-      const overwriteStub = sinon
-        .stub(serverless.variables, 'overwrite').resolves('\'prod\'');
-      const populateVariableStub = sinon
-        .stub(serverless.variables, 'populateVariable').resolves('my stage is prod');
-
       return serverless.variables.populateProperty(property).then(newProperty => {
-        expect(overwriteStub.called).to.equal(true);
-        expect(populateVariableStub.called).to.equal(true);
         expect(newProperty).to.equal('my stage is prod');
 
-        serverless.variables.overwrite.restore();
-        serverless.variables.populateVariable.restore();
         return BbPromise.resolve();
       });
     });
@@ -182,21 +176,15 @@ describe('Variables', () => {
     it('should allow a double-quoted string if overwrite syntax provided', () => {
       const serverless = new Serverless();
       const property = 'my stage is ${opt:stage, "prod"}';
+      serverless.variables.options = {
+        stage: undefined,
+      };
 
       serverless.variables.loadVariableSyntax();
 
-      const overwriteStub = sinon
-        .stub(serverless.variables, 'overwrite').resolves('\'prod\'');
-      const populateVariableStub = sinon
-        .stub(serverless.variables, 'populateVariable').resolves('my stage is prod');
-
       return serverless.variables.populateProperty(property).then(newProperty => {
-        expect(overwriteStub.called).to.equal(true);
-        expect(populateVariableStub.called).to.equal(true);
         expect(newProperty).to.equal('my stage is prod');
 
-        serverless.variables.overwrite.restore();
-        serverless.variables.populateVariable.restore();
         return BbPromise.resolve();
       });
     });

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const proxyquire = require('proxyquire');
 const YAML = require('js-yaml');
-const expect = require('chai').expect;
+const chai = require('chai');
 const Variables = require('../../lib/classes/Variables');
 const Utils = require('../../lib/classes/Utils');
 const Serverless = require('../../lib/Serverless');
@@ -13,6 +13,10 @@ const slsError = require('./Error');
 const AwsProvider = require('../plugins/aws/provider/awsProvider');
 const BbPromise = require('bluebird');
 const os = require('os');
+
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
 
 describe('Variables', () => {
   describe('#constructor()', () => {
@@ -166,11 +170,8 @@ describe('Variables', () => {
 
       serverless.variables.loadVariableSyntax();
 
-      return serverless.variables.populateProperty(property).then(newProperty => {
-        expect(newProperty).to.equal('my stage is prod');
-
-        return BbPromise.resolve();
-      });
+      return expect(serverless.variables.populateProperty(property)).to.be.fulfilled
+        .then(newProperty => expect(newProperty).to.equal('my stage is prod'));
     });
 
     it('should allow a double-quoted string if overwrite syntax provided', () => {
@@ -182,11 +183,8 @@ describe('Variables', () => {
 
       serverless.variables.loadVariableSyntax();
 
-      return serverless.variables.populateProperty(property).then(newProperty => {
-        expect(newProperty).to.equal('my stage is prod');
-
-        return BbPromise.resolve();
-      });
+      return expect(serverless.variables.populateProperty(property)).to.be.fulfilled
+        .then(newProperty => expect(newProperty).to.equal('my stage is prod'));
     });
 
     it('should call getValueFromSource if no overwrite syntax provided', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When using the new string syntax for a variable, a double-quoted string would be rendered with the double-quotes escaped around the value.

## How can we verify it:

serverless.yml:

```
service: hello

provider:
  name: aws
  runtime: nodejs6.10
  environment:
    STRING_DOUBLEQUOTE: ${env:STRING_DOUBLEQUOTE, "foo"}
    STRING_SINGLEQUOTE: ${env:STRING_SINGLEQUOTE, 'foo'}

functions:
  hello:
    handler: handler.hello
```

Rendered cfn template **without** the patch:

```
        "Environment": {
          "Variables": {
            "STRING_DOUBLEQUOTE": "\"foo\"",
            "STRING_SINGLEQUOTE": "foo"
          }
        }
```

Rendered cfn template **with** the patch:

```
        "Environment": {
          "Variables": {
            "STRING_DOUBLEQUOTE": "foo",
            "STRING_SINGLEQUOTE": "foo"
          }
        }
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
