### PR TITLE
Allow UsagePlan's to be created without ApiKeys defined. Issue #4459

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -5,7 +5,7 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileUsagePlan() {
-    if (this.serverless.service.provider.apiKeys) {
+    if (this.serverless.service.provider.usagePlan || this.serverless.service.provider.apiKeys) {
       this.apiGatewayUsagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [this.apiGatewayUsagePlanLogicalId]: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -17,21 +17,6 @@ describe('#compileUsagePlan()', () => {
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
-    serverless.service.provider = {
-      name: 'aws',
-      apiKeys: ['1234567890'],
-      usagePlan: {
-        quota: {
-          limit: 500,
-          offset: 10,
-          period: 'MONTH',
-        },
-        throttle: {
-          burstLimit: 200,
-          rateLimit: 100,
-        },
-      },
-    };
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
       Outputs: {},
@@ -41,8 +26,67 @@ describe('#compileUsagePlan()', () => {
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
   });
 
-  it('should compile usage plan resource', () =>
-    awsCompileApigEvents.compileUsagePlan().then(() => {
+  it('should compile default usage plan resource', () => {
+    serverless.service.provider['apiKeys'] = ['1234567890'];
+    return awsCompileApigEvents.compileUsagePlan().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Type
+      ).to.equal('AWS::ApiGateway::UsagePlan');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].DependsOn
+      ).to.equal('ApiGatewayDeploymentTest');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.ApiStages[0].ApiId.Ref
+      ).to.equal('ApiGatewayRestApi');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.ApiStages[0].Stage
+      ).to.equal('dev');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.Description
+      ).to.equal('Usage plan for first-service dev stage');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.UsagePlanName
+      ).to.equal('first-service-dev');
+    })
+  });
+
+  it('should compile custom usage plan resource', () => {
+    serverless.service.provider['usagePlan'] = {
+      quota: {
+        limit: 500,
+        offset: 10,
+        period: 'MONTH',
+      },
+      throttle: {
+        burstLimit: 200,
+        rateLimit: 100,
+      }
+    };
+
+    return awsCompileApigEvents.compileUsagePlan().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[
@@ -106,5 +150,5 @@ describe('#compileUsagePlan()', () => {
           ].Properties.UsagePlanName
       ).to.equal('first-service-dev');
     })
-  );
+  });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -27,7 +27,7 @@ describe('#compileUsagePlan()', () => {
   });
 
   it('should compile default usage plan resource', () => {
-    serverless.service.provider['apiKeys'] = ['1234567890'];
+    serverless.service.provider.apiKeys = ['1234567890'];
     return awsCompileApigEvents.compileUsagePlan().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -70,11 +70,11 @@ describe('#compileUsagePlan()', () => {
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
           ].Properties.UsagePlanName
       ).to.equal('first-service-dev');
-    })
+    });
   });
 
   it('should compile custom usage plan resource', () => {
-    serverless.service.provider['usagePlan'] = {
+    serverless.service.provider.usagePlan = {
       quota: {
         limit: 500,
         offset: 10,
@@ -83,7 +83,7 @@ describe('#compileUsagePlan()', () => {
       throttle: {
         burstLimit: 200,
         rateLimit: 100,
-      }
+      },
     };
 
     return awsCompileApigEvents.compileUsagePlan().then(() => {
@@ -149,6 +149,6 @@ describe('#compileUsagePlan()', () => {
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
           ].Properties.UsagePlanName
       ).to.equal('first-service-dev');
-    })
+    });
   });
 });


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4459 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
See PR #4459 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
