### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **The Serverless Framework** – Build applications comprised of microservices that run in response to events, auto-scale for you, and only charge you when they run.  This lowers the total cost of maintaining your apps, enabling you to build more logic, faster.
 
-The Framework uses new event-driven compute services, like AWS Lambda, Google CloudFunctions, and more.  It's a command-line tool, providing scaffolding, workflow automation and best practices for developing and deploying your serverless architecture. It's also completely extensible via plugins.
+The Framework uses new event-driven compute services, like AWS Lambda, Google Cloud Functions, and more.  It's a command-line tool, providing scaffolding, workflow automation and best practices for developing and deploying your serverless architecture. It's also completely extensible via plugins.
 
 Serverless is an MIT open-source project, actively maintained by a full-time, venture-backed team.
 


### PR DESCRIPTION
## What did you implement:

Fixed a typo in the README. It's "Google Cloud Functions" (with a space), not "Google CloudFunctions."

## How did you implement it:

Edited the markdown

## How can we verify it:

Read the text

## Todos:

- [*] Write documentation
- [*] Enable "Allow edits from maintainers" for this PR
- [*] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
