### PR TITLE
SQS queue, not SNS queue

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -305,7 +305,7 @@ These versions are not cleaned up by serverless, so make sure you use a plugin o
 
 ## Dead Letter Queue (DLQ)
 
-When AWS lambda functions fail, they are [retried](http://docs.aws.amazon.com/lambda/latest/dg/retries-on-errors.html). If the retries also fail, AWS has a feature to send information about the failed request to a SNS topic or SNS queue, called the [Dead Letter Queue](http://docs.aws.amazon.com/lambda/latest/dg/dlq.html), which you can use to track and diagnose and react to lambda failures.
+When AWS lambda functions fail, they are [retried](http://docs.aws.amazon.com/lambda/latest/dg/retries-on-errors.html). If the retries also fail, AWS has a feature to send information about the failed request to a SNS topic or SQS queue, called the [Dead Letter Queue](http://docs.aws.amazon.com/lambda/latest/dg/dlq.html), which you can use to track and diagnose and react to lambda failures.
 
 You can setup a dead letter queue for your serverless functions with the help of a SNS topic and the `onError` config parameter.
 


### PR DESCRIPTION
## What did you implement:

One character documentation typo. No such thing as an SNS queue AFAIK: SQS queue.