### PR TITLE
Restricting alexaSkill functions to specific Alexa skills

### DIFF
--- a/docs/providers/aws/events/alexa-skill.md
+++ b/docs/providers/aws/events/alexa-skill.md
@@ -14,14 +14,41 @@ layout: Doc
 
 ## Event definition
 
-This will enable your Lambda function to be called by an Alexa skill kit.
+This will enable your Lambda function to be called by an Alexa Skill kit.
+`amzn1.ask.skill.xx-xx-xx-xx-xx` is a skill ID for Alexa Skills kit. You receive a skill ID once you register and create a skill in [Amazon Developer Console](https://developer.amazon.com/).
+After deploying, add your deployed Lambda function ARN to which this event is attached to the Service Endpoint under Configuration on Amazon Developer Console.
 
 ```yml
 functions:
   mySkill:
     handler: mySkill.handler
     events:
-      - alexaSkill
+      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx-xx
 ```
 
 You can find detailed guides on how to create an Alexa Skill with Serverless using NodeJS [here](https://github.com/serverless/examples/tree/master/aws-node-alexa-skill) as well as in combination with Python [here](https://github.com/serverless/examples/tree/master/aws-python-alexa-skill).
+
+## Enabling / Disabling
+
+**Note:** `alexaSkill` events are enabled by default.
+
+This will create and attach a alexaSkill event for the `mySkill` function which is disabled. If enabled it will call
+the `mySkill` function by an Alexa Skill.
+
+```yaml
+functions:
+  mySkill:
+    handler: mySkill.handler
+    events:
+      - alexaSkill:
+          appId: amzn1.ask.skill.xx-xx-xx-xx
+          enabled: false
+```
+
+## Backwards compatability
+
+Previous syntax of this event didn't require a skill ID as parameter, but according to [Amazon's documentation](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#configuring-the-alexa-skills-kit-trigger) you should restrict your lambda function to be executed only by your skill.
+
+Omitting the skill id will make your Lambda function available for the public, allowing any other skill developer to invoke it.
+
+(This is important, as [opposing to custom HTTPS endpoints](https://developer.amazon.com/docs/custom-skills/handle-requests-sent-by-alexa.html#request-verify), there's no way to validate the request was sent by your skill.)

--- a/docs/providers/aws/examples/hello-world/fsharp/serverless.yml
+++ b/docs/providers/aws/examples/hello-world/fsharp/serverless.yml
@@ -66,7 +66,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -159,7 +159,9 @@ functions:
           batchSize: 100
           startingPosition: LATEST
           enabled: false
-      - alexaSkill
+      - alexaSkill:
+          appId: amzn1.ask.skill.xx-xx-xx-xx
+          enabled: true
       - alexaSmartHome:
           appId: amzn1.ask.skill.xx-xx-xx-xx
           enabled: true

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -6,7 +6,6 @@ const path = require('path');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
-const BbPromise = require('bluebird');
 const testUtils = require('../../../../../tests/utils');
 
 describe('createStack', () => {
@@ -98,8 +97,7 @@ describe('createStack', () => {
 
     it('should set the createLater flag and resolve if deployment bucket is provided', () => {
       awsDeploy.serverless.service.provider.deploymentBucket = 'serverless';
-      sandbox.stub(awsDeploy.provider, 'request')
-        .returns(BbPromise.reject({ message: 'does not exist' }));
+      sandbox.stub(awsDeploy.provider, 'request').rejects(new Error('does not exist'));
 
       return awsDeploy.createStack().then(() => {
         expect(awsDeploy.createLater).to.equal(true);

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -11,7 +11,7 @@ const testUtils = require('../../../../../tests/utils');
 
 describe('createStack', () => {
   let awsDeploy;
-  let sandbox;
+  const sandbox = sinon.sandbox.create();
   const tmpDirPath = testUtils.getTmpDirPath();
 
   const serverlessYmlPath = path.join(tmpDirPath, 'serverless.yml');
@@ -26,7 +26,6 @@ describe('createStack', () => {
   };
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
     const serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -11,7 +11,7 @@ const testUtils = require('../../../../../tests/utils');
 
 describe('createStack', () => {
   let awsDeploy;
-  const sandbox = sinon.sandbox.create();
+  let sandbox;
   const tmpDirPath = testUtils.getTmpDirPath();
 
   const serverlessYmlPath = path.join(tmpDirPath, 'serverless.yml');
@@ -26,6 +26,7 @@ describe('createStack', () => {
   };
 
   beforeEach(() => {
+    sandbox = sinon.sandbox.create();
     const serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -60,8 +60,8 @@ describe('extendedValidate', () => {
     });
 
     afterEach(() => {
-      awsDeploy.serverless.utils.fileExistsSync.restore();
-      awsDeploy.serverless.utils.readFileSync.restore();
+      fileExistsSyncStub.restore();
+      readFileSyncStub.restore();
     });
 
     it('should throw error if state file does not exist', () => {
@@ -126,7 +126,7 @@ describe('extendedValidate', () => {
       return awsDeploy.extendedValidate().then(() => {
         expect(fileExistsSyncStub.calledTwice).to.equal(true);
         expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(fileExistsSyncStub).to.have.been.calledWithExactly('artifact.zip');
+        expect(fileExistsSyncStub.calledWithExactly('artifact.zip'));
       });
     });
 

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -1,12 +1,16 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
 const sinon = require('sinon');
 const path = require('path');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
 const testUtils = require('../../../../../tests/utils');
+
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
 
 describe('extendedValidate', () => {
   let awsDeploy;
@@ -126,7 +130,7 @@ describe('extendedValidate', () => {
       return awsDeploy.extendedValidate().then(() => {
         expect(fileExistsSyncStub.calledTwice).to.equal(true);
         expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(fileExistsSyncStub.calledWithExactly('artifact.zip'));
+        expect(fileExistsSyncStub).to.have.been.calledWithExactly('artifact.zip');
       });
     });
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -294,6 +294,7 @@ describe('uploadArtifacts', () => {
           .to.be.equal(awsDeploy.serverless.service.functions.first.package.artifact);
         expect(uploadZipFileStub.args[1][0])
           .to.be.equal(awsDeploy.serverless.service.package.artifact);
+      }).finally(() => {
         uploadZipFileStub.restore();
         statSyncStub.restore();
       });
@@ -310,7 +311,7 @@ describe('uploadArtifacts', () => {
       return awsDeploy.uploadFunctions().then(() => {
         const expected = 'Uploading service .zip file to S3 (1 KB)...';
         expect(awsDeploy.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);
-
+      }).finally(() => {
         statSyncStub.restore();
         uploadZipFileStub.restore();
       });

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -90,8 +90,8 @@ describe('uploadArtifacts', () => {
     });
 
     afterEach(() => {
-      normalizeFiles.normalizeCloudFormationTemplate.restore();
-      awsDeploy.provider.request.restore();
+      normalizeCloudFormationTemplateStub.restore();
+      uploadStub.restore();
     });
 
     it('should upload the CloudFormation file to the S3 bucket', () => {
@@ -159,8 +159,8 @@ describe('uploadArtifacts', () => {
     });
 
     afterEach(() => {
-      fs.readFileSync.restore();
-      awsDeploy.provider.request.restore();
+      readFileSyncStub.restore();
+      uploadStub.restore();
     });
 
     it('should throw for null artifact paths', () => {
@@ -265,7 +265,7 @@ describe('uploadArtifacts', () => {
           .to.be.equal(awsDeploy.serverless.service.functions.first.package.artifact);
         expect(uploadZipFileStub.args[1][0])
           .to.be.equal(awsDeploy.serverless.service.functions.second.package.artifact);
-        awsDeploy.uploadZipFile.restore();
+        uploadZipFileStub.restore();
       });
     });
 
@@ -286,7 +286,7 @@ describe('uploadArtifacts', () => {
 
       const uploadZipFileStub = sinon
         .stub(awsDeploy, 'uploadZipFile').resolves();
-      sinon.stub(fs, 'statSync').returns({ size: 1024 });
+      const statSyncStub = sinon.stub(fs, 'statSync').returns({ size: 1024 });
 
       return awsDeploy.uploadFunctions().then(() => {
         expect(uploadZipFileStub.calledTwice).to.be.equal(true);
@@ -294,8 +294,8 @@ describe('uploadArtifacts', () => {
           .to.be.equal(awsDeploy.serverless.service.functions.first.package.artifact);
         expect(uploadZipFileStub.args[1][0])
           .to.be.equal(awsDeploy.serverless.service.package.artifact);
-        awsDeploy.uploadZipFile.restore();
-        fs.statSync.restore();
+        uploadZipFileStub.restore();
+        statSyncStub.restore();
       });
     });
 
@@ -303,16 +303,16 @@ describe('uploadArtifacts', () => {
       awsDeploy.serverless.config.servicePath = 'some/path';
       awsDeploy.serverless.service.service = 'new-service';
 
-      sinon.stub(fs, 'statSync').returns({ size: 1024 });
-      sinon.stub(awsDeploy, 'uploadZipFile').resolves();
+      const statSyncStub = sinon.stub(fs, 'statSync').returns({ size: 1024 });
+      const uploadZipFileStub = sinon.stub(awsDeploy, 'uploadZipFile').resolves();
       sinon.spy(awsDeploy.serverless.cli, 'log');
 
       return awsDeploy.uploadFunctions().then(() => {
         const expected = 'Uploading service .zip file to S3 (1 KB)...';
         expect(awsDeploy.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);
 
-        fs.statSync.restore();
-        awsDeploy.uploadZipFile.restore();
+        statSyncStub.restore();
+        uploadZipFileStub.restore();
       });
     });
   });

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -284,7 +284,7 @@ module.exports = {
   },
   getLambdaAlexaSkillPermissionLogicalId(functionName, alexaSkillIndex) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlexaSkill${
-      alexaSkillIndex}`;
+      alexaSkillIndex || '0'}`;
   },
   getLambdaAlexaSmartHomePermissionLogicalId(functionName, alexaSmartHomeIndex) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlexaSmartHome${

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -282,8 +282,9 @@ module.exports = {
   getLambdaApiGatewayPermissionLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionApiGateway`;
   },
-  getLambdaAlexaSkillPermissionLogicalId(functionName) {
-    return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlexaSkill`;
+  getLambdaAlexaSkillPermissionLogicalId(functionName, alexaSkillIndex) {
+    return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlexaSkill${
+      alexaSkillIndex}`;
   },
   getLambdaAlexaSmartHomePermissionLogicalId(functionName, alexaSmartHomeIndex) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlexaSmartHome${

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -465,8 +465,8 @@ describe('#naming()', () => {
   describe('#getLambdaAlexaSkillPermissionLogicalId()', () => {
     it('should normalize the function name and append the standard suffix',
       () => {
-        expect(sdk.naming.getLambdaAlexaSkillPermissionLogicalId('functionName'))
-          .to.equal('FunctionNameLambdaPermissionAlexaSkill');
+        expect(sdk.naming.getLambdaAlexaSkillPermissionLogicalId('functionName', 0))
+          .to.equal('FunctionNameLambdaPermissionAlexaSkill0');
       });
   });
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -465,7 +465,13 @@ describe('#naming()', () => {
   describe('#getLambdaAlexaSkillPermissionLogicalId()', () => {
     it('should normalize the function name and append the standard suffix',
       () => {
-        expect(sdk.naming.getLambdaAlexaSkillPermissionLogicalId('functionName', 0))
+        expect(sdk.naming.getLambdaAlexaSkillPermissionLogicalId('functionName', 2))
+          .to.equal('FunctionNameLambdaPermissionAlexaSkill2');
+      });
+
+    it('should normalize the function name and append a default suffix if not defined',
+      () => {
+        expect(sdk.naming.getLambdaAlexaSkillPermissionLogicalId('functionName'))
           .to.equal('FunctionNameLambdaPermissionAlexaSkill0');
       });
   });

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.js
@@ -15,37 +15,34 @@ class AwsCompileAlexaSkillEvents {
   compileAlexaSkillEvents() {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionObj = this.serverless.service.getFunction(functionName);
+      let alexaSkillNumberInFunction = 0;
 
       if (functionObj.events) {
         functionObj.events.forEach(event => {
+          let enabled = true;
+          let appId;
           if (event === 'alexaSkill') {
-            const lambdaLogicalId = this.provider.naming
-              .getLambdaLogicalId(functionName);
-
-            const permissionTemplate = {
-              Type: 'AWS::Lambda::Permission',
-              Properties: {
-                FunctionName: {
-                  'Fn::GetAtt': [
-                    lambdaLogicalId,
-                    'Arn',
-                  ],
-                },
-                Action: 'lambda:InvokeFunction',
-                Principal: 'alexa-appkit.amazon.com',
-              },
-            };
-
-            const lambdaPermissionLogicalId = this.provider.naming
-              .getLambdaAlexaSkillPermissionLogicalId(functionName);
-
-            const permissionCloudForamtionResource = {
-              [lambdaPermissionLogicalId]: permissionTemplate,
-            };
-
-            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-              permissionCloudForamtionResource);
-          } else if (event.alexaSkill) {
+            const warningMessage = [
+              'Warning! You are using an old syntax for alexaSkill which doesn\'t',
+              ' restrict the invocation solely to your skill.',
+              ' Please refer to the documentation for additional information.',
+            ].join('');
+            this.serverless.cli.log(warningMessage);
+          } else if (typeof event.alexaSkill === 'string') {
+            appId = event.alexaSkill;
+          } else if (typeof event.alexaSkill === 'object') {
+            if (typeof event.alexaSkill.appId !== 'string') {
+              const errorMessage = [
+                `Missing "appId" property for alexaSkill event in function ${functionName}`,
+                ' The correct syntax is: appId: amzn1.ask.skill.xx-xx-xx-xx-xx',
+                ' OR an object with "appId" property.',
+                ' Please check the docs for more info.',
+              ].join('');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
+            appId = event.alexaSkill.appId;
+            enabled = event.alexaSkill.enabled !== false;
+          } else {
             const errorMessage = [
               `Alexa Skill event of function "${functionName}" is not an object or string.`,
               ' The correct syntax is: alexaSkill.',
@@ -53,6 +50,39 @@ class AwsCompileAlexaSkillEvents {
             ].join('');
             throw new this.serverless.classes.Error(errorMessage);
           }
+          alexaSkillNumberInFunction++;
+
+          const lambdaLogicalId = this.provider.naming
+            .getLambdaLogicalId(functionName);
+
+          const permissionTemplate = {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+              FunctionName: {
+                'Fn::GetAtt': [
+                  lambdaLogicalId,
+                  'Arn',
+                ],
+              },
+              Action: enabled ? 'lambda:InvokeFunction' : 'lambda:DisableInvokeFunction',
+              Principal: 'alexa-appkit.amazon.com',
+            },
+          };
+
+          if (appId) {
+            permissionTemplate.Properties.EventSourceToken = appId.replace(/\\n|\\r/g, '');
+          }
+
+          const lambdaPermissionLogicalId = this.provider.naming
+            .getLambdaAlexaSkillPermissionLogicalId(functionName,
+              alexaSkillNumberInFunction);
+
+          const permissionCloudForamtionResource = {
+            [lambdaPermissionLogicalId]: permissionTemplate,
+          };
+
+          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+            permissionCloudForamtionResource);
         });
       }
     });

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.js
@@ -28,10 +28,10 @@ class AwsCompileAlexaSkillEvents {
               ' Please refer to the documentation for additional information.',
             ].join('');
             this.serverless.cli.log(warningMessage);
-          } else if (typeof event.alexaSkill === 'string') {
+          } else if (_.isString(event.alexaSkill)) {
             appId = event.alexaSkill;
-          } else if (typeof event.alexaSkill === 'object') {
-            if (typeof event.alexaSkill.appId !== 'string') {
+          } else if (_.isPlainObject(event.alexaSkill)) {
+            if (!_.isString(event.alexaSkill.appId)) {
               const errorMessage = [
                 `Missing "appId" property for alexaSkill event in function ${functionName}`,
                 ' The correct syntax is: appId: amzn1.ask.skill.xx-xx-xx-xx-xx',
@@ -41,6 +41,7 @@ class AwsCompileAlexaSkillEvents {
               throw new this.serverless.classes.Error(errorMessage);
             }
             appId = event.alexaSkill.appId;
+            // Parameter `enabled` is optional, hence the explicit non-equal check for false.
             enabled = event.alexaSkill.enabled !== false;
           } else {
             const errorMessage = [

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
@@ -82,6 +82,22 @@ describe('AwsCompileAlexaSkillEvents', () => {
       expect(() => awsCompileAlexaSkillEvents.compileAlexaSkillEvents()).to.throw(Error);
     });
 
+    it('should throw an error if alexaSkill event appId is not a string', () => {
+      awsCompileAlexaSkillEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              alexaSkill: {
+                appId: 42,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileAlexaSkillEvents.compileAlexaSkillEvents()).to.throw(Error);
+    });
+
     it('should create corresponding resources when multiple alexaSkill events are provided', () => {
       const skillId1 = 'amzn1.ask.skill.xx-xx-xx-xx';
       const skillId2 = 'amzn1.ask.skill.yy-yy-yy-yy';

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-unused-expressions */
+
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileAlexaSkillEvents = require('./index');
@@ -65,7 +67,7 @@ describe('AwsCompileAlexaSkillEvents', () => {
       expect(awsCompileAlexaSkillEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstLambdaPermissionAlexaSkill1.Properties.EventSourceToken
-      ).to.be.an('undefined');
+      ).to.be.undefined;
     });
 
     it('should throw an error if alexaSkill event is not a string or an object', () => {

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
@@ -16,6 +16,7 @@ describe('AwsCompileAlexaSkillEvents', () => {
     serverless.setProvider('aws', new AwsProvider(serverless));
     consolePrinted = '';
     serverless.cli = {
+      // serverless.cli isn't available in tests, so we will mimic it.
       log: txt => {
         consolePrinted += `${txt}\r\n`;
       },

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
@@ -8,11 +8,18 @@ const Serverless = require('../../../../../../Serverless');
 describe('AwsCompileAlexaSkillEvents', () => {
   let serverless;
   let awsCompileAlexaSkillEvents;
+  let consolePrinted;
 
   beforeEach(() => {
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
+    consolePrinted = '';
+    serverless.cli = {
+      log: txt => {
+        consolePrinted += `${txt}\r\n`;
+      },
+    };
     awsCompileAlexaSkillEvents = new AwsCompileAlexaSkillEvents(serverless);
   });
 
@@ -25,7 +32,42 @@ describe('AwsCompileAlexaSkillEvents', () => {
   });
 
   describe('#compileAlexaSkillEvents()', () => {
-    it('should throw an error if alexaSkill event is not an string', () => {
+    it('should show a warning if alexaSkill appId is not specified', () => {
+      awsCompileAlexaSkillEvents.serverless.service.functions = {
+        first: {
+          events: [
+            'alexaSkill',
+          ],
+        },
+      };
+
+      awsCompileAlexaSkillEvents.compileAlexaSkillEvents();
+
+      expect(consolePrinted).to.contain.string('old syntax for alexaSkill');
+
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.FunctionName
+      ).to.deep.equal({ 'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'] });
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.Action
+      ).to.equal('lambda:InvokeFunction');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.Principal
+      ).to.equal('alexa-appkit.amazon.com');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.EventSourceToken
+      ).to.be.an('undefined');
+    });
+
+    it('should throw an error if alexaSkill event is not a string or an object', () => {
       awsCompileAlexaSkillEvents.serverless.service.functions = {
         first: {
           events: [
@@ -39,11 +81,20 @@ describe('AwsCompileAlexaSkillEvents', () => {
       expect(() => awsCompileAlexaSkillEvents.compileAlexaSkillEvents()).to.throw(Error);
     });
 
-    it('should create corresponding resources when a alexaSkill event is provided', () => {
+    it('should create corresponding resources when multiple alexaSkill events are provided', () => {
+      const skillId1 = 'amzn1.ask.skill.xx-xx-xx-xx';
+      const skillId2 = 'amzn1.ask.skill.yy-yy-yy-yy';
       awsCompileAlexaSkillEvents.serverless.service.functions = {
         first: {
           events: [
-            'alexaSkill',
+            {
+              alexaSkill: skillId1,
+            },
+            {
+              alexaSkill: {
+                appId: skillId2,
+              },
+            },
           ],
         },
       };
@@ -52,20 +103,84 @@ describe('AwsCompileAlexaSkillEvents', () => {
 
       expect(awsCompileAlexaSkillEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionAlexaSkill.Type
+        .FirstLambdaPermissionAlexaSkill1.Type
       ).to.equal('AWS::Lambda::Permission');
       expect(awsCompileAlexaSkillEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionAlexaSkill.Properties.FunctionName
+        .FirstLambdaPermissionAlexaSkill1.Properties.FunctionName
       ).to.deep.equal({ 'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'] });
       expect(awsCompileAlexaSkillEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionAlexaSkill.Properties.Action
+        .FirstLambdaPermissionAlexaSkill1.Properties.Action
       ).to.equal('lambda:InvokeFunction');
       expect(awsCompileAlexaSkillEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstLambdaPermissionAlexaSkill.Properties.Principal
+        .FirstLambdaPermissionAlexaSkill1.Properties.Principal
       ).to.equal('alexa-appkit.amazon.com');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.EventSourceToken
+      ).to.equal(skillId1);
+
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill2.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill2.Properties.FunctionName
+      ).to.deep.equal({ 'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'] });
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill2.Properties.Action
+      ).to.equal('lambda:InvokeFunction');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill2.Properties.Principal
+      ).to.equal('alexa-appkit.amazon.com');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill2.Properties.EventSourceToken
+      ).to.equal(skillId2);
+    });
+
+    it('should create corresponding resources when a disabled alexaSkill event is provided', () => {
+      const skillId1 = 'amzn1.ask.skill.xx-xx-xx-xx';
+      awsCompileAlexaSkillEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              alexaSkill: {
+                appId: skillId1,
+                enabled: false,
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileAlexaSkillEvents.compileAlexaSkillEvents();
+
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.FunctionName
+      ).to.deep.equal({ 'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'] });
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.Action
+      ).to.equal('lambda:DisableInvokeFunction');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.Principal
+      ).to.equal('alexa-appkit.amazon.com');
+      expect(awsCompileAlexaSkillEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionAlexaSkill1.Properties.EventSourceToken
+      ).to.equal(skillId1);
     });
 
     it('should not create corresponding resources when alexaSkill event is not given', () => {

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -67,7 +67,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-fsharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-fsharp/serverless.yml
@@ -67,7 +67,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-go-dep/serverless.yml
+++ b/lib/plugins/create/templates/aws-go-dep/serverless.yml
@@ -69,7 +69,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-go/serverless.yml
+++ b/lib/plugins/create/templates/aws-go/serverless.yml
@@ -69,7 +69,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-groovy-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-groovy-gradle/serverless.yml
@@ -64,7 +64,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -64,7 +64,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -64,7 +64,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle/serverless.yml
@@ -64,7 +64,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
@@ -64,7 +64,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
@@ -60,7 +60,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -69,7 +69,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -69,7 +69,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-python3/serverless.yml
+++ b/lib/plugins/create/templates/aws-python3/serverless.yml
@@ -69,7 +69,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -66,7 +66,7 @@ functions:
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic
 #      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
 #      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
 #      - iot:
 #          sql: "SELECT * FROM 'some_topic'"


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4700 - using the same concept as `alexaSmartHome` event which forces you to specify skill ID.
This implementation is *backwards compatible* and alerts the users to migrate to the new syntax.

Also, added the option to provide multiple `alexaSkill` events per a function, allowing it to be invoked by multiple skills.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Added the options to provide either a string or an object to the event, while the values impact the Permission Policy which is sent to AWS.
By default, the alexaSkill is enabled.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Example configs (also available in the updated documents):

### one function, one skill:
```yml
functions:
  mySkill:
    handler: mySkill.handler
    events:
      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx-xx
```

### one function, two skills (of which one is disabled):
```yaml
functions:
  mySkill:
    handler: mySkill.handler
    events:
      - alexaSkill:
          appId: amzn1.ask.skill.xx-xx-xx-xx
      - alexaSkill:
          appId: amzn1.ask.skill.yy-yy-yy-yy
          enabled: false
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
