### PR TITLE
Issue 3821: Only request CloudFormation variables once

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -311,6 +311,13 @@ class Variables {
     const variableStringWithoutSource = variableString.split(':')[1].split('.');
     const stackName = variableStringWithoutSource[0];
     const outputLogicalId = variableStringWithoutSource[1];
+    if (
+      this.cfVars &&
+      this.cfVars[stackName] &&
+      this.cfVars[stackName][outputLogicalId]
+    ) {
+      return this.cfVars[stackName][outputLogicalId];
+    }
     const promise = this.serverless.getProvider('aws')
       .request('CloudFormation',
         'describeStacks',
@@ -320,13 +327,7 @@ class Variables {
       .then(result => {
         const outputs = result.Stacks[0].Outputs;
         const output = outputs.find(x => x.OutputKey === outputLogicalId);
-        if (
-          this.cfVars &&
-          this.cfVars[stackName] &&
-          this.cfVars[stackName][outputLogicalId]
-        ) {
-          return this.cfVars[stackName][outputLogicalId];
-        }
+
         if (output === undefined) {
           const errorMessage = [
             'Trying to request a non exported variable from CloudFormation.',

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -311,12 +311,9 @@ class Variables {
     const variableStringWithoutSource = variableString.split(':')[1].split('.');
     const stackName = variableStringWithoutSource[0];
     const outputLogicalId = variableStringWithoutSource[1];
-    if (
-      this.cfVars &&
-      this.cfVars[stackName] &&
-      this.cfVars[stackName][outputLogicalId]
-    ) {
-      return this.cfVars[stackName][outputLogicalId];
+    const cachedPromise = _.get(this, `cfVars.${stackName}.${outputLogicalId}`);
+    if (cachedPromise) {
+      return cachedPromise;
     }
     const promise = this.serverless.getProvider('aws')
       .request('CloudFormation',
@@ -340,13 +337,7 @@ class Variables {
 
         return output.OutputValue;
       });
-    if (!this.cfVars) {
-      this.cfVars = {};
-    }
-    if (!this.cfVars[stackName]) {
-      this.cfVars[stackName] = {};
-    }
-    this.cfVars[stackName][outputLogicalId] = promise;
+    _.set(this, `cfVars.${stackName}.${outputLogicalId}`, promise);
     return promise;
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -311,7 +311,7 @@ class Variables {
     const variableStringWithoutSource = variableString.split(':')[1].split('.');
     const stackName = variableStringWithoutSource[0];
     const outputLogicalId = variableStringWithoutSource[1];
-    return this.serverless.getProvider('aws')
+    const promise = this.serverless.getProvider('aws')
       .request('CloudFormation',
         'describeStacks',
         { StackName: stackName },
@@ -320,7 +320,13 @@ class Variables {
       .then(result => {
         const outputs = result.Stacks[0].Outputs;
         const output = outputs.find(x => x.OutputKey === outputLogicalId);
-
+        if (
+          this.cfVars &&
+          this.cfVars[stackName] &&
+          this.cfVars[stackName][outputLogicalId]
+        ) {
+          return this.cfVars[stackName][outputLogicalId];
+        }
         if (output === undefined) {
           const errorMessage = [
             'Trying to request a non exported variable from CloudFormation.',
@@ -333,6 +339,14 @@ class Variables {
 
         return output.OutputValue;
       });
+    if (!this.cfVars) {
+      this.cfVars = {};
+    }
+    if (!this.cfVars[stackName]) {
+      this.cfVars[stackName] = {};
+    }
+    this.cfVars[stackName][outputLogicalId] = promise;
+    return promise;
   }
 
   getValueFromS3(variableString) {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
When requesting CloudFormation variables first check if there has already been a request for the same variable and if so return the promise from the first request.

Hotfix for #3821 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Store the AWS request promises in an instance variable map keyed by stack and variable name. Check the map before going to AWS.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
To check this, create multiple variables in the serverless.yml all referring to the same CloudFormation variable. e.g.:
```
custom:
  userPool: ${cf:sls-test-variable.userPool}

functions:
  someFunc1:
    handler: ...
    events:
      - http:
          authorizer: ${self:custom.userPool}
  someFunc2:
    handler: ...
    events:
      - http:
          authorizer: ${self:custom.userPool}
  someFunc3:
    handler: ...
    events:
      - http:
          authorizer: ${self:custom.userPool}
```
Only one call should be made to AWS.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
