### PR TITLE
AWS Environment variables should contain only strings

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -254,7 +254,7 @@ In order for other services such as Kinesis streams to be made available, a NAT 
 
 ## Environment Variables
 
-You can add environment variable configuration to a specific function in `serverless.yml` by adding an `environment` object property in the function configuration. This object should contain a key/value collection of strings:
+You can add environment variable configuration to a specific function in `serverless.yml` by adding an `environment` object property in the function configuration. This object should contain a key-value pairs of string to string:
 
 ```yml
 # serverless.yml

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -164,6 +164,10 @@ class AwsDeployFunction {
             const errorMessage = 'Invalid characters in environment variable';
             throw new this.serverless.classes.Error(errorMessage);
           }
+          if (typeof params.Environment.Variables[key] !== 'string') {
+            const errorMessage = `Environment variable ${key} must contain strings`;
+            throw new this.serverless.classes.Error(errorMessage);
+          }
         });
       }
     }

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -164,7 +164,7 @@ class AwsDeployFunction {
             const errorMessage = 'Invalid characters in environment variable';
             throw new this.serverless.classes.Error(errorMessage);
           }
-          if (typeof params.Environment.Variables[key] !== 'string') {
+          if (!_.isString(params.Environment.Variables[key])) {
             const errorMessage = `Environment variable ${key} must contain strings`;
             throw new this.serverless.classes.Error(errorMessage);
           }

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -353,6 +353,20 @@ describe('AwsDeployFunction', () => {
       expect(() => awsDeployFunction.updateFunctionConfiguration()).to.throw(Error);
     });
 
+    it('should fail when using non-string values as environment variables', () => {
+      options.functionObj = {
+        name: 'first',
+        description: 'change',
+        environment: {
+          COUNTER: 6,
+        },
+      };
+
+      awsDeployFunction.options = options;
+
+      expect(() => awsDeployFunction.updateFunctionConfiguration()).to.throw(Error);
+    });
+
     it('should inherit provider-level config', () => {
       options.functionObj = {
         name: 'first',

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -249,7 +249,10 @@ class AwsCompileFunctions {
             invalidEnvVar = `Invalid characters in environment variable ${key}`;
             return false;   // break loop with lodash
           }
-          if (typeof newFunction.Properties.Environment.Variables[key] !== 'string') {
+          const value = newFunction.Properties.Environment.Variables[key];
+          const isCFRef = _.isObject(value) &&
+            !_.some(value, (val, key) => key !== 'Ref' && !_.startsWith(key, 'Fn::'));
+          if (!isCFRef && !_.isString(value)) {
             invalidEnvVar = `Environment variable ${key} must contain string`;
             return false;
           }

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -251,7 +251,7 @@ class AwsCompileFunctions {
           }
           const value = newFunction.Properties.Environment.Variables[key];
           const isCFRef = _.isObject(value) &&
-            !_.some(value, (val, key) => key !== 'Ref' && !_.startsWith(key, 'Fn::'));
+            !_.some(value, (v, k) => k !== 'Ref' && !_.startsWith(k, 'Fn::'));
           if (!isCFRef && !_.isString(value)) {
             invalidEnvVar = `Environment variable ${key} must contain string`;
             return false;

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -249,6 +249,10 @@ class AwsCompileFunctions {
             invalidEnvVar = `Invalid characters in environment variable ${key}`;
             return false;   // break loop with lodash
           }
+          if (typeof newFunction.Properties.Environment.Variables[key] !== 'string') {
+            invalidEnvVar = `Environment variable ${key} must contain string`;
+            return false;
+          }
         }
       );
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1367,6 +1367,39 @@ describe('AwsCompileFunctions', () => {
       return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
     });
 
+    it('should accept an environment variable with CF ref and functions', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          environment: {
+            counter: {
+              Ref: 'TestVariable'
+            },
+            list: {
+              'Fn::Join:': [', ', ['a', 'b', 'c']]
+            },
+          },
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+              environment: {
+                counter: {
+                  NotRef: 'TestVariable'
+                },
+              },
+            },
+          };
+          return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
+        });
+    });
+
     it('should consider function based config when creating a function resource', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1374,10 +1374,10 @@ describe('AwsCompileFunctions', () => {
           name: 'new-service-dev-func',
           environment: {
             counter: {
-              Ref: 'TestVariable'
+              Ref: 'TestVariable',
             },
             list: {
-              'Fn::Join:': [', ', ['a', 'b', 'c']]
+              'Fn::Join:': [', ', ['a', 'b', 'c']],
             },
           },
         },
@@ -1391,7 +1391,7 @@ describe('AwsCompileFunctions', () => {
               name: 'new-service-dev-func',
               environment: {
                 counter: {
-                  NotRef: 'TestVariable'
+                  NotRef: 'TestVariable',
                 },
               },
             },

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1353,6 +1353,20 @@ describe('AwsCompileFunctions', () => {
       return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
     });
 
+    it('should throw an error if environment variable is not a string', () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          environment: {
+            counter: 18,
+          },
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
+    });
+
     it('should consider function based config when creating a function resource', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact

--- a/lib/plugins/plugin/install/install.test.js
+++ b/lib/plugins/plugin/install/install.test.js
@@ -253,16 +253,16 @@ describe('PluginInstall', () => {
       serverless.utils
         .writeFileSync(packageJsonFilePath, packageJson);
 
-      return expect(pluginInstall.pluginInstall()).to.be.fulfilled.then(() => {
-        return Promise.all([
+      return expect(pluginInstall.pluginInstall()).to.be.fulfilled.then(() =>
+        Promise.all([
           expect(consoleLogStub.called).to.equal(true),
           expect(npmInstallStub.calledWithExactly(
             'npm install --save-dev serverless-plugin-1@latest',
             { stdio: 'ignore' }
           )).to.equal(true),
-          expect(serverlessErrorStub.calledOnce).to.equal(false)
-        ]);
-      });
+          expect(serverlessErrorStub.calledOnce).to.equal(false),
+        ])
+      );
     });
 
     it('should generate a package.json file in the service directory if not present',

--- a/lib/plugins/plugin/install/install.test.js
+++ b/lib/plugins/plugin/install/install.test.js
@@ -254,12 +254,14 @@ describe('PluginInstall', () => {
         .writeFileSync(packageJsonFilePath, packageJson);
 
       return expect(pluginInstall.pluginInstall()).to.be.fulfilled.then(() => {
-        expect(consoleLogStub.called).to.equal(true);
-        expect(npmInstallStub.calledWithExactly(
-          'npm install --save-dev serverless-plugin-1@latest',
-          { stdio: 'ignore' }
-        )).to.equal(true);
-        expect(serverlessErrorStub.calledOnce).to.equal(false);
+        return Promise.all([
+          expect(consoleLogStub.called).to.equal(true),
+          expect(npmInstallStub.calledWithExactly(
+            'npm install --save-dev serverless-plugin-1@latest',
+            { stdio: 'ignore' }
+          )).to.equal(true),
+          expect(serverlessErrorStub.calledOnce).to.equal(false)
+        ]);
       });
     });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4884

Lambda environment variables must only contain strings. Although both [CloudFormation template documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) and [Lambda's API](https://docs.aws.amazon.com/lambda/latest/dg/API_Environment.html) state that, only Lambda's API enforces it.

As `deploy --function` uses [Lambda's UpdateFunctionConfiguration](https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html) and `deploy` updates the CF template, you only see a validation issue when running the function deploy command.

This makes sure both uses will go through the same check to make sure everything is ok (and hopefully in the future, the CF validation will be fixed and no one will be shocked _serverless_ didn't validate this before).

## How did you implement it:

Making sure the `Environment.Variables` parameter in both the CF template and _updateFunctionConfiguration_ call will contain only string values.

## How can we verify it:

```yml
functions:
  error-function:
    handler: handler.func
    environment:
      INPUT: 80

  good-function:
    handler: handler.func
    environment:
      INPUT: '80'
      SOMEREF:
        Ref: MyVar

resources:
  Parameters:
    MyVar:
      Type: Number
      Default: 7
```

### Interesting thing about using [CF refs of type Number](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties-type)
> An integer or float. AWS CloudFormation validates the parameter value as a number; however, when you use the parameter elsewhere in your template (for example, by using the Ref intrinsic function), the parameter value becomes a string.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
