### PR TITLE
Fixed S3 Transfer Acceleration bug with custom deployment buckets

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -58,7 +58,12 @@ module.exports = {
         { StackName: stackName }
       )
       .then((data) => {
-        if (this.provider.isS3TransferAccelerationEnabled()) {
+        const shouldCheckStackOutput =
+          // check stack output only if acceleration is requested
+          this.provider.isS3TransferAccelerationEnabled() &&
+          // custom deployment bucket won't generate any output (no check)
+          !this.serverless.service.provider.deploymentBucket;
+        if (shouldCheckStackOutput) {
           const isAlreadyAccelerated = !!_.find(data.Stacks[0].Outputs,
             { OutputKey: 'ServerlessDeploymentBucketAccelerated' });
           if (!isAlreadyAccelerated) {

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -71,7 +71,7 @@ module.exports = {
             this.provider.disableTransferAccelerationForCurrentDeploy();
           }
         }
-        BbPromise.resolve('alreadyCreated');
+        return BbPromise.resolve('alreadyCreated');
       }))
       .catch((e) => {
         if (e.message.indexOf('does not exist') > -1) {

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -87,6 +87,15 @@ describe('createStack', () => {
       });
     });
 
+    it('should throw error if invalid stack name', () => {
+      sandbox.stub(awsDeploy, 'create').resolves();
+      sandbox.stub(awsDeploy.provider, 'request').resolves();
+      awsDeploy.serverless.service.service = 'service-name'.repeat(100);
+
+      return expect(awsDeploy.createStack.bind(awsDeploy))
+        .to.throw(awsDeploy.serverless.classes.Error, /not valid/);
+    });
+
     it('should set the createLater flag and resolve if deployment bucket is provided', () => {
       awsDeploy.serverless.service.provider.deploymentBucket = 'serverless';
       sandbox.stub(awsDeploy.provider, 'request')
@@ -104,7 +113,7 @@ describe('createStack', () => {
 
       sandbox.stub(awsDeploy.provider, 'request').rejects(errorMock);
 
-      const createStub = sinon
+      const createStub = sandbox
         .stub(awsDeploy, 'create').resolves();
 
       return awsDeploy.createStack().catch((e) => {
@@ -121,7 +130,7 @@ describe('createStack', () => {
 
       sandbox.stub(awsDeploy.provider, 'request').rejects(errorMock);
 
-      const createStub = sinon
+      const createStub = sandbox
         .stub(awsDeploy, 'create').resolves();
 
       return awsDeploy.createStack().then(() => {
@@ -147,7 +156,6 @@ describe('createStack', () => {
 
       return awsDeploy.createStack().then(() => {
         expect(disableTransferAccelerationStub.called).to.be.equal(true);
-        sandbox.restore();
       });
     });
 
@@ -170,7 +178,6 @@ describe('createStack', () => {
 
       return awsDeploy.createStack().then(() => {
         expect(disableTransferAccelerationStub.called).to.be.equal(false);
-        sandbox.restore();
       });
     });
   });

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -149,5 +149,27 @@ describe('createStack', () => {
         expect(disableTransferAccelerationStub.called).to.be.equal(true);
       });
     });
+
+    it('should not disable S3 Transfer Acceleration if custom bucket is used', () => {
+      const disableTransferAccelerationStub = sandbox
+        .stub(awsDeploy.provider,
+          'disableTransferAccelerationForCurrentDeploy').resolves();
+
+      const describeStacksOutput = {
+        Stacks: [
+          {
+            Outputs: [],
+          },
+        ],
+      };
+      sandbox.stub(awsDeploy.provider, 'request').resolves(describeStacksOutput);
+
+      awsDeploy.provider.options['aws-s3-accelerate'] = true;
+      awsDeploy.serverless.service.provider.deploymentBucket = 'my-custom-bucket';
+
+      return awsDeploy.createStack().then(() => {
+        expect(disableTransferAccelerationStub.called).to.be.equal(false);
+      });
+    });
   });
 });

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -147,6 +147,7 @@ describe('createStack', () => {
 
       return awsDeploy.createStack().then(() => {
         expect(disableTransferAccelerationStub.called).to.be.equal(true);
+        sandbox.restore();
       });
     });
 
@@ -169,6 +170,7 @@ describe('createStack', () => {
 
       return awsDeploy.createStack().then(() => {
         expect(disableTransferAccelerationStub.called).to.be.equal(false);
+        sandbox.restore();
       });
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I've fixed a bug that was disabling s3 transfer acceleration for already-deployed services using custom deployment buckets.

Closes #4605 


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I have improved the condition that checks on the CloudFormation Stack's Outputs to verify whether S3 transfer acceleration has been already enabled or not. Such condition did not make sense if a custom bucket has been used.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. Create a custom deployment bucket named `my-custom-sls-deployment-bucket`
2. Deploy the stack below (without using `--aws-s3-accelerate`)
3. Update the handler
4. Re-deploy (using `--aws-s3-accelerate`).

```yaml
service: s3-custom-bucket-accel-test
package:
  exclude:
    - "**/*"
  include:
    - handler.js
    - huge-file.jpg  # not strictly necessary
provider:
  name: aws
  runtime: nodejs6.10
  region: us-west-2
  deploymentBucket:
    name: my-custom-deployment-bucket
functions:
  hello:
    handler: handler.hello

```

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
