### PR TITLE
Add --no-color flag notice

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -140,7 +140,7 @@ class CLI {
     this.consoleLog(chalk.yellow.underline('Commands'));
     this.consoleLog(chalk.dim('* You can run commands with "serverless" or the shortcut "sls"'));
     this.consoleLog(chalk.dim('* Pass "--verbose" to this command to get in-depth plugin info'));
-    this.consoleLog(chalk.dim('* Pass "--no-color" to get disable CLI colors'));
+    this.consoleLog(chalk.dim('* Pass "--no-color" to disable CLI colors'));
     this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
 
     this.consoleLog('');

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -140,6 +140,7 @@ class CLI {
     this.consoleLog(chalk.yellow.underline('Commands'));
     this.consoleLog(chalk.dim('* You can run commands with "serverless" or the shortcut "sls"'));
     this.consoleLog(chalk.dim('* Pass "--verbose" to this command to get in-depth plugin info'));
+    this.consoleLog(chalk.dim('* Pass "--no-color" to get disable CLI colors'));
     this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
 
     this.consoleLog('');


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/3608#issuecomment-329175859

Adds notice about `--no-color` flag.

## How did you implement it:

https://github.com/chalk/supports-color#info

## How can we verify it:

```
serverless --no-color
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO