### PR TITLE
fix #4272 use instanceof to detect duplicate plugins and log a warning

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -67,8 +67,10 @@ class PluginManager {
     }
 
     // don't load plugins twice
-    const loadedPlugins = this.plugins.map(plugin => plugin.constructor.name);
-    if (_.includes(loadedPlugins, Plugin.name)) return;
+    if (this.plugins.some(plugin => plugin instanceof Plugin)) {
+      this.serverless.cli.log(`WARNING: duplicate plugin ${Plugin.name} was not loaded\n`);
+      return;
+    }
 
     this.loadCommands(pluginInstance);
     this.loadHooks(pluginInstance);

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -546,6 +546,28 @@ describe('PluginManager', () => {
       expect(pluginManager.plugins.length).to.equal(1);
     });
 
+    it('should load two plugins that happen to have the same class name', () => {
+      function getFirst() {
+        return class PluginMock {
+        };
+      }
+
+      function getSecond() {
+        return class PluginMock {
+        };
+      }
+
+      const first = getFirst();
+      const second = getSecond();
+
+      pluginManager.addPlugin(first);
+      pluginManager.addPlugin(second);
+
+      expect(pluginManager.plugins[0]).to.be.instanceof(first);
+      expect(pluginManager.plugins[1]).to.be.instanceof(second);
+      expect(pluginManager.plugins.length).to.equal(2);
+    });
+
     it('should load the plugin commands', () => {
       pluginManager.addPlugin(SynchronousPluginMock);
 


### PR DESCRIPTION
## What did you implement:

Closes #4272

## How did you implement it:

`instanceof` vs `constructor.name`

## How can we verify it:

Test passes and new test added to cover defect scenario.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
