### PR TITLE
Continue recursion for #4687

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -334,7 +334,7 @@ class Variables {
       .then(results => this.renderMatches(property, matches, results))
       .then((result) => {
         if (root && matches.length) {
-          return this.populateValue(result);
+          return this.populateValue(result, root);
         }
         return result;
       });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -27,7 +27,7 @@ describe('#compileUsagePlan()', () => {
   });
 
   it('should compile default usage plan resource', () => {
-    serverless.service.provider['apiKeys'] = ['1234567890'];
+    serverless.service.provider.apiKeys = ['1234567890'];
     return awsCompileApigEvents.compileUsagePlan().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -70,11 +70,11 @@ describe('#compileUsagePlan()', () => {
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
           ].Properties.UsagePlanName
       ).to.equal('first-service-dev');
-    })
+    });
   });
 
   it('should compile custom usage plan resource', () => {
-    serverless.service.provider['usagePlan'] = {
+    serverless.service.provider.usagePlan = {
       quota: {
         limit: 500,
         offset: 10,
@@ -83,7 +83,7 @@ describe('#compileUsagePlan()', () => {
       throttle: {
         burstLimit: 200,
         rateLimit: 100,
-      }
+      },
     };
 
     return awsCompileApigEvents.compileUsagePlan().then(() => {
@@ -149,6 +149,6 @@ describe('#compileUsagePlan()', () => {
           awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
           ].Properties.UsagePlanName
       ).to.equal('first-service-dev');
-    })
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Additional fix for #4687

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Continue recursion for populateValue root case.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

The following serverless.yml can be used to reproduce the problem. Adjust cf reference to an existing stack with an export.

```yaml
service: test

custom: ${file(custom-properties-${opt:stage, self:provider.stage}.yml)}

provider:
  name: aws
  region: ${self:custom.region}

  environment:
    TEST: ${cf:resources-v1-dev.UserPoolArn}
```

## Todos:

- [X] Write tests
- [n/a] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
