### PR TITLE
Exclude ApiGatewayDeployment in CF Template normalization

### DIFF
--- a/lib/plugins/aws/lib/normalizeFiles.js
+++ b/lib/plugins/aws/lib/normalizeFiles.js
@@ -7,10 +7,15 @@ module.exports = {
     const normalizedTemplate = _.cloneDeep(template);
 
     // reset all the S3Keys for AWS::Lambda::Function resources
-    _.forEach(normalizedTemplate.Resources, (value) => {
+    _.forEach(normalizedTemplate.Resources, (value, key) => {
       if (value.Type && value.Type === 'AWS::Lambda::Function') {
         const newVal = value;
         newVal.Properties.Code.S3Key = '';
+      }
+
+      if (key.indexOf('ApiGatewayDeployment') > -1) {
+        normalizedTemplate.Resources.ApiGatewayDeploy = JSON.parse(JSON.stringify(value));
+        delete normalizedTemplate.Resources[key];
       }
     });
 

--- a/lib/plugins/aws/lib/normalizeFiles.test.js
+++ b/lib/plugins/aws/lib/normalizeFiles.test.js
@@ -54,5 +54,25 @@ describe('normalizeFiles', () => {
         },
       });
     });
+
+    it('should exclude ApiGatewayDeployment from normalization', () => {
+      const input = {
+        Resources: {
+          ApiGatewayDeployment123: {
+            key: 'value',
+          },
+        },
+      };
+
+      const result = normalizeFiles.normalizeCloudFormationTemplate(input);
+
+      expect(result).to.deep.equal({
+        Resources: {
+          ApiGatewayDeploy: {
+            key: 'value',
+          },
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Followup to https://github.com/serverless/serverless/pull/4299
Fixes https://github.com/serverless/serverless/issues/4289

## How did you implement it:

Excludes ApiGatewayDeployment<timestamp_here> from

## How can we verify it:

```bash
serverless deploy
serverless deploy    # This deployment should be skipped

# Perform a change in serverless.yml

serverless deploy    # This should succeed
serverless deploy    # This should be skipped
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO