### PR TITLE
Generalize handling of AWS retryable errors

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -23,7 +23,7 @@ module.exports = {
       }
 
 
-      if (!validEndpointTypes.includes(endpointType.toUpperCase())) {
+      if (!_.includes(validEndpointTypes, endpointType.toUpperCase())) {
         const message = 'endpointType must be one of "REGIONAL" or "EDGE". ' +
                         `You provided ${endpointType}.`;
         throw new this.serverless.classes.Error(message);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -83,6 +83,6 @@ describe('#compileRestApi()', () => {
 
   it('throw error if endpointType property is not EDGE or REGIONAL', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
-    expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
+    expect(() => awsCompileApigEvents.compileRestApi()).to.throw('endpointType must be one of');
   });
 });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -204,8 +204,7 @@ class AwsProvider {
     const persistentRequest = (f) => new BbPromise((resolve, reject) => {
       const doCall = () => {
         f()
-          .then(resolve)
-          .catch((e) => {
+          .then(resolve, e => {
             if (e.providerError && e.providerError.retryable) {
               that.serverless.cli.log(
                 `Recoverable error occured (${e.message}), sleeping 5 seconds`

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -206,8 +206,10 @@ class AwsProvider {
         f()
           .then(resolve)
           .catch((e) => {
-            if (e.statusCode === 429) {
-              that.serverless.cli.log("'Too many requests' received, sleeping 5 seconds");
+            if (e.providerError && e.providerError.retryable) {
+              that.serverless.cli.log(
+                `Recoverable error occured (${e.message}), sleeping 5 seconds`
+              );
               setTimeout(doCall, 5000);
             } else {
               reject(e);
@@ -256,7 +258,10 @@ class AwsProvider {
           message = errorMessage;
           userStats.track('user_awsCredentialsNotFound');
         }
-        return BbPromise.reject(new this.serverless.classes.Error(message, err.statusCode));
+        return BbPromise.reject(Object.assign(
+          new this.serverless.classes.Error(message, err.statusCode),
+          { providerError: err }
+        ));
       });
     })
       .then(data => {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -204,6 +204,7 @@ class AwsProvider {
     const persistentRequest = (f) => new BbPromise((resolve, reject) => {
       const doCall = () => {
         f()
+          // We're resembling if/else logic, therefore single `then` instead of `then`/`catch` pair
           .then(resolve, e => {
             if (e.providerError && e.providerError.retryable) {
               that.serverless.cli.log(

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -233,6 +233,7 @@ describe('AwsProvider', () => {
       let first = true;
       const error = {
         statusCode: 429,
+        retryable: true,
         message: 'Testing retry',
       };
       class FakeS3 {


### PR DESCRIPTION
## What did you implement:

Fixes handling of `Rate exceeded` and other recoverable errors.

## How did you implement it:

AWS when throwing recoverable error, exposes the `retryable: true` property on error.

e.g. we can see that on `Rate exceeded` error:

```
{ Throttling: Rate exceeded
    at Request.extractError (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at callNextListener (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at IncomingMessage.onEnd (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/event_listeners.js:269:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:422:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
From previous event:
    at persistentRequest (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:247:24)
    at doCall (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:205:9)
    at BbPromise (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:218:14)
From previous event:
    at persistentRequest (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:203:38)
    at Object.request.requestQueue.add [as promiseGenerator] (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:240:49)
    at Queue._dequeue (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:153:30)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:160:26
From previous event:
    at Queue._dequeue (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:155:18)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:109:18
From previous event:
    at Queue.add (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:94:16)
    at AwsProvider.request (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:240:39)
    at listStackResources (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/utils.js:261:23)
    at ServerlessPluginSplitStacks.getStackSummary (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/utils.js:273:12)
    at Promise.all.nestedStacks.map.stack (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:19:21)
    at Array.map (<anonymous>)
    at getStackSummary.catch.then.then.nestedStacks (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:15:39)
    at runCallback (timers.js:763:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate (timers.js:716:5)
    at process.topLevelDomainCallback (domain.js:102:23)
From previous event:
    at ServerlessPluginSplitStacks.getCurrentState [as migrateExistingResources] (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:14:6)
    at Promise.resolve.then (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/split-stacks.js:67:24)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
  cause: 
   { Throttling: Rate exceeded
    at Request.extractError (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at callNextListener (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at IncomingMessage.onEnd (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/event_listeners.js:269:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:422:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
     message: 'Rate exceeded',
     code: 'Throttling',
     time: 2018-04-05T14:24:34.995Z,
     requestId: '1072d930-38dd-11e8-86e4-e9d540b54859',
     statusCode: 400,
     retryable: true },
  isOperational: true,
  code: 'Throttling',
  time: 2018-04-05T14:24:34.995Z,
  requestId: '1072d930-38dd-11e8-86e4-e9d540b54859',
  statusCode: 400,
  retryable: true }
```

## How can we verify it:

It's a documented property -> https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Response.html#error-property (still there seems to be a documentation error as it's an error that's retryable and not message ;-)

Additionally I tested it by running it against reproducible case I had on my side, and with additional logs we can see it does the job:

In below logs we can see multiple concurrent `CloudFormation.listStackResources` requests, with latter ones being rejected with `RateExceeded` errors, that are later recovered:

```
AWS request: CloudFormation.listStackResources({
	"StackName": "maas-tsp-devmedikoo"
}) (duration: 0.47s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDasharrivaNestedStack-L8VFJ0AECRJW/3857b6b0-0d99-11e8-a965-500c3d7df6d2"
}) (duration: 0.33s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashaldNestedStack-1CMN6BQ3AQ9MN/ffe51730-e4a5-11e7-ad8f-50faeb59c0d2"
}) (duration: 0.36s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashcitybikesNestedStack-UKG4A6Z65CT5/1f378fd0-bfaa-11e7-ad9d-500c4225ee36"
}) (duration: 0.30s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashconnexxionNestedStack-1RXY326N0SCWI/e7fd5480-d518-11e7-8b8d-50faeb53b42a"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashdelijnDashcallbackNestedStack-MXYFBUWD7WF5/044570d0-2912-11e8-a76b-50a68645b429"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashdelijnNestedStack-1FQU49W53H4LR/e5ba6120-2911-11e8-9932-500c3cb898d2"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashdtmtaxiNestedStack-6CI5SU3139DQ/e11bacf0-fa04-11e7-8096-503abe701c99"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashenterpriseNestedStack-1KCB0ZLQ4QTOC/1f89f590-bfaa-11e7-a20c-500c3d483899"
}) (duration: 0.30s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashgettNestedStack-W8U47BKYOWH2/1fa63020-bfaa-11e7-8874-503ac9eaaa61"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashhertzNestedStack-L86Z1RFE82X8/b24047a0-e1a5-11e7-bf86-503ac9e74cfd"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashhslNestedStack-1DY0K41QLRFUD/1f4e4c20-bfaa-11e7-8cf9-500c3d3cda29"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashhtdNestedStack-12BYNRRQ09403/20a2dfa0-bfaa-11e7-ab50-503ac9e74c61"
}) (duration: 0.31s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashnextbikeNestedStack-TM16NWU83WCV/1f35bb10-bfaa-11e7-9f45-500c44f19ed2"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashnxNestedStack-1A4W6SAOZLWUH/1f758330-bfaa-11e7-9e43-503abe701cfd"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashpayiqNestedStack-BPFP5QYH4SSD/e781e2f0-d518-11e7-867f-503ac9eaaad1"
}) (duration: 0.27s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashproxyNestedStack-1RR5MS35UXW41/deb97710-38db-11e8-be3d-500c4266c6d2"
}) (duration: 0.28s)
AWS request (errored): CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashtaxiDashmunichNestedStack-KMREQW9K0692/0cd9b650-ff84-11e7-9663-50faea5d48d2"
}) (duration: 1.05s)
{ Throttling: Rate exceeded
    at Request.extractError (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at callNextListener (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at IncomingMessage.onEnd (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/event_listeners.js:269:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:422:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
From previous event:
    at persistentRequest (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:247:24)
    at doCall (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:205:9)
    at BbPromise (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:218:14)
From previous event:
    at persistentRequest (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:203:38)
    at Object.request.requestQueue.add [as promiseGenerator] (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:240:49)
    at Queue._dequeue (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:153:30)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:160:26
From previous event:
    at Queue._dequeue (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:155:18)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:109:18
From previous event:
    at Queue.add (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:94:16)
    at AwsProvider.request (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:240:39)
    at listStackResources (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/utils.js:261:23)
    at ServerlessPluginSplitStacks.getStackSummary (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/utils.js:273:12)
    at Promise.all.nestedStacks.map.stack (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:19:21)
    at Array.map (<anonymous>)
    at getStackSummary.catch.then.then.nestedStacks (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:15:39)
    at runCallback (timers.js:763:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate (timers.js:716:5)
    at process.topLevelDomainCallback (domain.js:102:23)
From previous event:
    at ServerlessPluginSplitStacks.getCurrentState [as migrateExistingResources] (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:14:6)
    at Promise.resolve.then (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/split-stacks.js:67:24)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
  cause: 
   { Throttling: Rate exceeded
    at Request.extractError (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at callNextListener (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at IncomingMessage.onEnd (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/event_listeners.js:269:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:422:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
     message: 'Rate exceeded',
     code: 'Throttling',
     time: 2018-04-05T14:24:34.931Z,
     requestId: '1069ff49-38dd-11e8-a758-a703095935df',
     statusCode: 400,
     retryable: true },
  isOperational: true,
  code: 'Throttling',
  time: 2018-04-05T14:24:34.931Z,
  requestId: '1069ff49-38dd-11e8-a758-a703095935df',
  statusCode: 400,
  retryable: true }
Serverless: Recoverable error occured (Rate exceeded), sleeping 5 seconds
AWS request (errored): CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashsixtNestedStack-1IO4H93QJ0BKW/1f4bb410-bfaa-11e7-b7ae-50a686335cd2"
}) (duration: 1.19s)
{ Throttling: Rate exceeded
    at Request.extractError (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at callNextListener (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at IncomingMessage.onEnd (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/event_listeners.js:269:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:422:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
From previous event:
    at persistentRequest (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:247:24)
    at doCall (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:205:9)
    at BbPromise (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:218:14)
From previous event:
    at persistentRequest (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:203:38)
    at Object.request.requestQueue.add [as promiseGenerator] (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:240:49)
    at Queue._dequeue (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:153:30)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:160:26
From previous event:
    at Queue._dequeue (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:155:18)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:109:18
From previous event:
    at Queue.add (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/promise-queue/lib/index.js:94:16)
    at AwsProvider.request (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:240:39)
    at listStackResources (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/utils.js:261:23)
    at ServerlessPluginSplitStacks.getStackSummary (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/utils.js:273:12)
    at Promise.all.nestedStacks.map.stack (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:19:21)
    at Array.map (<anonymous>)
    at getStackSummary.catch.then.then.nestedStacks (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:15:39)
    at runCallback (timers.js:763:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate (timers.js:716:5)
    at process.topLevelDomainCallback (domain.js:102:23)
From previous event:
    at ServerlessPluginSplitStacks.getCurrentState [as migrateExistingResources] (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/lib/migrate-existing-resources.js:14:6)
    at Promise.resolve.then (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/serverless-plugin-split-stacks/split-stacks.js:67:24)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
  cause: 
   { Throttling: Rate exceeded
    at Request.extractError (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at callNextListener (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at IncomingMessage.onEnd (/Users/medikoo/Projects/maas/maas-transport-booking/node_modules/aws-sdk/lib/event_listeners.js:269:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:422:20)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
     message: 'Rate exceeded',
     code: 'Throttling',
     time: 2018-04-05T14:24:34.995Z,
     requestId: '1072d930-38dd-11e8-86e4-e9d540b54859',
     statusCode: 400,
     retryable: true },
  isOperational: true,
  code: 'Throttling',
  time: 2018-04-05T14:24:34.995Z,
  requestId: '1072d930-38dd-11e8-86e4-e9d540b54859',
  statusCode: 400,
  retryable: true }
Serverless: Recoverable error occured (Rate exceeded), sleeping 5 seconds
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashtaxiDashmunichNestedStack-KMREQW9K0692/0cd9b650-ff84-11e7-9663-50faea5d48d2"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashsixtNestedStack-1IO4H93QJ0BKW/1f4bb410-bfaa-11e7-b7ae-50a686335cd2"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashtcataxiNestedStack-VWQA0M0NLWG1/1f6c3460-bfaa-11e7-9757-503ac9eaaa99"
}) (duration: 0.29s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashvalopilkkuNestedStack-XN6QCDYJVF4T/20c2c3b0-bfaa-11e7-a2a2-50fae9b6ecd2"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-BookingDashwienerDashlinienNestedStack-IFGGH7IFYS4J/e297b820-22e1-11e8-a6de-500c426596d2"
}) (duration: 0.28s)
AWS request: CloudFormation.listStackResources({
	"StackName": "arn:aws:cloudformation:eu-west-1:756207178743:stack/maas-tsp-devmedikoo-EnterpriseDashupdateDashstationsDashdataNestedStack-170AFOM1N59Z8/1f5fd850-bfaa-11e7-9757-503ac9eaaa99"
}) (duration: 0.26s)
```

## Todos:

- [x] Write tests
- [ ] (N/A) Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
