### PR TITLE
Ensure to resolve 'provider.region' variable upfront

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -44,12 +44,23 @@ class Variables {
     // remove
     this.service.provider.variableSyntax = true; // matches itself
     this.serverless.service.serverless = null;
-    return this.populateObject(this.service).then(() => {
-      // restore
-      this.service.provider.variableSyntax = variableSyntaxProperty;
-      this.serverless.service.serverless = this.serverless;
-      return BbPromise.resolve(this.service);
-    });
+
+    // Ensure to have provider.region resolved upfront,
+    // as some resolvers (e.g. S3 or SSM) depend on it
+    const regionResolvePromise = this.service.provider.region
+      ? this.populateProperty(this.service.provider.region).then(
+          region => (this.service.provider.region = region)
+        )
+      : BbPromise.resolve();
+
+    return regionResolvePromise.then(() =>
+      this.populateObject(this.service).then(() => {
+        // restore
+        this.service.provider.variableSyntax = variableSyntaxProperty;
+        this.serverless.service.serverless = this.serverless;
+        return this.service;
+      })
+    );
   }
   /**
    * Populate the variables in the given object.

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -87,6 +87,29 @@ describe('Variables', () => {
         expect(serverless.service.resources.bar).to.equal(barValue);
       });
     });
+
+    it('should resolve provider.region upfront', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = testUtils.getTmpDirPath();
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+
+      const regionValuePath = 'region-var.json';
+      const regionValue = 'eu-west-1';
+      SUtils.writeFileSync(path.join(tmpDirPath, regionValuePath), JSON.stringify(regionValue));
+      serverless.service.provider.region = `\${file(${regionValuePath})}`;
+      serverless.service.custom.someSsm = '${ssm:/some/path/to/param}';
+
+      const awsProvider = new AwsProvider(serverless);
+      const requestStub = sinon.stub(awsProvider, 'request', function () {
+        expect(this.getRegion()).to.equal(regionValue);
+        return BbPromise.resolve({ Parameter: { Value: 'some-value' } });
+      });
+
+      return serverless.variables.populateService().then(() => {
+        expect(serverless.service.provider.region).to.equal(regionValue);
+        requestStub.restore();
+      });
+    });
   });
 
   describe('#populateObject()', () => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -110,6 +110,25 @@ describe('Variables', () => {
         requestStub.restore();
       });
     });
+
+    it('should not pursue upfront region resolution if provider.region not provided', () => {
+      const serverless = new Serverless();
+
+      const defaultRegion = serverless.service.provider.region;
+      delete serverless.service.provider.region;
+      serverless.service.custom.someSsm = '${ssm:/some/path/to/param}';
+
+      const awsProvider = new AwsProvider(serverless);
+      const requestStub = sinon.stub(awsProvider, 'request', function () {
+        expect(this.getRegion()).to.equal(defaultRegion);
+        return BbPromise.resolve({ Parameter: { Value: 'some-value' } });
+      });
+
+      return serverless.variables.populateService().then(() => {
+        expect(serverless.service.provider.region).to.equal(undefined);
+        requestStub.restore();
+      });
+    });
   });
 
   describe('#populateObject()', () => {


### PR DESCRIPTION
## What did you implement:

`provider.region` is resolved upfront to other variables.

If `provider.region` is provided as a variable (e.g. `${file(aws-region.json)}`), then SSM and S3 resolvers do not work as they attempt to do AWS request before variable is resolved, and crash with following error

```
 Inaccessible host: `ssm.'. This service may not be available in the `${file(aws-region.json)}' region.
```

## How did you implement it:

Ensured `provider.region` is resolved prior resolution of all other variables.

## How can we verify it:

I've added test that fails, if patch is not in action.

## Todos:

- [x] Write tests
- [ ] ~Write documentation~ (N/A as it's a bug fix)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
