### PR TITLE
Installs @types/aws-lambda and uses types in handler, per issue #4546

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/handler.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/handler.ts
@@ -1,4 +1,6 @@
-export const hello = (event, context, cb) => {
+import { Handler, Callback, Context } from 'aws-lambda';
+
+export const hello : Handler = (event, context : Context, cb : Callback) => {
   const response = {
     statusCode: 200,
     body: JSON.stringify({

--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "@types/aws-lambda": "0.0.22",
     "@types/node": "^8.0.57",
     "serverless-webpack": "^4.0.0",
     "ts-loader": "^2.3.7",

--- a/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
-    "sourceMap": true
+    "sourceMap": true,
+    "lib": [
+      "es5",
+      "es2015.promise"
+    ]
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4546

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I added the required configuration to include `@types/aws-lambda` as a dev dependency and updated `handler.ts` to make use of the Handler, Callback, and Context types.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Use the template and call `npm install`:

```bash
serverless create --template aws-nodejs-typescript && npm install
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
