### PR TITLE
Follow up fixes for #4713

### DIFF
--- a/lib/classes/PromiseTracker.js
+++ b/lib/classes/PromiseTracker.js
@@ -4,11 +4,15 @@ const logWarning = require('./Error').logWarning;
 
 class PromiseTracker {
   constructor() {
+    this.reset();
+  }
+  reset() {
     this.promiseList = [];
     this.promiseMap = {};
     this.startTime = Date.now();
   }
   start() {
+    this.reset();
     this.interval = setInterval(this.report.bind(this), 2500);
   }
   report() {
@@ -25,6 +29,7 @@ class PromiseTracker {
   }
   stop() {
     clearInterval(this.interval);
+    this.reset();
   }
   add(variable, prms, specifier) {
     const promise = prms;

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -87,9 +87,6 @@ class Service {
   }
 
   loadServiceFileParam(serviceFilename, serverlessFileParam) {
-    // #######################################################################
-    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
-    // #######################################################################
     const that = this;
 
     const serverlessFile = serverlessFileParam;
@@ -113,6 +110,14 @@ class Service {
       throw new ServerlessError(`"provider" property is missing in ${serviceFilename}`);
     }
 
+    // #######################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
+    // #######################################################################
+    // #####################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Variables.js ##
+    // ##   there, see `getValueFromSelf`                                 ##
+    // ##   here, see below                                               ##
+    // #####################################################################
     if (!_.isObject(serverlessFile.provider)) {
       const providerName = serverlessFile.provider;
       serverlessFile.provider = {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -8,6 +8,9 @@ const semver = require('semver');
 
 class Service {
   constructor(serverless, data) {
+    // #######################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
+    // #######################################################################
     this.serverless = serverless;
 
     // Default properties
@@ -84,6 +87,9 @@ class Service {
   }
 
   loadServiceFileParam(serviceFilename, serverlessFileParam) {
+    // #######################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
+    // #######################################################################
     const that = this;
 
     const serverlessFile = serverlessFileParam;

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -17,16 +17,16 @@ class Variables {
     this.tracker = new PromiseTracker();
 
     this.deep = [];
-    this.deepRefSyntax = RegExp(/^(\${)?deep:\d+(\.[^}]+)*()}?$/);
+    this.deepRefSyntax = RegExp(/(\${)?deep:\d+(\.[^}]+)*()}?/);
     this.overwriteSyntax = RegExp(/\s*(?:,\s*)+/g);
     this.fileRefSyntax = RegExp(/^file\((~?[a-zA-Z0-9._\-/]+?)\)/g);
     this.envRefSyntax = RegExp(/^env:/g);
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
     this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
-    this.cfRefSyntax = RegExp(/^cf:/g);
-    this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
-    this.ssmRefSyntax = RegExp(/^ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false)?/);
+    this.cfRefSyntax = RegExp(/^(?:\${)?cf:/g);
+    this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
+    this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false)?/);
   }
 
   loadVariableSyntax() {
@@ -58,14 +58,12 @@ class Variables {
           accumulation.concat(this.splitByComma(current.variable)),
         []);
     };
-    const serviceMatch = variablePart =>
-      dependentServices.find((service) => {
-        let variable = variablePart;
-        if (variable.match(this.deepRefSyntax)) {
-          variable = this.getVariableFromDeep(variablePart);
-        }
-        return variable.match(service.regex);
-      });
+    const serviceMatch = (variablePart) => {
+      const variable = variablePart.match(this.deepRefSyntax) ?
+        this.getVariableFromDeep(variablePart) :
+        variablePart;
+      return dependentServices.find(service => variable.match(service.regex));
+    };
     const getUntilValid = (config) => {
       const parts = getVariableParts(config.value);
       const service = parts.reduce(
@@ -506,7 +504,7 @@ class Variables {
   getValueFromSelf(variableString) {
     const valueToPopulate = this.service;
     const deepProperties = variableString.split(':')[1].split('.');
-    return this.getDeepValue(deepProperties, valueToPopulate);
+    return this.getDeeperValue(deepProperties, valueToPopulate);
   }
 
   getValueFromFile(variableString) {
@@ -561,7 +559,7 @@ class Variables {
         let deepProperties = variableString.replace(matchedFileRefString, '');
         deepProperties = deepProperties.slice(1).split('.');
         deepProperties.splice(0, 1);
-        return this.getDeepValue(deepProperties, valueToPopulateResolved)
+        return this.getDeeperValue(deepProperties, valueToPopulateResolved)
           .then((deepValueToPopulateResolved) => {
             if (typeof deepValueToPopulateResolved === 'undefined') {
               const errorMessage = [
@@ -591,7 +589,7 @@ class Variables {
           return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
         }
         deepProperties = deepProperties.slice(1).split('.');
-        return this.getDeepValue(deepProperties, valueToPopulate);
+        return this.getDeeperValue(deepProperties, valueToPopulate);
       }
     }
     return BbPromise.resolve(valueToPopulate);
@@ -675,42 +673,60 @@ class Variables {
     const deepPrefixReplace = RegExp(/(?:^deep:)\d+\.?/g);
     const variable = this.getVariableFromDeep(variableString);
     const deepRef = variableString.replace(deepPrefixReplace, '');
-    const sourceString = `\${deep:\${${variable}}${deepRef.length ? `.${deepRef}` : ''}}`;
-    return this.splitAndGet(variable, sourceString);
+    let ret = this.populateValue(variable);
+    if (deepRef.length) { // if there is a deep reference remaining
+      ret = ret.then((result) => {
+        if (_.isString(result) && result.match(this.variableSyntax)) {
+          const deepVariable = this.makeDeepVariable(result);
+          return BbPromise.resolve(this.appendDeepVariable(deepVariable, deepRef));
+        }
+        return this.getDeeperValue(deepRef.split('.'), result);
+      });
+    }
+    return ret;
   }
 
-  getDeepValue(deepProperties, valueToPopulate) {
-    return BbPromise.reduce(deepProperties, (computedValueToPopulateParam, subProperty) => {
-      let computedValueToPopulate = computedValueToPopulateParam;
-      if ( // in build deep variable mode
-        _.isString(computedValueToPopulate) &&
-        computedValueToPopulate.match(this.deepRefSyntax)
-      ) {
-        if (subProperty !== '') {
-          computedValueToPopulate = `${
-            computedValueToPopulate.slice(0, computedValueToPopulate.length - 1)
-          }.${
-            subProperty
-          }}`;
+  makeDeepVariable(variable) {
+    let index = this.deep.findIndex((item) => variable === item);
+    if (index < 0) {
+      index = this.deep.push(variable) - 1;
+    }
+    return `\${deep:${index}}`;
+  }
+  appendDeepVariable(variable, subProperty) {
+    return `${variable.slice(0, variable.length - 1)}.${subProperty}}`;
+  }
+
+  /**
+   * Get a value that is within the given valueToPopulate.  The deepProperties specify what value
+   * to retrieve from the given valueToPopulate.  The trouble is that anywhere along this chain a
+   * variable can be discovered.  If this occurs, to avoid cyclic dependencies, the resolution of
+   * the deep value from the given valueToPopulate must be halted.  The discovered variable is thus
+   * set aside into a "deep variable" (see makeDeepVariable).  The indexing into the given
+   * valueToPopulate is then resolved with a replacement ${deep:${index}.${remaining.properties}}
+   * variable (e.g. ${deep:1.foo}).  This pauses the population for continuation during the next
+   * generation of evaluation (see getValueFromDeep)
+   * @param deepProperties The "path" of properties to follow in obtaining the deeper value
+   * @param valueToPopulate The value from which to obtain the deeper value
+   * @returns {Promise} A promise resolving to the deeper value or to a `deep` variable that
+   * will later resolve to the deeper value
+   */
+  getDeeperValue(deepProperties, valueToPopulate) {
+    return BbPromise.reduce(deepProperties, (reducedValueParam, subProperty) => {
+      let reducedValue = reducedValueParam;
+      if (_.isString(reducedValue) && reducedValue.match(this.deepRefSyntax)) { // build mode
+        reducedValue = this.appendDeepVariable(reducedValue, subProperty);
+      } else { // get mode
+        if (typeof reducedValue === 'undefined') {
+          reducedValue = {};
+        } else if (subProperty !== '' || '' in reducedValue) {
+          reducedValue = reducedValue[subProperty];
         }
-        return BbPromise.resolve(computedValueToPopulate);
-      } else if (typeof computedValueToPopulate === 'undefined') { // in get deep value mode
-        computedValueToPopulate = {};
-      } else if (subProperty !== '' || '' in computedValueToPopulate) {
-        computedValueToPopulate = computedValueToPopulate[subProperty];
-      }
-      if (
-        typeof computedValueToPopulate === 'string' &&
-        computedValueToPopulate.match(this.variableSyntax)
-      ) {
-        const computedVariable = this.cleanVariable(computedValueToPopulate);
-        let index = this.deep.findIndex((item) => computedVariable === item);
-        if (index < 0) {
-          index = this.deep.push(computedVariable) - 1;
+        if (typeof reducedValue === 'string' && reducedValue.match(this.variableSyntax)) {
+          reducedValue = this.makeDeepVariable(reducedValue);
         }
-        return BbPromise.resolve(`\${deep:${index}}`);
       }
-      return BbPromise.resolve(computedValueToPopulate);
+      return BbPromise.resolve(reducedValue);
     }, valueToPopulate);
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -523,6 +523,10 @@ class Variables {
 
   getValueFromSelf(variableString) {
     let variable = variableString;
+    // ###################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Service.js ##
+    // ##   there, see `loadServiceFileParam`                           ##
+    // ###################################################################
     // The loaded service is altered during load in ~/lib/classes/Service (see loadServiceFileParam)
     // Account for these so that user's reference to their file populate properly
     if (variable === 'self:service.name') {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -23,9 +23,9 @@ class Variables {
     this.envRefSyntax = RegExp(/^env:/g);
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
+    this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
     this.cfRefSyntax = RegExp(/^cf:/g);
     this.s3RefSyntax = RegExp(/^s3:(.+?)\/(.+)$/);
-    this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
     this.ssmRefSyntax = RegExp(/^ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false)?/);
   }
 
@@ -279,14 +279,8 @@ class Variables {
    * @param {MatchResult[]} matches The matches to populate
    * @returns {Promise[]} Promises for the eventual populated values of the given matches
    */
-  populateMatches(matches) {
-    return _.map(matches, (match) => {
-      const parts = this.splitByComma(match.variable);
-      if (parts.length > 1) {
-        return this.overwrite(parts, match.match);
-      }
-      return this.getValueFromSource(parts[0], match.match);
-    });
+  populateMatches(matches, property) {
+    return _.map(matches, (match) => this.splitAndGet(match.variable, property));
   }
   /**
    * Render the given matches and their associated results to the given value
@@ -317,7 +311,7 @@ class Variables {
     if (!_.isArray(matches)) {
       return BbPromise.resolve(property);
     }
-    const populations = this.populateMatches(matches);
+    const populations = this.populateMatches(matches, valueToPopulate);
     return BbPromise.all(populations)
       .then(results => this.renderMatches(property, matches, results))
       .then((result) => {
@@ -334,6 +328,21 @@ class Variables {
    */
   populateProperty(propertyToPopulate) {
     return this.populateValue(propertyToPopulate, true);
+  }
+
+  /**
+   * Split the cleaned variable string containing one or more comma delimited variables and get a
+   * final value for the entirety of the string
+   * @param varible The variable string to split and get a final value for
+   * @param property The original property string the given variable was extracted from
+   * @returns {Promise} A promise resolving to the final value of the given variable
+   */
+  splitAndGet(variable, property) {
+    const parts = this.splitByComma(variable);
+    if (parts.length > 1) {
+      return this.overwrite(parts, property);
+    }
+    return this.getValueFromSource(parts[0], property);
   }
   /**
    * Populate a given property, given the matched string to replace and the value to replace the
@@ -667,7 +676,7 @@ class Variables {
     const variable = this.getVariableFromDeep(variableString);
     const deepRef = variableString.replace(deepPrefixReplace, '');
     const sourceString = `\${deep:\${${variable}}${deepRef.length ? `.${deepRef}` : ''}}`;
-    return this.getValueFromSource(variable, sourceString);
+    return this.splitAndGet(variable, sourceString);
   }
 
   getDeepValue(deepProperties, valueToPopulate) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -10,6 +10,33 @@ const fse = require('../utils/fs/fse');
 const logWarning = require('./Error').logWarning;
 const PromiseTracker = require('./PromiseTracker');
 
+/**
+ * Maintainer's notes:
+ *
+ * This is a tricky class to modify and maintain.  A few rules on how it works...
+ *
+ * 0. The population of a service consists of pre-population, followed by population.  Pre-
+ *   population consists of populating only those settings which are required for variable
+ *   resolution.  Current examples include region and stage as they must be resolved to a
+ *   concrete value before they can be used in the provider's `request` method (used by
+ *   `getValueFromCf`, `getValueFromS3`, and `getValueFromSsm`) to resolve the associated values.
+ *   Original issue: #4725
+ * 1. All variable populations occur in generations.  Each of these generations resolves each
+ *   present variable in the given object or property (i.e. terminal string properties and/or
+ *   property parts) once.  This is to say that recursive resolutions should not be made.  This is
+ *   because cyclic references are allowed [i.e. ${self:} and the like]) and doing so leads to
+ *   dependency and dead-locking issues.  This leads to a problem with deep value population (i.e.
+ *   populating ${self:foo.bar} when ${self:foo} has a value of {opt:bar}).  To pause that, one must
+ *   pause population, noting the continued depth to traverse.  This motivated "deep" variables.
+ *   Original issue #4687
+ * 2. The resolution of variables can get very confusing if the same object is used multiple times.
+ *   An example of this is the print command which *implicitly/invisibly* populates the
+ *   serverless.yml and then *explicitly/visibily* renders the same file again, without the
+ *   adornments that the framework's components make to the originally loaded service.  As a result,
+ *   it is important to reset this object for each use.
+ * 3. Note that despite some AWS code herein that this class is used in all plugins.  Obviously
+ *   users avoid the AWS-specific variable types when targetting other clouds.
+ */
 class Variables {
   constructor(serverless) {
     this.serverless = serverless;
@@ -32,66 +59,53 @@ class Variables {
   loadVariableSyntax() {
     this.variableSyntax = RegExp(this.service.provider.variableSyntax, 'g');
   }
+
+  initialCall(func) {
+    this.deep = [];
+    this.tracker.start();
+    return func().finally(() => {
+      this.tracker.stop();
+      this.deep = [];
+    });
+  }
+
   // #############
   // ## SERVICE ##
   // #############
-  prepopulateService() {
+  prepopulateObject(objectToPopulate) {
     const dependentServices = [
-      { name: 'CloudFormation', regex: this.cfRefSyntax },
-      { name: 'S3', regex: this.s3RefSyntax },
-      { name: 'SSM', regex: this.ssmRefSyntax },
+      { name: 'CloudFormation', method: 'getValueFromCf', original: this.getValueFromCf },
+      { name: 'S3', method: 'getValueFromS3', original: this.getValueFromS3 },
+      { name: 'SSM', method: 'getValueFromSsm', original: this.getValueFromSsm },
     ];
     const dependencyMessage = (configName, configValue, serviceName) =>
-      `Variable Failure: value ${
-        configName
-        } set to '${
-        configValue
-        }' references ${
-        serviceName
-        } which requires a ${
-        configName
-        } value for use.`;
-    const getVariableParts = (variableString) => {
-      const matches = this.getMatches(variableString);
-      return matches.reduce(
-        (accumulation, current) =>
-          accumulation.concat(this.splitByComma(current.variable)),
-        []);
-    };
-    const serviceMatch = (variablePart) => {
-      const variable = variablePart.match(this.deepRefSyntax) ?
-        this.getVariableFromDeep(variablePart) :
-        variablePart;
-      return dependentServices.find(service => variable.match(service.regex));
-    };
-    const getUntilValid = (config) => {
-      const parts = getVariableParts(config.value);
-      const service = parts.reduce(
-        (accumulation, part) => accumulation || serviceMatch(part),
-        undefined);
-      if (service) {
-        const msg = dependencyMessage(config.name, config.value, service.name);
-        return BbPromise.reject(new this.serverless.classes.Error(msg));
-      }
-      return this.populateValue(config.value, false)
-        .then(populated => (
-          populated.match(this.variableSyntax) ?
-            getUntilValid(_.assign(config, { value: populated })) :
-            _.assign({}, config, { populated })
-        ));
-    };
-
+      `Variable Failure: value ${configName} set to '${configValue}' references ${
+        serviceName} which requires a ${configName} value for use.`;
+    // replace and then restore the methods for obtaining values from dependent services.  the
+    // replacement naturally rejects dependencies on these services that occur during prepopulation.
+    // prepopulation is, of course, the process of obtaining the required configuration for using
+    // these services.
+    dependentServices.forEach((dependentService) => { // knock out
+      this[dependentService.method] = (variableString) => BbPromise.reject(
+        dependencyMessage(objectToPopulate.name, variableString, dependentService.name));
+    });
+    return this.populateValue(objectToPopulate.value, true) // populate
+      .then(populated => _.assign(objectToPopulate, { populated }))
+      .finally(() => {
+        dependentServices.forEach((dependentService) => { // restore
+          this[dependentService.method] = dependentService.original;
+        });
+      });
+  }
+  prepopulateService() {
     const provider = this.serverless.getProvider('aws');
     if (provider) {
       const requiredConfig = [
         _.assign({ name: 'region' }, provider.getRegionSourceValue()),
         _.assign({ name: 'stage' }, provider.getStageSourceValue()),
       ];
-      const configToPopulate = requiredConfig.filter(config =>
-        !_.isUndefined(config.value) &&
-        (_.isString(config.value) && config.value.match(this.variableSyntax)));
-      const configPromises = configToPopulate.map(getUntilValid);
-      return this.assignProperties(provider, configPromises);
+      const prepopulations = requiredConfig.map(this.prepopulateObject.bind(this));
+      return this.assignProperties(provider, prepopulations);
     }
     return BbPromise.resolve();
   }
@@ -102,6 +116,9 @@ class Variables {
    * @returns {Promise.<TResult>|*} A promise resolving to the populated service.
    */
   populateService(processedOptions) {
+    // #######################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
+    // #######################################################################
     this.options = processedOptions || {};
 
     this.loadVariableSyntax();
@@ -110,16 +127,15 @@ class Variables {
     // remove
     this.service.provider.variableSyntax = undefined; // otherwise matches itself
     this.service.serverless = undefined;
-    this.tracker.start();
-    return this.prepopulateService()
-      .then(() => this.populateObject(this.service))
-      .finally(() => {
-        // restore
-        this.tracker.stop();
-        this.service.serverless = this.serverless;
-        this.service.provider.variableSyntax = variableSyntaxProperty;
-      })
-      .then(() => this.service);
+    return this.initialCall(() =>
+      this.prepopulateService()
+        .then(() => this.populateObjectImpl(this.service)
+          .finally(() => {
+            // restore
+            this.service.serverless = this.serverless;
+            this.service.provider.variableSyntax = variableSyntaxProperty;
+          }))
+        .then(() => this.service));
   }
   // ############
   // ## OBJECT ##
@@ -225,12 +241,16 @@ class Variables {
    * @returns {Promise.<TResult>|*} A promise resolving to the in-place populated object.
    */
   populateObject(objectToPopulate) {
+    return this.initialCall(() => this.populateObjectImpl(objectToPopulate));
+  }
+  populateObjectImpl(objectToPopulate) {
     const leaves = this.getProperties(objectToPopulate, true, objectToPopulate);
     const populations = this.populateVariables(leaves);
+    if (populations.length === 0) {
+      return BbPromise.resolve(objectToPopulate);
+    }
     return this.assignProperties(objectToPopulate, populations)
-      .then(() => (populations.length ?
-        this.populateObject(objectToPopulate) :
-        objectToPopulate));
+      .then(() => this.populateObjectImpl(objectToPopulate));
   }
   // ##############
   // ## PROPERTY ##
@@ -304,7 +324,7 @@ class Variables {
    * is true
    */
   populateValue(valueToPopulate, root) {
-    const property = _.cloneDeep(valueToPopulate);
+    const property = valueToPopulate;
     const matches = this.getMatches(property);
     if (!_.isArray(matches)) {
       return BbPromise.resolve(property);
@@ -325,7 +345,7 @@ class Variables {
    * @returns {Promise.<TResult>|*} A promise resolving to the populated result.
    */
   populateProperty(propertyToPopulate) {
-    return this.populateValue(propertyToPopulate, true);
+    return this.initialCall(() => this.populateValue(propertyToPopulate, true));
   }
 
   /**
@@ -503,7 +523,7 @@ class Variables {
 
   getValueFromSelf(variableString) {
     const valueToPopulate = this.service;
-    const deepProperties = variableString.split(':')[1].split('.');
+    const deepProperties = variableString.split(':')[1].split('.').filter(property => property);
     return this.getDeeperValue(deepProperties, valueToPopulate);
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -522,8 +522,17 @@ class Variables {
   }
 
   getValueFromSelf(variableString) {
+    let variable = variableString;
+    // The loaded service is altered during load in ~/lib/classes/Service (see loadServiceFileParam)
+    // Account for these so that user's reference to their file populate properly
+    if (variable === 'self:service.name') {
+      variable = 'self:service';
+    }
+    if (variable === 'self:provider') {
+      variable = 'self:provider.name';
+    }
     const valueToPopulate = this.service;
-    const deepProperties = variableString.split(':')[1].split('.').filter(property => property);
+    const deepProperties = variable.split(':')[1].split('.').filter(property => property);
     return this.getDeeperValue(deepProperties, valueToPopulate);
   }
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -21,10 +21,10 @@ const Variables = require('../../lib/classes/Variables');
 
 BbPromise.longStackTraces(true);
 
-chai.should();
-
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
+
+chai.should();
 
 const expect = chai.expect;
 
@@ -55,32 +55,73 @@ describe('Variables', () => {
   });
 
   describe('#populateService()', () => {
-    it('should call loadVariableSyntax and then populateProperty', () => {
-      const loadVariableSyntaxStub = sinon.stub(serverless.variables, 'loadVariableSyntax')
-        .returns();
-      const populateObjectStub = sinon.stub(serverless.variables, 'populateObject')
-        .returns(BbPromise.resolve());
-      return expect(serverless.variables.populateService()).to.be.fulfilled
-        .then(() => {
-          expect(loadVariableSyntaxStub).to.be.calledOnce;
-          expect(populateObjectStub).to.be.calledOnce;
-          expect(loadVariableSyntaxStub).to.be.calledBefore(populateObjectStub);
-        })
-        .finally(() => {
-          populateObjectStub.restore();
-          loadVariableSyntaxStub.restore();
-        });
-    });
-    it('should remove problematic attributes bofore calling populateObject with the service',
+    it('should remove problematic attributes bofore calling populateObjectImpl with the service',
       () => {
-        const populateObjectStub = sinon.stub(serverless.variables, 'populateObject', (val) => {
+        const prepopulateServiceStub = sinon.stub(serverless.variables, 'prepopulateService')
+          .returns(BbPromise.resolve());
+        const populateObjectStub = sinon.stub(serverless.variables, 'populateObjectImpl', (val) => {
           expect(val).to.equal(serverless.service);
           expect(val.provider.variableSyntax).to.be.undefined;
           expect(val.serverless).to.be.undefined;
           return BbPromise.resolve();
         });
-        return expect(serverless.variables.populateService()).to.be.fulfilled
-          .then().finally(() => populateObjectStub.restore());
+        return serverless.variables.populateService().should.be.fulfilled
+          .then().finally(() => {
+            prepopulateServiceStub.restore();
+            populateObjectStub.restore();
+          });
+      });
+    it('should clear caches and remaining state *before* [pre]populating service',
+      () => {
+        const prepopulateServiceStub = sinon.stub(serverless.variables, 'prepopulateService',
+          (val) => {
+            expect(serverless.variables.deep).to.eql([]);
+            expect(serverless.variables.tracker.getAll()).to.eql([]);
+            return BbPromise.resolve(val);
+          });
+        const populateObjectStub = sinon.stub(serverless.variables, 'populateObjectImpl',
+          (val) => {
+            expect(serverless.variables.deep).to.eql([]);
+            expect(serverless.variables.tracker.getAll()).to.eql([]);
+            return BbPromise.resolve(val);
+          });
+        serverless.variables.deep.push('${foo:}');
+        const prms = BbPromise.resolve('foo');
+        serverless.variables.tracker.add('foo:', prms, '${foo:}');
+        prms.state = 'resolved';
+        return serverless.variables.populateService().should.be.fulfilled
+          .then().finally(() => {
+            prepopulateServiceStub.restore();
+            populateObjectStub.restore();
+          });
+      });
+    it('should clear caches and remaining *after* [pre]populating service',
+      () => {
+        const prepopulateServiceStub = sinon.stub(serverless.variables, 'prepopulateService',
+          (val) => {
+            serverless.variables.deep.push('${foo:}');
+            const promise = BbPromise.resolve(val);
+            serverless.variables.tracker.add('foo:', promise, '${foo:}');
+            promise.state = 'resolved';
+            return BbPromise.resolve();
+          });
+        const populateObjectStub = sinon.stub(serverless.variables, 'populateObjectImpl',
+          (val) => {
+            serverless.variables.deep.push('${bar:}');
+            const promise = BbPromise.resolve(val);
+            serverless.variables.tracker.add('bar:', promise, '${bar:}');
+            promise.state = 'resolved';
+            return BbPromise.resolve();
+          });
+        return serverless.variables.populateService().should.be.fulfilled
+          .then(() => {
+            expect(serverless.variables.deep).to.eql([]);
+            expect(serverless.variables.tracker.getAll()).to.eql([]);
+          })
+          .finally(() => {
+            prepopulateServiceStub.restore();
+            populateObjectStub.restore();
+          });
       });
   });
   describe('#prepopulateService', () => {
@@ -90,17 +131,17 @@ describe('Variables', () => {
     // variable syntax is loaded, and that the service object is cleaned up.  Just use
     // populateService to do that work.
     let awsProvider;
-    let populateObjectStub;
+    let populateObjectImplStub;
     let requestStub; // just in case... don't want to actually call...
     beforeEach(() => {
       awsProvider = new AwsProvider(serverless, {});
-      populateObjectStub = sinon.stub(serverless.variables, 'populateObject');
-      populateObjectStub.withArgs(serverless.variables.service).returns(BbPromise.resolve());
+      populateObjectImplStub = sinon.stub(serverless.variables, 'populateObjectImpl');
+      populateObjectImplStub.withArgs(serverless.variables.service).returns(BbPromise.resolve());
       requestStub = sinon.stub(awsProvider, 'request', () =>
         BbPromise.reject(new Error('unexpected')));
     });
     afterEach(() => {
-      populateObjectStub.restore();
+      populateObjectImplStub.restore();
       requestStub.restore();
     });
     const prepopulatedProperties = [

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1086,22 +1086,39 @@ module.exports = {
   });
 
   describe('#getValueFromSelf()', () => {
+    beforeEach(() => {
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
+      serverless.variables.loadVariableSyntax();
+      delete serverless.service.provider.variableSyntax;
+    });
     it('should get variable from self serverless.yml file', () => {
       serverless.variables.service = {
         service: 'testService',
         provider: serverless.service.provider,
       };
-      serverless.variables.loadVariableSyntax();
       return serverless.variables.getValueFromSelf('self:service').should.become('testService');
     });
-
+    it('should redirect ${self:service.name} to ${self:service}', () => {
+      serverless.variables.service = {
+        service: 'testService',
+        provider: serverless.service.provider,
+      };
+      return serverless.variables.getValueFromSelf('self:service.name')
+        .should.become('testService');
+    });
+    it('should redirect ${self:provider} to ${self:provider.name}', () => {
+      serverless.variables.service = {
+        service: 'testService',
+        provider: { name: 'aws' },
+      };
+      return serverless.variables.getValueFromSelf('self:provider').should.become('aws');
+    });
     it('should handle self-references to the root of the serverless.yml file', () => {
       serverless.variables.service = {
         service: 'testService',
         provider: 'testProvider',
         defaults: serverless.service.defaults,
       };
-      serverless.variables.loadVariableSyntax();
       return serverless.variables.getValueFromSelf('self:')
         .should.eventually.equal(serverless.variables.service);
     });

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -390,6 +390,18 @@ describe('Variables', () => {
           expect(result).to.eql(expected);
         })).to.be.fulfilled;
       });
+      it('should handle deep variables that are overrides', () => {
+        service.custom = {
+          val1: '${self:not.a.value, "bar"}',
+          val2: 'foo${self:custom.val1}',
+        };
+        const expected = {
+          val1: 'bar',
+          val2: 'foobar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
       describe('file reading cases', () => {
         let tmpDirPath;
         beforeEach(() => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -94,8 +94,8 @@ describe('Variables', () => {
     let requestStub; // just in case... don't want to actually call...
     beforeEach(() => {
       awsProvider = new AwsProvider(serverless, {});
-      populateObjectStub = sinon.stub(serverless.variables, 'populateObject', () =>
-        BbPromise.resolve());
+      populateObjectStub = sinon.stub(serverless.variables, 'populateObject');
+      populateObjectStub.withArgs(serverless.variables.service).returns(BbPromise.resolve());
       requestStub = sinon.stub(awsProvider, 'request', () =>
         BbPromise.reject(new Error('unexpected')));
     });
@@ -130,15 +130,15 @@ describe('Variables', () => {
             return serverless.variables.populateService()
               .should.be.rejectedWith('Variable Failure');
           });
+          it(`should reject recursively dependent ${config.name} service dependencies`, () => {
+            serverless.variables.service.custom = {
+              settings: config.value,
+            };
+            awsProvider.options.region = '${self:custom.settings.region}';
+            return serverless.variables.populateService()
+              .should.be.rejectedWith('Variable Failure');
+          });
         });
-      });
-      it('should reject recursively dependent service dependencies', () => {
-        serverless.variables.service.custom = {
-          settings: '${s3:bucket/key}',
-        };
-        awsProvider.options.region = '${self:custom.settings.region}';
-        return serverless.variables.populateService()
-          .should.be.rejectedWith('Variable Failure');
       });
     });
   });
@@ -390,7 +390,67 @@ describe('Variables', () => {
           expect(result).to.eql(expected);
         })).to.be.fulfilled;
       });
-      it('should handle deep variables that are overrides', () => {
+      // see https://github.com/serverless/serverless/pull/4713#issuecomment-366975172
+      it('should handle deep references into deep variables', () => {
+        service.provider.stage = 'dev';
+        service.custom = {
+          stage: '${env:stage, self:provider.stage}',
+          secrets: '${self:custom.${self:custom.stage}}',
+          dev: {
+            SECRET: 'secret',
+          },
+          environment: {
+            SECRET: '${self:custom.secrets.SECRET}',
+          },
+        };
+        const expected = {
+          stage: 'dev',
+          secrets: {
+            SECRET: 'secret',
+          },
+          dev: {
+            SECRET: 'secret',
+          },
+          environment: {
+            SECRET: 'secret',
+          },
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle deep variables that reference overrides', () => {
+        service.custom = {
+          val1: '${self:not.a.value, "bar"}',
+          val2: '${self:custom.val1}',
+        };
+        const expected = {
+          val1: 'bar',
+          val2: 'bar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle deep references into deep variables', () => {
+        service.custom = {
+          val0: {
+            foo: 'bar',
+          },
+          val1: '${self:custom.val0}',
+          val2: '${self:custom.val1.foo}',
+        };
+        const expected = {
+          val0: {
+            foo: 'bar',
+          },
+          val1: {
+            foo: 'bar',
+          },
+          val2: 'bar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle deep variables that reference overrides', () => {
         service.custom = {
           val1: '${self:not.a.value, "bar"}',
           val2: 'foo${self:custom.val1}',
@@ -398,6 +458,64 @@ describe('Variables', () => {
         const expected = {
           val1: 'bar',
           val2: 'foobar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle referenced deep variables that reference overrides', () => {
+        service.custom = {
+          val1: '${self:not.a.value, "bar"}',
+          val2: '${self:custom.val1}',
+          val3: '${self:custom.val2}',
+        };
+        const expected = {
+          val1: 'bar',
+          val2: 'bar',
+          val3: 'bar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle partial referenced deep variables that reference overrides', () => {
+        service.custom = {
+          val1: '${self:not.a.value, "bar"}',
+          val2: '${self:custom.val1}',
+          val3: 'foo${self:custom.val2}',
+        };
+        const expected = {
+          val1: 'bar',
+          val2: 'bar',
+          val3: 'foobar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle referenced contained deep variables that reference overrides', () => {
+        service.custom = {
+          val1: '${self:not.a.value, "bar"}',
+          val2: 'foo${self:custom.val1}',
+          val3: '${self:custom.val2}',
+        };
+        const expected = {
+          val1: 'bar',
+          val2: 'foobar',
+          val3: 'foobar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle multiple referenced contained deep variables referencing overrides', () => {
+        service.custom = {
+          val0: '${self:not.a.value, "foo"}',
+          val1: '${self:not.a.value, "bar"}',
+          val2: '${self:custom.val0}:${self:custom.val1}',
+          val3: '${self:custom.val2}',
+        };
+        const expected = {
+          val0: 'foo',
+          val1: 'bar',
+          val2: 'foo:bar',
+          val3: 'foo:bar',
         };
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);
@@ -1365,7 +1483,7 @@ module.exports = {
     });
   });
 
-  describe('#getDeepValue()', () => {
+  describe('#getDeeperValue()', () => {
     it('should get deep values', () => {
       const valueToPopulateMock = {
         service: 'testService',
@@ -1376,7 +1494,7 @@ module.exports = {
         },
       };
       serverless.variables.loadVariableSyntax();
-      return serverless.variables.getDeepValue(['custom', 'subProperty', 'deep'],
+      return serverless.variables.getDeeperValue(['custom', 'subProperty', 'deep'],
         valueToPopulateMock).should.become('deepValue');
     });
     it('should not throw error if referencing invalid properties', () => {
@@ -1387,7 +1505,7 @@ module.exports = {
         },
       };
       serverless.variables.loadVariableSyntax();
-      return serverless.variables.getDeepValue(['custom', 'subProperty', 'deep', 'deeper'],
+      return serverless.variables.getDeeperValue(['custom', 'subProperty', 'deep', 'deeper'],
         valueToPopulateMock).should.eventually.deep.equal({});
     });
     it('should return a simple deep variable when final deep value is variable', () => {
@@ -1402,7 +1520,7 @@ module.exports = {
         provider: serverless.service.provider,
       };
       serverless.variables.loadVariableSyntax();
-      return serverless.variables.getDeepValue(
+      return serverless.variables.getDeeperValue(
         ['custom', 'subProperty', 'deep'],
         serverless.variables.service
       ).should.become('${deep:0}');
@@ -1416,7 +1534,7 @@ module.exports = {
         provider: serverless.service.provider,
       };
       serverless.variables.loadVariableSyntax();
-      return serverless.variables.getDeepValue(
+      return serverless.variables.getDeeperValue(
         ['custom', 'anotherVar', 'veryDeep'],
         serverless.variables.service)
         .should.become('${deep:0.veryDeep}');

--- a/lib/plugins/print/print.js
+++ b/lib/plugins/print/print.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const BbPromise = require('bluebird');
 const getServerlessConfigFile = require('../../utils/getServerlessConfigFile');
 const jc = require('json-cycle');
@@ -8,6 +9,7 @@ const YAML = require('js-yaml');
 class Print {
   constructor(serverless) {
     this.serverless = serverless;
+    this.cache = {};
 
     this.commands = {
       print: {
@@ -23,29 +25,76 @@ class Print {
     };
   }
 
+  adorn(svc) {
+    const service = svc;
+    // service object treatment
+    this.cache.serviceService = service.service;
+    if (_.isObject(this.cache.serviceService)) {
+      service.service = service.service.name;
+      service.serviceObject = this.cache.serviceService;
+    }
+    // provider treatment and defaults
+    this.cache.serviceProvider = service.provider;
+    if (_.isString(this.cache.serviceProvider)) {
+      service.provider = { name: this.cache.serviceProvider };
+    }
+    service.provider = _.merge({
+      stage: 'dev',
+      region: 'us-east-1',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+    }, service.provider);
+  }
+  strip(svc) {
+    const service = svc;
+    if (_.isObject(this.cache.serviceService)) {
+      service.service = this.cache.serviceService;
+      delete service.serviceObject;
+    }
+    if (_.isString(this.cache.serviceProvider)) {
+      service.provider = this.cache.serviceProvider;
+    } else { // is object
+      if (!this.cache.serviceProvider.stage) {
+        delete service.provider.stage;
+      }
+      if (!this.cache.serviceProvider.region) {
+        delete service.provider.region;
+      }
+      if (this.cache.serviceProvider.variableSyntax) {
+        service.provider.variableSyntax = this.cache.serviceProvider.variableSyntax;
+      }
+    }
+  }
   print() {
-    let variableSyntax;
-    this.serverless.variables.options = this.serverless.processedInput.options;
-    this.serverless.variables.loadVariableSyntax();
+    // #####################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Variables.js ##
+    // ##   there, see `populateService`                                  ##
+    // ##   here, see below                                               ##
+    // #####################################################################
+    // ###################################################################
+    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Service.js ##
+    // ##   there, see `constructor` and `loadServiceFileParam`         ##
+    // ##   here, see `strip` and `adorn`                               ##
+    // ###################################################################
+    // The *already loaded* Service (i.e. serverless.yml) is adorned with extras for use by the
+    // framework and throughout its codebase.  We could try using the populated service but that
+    // would require playing whack-a-mole on issues as changes are made to the service anywhere in
+    // the codebase.  Avoiding that, this method must read the serverless.yml file itself, adorn it
+    // as the Service class would and then populate it, reversing the adornments thereafter in
+    // preparation for printing the service for the user.
     return getServerlessConfigFile(process.cwd())
-      .then((data) => {
-        const conf = data;
-        // Need to delete variableSyntax to avoid potential matching errors
-        if (conf.provider.variableSyntax) {
-          variableSyntax = conf.provider.variableSyntax;
-          delete conf.provider.variableSyntax;
-        }
-        this.serverless.variables.service = conf;
-        this.serverless.variables.cache = {};
-        return this.serverless.variables.populateObject(conf);
-      })
-      .then((data) => {
-        const conf = data;
-        if (variableSyntax !== undefined) {
-          conf.provider.variableSyntax = variableSyntax;
-        }
-        const out = JSON.parse(jc.stringify(conf));
-        this.serverless.cli.consoleLog(YAML.dump(out, { noRefs: true }));
+      .then((svc) => {
+        const service = svc;
+        this.adorn(service);
+        // Need to delete variableSyntax to avoid self-matching errors
+        this.serverless.variables.loadVariableSyntax();
+        delete service.provider.variableSyntax; // cached by adorn, restored by strip
+        this.serverless.variables.service = service;
+        return this.serverless.variables.populateObject(service)
+          .then((populated) => {
+            this.strip(populated);
+            const out = JSON.parse(jc.stringify(populated));
+            this.serverless.cli.consoleLog(YAML.dump(out, { noRefs: true }));
+          });
       });
   }
 

--- a/lib/plugins/print/print.test.js
+++ b/lib/plugins/print/print.test.js
@@ -19,9 +19,9 @@ describe('Print', () => {
       '../../utils/getServerlessConfigFile': getServerlessConfigFileStub,
     });
     serverless = new Serverless();
-    serverless.processedInput = {
-      commands: ['print'],
-      options: { stage: undefined, region: undefined },
+    serverless.variables.options = {
+      stage: 'dev',
+      region: 'us-east-1',
     };
     serverless.cli = new CLI(serverless);
     print = new PrintPlugin(serverless);
@@ -48,7 +48,25 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(message).to.have.string(YAML.dump(conf));
+      expect(YAML.load(message)).to.eql(conf);
+    });
+  });
+
+  it('should print special service object and provider string configs', () => {
+    const conf = {
+      service: {
+        name: 'my-service',
+      },
+      provider: 'aws',
+    };
+    getServerlessConfigFileStub.resolves(conf);
+
+    return print.print().then(() => {
+      const message = print.serverless.cli.consoleLog.args.join();
+
+      expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
+      expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
+      expect(YAML.load(message)).to.eql(conf);
     });
   });
 
@@ -80,7 +98,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(message).to.equal(YAML.dump(expected));
+      expect(YAML.load(message)).to.eql(expected);
     });
   });
 
@@ -115,7 +133,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(message).to.equal(YAML.dump(expected));
+      expect(YAML.load(message)).to.eql(expected);
     });
   });
 
@@ -154,7 +172,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(message).to.equal(YAML.dump(expected));
+      expect(YAML.load(message)).to.eql(expected);
     });
   });
 
@@ -186,7 +204,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(message).to.equal(YAML.dump(expected));
+      expect(YAML.load(message)).to.eql(expected);
     });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Fixes:
1. deep variables can contain overwrites (see https://github.com/serverless/serverless/pull/4713#issuecomment-366975172 - thank you @laardee).  Reported on #4687.
2. deep variables can render to different variables and must thereby be deep-variable-ified too.  New bug of #4687 discovered fixing previous.
3. errors with the print command cross contaminating the given `serverless.yml` with the previously populated and adorned version processed by the framework.  OLD, painful, and previously unreported.
4. cleans a messy prepopulation implementation.  Closes #4744.
5. a cyclic references bug leading to crashes when using print.  Closes #3627, Closes #3711, Closes #3740, Closes #3882, Closes #4556, Closes #4687.
6. Silently undetected unresolved variables Closes #4699.
7. Support the variables `"${self:service.name}"` and `"${self:provider}"` which users expect to be valid because they are present in their `serverless.yml` but are mutated by the `Service` class.  Closes #4744.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

1. ensure that the `getValueFromDeep` method uses the standard logic for detecting and resolving overwrites rather than assuming that all deep variables are standard single variable strings.
2. add sophistication to `getValueFromDeep`, detecting recursive resolution to a new variable containing string.
3. clean caches for each invocation of variable population methods (primary entry points only).
4. knock out retrieval of restricted variable types for prepopulation, use existing methods.
5. clean caches.
6. Not exactly sure which change fixed this one.
7. Implement variable replacement for these special cases.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

`npm run test`

## Todos:

- [x] Write tests
- [n/a] Write documentation (no changes to existing documented variable system)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
