### PR TITLE
Pass authorizer custom context to target lambda

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -497,6 +497,7 @@ This method is more complicated and involves a lot more configuration of the `ht
     "cognitoPoolClaims": {
         "sub": ""
     },
+    "enhancedAuthContext": {},
     "headers": {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
         "Accept-Encoding": "gzip, deflate, br",

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -26,6 +26,9 @@ const DEFAULT_COMMON_TEMPLATE = `
        "sub": "$context.authorizer.claims.sub"
     },
 
+    #set( $map = $context.authorizer )
+    "enhancedAuthContext": $loop,
+
     #set( $map = $input.params().header )
     "headers": $loop,
 


### PR DESCRIPTION
## What did you implement:

Closes #4374 

## How did you implement it:

Dropped in @behrangsa's fix that has worked for myself and others.

## How can we verify it:

Deploy a lambda authorizer that passes custom context in its callback (lines 4-6):
```
const generatePolicy = (principalId, effect, resourc) => {
  const authResponse = {
    principalId: principalId,
    context: { 
        myCustomKey: "myCustomValue"
    }
  }
  if (effect && resource) {
    const policyDocument = {}
    policyDocument.Version = '2012-10-17'
    policyDocument.Statement = []
    const statementOne = {}
    statementOne.Action = 'execute-api:Invoke'
    statementOne.Effect = effect
    statementOne.Resource = resource
    policyDocument.Statement[0] = statementOne
    authResponse.policyDocument = policyDocument
  }
  return authResponse
}
```
Then deploy a lambda that requires the authorizer and attempts to access the custom context:
```
module.exports.default = (event, context, callback) => {
   return context.authorizer.myCustomKey
}

```

## Todos:

- [X] Write tests
- [x] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
