### PR TITLE
Do not update function configuration parts that contain references.

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -122,29 +122,29 @@ class AwsDeployFunction {
       FunctionName: functionObj.name,
     };
 
-    if ('awsKmsKeyArn' in functionObj) {
+    if ('awsKmsKeyArn' in functionObj && !_.isObject(functionObj.awsKmsKeyArn)) {
       params.KMSKeyArn = functionObj.awsKmsKeyArn;
-    } else if (serviceObj && 'awsKmsKeyArn' in serviceObj) {
+    } else if (serviceObj && 'awsKmsKeyArn' in serviceObj && !_.isObject(serviceObj.awsKmsKeyArn)) {
       params.KMSKeyArn = serviceObj.awsKmsKeyArn;
     }
 
-    if ('description' in functionObj) {
+    if ('description' in functionObj && !_.isObject(functionObj.description)) {
       params.Description = functionObj.description;
     }
 
-    if ('memorySize' in functionObj) {
+    if ('memorySize' in functionObj && !_.isObject(functionObj.memorySize)) {
       params.MemorySize = functionObj.memorySize;
-    } else if ('memorySize' in providerObj) {
+    } else if ('memorySize' in providerObj && !_.isObject(providerObj.memorySize)) {
       params.MemorySize = providerObj.memorySize;
     }
 
-    if ('timeout' in functionObj) {
+    if ('timeout' in functionObj && !_.isObject(functionObj.timeout)) {
       params.Timeout = functionObj.timeout;
-    } else if ('timeout' in providerObj) {
+    } else if ('timeout' in providerObj && !_.isObject(providerObj.timeout)) {
       params.Timeout = providerObj.timeout;
     }
 
-    if (functionObj.onError) {
+    if (functionObj.onError && !_.isObject(functionObj.onError)) {
       params.DeadLetterConfig = {
         TargetArn: functionObj.onError,
       };
@@ -158,43 +158,52 @@ class AwsDeployFunction {
         functionObj.environment
       );
 
-      Object.keys(params.Environment.Variables).forEach((key) => {
-        // taken from the bash man pages
-        if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
-          const errorMessage = 'Invalid characters in environment variable';
-          throw new this.serverless.classes.Error(errorMessage);
-        }
-      });
+      if (_.some(params.Environment.Variables, value => _.isObject(value))) {
+        delete params.Environment;
+      } else {
+        Object.keys(params.Environment.Variables).forEach((key) => {
+          // taken from the bash man pages
+          if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
+            const errorMessage = 'Invalid characters in environment variable';
+            throw new this.serverless.classes.Error(errorMessage);
+          }
+        });
+      }
     }
 
     if (functionObj.vpc || providerObj.vpc) {
+      const vpc = functionObj.vpc || providerObj.vpc;
       params.VpcConfig = {};
+
+      if (_.isArray(vpc.securityGroupIds) && !_.some(vpc.securityGroupIds, _.isObject)) {
+        params.VpcConfig.SecurityGroupIds = vpc.securityGroupIds;
+      }
+
+      if (_.isArray(vpc.subnetIds) && !_.some(vpc.subnetIds, _.isObject)) {
+        params.VpcConfig.SubnetIds = vpc.subnetIds;
+      }
+
+      if (_.isEmpty(params.VpcConfig)) {
+        delete params.VpcConfig;
+      }
     }
 
-    if (functionObj.vpc && functionObj.vpc.securityGroupIds) {
-      params.VpcConfig.SecurityGroupIds = functionObj.vpc.securityGroupIds;
-    } else if (providerObj.vpc && providerObj.vpc.securityGroupIds) {
-      params.VpcConfig.SecurityGroupIds = providerObj.vpc.securityGroupIds;
-    }
-
-    if (functionObj.vpc && functionObj.vpc.subnetIds) {
-      params.VpcConfig.SubnetIds = functionObj.vpc.subnetIds;
-    } else if (providerObj.vpc && providerObj.vpc.subnetIds) {
-      params.VpcConfig.SubnetIds = providerObj.vpc.subnetIds;
-    }
-
-    if ('role' in functionObj) {
+    if ('role' in functionObj && !_.isObject(functionObj.role)) {
       return this.normalizeArnRole(functionObj.role).then(roleArn => {
         params.Role = roleArn;
 
         return this.callUpdateFunctionConfiguration(params);
       });
-    } else if ('role' in providerObj) {
+    } else if ('role' in providerObj && !_.isObject(providerObj.role)) {
       return this.normalizeArnRole(providerObj.role).then(roleArn => {
         params.Role = roleArn;
 
         return this.callUpdateFunctionConfiguration(params);
       });
+    }
+
+    if (_.isEmpty(_.omit(params, 'FunctionName'))) {
+      return BbPromise.resolve();
     }
 
     return this.callUpdateFunctionConfiguration(params);

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -288,6 +288,36 @@ describe('AwsDeployFunction', () => {
       });
     });
 
+    it('should skip elements that contain references', () => {
+      options.functionObj = {
+        name: 'first',
+        description: 'change',
+        vpc: undefined,
+        environment: {
+          myvar: 'this is my var',
+          myref: {
+            ref: 'aCFReference',
+          },
+        },
+      };
+
+      awsDeployFunction.options = options;
+
+      return awsDeployFunction.updateFunctionConfiguration().then(() => {
+        expect(updateFunctionConfigurationStub.calledOnce).to.be.equal(true);
+        expect(updateFunctionConfigurationStub.calledWithExactly(
+          'Lambda',
+          'updateFunctionConfiguration',
+          {
+            FunctionName: 'first',
+            Description: 'change',
+          },
+          awsDeployFunction.options.stage,
+          awsDeployFunction.options.region
+        )).to.be.equal(true);
+      });
+    });
+
     it('should fail when using invalid characters in environment variable', () => {
       options.functionObj = {
         name: 'first',

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
 const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs');
@@ -8,6 +8,11 @@ const proxyquire = require('proxyquire');
 const AwsProvider = require('../provider/awsProvider');
 const Serverless = require('../../../Serverless');
 const testUtils = require('../../../../tests/utils');
+
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
 
 describe('AwsDeployFunction', () => {
   let AwsDeployFunction;
@@ -292,7 +297,14 @@ describe('AwsDeployFunction', () => {
       options.functionObj = {
         name: 'first',
         description: 'change',
-        vpc: undefined,
+        vpc: {
+          securityGroupIds: ['xxxxx', {
+            ref: 'myVPCRef',
+          }],
+          subnetIds: ['xxxxx', {
+            ref: 'myVPCRef',
+          }],
+        },
         environment: {
           myvar: 'this is my var',
           myref: {
@@ -316,6 +328,23 @@ describe('AwsDeployFunction', () => {
           awsDeployFunction.options.region
         )).to.be.equal(true);
       });
+    });
+
+    it('should do nothing if only references are in', () => {
+      options.functionObj = {
+        name: 'first',
+        environment: {
+          myvar: 'this is my var',
+          myref: {
+            ref: 'aCFReference',
+          },
+        },
+      };
+
+      awsDeployFunction.options = options;
+
+      return expect(awsDeployFunction.updateFunctionConfiguration()).to.be.fulfilled
+      .then(() => expect(updateFunctionConfigurationStub).to.not.be.called);
     });
 
     it('should fail when using invalid characters in environment variable', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4329 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

All parts of the function configuration that contain CF references or other constructs are now omitted from the function configuration update. This should be safe as these are controlled by CF anyway.

If any reference is encountered in the environment block, this is skipped as a whole, because otherwise it would leave an incomplete set of environment variables.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Use a project that has references either in the VPC config or in the environment variables.
A following `deploy function` should now succeed.

For projects that do not use references at all nothing has changed.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
