### PR TITLE
Added name property to cloudwatchEvent CF template

### DIFF
--- a/docs/providers/aws/events/cloudwatch-event.md
+++ b/docs/providers/aws/events/cloudwatch-event.md
@@ -111,3 +111,24 @@ functions:
               state:
                 - pending
 ```
+
+## Specifying a Name
+
+You can also specify a CloudWatch Event name. Keep in mind that the name must begin with a letter; contain only ASCII letters, digits, and hyphens; and not end with a hyphen or contain two consecutive hyphens. More infomation [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html).
+
+```yml
+functions:
+  myCloudWatch:
+    handler: myCloudWatch.handler
+    events:
+      - cloudwatchEvent:
+          name: 'my-cloudwatch-event-name'
+          event:
+            source:
+              - "aws.ec2"
+            detail-type:
+              - "EC2 Instance State-change Notification"
+            detail:
+              state:
+                - pending
+```

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
@@ -26,6 +26,7 @@ class AwsCompileCloudWatchEventEvents {
             let Input;
             let InputPath;
             let Description;
+            let Name;
 
             if (typeof event.cloudwatchEvent === 'object') {
               if (!event.cloudwatchEvent.event) {
@@ -45,6 +46,7 @@ class AwsCompileCloudWatchEventEvents {
               Input = event.cloudwatchEvent.input;
               InputPath = event.cloudwatchEvent.inputPath;
               Description = event.cloudwatchEvent.description;
+              Name = event.cloudwatchEvent.name;
 
               if (Input && InputPath) {
                 const errorMessage = [
@@ -87,6 +89,7 @@ class AwsCompileCloudWatchEventEvents {
                   "EventPattern": ${EventPattern.replace(/\\n|\\r/g, '')},
                   "State": "${State}",
                   ${Description ? `"Description": "${Description}",` : ''}
+                  ${Name ? `"Name": "${Name}",` : ''}
                   "Targets": [{
                     ${Input ? `"Input": "${Input.replace(/\\n|\\r/g, '')}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath.replace(/\r?\n/g, '')}",` : ''}

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
@@ -246,6 +246,34 @@ describe('awsCompileCloudWatchEventEvents', () => {
       ).to.equal('test description');
     });
 
+    it('should respect name variable', () => {
+      awsCompileCloudWatchEventEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cloudwatchEvent: {
+                event: {
+                  source: ['aws.ec2'],
+                  'detail-type': ['EC2 Instance State-change Notification'],
+                  detail: { state: ['pending'] },
+                },
+                enabled: false,
+                input: '{"key":"value"}',
+                description: 'test-event-name',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileCloudWatchEventEvents.compileCloudWatchEventEvents();
+
+      expect(awsCompileCloudWatchEventEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.Name
+      ).to.equal('test-event-name');
+    });
+
     it('should respect input variable as an object', () => {
       awsCompileCloudWatchEventEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
@@ -259,7 +259,7 @@ describe('awsCompileCloudWatchEventEvents', () => {
                 },
                 enabled: false,
                 input: '{"key":"value"}',
-                description: 'test-event-name',
+                name: 'test-event-name',
               },
             },
           ],


### PR DESCRIPTION
Now when a user specifies a name property under the cloudwatchEvent, it will be carried over to the CF template.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4762 

Allows one to specify a custom name for a cloudwatchEvent event.

## How did you implement it:

Added references to Name in the cloudwatchEvent's index.js in the same way Description is handled.

## How can we verify it:

Using the proposed branch, create a project and add a cloudwatchEvent to the serverless.yml like this:

```yaml
service: add-cw-event-name

# You can pin your service to only deploy with a specific Serverless version
# Check out our docs for more details
# frameworkVersion: "=X.X.X"

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    events:
      - cloudwatchEvent:
          name: 'this-is-my-name'
          description: 'This is my description'
          event:
            source:
              - "aws:ec2"
            detail-type:
              - "EC2 Instance Terminate Successful"
            detail:
              AutoScalingGroupName:
                - "test-asg"
          enabled: false
```

Then run `sls package` and confirm that the CF template includes the name property:
```
"HelloEventsRuleCloudWatchEvent1": {
      "Type": "AWS::Events::Rule",
      "Properties": {
        "EventPattern": {
          "source": [
            "aws:ec2"
          ],
          "detail-type": [
            "EC2 Instance Terminate Successful"
          ],
          "detail": {
            "AutoScalingGroupName": [
              "test-asg"
            ]
          }
        },
        "State": "DISABLED",
        "Description": "This is my description",
        "Name": "this-is-my-name",
        "Targets": [
          {
            "Arn": {
              "Fn::GetAtt": [
                "HelloLambdaFunction",
                "Arn"
              ]
            },
            "Id": "helloCloudWatchEvent"
          }
        ]
      }
    },
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
