### PR TITLE
Fixed a bug which you cannot deploy with lambda integration in v1.26.0

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -78,6 +78,11 @@ module.exports = {
             http.request = this.getRequest(http);
             http.request.passThrough = this.getRequestPassThrough(http);
             http.response = this.getResponse(http);
+            if (http.integration === 'AWS' && _.isEmpty(http.response)) {
+              http.response = {
+                statusCodes: DEFAULT_STATUS_CODES,
+              };
+            }
           } else if (http.integration === 'AWS_PROXY' || http.integration === 'HTTP_PROXY') {
             // show a warning when request / response config is used with AWS_PROXY (LAMBDA-PROXY)
             if (http.request) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -1728,4 +1728,54 @@ describe('#validate()', () => {
     expect(validated.events).to.be.an('Array').with.length(1);
     expect(validated.events[0].http.request.passThrough).to.equal(undefined);
   });
+
+  it('should set default statusCodes to response for lambda by default', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'users/list',
+              integration: 'lambda',
+              integrationMethod: 'GET',
+            },
+          },
+        ],
+      },
+    };
+
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events).to.be.an('Array').with.length(1);
+    expect(validated.events[0].http.response.statusCodes).to.deep.equal({
+      200: {
+        pattern: '',
+      },
+      400: {
+        pattern: '[\\s\\S]*\\[400\\][\\s\\S]*',
+      },
+      401: {
+        pattern: '[\\s\\S]*\\[401\\][\\s\\S]*',
+      },
+      403: {
+        pattern: '[\\s\\S]*\\[403\\][\\s\\S]*',
+      },
+      404: {
+        pattern: '[\\s\\S]*\\[404\\][\\s\\S]*',
+      },
+      422: {
+        pattern: '[\\s\\S]*\\[422\\][\\s\\S]*',
+      },
+      500: {
+        pattern:
+        '[\\s\\S]*(Process\\s?exited\\s?before\\s?completing\\s?request|\\[500\\])[\\s\\S]*',
+      },
+      502: {
+        pattern: '[\\s\\S]*\\[502\\][\\s\\S]*',
+      },
+      504: {
+        pattern: '([\\s\\S]*\\[504\\][\\s\\S]*)|(^[Task timed out].*)',
+      },
+    });
+  });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4705

This bug was introduced by #3953, and I found the root cause was generated CloudFomation template was broken like this.

<img width="801" alt="diff" src="https://user-images.githubusercontent.com/1301012/36683239-6bfb4f3e-1b60-11e8-8bb1-9a7bbbd3641f.png">
Both of integrationresponses and methodresponses were empty in v1.26.0

## How did you implement it:
Set default statusCodes to response template for lambda integration if it is empty

## How can we verify it:

Run `sls deploy` ,and then run `sls invoke -f hello` with following serverless.yml

serverless.yml
``` yaml
service: aws-nodejsefrefrxs

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: hello
          method: get
          integration: lambda
```

handler.js
```js
'use strict';

module.exports.hello = (event, context, callback) => {
  callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!' });
};
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
