### PR TITLE
Add support for concurrency option in AWS Lambda

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -37,6 +37,7 @@ functions:
     runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, in MB, default is 1024
     timeout: 10 # optional, in seconds, default is 6
+    reservedConcurrency: 5 # optional, reserved concurrency limit for this function. By default, it is not set and AWS use Account concurrency limit
 ```
 
 The `handler` property points to the file and module containing the code you want to run in your function.

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -37,7 +37,7 @@ functions:
     runtime: python2.7 # optional overwrite, default is provider runtime
     memorySize: 512 # optional, in MB, default is 1024
     timeout: 10 # optional, in seconds, default is 6
-    reservedConcurrency: 5 # optional, reserved concurrency limit for this function. By default, it is not set and AWS use Account concurrency limit
+    reservedConcurrency: 5 # optional, reserved concurrency limit for this function. By default, AWS uses account concurrency limit
 ```
 
 The `handler` property points to the file and module containing the code you want to run in your function.

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -288,7 +288,7 @@ class AwsCompileFunctions {
           `${newFunction.Properties.FunctionName}`,
         ].join('');
 
-        throw new this.serverless.classes.Error(errorMessage);
+        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
       }
     }
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -279,6 +279,19 @@ class AwsCompileFunctions {
       delete newFunction.Properties.VpcConfig;
     }
 
+    if (functionObject.reservedConcurrency) {
+      if (_.isInteger(functionObject.reservedConcurrency)) {
+        newFunction.Properties.ReservedConcurrentExecutions = functionObject.reservedConcurrency;
+      } else {
+        const warningMessage = [
+          'WARNING! You should use integer as reservedConcurrency value on function: ',
+          `${newFunction.Properties.FunctionName}`,
+        ].join('');
+
+        this.serverless.cli.log(warningMessage);
+      }
+    }
+
     newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)]
       .concat(newFunction.DependsOn || []);
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -283,12 +283,12 @@ class AwsCompileFunctions {
       if (_.isInteger(functionObject.reservedConcurrency)) {
         newFunction.Properties.ReservedConcurrentExecutions = functionObject.reservedConcurrency;
       } else {
-        const warningMessage = [
-          'WARNING! You should use integer as reservedConcurrency value on function: ',
+        const errorMessage = [
+          'You should use integer as reservedConcurrency value on function: ',
           `${newFunction.Properties.FunctionName}`,
         ].join('');
 
-        this.serverless.cli.log(warningMessage);
+        throw new this.serverless.classes.Error(errorMessage);
       }
     }
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const path = require('path');
 const chai = require('chai');
-const sinon = require('sinon');
 const AwsProvider = require('../../../provider/awsProvider');
 const AwsCompileFunctions = require('./index');
 const testUtils = require('../../../../../../tests/utils');
@@ -16,7 +15,6 @@ const expect = chai.expect;
 describe('AwsCompileFunctions', () => {
   let serverless;
   let awsCompileFunctions;
-  let logStub;
   const functionName = 'test';
   const compiledFunctionName = 'TestLambdaFunction';
 
@@ -28,7 +26,6 @@ describe('AwsCompileFunctions', () => {
     serverless = new Serverless(options);
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.cli = new serverless.classes.CLI();
-    logStub = sinon.stub(serverless.cli, 'log');
     awsCompileFunctions = new AwsCompileFunctions(serverless, options);
     awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
@@ -1776,47 +1773,8 @@ describe('AwsCompileFunctions', () => {
         });
     });
 
-    it('should ignore non-integer reserved concurrency limit set on function', () => {
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep).pop();
-      awsCompileFunctions.serverless.service.functions = {
-        func: {
-          handler: 'func.function.handler',
-          name: 'new-service-dev-func',
-          reservedConcurrency: '1',
-        },
-      };
-      const compiledFunction = {
-        Type: 'AWS::Lambda::Function',
-        DependsOn: [
-          'FuncLogGroup',
-          'IamRoleLambdaExecution',
-        ],
-        Properties: {
-          Code: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
-          Timeout: 6,
-        },
-      };
-
-      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
-        .then(() => {
-          expect(
-            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-              .Resources.FuncLambdaFunction
-          ).to.deep.equal(compiledFunction);
-        });
-    });
-
-    it('should show warning if non-integer reserved concurrency limit set on function', () => {
+    it('should throw an informative error message if non-integer reserved concurrency limit set ' +
+      'on function', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -1825,17 +1783,12 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
-        .then(() => {
-          const warningMessage = [
-            'WARNING! You should use integer as reservedConcurrency value on function: ',
-            'new-service-dev-func',
-          ].join('');
+      const errorMessage = [
+        'You should use integer as reservedConcurrency value on function: ',
+        'new-service-dev-func',
+      ].join('');
 
-          expect(
-            logStub.calledWithExactly(warningMessage)
-          ).to.be.equal(true);
-        });
+      return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(errorMessage);
     });
   });
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const path = require('path');
 const chai = require('chai');
+const sinon = require('sinon');
 const AwsProvider = require('../../../provider/awsProvider');
 const AwsCompileFunctions = require('./index');
 const testUtils = require('../../../../../../tests/utils');
@@ -15,6 +16,7 @@ const expect = chai.expect;
 describe('AwsCompileFunctions', () => {
   let serverless;
   let awsCompileFunctions;
+  let logStub;
   const functionName = 'test';
   const compiledFunctionName = 'TestLambdaFunction';
 
@@ -25,6 +27,8 @@ describe('AwsCompileFunctions', () => {
     };
     serverless = new Serverless(options);
     serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.cli = new serverless.classes.CLI();
+    logStub = sinon.stub(serverless.cli, 'log');
     awsCompileFunctions = new AwsCompileFunctions(serverless, options);
     awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
@@ -1729,6 +1733,109 @@ describe('AwsCompileFunctions', () => {
           expectedOutputs
         );
       });
+    });
+
+    it('should set function declared reserved concurrency limit', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          reservedConcurrency: 5,
+        },
+      };
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          ReservedConcurrentExecutions: 5,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          expect(
+            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+              .Resources.FuncLambdaFunction
+          ).to.deep.equal(compiledFunction);
+        });
+    });
+
+    it('should ignore non-integer reserved concurrency limit set on function', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          reservedConcurrency: '1',
+        },
+      };
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          expect(
+            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+              .Resources.FuncLambdaFunction
+          ).to.deep.equal(compiledFunction);
+        });
+    });
+
+    it('should show warning if non-integer reserved concurrency limit set on function', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          reservedConcurrency: '1',
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          const warningMessage = [
+            'WARNING! You should use integer as reservedConcurrency value on function: ',
+            'new-service-dev-func',
+          ].join('');
+
+          expect(
+            logStub.calledWithExactly(warningMessage)
+          ).to.be.equal(true);
+        });
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #4555 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
I added new `reservedConcurrency` option to functionObject in `AwsCompileFunctions` class.
If it is number and is not empty, I assign it to `ReservedConcurrentExecutions` option into CloudFormation template. Otherwise, ReservedConcurrentExecutions will not be present in CloudFormation template.

More information about ReservedConcurrentExecutions can be found at: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
**serverless.yml**
```
functions:
  hello:
    handler: handler.hello # required, handler set in AWS Lambda
    name: ${self:provider.stage}-lambdaName # optional, Deployed Lambda name
    description: Description of what the lambda function does 
    reservedConcurrency: 5
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO