### PR TITLE
Fix deploy function not inheriting provider config

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -33,8 +33,10 @@ class AwsDeployFunction {
       'deploy:function:deploy': () => BbPromise.bind(this)
         .then(() => {
           if (!this.options['update-config']) {
-            this.deployFunction();
+            return this.deployFunction();
           }
+
+          return new Promise().resolve();
         })
         .then(this.updateFunctionConfiguration)
         .then(() => this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')),

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -36,7 +36,7 @@ class AwsDeployFunction {
             return this.deployFunction();
           }
 
-          return new BbPromise().resolve();
+          return BbPromise.resolve();
         })
         .then(this.updateFunctionConfiguration)
         .then(() => this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')),

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -36,7 +36,7 @@ class AwsDeployFunction {
             return this.deployFunction();
           }
 
-          return new Promise().resolve();
+          return new BbPromise().resolve();
         })
         .then(this.updateFunctionConfiguration)
         .then(() => this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')),

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -132,10 +132,18 @@ class AwsDeployFunction {
 
     if (functionObj.vpc || providerObj.vpc) {
       params.VpcConfig = {};
-      params.VpcConfig.SecurityGroupIds = functionObj.vpc.securityGroupIds
-        || providerObj.vpc.securityGroupIds;
-      params.VpcConfig.SubnetIds = functionObj.vpc.subnetIds
-        || providerObj.vpc.subnetIds;
+    }
+
+    if (functionObj.vpc && functionObj.vpc.securityGroupIds) {
+      params.VpcConfig.SecurityGroupIds = functionObj.vpc.securityGroupIds;
+    } else if (providerObj.vpc && providerObj.vpc.securityGroupIds) {
+      params.VpcConfig.SecurityGroupIds = providerObj.vpc.securityGroupIds;
+    }
+
+    if (functionObj.vpc && functionObj.vpc.subnetIds) {
+      params.VpcConfig.SubnetIds = functionObj.vpc.subnetIds;
+    } else if (providerObj.vpc && providerObj.vpc.subnetIds) {
+      params.VpcConfig.SubnetIds = providerObj.vpc.subnetIds;
     }
 
     return this.provider.request(

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -135,6 +135,10 @@ describe('AwsDeployFunction', () => {
 
     afterEach(() => {
       awsDeployFunction.provider.request.restore();
+      awsDeployFunction.serverless.service.provider.timeout = undefined;
+      awsDeployFunction.serverless.service.provider.memorySize = undefined;
+      awsDeployFunction.serverless.service.provider.role = undefined;
+      awsDeployFunction.serverless.service.provider.vpc = undefined;
     });
 
     it('should update function\'s configuration', () => {
@@ -205,6 +209,44 @@ describe('AwsDeployFunction', () => {
           {
             FunctionName: 'first',
             Description: 'change',
+          },
+          awsDeployFunction.options.stage,
+          awsDeployFunction.options.region
+        )).to.be.equal(true);
+      });
+    });
+
+    it('should inherit provider-level config', () => {
+      options.functionObj = {
+        name: 'first',
+        description: 'change',
+      };
+
+      awsDeployFunction.serverless.service.provider.timeout = 12;
+      awsDeployFunction.serverless.service.provider.memorySize = 512;
+      awsDeployFunction.serverless.service.provider.role = 'role';
+      awsDeployFunction.serverless.service.provider.vpc = {
+        securityGroupIds: [123, 12],
+        subnetIds: [1234, 12345],
+      };
+
+      awsDeployFunction.options = options;
+
+      return awsDeployFunction.updateFunctionConfiguration().then(() => {
+        expect(updateFunctionConfigurationStub.calledOnce).to.be.equal(true);
+        expect(updateFunctionConfigurationStub.calledWithExactly(
+          'Lambda',
+          'updateFunctionConfiguration',
+          {
+            FunctionName: 'first',
+            Description: 'change',
+            VpcConfig: {
+              SubnetIds: [1234, 12345],
+              SecurityGroupIds: [123, 12],
+            },
+            Timeout: 12,
+            MemorySize: 512,
+            Role: 'role',
           },
           awsDeployFunction.options.stage,
           awsDeployFunction.options.region

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -216,6 +216,20 @@ describe('AwsDeployFunction', () => {
       });
     });
 
+    it('should fail when using invalid characters in environment variable', () => {
+      options.functionObj = {
+        name: 'first',
+        description: 'change',
+        environment: {
+          '!llegal_v@riable': 1,
+        },
+      };
+
+      awsDeployFunction.options = options;
+
+      expect(() => awsDeployFunction.updateFunctionConfiguration()).to.throw(Error);
+    });
+
     it('should inherit provider-level config', () => {
       options.functionObj = {
         name: 'first',


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4261

## How did you implement it:

- Fixed inheriting provider config in `vpc` section
- Fix concurrent & conflicting `updateFunctionConfiguration` & `updateFunctionCode`. Now they are serial.

## How can we verify it:

```yml
custom:
  env:
    common:
      aws:
        vpc:
          securityGroupIds:
            - sg-xxxxxxxx
          subnetIds:
            - subnet-xxxxxxxx

provider:
  name: aws
  runtime: nodejs6.10
  vpc: ${self:custom.env.common.aws.vpc}

functions:
  hello:
    handler: handler.hello
```

```bash
serverless deploy
serverless deploy function -f hello
# Make code change
serverless deploy function -f hello
serverless deploy function -f hello
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO