### PR TITLE
Stop throwing errors if alexaSkill is not in the events list

### DIFF
--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.js
@@ -19,71 +19,73 @@ class AwsCompileAlexaSkillEvents {
 
       if (functionObj.events) {
         functionObj.events.forEach(event => {
-          let enabled = true;
-          let appId;
-          if (event === 'alexaSkill') {
-            const warningMessage = [
-              'Warning! You are using an old syntax for alexaSkill which doesn\'t',
-              ' restrict the invocation solely to your skill.',
-              ' Please refer to the documentation for additional information.',
-            ].join('');
-            this.serverless.cli.log(warningMessage);
-          } else if (_.isString(event.alexaSkill)) {
-            appId = event.alexaSkill;
-          } else if (_.isPlainObject(event.alexaSkill)) {
-            if (!_.isString(event.alexaSkill.appId)) {
+          if (event === 'alexaSkill' || event.alexaSkill) {
+            let enabled = true;
+            let appId;
+            if (event === 'alexaSkill') {
+              const warningMessage = [
+                'Warning! You are using an old syntax for alexaSkill which doesn\'t',
+                ' restrict the invocation solely to your skill.',
+                ' Please refer to the documentation for additional information.',
+              ].join('');
+              this.serverless.cli.log(warningMessage);
+            } else if (_.isString(event.alexaSkill)) {
+              appId = event.alexaSkill;
+            } else if (_.isPlainObject(event.alexaSkill)) {
+              if (!_.isString(event.alexaSkill.appId)) {
+                const errorMessage = [
+                  `Missing "appId" property for alexaSkill event in function ${functionName}`,
+                  ' The correct syntax is: appId: amzn1.ask.skill.xx-xx-xx-xx-xx',
+                  ' OR an object with "appId" property.',
+                  ' Please check the docs for more info.',
+                ].join('');
+                throw new this.serverless.classes.Error(errorMessage);
+              }
+              appId = event.alexaSkill.appId;
+              // Parameter `enabled` is optional, hence the explicit non-equal check for false.
+              enabled = event.alexaSkill.enabled !== false;
+            } else {
               const errorMessage = [
-                `Missing "appId" property for alexaSkill event in function ${functionName}`,
-                ' The correct syntax is: appId: amzn1.ask.skill.xx-xx-xx-xx-xx',
-                ' OR an object with "appId" property.',
+                `Alexa Skill event of function "${functionName}" is not an object or string.`,
+                ' The correct syntax is: alexaSkill.',
                 ' Please check the docs for more info.',
               ].join('');
               throw new this.serverless.classes.Error(errorMessage);
             }
-            appId = event.alexaSkill.appId;
-            // Parameter `enabled` is optional, hence the explicit non-equal check for false.
-            enabled = event.alexaSkill.enabled !== false;
-          } else {
-            const errorMessage = [
-              `Alexa Skill event of function "${functionName}" is not an object or string.`,
-              ' The correct syntax is: alexaSkill.',
-              ' Please check the docs for more info.',
-            ].join('');
-            throw new this.serverless.classes.Error(errorMessage);
-          }
-          alexaSkillNumberInFunction++;
+            alexaSkillNumberInFunction++;
 
-          const lambdaLogicalId = this.provider.naming
-            .getLambdaLogicalId(functionName);
+            const lambdaLogicalId = this.provider.naming
+              .getLambdaLogicalId(functionName);
 
-          const permissionTemplate = {
-            Type: 'AWS::Lambda::Permission',
-            Properties: {
-              FunctionName: {
-                'Fn::GetAtt': [
-                  lambdaLogicalId,
-                  'Arn',
-                ],
+            const permissionTemplate = {
+              Type: 'AWS::Lambda::Permission',
+              Properties: {
+                FunctionName: {
+                  'Fn::GetAtt': [
+                    lambdaLogicalId,
+                    'Arn',
+                  ],
+                },
+                Action: enabled ? 'lambda:InvokeFunction' : 'lambda:DisableInvokeFunction',
+                Principal: 'alexa-appkit.amazon.com',
               },
-              Action: enabled ? 'lambda:InvokeFunction' : 'lambda:DisableInvokeFunction',
-              Principal: 'alexa-appkit.amazon.com',
-            },
-          };
+            };
 
-          if (appId) {
-            permissionTemplate.Properties.EventSourceToken = appId.replace(/\\n|\\r/g, '');
+            if (appId) {
+              permissionTemplate.Properties.EventSourceToken = appId.replace(/\\n|\\r/g, '');
+            }
+
+            const lambdaPermissionLogicalId = this.provider.naming
+              .getLambdaAlexaSkillPermissionLogicalId(functionName,
+                alexaSkillNumberInFunction);
+
+            const permissionCloudForamtionResource = {
+              [lambdaPermissionLogicalId]: permissionTemplate,
+            };
+
+            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+              permissionCloudForamtionResource);
           }
-
-          const lambdaPermissionLogicalId = this.provider.naming
-            .getLambdaAlexaSkillPermissionLogicalId(functionName,
-              alexaSkillNumberInFunction);
-
-          const permissionCloudForamtionResource = {
-            [lambdaPermissionLogicalId]: permissionTemplate,
-          };
-
-          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-            permissionCloudForamtionResource);
         });
       }
     });

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
@@ -231,7 +231,7 @@ describe('AwsCompileAlexaSkillEvents', () => {
         },
       };
 
-      expect(awsCompileAlexaSkillEvents.compileAlexaSkillEvents()).to.not.throw;
+      expect(() => awsCompileAlexaSkillEvents.compileAlexaSkillEvents()).to.not.throw();
     });
   });
 });

--- a/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
+++ b/lib/plugins/aws/package/compile/events/alexaSkill/index.test.js
@@ -216,5 +216,22 @@ describe('AwsCompileAlexaSkillEvents', () => {
           .compiledCloudFormationTemplate.Resources
       ).to.deep.equal({});
     });
+
+    it('should not not throw error when other events are present', () => {
+      awsCompileAlexaSkillEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'get',
+                path: '/',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(awsCompileAlexaSkillEvents.compileAlexaSkillEvents()).to.not.throw;
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

#4701 changes were throwing an error if an event other than `alexaSkill` was present in the events list. This fixes the issue.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Making sure the event is `alexaSkill` (whether as a string or an object)
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

A simple serverless.yml with an http handler for a function.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
