### PR TITLE
Wraps Poorly Parsing URL in Angle Brackets

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -250,7 +250,7 @@ class AwsProvider {
           const errorMessage = [
             'AWS provider credentials not found.',
             ' Learn how to set up AWS provider credentials',
-            ` in our docs here: ${chalk.green('http://bit.ly/aws-creds-setup')}.`,
+            ` in our docs here: <${chalk.green('http://bit.ly/aws-creds-setup')}>.`,
           ].join('');
           message = errorMessage;
           userStats.track('user_awsCredentialsNotFound');


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4674

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

In order to maintain the end-of-sentence period, I wrapped the offending URL in angle brackets, as suggested by [RFC 3986][].

[RFC 3986]: https://tools.ietf.org/html/rfc3986?#appendix-C

It's a convention for plain text communication, and due to its inclusion in RFC 3986, it may be _the_ convention. I can confirm that it fixes the problem for VS Code. Additionally, it's safer in URL terms, as some do end with a period. (I can demonstrate it here because GitHub strips trailing periods from raw URLs.)

- Redirects: https://en.wikipedia.org/wiki/Inc. (`Redirects: https://en.wikipedia.org/wiki/Inc.`)
- Does not: <https://en.wikipedia.org/wiki/Inc.> (`Does not: <https://en.wikipedia.org/wiki/Inc.>`)

It wouldn't be the worst idea to wrap all of them in angle brackets, but only this one seems to have been bitten by ambiguity.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. Move your `~/.aws` directory to `~/.aws-old`.
2. In Visual Studio Code's integrated terminal, attempt to deploy a service.
3. In this error message:
    ```
    ServerlessError: AWS provider credentials not found. Learn how to set up AWS provider credentials in 
    our docs here: <http://bit.ly/aws-creds-setup>.
    ```
    ...hover your mouse over the URL. The underline will extend only from the "h" to the terminal "p".
4. Clicking the link will take you to the correct (non-404) page.
5. Oh, right, move your aws config back.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
