### PR TITLE
add artifact full local path to serverless-state

### DIFF
--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -15,9 +15,11 @@ module.exports = {
       serviceStateFileName
     );
 
+    const artifactLocalPath = _.get(this.serverless.service, 'package.artifact', '');
+
     const artifact = _.last(
       _.split(
-        _.get(this.serverless.service, 'package.artifact', ''), path.sep
+        artifactLocalPath, path.sep
       )
     );
 
@@ -33,6 +35,7 @@ module.exports = {
         individually: this.serverless.service.package.individually,
         artifactDirectoryName: this.serverless.service.package.artifactDirectoryName,
         artifact,
+        artifactLocalPath,
       },
     };
 

--- a/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -58,6 +58,7 @@ describe('#saveServiceState()', () => {
           individually: false,
           artifactDirectoryName: 'artifact-directory',
           artifact: 'service.zip',
+          artifactLocalPath: 'service.zip',
         },
       };
 
@@ -92,6 +93,7 @@ describe('#saveServiceState()', () => {
           individually: false,
           artifactDirectoryName: 'artifact-directory',
           artifact: 'service.zip',
+          artifactLocalPath: 'service.zip',
         },
       };
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Include full local artifact path in serverless-state json
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
serverless.yml
```yaml
...
package:
  artifact: server/target/myprogram-${opt:stage, self:provider.stage}.jar
...
```
will produce following serverless-state.json:
```json
...
  "package": {
    "artifactDirectoryName": "serverless/myprogram/dev/1510669544434-2017-11-14T14:25:44.434Z",
    "artifact": "myprogram-dev.jar",
    "artifactLocalPath": "server/target/myprogram-dev.jar"
  }
...
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
