### PR TITLE
Fixes #4434

### DIFF
--- a/lib/plugins/logs/logs.js
+++ b/lib/plugins/logs/logs.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const defaultUserStats = require('../../utils/userStats');
+const userStats = require('../../utils/userStats');
 
 class Logs {
-  constructor(serverless, userStats) {
+  constructor(serverless) {
     this.serverless = serverless;
-    this.userStats = userStats || defaultUserStats;
+    this.userStats = userStats;
 
     this.commands = {
       logs: {

--- a/lib/plugins/logs/logs.test.js
+++ b/lib/plugins/logs/logs.test.js
@@ -27,7 +27,8 @@ describe('Logs', () => {
 
     describe('Without cli processed input', () => {
       it('do not track user stats', () => {
-        const newLogs = new Logs(serverless, userStats);
+        const newLogs = new Logs(serverless);
+        newLogs.userStats = userStats;
 
         return newLogs.track()
         .then(() => {
@@ -40,7 +41,10 @@ describe('Logs', () => {
       it('tracks user stats with viewed option', () => {
         serverless.processedInput = { commands: [], options: {} };
 
-        return new Logs(serverless, userStats).track()
+        const newLogs = new Logs(serverless);
+        newLogs.userStats = userStats;
+
+        return newLogs.track()
         .then(() => {
           expect(userStats.track.calledWithExactly('service_logsViewed'))
           .to.be.equal(true);
@@ -50,7 +54,10 @@ describe('Logs', () => {
       it('tracks user stats with tailed option', () => {
         serverless.processedInput = { commands: [], options: { tail: true } };
 
-        return new Logs(serverless, userStats).track()
+        const newLogs = new Logs(serverless);
+        newLogs.userStats = userStats;
+
+        return newLogs.track()
         .then(() => {
           expect(userStats.track.calledWithExactly('service_logsTailed'))
           .to.be.equal(true);


### PR DESCRIPTION

## What did you implement:

Fixes #4434 

The 2nd argument of Logs constructor contains just a command line
arguments like `{"-f", "hello"}`.

As of the above, logs command always fail on the last of logs command.

## How did you implement it:

PR #4344 aims to inject userStats, so I've solved this problem by
injecting userStats by substitution not the constructor argument.

## How can we verify it:

`sls logs -f <function>`

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
