### PR TITLE
Added a `--template-path` option to `serverless create`

### DIFF
--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -33,8 +33,9 @@ serverless create --template-url https://github.com/serverless/serverless/tree/m
 ```
 
 ## Options
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -89,6 +90,14 @@ will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be
 renamed to `my-new-service`.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.
 
 ### Creating a new plugin
 

--- a/docs/providers/azure/cli-reference/create.md
+++ b/docs/providers/azure/cli-reference/create.md
@@ -28,8 +28,9 @@ serverless create --template azure-nodejs --path myService
 ```
 
 ## Options
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -69,6 +70,14 @@ Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you
 provide. In this example the service will be renamed to `my-new-service`.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.
 
 ### Create service in new folder using a custom template
 

--- a/docs/providers/google/cli-reference/create.md
+++ b/docs/providers/google/cli-reference/create.md
@@ -28,8 +28,9 @@ serverless create --template google-nodejs --path my-service
 
 ## Options
 
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -60,6 +61,14 @@ serverless create --template google-nodejs --path my-new-service
 This example will generate scaffolding for a service with `google` as a provider and `nodejs` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.
 
 ### Create service in new folder using a custom template
 

--- a/docs/providers/kubeless/cli-reference/create.md
+++ b/docs/providers/kubeless/cli-reference/create.md
@@ -35,8 +35,9 @@ serverless create --template kubeless-nodejs --path my-service
 ```
 
 ## Options
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -73,3 +74,11 @@ serverless create --template kubeless-python --path my-new-service
 This example will generate scaffolding for a service with `kubeless` as a provider and `python2.7` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.

--- a/docs/providers/openwhisk/cli-reference/create.md
+++ b/docs/providers/openwhisk/cli-reference/create.md
@@ -27,8 +27,9 @@ serverless create --template openwhisk-nodejs --path myService
 ```
 
 ## Options
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -68,6 +69,14 @@ serverless create --template openwhisk-nodejs --path my-new-service
 This example will generate scaffolding for a service with `openwhisk` as a provider and `nodejs` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.
 
 ### Create service in new folder using a custom template
 

--- a/docs/providers/spotinst/cli-reference/create.md
+++ b/docs/providers/spotinst/cli-reference/create.md
@@ -27,8 +27,9 @@ serverless create -t spotinst-nodejs -p myService
 ```
 
 ## Options
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -70,3 +71,11 @@ serverless create -t spotinst-nodejs -p my-new-service
 This example will generate scaffolding for a service with `Spotinst` as a provider and `ruby` as runtime. The scaffolding
 will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless
 will use the already present directory.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.

--- a/docs/providers/webtasks/cli-reference/create.md
+++ b/docs/providers/webtasks/cli-reference/create.md
@@ -28,8 +28,9 @@ serverless create --template webtasks-nodejs --path my-service
 
 ## Options
 
-- `--template` or `-t` The name of one of the available templates. **Required if --template-url is not present**.
-- `--template-url` or `-u` The name of one of the available templates. **Required if --template is not present**.
+- `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
+- `--template-url` or `-u` The name of one of the available templates. **Required if --template and --template-path are not present**.
+- `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
 - `--path` or `-p` The path where the service should be created.
 - `--name` or `-n` the name of the service in `serverless.yml`.
 
@@ -60,3 +61,11 @@ serverless create --template webtasks-nodejs --path my-new-service
 This example will generate scaffolding for a service with `webtasks` as a provider. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
+
+### Creating a new service using a local template
+
+```bash
+serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+```
+
+This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -131,8 +131,8 @@ class Create {
       }
     } else {
       const errorMessage = [
-        'You must either pass a template name (--template) or a ',
-        'a URL (--template-url).',
+        'You must either pass a template name (--template), ',
+        'a URL (--template-url) or a local path (--template-path).',
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -5,8 +5,12 @@ const path = require('path');
 const fse = require('fs-extra');
 const _ = require('lodash');
 
+const ServerlessError = require('../../classes/Error').ServerlessError;
 const userStats = require('../../utils/userStats');
 const download = require('../../utils/downloadTemplateFromRepo');
+const renameService = require('../../utils/renameService').renameService;
+const copyDirContentsSync = require('../../utils/fs/copyDirContentsSync');
+const dirExistsSync = require('../../utils/fs/dirExistsSync');
 
 // class wide constants
 const validTemplates = [
@@ -66,6 +70,9 @@ class Create {
             usage: 'Template URL for the service. Supports: GitHub, BitBucket',
             shortcut: 'u',
           },
+          'template-path': {
+            usage: 'Template local path for the service.',
+          },
           path: {
             usage: 'The path where the service should be created (e.g. --path my-service)',
             shortcut: 'p',
@@ -111,6 +118,17 @@ class Create {
         .catch(err => {
           throw new this.serverless.classes.Error(err);
         });
+    } else if ('template-path' in this.options) {
+      // Copying template from a local directory
+      const servicePath = this.options.path || path.join(process.cwd(), this.options.name);
+      if (dirExistsSync(servicePath)) {
+        const errorMessage = `A folder named "${servicePath}" already exists.`;
+        throw new ServerlessError(errorMessage);
+      }
+      copyDirContentsSync(this.options['template-path'], servicePath);
+      if (this.options.name) {
+        renameService(this.options.name, servicePath);
+      }
     } else {
       const errorMessage = [
         'You must either pass a template name (--template) or a ',

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -125,7 +125,9 @@ class Create {
         const errorMessage = `A folder named "${servicePath}" already exists.`;
         throw new ServerlessError(errorMessage);
       }
-      copyDirContentsSync(this.options['template-path'], servicePath);
+      copyDirContentsSync(this.options['template-path'], servicePath, {
+        noLinks: true,
+      });
       if (this.options.name) {
         renameService(this.options.name, servicePath);
       }

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -680,6 +680,12 @@ describe('Create', () => {
         expect(dirContent).to.include('serverless.yml');
         expect(dirContent).to.include('handler.js');
         expect(dirContent).to.include('gitignore');
+
+        // check if the service was renamed
+        const serverlessYmlfileContent = fse
+          .readFileSync(path.join(distDir, 'serverless.yml')).toString();
+
+        expect((/service: aws-nodejs/).test(serverlessYmlfileContent)).to.equal(true);
       });
     });
 
@@ -695,6 +701,12 @@ describe('Create', () => {
         expect(dirContent).to.include('serverless.yml');
         expect(dirContent).to.include('handler.js');
         expect(dirContent).to.include('gitignore');
+
+        // check if the service was renamed
+        const serverlessYmlfileContent = fse
+          .readFileSync(path.join(tmpDir, 'my-awesome-service', 'serverless.yml')).toString();
+
+        expect((/service: my-awesome-service/).test(serverlessYmlfileContent)).to.equal(true);
       });
     });
   });

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -666,5 +666,36 @@ describe('Create', () => {
 
       return create.create().catch(() => download.downloadTemplateFromRepo.restore());
     });
+
+    it('should copy "aws-nodejs" template from local path', () => {
+      process.chdir(tmpDir);
+      const distDir = path.join(tmpDir, 'my-awesome-service');
+      create.options = {};
+      create.options.path = distDir;
+      create.options['template-path'] = path.join(__dirname, 'templates/aws-nodejs');
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(distDir);
+
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('handler.js');
+        expect(dirContent).to.include('gitignore');
+      });
+    });
+
+    it('should copy "aws-nodejs" template from local path with a custom name', () => {
+      process.chdir(tmpDir);
+      create.options = {};
+      create.options['template-path'] = path.join(__dirname, 'templates/aws-nodejs');
+      create.options.name = 'my-awesome-service';
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(path.join(tmpDir, 'my-awesome-service'));
+
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('handler.js');
+        expect(dirContent).to.include('gitignore');
+      });
+    });
   });
 });

--- a/lib/utils/fs/copyDirContentsSync.js
+++ b/lib/utils/fs/copyDirContentsSync.js
@@ -4,8 +4,8 @@ const path = require('path');
 const fse = require('./fse');
 const walkDirSync = require('./walkDirSync');
 
-function fileExists(srcDir, destDir) {
-  const fullFilesPaths = walkDirSync(srcDir);
+function fileExists(srcDir, destDir, options) {
+  const fullFilesPaths = walkDirSync(srcDir, options);
 
   fullFilesPaths.forEach(fullFilePath => {
     const relativeFilePath = fullFilePath.replace(srcDir, '');

--- a/lib/utils/fs/walkDirSync.js
+++ b/lib/utils/fs/walkDirSync.js
@@ -3,15 +3,21 @@
 const path = require('path');
 const fs = require('fs');
 
-function walkDirSync(dirPath) {
+function walkDirSync(dirPath, opts) {
+  const options = Object.assign({
+    noLinks: false,
+  }, opts);
   let filePaths = [];
   const list = fs.readdirSync(dirPath);
   list.forEach((filePathParam) => {
     let filePath = filePathParam;
     filePath = path.join(dirPath, filePath);
-    const stat = fs.lstatSync(filePath);
-    if (stat && stat.isDirectory()) {
-      filePaths = filePaths.concat(walkDirSync(filePath));
+    const stat = options.noLinks ? fs.lstatSync(filePath) : fs.statSync(filePath);
+    // skipping symbolic links when noLinks option
+    if (options.noLinks && stat && stat.isSymbolicLink()) {
+      return;
+    } else if (stat && stat.isDirectory()) {
+      filePaths = filePaths.concat(walkDirSync(filePath, opts));
     } else {
       filePaths.push(filePath);
     }

--- a/lib/utils/fs/walkDirSync.js
+++ b/lib/utils/fs/walkDirSync.js
@@ -9,7 +9,7 @@ function walkDirSync(dirPath) {
   list.forEach((filePathParam) => {
     let filePath = filePathParam;
     filePath = path.join(dirPath, filePath);
-    const stat = fs.statSync(filePath);
+    const stat = fs.lstatSync(filePath);
     if (stat && stat.isDirectory()) {
       filePaths = filePaths.concat(walkDirSync(filePath));
     } else {

--- a/lib/utils/fs/walkDirSync.test.js
+++ b/lib/utils/fs/walkDirSync.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const expect = require('chai').expect;
 const testUtils = require('../../../tests/utils');
@@ -27,5 +28,22 @@ describe('#walkDirSync()', () => {
     expect(filePaths).to.include(tmpFilePath1);
     expect(filePaths).to.include(tmpFilePath2);
     expect(filePaths).to.include(tmpFilePath3);
+  });
+
+  it('should check noLinks option', () => {
+    const tmpDirPath = testUtils.getTmpDirPath();
+
+    const realFile = path.join(tmpDirPath, 'real');
+    writeFileSync(realFile, 'content');
+
+    const symLink = path.join(tmpDirPath, 'sym');
+    fs.symlinkSync(realFile, symLink);
+
+    const filePaths = walkDirSync(tmpDirPath, {
+      noLinks: true,
+    });
+
+    expect(filePaths).to.include(realFile);
+    expect(filePaths).not.to.include(symLink);
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #4566

Added a `--template-path` option for `serverless create`
The use case is to copy a template from a local directory (for instance a monorepo). This has 2 advantages:
- avoid to create a special repo for the template if you don't need it, or prefer it to be in your monorepo
- bypass the fact that we can't download a template from a private repo

## How did you implement it:

When `--template-url` is passed, do not download but copy a local folder to the local destination

## How can we verify it:
You can try to copy a template that you have locally in serverless repo:
```
cd path/to/serverless
serverless create --template-path lib/plugins/create/templates/aws-nodejs --path destination/path
serverless create --template-path lib/plugins/create/templates/aws-nodejs --path destination/path --name my-awesome-service
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
