### PR TITLE
Add Basic authorization to get privet repos

### DIFF
--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -18,6 +18,7 @@ const log = require('./log/serverlessLog');
  * @returns {Object}
  */
 function parseGitHubURL(url) {
+  const auth = url.auth;
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > 4;
   const owner = parts[1];
@@ -49,6 +50,7 @@ function parseGitHubURL(url) {
   ].join('');
 
   return {
+    auth,
     owner,
     repo,
     branch,
@@ -63,6 +65,7 @@ function parseGitHubURL(url) {
  * @returns {Object}
  */
 function parseBitBucketURL(url) {
+  const auth = url.auth;
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > 4;
   const owner = parts[1];
@@ -96,6 +99,7 @@ function parseBitBucketURL(url) {
   ].join('');
 
   return {
+    auth,
     owner,
     repo,
     branch,
@@ -176,7 +180,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
   return download(
     repoInformation.downloadUrl,
     downloadServicePath,
-    { timeout: 30000, extract: true, strip: 1, mode: '755' }
+    { timeout: 30000, extract: true, strip: 1, mode: '755', auth: repoInformation.auth }
   ).then(() => {
     // if it's a directory inside of git
     if (repoInformation.isSubdirectory) {


### PR DESCRIPTION
Add Basic authorization to get privet repos for github and bitbucket

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
