### PR TITLE
fix: binary support for pre-flight requests (OPTIONS method)

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -54,6 +54,7 @@ module.exports = {
               RequestTemplates: {
                 'application/json': '{statusCode:200}',
               },
+              ContentHandling: 'CONVERT_TO_TEXT',
               IntegrationResponses: this.generateCorsIntegrationResponses(preflightHeaders),
             },
             ResourceId: resourceRef,


### PR DESCRIPTION
## What did you implement:

Closes #2797 partially

## How did you implement it:

set CONVERT_TO_TEXT for OPTIONS method in cors config

## How can we verify it:

you can test pre-flight requests (OPTIONS method) using curl or something like test-cors.org

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** MAYBE

I realize there are no tests, and I don't have time to write them, but I've been running this for a few months now without issue with BinaryMediaTypes set to "*/*". See https://github.com/serverless/serverless/issues/2797#issuecomment-367342494 for more info. @eraserfusion mentioned this change helped him, perhaps it'll be of use to others.