### PR TITLE
Default value for Timer Trigger Fixed

### DIFF
--- a/docs/providers/azure/events/timer.md
+++ b/docs/providers/azure/events/timer.md
@@ -33,7 +33,7 @@ functions:
     events:
       - timer:
         x-azure-settings:
-            name: item #<string>, default - "myQueueItem", specifies which name it's available on `context.bindings`
+            name: timerObj #<string>, default - "myTimer", specifies which name it's available on `context.bindings`
             schedule: 0 */5 * * * * #<string>, cron expression to run on
 ```
 


### PR DESCRIPTION
Very tiny documentation fix. 

Based on [this](https://github.com/serverless/serverless-azure-functions/blob/629ade76534b82df0977f9e629906ded29a94fce/shared/bindings.json#L32) the default value needs to be `myTimer`