### PR TITLE
Add function attached to API Gateway effective timeout warning

### DIFF
--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -29,6 +29,28 @@ module.exports = {
       this.serverless.service.package.artifact = path
         .join(this.serverless.config.servicePath, '.serverless', state.package.artifact);
     }
+
+    // Check function's attached to API Gateway timeout
+    if (!_.isEmpty(this.serverless.service.functions)) {
+      this.serverless.service.getAllFunctions().forEach(functionName => {
+        const functionObject = this.serverless.service.getFunction(functionName);
+
+        // Check if function timeout is greater than API Gateway timeout
+        if (functionObject.timeout > 30 && functionObject.events) {
+          functionObject.events.forEach(event => {
+            if (Object.keys(event)[0] === 'http') {
+              const warnMessage = [
+                `WARNING: Function ${functionName} has timeout of ${functionObject.timeout} seconds, `, 
+                `however, it's attached to API Gateway so it's automatically limited to 30 seconds.`
+              ].join('');
+              
+              this.serverless.cli.log(warnMessage);
+            }
+          });
+        }
+      });
+    }
+
     if (!_.isEmpty(this.serverless.service.functions) &&
         this.serverless.service.package.individually) {
       // artifact file validation (multiple function artifacts)

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -40,10 +40,11 @@ module.exports = {
           functionObject.events.forEach(event => {
             if (Object.keys(event)[0] === 'http') {
               const warnMessage = [
-                `WARNING: Function ${functionName} has timeout of ${functionObject.timeout} seconds, `, 
-                `however, it's attached to API Gateway so it's automatically limited to 30 seconds.`
+                `WARNING: Function ${functionName} has timeout of ${functionObject.timeout} `,
+                'seconds, however, it\'s attached to API Gateway so it\'s automatically ',
+                'limited to 30 seconds.'
               ].join('');
-              
+
               this.serverless.cli.log(warnMessage);
             }
           });

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -42,7 +42,7 @@ module.exports = {
               const warnMessage = [
                 `WARNING: Function ${functionName} has timeout of ${functionObject.timeout} `,
                 'seconds, however, it\'s attached to API Gateway so it\'s automatically ',
-                'limited to 30 seconds.'
+                'limited to 30 seconds.',
               ].join('');
 
               this.serverless.cli.log(warnMessage);

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -152,7 +152,7 @@ describe('extendedValidate', () => {
       });
     });
 
-    it('should warn user if function\'s timeout is greater than 30 and it\'s attached to APIGW', () => {
+    it('should warn if function\'s timeout is greater than 30 and it\'s attached to APIGW', () => {
       stateFileMock.service.functions = {
         first: {
           timeout: 31,

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -43,6 +43,9 @@ describe('extendedValidate', () => {
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.serverless.service.service = `service-${(new Date()).getTime().toString()}`;
     awsDeploy.serverless.cli = new serverless.classes.CLI();
+    awsDeploy.serverless.cli = {
+      log: sinon.spy(),
+    };
   });
 
   describe('extendedValidate()', () => {
@@ -146,6 +149,31 @@ describe('extendedValidate', () => {
       awsDeploy.serverless.service.package.artifact = 'some/file.zip';
       return awsDeploy.extendedValidate().then(() => {
         delete awsDeploy.serverless.service.package.artifact;
+      });
+    });
+
+    it('should warn user if function\'s timeout is greater than 30 and it\'s attached to APIGW', () => {
+      stateFileMock.service.functions = {
+        first: {
+          timeout: 31,
+          package: {
+            artifact: 'artifact.zip',
+          },
+          events: [{
+            http: {},
+          }],
+        },
+      };
+      awsDeploy.serverless.service.package.individually = true;
+      fileExistsSyncStub.returns(true);
+      readFileSyncStub.returns(stateFileMock);
+
+      return awsDeploy.extendedValidate().then(() => {
+        console.log(awsDeploy.serverless.cli.log);
+        const msg = [
+          'WARNING: Function first has timeout of 31 seconds, however, it\'s attached to API Gateway so it\'s automatically limited to 30 seconds.'
+        ].join('');
+        expect(awsDeploy.serverless.cli.log.firstCall.calledWithExactly(msg)).to.be.equal(true);
       });
     });
   });

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -169,9 +169,9 @@ describe('extendedValidate', () => {
       readFileSyncStub.returns(stateFileMock);
 
       return awsDeploy.extendedValidate().then(() => {
-        console.log(awsDeploy.serverless.cli.log);
         const msg = [
-          'WARNING: Function first has timeout of 31 seconds, however, it\'s attached to API Gateway so it\'s automatically limited to 30 seconds.'
+          'WARNING: Function first has timeout of 31 seconds, however, it\'s ',
+          'attached to API Gateway so it\'s automatically limited to 30 seconds.',
         ].join('');
         expect(awsDeploy.serverless.cli.log.firstCall.calledWithExactly(msg)).to.be.equal(true);
       });


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4371

## How can we verify it:

```yml
service: aws-nodejs-timeout-test
provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    timeout: 31
    events:
      - http:
          path: /
          method: GET
      - s3:
          bucket: idk
```

and then `serverless deploy`.

Expected output:

```
Serverless: WARNING: Function hello has timeout of 31 seconds, however, it's attached to API Gateway so it's automatically limited to 30 seconds.
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO