### PR TITLE
Improve Stage and Region Usage

### DIFF
--- a/lib/plugins/aws/common/index.test.js
+++ b/lib/plugins/aws/common/index.test.js
@@ -15,7 +15,7 @@ describe('AwsCommon', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.config.servicePath = 'foo';
     awsCommon = new AwsCommon(serverless, options);
     awsCommon.serverless.cli = new serverless.classes.CLI();

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -25,7 +25,7 @@ describe('AwsDeploy', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.config.servicePath = 'foo';
     awsDeploy = new AwsDeploy(serverless, options);
   });

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -27,7 +27,7 @@ module.exports = {
 
     const params = {
       Bucket: this.bucketName,
-      Prefix: `serverless/${service}/${this.options.stage}`,
+      Prefix: `serverless/${service}/${this.provider.getStage()}`,
     };
 
     return this.provider.request('S3',

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -20,6 +20,7 @@ const expect = require('chai').expect;
 
 describe('checkForChanges', () => {
   let serverless;
+  let provider;
   let awsDeploy;
   let s3Key;
   let cryptoStub;
@@ -27,7 +28,8 @@ describe('checkForChanges', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.config.servicePath = 'my-service';
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    provider = new AwsProvider(serverless);
+    serverless.setProvider('aws', provider);
     serverless.service.service = 'my-service';
     const options = {
       stage: 'dev',
@@ -38,7 +40,7 @@ describe('checkForChanges', () => {
     awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {
       foo: 'bar',
     };
-    s3Key = `serverless/${serverless.service.service}/${options.stage}`;
+    s3Key = `serverless/${serverless.service.service}/${provider.getStage()}`;
     awsDeploy.serverless.cli = { log: sinon.spy() };
     cryptoStub = {
       createHash: function () { return this; }, // eslint-disable-line

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -26,15 +26,15 @@ describe('checkForChanges', () => {
   let cryptoStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.config.servicePath = 'my-service';
-    provider = new AwsProvider(serverless);
-    serverless.setProvider('aws', provider);
-    serverless.service.service = 'my-service';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.config.servicePath = 'my-service';
+    provider = new AwsProvider(serverless, options);
+    serverless.setProvider('aws', provider);
+    serverless.service.service = 'my-service';
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.bucketName = 'deployment-bucket';
     awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
@@ -9,7 +9,7 @@ module.exports = {
   getObjectsToRemove() {
     const stacksToKeepCount = 5;
     const service = this.serverless.service.service;
-    const stage = this.options.stage;
+    const stage = this.provider.getStage();
 
     return this.provider.request('S3',
       'listObjectsV2',

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
@@ -20,15 +20,15 @@ describe('cleanupS3Bucket', () => {
   let s3Key;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
-    provider = new AwsProvider(serverless);
-    serverless.setProvider('aws', provider);
-    serverless.service.service = 'cleanupS3Bucket';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.config.servicePath = 'foo';
+    provider = new AwsProvider(serverless, options);
+    serverless.setProvider('aws', provider);
+    serverless.service.service = 'cleanupS3Bucket';
     s3Key = `serverless/${serverless.service.service}/${provider.getStage()}`;
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.bucketName = 'deployment-bucket';

--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
@@ -15,19 +15,21 @@ const expect = chai.expect;
 
 describe('cleanupS3Bucket', () => {
   let serverless;
+  let provider;
   let awsDeploy;
   let s3Key;
 
   beforeEach(() => {
     serverless = new Serverless();
     serverless.config.servicePath = 'foo';
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    provider = new AwsProvider(serverless);
+    serverless.setProvider('aws', provider);
     serverless.service.service = 'cleanupS3Bucket';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
-    s3Key = `serverless/${serverless.service.service}/${options.stage}`;
+    s3Key = `serverless/${serverless.service.service}/${provider.getStage()}`;
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.bucketName = 'deployment-bucket';
     awsDeploy.serverless.cli = new serverless.classes.CLI();

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -9,7 +9,7 @@ module.exports = {
     this.serverless.cli.log('Creating Stack...');
     const stackName = this.provider.naming.getStackName();
 
-    let stackTags = { STAGE: this.options.stage };
+    let stackTags = { STAGE: this.provider.getStage() };
 
     // Merge additional stack tags
     if (typeof this.serverless.service.provider.stackTags === 'object') {

--- a/lib/plugins/aws/deploy/lib/existsDeploymentBucket.js
+++ b/lib/plugins/aws/deploy/lib/existsDeploymentBucket.js
@@ -15,7 +15,7 @@ module.exports = {
         const result = resultParam;
         if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
         if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
-        if (result.LocationConstraint !== this.options.region) {
+        if (result.LocationConstraint !== this.provider.getRegion()) {
           throw new this.serverless.classes.Error(
             'Deployment bucket is not in the same region as the lambda function'
           );

--- a/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
+++ b/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
@@ -17,7 +17,7 @@ describe('#existsDeploymentBucket()', () => {
     serverless = new Serverless();
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless);
-    awsPlugin.options = {
+    awsPlugin.provider.options = {
       stage: 'dev',
       region: 'us-east-1',
     };
@@ -29,7 +29,7 @@ describe('#existsDeploymentBucket()', () => {
     const bucketName = 'com.serverless.deploys';
 
     awsPluginStub = sinon.stub(awsPlugin.provider, 'request').resolves({
-      LocationConstraint: awsPlugin.options.region,
+      LocationConstraint: awsPlugin.provider.options.region,
     });
 
     return expect(awsPlugin.existsDeploymentBucket(bucketName)).to.be.fulfilled
@@ -78,7 +78,7 @@ describe('#existsDeploymentBucket()', () => {
     it(`should handle inconsistent getBucketLocation responses for ${value.region} region`, () => {
       const bucketName = 'com.serverless.deploys';
 
-      awsPlugin.options.region = value.region;
+      awsPlugin.provider.options.region = value.region;
 
       sinon
         .stub(awsPlugin.provider, 'request').resolves({

--- a/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
+++ b/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
@@ -14,13 +14,13 @@ describe('#existsDeploymentBucket()', () => {
   const awsPlugin = {};
 
   beforeEach(() => {
-    serverless = new Serverless();
-    awsPlugin.serverless = serverless;
-    awsPlugin.provider = new AwsProvider(serverless);
-    awsPlugin.provider.options = {
+    const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    awsPlugin.serverless = serverless;
+    awsPlugin.provider = new AwsProvider(serverless, options);
 
     Object.assign(awsPlugin, existsDeploymentBucket);
   });

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -32,14 +32,14 @@ describe('extendedValidate', () => {
   };
 
   beforeEach(() => {
-    const serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
-    serverless.config.servicePath = tmpDirPath;
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    const serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
+    serverless.config.servicePath = tmpDirPath;
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.serverless.service.service = `service-${(new Date()).getTime().toString()}`;
     awsDeploy.serverless.cli = {

--- a/lib/plugins/aws/deploy/lib/validateTemplate.test.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.test.js
@@ -19,13 +19,13 @@ describe('validateTemplate', () => {
   let validateTemplateStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
-    serverless.setProvider('aws', new AwsProvider(serverless));
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.config.servicePath = 'foo';
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.bucketName = 'deployment-bucket';
     awsDeploy.serverless.service.package.artifactDirectoryName = 'somedir';

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -50,7 +50,7 @@ describe('AwsDeployFunction', () => {
       },
     };
     serverless.init();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     cryptoStub = {
       createHash: function () { return this; }, // eslint-disable-line
       update: function () { return this; }, // eslint-disable-line

--- a/lib/plugins/aws/deployList/index.js
+++ b/lib/plugins/aws/deployList/index.js
@@ -34,7 +34,7 @@ class AwsDeployList {
 
   listDeployments() {
     const service = this.serverless.service.service;
-    const stage = this.options.stage;
+    const stage = this.provider.getStage();
 
     return this.provider.request('S3',
       'listObjectsV2',
@@ -128,7 +128,7 @@ class AwsDeployList {
 
       let name = func.Versions[0].FunctionName;
       name = name.replace(`${this.serverless.service.service}-`, '');
-      name = name.replace(`${this.options.stage}-`, '');
+      name = name.replace(`${this.provider.getStage()}-`, '');
 
       message += `${name}: `;
       const versions = func.Versions.map((funcEntry) => funcEntry.Version)

--- a/lib/plugins/aws/deployList/index.test.js
+++ b/lib/plugins/aws/deployList/index.test.js
@@ -8,18 +8,20 @@ const Serverless = require('../../../Serverless');
 
 describe('AwsDeployList', () => {
   let serverless;
+  let provider;
   let awsDeployList;
   let s3Key;
 
   beforeEach(() => {
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    provider = new AwsProvider(serverless);
+    serverless.setProvider('aws', provider);
     serverless.service.service = 'listDeployments';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
-    s3Key = `serverless/${serverless.service.service}/${options.stage}`;
+    s3Key = `serverless/${serverless.service.service}/${provider.getStage()}`;
     awsDeployList = new AwsDeployList(serverless, options);
     awsDeployList.bucketName = 'deployment-bucket';
     awsDeployList.serverless.cli = {

--- a/lib/plugins/aws/deployList/index.test.js
+++ b/lib/plugins/aws/deployList/index.test.js
@@ -13,14 +13,14 @@ describe('AwsDeployList', () => {
   let s3Key;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    provider = new AwsProvider(serverless);
-    serverless.setProvider('aws', provider);
-    serverless.service.service = 'listDeployments';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    provider = new AwsProvider(serverless, options);
+    serverless.setProvider('aws', provider);
+    serverless.service.service = 'listDeployments';
     s3Key = `serverless/${serverless.service.service}/${provider.getStage()}`;
     awsDeployList = new AwsDeployList(serverless, options);
     awsDeployList.bucketName = 'deployment-bucket';

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -14,14 +14,14 @@ describe('#display()', () => {
   let consoleLogStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.cli = new CLI(serverless);
-    serverless.service.service = 'my-service';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.cli = new CLI(serverless);
+    serverless.service.service = 'my-service';
     awsInfo = new AwsInfo(serverless, options);
     awsInfo.gatheredData = {
       info: {

--- a/lib/plugins/aws/info/getApiKeyValues.test.js
+++ b/lib/plugins/aws/info/getApiKeyValues.test.js
@@ -12,13 +12,13 @@ describe('#getApiKeyValues()', () => {
   let requestStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.service = 'my-service';
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.service.service = 'my-service';
     awsInfo = new AwsInfo(serverless, options);
     requestStub = sinon.stub(awsInfo.provider, 'request');
   });

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -10,14 +10,14 @@ module.exports = {
         functions: [],
         endpoint: '',
         service: this.serverless.service.service,
-        stage: this.options.stage,
-        region: this.options.region,
-        stack: this.provider.naming.getStackName(this.options.stage),
+        stage: this.provider.getStage(),
+        region: this.provider.getRegion(),
+        stack: this.provider.naming.getStackName(),
       },
       outputs: [],
     };
 
-    const stackName = this.provider.naming.getStackName(this.options.stage);
+    const stackName = this.provider.naming.getStackName();
 
     // Get info from CloudFormation Outputs
     return this.provider.request('CloudFormation',
@@ -40,7 +40,7 @@ module.exports = {
           const functionInfo = {};
           functionInfo.name = func;
           functionInfo.deployedName = `${
-            this.serverless.service.service}-${this.options.stage}-${func}`;
+            this.serverless.service.service}-${this.provider.getStage()}-${func}`;
           this.gatheredData.info.functions.push(functionInfo);
         });
 

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -12,16 +12,16 @@ describe('#getStackInfo()', () => {
   let describeStacksStub;
 
   beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     serverless.service.functions = {
       hello: {},
       world: {},
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
     };
     awsInfo = new AwsInfo(serverless, options);
 

--- a/lib/plugins/aws/info/index.test.js
+++ b/lib/plugins/aws/info/index.test.js
@@ -19,12 +19,12 @@ describe('AwsInfo', () => {
   let displayStackOutputsStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.cli = {
       log: sinon.stub().returns(),
     };

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -79,8 +79,7 @@ class AwsInvoke {
       Payload: new Buffer(JSON.stringify(this.options.data || {})),
     };
 
-    return this.provider
-      .request('Lambda', 'invoke', params);
+    return this.provider.request('Lambda', 'invoke', params);
   }
 
   log(invocationReply) {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -10,13 +10,13 @@ const chalk = require('chalk');
 const testUtils = require('../../../../tests/utils');
 
 describe('AwsInvoke', () => {
-  const serverless = new Serverless();
-  serverless.setProvider('aws', new AwsProvider(serverless));
   const options = {
     stage: 'dev',
     region: 'us-east-1',
     function: 'first',
   };
+  const serverless = new Serverless();
+  serverless.setProvider('aws', new AwsProvider(serverless, options));
   const awsInvoke = new AwsInvoke(serverless, options);
 
   describe('#constructor()', () => {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -95,8 +95,8 @@ class AwsInvokeLocal {
       LD_LIBRARY_PATH: '/usr/local/lib64/node-v4.3.x/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib', // eslint-disable-line max-len
       LAMBDA_TASK_ROOT: '/var/task',
       LAMBDA_RUNTIME_DIR: '/var/runtime',
-      AWS_REGION: this.options.region || _.get(this.serverless, 'service.provider.region'),
-      AWS_DEFAULT_REGION: this.options.region || _.get(this.serverless, 'service.provider.region'),
+      AWS_REGION: this.provider.getRegion(),
+      AWS_DEFAULT_REGION: this.provider.getRegion(),
       AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
       AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',
       AWS_LAMBDA_FUNCTION_NAME: lambdaName,

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -13,14 +13,23 @@ const CLI = require('../../../classes/CLI');
 const testUtils = require('../../../../tests/utils');
 
 describe('AwsInvokeLocal', () => {
-  const serverless = new Serverless();
-  serverless.setProvider('aws', new AwsProvider(serverless));
-  const options = {
-    stage: 'dev',
-    region: 'us-east-1',
-    function: 'first',
-  };
-  const awsInvokeLocal = new AwsInvokeLocal(serverless, options);
+  let options;
+  let serverless;
+  let provider;
+  let awsInvokeLocal;
+  beforeEach(() => {
+    options = {
+      stage: 'dev',
+      region: 'us-east-1',
+      function: 'first',
+    };
+    serverless = new Serverless();
+    serverless.cli = new CLI(serverless);
+    provider = new AwsProvider(serverless, options);
+    serverless.setProvider('aws', provider);
+    awsInvokeLocal = new AwsInvokeLocal(serverless, options);
+    awsInvokeLocal.provider = provider;
+  });
 
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsInvokeLocal.hooks).to.be.not.empty);
@@ -214,8 +223,8 @@ describe('AwsInvokeLocal', () => {
         },
       };
 
+      awsInvokeLocal.provider.options.region = 'us-east-1';
       awsInvokeLocal.options = {
-        region: 'us-east-1',
         functionObj: {
           name: 'serviceName-dev-hello',
           environment: {
@@ -258,7 +267,7 @@ describe('AwsInvokeLocal', () => {
 
 
     it('should fallback to service provider configuration when options are not available', () => {
-      awsInvokeLocal.options.region = null;
+      awsInvokeLocal.provider.options.region = null;
       awsInvokeLocal.serverless.service.provider.region = 'us-west-1';
 
       return awsInvokeLocal.loadEnvVars().then(() => {
@@ -290,8 +299,8 @@ describe('AwsInvokeLocal', () => {
         sinon.stub(awsInvokeLocal, 'invokeLocalJava').resolves();
 
       awsInvokeLocal.serverless.service.service = 'new-service';
+      awsInvokeLocal.provider.options.stage = 'dev';
       awsInvokeLocal.options = {
-        stage: 'dev',
         function: 'first',
         functionObj: {
           handler: 'handler.hello',
@@ -392,7 +401,6 @@ describe('AwsInvokeLocal', () => {
         },
       };
 
-      serverless.cli = new CLI(serverless);
       sinon.stub(serverless.cli, 'consoleLog');
     });
 
@@ -506,7 +514,6 @@ describe('AwsInvokeLocal', () => {
         },
       };
 
-      serverless.cli = new CLI(serverless);
       sinon.stub(serverless.cli, 'consoleLog');
     });
 
@@ -596,8 +603,8 @@ describe('AwsInvokeLocal', () => {
     beforeEach(() => {
       fse.mkdirsSync(bridgePath);
       callJavaBridgeStub = sinon.stub(awsInvokeLocal, 'callJavaBridge').resolves();
+      awsInvokeLocal.provider.options.stage = 'dev';
       awsInvokeLocal.options = {
-        stage: 'dev',
         function: 'first',
         functionObj: {
           handler: 'handler.hello',
@@ -660,7 +667,7 @@ describe('AwsInvokeLocal', () => {
 
         const AwsInvokeLocalMocked = require('./index'); // eslint-disable-line global-require
 
-        serverless.setProvider('aws', new AwsProvider(serverless));
+        serverless.setProvider('aws', new AwsProvider(serverless, options));
         awsInvokeLocalMocked = new AwsInvokeLocalMocked(serverless, options);
         callJavaBridgeMockedStub = sinon.stub(awsInvokeLocalMocked, 'callJavaBridge').resolves();
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -563,10 +563,7 @@ describe('AwsInvokeLocal', () => {
 
       const AwsInvokeLocalMocked = require('./index'); // eslint-disable-line global-require
 
-      serverless.setProvider('aws', new AwsProvider(serverless));
-      awsInvokeLocalMocked = new AwsInvokeLocalMocked(serverless, options);
-
-      awsInvokeLocalMocked.options = {
+      options = {
         stage: 'dev',
         function: 'first',
         functionObj: {
@@ -576,6 +573,10 @@ describe('AwsInvokeLocal', () => {
         },
         data: {},
       };
+      serverless.setProvider('aws', new AwsProvider(serverless, options));
+      awsInvokeLocalMocked = new AwsInvokeLocalMocked(serverless, options);
+
+      awsInvokeLocalMocked.options = options;
     });
 
     afterEach(() => {

--- a/lib/plugins/aws/lib/monitorStack.test.js
+++ b/lib/plugins/aws/lib/monitorStack.test.js
@@ -12,13 +12,14 @@ describe('monitorStack', () => {
   const awsPlugin = {};
 
   beforeEach(() => {
-    awsPlugin.serverless = serverless;
-    awsPlugin.provider = new AwsProvider(serverless);
-    awsPlugin.serverless.cli = new CLI(serverless);
-    awsPlugin.options = {
+    const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    awsPlugin.serverless = serverless;
+    awsPlugin.provider = new AwsProvider(serverless, options);
+    awsPlugin.serverless.cli = new CLI(serverless);
+    awsPlugin.options = options;
 
     Object.assign(awsPlugin, monitorStack);
   });

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -96,7 +96,8 @@ describe('#naming()', () => {
   describe('#getStackName()', () => {
     it('should use the service name and stage from the service and config', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getStackName()).to.equal(`${serverless.service.service}-${options.stage}`);
+      expect(sdk.naming.getStackName()).to.equal(`${serverless.service.service}-${
+        sdk.naming.provider.getStage()}`);
     });
   });
 
@@ -114,8 +115,8 @@ describe('#naming()', () => {
           '-',
           [
             serverless.service.service,
-            options.stage,
-            options.region,
+            sdk.naming.provider.getStage(),
+            sdk.naming.provider.getRegion(),
             'lambdaRole',
           ],
         ],
@@ -136,7 +137,7 @@ describe('#naming()', () => {
         'Fn::Join': [
           '-',
           [
-            options.stage,
+            sdk.naming.provider.getStage(),
             serverless.service.service,
             'lambda',
           ],
@@ -216,7 +217,7 @@ describe('#naming()', () => {
     it('should return the composition of stage and service name', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getApiGatewayName())
-        .to.equal(`${options.stage}-${serverless.service.service}`);
+        .to.equal(`${sdk.naming.provider.getStage()}-${serverless.service.service}`);
     });
   });
 

--- a/lib/plugins/aws/lib/setBucketName.js
+++ b/lib/plugins/aws/lib/setBucketName.js
@@ -8,7 +8,7 @@ module.exports = {
       return BbPromise.resolve(this.bucketName);
     }
 
-    return this.provider.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
+    return this.provider.getServerlessDeploymentBucketName()
       .then((bucketName) => {
         this.bucketName = bucketName;
       });

--- a/lib/plugins/aws/lib/setBucketName.test.js
+++ b/lib/plugins/aws/lib/setBucketName.test.js
@@ -30,10 +30,7 @@ describe('#setBucketName()', () => {
     .setBucketName().then(() => {
       expect(awsDeploy.bucketName).to.equal('bucket-name');
       expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-      expect(getServerlessDeploymentBucketNameStub.calledWithExactly(
-        awsDeploy.options.stage,
-        awsDeploy.options.region
-      )).to.be.equal(true);
+      expect(getServerlessDeploymentBucketNameStub.calledWithExactly()).to.be.equal(true);
       awsDeploy.provider.getServerlessDeploymentBucketName.restore();
     })
   );

--- a/lib/plugins/aws/lib/setBucketName.test.js
+++ b/lib/plugins/aws/lib/setBucketName.test.js
@@ -14,11 +14,11 @@ describe('#setBucketName()', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.config.servicePath = 'foo';
-    serverless.setProvider('aws', new AwsProvider(serverless));
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);
 
     getServerlessDeploymentBucketNameStub = sinon

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -11,7 +11,7 @@ module.exports = {
     this.serverless.cli.log('Creating Stack...');
 
     const stackName = this.provider.naming.getStackName();
-    let stackTags = { STAGE: this.options.stage };
+    let stackTags = { STAGE: this.provider.getStage() };
     const compiledTemplateFileName = 'compiled-cloudformation-template.json';
     const templateUrl = `https://s3.amazonaws.com/${this.bucketName}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`;
 
@@ -48,7 +48,7 @@ module.exports = {
 
     this.serverless.cli.log('Updating Stack...');
     const stackName = this.provider.naming.getStackName();
-    let stackTags = { STAGE: this.options.stage };
+    let stackTags = { STAGE: this.provider.getStage() };
 
     // Merge additional stack tags
     if (typeof this.serverless.service.provider.stackTags === 'object') {

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -13,13 +13,13 @@ describe('updateStack', () => {
   const tmpDirPath = testUtils.getTmpDirPath();
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
-    serverless.setProvider('aws', new AwsProvider(serverless));
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.config.servicePath = 'foo';
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);
 
     awsDeploy.deployedFunctions = [{ name: 'first', zipFileKey: 'zipFileOfFirstFunction' }];

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -53,7 +53,7 @@ describe('updateStack', () => {
             Parameters: [],
             TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
               .service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
-            Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
+            Tags: [{ Key: 'STAGE', Value: awsDeploy.provider.getStage() }],
           }
         )).to.be.equal(true);
         awsDeploy.provider.request.restore();
@@ -124,7 +124,7 @@ describe('updateStack', () => {
             Parameters: [],
             TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless
               .service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
-            Tags: [{ Key: 'STAGE', Value: awsDeploy.options.stage }],
+            Tags: [{ Key: 'STAGE', Value: awsDeploy.provider.getStage() }],
           }
         )).to.be.equal(true);
       })

--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -9,12 +9,8 @@ module.exports = {
         .Error('This command can only be run inside a service directory');
     }
 
-    this.options.stage = this.options.stage
-      || (this.serverless.service.provider && this.serverless.service.provider.stage)
-      || 'dev';
-    this.options.region = this.options.region
-      || (this.serverless.service.provider && this.serverless.service.provider.region)
-      || 'us-east-1';
+    this.options.stage = this.provider.getStage();
+    this.options.region = this.provider.getRegion();
 
     return BbPromise.resolve();
   },

--- a/lib/plugins/aws/lib/validate.test.js
+++ b/lib/plugins/aws/lib/validate.test.js
@@ -1,19 +1,25 @@
 'use strict';
 
 const expect = require('chai').expect;
+
+const AwsProvider = require('../provider/awsProvider');
 const validate = require('../lib/validate');
 const Serverless = require('../../../Serverless');
 
 describe('#validate', () => {
   const serverless = new Serverless();
+  let provider;
   const awsPlugin = {};
 
   beforeEach(() => {
-    awsPlugin.serverless = serverless;
     awsPlugin.options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    provider = new AwsProvider(serverless, awsPlugin.options);
+    awsPlugin.provider = provider;
+    awsPlugin.serverless = serverless;
+    awsPlugin.serverless.setProvider('aws', provider);
 
     awsPlugin.serverless.config.servicePath = true;
 
@@ -35,7 +41,7 @@ describe('#validate', () => {
     it('should default to "dev" if stage is not provided', () => {
       awsPlugin.options.stage = false;
       return awsPlugin.validate().then(() => {
-        expect(awsPlugin.options.stage).to.equal('dev');
+        expect(awsPlugin.provider.getStage()).to.equal('dev');
       });
     });
 
@@ -46,7 +52,7 @@ describe('#validate', () => {
       };
 
       return awsPlugin.validate().then(() => {
-        expect(awsPlugin.options.stage).to.equal('some-stage');
+        expect(awsPlugin.provider.getStage()).to.equal('some-stage');
       });
     });
 

--- a/lib/plugins/aws/logs/index.test.js
+++ b/lib/plugins/aws/logs/index.test.js
@@ -17,7 +17,7 @@ describe('AwsLogs', () => {
       function: 'first',
     };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsLogs = new AwsLogs(serverless, options);
   });
 

--- a/lib/plugins/aws/metrics/awsMetrics.test.js
+++ b/lib/plugins/aws/metrics/awsMetrics.test.js
@@ -16,11 +16,11 @@ describe('AwsMetrics', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.cli = new CLI(serverless);
-    serverless.setProvider('aws', new AwsProvider(serverless));
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsMetrics = new AwsMetrics(serverless, options);
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -30,7 +30,7 @@ describe('AwsCompileApigEvents', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -28,7 +28,7 @@ module.exports = {
               Name: apiKey,
               StageKeys: [{
                 RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
-                StageName: this.options.stage,
+                StageName: this.provider.getStage(),
               }],
             },
             DependsOn: this.apiGatewayDeploymentLogicalId,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
@@ -10,8 +10,12 @@ describe('#compileApiKeys()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider = {
       name: 'aws',
@@ -20,10 +24,6 @@ describe('#compileApiKeys()', () => {
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
       Outputs: {},
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -10,8 +10,12 @@ describe('#compileCors()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.service.environment = {
@@ -27,10 +31,6 @@ describe('#compileCors()', () => {
           },
         },
       },
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
@@ -13,7 +13,7 @@ module.exports = {
         Type: 'AWS::ApiGateway::Deployment',
         Properties: {
           RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
-          StageName: this.options.stage,
+          StageName: this.provider.getStage(),
         },
         DependsOn: this.apiGatewayMethodLogicalIds,
       },
@@ -28,7 +28,11 @@ module.exports = {
             [
               'https://',
               { Ref: this.apiGatewayRestApiLogicalId },
-              `.execute-api.${this.options.region}.amazonaws.com/${this.options.stage}`,
+              `.execute-api.${
+                this.provider.getRegion()
+              }.amazonaws.com/${
+                this.provider.getStage()
+              }`,
             ],
           ],
         },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
@@ -7,22 +7,25 @@ const AwsProvider = require('../../../../../provider/awsProvider');
 
 describe('#compileDeployment()', () => {
   let serverless;
+  let provider;
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-      Outputs: {},
-    };
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    provider = new AwsProvider(serverless, options);
+    serverless.setProvider('aws', provider);
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+      Outputs: {},
+    };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayMethodLogicalIds = ['method-dependency1', 'method-dependency2'];
+    awsCompileApigEvents.provider = provider;
   });
 
   it('should create a deployment resource', () => awsCompileApigEvents

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.js
@@ -9,7 +9,7 @@ module.exports = {
 
     if (apiKeys && apiKeys.length) {
       this.serverless.cli.log('Removing usage plan association...');
-      const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+      const stackName = `${this.serverless.service.service}-${this.provider.getStage()}`;
       return BbPromise.all([
         this.provider.request('CloudFormation',
           'describeStackResource',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/disassociateUsagePlan.test.js
@@ -22,7 +22,7 @@ describe('#disassociateUsagePlan()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    awsProvider = new AwsProvider(serverless);
+    awsProvider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', awsProvider);
     providerRequestStub = sinon.stub(awsProvider, 'request');
 
@@ -69,7 +69,7 @@ describe('#disassociateUsagePlan()', () => {
         'CloudFormation',
         'describeStackResource',
         {
-          StackName: `${serverless.service.service}-${options.stage}`,
+          StackName: `${serverless.service.service}-${awsProvider.getStage()}`,
           LogicalResourceId: 'ApiGatewayRestApi',
         }
       )).to.be.equal(true);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -10,8 +10,12 @@ describe('#compileMethods()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.service.environment = {
@@ -27,10 +31,6 @@ describe('#compileMethods()', () => {
           },
         },
       },
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.validated = {};

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -26,13 +26,13 @@ describe('#compileRestApi()', () => {
   };
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.serverless.service.service = 'new-service';
     awsCompileApigEvents.serverless.service.functions = {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -17,12 +17,13 @@ module.exports = {
                 ApiId: {
                   Ref: this.apiGatewayRestApiLogicalId,
                 },
-                Stage: this.options.stage,
+                Stage: this.provider.getStage(),
               },
             ],
-            Description:
-              `Usage plan for ${this.serverless.service.service} ${this.options.stage} stage`,
-            UsagePlanName: `${this.serverless.service.service}-${this.options.stage}`,
+            Description: `Usage plan for ${this.serverless.service.service} ${
+              this.provider.getStage()} stage`,
+            UsagePlanName: `${this.serverless.service.service}-${
+              this.provider.getStage()}`,
           },
         },
       });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -10,8 +10,12 @@ describe('#compileUsagePlan()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider = {
       name: 'aws',
@@ -31,10 +35,6 @@ describe('#compileUsagePlan()', () => {
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
       Outputs: {},
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
@@ -10,8 +10,12 @@ describe('#compileUsagePlanKeys()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider = {
       name: 'aws',
@@ -20,10 +24,6 @@ describe('#compileUsagePlanKeys()', () => {
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
       Outputs: {},
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -11,12 +11,12 @@ describe('#validate()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
   });
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -24,7 +24,7 @@ describe('AwsCompileFunctions', () => {
       region: 'us-east-1',
     };
     serverless = new Serverless(options);
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileFunctions = new AwsCompileFunctions(serverless, options);
     awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},

--- a/lib/plugins/aws/package/index.test.js
+++ b/lib/plugins/aws/package/index.test.js
@@ -19,7 +19,7 @@ describe('AwsPackage', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.config.servicePath = 'foo';
     serverless.cli = new CLI(serverless);
     awsPackage = new AwsPackage(serverless, options);

--- a/lib/plugins/aws/package/lib/generateArtifactDirectoryName.js
+++ b/lib/plugins/aws/package/lib/generateArtifactDirectoryName.js
@@ -5,7 +5,7 @@ const BbPromise = require('bluebird');
 module.exports = {
   generateArtifactDirectoryName() {
     const date = new Date();
-    const serviceStage = `${this.serverless.service.service}/${this.options.stage}`;
+    const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
     const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
     this.serverless.service.package
       .artifactDirectoryName = `serverless/${serviceStage}/${dateString}`;

--- a/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
+++ b/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
@@ -15,7 +15,7 @@ describe('#generateArtifactDirectoryName()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
     awsPackage.serverless.cli = new serverless.classes.CLI();
   });

--- a/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
+++ b/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const AwsPackage = require('../index');
+const AwsProvider = require('../../provider/awsProvider');
 const Serverless = require('../../../../Serverless');
 
 describe('#generateArtifactDirectoryName()', () => {
@@ -14,6 +15,7 @@ describe('#generateArtifactDirectoryName()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
+    serverless.setProvider('aws', new AwsProvider(serverless));
     awsPackage = new AwsPackage(serverless, options);
     awsPackage.serverless.cli = new serverless.classes.CLI();
   });

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -79,7 +79,7 @@ describe('#mergeIamTemplates()', () => {
                   'Fn::Join': [
                     '-',
                     [
-                      awsPackage.options.stage,
+                      awsPackage.provider.getStage(),
                       awsPackage.serverless.service.service,
                       'lambda',
                     ],
@@ -121,8 +121,8 @@ describe('#mergeIamTemplates()', () => {
                 '-',
                 [
                   awsPackage.serverless.service.service,
-                  awsPackage.options.stage,
-                  awsPackage.options.region,
+                  awsPackage.provider.getStage(),
+                  awsPackage.provider.getRegion(),
                   'lambdaRole',
                 ],
               ],

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -17,7 +17,7 @@ describe('#mergeIamTemplates()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
     awsPackage.serverless.cli = new serverless.classes.CLI();
     awsPackage.serverless.service.provider.compiledCloudFormationTemplate = {

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
@@ -14,9 +14,10 @@ describe('#saveCompiledTemplate()', () => {
   let writeFileSyncStub;
 
   beforeEach(() => {
+    const options = {};
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsPackage = new AwsPackage(serverless, {});
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    awsPackage = new AwsPackage(serverless, options);
     serverless.config.servicePath = 'my-service';
     serverless.service = {
       provider: {

--- a/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -14,9 +14,10 @@ describe('#saveServiceState()', () => {
   let writeFileSyncStub;
 
   beforeEach(() => {
+    const options = {};
     serverless = new Serverless();
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsPackage = new AwsPackage(serverless, {});
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    awsPackage = new AwsPackage(serverless, options);
     serverless.config.servicePath = 'my-service';
     serverless.service = {
       provider: {

--- a/lib/plugins/aws/remove/index.test.js
+++ b/lib/plugins/aws/remove/index.test.js
@@ -12,7 +12,7 @@ describe('AwsRemove', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
-  serverless.setProvider('aws', new AwsProvider(serverless));
+  serverless.setProvider('aws', new AwsProvider(serverless, options));
   const awsRemove = new AwsRemove(serverless, options);
   awsRemove.serverless.cli = new serverless.classes.CLI();
 

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -4,7 +4,7 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   setServerlessDeploymentBucketName() {
-    return this.provider.getServerlessDeploymentBucketName(this.options.stage, this.options.region)
+    return this.provider.getServerlessDeploymentBucketName()
       .then((bucketName) => {
         this.bucketName = bucketName;
       });
@@ -14,7 +14,7 @@ module.exports = {
     this.objectsInBucket = [];
 
     this.serverless.cli.log('Getting all objects in S3 bucket...');
-    const serviceStage = `${this.serverless.service.service}/${this.options.stage}`;
+    const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
 
     return this.provider.request('S3', 'listObjectsV2', {
       Bucket: this.bucketName,

--- a/lib/plugins/aws/remove/lib/bucket.test.js
+++ b/lib/plugins/aws/remove/lib/bucket.test.js
@@ -7,17 +7,17 @@ const AwsRemove = require('../index');
 const Serverless = require('../../../../Serverless');
 
 describe('emptyS3Bucket', () => {
+  const options = {
+    stage: 'dev',
+    region: 'us-east-1',
+  };
   const serverless = new Serverless();
   serverless.service.service = 'emptyS3Bucket';
-  serverless.setProvider('aws', new AwsProvider(serverless));
+  serverless.setProvider('aws', new AwsProvider(serverless, options));
 
   let awsRemove;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
     awsRemove = new AwsRemove(serverless, options);
     awsRemove.serverless.cli = new serverless.classes.CLI();
   });

--- a/lib/plugins/aws/remove/lib/bucket.test.js
+++ b/lib/plugins/aws/remove/lib/bucket.test.js
@@ -31,10 +31,7 @@ describe('emptyS3Bucket', () => {
       return awsRemove.setServerlessDeploymentBucketName().then(() => {
         expect(awsRemove.bucketName).to.equal('new-service-dev-us-east-1-12345678');
         expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-        expect(getServerlessDeploymentBucketNameStub.calledWithExactly(
-          awsRemove.options.stage,
-          awsRemove.options.region
-        )).to.be.equal(true);
+        expect(getServerlessDeploymentBucketNameStub.calledWithExactly()).to.be.equal(true);
         awsRemove.provider.getServerlessDeploymentBucketName.restore();
       });
     });
@@ -52,7 +49,7 @@ describe('emptyS3Bucket', () => {
           'listObjectsV2',
           {
             Bucket: awsRemove.bucketName,
-            Prefix: `serverless/${serverless.service.service}/${awsRemove.options.stage}`,
+            Prefix: `serverless/${serverless.service.service}/${awsRemove.provider.getStage()}`,
           }
         )).to.be.equal(true);
         expect(awsRemove.objectsInBucket.length).to.equal(0);
@@ -76,7 +73,7 @@ describe('emptyS3Bucket', () => {
           'listObjectsV2',
           {
             Bucket: awsRemove.bucketName,
-            Prefix: `serverless/${serverless.service.service}/${awsRemove.options.stage}`,
+            Prefix: `serverless/${serverless.service.service}/${awsRemove.provider.getStage()}`,
           }
         )).to.be.equal(true);
         expect(awsRemove.objectsInBucket[0]).to.deep.equal({ Key: 'object1' });

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -7,18 +7,18 @@ const AwsRemove = require('../index');
 const Serverless = require('../../../../Serverless');
 
 describe('removeStack', () => {
+  const options = {
+    stage: 'dev',
+    region: 'us-east-1',
+  };
   const serverless = new Serverless();
   serverless.service.service = 'removeStack';
-  serverless.setProvider('aws', new AwsProvider(serverless));
+  serverless.setProvider('aws', new AwsProvider(serverless, options));
 
   let awsRemove;
   let removeStackStub;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
     awsRemove = new AwsRemove(serverless, options);
     awsRemove.serverless.cli = new serverless.classes.CLI();
     removeStackStub = sinon.stub(awsRemove.provider, 'request').resolves();

--- a/lib/plugins/aws/remove/lib/stack.test.js
+++ b/lib/plugins/aws/remove/lib/stack.test.js
@@ -31,7 +31,7 @@ describe('removeStack', () => {
         'CloudFormation',
         'deleteStack',
         {
-          StackName: `${serverless.service.service}-${awsRemove.options.stage}`,
+          StackName: `${serverless.service.service}-${awsRemove.provider.getStage()}`,
         }
       )).to.be.equal(true);
       awsRemove.provider.request.restore();

--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -46,7 +46,7 @@ class AwsRollback {
   setStackToUpdate() {
     const service = this.serverless.service;
     const serviceName = this.serverless.service.service;
-    const stage = this.options.stage;
+    const stage = this.provider.getStage();
     const prefix = `serverless/${serviceName}/${stage}`;
 
     return this.provider.request('S3',

--- a/lib/plugins/aws/rollback/index.test.js
+++ b/lib/plugins/aws/rollback/index.test.js
@@ -12,6 +12,7 @@ describe('AwsRollback', () => {
   let s3Key;
   let spawnStub;
   let serverless;
+  let provider;
 
   beforeEach(() => {
     serverless = new Serverless();
@@ -20,12 +21,13 @@ describe('AwsRollback', () => {
       region: 'us-east-1',
       timestamp: 1476779096930,
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    provider = new AwsProvider(serverless);
+    serverless.setProvider('aws', provider);
     serverless.service.service = 'rollback';
     spawnStub = sinon.stub(serverless.pluginManager, 'spawn');
     awsRollback = new AwsRollback(serverless, options);
     awsRollback.serverless.cli = new serverless.classes.CLI();
-    s3Key = `serverless/${serverless.service.service}/${options.stage}`;
+    s3Key = `serverless/${serverless.service.service}/${provider.getStage()}`;
   });
 
   afterEach(() => {

--- a/lib/plugins/aws/rollback/index.test.js
+++ b/lib/plugins/aws/rollback/index.test.js
@@ -21,7 +21,7 @@ describe('AwsRollback', () => {
       region: 'us-east-1',
       timestamp: 1476779096930,
     };
-    provider = new AwsProvider(serverless);
+    provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'rollback';
     spawnStub = sinon.stub(serverless.pluginManager, 'spawn');

--- a/lib/plugins/aws/rollbackFunction/index.test.js
+++ b/lib/plugins/aws/rollbackFunction/index.test.js
@@ -32,7 +32,7 @@ describe('AwsRollbackFunction', () => {
       region: 'us-east-1',
       function: 'hello',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.cli = new CLI(serverless);
     awsRollbackFunction = new AwsRollbackFunction(serverless, options);
     consoleLogStub = sinon.stub(serverless.cli, 'consoleLog').returns();

--- a/lib/plugins/platform/platform.js
+++ b/lib/plugins/platform/platform.js
@@ -32,14 +32,13 @@ function addReadme(attributes, readmePath) {
   return attributes;
 }
 
-function fetchEndpoint(provider, stage, region) {
+function fetchEndpoint(provider) {
   return provider
     .request(
       'CloudFormation',
       'describeStacks',
-      { StackName: provider.naming.getStackName(stage) },
-      stage,
-      region
+      { StackName: provider.naming.getStackName() },
+      { useCache: true }   // Use request cache
     )
     .then(result => {
       let endpoint = null;
@@ -134,11 +133,10 @@ class Platform {
 
     const clientWithAuth = createApolloClient(config.GRAPHQL_ENDPOINT_URL, authToken);
 
-    const region = this.serverless.service.provider.region;
-    const stage = this.serverless.processedInput.options.stage;
+    const region = this.provider.getRegion();
 
     return this.provider.getAccountId().then(accountId =>
-      fetchEndpoint(this.provider, stage, region).then(endpoint => {
+      fetchEndpoint(this.provider).then(endpoint => {
         const funcs = this.serverless.service.getAllFunctions().map(key => {
           const arnName = functionInfoUtils.aws.getArnName(key, this.serverless);
           let funcAttributes = {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:


Centralize throughout the codebase to using the `aws` provider's `getStage` and `getRegion` methods.

Remove the errant (but understandable) distributed usage of region and stage settings.  This otherwise locks in a multitude of bugs around the improper algorithm for selecting (given all context) the proper region or stage setting.  Instead, all code should use the centralized algorithm for determining such values.  This creates a strange first and second class configuration concept but these two are sufficiently varied and complex in their creation and use that this seems appropriate.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Centralize throughout the codebase to using the `aws` provider's `getStage` and `getRegion` methods.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

verify by noting the tests continue to pass.

is there something more extensive than the unit tests that I should run in the future to verify across the cli interactions or the like?

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
