### PR TITLE
Re-write `self:service.[...]` to `self:serviceObject.[...]`

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -525,6 +525,7 @@ class Variables {
   }
 
   getValueFromSelf(variableString) {
+    const selfServiceRex = /self:service\./;
     let variable = variableString;
     // ###################################################################
     // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Service.js ##
@@ -534,8 +535,9 @@ class Variables {
     // Account for these so that user's reference to their file populate properly
     if (variable === 'self:service.name') {
       variable = 'self:service';
-    }
-    if (variable === 'self:provider') {
+    } else if (variable.match(selfServiceRex)) {
+      variable = variable.replace(selfServiceRex, 'self:serviceObject.');
+    } else if (variable === 'self:provider') {
       variable = 'self:provider.name';
     }
     const valueToPopulate = this.service;

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1156,6 +1156,18 @@ module.exports = {
       };
       return serverless.variables.getValueFromSelf('self:provider').should.become('aws');
     });
+    it('should redirect ${self:service.awsKmsKeyArn} to ${self:serviceObject.awsKmsKeyArn}', () => {
+      const keyArn = 'arn:aws:kms:us-east-1:xxxxxxxxxxxx:key/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+      serverless.variables.service = {
+        service: 'testService',
+        serviceObject: {
+          name: 'testService',
+          awsKmsKeyArn: keyArn,
+        },
+      };
+      return serverless.variables.getValueFromSelf('self:service.awsKmsKeyArn')
+        .should.become(keyArn);
+    });
     it('should handle self-references to the root of the serverless.yml file', () => {
       serverless.variables.service = {
         service: 'testService',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes reported issue on #4754 by @dschep 

<!--
Briefly describe the feature if no issue exists for this PR
-->

Handle `self:service.[...]` references properly.  The prior represents what the user typed into their configuration.  In service, we move all this from `service` to `serviceObject`, therefore, by rewriting `self:service.[...]` to `self:serviceObject.[...]` user's will get the result they expect.
Cleanup: use `else if`, given exclusivity of conditions

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
filter `self:service.` variables, replacing that part with `self:serviceObject.` to avoid failed resolutions.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Run the offered test.

## Todos:

- [x] Write tests
- [n/a] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
