### PR TITLE
Escapes the hyphen in the ssm variable syntax

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -21,7 +21,7 @@ class Variables {
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
     this.stringRefSynax = RegExp(/('.*')|(".*")/g);
-    this.ssmRefSyntax = RegExp(/^ssm:([a-zA-Z0-9_.-/]+)[~]?(true|false)?/);
+    this.ssmRefSyntax = RegExp(/^ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false)?/);
   }
 
   loadVariableSyntax() {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -946,21 +946,23 @@ describe('Variables', () => {
     });
 
     it('should get variable from Ssm using regular-style param', () => {
+      const param = 'Param-01_valid.chars';
+      const value = 'MockValue';
       const awsResponseMock = {
         Parameter: {
-          Value: 'MockValue',
+          Value: value,
         },
       };
       const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
 
-      return serverless.variables.getValueFromSsm('ssm:param').then(value => {
-        expect(value).to.be.equal('MockValue');
+      return serverless.variables.getValueFromSsm(`ssm:${param}`).then(resolved => {
+        expect(resolved).to.be.equal(value);
         expect(ssmStub.calledOnce).to.be.equal(true);
         expect(ssmStub.calledWithExactly(
           'SSM',
           'getParameter',
           {
-            Name: 'param',
+            Name: param,
             WithDecryption: false,
           },
           serverless.variables.options.stage,
@@ -970,21 +972,23 @@ describe('Variables', () => {
     });
 
     it('should get variable from Ssm using path-style param', () => {
+      const param = '/path/to/Param-01_valid.chars';
+      const value = 'MockValue';
       const awsResponseMock = {
         Parameter: {
-          Value: 'MockValue',
+          Value: value,
         },
       };
       const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
 
-      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param').then(value => {
-        expect(value).to.be.equal('MockValue');
+      return serverless.variables.getValueFromSsm(`ssm:${param}`).then(resolved => {
+        expect(resolved).to.be.equal(value);
         expect(ssmStub.calledOnce).to.be.equal(true);
         expect(ssmStub.calledWithExactly(
           'SSM',
           'getParameter',
           {
-            Name: '/some/path/to/param',
+            Name: param,
             WithDecryption: false,
           },
           serverless.variables.options.stage,
@@ -994,21 +998,23 @@ describe('Variables', () => {
     });
 
     it('should get encrypted variable from Ssm using extended syntax', () => {
+      const param = '/path/to/Param-01_valid.chars';
+      const value = 'MockValue';
       const awsResponseMock = {
         Parameter: {
-          Value: 'MockValue',
+          Value: value,
         },
       };
       const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
 
-      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param~true').then(value => {
-        expect(value).to.be.equal('MockValue');
+      return serverless.variables.getValueFromSsm(`ssm:${param}~true`).then(resolved => {
+        expect(resolved).to.be.equal(value);
         expect(ssmStub.calledOnce).to.be.equal(true);
         expect(ssmStub.calledWithExactly(
           'SSM',
           'getParameter',
           {
-            Name: '/some/path/to/param',
+            Name: param,
             WithDecryption: true,
           },
           serverless.variables.options.stage,
@@ -1018,21 +1024,23 @@ describe('Variables', () => {
     });
 
     it('should get unencrypted variable from Ssm using extended syntax', () => {
+      const param = '/path/to/Param-01_valid.chars';
+      const value = 'MockValue';
       const awsResponseMock = {
         Parameter: {
-          Value: 'MockValue',
+          Value: value,
         },
       };
       const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
 
-      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param~false').then(value => {
-        expect(value).to.be.equal('MockValue');
+      return serverless.variables.getValueFromSsm(`ssm:${param}~false`).then(resolved => {
+        expect(resolved).to.be.equal(value);
         expect(ssmStub.calledOnce).to.be.equal(true);
         expect(ssmStub.calledWithExactly(
           'SSM',
           'getParameter',
           {
-            Name: '/some/path/to/param',
+            Name: param,
             WithDecryption: false,
           },
           serverless.variables.options.stage,
@@ -1042,28 +1050,29 @@ describe('Variables', () => {
     });
 
     it('should ignore bad values for extended syntax', () => {
+      const param = '/path/to/Param-01_valid.chars';
+      const value = 'MockValue';
       const awsResponseMock = {
         Parameter: {
-          Value: 'MockValue',
+          Value: value,
         },
       };
       const ssmStub = sinon.stub(awsProvider, 'request').resolves(awsResponseMock);
 
-      return serverless.variables.getValueFromSsm('ssm:/some/path/to/param~badvalue')
-        .then(value => {
-          expect(value).to.be.equal('MockValue');
-          expect(ssmStub.calledOnce).to.be.equal(true);
-          expect(ssmStub.calledWithExactly(
-            'SSM',
-            'getParameter',
-            {
-              Name: '/some/path/to/param',
-              WithDecryption: false,
-            },
-            serverless.variables.options.stage,
-            serverless.variables.options.region
-          )).to.be.equal(true);
-        });
+      return serverless.variables.getValueFromSsm(`ssm:${param}~badvalue`).then(resolved => {
+        expect(resolved).to.be.equal(value);
+        expect(ssmStub.calledOnce).to.be.equal(true);
+        expect(ssmStub.calledWithExactly(
+          'SSM',
+          'getParameter',
+          {
+            Name: param,
+            WithDecryption: false,
+          },
+          serverless.variables.options.stage,
+          serverless.variables.options.region
+        )).to.be.equal(true);
+      });
     });
 
     it('should return undefined if SSM parameter does not exist', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4248 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Modified the SSM variable reference so the hyphen is escaped, so that SSM parameters with a hyphen in the name will match the pattern.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create the parameter:
```
aws ssm put-parameter --name /foo/foo-bar/param --value bar --type String
```

Package this serverless.yml:
```
service: hello

provider:
  name: aws
  runtime: nodejs6.10
  environment:
    FOOBAR: ${ssm:/foo/foo-bar/param}

functions:
  hello:
    handler: handler.hello
```

Ensure package command does not generate a warning. Check the rendered template:
```
grep FOO .serverless/cloudformation-template-update-stack.json
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
