### PR TITLE
Fixed a typo

### DIFF
--- a/docs/providers/spotinst/guide/variables.md
+++ b/docs/providers/spotinst/guide/variables.md
@@ -42,4 +42,4 @@ To access URL parameters in your NodeJS code you just need to put `event.query['
 
 ### 2. Python
 
-To access URL parameters in your NodeJS code you just need to put `os.environ['{Your Parameter Name}']` as needed
+To access URL parameters in your Python code you just need to put `os.environ['{Your Parameter Name}']` as needed


### PR DESCRIPTION
It's supposed to say python code, but it says nodejs two times

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Edited the text of the page it had a typo

## How did you implement it:

-

## How can we verify it:

Just check the text e.e

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
