### PR TITLE
Upgrade serverless-webpack plugin from version 2.2.0 to 3.1.1 for aws…

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",
-    "serverless-webpack": "^2.2.0",
+    "serverless-webpack": "^3.1.1",
     "webpack": "^3.3.0"
   },
   "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -10,14 +10,8 @@ provider:
   runtime: nodejs6.10
 
 functions:
-  # Example without LAMBDA-PROXY integration
-  # Invoking locally:
-  # sls webpack invoke -f first
   first:
     handler: first.hello
-  # Example with LAMBDA-PROXY integration
-  # Invoking locally:
-  # sls webpack invoke -f second
   second:
     handler: second.hello
     events:


### PR DESCRIPTION
…-nodejs-ecma-script template

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4364

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create a new serverless with the `aws-nodejs-ecma-script` template. Run `serverless invoke local --function first` to invoke the first function instead of `sls webpack invoke -f first`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
