### PR TITLE
Update on DEFAULT REQUEST_TEMPLATE behaviour

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -157,18 +157,18 @@ module.exports = {
   getIntegrationRequestTemplates(http, useDefaults) {
     // default request templates
     const integrationRequestTemplates = {};
+    
+    // set custom request templates if provided
+    if (http.request && typeof http.request.template === 'object') {
+      _.assign(integrationRequestTemplates, http.request.template);
+    }
 
-    // Only set defaults for AWS (lambda) integration
-    if (useDefaults) {
+    // Only set defaults for AWS (lambda) integration if custom request templates is not specified
+    if (useDefaults && _.isEmpty(integrationRequestTemplates)) {
       _.assign(integrationRequestTemplates, {
         'application/json': this.DEFAULT_JSON_REQUEST_TEMPLATE,
         'application/x-www-form-urlencoded': this.DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE,
       });
-    }
-
-    // set custom request templates if provided
-    if (http.request && typeof http.request.template === 'object') {
-      _.assign(integrationRequestTemplates, http.request.template);
     }
 
     return !_.isEmpty(integrationRequestTemplates) ? integrationRequestTemplates : undefined;


### PR DESCRIPTION
Modified the code to only assign DEFAULT_JSON_REQUEST_TEMPLATE and DEFAULT_FORM_URL_ENCODED_REQUEST_TEMPLATE if none is specified. This is to enable exclusion if one is not interested to use default templates for either 'application/json' or 'application/x-www-form-urlencoded' or both.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
