### PR TITLE
Basic logging for python invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import sys
 from time import time
 from importlib import import_module
@@ -36,6 +37,8 @@ class FakeLambdaContext(object):
     def aws_request_id(self):
         return '1234567890'
 
+
+logging.basicConfig()
 
 parser = argparse.ArgumentParser(
     prog='invoke',


### PR DESCRIPTION
## What did you implement:

Closes #4147

This affects both Python 2.7 and Python 3.6 when you try to use `logging`.

## How did you implement it:

Just force `logging` module to provide a basic config, check [logging.basicConfig](https://docs.python.org/2.7/library/logging.html#logging.basicConfig). Worthy to mention:

> This function does nothing if the root logger already has handlers configured for it.

## How can we verify it:

YAML:

```yaml
service: hello

provider:
  name: aws
  runtime: python2.7

functions:
  hello:
    handler: handler.hello
```

handler.py

```python
from __future__ import print_function
import logging

logger = logging.getLogger(__name__)
logger.setLevel(logging.INFO)


def hello(event, context):
    print('hello')
    logger.info('world')

    return '!'
```

Invoking `sls invoke local -f hello`, before:

```
No handlers could be found for logger "handler"

hello
"!"
```

after:

```
INFO:handler:world

hello
"!"
```

With Python 3.6 (changing `serverless.yml`) it fails silently, before:
```
hello
"!"
```

after:
```
INFO:handler:world

hello
"!"
```


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO