### PR TITLE
Set stdin to a TTY in invoke.py to allow PDB use

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -58,6 +58,8 @@ if __name__ == '__main__':
     handler = getattr(module, args.handler_name)
 
     input = json.load(sys.stdin)
+    if sys.platform != 'win32':
+        sys.stdin = open('/dev/tty')
     context = FakeLambdaContext(**input.get('context', {}))
     result = handler(input['event'], context)
     sys.stdout.write(json.dumps(result, indent=4))


### PR DESCRIPTION
Setting `sys.stdin` to a TTY prevents `pdb.set_trace()` from immediatly throwing
`BdbQuit`. I am unsure if there is a way to make this work in Windows

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

PDB support in Python Invoke Local, which didn't work because it requires a TTY.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Set `sys.stdin` to a TTY in `invoke.py` after the JSON event is read from it.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
1. create a new python project: `sls create -t aws-python3`
2. add `import pdb;pdb.set_trace()` in the sample handler, ie:
```python
def hello(event, context):
    body = {
        "message": "Go Serverless v1.0! Your function executed successfully!",
        "input": event
    }

    response = {
        "statusCode": 200,
        "body": json.dumps(body)
    }
    import pdb;pdb.set_trace()


    return response
```
3. run `sls invoke local -f hello` You should get a PDB prompt rather than a `BdbExit` error. (type `c` and Enter to continue execution)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
