### PR TITLE
Serverless should fail if provided profile is not valid

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -71,7 +71,12 @@ const impl = {
       if (process.env.AWS_SHARED_CREDENTIALS_FILE) {
         params.filename = process.env.AWS_SHARED_CREDENTIALS_FILE;
       }
+
       const profileCredentials = new AWS.SharedIniFileCredentials(params);
+      if (!(profileCredentials.accessKeyId || profileCredentials.sessionToken)) {
+        throw new Error(`Profile ${profile} does not exist`);
+      }
+
       impl.addCredentials(results, profileCredentials);
     }
   },

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -73,7 +73,9 @@ const impl = {
       }
 
       const profileCredentials = new AWS.SharedIniFileCredentials(params);
-      if (!(profileCredentials.accessKeyId || profileCredentials.sessionToken)) {
+      if (!(profileCredentials.accessKeyId
+          || profileCredentials.sessionToken
+          || profileCredentials.roleArn)) {
         throw new Error(`Profile ${profile} does not exist`);
       }
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -385,10 +385,11 @@ describe('AwsProvider', () => {
       expect(credentials.credentials.roleArn).to.equal(fakeCredentials.roleArn);
     });
 
-    it('should not set credentials if a non-existent profile is set', () => {
+    it('should throw an error if a non-existent profile is set', () => {
       serverless.service.provider.profile = 'not-a-defined-profile';
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => {
+        newAwsProvider.getCredentials();
+      }).to.throw(Error);
     });
 
     it('should not set credentials if empty profile is set', () => {
@@ -461,7 +462,7 @@ describe('AwsProvider', () => {
     });
 
     it('should get credentials when profile is provied via --aws-profile option', () => {
-      process.env.AWS_PROFILE = 'envDefault';
+      process.env.AWS_PROFILE = 'notDefaultTemporary';
       newAwsProvider.options['aws-profile'] = 'notDefault';
 
       const credentials = newAwsProvider.getCredentials();


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4242

## How can we verify it:

```bash
serverless info --aws-profile this-does-not-exists-for-sure
```

OR

```yml
provider:
  profile: this-does-not-exists-for-sure
```
AND
```
serverless info
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO