### PR TITLE
Throw an error if package.json is corrupted while excluding devDependencies

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -160,7 +160,13 @@ function excludeNodeDevDependencies(servicePath) {
         return childProcess.execAsync(
           `npm ls --${env}=true --parseable=true --long=false --silent >> ${depFile}`,
           { cwd: dirWithPackageJson }
-        ).catch(() => BbPromise.resolve());
+        ).catch(() => {
+          const errorMessage = [
+            'Failed to exclude devDependencies.',
+            ' Check your package.json file for any syntax errors.',
+          ].join('');
+          throw new Error(errorMessage);
+        });
       });
     })
     // NOTE: using mapSeries here for a sequential computation (w/o race conditions)


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4358

## How can we verify it:

```bash
serverless create -t aws-nodejs
npm init
npm install aws-sdk --save-dev
echo 'syntax error' >> package.json
serverless package
```

Should throw an error

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO