### PR TITLE
Fix the plugin commands fail if listed plugins does not exist

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -90,6 +90,9 @@ class PluginManager {
 
         this.addPlugin(Plugin);
       } catch (error) {
+        if (this.cliCommands[0] === 'plugin') {
+          return;
+        }
         let errorMessage;
         if (error && error.code === 'MODULE_NOT_FOUND' && error.message.endsWith(`'${plugin}'`)) {
           // Plugin not installed
@@ -135,7 +138,6 @@ class PluginManager {
     if (this.serverless && this.serverless.config && this.serverless.config.servicePath) {
       module.paths.unshift(path.join(this.serverless.config.servicePath, '.serverless_plugins'));
     }
-
     this.loadPlugins(servicePlugins);
   }
 

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -665,6 +665,16 @@ describe('PluginManager', () => {
       });
     });
 
+    it('should not throw error when running the plugin commands and given plugins does not exist',
+    () => {
+      const servicePlugins = ['ServicePluginMock3'];
+      const cliCommandsMock = ['plugin'];
+      pluginManager.setCliCommands(cliCommandsMock);
+
+      expect(() => pluginManager.loadPlugins(servicePlugins))
+        .to.not.throw(serverless.classes.Error);
+    });
+
     afterEach(() => {
       mockRequire.stop('ServicePluginMock1');
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
The plugin commands failed if listed plugins within serverless.yml do not exist in node_modules. 
All plugin commands shouldn't catch the error related to the state of another plugin. Then I fixed it.

Closes #4259 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
when running the `plugin` commands, errors are ignored even if listed plugins within serverless.yml do not exist.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
- Run `serverless create -t spotinst-nodejs`. At this time, you will see listed the spotinst plugin but that is not actually installed
- Run `serverless plugin` commands
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
