### PR TITLE
Ignore & warn on invalid yaml values

### DIFF
--- a/lib/utils/log/serverlessLog.js
+++ b/lib/utils/log/serverlessLog.js
@@ -1,0 +1,11 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+const chalk = require('chalk');
+
+const log = function (message) {
+  console.log(`Serverless: ${chalk.yellow(message)}`);
+};
+
+module.exports = log;

--- a/lib/utils/yamlAstParser.js
+++ b/lib/utils/yamlAstParser.js
@@ -29,7 +29,8 @@ const parseAST = (ymlAstContent, astObject) => {
       if (!v.value) {
         const errorMessage = [
           'Serverless: ',
-          `${chalk.red('Your serverless.yml has an invalid value with key:', v.key.value)}`,
+          `${chalk.red('Your serverless.yml has an invalid value with key:')} `,
+          `${chalk.red(`"${v.key.value}"`)}`,
         ].join('');
         log(errorMessage);
         return;

--- a/lib/utils/yamlAstParser.js
+++ b/lib/utils/yamlAstParser.js
@@ -6,6 +6,7 @@ const fs = BbPromise.promisifyAll(require('fs'));
 const _ = require('lodash');
 const os = require('os');
 const chalk = require('chalk');
+const log = require('./log/serverlessLog');
 
 const findKeyChain = (astContent) => {
   let content = astContent;
@@ -26,7 +27,11 @@ const parseAST = (ymlAstContent, astObject) => {
   if (ymlAstContent.mappings && _.isArray(ymlAstContent.mappings)) {
     _.forEach(ymlAstContent.mappings, (v) => {
       if (!v.value) {
-        console.log(`Serverless: ${chalk.red(`Your serverless.yml has an invalid value with key: ${v.key.value}. Ignoring...`)}`);
+        const errorMessage = [
+          'Serverless: ',
+          `${chalk.red('Your serverless.yml has an invalid value with key:', v.key.value)}`,
+        ].join('');
+        log(errorMessage);
         return;
       }
 

--- a/lib/utils/yamlAstParser.js
+++ b/lib/utils/yamlAstParser.js
@@ -5,6 +5,7 @@ const BbPromise = require('bluebird');
 const fs = BbPromise.promisifyAll(require('fs'));
 const _ = require('lodash');
 const os = require('os');
+const chalk = require('chalk');
 
 const findKeyChain = (astContent) => {
   let content = astContent;
@@ -24,6 +25,11 @@ const parseAST = (ymlAstContent, astObject) => {
   let newAstObject = astObject || {};
   if (ymlAstContent.mappings && _.isArray(ymlAstContent.mappings)) {
     _.forEach(ymlAstContent.mappings, (v) => {
+      if (!v.value) {
+        console.log(`Serverless: ${chalk.red(`Your serverless.yml has an invalid value with key: ${v.key.value}. Ignoring...`)}`);
+        return;
+      }
+
       if (v.key.kind === 0 && v.value.kind === 0) {
         newAstObject[findKeyChain(v)] = v.value;
       } else if (v.key.kind === 0 && v.value.kind === 2) {

--- a/lib/utils/yamlAstParser.test.js
+++ b/lib/utils/yamlAstParser.test.js
@@ -20,7 +20,7 @@ describe('#yamlAstParser', () => {
     it('should add a top level object and item into the yaml file', () => {
       const yamlFilePath = path.join(tmpDirPath, 'test.yaml');
 
-      writeFileSync(yamlFilePath, 'serveice: test-service');
+      writeFileSync(yamlFilePath, 'service: test-service');
       return expect(yamlAstParser.addNewArrayItem(yamlFilePath, 'toplevel', 'foo'))
         .to.be.fulfilled.then(() => {
           const yaml = readFileSync(yamlFilePath, 'utf8');
@@ -44,7 +44,7 @@ describe('#yamlAstParser', () => {
     it('should add a multiple level object and item into the yaml file', () => {
       const yamlFilePath = path.join(tmpDirPath, 'test.yaml');
 
-      writeFileSync(yamlFilePath, 'serveice: test-service');
+      writeFileSync(yamlFilePath, 'service: test-service');
       return expect(yamlAstParser.addNewArrayItem(yamlFilePath, 'toplevel.second.third', 'foo'))
         .to.be.fulfilled.then(() => {
           const yaml = readFileSync(yamlFilePath, 'utf8');
@@ -83,6 +83,18 @@ describe('#yamlAstParser', () => {
       const yamlFilePath = path.join(tmpDirPath, 'test.yaml');
 
       writeFileSync(yamlFilePath, { toplevel: ['foo'] });
+      return expect(yamlAstParser.addNewArrayItem(yamlFilePath, 'toplevel', 'foo'))
+        .to.be.fulfilled.then(() => {
+          const yaml = readFileSync(yamlFilePath, 'utf8');
+          expect(yaml).to.have.property('toplevel');
+          expect(yaml.toplevel).to.be.deep.equal(['foo']);
+        });
+    });
+
+    it('should survive with invalid yaml', () => {
+      const yamlFilePath = path.join(tmpDirPath, 'test.yaml');
+
+      writeFileSync(yamlFilePath, 'service:');
       return expect(yamlAstParser.addNewArrayItem(yamlFilePath, 'toplevel', 'foo'))
         .to.be.fulfilled.then(() => {
           const yaml = readFileSync(yamlFilePath, 'utf8');


### PR DESCRIPTION
## What did you implement:

Fixes #4258.
If the yaml is being parsed and an invalid value is found:
eg.
```yaml
service:
  name: my-service
  spotinst:

functions:
...
```
Previously, the process would fail completely. This change is to warn the user and continue on, ignoring the invalid value.

## How did you implement it:

Log a warning to the console and continue.

## How can we verify it:

Create a `serverless.yml` with an invalid value and try to install a plugin in the directory:
`serverless plugin install --name serverless-webpack`

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
