### PR TITLE
Fix AWS credentials order of precedence

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -14,7 +14,7 @@ layout: Doc
 
 The Serverless Framework needs access to your cloud provider's account so that it can create and manage resources on your behalf.
 
-This guide is for the Amazon Web Services (AWS) provider, so we'll step through the process of setting up credential for AWS and using them with Serverless.
+This guide is for the Amazon Web Services (AWS) provider, so we'll step through the process of setting up credentials for AWS and using them with Serverless.
 
 [Watch the video on setting up credentials](https://www.youtube.com/watch?v=HSd9uYj2LJA)
 
@@ -174,6 +174,17 @@ custom:
     dev: devProfile
     prod: prodProfile
 ```
+
+#### Credentials Precedence
+If you are specifying AWS credentials in more than one place, this is the order of precedence:
+
+1. `--aws-profile` CLI option.
+2. `provider.profile` specified in serverless.yml.
+3. `provider.credentials` specified in serverless.yml.
+4. `AWS_<STAGE>_PROFILE` environment variable.
+5. `AWS_<STAGE>_SECRET_ACCESS_KEY` and `AWS_<STAGE>_ACCESS_KEY_ID` environment variables.
+6. `AWS_PROFILE` environment variable.
+7. `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` environment variables.
 
 #### Profile in place with the 'invoke local' command
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -283,18 +283,19 @@ class AwsProvider {
     const stageUpper = this.getStage() ? this.getStage().toUpperCase() : null;
 
     // add specified credentials, overriding with more specific declarations
+    impl.addEnvironmentCredentials(result, 'AWS'); // creds for all stages
+    impl.addEnvironmentProfile(result, 'AWS');
+    impl.addEnvironmentCredentials(result, `AWS_${stageUpper}`); // stage specific creds
+    impl.addEnvironmentProfile(result, `AWS_${stageUpper}`);
     impl.addCredentials(result, this.serverless.service.provider.credentials); // config creds
     if (this.serverless.service.provider.profile) {
       // config profile
       impl.addProfileCredentials(result, this.serverless.service.provider.profile);
     }
-    impl.addEnvironmentCredentials(result, 'AWS'); // creds for all stages
-    impl.addEnvironmentProfile(result, 'AWS');
-    impl.addEnvironmentCredentials(result, `AWS_${stageUpper}`); // stage specific creds
-    impl.addEnvironmentProfile(result, `AWS_${stageUpper}`);
     if (this.options['aws-profile']) {
       impl.addProfileCredentials(result, this.options['aws-profile']); // CLI option profile
     }
+
     result.region = this.getRegion();
 
     const deploymentBucketObject = this.serverless.service.provider.deploymentBucketObject;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -541,6 +541,7 @@ describe('AwsProvider', () => {
       replaceEnv(originalEnvironmentVariables);
       serverless.service.provider.profile = originalProviderProfile;
       serverless.service.provider.credentials = originalProviderCredentials;
+      newAwsProvider.options['aws-profile'] = originalProviderProfile;
     });
 
     it('should set region for credentials', () => {
@@ -681,6 +682,108 @@ describe('AwsProvider', () => {
 
       const credentials = newAwsProvider.getCredentials();
       expect(credentials.credentials.profile).to.equal('notDefault');
+    });
+
+    context('when determining which credentials take precedence', () => {
+      it('for-all-stages profile takes precedence over for-all-stages credentials', () => {
+        process.env.AWS_PROFILE = 'notDefault';
+
+        const testVal = {
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken',
+        };
+        process.env.AWS_ACCESS_KEY_ID = testVal.accessKeyId;
+        process.env.AWS_SECRET_ACCESS_KEY = testVal.secretAccessKey;
+        process.env.AWS_SESSION_TOKEN = testVal.sessionToken;
+
+        const credentials = newAwsProvider.getCredentials();
+        expect(credentials.credentials.profile).to.equal('notDefault');
+        expect(credentials.credentials.accessKeyId).to.equal(fakeCredentials.accessKeyId);
+        expect(credentials.credentials.secretAccessKey).to.equal(fakeCredentials.secretAccessKey);
+      });
+
+      it('stage-specific credentials takes precedence over for-all-stages profile', () => {
+        const testVal = {
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken',
+        };
+        process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = testVal.accessKeyId;
+        process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = testVal.secretAccessKey;
+        process.env.AWS_TESTSTAGE_SESSION_TOKEN = testVal.sessionToken;
+
+        process.env.AWS_PROFILE = 'notDefault';
+
+        const credentials = newAwsProvider.getCredentials();
+        expect(credentials.credentials.profile).to.equal(undefined);
+        expect(credentials.credentials.accessKeyId).to.equal(testVal.accessKeyId);
+        expect(credentials.credentials.secretAccessKey).to.equal(testVal.secretAccessKey);
+        expect(credentials.credentials.sessionToken).to.equal(testVal.sessionToken);
+      });
+
+      it('stage-specific profile takes precedence over stage-specific credentials', () => {
+        process.env.AWS_TESTSTAGE_PROFILE = 'notDefault';
+
+        const testVal = {
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken',
+        };
+        process.env.AWS_TESTSTAGE_ACCESS_KEY_ID = testVal.accessKeyId;
+        process.env.AWS_TESTSTAGE_SECRET_ACCESS_KEY = testVal.secretAccessKey;
+        process.env.AWS_TESTSTAGE_SESSION_TOKEN = testVal.sessionToken;
+
+        const credentials = newAwsProvider.getCredentials();
+        expect(credentials.credentials.profile).to.equal('notDefault');
+        expect(credentials.credentials.accessKeyId).to.equal(fakeCredentials.accessKeyId);
+        expect(credentials.credentials.secretAccessKey).to.equal(fakeCredentials.secretAccessKey);
+      });
+
+      it('provider declared credentials take precedence over stage-specific profile', () => {
+        const testVal = {
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken',
+        };
+        serverless.service.provider.credentials = testVal;
+
+        process.env.AWS_TESTSTAGE_PROFILE = 'notDefault';
+
+        const credentials = newAwsProvider.getCredentials();
+        expect(credentials.credentials.profile).to.equal(undefined);
+        expect(credentials.credentials.accessKeyId).to.equal(testVal.accessKeyId);
+        expect(credentials.credentials.secretAccessKey).to.equal(testVal.secretAccessKey);
+        expect(credentials.credentials.sessionToken).to.equal(testVal.sessionToken);
+      });
+
+      it('provider declared profile takes precedence over provider-declared credentials', () => {
+        serverless.service.provider.profile = 'notDefault';
+
+        const testVal = {
+          accessKeyId: 'accessKeyId',
+          secretAccessKey: 'secretAccessKey',
+          sessionToken: 'sessionToken',
+        };
+        serverless.service.provider.credentials = testVal;
+
+        const credentials = newAwsProvider.getCredentials();
+        expect(credentials.credentials.profile).to.equal('notDefault');
+        expect(credentials.credentials.accessKeyId).to.equal(fakeCredentials.accessKeyId);
+        expect(credentials.credentials.secretAccessKey).to.equal(fakeCredentials.secretAccessKey);
+      });
+
+      it('--aws-profile option takes precedence over provider-declared profile', () => {
+        newAwsProvider.options['aws-profile'] = 'notDefault';
+
+        serverless.service.provider.profile = 'notDefaultTemporary';
+
+        const credentials = newAwsProvider.getCredentials();
+        expect(credentials.credentials.profile).to.equal('notDefault');
+        expect(credentials.credentials.accessKeyId).to.equal(fakeCredentials.accessKeyId);
+        expect(credentials.credentials.secretAccessKey).to.equal(fakeCredentials.secretAccessKey);
+        expect(credentials.credentials.sessionToken).to.equal(undefined);
+      });
     });
 
     it('should set the signatureVersion to v4 if the serverSideEncryption is aws:kms', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3415

## How did you implement it:
Reordered the statements that add credentials. The order of priority for getting AWS Credentials is as follows:
1. `--aws-profile` CLI option.
2. `provider.profile` specified in serverless.yml.
3. `provider.credentials` specified in serverless.yml.
4. `AWS_<STAGE>_PROFILE` environment variable.
5. `AWS_<STAGE>_SECRET_ACCESS_KEY` and `AWS_<STAGE>_ACCESS_KEY_ID` environment variables.
6. `AWS_PROFILE` environment variable.
7. `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` environment variables.

## How can we verify it:
I added unit tests that test the ordering.

## Todos:

- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below
- [X] ~~Update console output to show profile?~~ Can be done in a follow-up PR.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** Yes? If people relied on the undocumented ordering.
