### PR TITLE
add auth to get template from repo for private repositories

### DIFF
--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -18,6 +18,7 @@ const log = require('./log/serverlessLog');
  * @returns {Object}
  */
 function parseGitHubURL(url) {
+  const auth = url.auth;
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > 4;
   const owner = parts[1];
@@ -49,6 +50,7 @@ function parseGitHubURL(url) {
   ].join('');
 
   return {
+    auth,
     owner,
     repo,
     branch,
@@ -63,6 +65,7 @@ function parseGitHubURL(url) {
  * @returns {Object}
  */
 function parseBitBucketURL(url) {
+  const auth = url.auth;
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > 4;
   const owner = parts[1];
@@ -96,6 +99,7 @@ function parseBitBucketURL(url) {
   ].join('');
 
   return {
+    auth,
     owner,
     repo,
     branch,
@@ -176,7 +180,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
   return download(
     repoInformation.downloadUrl,
     downloadServicePath,
-    { timeout: 30000, extract: true, strip: 1, mode: '755' }
+    { timeout: 30000, extract: true, strip: 1, mode: '755', auth: repoInformation.auth }
   ).then(() => {
     // if it's a directory inside of git
     if (repoInformation.isSubdirectory) {

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -146,9 +146,10 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should parse a valid GitHub URL', () => {
-      const output = parseRepoURL('https://github.com/serverless/serverless');
+      const output = parseRepoURL('https://username@github.com/serverless/serverless');
 
       expect(output).to.deep.eq({
+        auth: 'username',
         owner: 'serverless',
         repo: 'serverless',
         branch: 'master',
@@ -159,9 +160,10 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should parse a valid GitHub URL with subdirectory', () => {
-      const output = parseRepoURL('https://github.com/serverless/serverless/tree/master/assets');
+      const output = parseRepoURL('https://username@github.com/serverless/serverless/tree/master/assets');
 
       expect(output).to.deep.eq({
+        auth: 'username',
         owner: 'serverless',
         repo: 'serverless',
         branch: 'master',
@@ -172,9 +174,10 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should parse a valid BitBucket URL ', () => {
-      const output = parseRepoURL('https://bitbucket.org/atlassian/localstack');
+      const output = parseRepoURL('https://username@bitbucket.org/atlassian/localstack');
 
       expect(output).to.deep.eq({
+        auth: 'username',
         owner: 'atlassian',
         repo: 'localstack',
         branch: 'master',
@@ -185,9 +188,10 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should parse a valid BitBucket URL with subdirectory', () => {
-      const output = parseRepoURL('https://bitbucket.org/atlassian/localstack/src/85870856fd6941ae75c0fa946a51cf756ff2f53a/localstack/dashboard/?at=mvn');
+      const output = parseRepoURL('https://username@bitbucket.org/atlassian/localstack/src/85870856fd6941ae75c0fa946a51cf756ff2f53a/localstack/dashboard/?at=mvn');
 
       expect(output).to.deep.eq({
+        auth: 'username',
         owner: 'atlassian',
         repo: 'localstack',
         branch: 'mvn',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I added ability to create service from template served in private repository using basic authorization.
for example:

serverless create --template-url https://${user}:${password}@github.com/${owner}/${repo}/${folder}  --path myService

## How did you implement it:

I just added auth param to reterned object of parseGitHubURL and parseBitBucketURL methods in lib/utils/downloadTemplateFromRepo.js file. 
And then include it into "options" parameter of "download" function call

## How can we verify it:

before changes:
![master](https://user-images.githubusercontent.com/20103831/33180244-b9d5d5d0-d074-11e7-9f73-b01cb1ceed2c.png)

after changes:
![my](https://user-images.githubusercontent.com/20103831/33180407-41c0b73a-d075-11e7-9330-6efc0669efe7.png)


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
