### PR TITLE
Enable bluebird long stack traces only in SLS_DEBUG mode 

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -10,9 +10,12 @@ const initializeErrorReporter = require('../lib/utils/sentry').initializeErrorRe
 
 Error.stackTraceLimit = Infinity;
 
-BbPromise.config({
-  longStackTraces: true,
-});
+if (process.env.SLS_DEBUG) {
+  // For performance reasons enabled only in SLS_DEBUG mode
+  BbPromise.config({
+    longStackTraces: true,
+  });
+}
 
 process.on('unhandledRejection', (e) => {
   logError(e);

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "archiver": "^1.1.0",
     "async": "^1.5.2",
     "aws-sdk": "^2.75.0",
-    "bluebird": "^3.4.0",
+    "bluebird": "^3.5.0",
     "chalk": "^2.0.0",
     "ci-info": "^1.1.1",
     "download": "^5.0.2",


### PR DESCRIPTION
Closes #4331 

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
