### PR TITLE
Doc - Add AWS-only alternative for variableSyntax that is compatible with Serverless way

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -426,7 +426,7 @@ provider:
   name: aws
   runtime: nodejs6.10
   variableSyntax: "\\${{([ ~:a-zA-Z0-9._\\'\",\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
-#  variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._'\",\\-\\/\\(\\)]+?)}" # Use like this: ${AWS::stuff} - N.B: Only works for AWS!
+#  variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml -- e.g. ${AWS::Region}. All other Serverless variables work as usual.
 
 custom:
   myStage: ${{opt:stage}}

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -426,6 +426,7 @@ provider:
   name: aws
   runtime: nodejs6.10
   variableSyntax: "\\${{([ ~:a-zA-Z0-9._\\'\",\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
+#  variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._'\",\\-\\/\\(\\)]+?)}" # Use like this: ${AWS::stuff} - N.B: Only works for AWS!
 
 custom:
   myStage: ${{opt:stage}}


### PR DESCRIPTION
Add an alternative AWS-only variableSyntax in AWS doc, which is compatible with the current Serverless syntax `${stuff}`

Usage: `${AWS::stuff}`

(credits to @dschep)