### PR TITLE
Fix typo in 'syntax'

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -22,7 +22,7 @@ class Variables {
     this.selfRefSyntax = RegExp(/^self:/g);
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
-    this.stringRefSynax = RegExp(/('.*')|(".*")/g);
+    this.stringRefSyntax = RegExp(/('.*')|(".*")/g);
     this.ssmRefSyntax = RegExp(/^ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false)?/);
   }
 
@@ -199,7 +199,7 @@ class Variables {
         value = this.getValueFromCf(variableString);
       } else if (variableString.match(this.s3RefSyntax)) {
         value = this.getValueFromS3(variableString);
-      } else if (variableString.match(this.stringRefSynax)) {
+      } else if (variableString.match(this.stringRefSyntax)) {
         value = this.getValueFromString(variableString);
       } else if (variableString.match(this.ssmRefSyntax)) {
         value = this.getValueFromSsm(variableString);


### PR DESCRIPTION
## What did you implement:

There's a typo in the `Variables` class, which I have fixed.

## How did you implement it:

Corrected the spelling of 'syntax' in both places this variables was used.

## How can we verify it:

* Visual inspection.
* Grep the codebase for other uses of this variable - I did not find any.
* Run the tests to ensure nothing breaks.

## Todos:

- ~Write tests~
- ~Write documentation~
- ~Fix linting errors~
- [x] Make sure code coverage hasn't dropped
- ~Provide verification config / commands / resources~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO