### PR TITLE
Allow symlinks as custom variable files in serverless.yml

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -258,6 +258,8 @@ functions:
     events: ${file(./myCustomFile.json):myevents
 ```
 
+**Note:** If the referenced file is a symlink, the targeted file will be read.
+
 ## Reference Variables in Javascript Files
 
 You can reference JavaScript files to add dynamic data into your variables.

--- a/docs/providers/azure/guide/variables.md
+++ b/docs/providers/azure/guide/variables.md
@@ -113,6 +113,8 @@ functions:
     events: ${file(./myCustomFile.json):myevents
 ```
 
+**Note:** If the referenced file is a symlink, the targeted file will be read.
+
 ## Reference Variables in JavaScript Files
 
 You can reference JavaScript files to add dynamic data into your variables.

--- a/docs/providers/google/guide/variables.md
+++ b/docs/providers/google/guide/variables.md
@@ -116,6 +116,8 @@ functions:
     events: ${file(./myCustomFile.json):myevents
 ```
 
+**Note:** If the referenced file is a symlink, the targeted file will be read.
+
 ## Reference Variables in JavaScript Files
 
 You can reference JavaScript files to add dynamic data into your variables.

--- a/docs/providers/openwhisk/guide/variables.md
+++ b/docs/providers/openwhisk/guide/variables.md
@@ -135,6 +135,8 @@ functions:
     events: ${file(./myCustomFile.json):myevents
 ```
 
+**Note:** If the referenced file is a symlink, the targeted file will be read.
+
 ## Reference Variables in Javascript Files
 
 You can reference JavaScript files to add dynamic data into your variables.

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -236,7 +236,7 @@ class Variables {
         path.join(this.serverless.config.servicePath, referencedFileRelativePath));
 
     // Get real path to handle potential symlinks
-    referencedFileFullPath = fse.realpathSync(referencedFileFullPath, 'utf8');
+    referencedFileFullPath = fse.realpathSync(referencedFileFullPath);
 
     let fileExtension = referencedFileRelativePath.split('.');
     fileExtension = fileExtension[fileExtension.length - 1];

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -6,6 +6,7 @@ const replaceall = require('replaceall');
 const logWarning = require('./Error').logWarning;
 const BbPromise = require('bluebird');
 const os = require('os');
+const fse = require('../utils/fs/fse');
 
 class Variables {
 
@@ -230,9 +231,13 @@ class Variables {
       .replace(this.fileRefSyntax, (match, varName) => varName.trim())
       .replace('~', os.homedir());
 
-    const referencedFileFullPath = (path.isAbsolute(referencedFileRelativePath) ?
+    let referencedFileFullPath = (path.isAbsolute(referencedFileRelativePath) ?
         referencedFileRelativePath :
         path.join(this.serverless.config.servicePath, referencedFileRelativePath));
+
+    // Get real path to handle potential symlinks
+    referencedFileFullPath = fse.realpathSync(referencedFileFullPath, 'utf8');
+
     let fileExtension = referencedFileRelativePath.split('.');
     fileExtension = fileExtension[fileExtension.length - 1];
     // Validate file exists

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -6,6 +6,7 @@ const YAML = require('js-yaml');
 const chai = require('chai');
 const Variables = require('../../lib/classes/Variables');
 const Utils = require('../../lib/classes/Utils');
+const fse = require('../utils/fs/fse');
 const Serverless = require('../../lib/Serverless');
 const sinon = require('sinon');
 const testUtils = require('../../tests/utils');
@@ -593,14 +594,19 @@ describe('Variables', () => {
       const fileExistsStub = sinon
         .stub(serverless.utils, 'fileExistsSync').returns(true);
 
+      const realpathSync = sinon
+        .stub(fse, 'realpathSync').returns(expectedFileName);
+
       const readFileSyncStub = sinon
         .stub(serverless.utils, 'readFileSync').returns(configYml);
 
       return serverless.variables.getValueFromFile('file(~/somedir/config.yml)')
         .then(valueToPopulate => {
+          expect(realpathSync.calledWithMatch(expectedFileName));
           expect(fileExistsStub.calledWithMatch(expectedFileName));
           expect(readFileSyncStub.calledWithMatch(expectedFileName));
           expect(valueToPopulate).to.deep.equal(configYml);
+          realpathSync.restore();
           readFileSyncStub.restore();
           fileExistsStub.restore();
         });
@@ -632,12 +638,20 @@ describe('Variables', () => {
     it('should get undefined if non existing file and the second argument is true', () => {
       const serverless = new Serverless();
       const tmpDirPath = testUtils.getTmpDirPath();
+      const fileToTest = './config.yml';
+      const expectedFileName = path.join(tmpDirPath, fileToTest);
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      return serverless.variables.getValueFromFile('file(./config.yml)').then(valueToPopulate => {
-        expect(valueToPopulate).to.be.equal(undefined);
-      });
+      const realpathSync = sinon
+        .stub(fse, 'realpathSync').returns(expectedFileName);
+
+      return serverless.variables.getValueFromFile(`file(${fileToTest})`)
+        .then(valueToPopulate => {
+          expect(realpathSync.calledWithMatch(expectedFileName));
+          expect(valueToPopulate).to.be.equal(undefined);
+          realpathSync.restore();
+        });
     });
 
     it('should populate non json/yml files', () => {


### PR DESCRIPTION
## What did you implement:

Closes #4388

`serverless.yml` allows to include variables from external `json` files using the following syntax:
```yml
custom: ${file(./config.json)}
```
But if the file is a symlink, Serverless Framework considers it as a non-existing file.

## Verification config / commands / resources
* Create a `config/sls-variables.json` file
* Create a symlink to this file at your project root (`ln -s ./config/sls-variables.json .`)
* Reference the symlink inside your `serverless.yml`
* Run a `sls` command (ex: `sls deploy`) 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
