### PR TITLE
iamManagedPolicies merging with Vpc config

### DIFF
--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -131,11 +131,7 @@ module.exports = {
       const resource = this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.provider.naming.getRoleLogicalId()].Properties;
       if (iamManagedPolicies.length > 0) {
-        if (!_.has(resource, 'ManagedPolicyArns') || _.isEmpty(resource.ManagedPolicyArns)) {
-          resource.ManagedPolicyArns = [];
-        }
-        resource.ManagedPolicyArns = resource.ManagedPolicyArns
-          .concat(iamManagedPolicies);
+        this.mergeManagedPolicies(iamManagedPolicies);
       }
     }
 
@@ -150,10 +146,7 @@ module.exports = {
 
     if (_.includes(vpcConfigProvided, true) || this.serverless.service.provider.vpc) {
       // add managed iam policy to allow ENI management
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[this.provider.naming.getRoleLogicalId()]
-        .Properties
-        .ManagedPolicyArns = [{
+      this.mergeManagedPolicies([{
           'Fn::Join': ['',
             [
               'arn:',
@@ -161,10 +154,20 @@ module.exports = {
               ':iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
             ],
           ],
-        }];
+        }]);
     }
 
     return BbPromise.resolve();
+  },
+
+  mergeManagedPolicies(managedPolicies){
+    const resource = this.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources[this.provider.naming.getRoleLogicalId()]
+        .Properties;
+      if (!_.has(resource, 'ManagedPolicyArns') || _.isEmpty(resource.ManagedPolicyArns)) {
+        resource.ManagedPolicyArns = [];
+      }
+      resource.ManagedPolicyArns = resource.ManagedPolicyArns.concat(managedPolicies)
   },
 
   validateStatements(statements) {

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -128,8 +128,6 @@ module.exports = {
     if (this.serverless.service.provider.iamManagedPolicies) {
       // add iam managed policies
       const iamManagedPolicies = this.serverless.service.provider.iamManagedPolicies;
-      const resource = this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[this.provider.naming.getRoleLogicalId()].Properties;
       if (iamManagedPolicies.length > 0) {
         this.mergeManagedPolicies(iamManagedPolicies);
       }
@@ -147,27 +145,27 @@ module.exports = {
     if (_.includes(vpcConfigProvided, true) || this.serverless.service.provider.vpc) {
       // add managed iam policy to allow ENI management
       this.mergeManagedPolicies([{
-          'Fn::Join': ['',
-            [
-              'arn:',
-              { Ref: 'AWS::Partition' },
-              ':iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
-            ],
+        'Fn::Join': ['',
+          [
+            'arn:',
+            { Ref: 'AWS::Partition' },
+            ':iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
           ],
-        }]);
+        ],
+      }]);
     }
 
     return BbPromise.resolve();
   },
 
-  mergeManagedPolicies(managedPolicies){
+  mergeManagedPolicies(managedPolicies) {
     const resource = this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.provider.naming.getRoleLogicalId()]
         .Properties;
-      if (!_.has(resource, 'ManagedPolicyArns') || _.isEmpty(resource.ManagedPolicyArns)) {
-        resource.ManagedPolicyArns = [];
-      }
-      resource.ManagedPolicyArns = resource.ManagedPolicyArns.concat(managedPolicies)
+    if (!_.has(resource, 'ManagedPolicyArns') || _.isEmpty(resource.ManagedPolicyArns)) {
+      resource.ManagedPolicyArns = [];
+    }
+    resource.ManagedPolicyArns = resource.ManagedPolicyArns.concat(managedPolicies);
   },
 
   validateStatements(statements) {

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -171,6 +171,36 @@ describe('#mergeIamTemplates()', () => {
       });
   });
 
+  it('should merge managed policy arns when vpc config supplied', () => {
+    awsPackage.serverless.service.provider.vpc = {
+      securityGroupIds: ['xxx'],
+      subnetIds: ['xxx'],
+    };
+    const iamManagedPolicies = [
+      'some:aws:arn:xxx:*:*',
+      'someOther:aws:arn:xxx:*:*',
+      { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSAccountId' }, 'some/path']] },
+    ];
+    awsPackage.serverless.service.provider.iamManagedPolicies = iamManagedPolicies
+    const expectedManagedPolicyArns = [...iamManagedPolicies,{
+      'Fn::Join': ['',
+        [
+          'arn:',
+          { Ref: 'AWS::Partition' },
+          ':iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
+        ],
+      ],
+    } ]
+    return awsPackage.mergeIamTemplates()
+      .then(() => {
+        expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[awsPackage.provider.naming.getRoleLogicalId()]
+          .Properties
+          .ManagedPolicyArns
+        ).to.deep.equal(expectedManagedPolicyArns);
+      });
+  });
+
   it('should throw error if custom IAM policy statements is not an array', () => {
     awsPackage.serverless.service.provider.iamRoleStatements = {
       policy: 'some_value',

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -182,15 +182,19 @@ describe('#mergeIamTemplates()', () => {
       { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSAccountId' }, 'some/path']] },
     ];
     awsPackage.serverless.service.provider.iamManagedPolicies = iamManagedPolicies;
-    const expectedManagedPolicyArns = [...iamManagedPolicies, {
-      'Fn::Join': ['',
+    const expectedManagedPolicyArns = [
+      'some:aws:arn:xxx:*:*',
+      'someOther:aws:arn:xxx:*:*',
+      { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSAccountId' }, 'some/path']] },
+      { 'Fn::Join': ['',
         [
           'arn:',
           { Ref: 'AWS::Partition' },
           ':iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
         ],
       ],
-    }];
+      },
+    ];
     return awsPackage.mergeIamTemplates()
       .then(() => {
         expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -181,8 +181,8 @@ describe('#mergeIamTemplates()', () => {
       'someOther:aws:arn:xxx:*:*',
       { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSAccountId' }, 'some/path']] },
     ];
-    awsPackage.serverless.service.provider.iamManagedPolicies = iamManagedPolicies
-    const expectedManagedPolicyArns = [...iamManagedPolicies,{
+    awsPackage.serverless.service.provider.iamManagedPolicies = iamManagedPolicies;
+    const expectedManagedPolicyArns = [...iamManagedPolicies, {
       'Fn::Join': ['',
         [
           'arn:',
@@ -190,7 +190,7 @@ describe('#mergeIamTemplates()', () => {
           ':iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
         ],
       ],
-    } ]
+    }];
     return awsPackage.mergeIamTemplates()
       .then(() => {
         expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4876

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I have updated how iamManagedPolicies are merged with the default role so that when VPC Config is supplied it will include any managed policies on top of the AWSLambdaVPCAccessExecutionRole

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Example serverless yml: 
```yml
service: sandbox-for-managed-policies
provider:
  name: aws
  runtime: java8
  vpc:
    securityGroupIds:
      - sgs
    subnetIds:
      - subs
  iamManagedPolicies:
    - 'arn:aws:iam:*****:policy/some-managed-policy'
  iamRoleStatements:
    - Effect: Allow
      Action:
        - sns:Publish
      Resource: "*"

package:
  artifact: artifact.jar

functions:
  myFunction:
    handler: someClass
```

The CloudFormation template should have a default IAM role with the following managed policy arns:
```json
"ManagedPolicyArns": [
          "arn:aws:iam:*****:policy/some-managed-policy",
          {
            "Fn::Join": [
              "",
              [
                "arn:",
                {
                  "Ref": "AWS::Partition"
                },
                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
              ]
            ]
          }
        ]
```
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO