### PR TITLE
serverless invoke local error handling fix for #4852

### DIFF
--- a/lib/plugins/aws/invokeLocal/fixture/handlerWithLoadingError.js
+++ b/lib/plugins/aws/invokeLocal/fixture/handlerWithLoadingError.js
@@ -1,0 +1,2 @@
+'use strict';
+throw new Error('loading exception');

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -249,24 +249,24 @@ class AwsInvokeLocal {
 
   invokeLocalNodeJs(handlerPath, handlerName, event, customContext) {
     let lambda;
-
+    let pathToHandler;
     try {
       /*
        * we need require() here to load the handler from the file system
        * which the user has to supply by passing the function name
        */
-
+      pathToHandler = path.join(
+        this.serverless.config.servicePath,
+        this.options.extraServicePath || '',
+        handlerPath
+      );
       const handlersContainer = require( // eslint-disable-line global-require
-        path.join(
-          this.serverless.config.servicePath,
-          this.options.extraServicePath || '',
-          handlerPath
-        )
+        pathToHandler
       );
       lambda = handlersContainer[handlerName];
     } catch (error) {
       this.serverless.cli.consoleLog(error);
-      process.exit(0);
+      throw new Error(`Exception encountered when loading ${pathToHandler}`);
     }
 
     const callback = (err, result) => {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -503,6 +503,13 @@ describe('AwsInvokeLocal', () => {
 
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
     });
+
+    it('should throw when module loading error', () => {
+      awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+      expect(() => awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithLoadingError',
+        'anyMethod')).to.throw(Error);
+    });
   });
 
   // Ignored because it fails in CI

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -508,7 +508,7 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.serverless.config.servicePath = __dirname;
 
       expect(() => awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithLoadingError',
-        'anyMethod')).to.throw(Error);
+        'anyMethod')).to.throw(/Exception encountered when loading/);
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4852

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
By throwing an exception if the handler module can't be loaded
## How can we verify it:
A unit test has been added to verify the fix
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~ it's an expected behavior, not need to update the documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] ~~Provide verification config / commands / resources~~ unit test is there.
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
