### PR TITLE
removed redundant keywords from Handler when constructing and returni…

### DIFF
--- a/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/Handler.scala
+++ b/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/Handler.scala
@@ -6,7 +6,7 @@ import scala.collection.JavaConverters
 class Handler extends RequestHandler[Request, Response] {
 
 	def handleRequest(input: Request, context: Context): Response = {
-		return new Response("Go Serverless v1.0! Your function executed successfully!", input)
+		Response("Go Serverless v1.0! Your function executed successfully!", input)
 	}
 }
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Removes the redundant `return new` keywords from the `aws-scala-sbt` template.

Closes #4502

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:


Simply removed the `return new` keywords from the handler function of the `Handler` class in
In the file [`lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/Handler.scala`](https://github.com/serverless/serverless/blob/master/lib/plugins/create/templates/aws-scala-sbt/src/main/scala/hello/Handler.scala#L9)

```
def handleRequest(input: Request, context: Context): Response = {
  return new Response("Go Serverless v1.0! Your function executed successfully!", input)
}
```
to be 
```
def handleRequest(input: Request, context: Context): Response = {
  Response("Go Serverless v1.0! Your function executed successfully!", input)
}
```

`Response` is a case class, so we don't need to use `new` to construct it. `Response` is the last unassigned value, so will automatically be returned without the need for the `return` keyword.


<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

`sls create --template aws-scala-sbt` and confim that line 9 of `src/main/scala/hello/Handler.scala` no longer begins with `return new`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
