### PR TITLE
provide additional information for running lambda inside VPC as part docs

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -139,7 +139,7 @@ provider:
       -  Effect: "Allow"
          Action:
            - "s3:ListBucket"
-         # You can put CloudFormation syntax in here.  No one will judge you.  
+         # You can put CloudFormation syntax in here.  No one will judge you.
          # Remember, this all gets translated to CloudFormation.
          Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket"} ] ] }
       -  Effect: "Allow"
@@ -225,6 +225,11 @@ Then, when you run `serverless deploy`, VPC configuration will be deployed along
 **VPC IAM permissions**
 
 The Lambda function execution role must have permissions to create, describe and delete [Elastic Network Interfaces](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ElasticNetworkInterfaces.html) (ENI). When VPC configuration is provided the default AWS `AWSLambdaVPCAccessExecutionRole` will be associated with your Lambda execution role. In case custom roles are provided be sure to include the proper [ManagedPolicyArns](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-managepolicyarns). For more information please check [configuring a Lambda Function for Amazon VPC Access](http://docs.aws.amazon.com/lambda/latest/dg/vpc.html)
+
+**VPC Lambda Internet Access**
+
+By default, when a Lambda function is executed inside a VPC, it looses internet access and some resources inside AWS may become unavailable. In order for S3 resources and DynamoDB resources to be available for your Lambda function running inside the VPC, a VPC end point needs to be created. For more information please check [VPC Endpoint for Amazon S3](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/).
+In order for other services such as Kinesis streams to be made available, a NAT Gateway needs to be configured inside the subnets that are being used to run the Lambda, for the VPC used to execute the Lambda. For more information, please check [Enable Outgoing Internet Access within VPC](https://medium.com/@philippholly/aws-lambda-enable-outgoing-internet-access-within-vpc-8dd250e11e12)
 
 ## Environment Variables
 


### PR DESCRIPTION
## What did you implement:

Closes #4362

Provides additional configuration information and help when running AWS Lambdas inside VPC. Provides information that deals with access to internet via NAT Gateway for resources outside the VPC.

## How did you implement it:
This is just a documentation update. 



***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
