### PR TITLE
Remove not used parameters from request() and add options hive

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -352,9 +352,7 @@ class Variables {
       .request('CloudFormation',
         'describeStacks',
         { StackName: stackName },
-        this.options.stage,
-        this.options.region,
-        true   // Use request cache
+        { useCache: true }   // Use request cache
       )
       .then(result => {
         const outputs = result.Stacks[0].Outputs;
@@ -385,9 +383,7 @@ class Variables {
         Bucket: bucket,
         Key: key,
       },
-      this.options.stage,
-      this.options.region,
-      true   // Use request cache
+      { useCache: true }   // Use request cache
     )
     .then(
       response => response.Body.toString(),
@@ -409,9 +405,7 @@ class Variables {
         Name: param,
         WithDecryption: decrypt,
       },
-      this.options.stage,
-      this.options.region,
-      true   // Use request cache
+      { useCache: true }   // Use request cache
     )
     .then(
       response => BbPromise.resolve(response.Parameter.Value),

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1318,9 +1318,7 @@ module.exports = {
             {
               StackName: 'some-stack',
             },
-            serverless.variables.options.stage,
-            serverless.variables.options.region,
-            true
+            { useCache: true }
           );
         })
         .finally(() => serverless.getProvider('aws').request.restore());
@@ -1357,9 +1355,7 @@ module.exports = {
             {
               StackName: 'some-stack',
             },
-            serverless.variables.options.stage,
-            serverless.variables.options.region,
-            true
+            { useCache: true }
           );
           expect(error).to.be.an.instanceof(Error);
           expect(error.message).to.match(/to request a non exported variable from CloudFormation/);
@@ -1399,9 +1395,7 @@ module.exports = {
             Bucket: 'some.bucket',
             Key: 'path/to/key',
           },
-          serverless.variables.options.stage,
-          serverless.variables.options.region,
-          true
+          { useCache: true }
         );
       })
       .finally(() => serverless.getProvider('aws').request.restore());
@@ -1452,9 +1446,7 @@ module.exports = {
             Name: param,
             WithDecryption: false,
           },
-          serverless.variables.options.stage,
-          serverless.variables.options.region,
-          true
+          { useCache: true }
         );
       });
     });
@@ -1479,9 +1471,7 @@ module.exports = {
             Name: param,
             WithDecryption: false,
           },
-          serverless.variables.options.stage,
-          serverless.variables.options.region,
-          true
+          { useCache: true }
         );
       });
     });
@@ -1506,9 +1496,7 @@ module.exports = {
             Name: param,
             WithDecryption: true,
           },
-          serverless.variables.options.stage,
-          serverless.variables.options.region,
-          true
+          { useCache: true }
         );
       });
     });
@@ -1533,9 +1521,7 @@ module.exports = {
             Name: param,
             WithDecryption: false,
           },
-          serverless.variables.options.stage,
-          serverless.variables.options.region,
-          true
+          { useCache: true }
         );
       });
     });
@@ -1560,9 +1546,7 @@ module.exports = {
             Name: param,
             WithDecryption: false,
           },
-          serverless.variables.options.stage,
-          serverless.variables.options.region,
-          true
+          { useCache: true }
         );
       });
     });

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -32,9 +32,7 @@ module.exports = {
 
     return this.provider.request('S3',
       'listObjectsV2',
-      params,
-      this.options.stage,
-      this.options.region
+      params
     ).then((result) => {
       if (result && result.Contents && result.Contents.length) {
         const objects = result.Contents;
@@ -66,9 +64,7 @@ module.exports = {
           {
             Bucket: this.bucketName,
             Key: obj.Key,
-          },
-          this.options.stage,
-          this.options.region
+          }
         ));
 
       return BbPromise.all(headObjectObjects)

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -120,9 +120,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Prefix: 'serverless/my-service/dev',
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(result).to.deep.equal([]);
       });
@@ -142,9 +140,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Prefix: 'serverless/my-service/dev',
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(result).to.deep.equal([]);
       });
@@ -169,9 +165,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Prefix: 'serverless/my-service/dev',
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(result).to.deep.equal([
           { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
@@ -225,9 +219,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(headObjectStub).to.have.been.calledWithExactly(
           'S3',
@@ -235,9 +227,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(headObjectStub).to.have.been.calledWithExactly(
           'S3',
@@ -245,9 +235,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(headObjectStub).to.have.been.calledWithExactly(
           'S3',
@@ -255,9 +243,7 @@ describe('checkForChanges', () => {
           {
             Bucket: awsDeploy.bucketName,
             Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
       });
     });

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
@@ -16,9 +16,7 @@ module.exports = {
       {
         Bucket: this.bucketName,
         Prefix: `serverless/${service}/${stage}`,
-      },
-      this.options.stage,
-      this.options.region)
+      })
       .then((response) => {
         const stacks = findAndGroupDeployments(response, service, stage);
         const stacksToKeep = _.takeRight(stacks, stacksToKeepCount);
@@ -42,9 +40,7 @@ module.exports = {
         {
           Bucket: this.bucketName,
           Delete: { Objects: objectsToRemove },
-        },
-        this.options.stage,
-        this.options.region);
+        });
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
@@ -1,10 +1,17 @@
 'use strict';
 
+/* eslint-disable no-unused-expressions */
+
 const sinon = require('sinon');
-const expect = require('chai').expect;
+const chai = require('chai');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
 
 describe('cleanupS3Bucket', () => {
   let serverless;
@@ -36,17 +43,15 @@ describe('cleanupS3Bucket', () => {
         .stub(awsDeploy.provider, 'request').resolves(serviceObjects);
 
       return awsDeploy.getObjectsToRemove().then(() => {
-        expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.calledWithExactly(
+        expect(listObjectsStub).to.have.been.calledOnce;
+        expect(listObjectsStub).to.have.been.calledWithExactly(
           'S3',
           'listObjectsV2',
           {
             Bucket: awsDeploy.bucketName,
             Prefix: `${s3Key}`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
+          }
+        );
         awsDeploy.provider.request.restore();
       });
     });
@@ -98,16 +103,14 @@ describe('cleanupS3Bucket', () => {
           .include(
             { Key: `${s3Key}${s3Key}/903940390431-2016-08-18T23:42:08/cloudformation.json` });
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.calledWithExactly(
+        expect(listObjectsStub).to.have.been.calledWithExactly(
           'S3',
           'listObjectsV2',
           {
             Bucket: awsDeploy.bucketName,
             Prefix: `${s3Key}`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
+          }
+        );
         awsDeploy.provider.request.restore();
       });
     });
@@ -130,16 +133,14 @@ describe('cleanupS3Bucket', () => {
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
         expect(objectsToRemove.length).to.equal(0);
         expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.calledWithExactly(
+        expect(listObjectsStub).to.have.been.calledWithExactly(
           'S3',
           'listObjectsV2',
           {
             Bucket: awsDeploy.bucketName,
             Prefix: `${s3Key}`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
+          }
+        );
         awsDeploy.provider.request.restore();
       });
     });
@@ -162,18 +163,16 @@ describe('cleanupS3Bucket', () => {
         .stub(awsDeploy.provider, 'request').resolves(serviceObjects);
 
       return awsDeploy.getObjectsToRemove().then((objectsToRemove) => {
-        expect(objectsToRemove.length).to.equal(0);
-        expect(listObjectsStub.calledOnce).to.be.equal(true);
-        expect(listObjectsStub.calledWithExactly(
+        expect(objectsToRemove).to.have.lengthOf(0);
+        expect(listObjectsStub).to.have.been.calledOnce;
+        expect(listObjectsStub).to.have.been.calledWithExactly(
           'S3',
           'listObjectsV2',
           {
             Bucket: awsDeploy.bucketName,
             Prefix: `${s3Key}`,
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
+          }
+        );
         awsDeploy.provider.request.restore();
       });
     });
@@ -203,8 +202,8 @@ describe('cleanupS3Bucket', () => {
       ];
 
       return awsDeploy.removeObjects(objectsToRemove).then(() => {
-        expect(deleteObjectsStub.calledOnce).to.be.equal(true);
-        expect(deleteObjectsStub.calledWithExactly(
+        expect(deleteObjectsStub).to.have.been.calledOnce;
+        expect(deleteObjectsStub).to.have.been.calledWithExactly(
           'S3',
           'deleteObjects',
           {
@@ -212,10 +211,8 @@ describe('cleanupS3Bucket', () => {
             Delete: {
               Objects: objectsToRemove,
             },
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
+          }
+        );
         awsDeploy.provider.request.restore();
       });
     });

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -35,9 +35,7 @@ module.exports = {
     return this.provider.request(
       'CloudFormation',
       'createStack',
-      params,
-      this.options.stage,
-      this.options.region
+      params
     ).then((cfData) => this.monitorStack('create', cfData));
   },
 
@@ -56,21 +54,20 @@ module.exports = {
 
     return BbPromise.bind(this)
       .then(() => this.provider.request('CloudFormation',
-          'describeStacks',
-          { StackName: stackName },
-          this.options.stage,
-          this.options.region)
-          .then((data) => {
-            if (this.provider.isS3TransferAccelerationEnabled()) {
-              const isAlreadyAccelerated = !!_.find(data.Stacks[0].Outputs,
-                { OutputKey: 'ServerlessDeploymentBucketAccelerated' });
-              if (!isAlreadyAccelerated) {
-                this.serverless.cli.log('Not using S3 Transfer Acceleration (1st deploy)');
-                this.provider.disableTransferAccelerationForCurrentDeploy();
-              }
-            }
-            BbPromise.resolve('alreadyCreated');
-          }))
+        'describeStacks',
+        { StackName: stackName }
+      )
+      .then((data) => {
+        if (this.provider.isS3TransferAccelerationEnabled()) {
+          const isAlreadyAccelerated = !!_.find(data.Stacks[0].Outputs,
+            { OutputKey: 'ServerlessDeploymentBucketAccelerated' });
+          if (!isAlreadyAccelerated) {
+            this.serverless.cli.log('Not using S3 Transfer Acceleration (1st deploy)');
+            this.provider.disableTransferAccelerationForCurrentDeploy();
+          }
+        }
+        BbPromise.resolve('alreadyCreated');
+      }))
       .catch((e) => {
         if (e.message.indexOf('does not exist') > -1) {
           if (this.serverless.service.provider.deploymentBucket) {

--- a/lib/plugins/aws/deploy/lib/existsDeploymentBucket.js
+++ b/lib/plugins/aws/deploy/lib/existsDeploymentBucket.js
@@ -9,9 +9,7 @@ module.exports = {
         'getBucketLocation',
         {
           Bucket: bucketName,
-        },
-         this.options.stage,
-         this.options.region
+        }
       ))
       .then(resultParam => {
         const result = resultParam;

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -45,9 +45,7 @@ module.exports = {
 
     return this.provider.request('S3',
       'upload',
-      params,
-      this.options.stage,
-      this.options.region);
+      params);
   },
 
   uploadZipFile(artifactFilePath) {
@@ -74,9 +72,7 @@ module.exports = {
 
     return this.provider.request('S3',
       'upload',
-      params,
-      this.options.stage,
-      this.options.region);
+      params);
   },
 
   uploadFunctions() {

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -1,15 +1,22 @@
 'use strict';
 
+/* eslint-disable no-unused-expressions */
+
 const sinon = require('sinon');
 const fs = require('fs');
 const path = require('path');
-const expect = require('chai').expect;
+const chai = require('chai');
 const proxyquire = require('proxyquire');
 const normalizeFiles = require('../../lib/normalizeFiles');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 const testUtils = require('../../../../../tests/utils');
+
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
 
 describe('uploadArtifacts', () => {
   let serverless;
@@ -91,9 +98,9 @@ describe('uploadArtifacts', () => {
       cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-cf-template');
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
-        expect(normalizeCloudFormationTemplateStub.calledOnce).to.equal(true);
-        expect(uploadStub.calledOnce).to.equal(true);
-        expect(uploadStub.calledWithExactly(
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledWithExactly(
           'S3',
           'upload',
           {
@@ -105,12 +112,8 @@ describe('uploadArtifacts', () => {
             Metadata: {
               filesha256: 'local-hash-cf-template',
             },
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
-        expect(normalizeCloudFormationTemplateStub.calledWithExactly({ foo: 'bar' }))
-          .to.equal(true);
+          });
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly({ foo: 'bar' });
       });
     });
 
@@ -121,9 +124,9 @@ describe('uploadArtifacts', () => {
       };
 
       return awsDeploy.uploadCloudFormationFile().then(() => {
-        expect(normalizeCloudFormationTemplateStub.calledOnce).to.equal(true);
-        expect(uploadStub.calledOnce).to.be.equal(true);
-        expect(uploadStub.calledWithExactly(
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledWithExactly(
           'S3',
           'upload',
           {
@@ -136,12 +139,8 @@ describe('uploadArtifacts', () => {
             Metadata: {
               filesha256: 'local-hash-cf-template',
             },
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
-        expect(normalizeCloudFormationTemplateStub.calledWithExactly({ foo: 'bar' }))
-          .to.equal(true);
+          });
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly({ foo: 'bar' });
       });
     });
   });
@@ -176,9 +175,9 @@ describe('uploadArtifacts', () => {
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(uploadStub.calledOnce).to.be.equal(true);
-        expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(uploadStub.calledWithExactly(
+        expect(uploadStub).to.have.been.calledOnce;
+        expect(readFileSyncStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledWithExactly(
           'S3',
           'upload',
           {
@@ -189,11 +188,8 @@ describe('uploadArtifacts', () => {
             Metadata: {
               filesha256: 'local-hash-zip-file',
             },
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
-        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
+          });
+        expect(readFileSyncStub).to.have.been.calledWithExactly(artifactFilePath);
       });
     });
 
@@ -208,9 +204,9 @@ describe('uploadArtifacts', () => {
       };
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(uploadStub.calledOnce).to.be.equal(true);
-        expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(uploadStub.calledWithExactly(
+        expect(uploadStub).to.have.been.calledOnce;
+        expect(readFileSyncStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledWithExactly(
           'S3',
           'upload',
           {
@@ -222,11 +218,8 @@ describe('uploadArtifacts', () => {
             Metadata: {
               filesha256: 'local-hash-zip-file',
             },
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
-        )).to.be.equal(true);
-        expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
+          });
+        expect(readFileSyncStub).to.have.been.calledWithExactly(artifactFilePath);
       });
     });
   });

--- a/lib/plugins/aws/deploy/lib/validateTemplate.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.js
@@ -14,9 +14,7 @@ module.exports = {
     return this.provider.request(
       'CloudFormation',
       'validateTemplate',
-      params,
-      this.options.stage,
-      this.options.region
+      params
     ).catch((error) => {
       const errorMessage = [
         'The CloudFormation template is invalid:',

--- a/lib/plugins/aws/deploy/lib/validateTemplate.test.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.test.js
@@ -56,9 +56,7 @@ describe('validateTemplate', () => {
           'validateTemplate',
           {
             TemplateURL: 'https://s3.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
       });
     });
@@ -74,9 +72,7 @@ describe('validateTemplate', () => {
           'validateTemplate',
           {
             TemplateURL: 'https://s3.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         );
         expect(error.message).to.match(/is invalid: Some error while validating/);
       });

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -55,8 +55,7 @@ class AwsDeployFunction {
     return this.provider.request(
       'Lambda',
       'getFunction',
-      params,
-      this.options.stage, this.options.region
+      params
     )
     .then((result) => {
       this.serverless.service.provider.remoteFunctionData = result;
@@ -98,8 +97,7 @@ class AwsDeployFunction {
       'getRole',
       {
         RoleName: role['Fn::GetAtt'][0],
-      },
-      this.options.stage, this.options.region
+      }
     ).then((data) => data.Arn);
   }
 
@@ -107,8 +105,7 @@ class AwsDeployFunction {
     return this.provider.request(
       'Lambda',
       'updateFunctionConfiguration',
-      params,
-      this.options.stage, this.options.region
+      params
     ).then(() => {
       this.serverless.cli.log(`Successfully updated function: ${this.options.function}`);
     });
@@ -244,8 +241,7 @@ class AwsDeployFunction {
     return this.provider.request(
       'Lambda',
       'updateFunctionCode',
-      params,
-      this.options.stage, this.options.region
+      params
     ).then(() => {
       this.serverless.cli.log(`Successfully deployed function: ${this.options.function}`);
     });

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -108,9 +108,7 @@ describe('AwsDeployFunction', () => {
           'getFunction',
           {
             FunctionName: 'first',
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
         expect(awsDeployFunction.serverless.service.provider.remoteFunctionData).to.deep.equal({
           func: {
@@ -262,9 +260,7 @@ describe('AwsDeployFunction', () => {
               SecurityGroupIds: ['1'],
               SubnetIds: ['2'],
             },
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
       });
     });
@@ -286,9 +282,7 @@ describe('AwsDeployFunction', () => {
           {
             FunctionName: 'first',
             Description: 'change',
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
       });
     });
@@ -323,9 +317,7 @@ describe('AwsDeployFunction', () => {
           {
             FunctionName: 'first',
             Description: 'change',
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
       });
     });
@@ -394,9 +386,7 @@ describe('AwsDeployFunction', () => {
             Timeout: 12,
             MemorySize: 512,
             Role: 'arn:aws:us-east-1:123456789012:role/role',
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
       });
     });
@@ -450,9 +440,7 @@ describe('AwsDeployFunction', () => {
           {
             FunctionName: 'first',
             ZipFile: data,
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
         expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
       });
@@ -473,9 +461,7 @@ describe('AwsDeployFunction', () => {
           {
             FunctionName: 'first',
             ZipFile: data,
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
         expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
       });
@@ -538,9 +524,7 @@ describe('AwsDeployFunction', () => {
           {
             FunctionName: 'first',
             ZipFile: data,
-          },
-          awsDeployFunction.options.stage,
-          awsDeployFunction.options.region
+          }
         )).to.be.equal(true);
       }));
     });

--- a/lib/plugins/aws/deployList/index.js
+++ b/lib/plugins/aws/deployList/index.js
@@ -41,31 +41,30 @@ class AwsDeployList {
       {
         Bucket: this.bucketName,
         Prefix: `serverless/${service}/${stage}`,
-      },
-      this.options.stage,
-      this.options.region)
-      .then((response) => {
-        const directoryRegex = new RegExp('(.+)-(.+-.+-.+)');
-        const deployments = findAndGroupDeployments(response, service, stage);
+      }
+    )
+    .then((response) => {
+      const directoryRegex = new RegExp('(.+)-(.+-.+-.+)');
+      const deployments = findAndGroupDeployments(response, service, stage);
 
-        if (deployments.length === 0) {
-          this.serverless.cli.log('Couldn\'t find any existing deployments.');
-          this.serverless.cli.log('Please verify that stage and region are correct.');
-          return BbPromise.resolve();
-        }
-        this.serverless.cli.log('Listing deployments:');
-        deployments.forEach((deployment) => {
-          this.serverless.cli.log('-------------');
-          const match = deployment[0].directory.match(directoryRegex);
-          this.serverless.cli.log(`Timestamp: ${match[1]}`);
-          this.serverless.cli.log(`Datetime: ${match[2]}`);
-          this.serverless.cli.log('Files:');
-          deployment.forEach((entry) => {
-            this.serverless.cli.log(`- ${entry.file}`);
-          });
-        });
+      if (deployments.length === 0) {
+        this.serverless.cli.log('Couldn\'t find any existing deployments.');
+        this.serverless.cli.log('Please verify that stage and region are correct.');
         return BbPromise.resolve();
+      }
+      this.serverless.cli.log('Listing deployments:');
+      deployments.forEach((deployment) => {
+        this.serverless.cli.log('-------------');
+        const match = deployment[0].directory.match(directoryRegex);
+        this.serverless.cli.log(`Timestamp: ${match[1]}`);
+        this.serverless.cli.log(`Datetime: ${match[2]}`);
+        this.serverless.cli.log('Files:');
+        deployment.forEach((entry) => {
+          this.serverless.cli.log(`- ${entry.file}`);
+        });
       });
+      return BbPromise.resolve();
+    });
   }
 
   // list all functions and their versions
@@ -86,27 +85,24 @@ class AwsDeployList {
 
       return this.provider.request('Lambda',
         'getFunction',
-        params,
-        this.options.stage,
-        this.options.region);
+        params);
     }).then((result) => _.map(result, (item) => item.Configuration));
   }
 
   getFunctionPaginatedVersions(params, totalVersions) {
     return this.provider.request('Lambda',
       'listVersionsByFunction',
-      params,
-      this.options.stage,
-      this.options.region)
-      .then((response) => {
-        const Versions = (totalVersions || []).concat(response.Versions);
-        if (response.NextMarker) {
-          return this.getFunctionPaginatedVersions(
-            Object.assign({}, params, { Marker: response.NextMarker }), Versions);
-        }
+      params
+    )
+    .then((response) => {
+      const Versions = (totalVersions || []).concat(response.Versions);
+      if (response.NextMarker) {
+        return this.getFunctionPaginatedVersions(
+          Object.assign({}, params, { Marker: response.NextMarker }), Versions);
+      }
 
-        return Promise.resolve({ Versions });
-      });
+      return Promise.resolve({ Versions });
+    });
   }
 
   getFunctionVersions(funcs) {

--- a/lib/plugins/aws/deployList/index.test.js
+++ b/lib/plugins/aws/deployList/index.test.js
@@ -43,9 +43,7 @@ describe('AwsDeployList', () => {
           {
             Bucket: awsDeployList.bucketName,
             Prefix: `${s3Key}`,
-          },
-          awsDeployList.options.stage,
-          awsDeployList.options.region
+          }
         )).to.be.equal(true);
         const infoText = 'Couldn\'t find any existing deployments.';
         expect(awsDeployList.serverless.cli.log.calledWithExactly(infoText)).to.be.equal(true);
@@ -76,9 +74,7 @@ describe('AwsDeployList', () => {
           {
             Bucket: awsDeployList.bucketName,
             Prefix: `${s3Key}`,
-          },
-          awsDeployList.options.stage,
-          awsDeployList.options.region
+          }
         )).to.be.equal(true);
         const infoText = 'Listing deployments:';
         expect(awsDeployList.serverless.cli.log.calledWithExactly(infoText)).to.be.equal(true);

--- a/lib/plugins/aws/info/getApiKeyValues.js
+++ b/lib/plugins/aws/info/getApiKeyValues.js
@@ -14,9 +14,7 @@ module.exports = {
     if (apiKeyNames.length) {
       return this.provider.request('APIGateway',
         'getApiKeys',
-        { includeValues: true },
-        this.options.stage,
-        this.options.region
+        { includeValues: true }
       ).then((allApiKeys) => {
         const items = allApiKeys.items;
         if (items && items.length) {

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -22,9 +22,7 @@ module.exports = {
     // Get info from CloudFormation Outputs
     return this.provider.request('CloudFormation',
       'describeStacks',
-      { StackName: stackName },
-      this.options.stage,
-      this.options.region)
+      { StackName: stackName })
     .then((result) => {
       let outputs;
 

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -114,9 +114,7 @@ describe('#getStackInfo()', () => {
         'describeStacks',
         {
           StackName: awsInfo.provider.naming.getStackName(),
-        },
-        awsInfo.options.stage,
-        awsInfo.options.region
+        }
       )).to.equal(true);
 
       expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);
@@ -147,9 +145,7 @@ describe('#getStackInfo()', () => {
         'describeStacks',
         {
           StackName: awsInfo.provider.naming.getStackName(),
-        },
-        awsInfo.options.stage,
-        awsInfo.options.region
+        }
       )).to.equal(true);
 
       expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -80,7 +80,7 @@ class AwsInvoke {
     };
 
     return this.provider
-      .request('Lambda', 'invoke', params, this.options.stage, this.options.region);
+      .request('Lambda', 'invoke', params);
   }
 
   log(invocationReply) {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -204,9 +204,7 @@ describe('AwsInvoke', () => {
             InvocationType: 'RequestResponse',
             LogType: 'None',
             Payload: new Buffer(JSON.stringify({})),
-          },
-          awsInvoke.options.stage,
-          awsInvoke.options.region
+          }
         )).to.be.equal(true);
         awsInvoke.provider.request.restore();
       })
@@ -225,9 +223,7 @@ describe('AwsInvoke', () => {
             InvocationType: 'RequestResponse',
             LogType: 'Tail',
             Payload: new Buffer(JSON.stringify({})),
-          },
-          awsInvoke.options.stage,
-          awsInvoke.options.region
+          }
         )).to.be.equal(true);
         awsInvoke.provider.request.restore();
       });
@@ -246,9 +242,7 @@ describe('AwsInvoke', () => {
             InvocationType: 'OtherType',
             LogType: 'None',
             Payload: new Buffer(JSON.stringify({})),
-          },
-          awsInvoke.options.stage,
-          awsInvoke.options.region
+          }
         )).to.be.equal(true);
         awsInvoke.provider.request.restore();
       });

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -33,9 +33,7 @@ module.exports = {
             };
             return this.provider.request('CloudFormation',
               'describeStackEvents',
-              params,
-              this.options.stage,
-              this.options.region)
+              params)
               .then((data) => {
                 const stackEvents = data.StackEvents;
 

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -73,9 +73,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('CREATE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -122,9 +120,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('UPDATE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -171,9 +167,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -233,9 +227,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('CREATE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -295,9 +287,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('UPDATE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -357,9 +347,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -397,9 +385,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         expect(stackStatus).to.be.equal('DELETE_COMPLETE');
         awsPlugin.provider.request.restore();
@@ -477,9 +463,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
@@ -536,9 +520,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
@@ -563,9 +545,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
@@ -639,9 +619,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
@@ -719,9 +697,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
@@ -801,9 +777,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });
@@ -865,9 +839,7 @@ describe('monitorStack', () => {
           'describeStackEvents',
           {
             StackName: cfDataMock.StackId,
-          },
-          awsPlugin.options.stage,
-          awsPlugin.options.region
+          }
         )).to.be.equal(true);
         awsPlugin.provider.request.restore();
       });

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -38,9 +38,7 @@ module.exports = {
 
     return this.provider.request('CloudFormation',
       'createStack',
-      params,
-      this.options.stage,
-      this.options.region)
+      params)
       .then((cfData) => this.monitorStack('create', cfData));
   },
 
@@ -82,9 +80,7 @@ module.exports = {
 
     return this.provider.request('CloudFormation',
       'updateStack',
-      params,
-      this.options.stage,
-      this.options.region)
+      params)
       .then((cfData) => this.monitorStack('update', cfData))
       .catch((e) => {
         if (e.message === NO_UPDATE_MESSAGE) {

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -54,9 +54,7 @@ describe('updateStack', () => {
             TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
               .service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
             Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         )).to.be.equal(true);
         awsDeploy.provider.request.restore();
         awsDeploy.monitorStack.restore();
@@ -127,9 +125,7 @@ describe('updateStack', () => {
             TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
               .service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
             Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
-          },
-          awsDeploy.options.stage,
-          awsDeploy.options.region
+          }
         )).to.be.equal(true);
       })
     );

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -45,9 +45,7 @@ class AwsLogs {
     return this.provider
       .request('CloudWatchLogs',
         'describeLogStreams',
-        params,
-        this.options.stage,
-        this.options.region)
+        params)
       .then(reply => {
         if (!reply || reply.logStreams.length === 0) {
           throw new this.serverless.classes
@@ -94,9 +92,7 @@ class AwsLogs {
     return this.provider
       .request('CloudWatchLogs',
         'filterLogEvents',
-        params,
-        this.options.stage,
-        this.options.region)
+        params)
       .then(results => {
         if (results.events) {
           results.events.forEach(e => {

--- a/lib/plugins/aws/logs/index.test.js
+++ b/lib/plugins/aws/logs/index.test.js
@@ -129,9 +129,7 @@ describe('AwsLogs', () => {
               descending: true,
               limit: 50,
               orderBy: 'LastEventTime',
-            },
-            awsLogs.options.stage,
-            awsLogs.options.region
+            }
           )).to.be.equal(true);
 
           expect(logStreamNames[0])
@@ -212,9 +210,7 @@ describe('AwsLogs', () => {
               logStreamNames: logStreamNamesMock,
               filterPattern: 'error',
               startTime: 1475269200000,
-            },
-            awsLogs.options.stage,
-            awsLogs.options.region
+            }
           )).to.be.equal(true);
           awsLogs.provider.request.restore();
         });
@@ -262,9 +258,7 @@ describe('AwsLogs', () => {
               logStreamNames: logStreamNamesMock,
               startTime: 1287532800000, // '2010-10-20'
               filterPattern: 'error',
-            },
-            awsLogs.options.stage,
-            awsLogs.options.region
+            }
           )).to.be.equal(true);
 
           awsLogs.provider.request.restore();

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.js
@@ -16,13 +16,9 @@ module.exports = {
           {
             StackName: stackName,
             LogicalResourceId: this.provider.naming.getRestApiLogicalId(),
-          },
-          this.options.stage,
-          this.options.region),
+          }),
         this.provider.request('APIGateway',
-          'getUsagePlans', {},
-          this.options.stage,
-          this.options.region),
+          'getUsagePlans', {}),
       ]).then((data) => data[1].items.filter((item) =>
           _.includes(item.apiStages
             .map(apistage => apistage.apiId), data[0].StackResourceDetail.PhysicalResourceId)))
@@ -36,9 +32,7 @@ module.exports = {
                   path: '/apiStages',
                   value: `${apiStage.apiId}:${apiStage.stage}`,
                 }],
-              },
-              this.options.stage,
-              this.options.region))))));
+              }))))));
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.test.js
@@ -71,17 +71,13 @@ describe('#disassociateUsagePlan()', () => {
         {
           StackName: `${serverless.service.service}-${options.stage}`,
           LogicalResourceId: 'ApiGatewayRestApi',
-        },
-        options.stage,
-        options.region
+        }
       )).to.be.equal(true);
 
       expect(providerRequestStub.calledWithExactly(
         'APIGateway',
         'getUsagePlans',
-        {},
-        options.stage,
-        options.region
+        {}
       )).to.be.equal(true);
 
       expect(providerRequestStub.calledWithExactly(
@@ -94,9 +90,7 @@ describe('#disassociateUsagePlan()', () => {
             path: '/apiStages',
             value: 'resource-id:dev',
           }],
-        },
-        options.stage,
-        options.region
+        }
       )).to.be.equal(true);
     });
   });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -218,7 +218,7 @@ class AwsProvider {
 
     // Emit a warning for misuses of the old signature including stage and region
     // TODO: Determine calling module and log that
-    if (process.env.SLS_DEBUG && !_.isObject(options)) {
+    if (process.env.SLS_DEBUG && !_.isNil(options) && !_.isObject(options)) {
       this.serverless.cli.log('WARNING: Inappropriate call of provider.request()');
     }
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -190,14 +190,15 @@ class AwsProvider {
    * @param {string} service - Service name
    * @param {string} method - Method name
    * @param {Object} params - Parameters
-   * @param {string} stage - Stage
-   * @param {string} region - AWS region
-   * @param {boolean} [useCache=false] - Utilize cache to retrieve results
+   * @param {Object} [options] - Options to modify the request behavior
+   * @prop [options.useCache] - Utilize cache to retrieve results
    */
-  request(service, method, params, stage, region, useCache) {
+  request(service, method, params, options) {
     const that = this;
     const credentials = that.getCredentials();
-    const shouldCache = !!useCache;
+    // Make sure options is an object (honors wrong calls of request)
+    const requestOptions = _.isObject(options) ? options : {};
+    const shouldCache = _.get(requestOptions, 'useCache', false);
     const paramsHash = objectHash.sha1(params);
     const persistentRequest = (f) => new BbPromise((resolve, reject) => {
       const doCall = () => {
@@ -214,6 +215,12 @@ class AwsProvider {
       };
       return doCall();
     });
+
+    // Emit a warning for misuses of the old signature including stage and region
+    // TODO: Determine calling module and log that
+    if (process.env.SLS_DEBUG && !_.isObject(options)) {
+      this.serverless.cli.log('WARNING: Inappropriate call of provider.request()');
+    }
 
     // Support S3 Transfer Acceleration
     if (this.canUseS3TransferAcceleration(service, method)) {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -391,9 +391,7 @@ describe('AwsProvider', () => {
           'CloudFormation',
           'describeStacks',
           {},
-          '',
-          '',
-          true
+          { useCache: true }
         )
         .then(data => {
           expect(data.called).to.equal(true);
@@ -436,9 +434,7 @@ describe('AwsProvider', () => {
           'CloudFormation',
           'describeStacks',
           {},
-          '',
-          '',
-          true
+          { useCache: true }
         );
         const requests = [];
         for (let n = 0; n < numTests; n++) {

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -19,7 +19,7 @@ module.exports = {
     return this.provider.request('S3', 'listObjectsV2', {
       Bucket: this.bucketName,
       Prefix: `serverless/${serviceStage}`,
-    }, this.options.stage, this.options.region).then((result) => {
+    }).then((result) => {
       if (result) {
         result.Contents.forEach((object) => {
           this.objectsInBucket.push({
@@ -39,7 +39,7 @@ module.exports = {
         Delete: {
           Objects: this.objectsInBucket,
         },
-      }, this.options.stage, this.options.region);
+      });
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/remove/lib/bucket.test.js
+++ b/lib/plugins/aws/remove/lib/bucket.test.js
@@ -53,9 +53,7 @@ describe('emptyS3Bucket', () => {
           {
             Bucket: awsRemove.bucketName,
             Prefix: `serverless/${serverless.service.service}/${awsRemove.options.stage}`,
-          },
-          awsRemove.options.stage,
-          awsRemove.options.region
+          }
         )).to.be.equal(true);
         expect(awsRemove.objectsInBucket.length).to.equal(0);
         awsRemove.provider.request.restore();
@@ -79,9 +77,7 @@ describe('emptyS3Bucket', () => {
           {
             Bucket: awsRemove.bucketName,
             Prefix: `serverless/${serverless.service.service}/${awsRemove.options.stage}`,
-          },
-          awsRemove.options.stage,
-          awsRemove.options.region
+          }
         )).to.be.equal(true);
         expect(awsRemove.objectsInBucket[0]).to.deep.equal({ Key: 'object1' });
         expect(awsRemove.objectsInBucket[1]).to.deep.equal({ Key: 'object2' });
@@ -107,9 +103,7 @@ describe('emptyS3Bucket', () => {
             Delete: {
               Objects: awsRemove.objectsInBucket,
             },
-          },
-          awsRemove.options.stage,
-          awsRemove.options.region
+          }
         )).to.be.equal(true);
         awsRemove.provider.request.restore();
       });

--- a/lib/plugins/aws/remove/lib/stack.js
+++ b/lib/plugins/aws/remove/lib/stack.js
@@ -20,9 +20,7 @@ module.exports = {
 
     return this.provider.request('CloudFormation',
       'deleteStack',
-      params,
-      this.options.stage,
-      this.options.region)
+      params)
       .then(() => cfData);
   },
 

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -32,9 +32,7 @@ describe('removeStack', () => {
         'deleteStack',
         {
           StackName: `${serverless.service.service}-${awsRemove.options.stage}`,
-        },
-        awsRemove.options.stage,
-        awsRemove.options.region
+        }
       )).to.be.equal(true);
       awsRemove.provider.request.restore();
     }));

--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -54,9 +54,7 @@ class AwsRollback {
       {
         Bucket: this.bucketName,
         Prefix: prefix,
-      },
-      this.options.stage,
-      this.options.region)
+      })
       .then((response) => {
         const deployments = findAndGroupDeployments(response, serviceName, stage);
 

--- a/lib/plugins/aws/rollback/index.test.js
+++ b/lib/plugins/aws/rollback/index.test.js
@@ -97,9 +97,7 @@ describe('AwsRollback', () => {
             {
               Bucket: awsRollback.bucketName,
               Prefix: `${s3Key}`,
-            },
-            awsRollback.options.stage,
-            awsRollback.options.region
+            }
           )).to.be.equal(true);
           awsRollback.provider.request.restore();
         });
@@ -135,9 +133,7 @@ describe('AwsRollback', () => {
             {
               Bucket: awsRollback.bucketName,
               Prefix: `${s3Key}`,
-            },
-            awsRollback.options.stage,
-            awsRollback.options.region
+            }
           )).to.be.equal(true);
           awsRollback.provider.request.restore();
         });
@@ -171,9 +167,7 @@ describe('AwsRollback', () => {
             {
               Bucket: awsRollback.bucketName,
               Prefix: `${s3Key}`,
-            },
-            awsRollback.options.stage,
-            awsRollback.options.region
+            }
           )).to.be.equal(true);
           awsRollback.provider.request.restore();
         });

--- a/lib/plugins/aws/rollbackFunction/index.js
+++ b/lib/plugins/aws/rollbackFunction/index.js
@@ -73,8 +73,7 @@ class AwsRollbackFunction {
     return this.provider.request(
       'Lambda',
       'getFunction',
-      params,
-      this.options.stage, this.options.region
+      params
     )
     .then((func) => func)
     .catch((error) => {
@@ -112,8 +111,7 @@ class AwsRollbackFunction {
     return this.provider.request(
       'Lambda',
       'updateFunctionCode',
-      params,
-      this.options.stage, this.options.region
+      params
     ).then(() => {
       this.serverless.cli.log(`Successfully rolled back function "${this.options.function}"`);
     });

--- a/lib/plugins/aws/rollbackFunction/index.test.js
+++ b/lib/plugins/aws/rollbackFunction/index.test.js
@@ -114,9 +114,7 @@ describe('AwsRollbackFunction', () => {
             {
               FunctionName: 'service-dev-hello',
               Qualifier: '4711',
-            },
-            awsRollbackFunction.options.stage,
-            awsRollbackFunction.options.region
+            }
           )).to.equal(true);
           expect(consoleLogStub.called).to.equal(true);
           expect(result).to.deep.equal({ function: 'hello' });
@@ -150,9 +148,7 @@ describe('AwsRollbackFunction', () => {
             {
               FunctionName: 'service-dev-hello',
               Qualifier: '4711',
-            },
-            awsRollbackFunction.options.stage,
-            awsRollbackFunction.options.region
+            }
           )).to.equal(true);
           expect(consoleLogStub.called).to.equal(true);
         });
@@ -185,9 +181,7 @@ describe('AwsRollbackFunction', () => {
             {
               FunctionName: 'service-dev-hello',
               Qualifier: '4711',
-            },
-            awsRollbackFunction.options.stage,
-            awsRollbackFunction.options.region
+            }
           )).to.equal(true);
           expect(consoleLogStub.called).to.equal(true);
         });
@@ -233,9 +227,7 @@ describe('AwsRollbackFunction', () => {
           {
             FunctionName: 'service-dev-hello',
             ZipFile: zipBuffer,
-          },
-          awsRollbackFunction.options.stage,
-          awsRollbackFunction.options.region
+          }
         )).to.equal(true);
         expect(consoleLogStub.called).to.equal(true);
       });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

There were many places were calls to provider.request() received a stage and region parameter, although these are not used since a long time anymore even if the function signature was changed too.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Removed the not-used parameters in all calls.

Additionally the new `useCache` parameter was too specific to be part of the signature, so I added an options object, that can be optionally given and is used as container for options that change the request method's behavior.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
