### PR TITLE
allow authorizer.name to override implied authorizer.arn name.

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -220,7 +220,11 @@ module.exports = {
         type = 'AWS_IAM';
       } else if (authorizer.arn) {
         arn = authorizer.arn;
-        name = this.provider.naming.extractAuthorizerNameFromArn(arn);
+        if (_.isString(authorizer.name)) {
+          name = authorizer.name;
+        } else {
+          name = this.provider.naming.extractAuthorizerNameFromArn(arn);
+        }
       } else if (authorizer.name) {
         name = authorizer.name;
         arn = this.getLambdaArn(name);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -934,6 +934,30 @@ describe('#validate()', () => {
     expect(validated.events[0].http.authorizer.arn).to.equal('xxx:dev-authorizer');
   });
 
+  it('should handle an authorizer.arn with an explicit authorizer.name object', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              path: 'foo/bar',
+              method: 'GET',
+              authorizer: {
+                arn: 'xxx:dev-authorizer',
+                name: 'custom-name',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events).to.be.an('Array').with.length(1);
+    expect(validated.events[0].http.authorizer.name).to.equal('custom-name');
+    expect(validated.events[0].http.authorizer.arn).to.equal('xxx:dev-authorizer');
+  });
+
   it('should throw an error if the provided config is not an object', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {


### PR DESCRIPTION
## What did you implement:

Closes #4648

This is an update of @kminkler 's PR #3413 which was closed after being sat in review too long. It also includes a test.

## How did you implement it:
* Added step in validate.js to see if authorizer.name had been set before automatically extracting an implicit name from the arn.

## How can we verify it:
* I have added at test: `it('should handle an authorizer.arn with an explicit authorizer.name object')`.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
