### PR TITLE
Error when file referenced in serverless.yml does not exist

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -236,9 +236,9 @@ class Variables {
         path.join(this.serverless.config.servicePath, referencedFileRelativePath));
 
     // Get real path to handle potential symlinks (but don't fatal error)
-    referencedFileFullPath = (fse.existsSync(referencedFileFullPath) ?
+    referencedFileFullPath = fse.existsSync(referencedFileFullPath) ?
                              fse.realpathSync(referencedFileFullPath) :
-                             referencedFileFullPath)
+                             referencedFileFullPath;
 
     let fileExtension = referencedFileRelativePath.split('.');
     fileExtension = fileExtension[fileExtension.length - 1];

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -237,7 +237,7 @@ class Variables {
 
     // Get real path to handle potential symlinks (but don't fatal error)
     referencedFileFullPath = (fse.existsSync(referencedFileFullPath) ?
-                             fse.realpathSync(referencedFileFullPath) : 
+                             fse.realpathSync(referencedFileFullPath) :
                              referencedFileFullPath)
 
     let fileExtension = referencedFileRelativePath.split('.');

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -235,8 +235,8 @@ class Variables {
         referencedFileRelativePath :
         path.join(this.serverless.config.servicePath, referencedFileRelativePath));
 
-    // Get real path to handle potential symlinks
-    referencedFileFullPath = fse.realpathSync(referencedFileFullPath);
+    // Get real path to handle potential symlinks (but don't fatal error if realpath doesn't exist for cascading defaults)
+    referencedFileFullPath = fse.existsSync(referencedFileFullPath) ? fse.realpathSync(referencedFileFullPath) : referencedFileFullPath
 
     let fileExtension = referencedFileRelativePath.split('.');
     fileExtension = fileExtension[fileExtension.length - 1];

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -235,8 +235,10 @@ class Variables {
         referencedFileRelativePath :
         path.join(this.serverless.config.servicePath, referencedFileRelativePath));
 
-    // Get real path to handle potential symlinks (but don't fatal error if realpath doesn't exist for cascading defaults)
-    referencedFileFullPath = fse.existsSync(referencedFileFullPath) ? fse.realpathSync(referencedFileFullPath) : referencedFileFullPath
+    // Get real path to handle potential symlinks (but don't fatal error)
+    referencedFileFullPath = (fse.existsSync(referencedFileFullPath) ?
+                             fse.realpathSync(referencedFileFullPath) : 
+                             referencedFileFullPath)
 
     let fileExtension = referencedFileRelativePath.split('.');
     fileExtension = fileExtension[fileExtension.length - 1];

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -638,19 +638,19 @@ describe('Variables', () => {
     it('should get undefined if non existing file and the second argument is true', () => {
       const serverless = new Serverless();
       const tmpDirPath = testUtils.getTmpDirPath();
-      const fileToTest = './config.yml';
-      const expectedFileName = path.join(tmpDirPath, fileToTest);
 
       serverless.config.update({ servicePath: tmpDirPath });
 
-      const realpathSync = sinon
-        .stub(fse, 'realpathSync').returns(expectedFileName);
+      const realpathSync = sinon.spy(fse, 'realpathSync');
+      const existsSync = sinon.spy(fse, 'existsSync');
 
-      return serverless.variables.getValueFromFile(`file(${fileToTest})`)
+      return serverless.variables.getValueFromFile('file(./non-existing.yml)')
         .then(valueToPopulate => {
-          expect(realpathSync.calledWithMatch(expectedFileName));
+          expect(realpathSync.calledOnce).to.be.equal(false);
+          expect(existsSync.calledOnce).to.be.equal(true);
           expect(valueToPopulate).to.be.equal(undefined);
           realpathSync.restore();
+          existsSync.restore();
         });
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #4435

## How did you implement it:

Found the bug/fatal error in the code and fixed it with a simple test to catch the failing exception

## How can we verify it:

Test a serverless stack with default values with a non-existing file in the first value.  This would fail in 1.24.0 but was not caught in any tests (see Notes).  Eg: 

```
custom:
  varname: ${file(non-existant-file.yml):config, ''}
```

## Notes:

 * In Variables.test.js for 1.24.0 the test `should get undefined if non existing file and the second argument is true` should have been catching this failure, but I believe that test is not robust enough or was not written properly and did not catch this.  Please someone (with more NodeJS experience) review and improve this test.
 * Sorry maintainers, I did not have time to write tests to ensure this does not happen again, hopefully someone else can do this.  This bug bit me hard so I had to fix it asap.
 * This bug was introduced by: https://github.com/serverless/serverless/pull/4389
   * Note: I don't believe that merge actually adds a test which tests if symlinks work.

## Todos:

- [ ] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
