### PR TITLE
Sync CHANGELOG to represent 1.26.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 1.26.1 (27.02.2018)
 - [Fix lambda integration regression](https://github.com/serverless/serverless/pull/4775)
 
+## Meta
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.26.0...v1.26.1)
+
 # 1.26.0 (29.01.2018)
 - [AWS Go support](https://github.com/serverless/serverless/pull/4669)
 - [Support for using an existing ApiGateway and Resources](https://github.com/serverless/serverless/pull/4247)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.26.1 (27.02.2018)
+- [Fix lambda integration regression](https://github.com/serverless/serverless/pull/4775)
+
 # 1.26.0 (29.01.2018)
 - [AWS Go support](https://github.com/serverless/serverless/pull/4669)
 - [Support for using an existing ApiGateway and Resources](https://github.com/serverless/serverless/pull/4247)


### PR DESCRIPTION
## What did you implement:

Updated changelog to show 1.26.1 release.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
