### PR TITLE
Mention log limit in the documentation

### DIFF
--- a/docs/providers/aws/cli-reference/logs.md
+++ b/docs/providers/aws/cli-reference/logs.md
@@ -21,6 +21,8 @@ serverless logs -f hello
 serverless logs -f hello -t
 ```
 
+This command returns as many log events as can fit in 1MB (up to 10,000 log events). You can use the `--filter` option to ensure the logs you're looking for are included.
+
 ## Options
 
 - `--function` or `-f` The function you want to fetch the logs for. **Required**


### PR DESCRIPTION
I initially thought this command would return *all* the logs within the date range. I can see why it doesn't do that, but I think mentioning the limit in the docs makes sense.

The number comes from [the AWS docs](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatchLogs.html#filterLogEvents-property)  about the function that's used for this command.

I'm not including the pull request template -- I hope that's alright. This is just a tweak to documentation.