### PR TITLE
Fix typo/language in resources documentation

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -91,10 +91,10 @@ We're also using the term `normalizedName` or similar terms in this guide. This 
 
 You can override the specific CloudFormation resource to apply your own options. For example, if you want to set `AWS::Logs::LogGroup` retention time to 30 days, override it with above table's `Name Template`.
 
-When you do overriding the basic resources, the important part is `normalizedFunctionName`. There are two rules.
+When you override basic resources, there are two things to keep in mind when it comes to `normalizedFunctionName`:
 
-- Should start with uppercase character.
-- The `-` will be changed to `Dash`, `_` will be changed to `Underscore`.
+- It should start with an uppercase character
+- The `-` will be changed to `Dash`, `_` will be changed to `Underscore`
 
 Here's an example:
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

The template told me to keep the parts of the template that weren't applicable, but I want to make sure that it's clear that I'm only changing documentation in this PR.

## What did you implement:

Closes #XXXXX

Small documentation update

## How did you implement it:

From the Github UI

## How can we verify it:

Review the changes.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
