### PR TITLE
Change packaging order in zipFiles function

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -81,7 +81,7 @@ module.exports = {
         zip.pipe(output);
 
         BbPromise.all(files.map(this.getFileContentAndStat.bind(this))).then((contents) => {
-          _.forEach(_.sortBy(contents, ['fullPath']), (file) => {
+          _.forEach(_.sortBy(contents, ['filePath']), (file) => {
             zip.append(file.data, {
               name: file.filePath,
               mode: file.stat.mode,

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -80,28 +80,35 @@ module.exports = {
       output.on('open', () => {
         zip.pipe(output);
 
-        BbPromise.all(files.map((filePath) => {
-          const fullPath = path.resolve(
-            this.serverless.config.servicePath,
-            filePath
-          );
+        BbPromise.all(files.map(this.getFileContentAndStat.bind(this))).then((contents) => {
+          _.forEach(_.sortBy(contents, ['fullPath']), (file) => {
+            zip.append(file.data, {
+              name: file.filePath,
+              mode: file.stat.mode,
+              date: new Date(0), // necessary to get the same hash when zipping the same content
+            });
+          });
 
-          return fs.statAsync(fullPath).then(stats =>
-            this.getFileContent(fullPath).then(fileContent =>
-              zip.append(fileContent, {
-                name: filePath,
-                mode: stats.mode,
-                date: new Date(0), // necessary to get the same hash when zipping the same content
-              })
-            )
-          );
-        })).then(() => zip.finalize()).catch(reject);
+          zip.finalize();
+        }).catch(reject);
       });
     });
   },
 
-  getFileContent(fullPath) {
-    return fs.readFileAsync(fullPath);
+  getFileContentAndStat(filePath) {
+    const fullPath = path.resolve(
+      this.serverless.config.servicePath,
+      filePath
+    );
+
+    return Promise.all([ // Get file contents and stat in parallel
+      fs.readFileAsync(fullPath),
+      fs.statAsync(fullPath),
+    ]).then((result) => ({
+      data: result[0],
+      stat: result[1],
+      filePath,
+    }));
   },
 };
 

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -68,7 +68,7 @@ describe('zipService', () => {
     });
   });
 
-  describe('#getFileContent()', () => {
+  describe('#getFileContentAndStat()', () => {
     let servicePath;
 
     beforeEach(() => {
@@ -82,9 +82,9 @@ describe('zipService', () => {
 
       fs.writeFileSync(filePath, buf);
 
-      return expect(packagePlugin.getFileContent(filePath)).to.be.fulfilled
+      return expect(packagePlugin.getFileContentAndStat(filePath)).to.be.fulfilled
         .then((result) => {
-          expect(result).to.deep.equal(buf);
+          expect(result.data).to.deep.equal(buf);
         });
     });
   });


### PR DESCRIPTION
## What did you implement:

Partially closes https://github.com/serverless/serverless/issues/4289 (part regarding packaging artifacts)

## How did you implement it:

- Instead of `forEach file { read -> append to zip }` -> `forEach file { read } onceDone sort(files) forEach readFile { append }`. This allows to sort files after all files being read and package them in the same order every time, instead of random.
- Parallelized `fs.readFileAsync` & `fs.statAsync` calls

## How can we verify it:

Create service with at least 5 files with different sizes. Then:

```bash
serverless deploy function -f hello
serverless deploy function -f hello # This deployment should be skipped
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO