### PR TITLE
Exclude dev dependency .bin executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ tracking-config.json
 
 # Misc
 jest
+
+# VIM
+*.swp

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -42,7 +42,6 @@ describe('extendedValidate', () => {
     };
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.serverless.service.service = `service-${(new Date()).getTime().toString()}`;
-    awsDeploy.serverless.cli = new serverless.classes.CLI();
     awsDeploy.serverless.cli = {
       log: sinon.spy(),
     };

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -185,7 +185,7 @@ function excludeNodeDevDependencies(servicePath) {
           .map(dependencies, (item) => item.replace(path.join(servicePath, path.sep), ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
           .map((item) => {
-            const packagePath = `${item}/package.json`;
+            const packagePath = path.join(servicePath, path.sep, `${item}/package.json`);
             return fs.readFileAsync(packagePath, 'utf-8').then((packageJsonFile) => {
               const lastIndex = item.lastIndexOf('/') + 1;
               const moduleName = item.substr(lastIndex);

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -181,11 +181,32 @@ function excludeNodeDevDependencies(servicePath) {
       const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
       if (!_.isEmpty(dependencies)) {
-        const globs = dependencies
-          .map((item) => item.replace(path.join(servicePath, path.sep), ''))
+        return BbPromise
+          .map(dependencies, (item) => item.replace(path.join(servicePath, path.sep), ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
-          .map((item) => `${item}/**`);
-        exAndIn.exclude = globs;
+          .map((item) => fs.readFileAsync(`${item}/package.json`, 'utf-8').then((packageJsonFile) => {
+            const lastIndex = item.lastIndexOf('/') + 1;
+            const moduleName = item.substr(lastIndex);
+            const modulePath = item.substr(0, lastIndex);
+
+            const globs = [`${item}/**`];
+
+            const packageJson = JSON.parse(packageJsonFile);
+            const bin = packageJson.bin;
+
+            // NOTE: pkg.bin can be object, string, or undefined
+            if (typeof bin === 'object') {
+              globs.push(`${modulePath}.bin/${Object.keys(bin)[0]}`);
+            } else if (typeof bin === 'string') {
+              globs.push(`${modulePath}.bin/${moduleName}`);
+            }
+
+            return globs;
+          }))
+          .then((globs) => {
+            exAndIn.exclude = exAndIn.exclude.concat(_.flatten(globs));
+            return exAndIn;
+          });
       }
 
       return exAndIn;

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -184,25 +184,28 @@ function excludeNodeDevDependencies(servicePath) {
         return BbPromise
           .map(dependencies, (item) => item.replace(path.join(servicePath, path.sep), ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
-          .map((item) => fs.readFileAsync(`${item}/package.json`, 'utf-8').then((packageJsonFile) => {
-            const lastIndex = item.lastIndexOf('/') + 1;
-            const moduleName = item.substr(lastIndex);
-            const modulePath = item.substr(0, lastIndex);
+          .map((item) => {
+            const packagePath = `${item}/package.json`;
+            return fs.readFileAsync(packagePath, 'utf-8').then((packageJsonFile) => {
+              const lastIndex = item.lastIndexOf('/') + 1;
+              const moduleName = item.substr(lastIndex);
+              const modulePath = item.substr(0, lastIndex);
 
-            const globs = [`${item}/**`];
+              const globs = [`${item}/**`];
 
-            const packageJson = JSON.parse(packageJsonFile);
-            const bin = packageJson.bin;
+              const packageJson = JSON.parse(packageJsonFile);
+              const bin = packageJson.bin;
 
-            // NOTE: pkg.bin can be object, string, or undefined
-            if (typeof bin === 'object') {
-              globs.push(`${modulePath}.bin/${Object.keys(bin)[0]}`);
-            } else if (typeof bin === 'string') {
-              globs.push(`${modulePath}.bin/${moduleName}`);
-            }
+              // NOTE: pkg.bin can be object, string, or undefined
+              if (typeof bin === 'object') {
+                globs.push(`${modulePath}.bin/${Object.keys(bin)[0]}`);
+              } else if (typeof bin === 'string') {
+                globs.push(`${modulePath}.bin/${moduleName}`);
+              }
 
-            return globs;
-          }))
+              return globs;
+            });
+          })
           .then((globs) => {
             exAndIn.exclude = exAndIn.exclude.concat(_.flatten(globs));
             return exAndIn;

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -185,25 +185,25 @@ function excludeNodeDevDependencies(servicePath) {
           .map(dependencies, (item) => item.replace(path.join(servicePath, path.sep), ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
           .map((item) => {
-            const packagePath = path.join(servicePath, path.sep, `${item}/package.json`);
+            const packagePath = path.join(servicePath, item, 'package.json');
             return fs.readFileAsync(packagePath, 'utf-8').then((packageJsonFile) => {
-              const lastIndex = item.lastIndexOf('/') + 1;
+              const lastIndex = item.lastIndexOf(path.sep) + 1;
               const moduleName = item.substr(lastIndex);
               const modulePath = item.substr(0, lastIndex);
 
               const packageJson = JSON.parse(packageJsonFile);
               const bin = packageJson.bin;
 
-              let globs = [`${item}/**`];
+              let globs = [path.join(item, '**')];
 
               // NOTE: pkg.bin can be object, string, or undefined
               if (typeof bin === 'object') {
                 const binGlobs = Object.keys(bin)
-                  .map((executable) => `${modulePath}.bin/${executable}`);
+                  .map((executable) => path.join(modulePath, '.bin', executable));
                 globs = globs.concat(binGlobs);
               // only 1 executable with same name as lib
               } else if (typeof bin === 'string') {
-                globs.push(`${modulePath}.bin/${moduleName}`);
+                globs.push(path.join(modulePath, '.bin', moduleName));
               }
 
               return globs;

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -191,14 +191,17 @@ function excludeNodeDevDependencies(servicePath) {
               const moduleName = item.substr(lastIndex);
               const modulePath = item.substr(0, lastIndex);
 
-              const globs = [`${item}/**`];
-
               const packageJson = JSON.parse(packageJsonFile);
               const bin = packageJson.bin;
 
+              let globs = [`${item}/**`];
+
               // NOTE: pkg.bin can be object, string, or undefined
               if (typeof bin === 'object') {
-                globs.push(`${modulePath}.bin/${Object.keys(bin)[0]}`);
+                const binGlobs = Object.keys(bin)
+                  .map((executable) => `${modulePath}.bin/${executable}`);
+                globs = globs.concat(binGlobs);
+              // only 1 executable with same name as lib
               } else if (typeof bin === 'string') {
                 globs.push(`${modulePath}.bin/${moduleName}`);
               }

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -184,7 +184,7 @@ function excludeNodeDevDependencies(servicePath) {
         return BbPromise
           .map(dependencies, (item) => item.replace(path.join(servicePath, path.sep), ''))
           .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
-          .map((item) => {
+          .reduce((globs, item) => {
             const packagePath = path.join(servicePath, item, 'package.json');
             return fs.readFileAsync(packagePath, 'utf-8').then((packageJsonFile) => {
               const lastIndex = item.lastIndexOf(path.sep) + 1;
@@ -194,23 +194,23 @@ function excludeNodeDevDependencies(servicePath) {
               const packageJson = JSON.parse(packageJsonFile);
               const bin = packageJson.bin;
 
-              let globs = [path.join(item, '**')];
+              const baseGlobs = [path.join(item, '**')];
 
               // NOTE: pkg.bin can be object, string, or undefined
               if (typeof bin === 'object') {
-                const binGlobs = Object.keys(bin)
-                  .map((executable) => path.join(modulePath, '.bin', executable));
-                globs = globs.concat(binGlobs);
+                _.each(_.keys(bin), (executable) => {
+                  baseGlobs.push(path.join(modulePath, '.bin', executable));
+                });
               // only 1 executable with same name as lib
               } else if (typeof bin === 'string') {
-                globs.push(path.join(modulePath, '.bin', moduleName));
+                baseGlobs.push(path.join(modulePath, '.bin', moduleName));
               }
 
-              return globs;
+              return globs.concat(baseGlobs);
             });
-          })
+          }, [])
           .then((globs) => {
-            exAndIn.exclude = exAndIn.exclude.concat(_.flatten(globs));
+            exAndIn.exclude = exAndIn.exclude.concat(globs);
             return exAndIn;
           });
       }

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -288,10 +288,14 @@ describe('zipService', () => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(6);
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-1/package.json');
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-2/package.json');
-            expect(readFileAsyncStub).to.have.been.calledWith('1st/2nd/node_modules/module-1/package.json');
-            expect(readFileAsyncStub).to.have.been.calledWith('1st/2nd/node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('node_modules/module-2/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('1st/2nd/node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('1st/2nd/node_modules/module-1/package.json');
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -563,8 +567,10 @@ describe('zipService', () => {
             expect(execAsyncStub).to.have.been.calledTwice;
 
             expect(readFileAsyncStub).to.have.callCount(4);
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/bro-module/package.json');
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/lumo-clj/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('node_modules/bro-module/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('node_modules/lumo-clj/package.json');
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -626,7 +632,7 @@ describe('zipService', () => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(8);
-            for (let depPath of deps) {
+            for (const depPath of deps) {
               expect(readFileAsyncStub).to.have.been.calledWith(`${depPath}/package.json`);
             }
             expect(globbySyncStub).to.have.been

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -532,6 +532,7 @@ describe('zipService', () => {
           'node_modules/bro-module',
           'node_modules/node-dude',
           'node_modules/lumo-clj',
+          'node_modules/meowmix',
         ];
 
         const prodPaths = [
@@ -560,17 +561,23 @@ describe('zipService', () => {
         readFileAsyncStub
           .onCall(3)
           .resolves('{"name": "lumo-clj", "bin": {"lumo": "./bin/lumo.js"}}');
+        readFileAsyncStub
+          .onCall(4)
+          // need to handle possibility of multiple executables provided by the lib
+          .resolves('{"name": "meowmix", "bin": {"meow": "./bin/meow.js", "mix": "./bin/mix.js"}}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.been.calledOnce;
             expect(execAsyncStub).to.have.been.calledTwice;
 
-            expect(readFileAsyncStub).to.have.callCount(4);
+            expect(readFileAsyncStub).to.have.callCount(5);
             expect(readFileAsyncStub).to.have.been
               .calledWith('node_modules/bro-module/package.json');
             expect(readFileAsyncStub).to.have.been
               .calledWith('node_modules/lumo-clj/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith('node_modules/meowmix/package.json');
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -578,6 +585,9 @@ describe('zipService', () => {
               `${path.join('node_modules/.bin/bro-module')}`,
               `${path.join('node_modules/lumo-clj')}/**`,
               `${path.join('node_modules/.bin/lumo')}`,
+              `${path.join('node_modules/meowmix')}/**`,
+              `${path.join('node_modules/.bin/meow')}`,
+              `${path.join('node_modules/.bin/mix')}`,
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -231,7 +231,8 @@ describe('zipService', () => {
 
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
-        readFileAsyncStub.onCall(0).resolves();
+
+        readFileAsyncStub.onCall(0).rejects();
         readFileAsyncStub.onCall(1).rejects();
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
@@ -277,12 +278,20 @@ describe('zipService', () => {
         ].join('\n');
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
+        readFileAsyncStub.onCall(2).resolves('{}');
+        readFileAsyncStub.onCall(3).resolves('{}');
+        readFileAsyncStub.onCall(4).resolves('{}');
+        readFileAsyncStub.onCall(5).resolves('{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub.callCount).to.equal(6);
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.callCount(6);
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-2/package.json');
+            expect(readFileAsyncStub).to.have.been.calledWith('1st/2nd/node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been.calledWith('1st/2nd/node_modules/module-1/package.json');
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -341,12 +350,16 @@ describe('zipService', () => {
         ].join('\n');
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
+        readFileAsyncStub.onCall(2).resolves('{}');
+        readFileAsyncStub.onCall(3).resolves('{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.callCount(4);
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-2/package.json');
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -397,15 +410,20 @@ describe('zipService', () => {
           path.join(`${servicePath}`, '1st/2nd/node_modules/module-1'),
           path.join(`${servicePath}`, '1st/2nd/node_modules/module-2'),
         ].join('\n');
-        readFileAsyncStub.resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
+        readFileAsyncStub.onCall(2).resolves('{}');
+        readFileAsyncStub.onCall(3).resolves('{}');
+        readFileAsyncStub.onCall(4).resolves('{}');
+        readFileAsyncStub.onCall(5).resolves('{}');
+        readFileAsyncStub.onCall(6).resolves('{}');
+        readFileAsyncStub.onCall(7).resolves('{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub.callCount).to.equal(6);
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.callCount(8);
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -470,12 +488,14 @@ describe('zipService', () => {
           path.join(`${servicePath}`, 'node_modules/module-2'),
         ];
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
+        readFileAsyncStub.onCall(2).resolves('{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(readFileAsyncStub).to.have.been.calledThrice;
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-1/package.json');
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -495,6 +515,143 @@ describe('zipService', () => {
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               `${path.join('node_modules/module-1')}/**`,
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should exclude dev dependency executables in node_modules/.bin', () => {
+        const devPaths = [
+          'node_modules/bro-module',
+          'node_modules/node-dude',
+          'node_modules/lumo-clj',
+        ];
+
+        const prodPaths = [
+          'node_modules/node-dude',
+        ];
+
+        const filePaths = [
+          'node_modules/',
+          'package.json',
+        ].concat(devPaths).concat(prodPaths);
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.resolves();
+
+        const mapper = (depPath) => path.join(`${servicePath}`, depPath);
+
+        const devDepPaths = devPaths.map(mapper).join('\n');
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
+
+        const prodDepPaths = prodPaths.map(mapper).join('\n');
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
+
+        readFileAsyncStub
+          .onCall(2)
+          .resolves('{"name": "bro-module", "bin": "main.js"}');
+        readFileAsyncStub
+          .onCall(3)
+          .resolves('{"name": "lumo-clj", "bin": {"lumo": "./bin/lumo.js"}}');
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.been.calledOnce;
+            expect(execAsyncStub).to.have.been.calledTwice;
+
+            expect(readFileAsyncStub).to.have.callCount(4);
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/bro-module/package.json');
+            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/lumo-clj/package.json');
+
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+              `${path.join('node_modules/bro-module')}/**`,
+              `${path.join('node_modules/.bin/bro-module')}`,
+              `${path.join('node_modules/lumo-clj')}/**`,
+              `${path.join('node_modules/.bin/lumo')}`,
+            ]);
+            expect(updatedParams.include).to.deep.equal([
+              'user-defined-include-me',
+            ]);
+            expect(updatedParams.zipFileName).to.equal(params.zipFileName);
+          });
+      });
+
+      it('should exclude .bin executables in deeply nested folders', () => {
+        const filePaths = [
+          'package.json', 'node_modules',
+          path.join('1st', 'package.json'),
+          path.join('1st', 'node_modules'),
+          path.join('1st', '2nd', 'package.json'),
+          path.join('1st', '2nd', 'node_modules'),
+        ];
+
+        globbySyncStub.returns(filePaths);
+        execAsyncStub.resolves();
+        const deps = [
+          'node_modules/module-1',
+          'node_modules/module-2',
+          '1st/node_modules/module-1',
+          '1st/node_modules/module-2',
+          '1st/2nd/node_modules/module-1',
+          '1st/2nd/node_modules/module-2',
+        ];
+        const depPaths = deps.map((depPath) => path.join(`${servicePath}`, depPath));
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths.join('\n'));
+        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
+
+        const module1PackageJson = JSON.stringify({
+          name: 'module-1',
+          bin: {
+            'cool-module': './index.js',
+          },
+        });
+        const module2PackageJson = JSON.stringify({
+          name: 'module-2',
+          bin: './main.js',
+        });
+
+        readFileAsyncStub.onCall(2).resolves(module1PackageJson);
+        readFileAsyncStub.onCall(3).resolves(module2PackageJson);
+        readFileAsyncStub.onCall(4).resolves(module1PackageJson);
+        readFileAsyncStub.onCall(5).resolves(module2PackageJson);
+        readFileAsyncStub.onCall(6).resolves(module1PackageJson);
+        readFileAsyncStub.onCall(7).resolves(module2PackageJson);
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be
+          .fulfilled.then((updatedParams) => {
+            expect(globbySyncStub).to.have.been.calledOnce;
+            expect(execAsyncStub.callCount).to.equal(6);
+            expect(readFileAsyncStub).to.have.callCount(8);
+            for (let depPath of deps) {
+              expect(readFileAsyncStub).to.have.been.calledWith(`${depPath}/package.json`);
+            }
+            expect(globbySyncStub).to.have.been
+              .calledWithExactly(['**/package.json'], {
+                cwd: packagePlugin.serverless.config.servicePath,
+                dot: true,
+                silent: true,
+                follow: true,
+                nosort: true,
+              });
+
+            expect(updatedParams.exclude).to.deep.equal([
+              'user-defined-exclude-me',
+              `${path.join('node_modules/module-1')}/**`,
+              `${path.join('node_modules/.bin/cool-module')}`,
+              `${path.join('node_modules/module-2')}/**`,
+              `${path.join('node_modules/.bin/module-2')}`,
+              `${path.join('1st/node_modules/module-1')}/**`,
+              `${path.join('1st/node_modules/.bin/cool-module')}`,
+              `${path.join('1st/node_modules/module-2')}/**`,
+              `${path.join('1st/node_modules/.bin/module-2')}`,
+              `${path.join('1st/2nd/node_modules/module-1')}/**`,
+              `${path.join('1st/2nd/node_modules/.bin/cool-module')}`,
+              `${path.join('1st/2nd/node_modules/module-2')}/**`,
+              `${path.join('1st/2nd/node_modules/.bin/module-2')}`,
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -293,9 +293,23 @@ describe('zipService', () => {
             expect(readFileAsyncStub).to.have.been
               .calledWith(path.join(servicePath, 'node_modules', 'module-2', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json'));
+              .calledWith(path.join(
+                servicePath,
+                '1st',
+                '2nd',
+                'node_modules',
+                'module-1',
+                'package.json'
+              ));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json'));
+              .calledWith(path.join(
+                servicePath,
+                '1st',
+                '2nd',
+                'node_modules',
+                'module-1',
+                'package.json'
+              ));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -289,13 +289,13 @@ describe('zipService', () => {
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(6);
             expect(readFileAsyncStub).to.have.been
-              .calledWith('node_modules/module-1/package.json');
+              .calledWith(path.join(servicePath, 'node_modules/module-1/package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith('node_modules/module-2/package.json');
+              .calledWith(path.join(servicePath, 'node_modules/module-2/package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith('1st/2nd/node_modules/module-1/package.json');
+              .calledWith(path.join(servicePath, '1st/2nd/node_modules/module-1/package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith('1st/2nd/node_modules/module-1/package.json');
+              .calledWith(path.join(servicePath, '1st/2nd/node_modules/module-1/package.json'));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -362,8 +362,10 @@ describe('zipService', () => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.callCount(4);
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-1/package.json');
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-2/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith(path.join(servicePath, 'node_modules/module-1/package.json'));
+            expect(readFileAsyncStub).to.have.been
+              .calledWith(path.join(servicePath, 'node_modules/module-2/package.json'));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -499,7 +501,8 @@ describe('zipService', () => {
             expect(globbySyncStub).to.have.been.calledOnce;
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledThrice;
-            expect(readFileAsyncStub).to.have.been.calledWith('node_modules/module-1/package.json');
+            expect(readFileAsyncStub).to.have.been
+              .calledWith(path.join(servicePath, 'node_modules/module-1/package.json'));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -573,11 +576,11 @@ describe('zipService', () => {
 
             expect(readFileAsyncStub).to.have.callCount(5);
             expect(readFileAsyncStub).to.have.been
-              .calledWith('node_modules/bro-module/package.json');
+              .calledWith(path.join(servicePath, 'node_modules/bro-module/package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith('node_modules/lumo-clj/package.json');
+              .calledWith(path.join(servicePath, 'node_modules/lumo-clj/package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith('node_modules/meowmix/package.json');
+              .calledWith(path.join(servicePath, 'node_modules/meowmix/package.json'));
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -643,7 +646,8 @@ describe('zipService', () => {
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(8);
             for (const depPath of deps) {
-              expect(readFileAsyncStub).to.have.been.calledWith(`${depPath}/package.json`);
+              expect(readFileAsyncStub).to.have.been
+                .calledWith(path.join(servicePath, (`${depPath}/package.json`)));
             }
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -232,7 +232,7 @@ describe('zipService', () => {
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
 
-        readFileAsyncStub.onCall(0).rejects();
+        readFileAsyncStub.onCall(0).resolves();
         readFileAsyncStub.onCall(1).rejects();
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -289,13 +289,13 @@ describe('zipService', () => {
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(6);
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/module-1/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'module-1', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/module-2/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'module-2', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, '1st/2nd/node_modules/module-1/package.json'));
+              .calledWith(path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, '1st/2nd/node_modules/module-1/package.json'));
+              .calledWith(path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json'));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -363,9 +363,9 @@ describe('zipService', () => {
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.callCount(4);
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/module-1/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'module-1', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/module-2/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'module-2', 'package.json'));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -502,7 +502,7 @@ describe('zipService', () => {
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledThrice;
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/module-1/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'module-1', 'package.json'));
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {
                 cwd: packagePlugin.serverless.config.servicePath,
@@ -576,11 +576,11 @@ describe('zipService', () => {
 
             expect(readFileAsyncStub).to.have.callCount(5);
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/bro-module/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'bro-module', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/lumo-clj/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'lumo-clj', 'package.json'));
             expect(readFileAsyncStub).to.have.been
-              .calledWith(path.join(servicePath, 'node_modules/meowmix/package.json'));
+              .calledWith(path.join(servicePath, 'node_modules', 'meowmix', 'package.json'));
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
@@ -647,7 +647,7 @@ describe('zipService', () => {
             expect(readFileAsyncStub).to.have.callCount(8);
             for (const depPath of deps) {
               expect(readFileAsyncStub).to.have.been
-                .calledWith(path.join(servicePath, (`${depPath}/package.json`)));
+                .calledWith(path.join(servicePath, depPath, 'package.json'));
             }
             expect(globbySyncStub).to.have.been
               .calledWithExactly(['**/package.json'], {

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -271,10 +271,10 @@ describe('zipService', () => {
         execAsyncStub.onCall(4).resolves();
         execAsyncStub.onCall(5).resolves();
         const depPaths = [
-          path.join(`${servicePath}`, 'node_modules/module-1'),
-          path.join(`${servicePath}`, 'node_modules/module-2'),
-          path.join(`${servicePath}`, '1st/2nd/node_modules/module-1'),
-          path.join(`${servicePath}`, '1st/2nd/node_modules/module-2'),
+          path.join(servicePath, 'node_modules', 'module-1'),
+          path.join(servicePath, 'node_modules', 'module-2'),
+          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
+          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
         ].join('\n');
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
@@ -344,10 +344,10 @@ describe('zipService', () => {
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              `${path.join('node_modules/module-1')}/**`,
-              `${path.join('node_modules/module-2')}/**`,
-              `${path.join('1st/2nd/node_modules/module-1')}/**`,
-              `${path.join('1st/2nd/node_modules/module-2')}/**`,
+              path.join('node_modules', 'module-1', '**'),
+              path.join('node_modules', 'module-2', '**'),
+              path.join('1st', '2nd', 'node_modules', 'module-1', '**'),
+              path.join('1st', '2nd', 'node_modules', 'module-2', '**'),
             ]);
             expect(updatedParams.include).to
               .deep.equal([
@@ -363,8 +363,8 @@ describe('zipService', () => {
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
         const depPaths = [
-          path.join(`${servicePath}`, 'node_modules/module-1'),
-          path.join(`${servicePath}`, 'node_modules/module-2'),
+          path.join(servicePath, 'node_modules', 'module-1'),
+          path.join(servicePath, 'node_modules', 'module-2'),
         ].join('\n');
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
@@ -398,8 +398,8 @@ describe('zipService', () => {
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              `${path.join('node_modules/module-1')}/**`,
-              `${path.join('node_modules/module-2')}/**`,
+              path.join('node_modules', 'module-1', '**'),
+              path.join('node_modules', 'module-2', '**'),
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',
@@ -423,12 +423,12 @@ describe('zipService', () => {
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
         const depPaths = [
-          path.join(`${servicePath}`, 'node_modules/module-1'),
-          path.join(`${servicePath}`, 'node_modules/module-2'),
-          path.join(`${servicePath}`, '1st/node_modules/module-1'),
-          path.join(`${servicePath}`, '1st/node_modules/module-2'),
-          path.join(`${servicePath}`, '1st/2nd/node_modules/module-1'),
-          path.join(`${servicePath}`, '1st/2nd/node_modules/module-2'),
+          path.join(servicePath, 'node_modules', 'module-1'),
+          path.join(servicePath, 'node_modules', 'module-2'),
+          path.join(servicePath, '1st', 'node_modules', 'module-1'),
+          path.join(servicePath, '1st', 'node_modules', 'module-2'),
+          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
+          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
         ].join('\n');
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
@@ -478,12 +478,12 @@ describe('zipService', () => {
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              `${path.join('node_modules/module-1')}/**`,
-              `${path.join('node_modules/module-2')}/**`,
-              `${path.join('1st/node_modules/module-1')}/**`,
-              `${path.join('1st/node_modules/module-2')}/**`,
-              `${path.join('1st/2nd/node_modules/module-1')}/**`,
-              `${path.join('1st/2nd/node_modules/module-2')}/**`,
+              path.join('node_modules', 'module-1', '**'),
+              path.join('node_modules', 'module-2', '**'),
+              path.join('1st', 'node_modules', 'module-1', '**'),
+              path.join('1st', 'node_modules', 'module-2', '**'),
+              path.join('1st', '2nd', 'node_modules', 'module-1', '**'),
+              path.join('1st', '2nd', 'node_modules', 'module-2', '**'),
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',
@@ -499,13 +499,13 @@ describe('zipService', () => {
         execAsyncStub.resolves();
 
         const devDepPaths = [
-          path.join(`${servicePath}`, 'node_modules/module-1'),
-          path.join(`${servicePath}`, 'node_modules/module-2'),
+          path.join(servicePath, 'node_modules', 'module-1'),
+          path.join(servicePath, 'node_modules', 'module-2'),
         ].join('\n');
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
 
         const prodDepPaths = [
-          path.join(`${servicePath}`, 'node_modules/module-2'),
+          path.join(servicePath, 'node_modules', 'module-2'),
         ];
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
         readFileAsyncStub.onCall(2).resolves('{}');
@@ -535,7 +535,7 @@ describe('zipService', () => {
               .match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              `${path.join('node_modules/module-1')}/**`,
+              path.join('node_modules', 'module-1', '**'),
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',
@@ -598,13 +598,13 @@ describe('zipService', () => {
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              `${path.join('node_modules/bro-module')}/**`,
-              `${path.join('node_modules/.bin/bro-module')}`,
-              `${path.join('node_modules/lumo-clj')}/**`,
-              `${path.join('node_modules/.bin/lumo')}`,
-              `${path.join('node_modules/meowmix')}/**`,
-              `${path.join('node_modules/.bin/meow')}`,
-              `${path.join('node_modules/.bin/mix')}`,
+              path.join('node_modules', 'bro-module', '**'),
+              path.join('node_modules', '.bin', 'bro-module'),
+              path.join('node_modules', 'lumo-clj', '**'),
+              path.join('node_modules', '.bin', 'lumo'),
+              path.join('node_modules', 'meowmix', '**'),
+              path.join('node_modules', '.bin', 'meow'),
+              path.join('node_modules', '.bin', 'mix'),
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',
@@ -674,18 +674,18 @@ describe('zipService', () => {
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              `${path.join('node_modules/module-1')}/**`,
-              `${path.join('node_modules/.bin/cool-module')}`,
-              `${path.join('node_modules/module-2')}/**`,
-              `${path.join('node_modules/.bin/module-2')}`,
-              `${path.join('1st/node_modules/module-1')}/**`,
-              `${path.join('1st/node_modules/.bin/cool-module')}`,
-              `${path.join('1st/node_modules/module-2')}/**`,
-              `${path.join('1st/node_modules/.bin/module-2')}`,
-              `${path.join('1st/2nd/node_modules/module-1')}/**`,
-              `${path.join('1st/2nd/node_modules/.bin/cool-module')}`,
-              `${path.join('1st/2nd/node_modules/module-2')}/**`,
-              `${path.join('1st/2nd/node_modules/.bin/module-2')}`,
+              path.join('node_modules', 'module-1', '**'),
+              path.join('node_modules', '.bin', 'cool-module'),
+              path.join('node_modules', 'module-2', '**'),
+              path.join('node_modules', '.bin/module-2'),
+              path.join('1st', 'node_modules', 'module-1', '**'),
+              path.join('1st', 'node_modules', '.bin', 'cool-module'),
+              path.join('1st', 'node_modules', 'module-2', '**'),
+              path.join('1st', 'node_modules', '.bin', 'module-2'),
+              path.join('1st', '2nd', 'node_modules', 'module-1', '**'),
+              path.join('1st', '2nd', 'node_modules', '.bin', 'cool-module'),
+              path.join('1st', '2nd', 'node_modules', 'module-2', '**'),
+              path.join('1st', '2nd', 'node_modules', '.bin', 'module-2'),
             ]);
             expect(updatedParams.include).to.deep.equal([
               'user-defined-include-me',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4359 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

The `bin` properly `package.json` files of dev deps are read to check the name of the executable(s). If they exist, they are added to the glob exclude patterns.

Existing tests were updated w/ appropriate `readFileAsync` call counts & resolve values. 2 new tests were added handling executable exclusion.

NOTE: `readFileAsync` is being used to read `package.json` files & loading them into memory to access the `.bin` property which is not ideal, but this seems to be the safest way to know the name of the executables. For ex. a lib may be named `lumo-cljs`, but the executable specified in `package.json` could be named `lumo` w/o reading the file, there would be no way to know that. Also, there could be multiple executables include in the [bin](https://docs.npmjs.com/files/package.json#bin) section such as

package.json

```
{
  "bin": {
    "executable1", "executable1.js",
    "executable2", "executable2.js"
  }
}
```

Any feedback would be helpful as this is my first contrib to this project!

## How can we verify it:

Run `yarn test` or pull these changes and try installing as a package locally then running `sls package`

Pull these changes and create a new project, `yarn init` and add a few dev & prod packages:

package.json

```
{
  "name": "sample-project",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "scripts": {
    "sls": "sls"
  },
  "dependencies": {
    "lodash": "^4.17.4",
    "lokka": "^1.7.0",
    "lokka-transport-http": "^1.6.1"
  },
  "devDependencies": {
    "serverless": "file:path-to-local-serverless",
    "lumo-cljs": "^1.8.0-beta",
  }
}
```

Run

```
$ sls create -t aws-nodejs
$ sls package
$ unzip .serverless/aws-nodejs.zip -lf | grep lumo
```

Should not print anything

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
