### PR TITLE
Bring back getFileContent (zipService)

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -101,7 +101,7 @@ module.exports = {
       filePath
     );
 
-    return Promise.all([ // Get file contents and stat in parallel
+    return BbPromise.all([ // Get file contents and stat in parallel
       this.getFileContent(fullPath),
       fs.statAsync(fullPath),
     ]).then((result) => ({

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -111,6 +111,7 @@ module.exports = {
     }));
   },
 
+  // Useful point of entry for e.g. transpilation plugins
   getFileContent(fullPath) {
     return fs.readFileAsync(fullPath);
   },

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -102,13 +102,17 @@ module.exports = {
     );
 
     return Promise.all([ // Get file contents and stat in parallel
-      fs.readFileAsync(fullPath),
+      this.getFileContent(fullPath),
       fs.statAsync(fullPath),
     ]).then((result) => ({
       data: result[0],
       stat: result[1],
       filePath,
     }));
+  },
+
+  getFileContent(fullPath) {
+    return fs.readFileAsync(fullPath);
   },
 };
 

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -89,6 +89,27 @@ describe('zipService', () => {
     });
   });
 
+  describe('#getFileContent()', () => {
+    let servicePath;
+
+    beforeEach(() => {
+      servicePath = serverless.config.servicePath;
+      fs.mkdirSync(servicePath);
+    });
+
+    it('should keep the file content as is', () => {
+      const buf = new Buffer([10, 20, 30, 40, 50]);
+      const filePath = path.join(servicePath, 'bin-file');
+
+      fs.writeFileSync(filePath, buf);
+
+      return expect(packagePlugin.getFileContent(filePath)).to.be.fulfilled
+        .then((result) => {
+          expect(result).to.deep.equal(buf);
+        });
+    });
+  });
+
   describe('#excludeDevDependencies()', () => {
     it('should resolve when opted out of dev dependency exclusion', () => {
       packagePlugin.serverless.service.package.excludeDevDependencies = false;


### PR DESCRIPTION
## What did you implement:

I've noticed that on the course of [internal improvements](https://github.com/serverless/serverless/pull/4299) `getFileContent` method was removed.

I think it's a good point of entry for eventual module decorations (e.g. transpiling) in plugins.
e.g. I rely on it in [serverless-plugin-transpiler](https://github.com/medikoo/serverless-plugin-transpiler/blob/67f36b4d19aa97628f0e917914f5e51ed5169339/index.js#L22).

Can we have it back?

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
