### PR TITLE
Fix lambda version generation when only function config changes

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const crypto = require('crypto');
 const fs = require('fs');
 const _ = require('lodash');
@@ -15,16 +16,14 @@ class AwsCompileFunctions {
 
     this.provider = this.serverless.getProvider('aws');
 
-    this.compileFunctions = this.compileFunctions.bind(this);
-    this.compileFunction = this.compileFunction.bind(this);
-
     if (this.serverless.service.provider.versionFunctions === undefined ||
         this.serverless.service.provider.versionFunctions === null) {
       this.serverless.service.provider.versionFunctions = true;
     }
 
     this.hooks = {
-      'package:compileFunctions': this.compileFunctions,
+      'package:compileFunctions': () => BbPromise.bind(this)
+        .then(this.compileFunctions),
     };
   }
 
@@ -103,8 +102,7 @@ class AwsCompileFunctions {
         ' For example: handler.hello.',
         ' Please check the docs for more info',
       ].join('');
-      throw new this.serverless.classes
-        .Error(errorMessage);
+      return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
     }
 
     const Handler = functionObject.handler;
@@ -165,7 +163,7 @@ class AwsCompileFunctions {
               ' race condition when using SQS queue arns and updating the IAM role.',
               ' Please check the docs for more info.',
             ].join('');
-            throw new this.serverless.classes.Error(errorMessage);
+            return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
           }
 
           // update the PolicyDocument statements (if default policy is used)
@@ -174,7 +172,7 @@ class AwsCompileFunctions {
           }
         } else {
           const errorMessage = 'onError config must be a SNS topic arn or SQS queue arn';
-          throw new this.serverless.classes.Error(errorMessage);
+          return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
         }
       } else if (this.isArnRefOrImportValue(arn)) {
         newFunction.Properties.DeadLetterConfig = {
@@ -185,7 +183,7 @@ class AwsCompileFunctions {
           'onError config must be provided as an arn string,',
           ' Ref or Fn::ImportValue',
         ].join('');
-        throw new this.serverless.classes.Error(errorMessage);
+        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
       }
     }
 
@@ -226,11 +224,11 @@ class AwsCompileFunctions {
           }
         } else {
           const errorMessage = 'awsKmsKeyArn config must be a KMS key arn';
-          throw new this.serverless.classes.Error(errorMessage);
+          return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
         }
       } else {
         const errorMessage = 'awsKmsKeyArn config must be provided as a string';
-        throw new this.serverless.classes.Error(errorMessage);
+        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
       }
     }
 
@@ -287,49 +285,79 @@ class AwsCompileFunctions {
 
     const newVersion = this.cfLambdaVersionTemplate();
 
-    const content = fs.readFileSync(artifactFilePath);
-    const hash = crypto.createHash('sha256');
-    hash.setEncoding('base64');
-    hash.write(content);
-    hash.end();
+    // Create hashes for the artifact and the logical id of the version resource
+    // The one for the version resource must include the function configuration
+    // to make sure that a new version is created on configuration changes and
+    // not only on source changes.
+    const fileHash = crypto.createHash('sha256');
+    const versionHash = crypto.createHash('sha256');
+    fileHash.setEncoding('base64');
+    versionHash.setEncoding('base64');
 
-    newVersion.Properties.CodeSha256 = hash.read();
-    newVersion.Properties.FunctionName = { Ref: functionLogicalId };
-    if (functionObject.description) {
-      newVersion.Properties.Description = functionObject.description;
-    }
+    // Read the file in chunks and add them to the hash (saves memory and performance)
+    return BbPromise.fromCallback(cb => {
+      fs.readFile(artifactFilePath, cb);
+    })
+    .then(content => {
+      fileHash.write(content);
+      versionHash.write(content);
 
-    // use the SHA in the logical resource ID of the version because
-    // AWS::Lambda::Version resource will not support updates
-    const versionLogicalId = this.provider.naming.getLambdaVersionLogicalId(
-            functionName, newVersion.Properties.CodeSha256);
-    const newVersionObject = {
-      [versionLogicalId]: newVersion,
-    };
-
-    if (this.serverless.service.provider.versionFunctions) {
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        newVersionObject);
-    }
-
-    // Add function versions to Outputs section
-    const functionVersionOutputLogicalId = this.provider.naming
-      .getLambdaVersionOutputLogicalId(functionName);
-    const newVersionOutput = this.cfOutputLatestVersionTemplate();
-
-    newVersionOutput.Value = { Ref: versionLogicalId };
-
-    if (this.serverless.service.provider.versionFunctions) {
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-        [functionVersionOutputLogicalId]: newVersionOutput,
+      // Include function configuration in version id hash (without the Code part)
+      const properties = _.omit(_.get(newFunction, 'Properties', {}), 'Code');
+      _.forOwn(properties, value => {
+        const hashedValue = _.isObject(value) ? JSON.stringify(value) : _.toString(value);
+        versionHash.write(hashedValue);
       });
-    }
+
+      // Finalize hashes
+      fileHash.end();
+      versionHash.end();
+
+      const fileDigest = fileHash.read();
+      const versionDigest = versionHash.read();
+
+      newVersion.Properties.CodeSha256 = fileDigest;
+      newVersion.Properties.FunctionName = { Ref: functionLogicalId };
+      if (functionObject.description) {
+        newVersion.Properties.Description = functionObject.description;
+      }
+
+      // use the version SHA in the logical resource ID of the version because
+      // AWS::Lambda::Version resource will not support updates
+      const versionLogicalId = this.provider.naming.getLambdaVersionLogicalId(
+              functionName, versionDigest);
+      const newVersionObject = {
+        [versionLogicalId]: newVersion,
+      };
+
+      if (this.serverless.service.provider.versionFunctions) {
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+          newVersionObject);
+      }
+
+      // Add function versions to Outputs section
+      const functionVersionOutputLogicalId = this.provider.naming
+        .getLambdaVersionOutputLogicalId(functionName);
+      const newVersionOutput = this.cfOutputLatestVersionTemplate();
+
+      newVersionOutput.Value = { Ref: versionLogicalId };
+
+      if (this.serverless.service.provider.versionFunctions) {
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+          [functionVersionOutputLogicalId]: newVersionOutput,
+        });
+      }
+
+      return BbPromise.resolve();
+    });
   }
 
   compileFunctions() {
-    this.serverless.service
-      .getAllFunctions()
-      .forEach((functionName) => this.compileFunction(functionName));
+    const allFunctions = this.serverless.service.getAllFunctions();
+    return BbPromise.each(
+      allFunctions,
+      functionName => this.compileFunction(functionName)
+    );
   }
 
   // helper functions

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -240,13 +240,21 @@ class AwsCompileFunctions {
         functionObject.environment
       );
 
-      Object.keys(newFunction.Properties.Environment.Variables).forEach((key) => {
-        // taken from the bash man pages
-        if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
-          const errorMessage = 'Invalid characters in environment variable';
-          throw new this.serverless.classes.Error(errorMessage);
+      let invalidEnvVar = null;
+      _.forEach(
+        _.keys(newFunction.Properties.Environment.Variables),
+        key => { // eslint-disable-line consistent-return
+          // taken from the bash man pages
+          if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
+            invalidEnvVar = `Invalid characters in environment variable ${key}`;
+            return false;   // break loop with lodash
+          }
         }
-      });
+      );
+
+      if (invalidEnvVar) {
+        return BbPromise.reject(new this.serverless.classes.Error(invalidEnvVar));
+      }
     }
 
     if ('role' in functionObject) {
@@ -296,12 +304,20 @@ class AwsCompileFunctions {
 
     // Read the file in chunks and add them to the hash (saves memory and performance)
     return BbPromise.fromCallback(cb => {
-      fs.readFile(artifactFilePath, cb);
-    })
-    .then(content => {
-      fileHash.write(content);
-      versionHash.write(content);
+      const readStream = fs.createReadStream(artifactFilePath);
 
+      readStream.on('data', chunk => {
+        fileHash.write(chunk);
+        versionHash.write(chunk);
+      })
+      .on('end', () => {
+        cb();
+      })
+      .on('error', error => {
+        cb(error);
+      });
+    })
+    .then(() => {
       // Include function configuration in version id hash (without the Code part)
       const properties = _.omit(_.get(newFunction, 'Properties', {}), 'Code');
       _.forOwn(properties, value => {

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1,11 +1,15 @@
 'use strict';
 
 const path = require('path');
-const expect = require('chai').expect;
+const chai = require('chai');
 const AwsProvider = require('../../../provider/awsProvider');
 const AwsCompileFunctions = require('./index');
 const testUtils = require('../../../../../../tests/utils');
 const Serverless = require('../../../../../Serverless');
+
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
 
 describe('AwsCompileFunctions', () => {
   let serverless;
@@ -70,51 +74,57 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.package.individually = false;
       const artifactTemp = awsCompileFunctions.serverless.service.functions.test.package.artifact;
       awsCompileFunctions.serverless.service.functions.test.package.artifact = false;
-      awsCompileFunctions.compileFunctions();
 
-      const functionResource = awsCompileFunctions.serverless.service.provider
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        const functionResource = awsCompileFunctions.serverless.service.provider
         .compiledCloudFormationTemplate.Resources[compiledFunctionName];
 
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-                          .split(path.sep).pop();
+        const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+        const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
 
-      expect(functionResource.Properties.Code.S3Key)
+        expect(functionResource.Properties.Code.S3Key)
         .to.deep.equal(`${s3Folder}/${s3FileName}`);
-      awsCompileFunctions.serverless.service.functions.test.package.artifact = artifactTemp;
+        awsCompileFunctions.serverless.service.functions.test.package.artifact = artifactTemp;
+      });
     });
 
     it('should use function artifact if individually', () => {
       awsCompileFunctions.serverless.service.package.individually = true;
-      awsCompileFunctions.compileFunctions();
 
-      const functionResource = awsCompileFunctions.serverless.service.provider
-        .compiledCloudFormationTemplate.Resources[compiledFunctionName];
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        const functionResource = awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources[compiledFunctionName];
 
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service
-        .functions[functionName].package.artifact.split(path.sep).pop();
+        const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+        const s3FileName = awsCompileFunctions.serverless.service
+          .functions[functionName].package.artifact.split(path.sep).pop();
 
-      expect(functionResource.Properties.Code.S3Key)
-        .to.deep.equal(`${s3Folder}/${s3FileName}`);
+        expect(functionResource.Properties.Code.S3Key)
+          .to.deep.equal(`${s3Folder}/${s3FileName}`);
+      });
     });
 
     it('should use function artifact if individually at function level', () => {
       awsCompileFunctions.serverless.service.functions[functionName].package.individually = true;
-      awsCompileFunctions.compileFunctions();
 
-      const functionResource = awsCompileFunctions.serverless.service.provider
-        .compiledCloudFormationTemplate.Resources[compiledFunctionName];
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        const functionResource = awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources[compiledFunctionName];
 
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service
-        .functions[functionName].package.artifact.split(path.sep).pop();
+        const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+        const s3FileName = awsCompileFunctions.serverless.service
+          .functions[functionName].package.artifact.split(path.sep).pop();
 
-      expect(functionResource.Properties.Code.S3Key)
-        .to.deep.equal(`${s3Folder}/${s3FileName}`);
-      awsCompileFunctions.serverless.service.functions[functionName].package = {
-        individually: false,
-      };
+        expect(functionResource.Properties.Code.S3Key)
+          .to.deep.equal(`${s3Folder}/${s3FileName}`);
+        awsCompileFunctions.serverless.service.functions[functionName].package = {
+          individually: false,
+        };
+      });
     });
 
     it('should add an ARN provider role', () => {
@@ -127,13 +137,14 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
+      });
     });
 
     it('should add a logical role name provider role', () => {
@@ -146,18 +157,19 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['FuncLogGroup', 'LogicalNameRole']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal({
-        'Fn::GetAtt': [
-          awsCompileFunctions.serverless.service.provider.role,
-          'Arn',
-        ],
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn
+        ).to.deep.equal(['FuncLogGroup', 'LogicalNameRole']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal({
+          'Fn::GetAtt': [
+            awsCompileFunctions.serverless.service.provider.role,
+            'Arn',
+          ],
+        });
       });
     });
 
@@ -176,14 +188,15 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn
+        ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
+      });
     });
 
     it('should add an ARN function role', () => {
@@ -196,13 +209,14 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      });
     });
 
     it('should add a logical role name function role', () => {
@@ -215,18 +229,19 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal({
-        'Fn::GetAtt': [
-          awsCompileFunctions.serverless.service.functions.func.role,
-          'Arn',
-        ],
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn
+        ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal({
+          'Fn::GetAtt': [
+            awsCompileFunctions.serverless.service.functions.func.role,
+            'Arn',
+          ],
+        });
       });
     });
 
@@ -245,14 +260,15 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn
-      ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn
+        ).to.deep.equal(['FuncLogGroup', 'LogicalRoleName']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      });
     });
 
     it('should add a "Fn::ImportValue" Object function role', () => {
@@ -267,13 +283,14 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      });
     });
 
     it('should prefer function declared role over provider declared role', () => {
@@ -287,13 +304,14 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction.Properties.Role
-      ).to.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.DependsOn).to.deep.equal(['FuncLogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Role
+        ).to.equal(awsCompileFunctions.serverless.service.functions.func.role);
+      });
     });
 
     it('should add function declared roles', () => {
@@ -311,19 +329,20 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func0LambdaFunction.DependsOn).to.deep.equal(['Func0LogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func0LambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func0.role);
 
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func0LambdaFunction.DependsOn).to.deep.equal(['Func0LogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func0LambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func0.role);
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func1LambdaFunction.DependsOn).to.deep.equal(['Func1LogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func1LambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func1.role);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func1LambdaFunction.DependsOn).to.deep.equal(['Func1LogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func1LambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func1.role);
+      });
     });
 
     it('should add function declared role and fill in with provider role', () => {
@@ -341,29 +360,30 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func0LambdaFunction.DependsOn).to.deep.equal(['Func0LogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func0LambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
 
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func0LambdaFunction.DependsOn).to.deep.equal(['Func0LogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func0LambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.provider.role);
-
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func1LambdaFunction.DependsOn).to.deep.equal(['Func1LogGroup']);
-      expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.Func1LambdaFunction.Properties.Role
-      ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func1.role);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func1LambdaFunction.DependsOn).to.deep.equal(['Func1LogGroup']);
+        expect(awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.Func1LambdaFunction.Properties.Role
+        ).to.deep.equal(awsCompileFunctions.serverless.service.functions.func1.role);
+      });
     });
 
-    it('should throw an error if the function handler is not present', () => {
+    it('should reject if the function handler is not present', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           name: 'new-service-dev-func',
         },
       };
 
-      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
+      expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
     });
 
     it('should create a simple function resource', () => {
@@ -396,12 +416,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should create a function resource with provider level vpc config', () => {
@@ -443,12 +464,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should create a function resource with function level vpc config', () => {
@@ -489,12 +511,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should create a function resource with tags', () => {
@@ -536,12 +559,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     describe('when using onError config', () => {
@@ -554,7 +578,7 @@ describe('AwsCompileFunctions', () => {
           .split(path.sep).pop();
       });
 
-      it('should throw an error if config is provided as a number', () => {
+      it('should reject if config is provided as a number', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -563,10 +587,10 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        expect(() => { awsCompileFunctions.compileFunctions(); }).to.throw(Error);
+        return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
       });
 
-      it('should throw an error if config is provided as an object', () => {
+      it('should reject if config is provided as an object', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -577,10 +601,10 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        expect(() => { awsCompileFunctions.compileFunctions(); }).to.throw(Error);
+        return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
       });
 
-      it('should throw an error if config is not a SNS or SQS arn', () => {
+      it('should reject if config is not a SNS or SQS arn', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -589,7 +613,7 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        expect(() => { awsCompileFunctions.compileFunctions(); }).to.throw(Error);
+        return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
       });
 
       describe('when IamRoleLambdaExecution is used', () => {
@@ -649,17 +673,18 @@ describe('AwsCompileFunctions', () => {
             Resource: ['arn:aws:sns:region:accountid:foo'],
           };
 
-          awsCompileFunctions.compileFunctions();
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+          .then(() => {
+            const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+              .compiledCloudFormationTemplate;
 
-          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-            .compiledCloudFormationTemplate;
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+            const dlqStatement = compiledCfTemplate.Resources
+              .IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[0];
 
-          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-          const dlqStatement = compiledCfTemplate.Resources
-            .IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[0];
-
-          expect(functionResource).to.deep.equal(compiledFunction);
-          expect(dlqStatement).to.deep.equal(compiledDlqStatement);
+            expect(functionResource).to.deep.equal(compiledFunction);
+            expect(dlqStatement).to.deep.equal(compiledDlqStatement);
+          });
         });
 
         it('should throw an informative error message if a SQS arn is provided', () => {
@@ -671,8 +696,8 @@ describe('AwsCompileFunctions', () => {
             },
           };
 
-          expect(() => { awsCompileFunctions.compileFunctions(); })
-            .to.throw(Error, 'only supports SNS');
+          return expect(awsCompileFunctions.compileFunctions())
+            .to.be.rejectedWith('only supports SNS');
         });
 
         it('should create necessary resources if a Ref is provided', () => {
@@ -711,13 +736,14 @@ describe('AwsCompileFunctions', () => {
             },
           };
 
-          awsCompileFunctions.compileFunctions();
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+          .then(() => {
+            const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+              .compiledCloudFormationTemplate;
 
-          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-            .compiledCloudFormationTemplate;
-
-          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-          expect(functionResource).to.deep.equal(compiledFunction);
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+            expect(functionResource).to.deep.equal(compiledFunction);
+          });
         });
 
         it('should create necessary resources if a Fn::ImportValue is provided', () => {
@@ -756,13 +782,14 @@ describe('AwsCompileFunctions', () => {
             },
           };
 
-          awsCompileFunctions.compileFunctions();
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+          .then(() => {
+            const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+              .compiledCloudFormationTemplate;
 
-          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-            .compiledCloudFormationTemplate;
-
-          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-          expect(functionResource).to.deep.equal(compiledFunction);
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+            expect(functionResource).to.deep.equal(compiledFunction);
+          });
         });
       });
 
@@ -799,17 +826,18 @@ describe('AwsCompileFunctions', () => {
             },
           };
 
-          awsCompileFunctions.compileFunctions();
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+          .then(() => {
+            const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+              .compiledCloudFormationTemplate;
 
-          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-            .compiledCloudFormationTemplate;
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
 
-          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-
-          expect(functionResource).to.deep.equal(compiledFunction);
+            expect(functionResource).to.deep.equal(compiledFunction);
+          });
         });
 
-        it('should throw an informative error message if a SQS arn is provided', () => {
+        it('should reject with an informative error message if a SQS arn is provided', () => {
           awsCompileFunctions.serverless.service.functions = {
             func: {
               handler: 'func.function.handler',
@@ -818,8 +846,8 @@ describe('AwsCompileFunctions', () => {
             },
           };
 
-          expect(() => { awsCompileFunctions.compileFunctions(); })
-            .to.throw(Error, 'only supports SNS');
+          return expect(awsCompileFunctions.compileFunctions())
+            .to.be.rejectedWith('only supports SNS');
         });
       });
     });
@@ -834,7 +862,7 @@ describe('AwsCompileFunctions', () => {
           .split(path.sep).pop();
       });
 
-      it('should throw an error if config is provided as a number', () => {
+      it('should reject if config is provided as a number', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -843,11 +871,11 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        expect(() => { awsCompileFunctions.compileFunctions(); })
-          .to.throw(Error, 'provided as a string');
+        return expect(awsCompileFunctions.compileFunctions())
+          .to.be.rejectedWith('provided as a string');
       });
 
-      it('should throw an error if config is provided as an object', () => {
+      it('should reject if config is provided as an object', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -858,8 +886,8 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        expect(() => { awsCompileFunctions.compileFunctions(); })
-          .to.throw(Error, 'provided as a string');
+        return expect(awsCompileFunctions.compileFunctions())
+          .to.be.rejectedWith('provided as a string');
       });
 
       it('should throw an error if config is not a KMS key arn', () => {
@@ -871,8 +899,8 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        expect(() => { awsCompileFunctions.compileFunctions(); })
-          .to.throw(Error, 'KMS key arn');
+        return expect(awsCompileFunctions.compileFunctions())
+          .to.be.rejectedWith('KMS key arn');
       });
 
       it('should use a the service KMS key arn if provided', () => {
@@ -909,12 +937,13 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        awsCompileFunctions.compileFunctions();
-
-        const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-          .compiledCloudFormationTemplate;
-        const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-        expect(functionResource).to.deep.equal(compiledFunction);
+        return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
       });
 
       it('should prefer a function KMS key arn over a service KMS key arn', () => {
@@ -977,15 +1006,16 @@ describe('AwsCompileFunctions', () => {
           },
         };
 
-        awsCompileFunctions.compileFunctions();
+        return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate;
 
-        const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-          .compiledCloudFormationTemplate;
-
-        const function1Resource = compiledCfTemplate.Resources.Func1LambdaFunction;
-        const function2Resource = compiledCfTemplate.Resources.Func2LambdaFunction;
-        expect(function1Resource).to.deep.equal(compiledFunction1);
-        expect(function2Resource).to.deep.equal(compiledFunction2);
+          const function1Resource = compiledCfTemplate.Resources.Func1LambdaFunction;
+          const function2Resource = compiledCfTemplate.Resources.Func2LambdaFunction;
+          expect(function1Resource).to.deep.equal(compiledFunction1);
+          expect(function2Resource).to.deep.equal(compiledFunction2);
+        });
       });
 
       describe('when IamRoleLambdaExecution is used', () => {
@@ -1043,17 +1073,18 @@ describe('AwsCompileFunctions', () => {
             Resource: ['arn:aws:kms:region:accountid:foo/bar'],
           };
 
-          awsCompileFunctions.compileFunctions();
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+          .then(() => {
+            const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+              .compiledCloudFormationTemplate;
 
-          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-            .compiledCloudFormationTemplate;
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+            const dlqStatement = compiledCfTemplate.Resources
+              .IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[0];
 
-          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-          const dlqStatement = compiledCfTemplate.Resources
-            .IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[0];
-
-          expect(functionResource).to.deep.equal(compiledFunction);
-          expect(dlqStatement).to.deep.equal(compiledKmsStatement);
+            expect(functionResource).to.deep.equal(compiledFunction);
+            expect(dlqStatement).to.deep.equal(compiledKmsStatement);
+          });
         });
       });
 
@@ -1088,14 +1119,15 @@ describe('AwsCompileFunctions', () => {
             },
           };
 
-          awsCompileFunctions.compileFunctions();
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+          .then(() => {
+            const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
+              .compiledCloudFormationTemplate;
 
-          const compiledCfTemplate = awsCompileFunctions.serverless.service.provider
-            .compiledCloudFormationTemplate;
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
 
-          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
-
-          expect(functionResource).to.deep.equal(compiledFunction);
+            expect(functionResource).to.deep.equal(compiledFunction);
+          });
         });
       });
     });
@@ -1146,12 +1178,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should create a function resource with function level environment config', () => {
@@ -1193,12 +1226,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should create a function resource with provider level environment config', () => {
@@ -1241,12 +1275,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should overwrite a provider level environment config when function config is given', () => {
@@ -1292,12 +1327,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should throw an error if environment variable has invalid name', () => {
@@ -1312,7 +1348,7 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      expect(() => awsCompileFunctions.compileFunctions()).to.throw(Error);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
     });
 
     it('should consider function based config when creating a function resource', () => {
@@ -1347,12 +1383,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should allow functions to use a different runtime' +
@@ -1368,32 +1405,33 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      const compiledFunction = {
-        Type: 'AWS::Lambda::Function',
-        DependsOn: [
-          'FuncLogGroup',
-          'IamRoleLambdaExecution',
-        ],
-        Properties: {
-          Code: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        const compiledFunction = {
+          Type: 'AWS::Lambda::Function',
+          DependsOn: [
+            'FuncLogGroup',
+            'IamRoleLambdaExecution',
+          ],
+          Properties: {
+            Code: {
+              S3Key: `${s3Folder}/${s3FileName}`,
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'python2.7',
+            Timeout: 6,
           },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'python2.7',
-          Timeout: 6,
-        },
-      };
+        };
 
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should default to the nodejs4.3 runtime when no provider runtime is given', () => {
@@ -1427,12 +1465,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should consider the providers runtime and memorySize ' +
@@ -1468,12 +1507,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should use a custom bucket if specified', () => {
@@ -1522,12 +1562,13 @@ describe('AwsCompileFunctions', () => {
       awsCompileFunctions.serverless.service.provider
         .compiledCloudFormationTemplate = coreCloudFormationTemplate;
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction
-      ).to.deep.equal(compiledFunction);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
     });
 
     it('should include description if specified', () => {
@@ -1538,12 +1579,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaFunction.Properties.Description
-      ).to.equal('Lambda function description');
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction.Properties.Description
+        ).to.equal('Lambda function description');
+      });
     });
 
     it('should create corresponding function output and version objects', () => {
@@ -1559,24 +1601,25 @@ describe('AwsCompileFunctions', () => {
       const expectedOutputs = {
         FuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
-          Value: { Ref: 'FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI' },
+          Value: { Ref: 'FuncLambdaVersionl6Rjpaz0gycgsEDI51sLed039fH2uR4W8Q2IW8cNo' },
         },
         AnotherFuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
           Value: {
-            Ref: 'AnotherFuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI',
+            Ref: 'AnotherFuncLambdaVersion6JZQneYqP4bC0Z3ywMc3XJPyECHK4RMGhpv8iis4E',
           },
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Outputs
-      ).to.deep.equal(
-        expectedOutputs
-      );
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs
+        ).to.deep.equal(
+          expectedOutputs
+        );
+      });
     });
 
     it('should include description under version too if function is specified', () => {
@@ -1587,13 +1630,14 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FuncLambdaVersionw6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI
-        .Properties.Description
-      ).to.equal('Lambda function description');
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaVersionOKy3yjVllZnozzdvQqHlRN8lBwkZyA6l76TCAEyork
+          .Properties.Description
+        ).to.equal('Lambda function description');
+      });
     });
 
     it('should not create function output objects when "versionFunctions" is false', () => {
@@ -1609,14 +1653,15 @@ describe('AwsCompileFunctions', () => {
 
       const expectedOutputs = {};
 
-      awsCompileFunctions.compileFunctions();
-
-      expect(
-        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-          .Outputs
-      ).to.deep.equal(
-        expectedOutputs
-      );
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs
+        ).to.deep.equal(
+          expectedOutputs
+        );
+      });
     });
   });
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const path = require('path');
 const chai = require('chai');
 const AwsProvider = require('../../../provider/awsProvider');
@@ -1613,6 +1614,72 @@ describe('AwsCompileFunctions', () => {
 
       return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
       .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs
+        ).to.deep.equal(
+          expectedOutputs
+        );
+      });
+    });
+
+    it('should create a new version object if only the configuration changed', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+        },
+        anotherFunc: {
+          handler: 'anotherFunc.function.handler',
+        },
+      };
+
+      const expectedOutputs = {
+        FuncLambdaFunctionQualifiedArn: {
+          Description: 'Current Lambda function version',
+          Value: { Ref: 'FuncLambdaVersionl6Rjpaz0gycgsEDI51sLed039fH2uR4W8Q2IW8cNo' },
+        },
+        AnotherFuncLambdaFunctionQualifiedArn: {
+          Description: 'Current Lambda function version',
+          Value: {
+            Ref: 'AnotherFuncLambdaVersion6JZQneYqP4bC0Z3ywMc3XJPyECHK4RMGhpv8iis4E',
+          },
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs
+        ).to.deep.equal(
+          expectedOutputs
+        );
+
+        // Change configuration
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate = {
+          Resources: {},
+          Outputs: {},
+        };
+
+        _.set(
+          awsCompileFunctions,
+          'serverless.service.functions.func.environment.MY_ENV_VAR',
+          'myvalue'
+        );
+
+        return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled;
+      })
+      .then(() => {
+        // Expect different version hash
+        _.set(
+          expectedOutputs,
+          'FuncLambdaFunctionQualifiedArn',
+          {
+            Description: 'Current Lambda function version',
+            Value: { Ref: 'FuncLambdaVersiona6VymfU25aF6eS2qysm7sHqPyy8RqYUzoTvDeBrrBA' },
+          }
+        );
+
         expect(
           awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
             .Outputs


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

There is a bug in the lambda version creation. Currently only the ZIP file hash is used to
create the logical id for the lambda version resource.
If you just change the function configuration (e.g. memory size, VPC or an environment
variable), the version resource created in the CF template will have the same logical id as before.

This leads to a bug, because if you now deploy, the function is deployed as $LATEST, but **no
new version is created**, because CF will not create one as the logical id of the version resource
is the same as before.

Only if you do source changes, a new version will be created.
This behavior is wrong. Also any change in the function configuration creates a differently
behaving deployment and thus must lead to a new function version created.

The bug gets visible and breaks your deployments, if you rely on the last version instead
of $LATEST (e.g. if you use the alias plugin, tag the latest versions or use the versions to
rollback).

## How did you implement it:

I added the function configuration to the hash used for generating the logical id
of the function version resource -> H(zip + config). With that change a new
version is now correctly created as soon as (1) the source (zip) changed and (2)
the function configuration changed.

Additionally I switched to reading the ZIP asynchronously (we should not use synchronous functions at all) in chunks to comply with Node so that the Node event loop is not unnecessarily stalled during this lengthy operation. This also lowers the memory footprint to a minimum and is much faster - to generate the hashes it is unnecessary to read the whole file at once!

Example:

A deployment creates this version:
```
    "ApiLambdaVersionU7fLjAh4hB6aBdBfab0OMjP36BIJFx0JvnYXBQ6H3w": {
      "Type": "AWS::Lambda::Version",
      "DeletionPolicy": "Retain",
      "Properties": {
        "FunctionName": {
          "Ref": "ApiLambdaFunction"
        },
        "CodeSha256": "Zqaq1qsB5+UrPXUlIKBgIlQJsKD0t9vRWDj8NkYqQGw=",
        "Description": "General API"
      }
    },
```

After change of an environment variable in the function configuration. Notice, that
the ZIP file hash did not change:

```
    "ApiLambdaVersionGgi0NalwGjBwqrM3eh5DjS1hsCW64EG7ePcOEGYaRCs": {
      "Type": "AWS::Lambda::Version",
      "DeletionPolicy": "Retain",
      "Properties": {
        "FunctionName": {
          "Ref": "ApiLambdaFunction"
        },
        "CodeSha256": "Zqaq1qsB5+UrPXUlIKBgIlQJsKD0t9vRWDj8NkYqQGw=",
        "Description": "General API"
      }
    },
```

As you see, although the code hash (zip file) stays the same, the version 
resource id changed, what means, that a new version will be created now. This 
is fully correct, because the last version that would have been in there before
the fix would have been substantially different than, the real last deployed
function. If you'd have tried to restore that one you're system would have been 
broken badly.

Now the last Lambda version will resemble the last changed version. If you deploy
without any changes, of course no new versions will be created. That's exactly the
expected behavior.

## How can we verify it:

Deploy any service. Open one of the service's functions in the AWS Lambda console and check the generated version (it should be of the same configuration as the $LATEST version).

Now change something in the configuration of the function, but leave its sources untouched.
Redeploy -> CF should now create a new version including the changed configuration. The version
should be shown in the AWS console.

I tested it with multiple of our complex projects and the version creation worked as expected.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
