### PR TITLE
Fixed the flaky unit tests

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -11,6 +11,7 @@ const testUtils = require('../../../../../tests/utils');
 
 describe('createStack', () => {
   let awsDeploy;
+  let sandbox;
   const tmpDirPath = testUtils.getTmpDirPath();
 
   const serverlessYmlPath = path.join(tmpDirPath, 'serverless.yml');
@@ -38,13 +39,21 @@ describe('createStack', () => {
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });
 
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   describe('#create()', () => {
     it('should include custom stack tags', () => {
       awsDeploy.serverless.service.provider.stackTags = { STAGE: 'overridden', tag1: 'value1' };
 
-      const createStackStub = sinon
+      const createStackStub = sandbox
         .stub(awsDeploy.provider, 'request').resolves();
-      sinon.stub(awsDeploy, 'monitorStack').resolves();
+      sandbox.stub(awsDeploy, 'monitorStack').resolves();
 
       return awsDeploy.create().then(() => {
         expect(createStackStub.args[0][2].Tags)
@@ -52,33 +61,29 @@ describe('createStack', () => {
             { Key: 'STAGE', Value: 'overridden' },
             { Key: 'tag1', Value: 'value1' },
           ]);
-        awsDeploy.provider.request.restore();
-        awsDeploy.monitorStack.restore();
       });
     });
 
     it('should use CloudFormation service role ARN if it is specified', () => {
       awsDeploy.serverless.service.provider.cfnRole = 'arn:aws:iam::123456789012:role/myrole';
 
-      const createStackStub = sinon
+      const createStackStub = sandbox
         .stub(awsDeploy.provider, 'request').resolves();
-      sinon.stub(awsDeploy, 'monitorStack').resolves();
+      sandbox.stub(awsDeploy, 'monitorStack').resolves();
 
       return awsDeploy.create().then(() => {
         expect(createStackStub.args[0][2].RoleARN)
           .to.equal('arn:aws:iam::123456789012:role/myrole');
-        awsDeploy.provider.request.restore();
-        awsDeploy.monitorStack.restore();
       });
     });
   });
 
   describe('#createStack()', () => {
     it('should resolve if stack already created', () => {
-      const createStub = sinon
+      const createStub = sandbox
         .stub(awsDeploy, 'create').resolves();
 
-      sinon.stub(awsDeploy.provider, 'request').resolves();
+      sandbox.stub(awsDeploy.provider, 'request').resolves();
 
       return awsDeploy.createStack().then(() => {
         expect(createStub.called).to.be.equal(false);
@@ -87,7 +92,7 @@ describe('createStack', () => {
 
     it('should set the createLater flag and resolve if deployment bucket is provided', () => {
       awsDeploy.serverless.service.provider.deploymentBucket = 'serverless';
-      sinon.stub(awsDeploy.provider, 'request')
+      sandbox.stub(awsDeploy.provider, 'request')
         .returns(BbPromise.reject({ message: 'does not exist' }));
 
       return awsDeploy.createStack().then(() => {
@@ -100,7 +105,7 @@ describe('createStack', () => {
         message: 'Something went wrong.',
       };
 
-      sinon.stub(awsDeploy.provider, 'request').rejects(errorMock);
+      sandbox.stub(awsDeploy.provider, 'request').rejects(errorMock);
 
       const createStub = sinon
         .stub(awsDeploy, 'create').resolves();
@@ -117,7 +122,7 @@ describe('createStack', () => {
         message: 'does not exist',
       };
 
-      sinon.stub(awsDeploy.provider, 'request').rejects(errorMock);
+      sandbox.stub(awsDeploy.provider, 'request').rejects(errorMock);
 
       const createStub = sinon
         .stub(awsDeploy, 'create').resolves();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Currently, unit tests are flaky, sometimes fails like this: https://travis-ci.org/serverless/serverless/jobs/287331366

One of the main reason is that stubs in createStack test are not restored properly, so I have reveraged the sandbox feature of `sinon`, then those are done inside `afterEach` even if failing the test in the process.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
sandbox creation and restore process has certainly done inside `beforeEach` and `afterEach`, and then it makes the createStack test stable.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Run test on Travis.
However, we can not see the error everytime. Therefore we might want to merge once and observe if the error will not occur again.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
