### PR TITLE
Throw an error if artifact is bigger than 50MB

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -75,7 +75,11 @@ module.exports = {
       output.on('close', () => resolve(artifactFilePath));
       output.on('error', (err) => reject(err));
       zip.on('error', (err) => reject(err));
-
+      zip.on('end', () => {
+        if (output.bytesWritten > 50000000) {
+          throw new Error('Artifact size limit of 50MB exceeded. Aborting deployment.');
+        }
+      });
 
       output.on('open', () => {
         zip.pipe(output);


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/4399

## How can we verify it:

```bash
mkfile -n 1500m bigfile.js  
npm install axios aws-sdk puppeteer --save      # Some random big modules
serverless package
```
## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO