### PR TITLE
Distinguish plugin initialization error from plugin not found error

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -90,17 +90,23 @@ class PluginManager {
 
         this.addPlugin(Plugin);
       } catch (error) {
-        // Rethrow the original error in case we're in debug mode.
-        if (process.env.SLS_DEBUG) {
-          throw error;
+        let errorMessage;
+        if (error && error.code === 'MODULE_NOT_FOUND' && error.message.endsWith(`'${plugin}'`)) {
+          // Plugin not installed
+          errorMessage = [
+            `Serverless plugin "${plugin}" not found.`,
+            ' Make sure it\'s installed and listed in the "plugins" section',
+            ' of your serverless config file.',
+          ].join('');
+        } else {
+          // Plugin initialization error
+          // Rethrow the original error in case we're in debug mode.
+          if (process.env.SLS_DEBUG) {
+            throw error;
+          }
+          errorMessage =
+            `Serverless plugin "${plugin}" initialization errored: ${error.message}`;
         }
-
-        const errorMessage = [
-          `Serverless plugin "${plugin}" not found.`,
-          ' Make sure it\'s installed and listed in the "plugins" section',
-          ' of your serverless config file.',
-        ].join('');
-
         if (!this.cliOptions.help) {
           throw new this.serverless.classes.Error(errorMessage);
         }


### PR DESCRIPTION
Distinguish _not found_ errors from _initialization_ errors (so far in both cases _not found_ error was thrown)



## What did you implement:

At this point serverless throws _plugin not found_ error, also if plugin exists and its initialization crashes. This patch, fixes that. Not found errors are reported as not found, and initialization crashes are reported more meaningfully

## How did you implement it:

I relied on error `MODULE_NOT_FOUND` code (recommended way to distinguish such errors)

## How can we verify it:

Create setup with non existing and crashing plugin

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
