### PR TITLE
Support returning promises from serverless.js

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -69,8 +69,10 @@ class Service {
       return BbPromise.try(() => {
         // use require to load serverless.js file
         // eslint-disable-next-line global-require
-        const config = require(serviceFilePath);
-
+        const configExport = require(serviceFilePath);
+        // In case of a promise result, first resolve it.
+        return configExport;
+      }).then(config => {
         if (!_.isPlainObject(config)) {
           throw new Error('serverless.js must export plain object');
         }

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -342,6 +342,61 @@ describe('Service', () => {
       });
     });
 
+    it('should load serverless.js from filesystem', () => {
+      const SUtils = new Utils();
+      const serverlessJSON = {
+        service: 'new-service',
+        provider: {
+          name: 'aws',
+          stage: 'dev',
+          region: 'us-east-1',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
+        },
+        plugins: ['testPlugin'],
+        functions: {
+          functionA: {},
+        },
+        resources: {
+          aws: {
+            resourcesProp: 'value',
+          },
+          azure: {},
+          google: {},
+        },
+        package: {
+          exclude: ['exclude-me'],
+          include: ['include-me'],
+          artifact: 'some/path/foo.zip',
+        },
+      };
+
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.js'),
+        `module.exports = new Promise(resolve => { resolve(${JSON.stringify(serverlessJSON)}) });`);
+
+      const serverless = new Serverless();
+      serverless.config.update({ servicePath: tmpDirPath });
+      serviceInstance = new Service(serverless);
+
+      return expect(serviceInstance.load()).to.eventually.be.fulfilled
+      .then(() => {
+        expect(serviceInstance.service).to.be.equal('new-service');
+        expect(serviceInstance.provider.name).to.deep.equal('aws');
+        expect(serviceInstance.provider.variableSyntax).to.equal(
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+        );
+        expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
+        expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
+        expect(serviceInstance.resources.azure).to.deep.equal({});
+        expect(serviceInstance.resources.google).to.deep.equal({});
+        expect(serviceInstance.package.exclude.length).to.equal(1);
+        expect(serviceInstance.package.exclude[0]).to.equal('exclude-me');
+        expect(serviceInstance.package.include.length).to.equal(1);
+        expect(serviceInstance.package.include[0]).to.equal('include-me');
+        expect(serviceInstance.package.artifact).to.equal('some/path/foo.zip');
+        expect(serviceInstance.package.excludeDevDependencies).to.equal(undefined);
+      });
+    });
+
     it('should throw error if serverless.js exports invalid config', () => {
       const SUtils = new Utils();
 

--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -28,8 +28,10 @@ const getServerlessConfigFile = _.memoize((servicePath) => {
       return BbPromise.try(() => {
         // use require to load serverless.js
         // eslint-disable-next-line global-require
-        const config = require(jsPath);
-
+        const configExport = require(jsPath);
+        // In case of a promise result, first resolve it.
+        return configExport;
+      }).then(config => {
         if (_.isPlainObject(config)) {
           return config;
         }

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -63,6 +63,20 @@ describe('#getServerlessConfigFile()', () => {
     );
   });
 
+  it('should return the resolved value if a promise-using serverless.js file found', () => {
+    const serverlessFilePath = path.join(tmpDirPath, 'serverless.js');
+    writeFileSync(
+      serverlessFilePath,
+      'module.exports = new Promise(resolve => { resolve({"service": "my-json-service"}); });'
+    );
+
+    return expect(getServerlessConfigFile(tmpDirPath)).to.be.fulfilled.then(
+      (result) => {
+        expect(result).to.deep.equal({ service: 'my-json-service' });
+      }
+    );
+  });
+
   it('should throw an error, if serverless.js export not a plain object', () => {
     const serverlessFilePath = path.join(tmpDirPath, 'serverless.js');
     writeFileSync(


### PR DESCRIPTION
## What did you implement:

From discussion in #4787 this is the low-hanging fruit that still adds useful functionality.

For the (undocumented) use of `serverless.js` as a config file, it is quite useful to be able to return a promise for a config, since nearly all node APIs and packages that do something interesting are async.

As a simple example, looking up VPC configuration by name.

## How did you implement it:

Fortunately, promises (including bluebird) are specified that if a promise-like value (ie. has a function-typed `then` property) would be used to resolve a promise, it gets unwrapped and the resolution value is instead used (or if it rejects, the outer promise rejects also). This handles the "might be a promise, might not be" case straightforwardly.

Oddly, I found the config is loaded in at least two places. Seems like something wiggy happened here?

## How can we verify it:

The new test is a rather unrealistic example, here's a more full example that pulls a VPC configuration 

```js
const EC2 = require('aws-sdk/clients/ec2');

// async functions return Promises
async function getVpcConfig() {
  const ec2 = new EC2({
    region: 'ap-southeast-2',
  });

  const vpcResponse = await ec2.describeVpcs({
    Filters: [
      { Name: 'tag:aws:cloudformation:stack-name', Values: ['test-core'] }
    ],
  }).promise();

  if (!vpcResponse.Vpcs.length) {
    throw new Error('Could not find test VPC');
  }

  const vpcId = vpcResponse.Vpcs[0].VpcId;

  const [sgResponse, subnetResponse] = await Promise.all([
      ec2.describeSecurityGroups({
        Filters: [
          { Name: 'vpc-id', Values: [vpcId] },
          { Name: 'tag:aws:cloudformation:logical-id', Values: ['securityGroupDb'] },
        ],
      }).promise(),

      ec2.describeSubnets({
        Filters: [
          { Name: 'vpc-id', Values: [vpcId] },
          { Name: 'tag:Name', Values: ['*Public*'] },
        ],
      }).promise(),
  ]);

  return {
    securityGroupIds: sgResponse.SecurityGroups.map(sg => sg.GroupId),
    subnetIds: subnetResponse.Subnets.map(sn => sn.SubnetId),
  };
}

async function getConfig() {
  const vpc = await getVpcConfig();

  return {
    service: 'promise-example',

    provider: {
      name: 'aws',
      runtime: 'node6.10',
    },

    functions: {
      example: {
        handler: 'src/example.default',
        vpc,
      },
    },
  };
}

module.exports = getConfig();
```

```
$ node_modules/serverless/bin/serverless print
service: promise-example
provider:
  name: aws
  runtime: node6.10
functions:
  example:
    handler: src/example.default
    vpc:
      securityGroupIds:
        - sg-SNIP
      subnetIds:
        - subnet-SNIP
        - subnet-SNIP
    events: []
    name: promise-example-dev-example
```

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~ - we don't have `serverless.js` docs yet?
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
