### PR TITLE
Add docs for scheduled events for Kubeless

### DIFF
--- a/docs/providers/kubeless/README.md
+++ b/docs/providers/kubeless/README.md
@@ -68,6 +68,7 @@ If you have questions, join the [chat in gitter](https://gitter.im/serverless/se
       <ul>
         <li><a href="./events/http.md">HTTP Events</a></li>
         <li><a href="./events/pubsub.md">PubSub Events</a></li>
+        <li><a href="./events/scheduler.md">Scheduled Events</a></li>
       </ul>
     </div>
   </div>

--- a/docs/providers/kubeless/cli-reference/remove.md
+++ b/docs/providers/kubeless/cli-reference/remove.md
@@ -20,5 +20,8 @@ serverless remove
 
 It will remove the Kubeless Function objects from your Kubernetes cluster, the Kubernetes Deployments and the Kubernetes Services associated with the Serverless service.
 
+## Options
+- `--verbose` or `-v` Shows additional information during the removal.
+
 ## Provided lifecycle events
 - `remove:remove`

--- a/docs/providers/kubeless/events/http.md
+++ b/docs/providers/kubeless/events/http.md
@@ -84,10 +84,6 @@ If the events HTTP definitions contain a `path` attribute, when deploying this S
 
 ```
 kubectl get ingress
-NAME               HOSTS     ADDRESS          PORTS     AGE
-ingress-create     *         192.168.99.100   80        2m
-ingress-delete     *         192.168.99.100   80        2m
-ingress-read-all   *         192.168.99.100   80        2m
-ingress-read-one   *         192.168.99.100   80        2m
-ingress-update     *         192.168.99.100   80        2m
+NAME                    HOSTS                   ADDRESS   PORTS     AGE
+ingress-1506350705094   192.168.99.100.nip.io             80        28s
 ```

--- a/docs/providers/kubeless/events/scheduler.md
+++ b/docs/providers/kubeless/events/scheduler.md
@@ -1,0 +1,34 @@
+<!--
+title: Serverless Framework - Kubeless Events - Schedule
+menuText: Schedule
+menuOrder: 3
+description:  Scheduled Events in Kubeless
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/kubeless/events/schedule)
+<!-- DOCS-SITE-LINK:END -->
+
+# Kubeless Scheduled Events
+
+Kubeless functions can be triggered following a certain schedule. The schedule can be specified events section of the `serverless.yml` following the Cron notation:
+
+```
+service: clock
+
+provider:
+  name: kubeless
+  runtime: nodejs6
+
+plugins:
+  - serverless-kubeless
+
+functions:
+  clock:
+    handler: handler.printClock
+    events:
+      - schedule: "* * * * *"
+```
+
+When deploying this `serverless.yml` file, Kubeless will create a Kubernetes cron job that will trigger the function `printClock` every minute.

--- a/docs/providers/kubeless/guide/deploying.md
+++ b/docs/providers/kubeless/guide/deploying.md
@@ -76,7 +76,7 @@ Kubeless will create a [Kubernetes Deployment](https://kubernetes.io/docs/concep
 
 ## Deploy Function
 
-This deployment method updates a single function. It performs the platform API call to deploy your package without the other resources. It is much faster than redeploying your whole service each time.
+This deployment method updates or deploys a single function. It performs the platform API call to deploy your package without the other resources. It is much faster than redeploying your whole service each time.
 
 ```bash
 serverless deploy function --function myFunction

--- a/docs/providers/kubeless/guide/installation.md
+++ b/docs/providers/kubeless/guide/installation.md
@@ -26,7 +26,7 @@ Go to the official [Node.js website](https://nodejs.org), download and follow th
 
 **Note:** Serverless runs on Node v4 or higher.
 
-You can verify that Node.js is installed successfully by runnning `node --version` in your terminal. You should see the corresponding Node version number printed out.
+You can verify that Node.js is installed successfully by running `node --version` in your terminal. You should see the corresponding Node version number printed out.
 
 ## Installing the Serverless Framework
 

--- a/docs/providers/kubeless/guide/intro.md
+++ b/docs/providers/kubeless/guide/intro.md
@@ -24,7 +24,7 @@ Here are the Serverless Framework's main concepts and how they pertain to Kubele
 
 ### Functions
 
-A Function is an [Kubeless Function](http://kubeless.io/).  It's an independent unit of deployment, like a microservice.  It's merely code, deployed in the cloud, that is most often written to perform a single job such as:
+A Function is a [Kubeless Function](http://kubeless.io/).  It's an independent unit of deployment, like a microservice.  It's merely code, deployed in the cloud, that is most often written to perform a single job such as:
 
 * *Saving a user to the database*
 * *Processing a file in a database*


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I updated the Kubeless docs for the version 0.2.0 of the `serverless-kubeless` plugin. It includes a new event type: `schedule`.

<!--
Briefly describe the feature if no issue exists for this PR
-->

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO