### PR TITLE
Add API Gateway endpoint configuration

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -421,6 +421,27 @@ Please note that those are the API keys names, not the actual values. Once you d
 
 Clients connecting to this Rest API will then need to set any of these API keys values in the `x-api-key` header of their request. This is only necessary for functions where the `private` property is set to true.
 
+### Configuring endpoint types
+
+API Gateway [supports regional endpoints](https://aws.amazon.com/about-aws/whats-new/2017/11/amazon-api-gateway-supports-regional-api-endpoints/) for associating your API Gateway REST APIs with a particular region. This can reduce latency if your requests originate from the same region as your REST API and can be helpful in building multi-region applications.
+
+By default, the Serverless Framework deploys your REST API using the EDGE endpoint configuration. If you would like to use the REGIONAL configuration, set the `endpointType` parameter in your `provider` block.
+
+Here's an example configuration for setting the endpoint configuration for your service Rest API:
+
+```yml
+service: my-service
+provider:
+  name: aws
+  endpointType: REGIONAL
+functions:
+  hello:
+    events:
+      - http:
+          path: user/create
+          method: get
+```
+
 ### Request Parameters
 
 To pass optional and required parameters to your functions, so you can use them in API Gateway tests and SDK generation, marking them as `true` will make them required, `false` will make them optional.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -39,6 +39,7 @@ provider:
   versionFunctions: false # Optional function versioning
   environment: # Service wide environment variables
     serviceEnvVar: 123456789
+  endpointType: regional # Optional endpoint configuration for API Gateway REST API. Default is Edge.
   apiKeys: # List of API keys to be used by your service API Gateway REST API
     - myFirstKey
     - ${opt:stage}-myFirstKey

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -7,11 +7,31 @@ module.exports = {
   compileRestApi() {
     this.apiGatewayRestApiLogicalId = this.provider.naming.getRestApiLogicalId();
 
+    let endpointType = 'EDGE';
+
+    if (this.serverless.service.provider.endpointType) {
+      const validEndpointTypes = ['REGIONAL', 'EDGE'];
+      endpointType = this.serverless.service.provider.endpointType;
+
+      if (typeof endpointType !== 'string') {
+        throw new this.serverless.classes.Error('endpointType must be a string');
+      }
+
+
+      if (!validEndpointTypes.includes(endpointType.toUpperCase())) {
+        const message = 'endpointType must be one of "REGIONAL" or "EDGE". ' +
+                        `You provided ${endpointType}.`;
+        throw new this.serverless.classes.Error(message);
+      }
+      endpointType = endpointType.toUpperCase();
+    }
+
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.apiGatewayRestApiLogicalId]: {
         Type: 'AWS::ApiGateway::RestApi',
         Properties: {
           Name: this.provider.naming.getApiGatewayName(),
+          EndpointConfiguration: [endpointType],
         },
       },
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -31,7 +31,9 @@ module.exports = {
         Type: 'AWS::ApiGateway::RestApi',
         Properties: {
           Name: this.provider.naming.getApiGatewayName(),
-          EndpointConfiguration: [endpointType],
+          EndpointConfiguration: {
+            Types: [endpointType],
+          },
         },
       },
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -15,6 +15,9 @@ describe('#compileRestApi()', () => {
         Type: 'AWS::ApiGateway::RestApi',
         Properties: {
           Name: 'dev-new-service',
+          EndpointConfiguration: [
+            "EDGE"
+          ],
         },
       },
     },
@@ -54,4 +57,15 @@ describe('#compileRestApi()', () => {
       );
     })
   );
+
+  it('throw error if endpointType property is not a string', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = ["EDGE"];
+    expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
+  });
+
+  it('throw error if endpointType property is not EDGE or REGIONAL', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
+    expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
+  });
+
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -15,9 +15,11 @@ describe('#compileRestApi()', () => {
         Type: 'AWS::ApiGateway::RestApi',
         Properties: {
           Name: 'dev-new-service',
-          EndpointConfiguration: [
-            "EDGE"
-          ],
+          EndpointConfiguration: {
+            Types: [
+              'EDGE',
+            ],
+          },
         },
       },
     },
@@ -59,7 +61,7 @@ describe('#compileRestApi()', () => {
   );
 
   it('throw error if endpointType property is not a string', () => {
-    awsCompileApigEvents.serverless.service.provider.endpointType = ["EDGE"];
+    awsCompileApigEvents.serverless.service.provider.endpointType = ['EDGE'];
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
   });
 
@@ -67,5 +69,4 @@ describe('#compileRestApi()', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
   });
-
 });


### PR DESCRIPTION
## What did you implement:

Closes #4440.

Adds ability to specify [regional endpoints](https://aws.amazon.com/about-aws/whats-new/2017/11/amazon-api-gateway-supports-regional-api-endpoints/) for API Gateway. :

```yml
# serverless.yml

provider:
  name: aws
  endpointType: regional
...
```

## How did you implement it:

Adds the [EndpointConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html) attribute when we compile the RestApi resource. By default, it sets to `EDGE`, which is the default API GW setting. 

## How can we verify it:

I used this example:

```yml
service: endpoint-test

# The `provider` block defines where your service will be deployed
provider:
  name: aws
  runtime: nodejs6.10
  endpointType: regional

functions:
  helloWorld:
    handler: handler.helloWorld
    events:
      - http:
          path: hello-world
          method: get
          cors: true
```

Then run `sls package` and check the `.serverless/cloudformation-template-update-stack.json` file that the RestAPI resource has the EndpointConfiguration defined as desired.

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
