### PR TITLE
S3 Transfer Acceleration IAM breaking change fix

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -25,7 +25,8 @@ serverless deploy
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.
 - `--conceal` Hides secrets from the output (e.g. API Gateway key values).
-- `--aws-s3-accelerate` Enables S3 Transfer Acceleration making uploading artifacts much faster. You can read more about it [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html). **Note: When using Transfer Acceleration, additional data transfer charges may apply**
+- `--aws-s3-accelerate` Enables S3 Transfer Acceleration making uploading artifacts much faster. You can read more about it [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html). It requires additional `s3:PutAccelerateConfiguration` permissions. **Note: When using Transfer Acceleration, additional data transfer charges may apply.**
+- `--no-aws-s3-accelerate` Explicitly disables S3 Transfer Acceleration). It also requires additional `s3:PutAccelerateConfiguration` permissions.
 
 ## Artifacts
 

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -31,7 +31,7 @@ module.exports = {
       const errorMessage = [
         'You cannot enable and disable S3 Transfer Acceleration at the same time',
       ].join('');
-      throw new this.serverless.classes.Error(errorMessage);
+      return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
     }
 
     if (bucketName) {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -45,15 +45,15 @@ module.exports = {
         });
     }
 
-    this.serverless.service.provider.compiledCloudFormationTemplate
-      .Resources.ServerlessDeploymentBucket.Properties = {
-        AccelerateConfiguration: {
-          AccelerationStatus:
-            isS3TransferAccelerationEnabled ? 'Enabled' : 'Suspended',
-        },
-      };
-
     if (isS3TransferAccelerationEnabled) {
+      // enable acceleration via CloudFormation
+      this.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.ServerlessDeploymentBucket.Properties = {
+          AccelerateConfiguration: {
+            AccelerationStatus: 'Enabled',
+          },
+        };
+      // keep track of acceleration status via CloudFormation Output
       this.serverless.service.provider.compiledCloudFormationTemplate
       .Outputs.ServerlessDeploymentBucketAccelerated = { Value: true };
     }

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -25,6 +25,14 @@ module.exports = {
 
     const bucketName = this.serverless.service.provider.deploymentBucket;
     const isS3TransferAccelerationEnabled = this.provider.isS3TransferAccelerationEnabled();
+    const isS3TransferAccelerationDisabled = this.provider.isS3TransferAccelerationDisabled();
+
+    if (isS3TransferAccelerationEnabled && isS3TransferAccelerationDisabled) {
+      const errorMessage = [
+        'You cannot enable and disable S3 Transfer Acceleration at the same time',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
 
     if (bucketName) {
       return BbPromise.bind(this)
@@ -56,6 +64,14 @@ module.exports = {
       // keep track of acceleration status via CloudFormation Output
       this.serverless.service.provider.compiledCloudFormationTemplate
       .Outputs.ServerlessDeploymentBucketAccelerated = { Value: true };
+    } else if (isS3TransferAccelerationDisabled) {
+      // explicitly disable acceleration via CloudFormation
+      this.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.ServerlessDeploymentBucket.Properties = {
+          AccelerateConfiguration: {
+            AccelerationStatus: 'Suspended',
+          },
+        };
     }
 
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -169,7 +169,7 @@ describe('#generateCoreTemplate()', () => {
     awsPlugin.provider.options['no-aws-s3-accelerate'] = true;
 
     return expect(
-      () => awsPlugin.generateCoreTemplate()
-    ).to.throw(/at the same time/);
+      awsPlugin.generateCoreTemplate()
+    ).to.be.rejectedWith(serverless.classes.Error, /at the same time/);
   });
 });

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -141,7 +141,7 @@ describe('#generateCoreTemplate()', () => {
       });
   });
 
-  it('should explode if transfer acceleration is both enabled and disabled', () => {
+  it('should explicitly disable S3 Transfer Acceleration, if requested', () => {
     sinon.stub(awsPlugin.provider, 'request').resolves();
     sinon.stub(serverless.utils, 'writeFileSync').resolves();
     serverless.config.servicePath = './';

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -61,14 +61,45 @@ describe('#generateCoreTemplate()', () => {
 
     return expect(awsPlugin.generateCoreTemplate()).to.be.fulfilled
       .then(() => {
+        const template = awsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
         expect(
-          awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-            .Outputs.ServerlessDeploymentBucketName.Value
+          template.Outputs.ServerlessDeploymentBucketName.Value
         ).to.equal(bucketName);
         // eslint-disable-next-line no-unused-expressions
         expect(
-          awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.ServerlessDeploymentBucket
+          template.Resources.ServerlessDeploymentBucket
+        ).to.not.exist;
+      });
+  });
+
+  it('should use a custom bucket if specified, even with S3 transfer acceleration', () => {
+    const bucketName = 'com.serverless.deploys';
+
+    awsPlugin.serverless.service.provider.deploymentBucket = bucketName;
+    awsPlugin.provider.options['aws-s3-accelerate'] = true;
+
+    const coreCloudFormationTemplate = awsPlugin.serverless.utils.readFileSync(
+      path.join(
+        __dirname,
+        'core-cloudformation-template.json'
+      )
+    );
+    awsPlugin.serverless.service.provider
+      .compiledCloudFormationTemplate = coreCloudFormationTemplate;
+
+    return expect(awsPlugin.generateCoreTemplate()).to.be.fulfilled
+      .then(() => {
+        const template = awsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
+        expect(
+          template.Outputs.ServerlessDeploymentBucketName.Value
+        ).to.equal(bucketName);
+        // eslint-disable-next-line no-unused-expressions
+        expect(
+          template.Resources.ServerlessDeploymentBucket
+        ).to.not.exist;
+        // eslint-disable-next-line no-unused-expressions
+        expect(
+          template.Outputs.ServerlessDeploymentBucketAccelerated
         ).to.not.exist;
       });
   });
@@ -108,5 +139,37 @@ describe('#generateCoreTemplate()', () => {
         expect(template.Outputs.ServerlessDeploymentBucketAccelerated).to.not.equal(null);
         expect(template.Outputs.ServerlessDeploymentBucketAccelerated.Value).to.equal(true);
       });
+  });
+
+  it('should explode if transfer acceleration is both enabled and disabled', () => {
+    sinon.stub(awsPlugin.provider, 'request').resolves();
+    sinon.stub(serverless.utils, 'writeFileSync').resolves();
+    serverless.config.servicePath = './';
+    awsPlugin.provider.options['no-aws-s3-accelerate'] = true;
+
+    return awsPlugin.generateCoreTemplate()
+      .then(() => {
+        const template = serverless.service.provider.coreCloudFormationTemplate;
+        expect(template.Resources.ServerlessDeploymentBucket).to.be.deep.equal({
+          Type: 'AWS::S3::Bucket',
+          Properties: {
+            AccelerateConfiguration: {
+              AccelerationStatus: 'Suspended',
+            },
+          },
+        });
+      });
+  });
+
+  it('should explode if transfer acceleration is both enabled and disabled', () => {
+    sinon.stub(awsPlugin.provider, 'request').resolves();
+    sinon.stub(serverless.utils, 'writeFileSync').resolves();
+    serverless.config.servicePath = './';
+    awsPlugin.provider.options['aws-s3-accelerate'] = true;
+    awsPlugin.provider.options['no-aws-s3-accelerate'] = true;
+
+    return expect(
+      () => awsPlugin.generateCoreTemplate()
+    ).to.throw(/at the same time/);
   });
 });

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -80,11 +80,6 @@ describe('#generateCoreTemplate()', () => {
           .Resources.ServerlessDeploymentBucket
         ).to.be.deep.equal({
           Type: 'AWS::S3::Bucket',
-          Properties: {
-            AccelerateConfiguration: {
-              AccelerationStatus: 'Suspended',
-            },
-          },
         });
     })
   );

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -317,6 +317,10 @@ class AwsProvider {
     return !!this.options['aws-s3-accelerate'];
   }
 
+  isS3TransferAccelerationDisabled() {
+    return !!this.options['no-aws-s3-accelerate'];
+  }
+
   disableTransferAccelerationForCurrentDeploy() {
     delete this.options['aws-s3-accelerate'];
   }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4625

I've made `s3:PutAccelerateConfiguration` IAM permissions optional (and documented it), and added a new `--no-aws-s3-accelerate` argument, as suggested.

## How did you implement it:

No `AccelerateConfiguration` will be added to the CloudFormation template unless `--aws-s3-accelerate` or `--no-aws-s3-accelerate` are provided.

## How can we verify it:

Deploy the service documented in #4293 with a limited IAM Role (i.e. without `s3:PutAccelerateConfiguration` permissions).

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

  