### PR TITLE
Allow SSM parameters to be referenced with profile and stage coming from cli-options (#4311)

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -398,24 +398,30 @@ class Variables {
     const groups = variableString.match(this.ssmRefSyntax);
     const param = groups[1];
     const decrypt = (groups[2] === 'true');
-    return this.serverless.getProvider('aws')
-    .request('SSM',
-      'getParameter',
-      {
-        Name: param,
-        WithDecryption: decrypt,
-      },
-      { useCache: true }   // Use request cache
-    )
-    .then(
-      response => BbPromise.resolve(response.Parameter.Value),
-      err => {
-        const expectedErrorMessage = `Parameter ${param} not found.`;
-        if (err.message !== expectedErrorMessage) {
-          throw new this.serverless.classes.Error(err.message);
+    return new BbPromise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 10);
+    }).then(() =>
+      this.serverless.getProvider('aws')
+      .request('SSM',
+        'getParameter',
+        {
+          Name: param,
+          WithDecryption: decrypt,
+        },
+        { useCache: true }   // Use request cache
+        )
+      .then(
+        response => BbPromise.resolve(response.Parameter.Value),
+        err => {
+          const expectedErrorMessage = `Parameter ${param} not found.`;
+          if (err.message !== expectedErrorMessage) {
+            throw new this.serverless.classes.Error(err.message);
+          }
+          return BbPromise.resolve(undefined);
         }
-        return BbPromise.resolve(undefined);
-      }
+      )
     );
   }
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4311

<!--
Briefly describe the feature if no issue exists for this PR
-->
`serverless.yml`:
``` yaml
service: serverless-ssm-test
frameworkVersion: "=1.26.0"
provider:
  name: aws
  runtime: nodejs6.10
  stage: ${opt:stage, 'dev'}
  profile: ${opt:profile}
  region: 'eu-central-1'
  environment:
    DB_USER: ${ssm:/some-path/to-a/db-username}
```

When there are options used for `provider.stage` or `provider.profile` with or without a default value, `serverless` can not resolve the ssm parameter and fails with `Profile ${opt:profile} does not exist`.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Before sending the request to `aws` to get the ssm parameter a short wait of 10 ms is introduced to wait for cli options to be resolved.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
1. Add the ssm parameter mentioned in the config above to a aws profile
2. Run `sls print --stage stage --profile <profile-with-ssm-parameter>`
The above `serverless.yml` should throw an error when run with the current release (=1.26.0).

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
