### PR TITLE
Fixed python module parsing

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -132,7 +132,7 @@ class AwsInvokeLocal {
     if (runtime === 'python2.7' || runtime === 'python3.6') {
       const handlerComponents = handler.split(/[.]+/);
       const handlerPath = handlerComponents.slice(0, -1).join('.');
-      const handlerName = handlerComponents.pop();      
+      const handlerName = handlerComponents.pop();
       return this.invokeLocalPython(
         process.platform === 'win32' ? 'python.exe' : runtime,
         handlerPath,

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -130,8 +130,9 @@ class AwsInvokeLocal {
     }
 
     if (runtime === 'python2.7' || runtime === 'python3.6') {
-      const handlerPath = handler.split('.')[0];
-      const handlerName = handler.split('.')[1];
+      const handlerComponents = handler.split(/[.]+/);
+      const handlerPath = handlerComponents.slice(0, -1).join('.');
+      const handlerName = handlerComponents.pop();      
       return this.invokeLocalPython(
         process.platform === 'win32' ? 'python.exe' : runtime,
         handlerPath,

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -130,7 +130,7 @@ class AwsInvokeLocal {
     }
 
     if (runtime === 'python2.7' || runtime === 'python3.6') {
-      const handlerComponents = handler.split(/[.]+/);
+      const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents.slice(0, -1).join('.');
       const handlerName = handlerComponents.pop();
       return this.invokeLocalPython(


### PR DESCRIPTION
Ref: https://github.com/serverless/serverless/issues/4663#issuecomment-366931491

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4663

<!--
Briefly describe the feature if no issue exists for this PR
-->

The problem is that Python module parsing wasn't correctly performed. For example, consider a function handler, `xyz.scripts.task.entrypoint`. Currently, it is converted into `handlerPath = 'xyz';` and `handlerName = 'scripts'`, but we actually want `handlerPath = 'xyz.scripts.task'` and `handlerName = 'entrypoint'`.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

The change is quite simple: rather than splitting the `handler` variable at the first `.`, we instead split it at the last `.`.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

https://github.com/dfee/serverless_pymodule_demo

If you run this with the unpatched invoke/index.js you'll get the following message:
```bash
$ sls invoke local -f entrypoint
Traceback (most recent call last):
  File "/usr/local/lib/node_modules/serverless/lib/plugins/aws/invokeLocal/invoke.py", line 61, in <module>

    handler = getattr(module, args.handler_name)
AttributeError: module 'mypackage' has no attribute 'mymodule'
```

If you invoke this with the patched invoke/index.js you'll get the following (as expected):
```bash
$ sls invoke local -f entrypoint
true
```


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** No
