### PR TITLE
Completion fixes

### DIFF
--- a/lib/utils/autocomplete.js
+++ b/lib/utils/autocomplete.js
@@ -12,7 +12,7 @@ const name = path.basename(process.argv[0]);
 
 const tab = require('tabtab')({ name });
 
-const getSugestions = (commands) => {
+const getSuggestions = (commands) => {
   tab.on(name, (data, done) => {
     if (data.words === 1) {
       done(null, Object.keys(commands));
@@ -58,7 +58,7 @@ const autocomplete = () => {
           if (!cacheFile || !cacheFileValid(serverlessConfigFile, cacheFile.validationHash)) {
             return;
           }
-          return getSugestions(cacheFile.commands); // eslint-disable-line consistent-return
+          return getSuggestions(cacheFile.commands); // eslint-disable-line consistent-return
         });
     });
 };

--- a/lib/utils/autocomplete.js
+++ b/lib/utils/autocomplete.js
@@ -14,7 +14,11 @@ const tab = require('tabtab')({ name });
 
 const getSugestions = (commands) => {
   tab.on(name, (data, done) => {
-    done(null, Object.keys(commands));
+    if (data.words === 1) {
+      done(null, Object.keys(commands));
+    } else {
+      done(null, []);
+    }
   });
 
   Object.keys(commands).forEach(command => {

--- a/lib/utils/autocomplete.js
+++ b/lib/utils/autocomplete.js
@@ -1,25 +1,19 @@
 'use strict';
 
+const path = require('path');
+
 const Serverless = require('../Serverless');
 const crypto = require('crypto');
 
 const getCacheFile = require('./getCacheFile');
 const getServerlessConfigFile = require('./getServerlessConfigFile');
 
-const tab = require('tabtab')({
-  name: 'serverless',
-});
+const name = path.basename(process.argv[0]);
 
-const tabSls = require('tabtab')({
-  name: 'sls',
-});
+const tab = require('tabtab')({ name });
 
 const getSugestions = (commands) => {
-  tab.on('serverless', (data, done) => {
-    done(null, Object.keys(commands));
-  });
-
-  tabSls.on('sls', (data, done) => {
+  tab.on(name, (data, done) => {
     done(null, Object.keys(commands));
   });
 
@@ -27,13 +21,9 @@ const getSugestions = (commands) => {
     tab.on(command, (data, done) => {
       done(null, commands[command]);
     });
-    tabSls.on(command, (data, done) => {
-      done(null, commands[command]);
-    });
   });
 
   tab.start();
-  tabSls.start();
 };
 
 const cacheFileValid = (serverlessConfigFile, validationHash) => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3777 
<!--
Briefly describe the feature if no issue exists for this PR
-->
Includes two separate instances of incorrect completion values:
- Duplication of commands (e.g., `create` showing up twice)
- Offering commands as sub-commands (e.g., `create` offered as an option for `serverless install` to produce `serverless install create`)

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
- Two `tabtab` instances were being created previously, one to deal with the `sls` alias, which was causing the issue. The solution here is to get the command name from `process.argv` and use a single `tabtab` instance.
- Because of the way `tabtab` is implemented, the completions for the root command (`serverless`) are applied to all completions by default. This implementation limits that manually.


## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Depending on what you have in your `.bashrc` or `.zshrc`, you may need to manually source the completion file after installing the package:

```sh
# bash
source node_modules/tabtab/.completions/serverless.bash

# zsh
source node_modules/tabtab/.completions/serverless.zsh
```

Also note there is a 5-minute completion cache. Make sure to clear it if you change branches/the code while testing:
```sh
rm node_modules/tabtab/.completions/cache.json
```

On the `master` branch, see the error by invoking the completion function the same way that tabtab does, noting how everything from `run` to `emit` is repeated. This case is specifically for completing `serverless i` where the cursor is immediately after the `i`:
```
$ COMP_CWORD='1' COMP_LINE='serverless i' COMP_POINT='12' serverless completion -- serverless i
run:
config:
create:
install:
package:
deploy:
invoke:
info:
logs:
login:
logout:
metrics:
print:
remove:
rollback:
slstats:
plugin:
emit:
run:
config:
create:
install:
package:
deploy:
invoke:
info:
logs:
login:
logout:
metrics:
print:
remove:
rollback:
slstats:
plugin:
emit:
```

On the PR branch, running the same command produces only one copy of the commands.

For the second issue, attempt to complete after a full command is typed out. This case covers `serverless install ` with the cursor after a space:
```
$ COMP_CWORD='2' COMP_LINE='serverless install ' COMP_POINT='19' serverless completion -- serverless install
--url:
--name:
run:
config:
create:
install:
package:
deploy:
invoke:
info:
logs:
login:
logout:
metrics:
print:
remove:
rollback:
slstats:
plugin:
emit:
```

Note how the command list still populates, despite the fact that only the flags should be valid in this scenario. Running again with the branch will produce the following:
```
$ COMP_CWORD='2' COMP_LINE='serverless install ' COMP_POINT='19' serverless completion -- serverless install
--url:
--name:
```

And a similar test case to prove it works with `sls` after sourcing `sls.zsh`:
```
COMP_CWORD='1' COMP_LINE='sls i' COMP_POINT='5' serverless completion -- sls i
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
