### PR TITLE
Updated postinstall.js to make it also work with spaces in path

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -27,12 +27,12 @@ function setupAutocomplete() {
     const tabtabCliPath = path.join(tabtabPath, 'src', 'cli.js');
 
     try {
-      execSync(`node ${tabtabCliPath} install --name serverless --auto`);
-      execSync(`node ${tabtabCliPath} install --name sls --auto`);
+      execSync(`node "${tabtabCliPath}" install --name serverless --auto`);
+      execSync(`node "${tabtabCliPath}" install --name sls --auto`);
       return resolve();
     } catch (error) {
-      execSync(`node ${tabtabCliPath} install --name serverless --stdout`);
-      execSync(`node ${tabtabCliPath} install --name sls --stdout`);
+      execSync(`node "${tabtabCliPath}" install --name serverless --stdout`);
+      execSync(`node "${tabtabCliPath}" install --name sls --stdout`);
       console.log('Could not auto-install serverless autocomplete script.');
       console.log('Please copy / paste the script above into your shell.');
       return reject(error);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Make sure postinstall.js works with paths with spaces.

Closes #4351 

## How can we verify it:

```
mkdir "path with spaces"
cd "path with spaces"
npm install serverless # Should not work
rm -Rf node_modules
npm install https://github.com/Wouter92/serverless/archive/master.tar.gz # Should work
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
