### PR TITLE
Fix provider plugin name in Azure Example

### DIFF
--- a/docs/providers/azure/examples/hello-world/node/README.md
+++ b/docs/providers/azure/examples/hello-world/node/README.md
@@ -19,7 +19,7 @@ Make sure `serverless` is installed. [See installation guide](../../../guide/ins
 
 ## 2. Install Provider Plugin
 
-`npm install -g serverless-azure` followed by `npm install` in the service directory.
+`npm install -g serverless-azure-functions` followed by `npm install` in the service directory.
 
 ## 3. Deploy
 


### PR DESCRIPTION
## What did you implement:

Change plugin name in example documentation from 'serverless-azure' to the correct 'serverless-azure-functions' name. The 'serverless-azure' listed currently is the incorrect name of the package and does not exist.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Changed package name in document.

## How can we verify it:

Try the current command 'npm install -g serverless-azure' and it will receive a 404. Try the new command 'npm install -g serverless-azure-functions' and it will succeed. 

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
