### PR TITLE
Add optional `name` under individual function

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -96,6 +96,7 @@ package: # Optional deployment packaging configuration
 functions:
   usersCreate: # A Function
     handler: users.create # The file and module for this specific function.
+    name: ${self:provider.stage}-lambdaName # optional, Deployed Lambda name
     description: My function # The description of your function.
     memorySize: 512 # memorySize for this specific function.
     runtime: nodejs6.10 # Runtime for this specific function. Overrides the default which is set on the provider level


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add missing `name` field under the sample function in [the Serverless.yml reference section of the guide](https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/).

## How did you implement it:

Copied the sample from <https://serverless.com/framework/docs/providers/aws/guide/functions/>

## How can we verify it:

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
