### PR TITLE
Fix `deploy function` command by normalizing role 

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -73,6 +73,40 @@ class AwsDeployFunction {
     });
   }
 
+  normalizeArnRole(role) {
+    if (typeof role === 'string') {
+      if (role.indexOf(':') === -1) {
+        const roleResource = this.serverless.service.resources.Resources[role];
+
+        if (roleResource.Type !== 'AWS::IAM::Role') {
+          throw new Error('Provided resource is not IAM Role.');
+        }
+
+        const roleProperties = roleResource.Properties;
+        const compiledFullRoleName = `${roleProperties.Path}${roleProperties.RoleName}`;
+
+        return this.provider.getAccountId().then((accountId) =>
+          `arn:aws:iam::${accountId}:role${compiledFullRoleName}`
+        );
+      }
+
+      return BbPromise.resolve(role);
+    }
+
+    return BbPromise.resolve(role['Fn::GetAtt'][0]);
+  }
+
+  callUpdateFunctionConfiguration(params) {
+    return this.provider.request(
+      'Lambda',
+      'updateFunctionConfiguration',
+      params,
+      this.options.stage, this.options.region
+    ).then(() => {
+      this.serverless.cli.log(`Successfully updated function: ${this.options.function}`);
+    });
+  }
+
   updateFunctionConfiguration() {
     const functionObj = this.options.functionObj;
     const serviceObj = this.serverless.service.serviceObject;
@@ -95,12 +129,6 @@ class AwsDeployFunction {
       params.MemorySize = functionObj.memorySize;
     } else if ('memorySize' in providerObj) {
       params.MemorySize = providerObj.memorySize;
-    }
-
-    if ('role' in functionObj) {
-      params.Role = functionObj.role;
-    } else if ('role' in providerObj) {
-      params.Role = providerObj.role;
     }
 
     if ('timeout' in functionObj) {
@@ -148,14 +176,21 @@ class AwsDeployFunction {
       params.VpcConfig.SubnetIds = providerObj.vpc.subnetIds;
     }
 
-    return this.provider.request(
-      'Lambda',
-      'updateFunctionConfiguration',
-      params,
-      this.options.stage, this.options.region
-    ).then(() => {
-      this.serverless.cli.log(`Successfully updated function: ${this.options.function}`);
-    });
+    if ('role' in functionObj) {
+      return this.normalizeArnRole(functionObj.role).then(roleArn => {
+        params.Role = roleArn;
+
+        return this.callUpdateFunctionConfiguration(params);
+      });
+    } else if ('role' in providerObj) {
+      return this.normalizeArnRole(providerObj.role).then(roleArn => {
+        params.Role = roleArn;
+
+        return this.callUpdateFunctionConfiguration(params);
+      });
+    }
+
+    return this.callUpdateFunctionConfiguration(params);
   }
 
   deployFunction() {

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -83,7 +83,7 @@ class AwsDeployFunction {
         }
 
         const roleProperties = roleResource.Properties;
-        const compiledFullRoleName = `${roleProperties.Path}${roleProperties.RoleName}`;
+        const compiledFullRoleName = `${roleProperties.Path || '/'}${roleProperties.RoleName}`;
 
         return this.provider.getAccountId().then((accountId) =>
           `arn:aws:iam::${accountId}:role${compiledFullRoleName}`
@@ -94,7 +94,7 @@ class AwsDeployFunction {
     }
 
     return this.provider.getAccountId().then((accountId) =>
-      `arn:aws:iam::${accountId}:role${role['Fn::GetAtt'][0]}`
+      `arn:aws:iam::${accountId}:role/${role['Fn::GetAtt'][0]}`
     );
   }
 
@@ -179,14 +179,12 @@ class AwsDeployFunction {
     }
 
     if ('role' in functionObj) {
-      console.log('functionObj');
       return this.normalizeArnRole(functionObj.role).then(roleArn => {
         params.Role = roleArn;
 
         return this.callUpdateFunctionConfiguration(params);
       });
     } else if ('role' in providerObj) {
-      console.log('providerObj');
       return this.normalizeArnRole(providerObj.role).then(roleArn => {
         params.Role = roleArn;
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -93,7 +93,9 @@ class AwsDeployFunction {
       return BbPromise.resolve(role);
     }
 
-    return BbPromise.resolve(role['Fn::GetAtt'][0]);
+    return this.provider.getAccountId().then((accountId) =>
+      `arn:aws:iam::${accountId}:role${role['Fn::GetAtt'][0]}`
+    );
   }
 
   callUpdateFunctionConfiguration(params) {

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -179,12 +179,14 @@ class AwsDeployFunction {
     }
 
     if ('role' in functionObj) {
+      console.log('functionObj');
       return this.normalizeArnRole(functionObj.role).then(roleArn => {
         params.Role = roleArn;
 
         return this.callUpdateFunctionConfiguration(params);
       });
     } else if ('role' in providerObj) {
+      console.log('providerObj');
       return this.normalizeArnRole(providerObj.role).then(roleArn => {
         params.Role = roleArn;
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -93,10 +93,14 @@ class AwsDeployFunction {
       return BbPromise.resolve(role);
     }
 
-    return this.provider.getAccountId().then((accountId) => {
-      const delimeter = role['Fn::GetAtt'][0][0] === '/' ? '' : '/';
-      return `arn:aws:iam::${accountId}:role${delimeter}${role['Fn::GetAtt'][0]}`;
-    });
+    return this.provider.request(
+      'IAM',
+      'getRole',
+      {
+        RoleName: role['Fn::GetAtt'][0],
+      },
+      this.options.stage, this.options.region
+    ).then((data) => data.Arn);
   }
 
   callUpdateFunctionConfiguration(params) {

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -93,9 +93,10 @@ class AwsDeployFunction {
       return BbPromise.resolve(role);
     }
 
-    return this.provider.getAccountId().then((accountId) =>
-      `arn:aws:iam::${accountId}:role/${role['Fn::GetAtt'][0]}`
-    );
+    return this.provider.getAccountId().then((accountId) => {
+      const delimeter = role['Fn::GetAtt'][0][0] === '/' ? '' : '/';
+      return `arn:aws:iam::${accountId}:role${delimeter}${role['Fn::GetAtt'][0]}`;
+    });
   }
 
   callUpdateFunctionConfiguration(params) {

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -116,6 +116,64 @@ describe('AwsDeployFunction', () => {
     });
   });
 
+  describe('#normalizeArnRole', () => {
+    let getAccountIdStub;
+
+    beforeEach(() => {
+      getAccountIdStub = sinon
+        .stub(awsDeployFunction.provider, 'getAccountId')
+        .resolves('123456789012');
+
+      serverless.service.resources = {
+        Resources: {
+          MyCustomRole: {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+              RoleName: 'role_123',
+            },
+          },
+        },
+      };
+    });
+
+    afterEach(() => {
+      awsDeployFunction.provider.getAccountId.restore();
+      serverless.service.resources = undefined;
+    });
+
+    it('should return unmodified ARN if ARN was provided', () => {
+      const arn = 'arn:aws:iam::123456789012:role/role';
+
+      return awsDeployFunction.normalizeArnRole(arn).then((result) => {
+        expect(getAccountIdStub.calledOnce).to.be.equal(false);
+        expect(result).to.be.equal(arn);
+      });
+    });
+
+    it('should return compiled ARN if role name was provided', () => {
+      const roleName = 'MyCustomRole';
+
+      return awsDeployFunction.normalizeArnRole(roleName).then((result) => {
+        expect(getAccountIdStub.calledOnce).to.be.equal(true);
+        expect(result).to.be.equal('arn:aws:iam::123456789012:role/role_123');
+      });
+    });
+
+    it('should return compiled ARN if object role was provided', () => {
+      const roleObj = {
+        'Fn::GetAtt': [
+          'role_123',
+          'arn',
+        ],
+      };
+
+      return awsDeployFunction.normalizeArnRole(roleObj).then((result) => {
+        expect(getAccountIdStub.calledOnce).to.be.equal(true);
+        expect(result).to.be.equal('arn:aws:iam::123456789012:role/role_123');
+      });
+    });
+  });
+
   describe('#updateFunctionConfiguration', () => {
     let updateFunctionConfigurationStub;
     let normalizeArnRoleStub;
@@ -140,6 +198,7 @@ describe('AwsDeployFunction', () => {
 
     afterEach(() => {
       awsDeployFunction.provider.request.restore();
+      awsDeployFunction.normalizeArnRole.restore();
       awsDeployFunction.serverless.service.provider.timeout = undefined;
       awsDeployFunction.serverless.service.provider.memorySize = undefined;
       awsDeployFunction.serverless.service.provider.role = undefined;

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -118,11 +118,15 @@ describe('AwsDeployFunction', () => {
 
   describe('#normalizeArnRole', () => {
     let getAccountIdStub;
+    let getRoleStub;
 
     beforeEach(() => {
       getAccountIdStub = sinon
         .stub(awsDeployFunction.provider, 'getAccountId')
         .resolves('123456789012');
+      getRoleStub = sinon
+        .stub(awsDeployFunction.provider, 'request')
+        .resolves({ Arn: 'arn:aws:iam::123456789012:role/role_2' });
 
       serverless.service.resources = {
         Resources: {
@@ -138,6 +142,7 @@ describe('AwsDeployFunction', () => {
 
     afterEach(() => {
       awsDeployFunction.provider.getAccountId.restore();
+      awsDeployFunction.provider.request.restore();
       serverless.service.resources = undefined;
     });
 
@@ -162,14 +167,15 @@ describe('AwsDeployFunction', () => {
     it('should return compiled ARN if object role was provided', () => {
       const roleObj = {
         'Fn::GetAtt': [
-          'role_123',
-          'arn',
+          'role_2',
+          'Arn',
         ],
       };
 
       return awsDeployFunction.normalizeArnRole(roleObj).then((result) => {
-        expect(getAccountIdStub.calledOnce).to.be.equal(true);
-        expect(result).to.be.equal('arn:aws:iam::123456789012:role/role_123');
+        expect(getRoleStub.calledOnce).to.be.equal(true);
+        expect(getAccountIdStub.calledOnce).to.be.equal(false);
+        expect(result).to.be.equal('arn:aws:iam::123456789012:role/role_2');
       });
     });
   });

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -118,6 +118,7 @@ describe('AwsDeployFunction', () => {
 
   describe('#updateFunctionConfiguration', () => {
     let updateFunctionConfigurationStub;
+    let normalizeArnRoleStub;
     const options = {
       stage: 'dev',
       region: 'us-east-1',
@@ -131,6 +132,10 @@ describe('AwsDeployFunction', () => {
       updateFunctionConfigurationStub = sinon
         .stub(awsDeployFunction.provider, 'request')
         .resolves();
+
+      normalizeArnRoleStub = sinon
+        .stub(awsDeployFunction, 'normalizeArnRole')
+        .resolves('arn:aws:us-east-1:123456789012:role/role');
     });
 
     afterEach(() => {
@@ -162,6 +167,8 @@ describe('AwsDeployFunction', () => {
       awsDeployFunction.options = options;
 
       return awsDeployFunction.updateFunctionConfiguration().then(() => {
+        expect(normalizeArnRoleStub.calledOnce).to.be.equal(true);
+        expect(normalizeArnRoleStub.calledWithExactly('arn:aws:iam::123456789012:role/Admin'));
         expect(updateFunctionConfigurationStub.calledOnce).to.be.equal(true);
         expect(updateFunctionConfigurationStub.calledWithExactly(
           'Lambda',
@@ -179,7 +186,7 @@ describe('AwsDeployFunction', () => {
             FunctionName: 'first',
             KMSKeyArn: 'arn:aws:kms:us-east-1:123456789012',
             MemorySize: 128,
-            Role: 'arn:aws:iam::123456789012:role/Admin',
+            Role: 'arn:aws:us-east-1:123456789012:role/role',
             Timeout: 3,
             VpcConfig: {
               SecurityGroupIds: ['1'],
@@ -247,6 +254,8 @@ describe('AwsDeployFunction', () => {
       awsDeployFunction.options = options;
 
       return awsDeployFunction.updateFunctionConfiguration().then(() => {
+        expect(normalizeArnRoleStub.calledOnce).to.be.equal(true);
+        expect(normalizeArnRoleStub.calledWithExactly('role'));
         expect(updateFunctionConfigurationStub.calledOnce).to.be.equal(true);
         expect(updateFunctionConfigurationStub.calledWithExactly(
           'Lambda',
@@ -260,7 +269,7 @@ describe('AwsDeployFunction', () => {
             },
             Timeout: 12,
             MemorySize: 512,
-            Role: 'role',
+            Role: 'arn:aws:us-east-1:123456789012:role/role',
           },
           awsDeployFunction.options.stage,
           awsDeployFunction.options.region


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4318

## How did you implement it:

Previous change introduced regression which broke uploading functions with `deploy function` command if `role` wasn't ARN-based string. 

## How can we verify it:

```yml
service: iam-function-fix
provider:
  name: aws
  runtime: nodejs6.10

resources:
  Resources:
    RoleOne:
      Type: AWS::IAM::Role
      Properties:
        Path: /somepath/a/
        RoleName: RoleOneTest
        AssumeRolePolicyDocument:
          Version: '2012-10-17'
          Statement:
            - Effect: Allow
              Principal:
                Service:
                  - lambda.amazonaws.com
              Action: sts:AssumeRole
        Policies:
          - PolicyName: myPolicyNameOne
            PolicyDocument:
              Version: '2012-10-17'
              Statement:
                - Effect: Allow
                  Action:
                    - '*'
                  Resource:
                    - '*'
    RoleTwo:
      Type: AWS::IAM::Role
      Properties:
        Path: /my/default/path/
        RoleName: RoleTwo
        AssumeRolePolicyDocument:
          Version: '2012-10-17'
          Statement:
            - Effect: Allow
              Principal:
                Service:
                  - lambda.amazonaws.com
              Action: sts:AssumeRole
        Policies:
          - PolicyName: myPolicyNameTwo
            PolicyDocument:
              Version: '2012-10-17'
              Statement:
                - Effect: Allow
                  Action:
                    - '*'
                  Resource:
                    - '*'

functions:
  helloOne:
    handler: handler.hello
    role: RoleOne
  helloTwo:
    handler: handler.hello
    role:
      Fn::GetAtt:
       - RoleTwo
       - Arn
  helloThree:
    handler: handler.hello
    role: arn:aws:iam::085108115628:role/aws-kotlin-jvm-dev-us-east-1-lambdaRole # Replace with one working for you
```

```bash
sls deploy        # Creates resources
sls deploy function -f helloOne
sls deploy function -f helloTwo
sls deploy function -f helloThree
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO