### PR TITLE
#4713 Follow up fixes, take 2

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -72,25 +72,24 @@ class Variables {
   // #############
   // ## SERVICE ##
   // #############
-  prepopulateObject(objectToPopulate) {
+  disableDepedentServices(func) {
     const dependentServices = [
       { name: 'CloudFormation', method: 'getValueFromCf', original: this.getValueFromCf },
       { name: 'S3', method: 'getValueFromS3', original: this.getValueFromS3 },
       { name: 'SSM', method: 'getValueFromSsm', original: this.getValueFromSsm },
     ];
-    const dependencyMessage = (configName, configValue, serviceName) =>
-      `Variable Failure: value ${configName} set to '${configValue}' references ${
-        serviceName} which requires a ${configName} value for use.`;
+    const dependencyMessage = (configValue, serviceName) =>
+      `Variable dependency failure: variable '${configValue}' references service ${
+        serviceName} but using that service requires a concrete value to be called.`;
     // replace and then restore the methods for obtaining values from dependent services.  the
     // replacement naturally rejects dependencies on these services that occur during prepopulation.
     // prepopulation is, of course, the process of obtaining the required configuration for using
     // these services.
     dependentServices.forEach((dependentService) => { // knock out
       this[dependentService.method] = (variableString) => BbPromise.reject(
-        dependencyMessage(objectToPopulate.name, variableString, dependentService.name));
+        dependencyMessage(variableString, dependentService.name));
     });
-    return this.populateValue(objectToPopulate.value, true) // populate
-      .then(populated => _.assign(objectToPopulate, { populated }))
+    return func()
       .finally(() => {
         dependentServices.forEach((dependentService) => { // restore
           this[dependentService.method] = dependentService.original;
@@ -100,12 +99,16 @@ class Variables {
   prepopulateService() {
     const provider = this.serverless.getProvider('aws');
     if (provider) {
-      const requiredConfig = [
+      const requiredConfigs = [
         _.assign({ name: 'region' }, provider.getRegionSourceValue()),
         _.assign({ name: 'stage' }, provider.getStageSourceValue()),
       ];
-      const prepopulations = requiredConfig.map(this.prepopulateObject.bind(this));
-      return this.assignProperties(provider, prepopulations);
+      return this.disableDepedentServices(() => {
+        const prepopulations = requiredConfigs.map(config =>
+          this.populateValue(config.value, true) // populate
+            .then(populated => _.assign(config, { populated })));
+        return this.assignProperties(provider, prepopulations);
+      });
     }
     return BbPromise.resolve();
   }

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -169,7 +169,7 @@ describe('Variables', () => {
           it(`should reject ${config.name} variables in ${property.name} values`, () => {
             awsProvider.options[property.name] = config.value;
             return serverless.variables.populateService()
-              .should.be.rejectedWith('Variable Failure');
+              .should.be.rejectedWith('Variable dependency failure');
           });
           it(`should reject recursively dependent ${config.name} service dependencies`, () => {
             serverless.variables.service.custom = {
@@ -177,8 +177,33 @@ describe('Variables', () => {
             };
             awsProvider.options.region = '${self:custom.settings.region}';
             return serverless.variables.populateService()
-              .should.be.rejectedWith('Variable Failure');
+              .should.be.rejectedWith('Variable dependency failure');
           });
+        });
+      });
+    });
+    describe('dependent service non-interference', () => {
+      const stateCombinations = [
+        { region: 'foo', state: 'bar' },
+        { region: 'foo', state: '${self:bar, "bar"}' },
+        { region: '${self:foo, "foo"}', state: 'bar' },
+        { region: '${self:foo, "foo"}', state: '${self:bar, "bar"}' },
+      ];
+      stateCombinations.forEach((combination) => {
+        it('must leave the dependent services in their original state', () => {
+          const dependentMethods = [
+            { name: 'getValueFromCf', original: serverless.variables.getValueFromCf },
+            { name: 'getValueFromS3', original: serverless.variables.getValueFromS3 },
+            { name: 'getValueFromSsm', original: serverless.variables.getValueFromSsm },
+          ];
+          awsProvider.options.region = combination.region;
+          awsProvider.options.state = combination.state;
+          return serverless.variables.populateService().should.be.fulfilled
+            .then(() => {
+              dependentMethods.forEach((method) => {
+                expect(serverless.variables[method.name]).to.equal(method.original);
+              });
+            });
         });
       });
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Only disable and restore dependent service resolution methods once.  Otherwise, subsequent removals may cache the previous replacements.  If they restore last then they will restore with the replacements, breaking standard usage.

Add tests for this guarantee.

This resolves the issue reported at https://github.com/serverless/serverless/pull/4754#issuecomment-368234177

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Rather than call off-limits method replacement for each dependent configuration, just do it once, process all the configuration that needs processing, and then do the restore.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

`npm run test`
and with any valid serverless.yml:
`sls print [<options>]`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [n/a] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
