### PR TITLE
Pass serverless variable when calling function in referenced file

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -285,7 +285,7 @@ functions:
 
 You can reference JavaScript files to add dynamic data into your variables.
 
-References can be either named or unnamed exports. To use the exported `someModule` in `myFile.js` you'd use the following code `${file(./myFile.js):someModule}`. For an unnamed export you'd write `${file(./myFile.js)}`.
+References can be either named or unnamed exports. To use the exported `someModule` in `myFile.js` you'd use the following code `${file(./myFile.js):someModule}`. For an unnamed export you'd write `${file(./myFile.js)}`. The first argument to your export will be a reference to the Serverless object, containing your configuration.
 
 Here are other examples:
 
@@ -299,7 +299,9 @@ module.exports.rate = () => {
 
 ```js
 // config.js
-module.exports = () => {
+module.exports = (serverless) => {
+  serverless.cli.consoleLog('You can access Serverless config and methods as well!');
+
   return {
     property1: 'some value',
     property2: 'some other value'

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -300,7 +300,7 @@ class Variables {
             ' Check if your javascript is exporting a function that returns a value.',
           ].join(''));
       }
-      valueToPopulate = returnValueFunction.call(jsFile);
+      valueToPopulate = returnValueFunction.call(jsFile, this.serverless);
 
       return BbPromise.resolve(valueToPopulate).then(valueToPopulateResolved => {
         let deepProperties = variableString.replace(matchedFileRefString, '');


### PR DESCRIPTION
When using the `${file(foo.js)` feature for `serverless.yml` it's very handy to have a reference to the serverless object available, if only for logging, but it of course be used for much more.

Specifically: I needed to generate/add a list of resources based on whether some other resource was available in the Resources section. I could have done this with CF conditionals or a plugin, but this keeps everything int he JS realm, which gives for more flexibility (especially since CF doesn't have for-loops).

## How did you implement it:

By default no parameter is passed to the given exported function, with this PR it will receive the serverless object, eg:

```js
// config.js
module.exports = (sls) => {
  sls.cli.consoleLog('You can access Serverless config and methods');
  // serverless.provider.

  return {
    property1: 'some value',
    property2: 'some other value'
  }
}
```

```yml
# serverless.yml
service: new-service
provider: aws

custom: ${file(./config.js)}

functions:
  hello:
      handler: handler.hello
      events:
        - schedule: ${file(./scheduleConfig.js):rate} # Reference a specific module
```
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
