### PR TITLE
Omit referenced values from environment variables in local invocation

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -105,8 +105,8 @@ class AwsInvokeLocal {
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
     };
 
-    const providerEnvVars = this.serverless.service.provider.environment || {};
-    const functionEnvVars = this.options.functionObj.environment || {};
+    const providerEnvVars = _.omitBy(this.serverless.service.provider.environment, _.isObject);
+    const functionEnvVars = _.omitBy(this.options.functionObj.environment, _.isObject);
 
     _.merge(process.env, lambdaDefaultEnvVars, providerEnvVars, functionEnvVars);
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -211,6 +211,9 @@ describe('AwsInvokeLocal', () => {
       serverless.service.provider = {
         environment: {
           providerVar: 'providerValue',
+          providerRefVar: {
+            Ref: 'RefResource',
+          },
         },
       };
 
@@ -220,6 +223,9 @@ describe('AwsInvokeLocal', () => {
           name: 'serviceName-dev-hello',
           environment: {
             functionVar: 'functionValue',
+            functionRefVar: {
+              Ref: 'RefResource',
+            },
           },
         },
       };
@@ -256,6 +262,17 @@ describe('AwsInvokeLocal', () => {
       })
     );
 
+    it('should not load referenced provider env vars', () => awsInvokeLocal
+      .loadEnvVars().then(() => {
+        expect(process.env.providerRefVar).to.equal(undefined);
+      })
+    );
+
+    it('should not load referenced function env vars', () => awsInvokeLocal
+      .loadEnvVars().then(() => {
+        expect(process.env.functionRefVar).to.equal(undefined);
+      })
+    );
 
     it('should fallback to service provider configuration when options are not available', () => {
       awsInvokeLocal.options.region = null;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3080

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Used lodash's `omitBy` function to omit all objects from environment variable values.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

*serverless.yml*
```yaml
service: testService

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    environment:
      QUEUE:
        Ref: Queue

resources:
  Resources:
    Queue:
      Type: AWS::SQS::Queue
```

*handler.js*
```js
module.exports.hello = function(event, context, callback) {
    const queue = process.env.QUEUE || 'http://localhost:4576/123456789012/test';
    callback(null, 'QUEUE: ' + queue);
}
```

When invoked with `sls invoke local -f hello` it should return `QUEUE: http://localhost:4576/123456789012/test` instead of `QUEUE: [object Object]`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
