### PR TITLE
Do not explicitly color messages in white

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -19,7 +19,7 @@ const writeMessage = (messageType, message) => {
   consoleLog(' ');
 
   if (message) {
-    consoleLog(chalk.white(`  ${message}`));
+    consoleLog(`  ${message}`);
   }
 
   consoleLog(' ');
@@ -61,17 +61,16 @@ module.exports.logError = (e) => {
       consoleLog(' ');
     }
 
-    const platform = chalk.white(process.platform);
-    const nodeVersion = chalk.white(process.version.replace(/^[v|V]/, ''));
-    const slsVersion = chalk.white(version);
+    const platform = process.platform;
+    const nodeVersion = process.version.replace(/^[v|V]/, '');
+    const slsVersion = version;
 
     consoleLog(chalk.yellow('  Get Support --------------------------------------------'));
-    consoleLog(`${chalk.yellow('     Docs:          ')}${chalk.white('docs.serverless.com')}`);
-    consoleLog(`${chalk.yellow('     Bugs:          ')}${chalk
-      .white('github.com/serverless/serverless/issues')}`);
-    consoleLog(`${chalk.yellow('     Forums:        ')}${chalk.white('forum.serverless.com')}`);
-    consoleLog(`${chalk.yellow('     Chat:          ')}${chalk
-            .white('gitter.im/serverless/serverless')}`);
+    consoleLog(`${chalk.yellow('     Docs:          ')}${'docs.serverless.com'}`);
+    consoleLog(`${chalk.yellow('     Bugs:          ')}${
+      'github.com/serverless/serverless/issues'}`);
+    consoleLog(`${chalk.yellow('     Forums:        ')}${'forum.serverless.com'}`);
+    consoleLog(`${chalk.yellow('     Chat:          ')}${'gitter.im/serverless/serverless'}`);
 
     consoleLog(' ');
     consoleLog(chalk.yellow('  Your Environment Information -----------------------------'));

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -83,12 +83,12 @@ class AwsInvoke {
   }
 
   log(invocationReply) {
-    const color = !invocationReply.FunctionError ? 'white' : 'red';
+    const color = !invocationReply.FunctionError ? (x => x) : chalk.red;
 
     if (invocationReply.Payload) {
       const response = JSON.parse(invocationReply.Payload);
 
-      this.consoleLog(chalk[color](JSON.stringify(response, null, 4)));
+      this.consoleLog(color(JSON.stringify(response, null, 4)));
     }
 
     if (invocationReply.LogResult) {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -6,7 +6,6 @@ const path = require('path');
 const AwsInvoke = require('./index');
 const AwsProvider = require('../provider/awsProvider');
 const Serverless = require('../../../Serverless');
-const chalk = require('chalk');
 const testUtils = require('../../../../tests/utils');
 
 describe('AwsInvoke', () => {
@@ -271,7 +270,7 @@ describe('AwsInvoke', () => {
       };
 
       return awsInvoke.log(invocationReplyMock).then(() => {
-        const expectedPayloadMessage = `${chalk.white('{\n    "testProp": "testValue"\n}')}`;
+        const expectedPayloadMessage = '{\n    "testProp": "testValue"\n}';
 
         expect(consoleLogStub.calledWith(expectedPayloadMessage)).to.equal(true);
       });

--- a/lib/plugins/aws/utils/formatLambdaLogEvent.js
+++ b/lib/plugins/aws/utils/formatLambdaLogEvent.js
@@ -34,7 +34,7 @@ module.exports = (msgParam) => {
   } else if (!isNaN((new Date(splitted[1])).getTime())) {
     date = splitted[1];
     reqId = splitted[2];
-    level = `${chalk.white(splitted[0])}\t`;
+    level = `${splitted[0]}\t`;
   } else {
     return msg;
   }

--- a/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
+++ b/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
@@ -37,7 +37,7 @@ describe('#formatLambdaLogEvent()', () => {
     const momentDate = moment('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS (Z)');
     expectedLogMessage += `${chalk.green(momentDate)}\t`;
     expectedLogMessage += `${chalk.yellow('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
-    expectedLogMessage += `${chalk.white('[INFO]')}\t`;
+    expectedLogMessage += `${'[INFO]'}\t`;
     expectedLogMessage += 'test';
 
     expect(formatLambdaLogEvent(pythonLoggerLine)).to.equal(expectedLogMessage);


### PR DESCRIPTION

## What did you implement:

Closes #4673 

Do not color any messages in white as it is unreadable on white background

## How did you implement it:

Remove any explicit calls to `chalk.white` so that no white text is output, and instead the default terminal color (e.g. black) is used.

This is consistent with the existing handling of black background as there are no explicit calls to `chalk.black` anywhere.

## How can we verify it:

* Configure a terminal to have a black-on-white color scheme
* Use `sls invoke` to display a function output
* Or, try causing an error to display a "Serverless Error" message
* All the text in the error messages and the invocation output should be readable as well as it is on a white-on-black terminal.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
