### PR TITLE
Adding typescript files extension to webpack resolves

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -7,10 +7,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "serverless-webpack": "^2.2.0",
-    "ts-loader": "^2.3.1",
-    "typescript": "^2.4.2",
-    "webpack": "^3.3.0"
+    "serverless-webpack": "^3.0.0",
+    "ts-loader": "^2.3.7",
+    "typescript": "^2.5.2",
+    "webpack": "^3.6.0"
   },
   "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
   "license": "MIT"

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
@@ -10,9 +10,6 @@ provider:
   runtime: nodejs6.10
 
 functions:
-  # Example with LAMBDA-PROXY integration
-  # Invoking locally:
-  # sls webpack invoke -f hello
   hello:
     handler: handler.hello
     events:

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   resolve: {
     extensions: [
       '.js',
+      '.jsx',
       '.json',
       '.ts',
       '.tsx'

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -1,9 +1,16 @@
 const path = require('path');
-// eslint-disable-next-line import/no-unresolved
 const slsw = require('serverless-webpack');
 
 module.exports = {
   entry: slsw.lib.entries,
+  resolve: {
+    extensions: [
+      '.js',
+      '.json',
+      '.ts',
+      '.tsx'
+    ]
+  },
   output: {
     libraryTarget: 'commonjs',
     path: path.join(__dirname, '.webpack'),


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4280 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Adding typescript extensions to webpack resolve


## How can we verify it:

Create a typescript project using `aws-nodejs-typescript` template from this PR, add a new typescript (`.ts`) module file and try to import it using something like `import typescript_module from './typescript_file'`.
Before this PR one needs to add the file extension for this to work, eg: `import typescript_module from './typescript_file.ts'`.

I am also upgrading dependencies.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
