### PR TITLE
Add support of serverless.js configuration file

### DIFF
--- a/docs/providers/aws/guide/intro.md
+++ b/docs/providers/aws/guide/intro.md
@@ -58,7 +58,7 @@ The Serverless Framework not only deploys your Functions and the Events that tri
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/azure/guide/intro.md
+++ b/docs/providers/azure/guide/intro.md
@@ -64,7 +64,7 @@ A **Service** is the Framework's unit of organization. You can think of it as a
 project file, though you can have multiple services for a single application.
 It's where you define your Functions, the Events that trigger them, and the
 Resources your Functions use, all in one file entitled `serverless.yml` (or
-`serverless.json`). It looks like this:
+`serverless.json` or `serverless.js`). It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/google/guide/intro.md
+++ b/docs/providers/google/guide/intro.md
@@ -46,7 +46,7 @@ When you define an event for your Google Cloud Function in the Serverless Framew
 
 ### Services
 
-A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`). It looks like this:
+A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`). It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/kubeless/guide/intro.md
+++ b/docs/providers/kubeless/guide/intro.md
@@ -42,7 +42,7 @@ Anything that triggers an Kubeless Event to execute is regarded by the Framework
 
 ### Services
 
-A **Service** is the Serverless Framework's unit of organization (not to be confused with [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/).  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions and the Events that trigger them, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
+A **Service** is the Serverless Framework's unit of organization (not to be confused with [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/).  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions and the Events that trigger them, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/openwhisk/guide/intro.md
+++ b/docs/providers/openwhisk/guide/intro.md
@@ -47,7 +47,7 @@ When you define an event for your Apache OpenWhisk Action in the Serverless Fram
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/spotinst/guide/intro.md
+++ b/docs/providers/spotinst/guide/intro.md
@@ -73,7 +73,7 @@ module.exports.main = function main (event, context, callback) {
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json`).  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 

--- a/docs/providers/webtasks/guide/intro.md
+++ b/docs/providers/webtasks/guide/intro.md
@@ -24,7 +24,7 @@ Here are the Framework's main concepts and how they pertain to Auth0 Webtasks...
 
 A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  
 
-The Auth0 Webtasks platform was designed to be simple and easy to use with minimal configuration. Therefore, services that uses Auth0 Webtasks are just a few lines of configuration in a single file, entitled `serverless.yml` (or `serverless.json`). It looks like this:
+The Auth0 Webtasks platform was designed to be simple and easy to use with minimal configuration. Therefore, services that uses Auth0 Webtasks are just a few lines of configuration in a single file, entitled `serverless.yml` (or `serverless.json` or `serverless.js`). It looks like this:
 
 ```yml
 # serverless.yml

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -46,6 +46,7 @@ class Service {
       'serverless.yaml',
       'serverless.yml',
       'serverless.json',
+      'serverless.js',
     ];
 
     const serviceFilePaths = _.map(serviceFilenames, filename => path.join(servicePath, filename));
@@ -61,65 +62,77 @@ class Service {
       serviceFilenames[serviceFileIndex] :
       _.first(serviceFilenames);
 
-    return that.serverless.yamlParser
-      .parse(serviceFilePath)
-      .then((serverlessFileParam) => {
-        const serverlessFile = serverlessFileParam;
-        // basic service level validation
-        const version = this.serverless.utils.getVersion();
-        const ymlVersion = serverlessFile.frameworkVersion;
-        if (ymlVersion && !semver.satisfies(version, ymlVersion)) {
-          const errorMessage = [
-            `The Serverless version (${version}) does not satisfy the`,
-            ` "frameworkVersion" (${ymlVersion}) in ${serviceFilename}`,
-          ].join('');
-          throw new ServerlessError(errorMessage);
-        }
-        if (!serverlessFile.service) {
-          throw new ServerlessError(`"service" property is missing in ${serviceFilename}`);
-        }
-        if (_.isObject(serverlessFile.service) && !serverlessFile.service.name) {
-          throw new ServerlessError(`"service" is missing the "name" property in ${serviceFilename}`);   // eslint-disable-line max-len
-        }
-        if (!serverlessFile.provider) {
-          throw new ServerlessError(`"provider" property is missing in ${serviceFilename}`);
-        }
-
-        if (typeof serverlessFile.provider !== 'object') {
-          const providerName = serverlessFile.provider;
-          serverlessFile.provider = {
-            name: providerName,
-          };
-        }
-
-        if (_.isObject(serverlessFile.service)) {
-          that.serviceObject = serverlessFile.service;
-          that.service = serverlessFile.service.name;
-        } else {
-          that.serviceObject = { name: serverlessFile.service };
-          that.service = serverlessFile.service;
-        }
-
-        that.custom = serverlessFile.custom;
-        that.plugins = serverlessFile.plugins;
-        that.resources = serverlessFile.resources;
-        that.functions = serverlessFile.functions || {};
-
-        // merge so that the default settings are still in place and
-        // won't be overwritten
-        that.provider = _.merge(that.provider, serverlessFile.provider);
-
-        if (serverlessFile.package) {
-          that.package.individually = serverlessFile.package.individually;
-          that.package.path = serverlessFile.package.path;
-          that.package.artifact = serverlessFile.package.artifact;
-          that.package.exclude = serverlessFile.package.exclude;
-          that.package.include = serverlessFile.package.include;
-          that.package.excludeDevDependencies = serverlessFile.package.excludeDevDependencies;
-        }
-
-        return this;
+    if (serviceFilename === 'serverless.js') {
+      return new BbPromise((resolve) => {
+        resolve(that.loadServiceFileParam(serviceFilename, require(serviceFilePath)));
       });
+    } else {
+      return that.serverless.yamlParser
+        .parse(serviceFilePath)
+        .then((serverlessFileParam) => {
+          return that.loadServiceFileParam(serviceFilename, serverlessFileParam);
+        });
+    }
+  }
+
+  loadServiceFileParam(serviceFilename, serverlessFileParam) {
+    const that = this;
+
+    const serverlessFile = serverlessFileParam;
+    // basic service level validation
+    const version = this.serverless.utils.getVersion();
+    const ymlVersion = serverlessFile.frameworkVersion;
+    if (ymlVersion && !semver.satisfies(version, ymlVersion)) {
+      const errorMessage = [
+        `The Serverless version (${version}) does not satisfy the`,
+        ` "frameworkVersion" (${ymlVersion}) in ${serviceFilename}`,
+      ].join('');
+      throw new ServerlessError(errorMessage);
+    }
+    if (!serverlessFile.service) {
+      throw new ServerlessError(`"service" property is missing in ${serviceFilename}`);
+    }
+    if (_.isObject(serverlessFile.service) && !serverlessFile.service.name) {
+      throw new ServerlessError(`"service" is missing the "name" property in ${serviceFilename}`);   // eslint-disable-line max-len
+    }
+    if (!serverlessFile.provider) {
+      throw new ServerlessError(`"provider" property is missing in ${serviceFilename}`);
+    }
+
+    if (typeof serverlessFile.provider !== 'object') {
+      const providerName = serverlessFile.provider;
+      serverlessFile.provider = {
+        name: providerName,
+      };
+    }
+
+    if (_.isObject(serverlessFile.service)) {
+      that.serviceObject = serverlessFile.service;
+      that.service = serverlessFile.service.name;
+    } else {
+      that.serviceObject = { name: serverlessFile.service };
+      that.service = serverlessFile.service;
+    }
+
+    that.custom = serverlessFile.custom;
+    that.plugins = serverlessFile.plugins;
+    that.resources = serverlessFile.resources;
+    that.functions = serverlessFile.functions || {};
+
+    // merge so that the default settings are still in place and
+    // won't be overwritten
+    that.provider = _.merge(that.provider, serverlessFile.provider);
+
+    if (serverlessFile.package) {
+      that.package.individually = serverlessFile.package.individually;
+      that.package.path = serverlessFile.package.path;
+      that.package.artifact = serverlessFile.package.artifact;
+      that.package.exclude = serverlessFile.package.exclude;
+      that.package.include = serverlessFile.package.include;
+      that.package.excludeDevDependencies = serverlessFile.package.excludeDevDependencies;
+    }
+
+    return this;
   }
 
   setFunctionNames(rawOptions) {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -63,10 +63,16 @@ class Service {
       _.first(serviceFilenames);
 
     if (serviceFilename === 'serverless.js') {
-      return new BbPromise((resolve) => {
+      return BbPromise.try(() => {
         // use require to load serverless.js file
         // eslint-disable-next-line global-require
-        resolve(that.loadServiceFileParam(serviceFilename, require(serviceFilePath)));
+        const config = require(serviceFilePath);
+
+        if (!_.isPlainObject(config)) {
+          throw new Error('serverless.js must export plain object');
+        }
+
+        return that.loadServiceFileParam(serviceFilename, config);
       });
     }
 
@@ -101,7 +107,7 @@ class Service {
       throw new ServerlessError(`"provider" property is missing in ${serviceFilename}`);
     }
 
-    if (typeof serverlessFile.provider !== 'object') {
+    if (!_.isObject(serverlessFile.provider)) {
       const providerName = serverlessFile.provider;
       serverlessFile.provider = {
         name: providerName,

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -64,15 +64,17 @@ class Service {
 
     if (serviceFilename === 'serverless.js') {
       return new BbPromise((resolve) => {
+        // use require to load serverless.js file
+        // eslint-disable-next-line global-require
         resolve(that.loadServiceFileParam(serviceFilename, require(serviceFilePath)));
       });
-    } else {
-      return that.serverless.yamlParser
-        .parse(serviceFilePath)
-        .then((serverlessFileParam) => {
-          return that.loadServiceFileParam(serviceFilename, serverlessFileParam);
-        });
     }
+
+    return that.serverless.yamlParser
+      .parse(serviceFilePath)
+      .then((serverlessFileParam) =>
+        that.loadServiceFileParam(serviceFilename, serverlessFileParam)
+      );
   }
 
   loadServiceFileParam(serviceFilename, serverlessFileParam) {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -287,6 +287,61 @@ describe('Service', () => {
       });
     });
 
+    it('should load serverless.js from filesystem', () => {
+      const SUtils = new Utils();
+      const serverlessJSON = {
+        service: 'new-service',
+        provider: {
+          name: 'aws',
+          stage: 'dev',
+          region: 'us-east-1',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
+        },
+        plugins: ['testPlugin'],
+        functions: {
+          functionA: {},
+        },
+        resources: {
+          aws: {
+            resourcesProp: 'value',
+          },
+          azure: {},
+          google: {},
+        },
+        package: {
+          exclude: ['exclude-me'],
+          include: ['include-me'],
+          artifact: 'some/path/foo.zip',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.js'),
+        `module.exports = ${JSON.stringify(serverlessJSON)};`);
+
+      const serverless = new Serverless();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+        );
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
+      });
+    });
+
     it('should load YAML in favor of JSON', () => {
       const SUtils = new Utils();
       const serverlessJSON = {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -342,6 +342,20 @@ describe('Service', () => {
       });
     });
 
+    it('should throw error if serverless.js exports invalid config', () => {
+      const SUtils = new Utils();
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.js'),
+        'module.exports = function config() {};');
+
+      const serverless = new Serverless();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load())
+        .to.be.rejectedWith('serverless.js must export plain object');
+    });
+
     it('should load YAML in favor of JSON', () => {
       const SUtils = new Utils();
       const serverlessJSON = {

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -105,6 +105,8 @@ class Utils {
       servicePath = process.cwd();
     } else if (fileExistsSync(path.join(process.cwd(), 'serverless.json'))) {
       servicePath = process.cwd();
+    } else if (fileExistsSync(path.join(process.cwd(), 'serverless.js'))) {
+      servicePath = process.cwd();
     }
 
     return servicePath;

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -281,6 +281,18 @@ describe('Utils', () => {
       expect(servicePath).to.not.equal(null);
     });
 
+    it('should detect if the CWD is a service directory when using Serverless .js files', () => {
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const tmpFilePath = path.join(tmpDirPath, 'serverless.js');
+
+      serverless.utils.writeFileSync(tmpFilePath, 'foo');
+      process.chdir(tmpDirPath);
+
+      const servicePath = serverless.utils.findServicePath();
+
+      expect(servicePath).to.not.equal(null);
+    });
+
     it('should detect if the CWD is not a service directory', () => {
       // just use the root of the tmpdir because findServicePath will
       // also check parent directories (and may find matching tmp dirs

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -14,6 +14,7 @@ module.exports = {
     'serverless.yml',
     'serverless.yaml',
     'serverless.json',
+    'serverless.js',
     '.serverless/**',
     '.serverless_plugins/**',
   ],

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -82,7 +82,7 @@ describe('#packageService()', () => {
       expect(exclude).to.deep.equal([
         '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log', 'serverless.yml',
-        'serverless.yaml', 'serverless.json',
+        'serverless.yaml', 'serverless.json', 'serverless.js',
         '.serverless/**', '.serverless_plugins/**',
         'dir', 'file.js',
       ]);
@@ -102,7 +102,7 @@ describe('#packageService()', () => {
       expect(exclude).to.deep.equal([
         '.git/**', '.gitignore', '.DS_Store',
         'npm-debug.log', 'serverless.yml',
-        'serverless.yaml', 'serverless.json',
+        'serverless.yaml', 'serverless.json', 'serverless.js',
         '.serverless/**', '.serverless_plugins/**',
         'dir', 'file.js', 'lib', 'other.js',
       ]);

--- a/lib/plugins/plugin/install/install.js
+++ b/lib/plugins/plugin/install/install.js
@@ -114,7 +114,7 @@ class PluginInstall {
           Can't automatically add plugin into "serverless.js" file.
           Please make it manually.
         `);
-        return new BbPromise((resolve) => resolve());
+        return BbPromise.resolve();
       }
 
       if (_.last(_.split(serverlessFilePath, '.')) === 'json') {

--- a/lib/plugins/plugin/install/install.js
+++ b/lib/plugins/plugin/install/install.js
@@ -109,6 +109,14 @@ class PluginInstall {
 
   addPluginToServerlessFile() {
     return this.getServerlessFilePath().then(serverlessFilePath => {
+      if (_.last(_.split(serverlessFilePath, '.')) === 'js') {
+        this.serverless.cli.log(`
+          Can't automatically add plugin into "serverless.js" file.
+          Please make it manually.
+        `);
+        return new BbPromise((resolve) => resolve());
+      }
+
       if (_.last(_.split(serverlessFilePath, '.')) === 'json') {
         return fse.readJsonAsync(serverlessFilePath).then(serverlessFileObj => {
           const newServerlessFileObj = serverlessFileObj;

--- a/lib/plugins/plugin/install/install.test.js
+++ b/lib/plugins/plugin/install/install.test.js
@@ -357,6 +357,21 @@ describe('PluginInstall', () => {
         });
       });
     });
+
+    it('should not modify serverless .js file', () => {
+      const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+      const serverlessJson = {
+        service: 'plugin-service',
+        provider: 'aws',
+      };
+      serverless.utils
+        .writeFileSync(serverlessJsFilePath, serverlessJson);
+      pluginInstall.options.pluginName = 'serverless-plugin-1';
+      return expect(pluginInstall.addPluginToServerlessFile()).to.be.fulfilled.then(() => {
+        expect(serverless.utils.readFileSync(serverlessJsFilePath, 'utf8').plugins)
+          .to.be.undefined;
+      })
+    });
   });
 
   describe('#installPeerDependencies()', () => {

--- a/lib/plugins/plugin/install/install.test.js
+++ b/lib/plugins/plugin/install/install.test.js
@@ -363,14 +363,17 @@ describe('PluginInstall', () => {
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
+        plugins: [],
       };
       serverless.utils
-        .writeFileSync(serverlessJsFilePath, serverlessJson);
+        .writeFileSync(serverlessJsFilePath, `module.exports = ${JSON.stringify(serverlessJson)};`);
       pluginInstall.options.pluginName = 'serverless-plugin-1';
       return expect(pluginInstall.addPluginToServerlessFile()).to.be.fulfilled.then(() => {
-        expect(serverless.utils.readFileSync(serverlessJsFilePath, 'utf8').plugins)
-          .to.be.undefined;
-      })
+        // use require to load serverless.js
+        // eslint-disable-next-line global-require
+        expect(require(serverlessJsFilePath).plugins)
+          .to.be.deep.equal([]);
+      });
     });
   });
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -22,6 +22,7 @@ module.exports = {
     const serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
     const serverlessYamlFilePath = path.join(servicePath, 'serverless.yaml');
     const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+    const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
 
     return fileExists(serverlessYmlFilePath)
     .then(ymlExists => {
@@ -29,7 +30,13 @@ module.exports = {
         return fileExists(serverlessYamlFilePath)
         .then(yamlExists => {
           if (!yamlExists) {
-            return serverlessJsonFilePath;
+            return fileExists(serverlessJsonFilePath).then((jsonExists) => {
+              if (jsonExists) {
+                return serverlessJsonFilePath;
+              } else {
+                return serverlessJsFilePath;
+              }
+            });
           }
           return serverlessYamlFilePath;
         });

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -19,28 +19,31 @@ module.exports = {
 
   getServerlessFilePath() {
     const servicePath = this.serverless.config.servicePath;
-    const serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
-    const serverlessYamlFilePath = path.join(servicePath, 'serverless.yaml');
-    const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
-    const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+    const ymlFilePath = path.join(servicePath, 'serverless.yml');
+    const yamlFilePath = path.join(servicePath, 'serverless.yaml');
+    const jsonFilePath = path.join(servicePath, 'serverless.json');
+    const jsFilePath = path.join(servicePath, 'serverless.js');
 
-    return fileExists(serverlessYmlFilePath)
-    .then(ymlExists => {
-      if (!ymlExists) {
-        return fileExists(serverlessYamlFilePath)
-        .then(yamlExists => {
-          if (!yamlExists) {
-            return fileExists(serverlessJsonFilePath).then((jsonExists) => {
-              if (jsonExists) {
-                return serverlessJsonFilePath;
-              }
-              return serverlessJsFilePath;
-            });
-          }
-          return serverlessYamlFilePath;
-        });
+    return BbPromise.props({
+      json: fileExists(jsonFilePath),
+      yml: fileExists(ymlFilePath),
+      yaml: fileExists(yamlFilePath),
+      js: fileExists(jsFilePath),
+    }).then((exists) => {
+      if (exists.yml) {
+        return ymlFilePath;
+      } else if (exists.yaml) {
+        return yamlFilePath;
+      } else if (exists.json) {
+        return jsonFilePath;
+      } else if (exists.js) {
+        return jsFilePath;
       }
-      return serverlessYmlFilePath;
+      return BbPromise.reject(
+          new this.serverless.classes.Error(
+            'Could not find any serverless service definition file.'
+          )
+        );
     });
   },
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -33,9 +33,8 @@ module.exports = {
             return fileExists(serverlessJsonFilePath).then((jsonExists) => {
               if (jsonExists) {
                 return serverlessJsonFilePath;
-              } else {
-                return serverlessJsFilePath;
               }
+              return serverlessJsFilePath;
             });
           }
           return serverlessYamlFilePath;

--- a/lib/plugins/plugin/lib/utils.test.js
+++ b/lib/plugins/plugin/lib/utils.test.js
@@ -109,6 +109,10 @@ describe('PluginUtils', () => {
         expect(serverlessFilePath).to.equal(serverlessJsFilePath);
       });
     });
+
+    it('should reject if no configuration file exists', () =>
+      expect(pluginUtils.getServerlessFilePath())
+        .to.be.rejectedWith('Could not find any serverless service definition file.'));
   });
 
   describe('#getPlugins()', () => {

--- a/lib/plugins/plugin/lib/utils.test.js
+++ b/lib/plugins/plugin/lib/utils.test.js
@@ -99,6 +99,16 @@ describe('PluginUtils', () => {
         expect(serverlessFilePath).to.equal(serverlessJsonFilePath);
       });
     });
+
+    it('should return the correct serverless file path for a .js file', () => {
+      const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+      fse.ensureFileSync(serverlessJsFilePath);
+
+      return expect(pluginUtils.getServerlessFilePath()).to.be.fulfilled
+      .then(serverlessFilePath => {
+        expect(serverlessFilePath).to.equal(serverlessJsFilePath);
+      });
+    });
   });
 
   describe('#getPlugins()', () => {

--- a/lib/plugins/plugin/uninstall/uninstall.js
+++ b/lib/plugins/plugin/uninstall/uninstall.js
@@ -78,6 +78,14 @@ class PluginUninstall {
 
   removePluginFromServerlessFile() {
     return this.getServerlessFilePath().then(serverlessFilePath => {
+      if (_.last(_.split(serverlessFilePath, '.')) === 'js') {
+        this.serverless.cli.log(`
+          Can't automatically remove plugin from "serverless.js" file.
+          Please make it manually.
+        `);
+        return BbPromise.resolve();
+      }
+
       if (_.last(_.split(serverlessFilePath, '.')) === 'json') {
         return fse.readJsonAsync(serverlessFilePath).then(serverlessFileObj => {
           if (serverlessFileObj.plugins) {

--- a/lib/plugins/plugin/uninstall/uninstall.test.js
+++ b/lib/plugins/plugin/uninstall/uninstall.test.js
@@ -339,6 +339,31 @@ describe('PluginUninstall', () => {
           .to.not.have.property('plugins');
       }));
     });
+
+    it('should not modify serverless .js file', () => {
+      it('should not modify serverless .js file', () => {
+        const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+        const serverlessJson = {
+          service: 'plugin-service',
+          provider: 'aws',
+          plugins: [
+            'serverless-plugin-1',
+            'serverless-plugin-2',
+          ],
+        };
+        serverless.utils.writeFileSync(
+          serverlessJsFilePath,
+          `module.exports = ${JSON.stringify(serverlessJson)};`
+        );
+        pluginUninstall.options.pluginName = 'serverless-plugin-1';
+        return expect(pluginUninstall.removePluginFromServerlessFile()).to.be.fulfilled.then(() => {
+          // use require to load serverless.js
+          // eslint-disable-next-line global-require
+          expect(require(serverlessJsFilePath).plugins)
+            .to.be.deep.equal(serverlessJson.plugins);
+        });
+      });
+    });
   });
 
   describe('#uninstallPeerDependencies()', () => {

--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -25,9 +25,16 @@ const getServerlessConfigFile = _.memoize((servicePath) => {
     } else if (exists.yaml) {
       return readFile(yamlPath);
     } else if (exists.js) {
-      // use require to load serverless.js
-      // eslint-disable-next-line global-require
-      return require(jsPath);
+      return BbPromise.try(() => {
+        // use require to load serverless.js
+        // eslint-disable-next-line global-require
+        const config = require(jsPath);
+
+        if (_.isPlainObject(config)) {
+          return config;
+        }
+        throw new Error('serverless.js must export plain object');
+      });
     }
     return '';
   });

--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -16,7 +16,7 @@ const getServerlessConfigFile = _.memoize((servicePath) => {
     json: fileExists(jsonPath),
     yml: fileExists(ymlPath),
     yaml: fileExists(yamlPath),
-    js: fileExists(jsPath)
+    js: fileExists(jsPath),
   }).then((exists) => {
     if (exists.json) {
       return readFile(jsonPath);
@@ -25,6 +25,8 @@ const getServerlessConfigFile = _.memoize((servicePath) => {
     } else if (exists.yaml) {
       return readFile(yamlPath);
     } else if (exists.js) {
+      // use require to load serverless.js
+      // eslint-disable-next-line global-require
       return require(jsPath);
     }
     return '';

--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -10,11 +10,13 @@ const getServerlessConfigFile = _.memoize((servicePath) => {
   const jsonPath = path.join(servicePath, 'serverless.json');
   const ymlPath = path.join(servicePath, 'serverless.yml');
   const yamlPath = path.join(servicePath, 'serverless.yaml');
+  const jsPath = path.join(servicePath, 'serverless.js');
 
   return BbPromise.props({
     json: fileExists(jsonPath),
     yml: fileExists(ymlPath),
     yaml: fileExists(yamlPath),
+    js: fileExists(jsPath)
   }).then((exists) => {
     if (exists.json) {
       return readFile(jsonPath);
@@ -22,6 +24,8 @@ const getServerlessConfigFile = _.memoize((servicePath) => {
       return readFile(ymlPath);
     } else if (exists.yaml) {
       return readFile(yamlPath);
+    } else if (exists.js) {
+      return require(jsPath);
     }
     return '';
   });

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -18,7 +18,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(randomFilePath, 'some content');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-        expect(result).to.equal('');
+      expect(result).to.equal('');
     });
   });
 
@@ -27,7 +27,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(serverlessFilePath, 'service: my-yml-service');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-        expect(result).to.deep.equal({ service: 'my-yml-service' });
+      expect(result).to.deep.equal({ service: 'my-yml-service' });
     });
   });
 
@@ -36,7 +36,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(serverlessFilePath, 'service: my-yaml-service');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-        expect(result).to.deep.equal({ service: 'my-yaml-service' });
+      expect(result).to.deep.equal({ service: 'my-yaml-service' });
     });
   });
 
@@ -45,7 +45,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(serverlessFilePath, '{ "service": "my-json-service" }');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-        expect(result).to.deep.equal({ service: 'my-json-service' });
+      expect(result).to.deep.equal({ service: 'my-json-service' });
     });
   });
 

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -62,4 +62,15 @@ describe('#getServerlessConfigFile()', () => {
       }
     );
   });
+
+  it('should throw an error, if serverless.js export not a plain object', () => {
+    const serverlessFilePath = path.join(tmpDirPath, 'serverless.js');
+    writeFileSync(
+      serverlessFilePath,
+      'module.exports = function config() {};'
+    );
+
+    return expect(getServerlessConfigFile(tmpDirPath))
+      .to.be.rejectedWith('serverless.js must export plain object');
+  });
 });

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -18,7 +18,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(randomFilePath, 'some content');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-      expect(result).to.equal('');
+        expect(result).to.equal('');
     });
   });
 
@@ -27,7 +27,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(serverlessFilePath, 'service: my-yml-service');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-      expect(result).to.deep.equal({ service: 'my-yml-service' });
+        expect(result).to.deep.equal({ service: 'my-yml-service' });
     });
   });
 
@@ -36,7 +36,7 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(serverlessFilePath, 'service: my-yaml-service');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-      expect(result).to.deep.equal({ service: 'my-yaml-service' });
+        expect(result).to.deep.equal({ service: 'my-yaml-service' });
     });
   });
 
@@ -45,7 +45,21 @@ describe('#getServerlessConfigFile()', () => {
 
     writeFileSync(serverlessFilePath, '{ "service": "my-json-service" }');
     return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then((result) => {
-      expect(result).to.deep.equal({ service: 'my-json-service' });
+        expect(result).to.deep.equal({ service: 'my-json-service' });
     });
+  });
+
+  it('should return the file content if a serverless.js file found', () => {
+    const serverlessFilePath = path.join(tmpDirPath, 'serverless.js');
+    writeFileSync(
+      serverlessFilePath,
+      'module.exports = {"service": "my-json-service"};'
+    );
+
+    return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then(
+      (result) => {
+        expect(result).to.deep.equal({ service: 'my-json-service' });
+      }
+    );
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #3269

## How did you implement it:

Uses require to load js configuration file (expects config exported).
Added exception for plugin install command to log warning instead of modifying existing config file.

## How can we verify it:

Changes are fully covered and tested with on my existing lambdas.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
