### PR TITLE
Support removeOldDeployments, stackVersionsToKeep options

### DIFF
--- a/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanupS3Bucket.js
@@ -5,9 +5,19 @@ const _ = require('lodash');
 const findAndGroupDeployments = require('../../utils/findAndGroupDeployments');
 const getS3ObjectsFromStacks = require('../../utils/getS3ObjectsFromStacks');
 
+const defaultOpts = {
+  removeOldDeployments: true,
+  stackVersionsToKeep: 5,
+};
+
 module.exports = {
   getObjectsToRemove() {
-    const stacksToKeepCount = 5;
+    const opts = _.defaults({}, this.serverless.service.provider, defaultOpts);
+    if (opts.removeOldDeployments === false) {
+      return BbPromise.resolve([]);
+    }
+
+    const stackVersionsToKeep = opts.stackVersionsToKeep;
     const service = this.serverless.service.service;
     const stage = this.provider.getStage();
 
@@ -19,7 +29,7 @@ module.exports = {
       })
       .then((response) => {
         const stacks = findAndGroupDeployments(response, service, stage);
-        const stacksToKeep = _.takeRight(stacks, stacksToKeepCount);
+        const stacksToKeep = _.takeRight(stacks, stackVersionsToKeep);
         const stacksToRemove = _.pullAllWith(stacks, stacksToKeep, _.isEqual);
         const objectsToRemove = getS3ObjectsFromStacks(stacksToRemove, service, stage);
 


### PR DESCRIPTION
## What did you implement:

currently the number of deployed versions kept in s3 is hardcorded to 5. This PR lets the user configure that number, or disable removal completely. It defaults to the currently hardcoded values.

additional config options in provider section (for aws):

```yaml
provider:
  removeOldDeployments: false
  stackVersionsToKeep: 100
```

## How did you implement it:

check additional config options in lib/plugins/aws/deploy/lib/cleanupS3Bucket.js

see the diff, it's just a few lines changed

## How can we verify it:

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Additional Data

* ***Serverless Framework Version you're using***:
1.24.1

* ***Operating System***:
macOS 10.13.3 (17D47)
Darwin 17.4.0
