### PR TITLE
Remove LAMBDA integration for TypeScript/EcmaScript sample

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -24,4 +24,3 @@ functions:
       - http:
           method: get
           path: second
-          integration: lambda

--- a/lib/plugins/create/templates/aws-nodejs-typescript/handler.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/handler.ts
@@ -1,3 +1,11 @@
-export const hello = (event, context, cb) => cb(null,
-  { message: 'Go Serverless Webpack (Typescript) v1.0! Your function executed successfully!', event }
-);
+export const hello = (event, context, cb) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Go Serverless Webpack (Typescript) v1.0! Your function executed successfully!',
+      input: event,
+    }),
+  };
+
+  cb(null, response);
+}

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
@@ -19,4 +19,3 @@ functions:
       - http:
           method: get
           path: hello
-          integration: lambda


### PR DESCRIPTION
## What did you implement:

Remove `LAMBDA` integration from TypeScript template.
`LAMBDA-PROXY` integration is the preferred integration and is actually stated on line 14 of the same file.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
