### PR TITLE
Adding service : cloudwatch alerts on slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The following are services you can instantly install and use by running `serverl
 * [Ruby](https://github.com/stewartlord/serverless-ruby) - Call a Ruby function from your lambda
 * [Slack App](https://github.com/johnagan/serverless-slack-app) - Slack App Boilerplate with OAuth and Bot actions
 * [Swift](https://github.com/choefele/swift-lambda-app) - Full-featured project template to develop Lambda functions in Swift
-* [Cloudwatch Alerts on Slack](github.com/dav009/serverless-aws-alarms-notifier) - Get AWS Cloudwatch alerts notifications on Slack
+* [Cloudwatch Alerts on Slack](https://github.com/dav009/serverless-aws-alarms-notifier) - Get AWS Cloudwatch alerts notifications on Slack
 
 **Note**: the `serverless install` command will only work on V1.0 or later.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The following are services you can instantly install and use by running `serverl
 * [Ruby](https://github.com/stewartlord/serverless-ruby) - Call a Ruby function from your lambda
 * [Slack App](https://github.com/johnagan/serverless-slack-app) - Slack App Boilerplate with OAuth and Bot actions
 * [Swift](https://github.com/choefele/swift-lambda-app) - Full-featured project template to develop Lambda functions in Swift
+* [Cloudwatch Alerts on Slack](github.com/dav009/serverless-aws-alarms-notifier) - Get AWS Cloudwatch alerts notifications on Slack
 
 **Note**: the `serverless install` command will only work on V1.0 or later.
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
I want to add a new service to the list of existing services.
The mention service  creates a lambda function which forward Cloudwatch alerts to slack.


## How did you implement it:

## How can we verify it:

## Todos:

