### PR TITLE
Support arrays in function definition too

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -100,6 +100,26 @@ functions:
     memorySize: 512 # function specific
 ```
 
+You can specify an array of functions, which is useful if you separate your functions in to different files:
+
+```yml
+# serverless.yml
+...
+
+functions:
+  - ${file(./foo-functions.yml)}
+  - ${file(./bar-functions.yml)}
+```
+
+```yml
+# foo-functions.yml
+getFoo:
+  handler: handler.foo
+deleteFoo:
+  handler: handler.foo
+```
+
+
 ## Permissions
 
 Every AWS Lambda function needs permission to interact with other AWS infrastructure resources within your account.  These permissions are set via an AWS IAM Role.  You can set permission policy statements within this role via the `provider.iamRoleStatements` property.

--- a/docs/providers/azure/guide/functions.md
+++ b/docs/providers/azure/guide/functions.md
@@ -62,3 +62,22 @@ functions:
   functionThree:
     handler: handler.functionThree
 ```
+
+You can specify an array of functions, which is useful if you separate your functions in to different files:
+
+```yml
+# serverless.yml
+...
+
+functions:
+  - ${file(./foo-functions.yml)}
+  - ${file(./bar-functions.yml)}
+```
+
+```yml
+# foo-functions.yml
+getFoo:
+  handler: handler.foo
+deleteFoo:
+  handler: handler.foo
+```

--- a/docs/providers/google/guide/functions.md
+++ b/docs/providers/google/guide/functions.md
@@ -35,6 +35,26 @@ functions:
       - http: path
 ```
 
+You can specify an array of functions, which is useful if you separate your functions in to different files:
+
+```yml
+# serverless.yml
+...
+
+functions:
+  - ${file(./foo-functions.yml)}
+  - ${file(./bar-functions.yml)}
+```
+
+```yml
+# foo-functions.yml
+getFoo:
+  handler: handler.foo
+deleteFoo:
+  handler: handler.foo
+```
+
+
 ## Handler
 
 The `handler` property should be the function name you've exported in your entrypoint file.

--- a/docs/providers/kubeless/guide/functions.md
+++ b/docs/providers/kubeless/guide/functions.md
@@ -85,6 +85,25 @@ functions:
     handler: handler.hello_two
 ```
 
+You can specify an array of functions, which is useful if you separate your functions in to different files:
+
+```yml
+# serverless.yml
+...
+
+functions:
+  - ${file(./foo-functions.yml)}
+  - ${file(./bar-functions.yml)}
+```
+
+```yml
+# foo-functions.yml
+getFoo:
+  handler: handler.foo
+deleteFoo:
+  handler: handler.foo
+```
+
 ## Runtimes
 
 The Kubeless provider plugin supports the following runtimes.

--- a/docs/providers/openwhisk/guide/functions.md
+++ b/docs/providers/openwhisk/guide/functions.md
@@ -100,6 +100,25 @@ functions:
       foo: bar // default parameters
 ```
 
+You can specify an array of functions, which is useful if you separate your functions in to different files:
+
+```yml
+# serverless.yml
+...
+
+functions:
+  - ${file(./foo-functions.yml)}
+  - ${file(./bar-functions.yml)}
+```
+
+```yml
+# foo-functions.yml
+getFoo:
+  handler: handler.foo
+deleteFoo:
+  handler: handler.foo
+```
+
 ## Packages
 
 OpenWhisk provides a concept called "packages" to manage related actions. Packages can contain multiple actions under a common identifier in a namespace. Configuration values needed by all actions in a package can be set as default properties on the package, rather than individually on each action.
@@ -133,12 +152,12 @@ functions:
   foo:
     handler: handler.foo
     name: "myPackage/foo"
-    
+
 resources:
   packages:
     myPackage:
       parameters:
-        hello: world 
+        hello: world
 ```
 
 *Explicit packages support the following properties: `parameters`, `annotations` and `shared`.*

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -87,13 +87,13 @@ class Serverless {
     // populate variables after --help, otherwise help may fail to print
     // (https://github.com/serverless/serverless/issues/2041)
     return this.variables.populateService(this.pluginManager.cliOptions).then(() => {
+      // merge arrays after variables have been populated
+      // (https://github.com/serverless/serverless/issues/3511)
+      this.service.mergeArrays();
+
       // populate function names after variables are loaded in case functions were externalized
       // (https://github.com/serverless/serverless/issues/2997)
       this.service.setFunctionNames(this.processedInput.options);
-
-      // merge custom resources after variables have been populated
-      // (https://github.com/serverless/serverless/issues/3511)
-      this.service.mergeResourceArrays();
 
       // validate the service configuration, now that variables are loaded
       this.service.validate();

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -174,19 +174,21 @@ class Service {
     });
   }
 
-  mergeResourceArrays() {
-    if (Array.isArray(this.resources)) {
-      this.resources = this.resources.reduce((memo, value) => {
-        if (value) {
-          if (typeof value === 'object') {
-            return _.merge(memo, value);
+  mergeArrays() {
+    ['resources', 'functions'].forEach(key => {
+      if (Array.isArray(this[key])) {
+        this[key] = this[key].reduce((memo, value) => {
+          if (value) {
+            if (typeof value === 'object') {
+              return _.merge(memo, value);
+            }
+            throw new Error(`Non-object value specified in ${key} array: ${value}`);
           }
-          throw new Error(`Non-object value specified in resources array: ${value}`);
-        }
 
-        return memo;
-      }, {});
-    }
+          return memo;
+        }, {});
+      }
+    });
   }
 
   validate() {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -669,7 +669,7 @@ describe('Service', () => {
     });
   });
 
-  describe('#mergeResourceArrays', () => {
+  describe('#mergeArrays', () => {
     it('should merge resources given as an array', () => {
       const serverless = new Serverless();
       const serviceInstance = new Service(serverless);
@@ -691,7 +691,7 @@ describe('Service', () => {
         },
       ];
 
-      serviceInstance.mergeResourceArrays();
+      serviceInstance.mergeArrays();
 
       expect(serviceInstance.resources).to.be.an('object');
       expect(serviceInstance.resources.Resources).to.be.an('object');
@@ -708,7 +708,7 @@ describe('Service', () => {
         Resources: 'foo',
       };
 
-      serviceInstance.mergeResourceArrays();
+      serviceInstance.mergeArrays();
 
       expect(serviceInstance.resources).to.deep.eql({
         Resources: 'foo',
@@ -728,7 +728,7 @@ describe('Service', () => {
         },
       ];
 
-      serviceInstance.mergeResourceArrays();
+      serviceInstance.mergeArrays();
       expect(serviceInstance.resources).to.deep.eql({
         aws: {
           resourcesProp: 'value',
@@ -744,7 +744,7 @@ describe('Service', () => {
         42,
       ];
 
-      expect(() => serviceInstance.mergeResourceArrays()).to.throw(Error);
+      expect(() => serviceInstance.mergeArrays()).to.throw(Error);
     });
 
     it('should throw when given a string', () => {
@@ -755,7 +755,24 @@ describe('Service', () => {
         'string',
       ];
 
-      expect(() => serviceInstance.mergeResourceArrays()).to.throw(Error);
+      expect(() => serviceInstance.mergeArrays()).to.throw(Error);
+    });
+
+    it('should merge functions given as an array', () => {
+      const serverless = new Serverless();
+      const serviceInstance = new Service(serverless);
+
+      serviceInstance.functions = [{
+        a: {},
+      }, {
+        b: {},
+      }];
+
+      serviceInstance.mergeArrays();
+
+      expect(serviceInstance.functions).to.be.an('object');
+      expect(serviceInstance.functions.a).to.be.an('object');
+      expect(serviceInstance.functions.b).to.be.an('object');
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes N/A

Support for

```yml
functions:
  - ${file(./functions/frontend.yml)`
  - ${file(./functions/backend.yml)`
```

just like how `resources:` works.

## How did you implement it:

I generalized the code that I previously wrote 😁 

## How can we verify it:

Factor a function block in to separate objects in an array, or externalize to files.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
