### PR TITLE
optimize excludeDevDependencies

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -126,21 +126,15 @@ function excludeNodeDevDependencies(servicePath) {
   const nodeProdDepFile = path.join(tmpDir, `node-dependencies-${randHash}-prod`);
 
   try {
-    const packageJsonFilePaths = globby.sync([
+    const packageJsonPaths = globby.sync([
       '**/package.json',
-      // TODO add glob for node_modules filtering
+      '!**/node_modules/**',
     ], {
       cwd: servicePath,
       dot: true,
       silent: true,
       follow: true,
-      nosort: true,
-    });
-
-    // filter out non node_modules file paths
-    const packageJsonPaths = _.filter(packageJsonFilePaths, (filePath) => {
-      const isNodeModulesDir = !!filePath.match(/node_modules/);
-      return !isNodeModulesDir;
+      nosort: true
     });
 
     if (_.isEmpty(packageJsonPaths)) {


### PR DESCRIPTION
## What did you implement:

Closes #4337

## How did you implement it:

added glob pattern to exclude node_modules

## How can we verify it:

The current test suite for zipService will not work after this change.

The tests would probably make more sense with an actual directory tree, like [node-glob](https://github.com/isaacs/node-glob) generates for its tests

## Todos:

- [ ] Write tests
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** Not if it works correctly
