### PR TITLE
upgrade typescript, types, node and webpack for typescript template

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -10,13 +10,14 @@
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {
-    "@types/aws-lambda": "0.0.22",
+    "@types/aws-lambda": "8.10.1",
     "@types/node": "^8.0.57",
-    "serverless-webpack": "^4.0.0",
-    "ts-loader": "^2.3.7",
-    "typescript": "^2.5.2",
-    "webpack": "^3.6.0"
+    "serverless-webpack": "^5.1.1",
+    "ts-loader": "^4.2.0",
+    "typescript": "^2.8.1",
+    "webpack": "^4.5.0"
   },
-  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "author":
+    "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
   "license": "MIT"
 }

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 functions:
   hello:

--- a/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "lib": [
-      "es5",
-      "es2015.promise"
+      "es6"
     ]
   },
   "exclude": [

--- a/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "sourceMap": true,
+    "target": "es6",
     "lib": [
-      "es6"
-    ]
+      "esnext"
+    ],
+    "moduleResolution": "node"
   },
   "exclude": [
     "node_modules"

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -8,6 +8,7 @@ Object.keys(slsw.lib.entries).forEach(key => (
 ));
 
 module.exports = {
+  mode: 'production',
   entry: entries,
   devtool: 'source-map',
   resolve: {
@@ -26,8 +27,9 @@ module.exports = {
   },
   target: 'node',
   module: {
-    loaders: [
-      { test: /\.ts(x?)$/, loader: 'ts-loader' },
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      { test: /\.tsx?$/, loader: 'ts-loader' },
     ],
   },
 };

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -3,22 +3,16 @@ const slsw = require('serverless-webpack');
 
 const entries = {};
 
-Object.keys(slsw.lib.entries).forEach(key => (
-  entries[key] = ['./source-map-install.js', slsw.lib.entries[key]]
-));
+Object.keys(slsw.lib.entries).forEach(
+  key => (entries[key] = ['./source-map-install.js', slsw.lib.entries[key]])
+);
 
 module.exports = {
-  mode: 'production',
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
   entry: entries,
   devtool: 'source-map',
   resolve: {
-    extensions: [
-      '.js',
-      '.jsx',
-      '.json',
-      '.ts',
-      '.tsx'
-    ]
+    extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
   },
   output: {
     libraryTarget: 'commonjs',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

I have updated template for typescript in order to use node 8, to have types for streams (missing in previous version) and to use webpack 4

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
I have updated release in package.json, modified node version in serverless.yml and modify webpack conf (rules) to support webpack 4

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
`~/bin/serverless create -t aws-nodejs-typescript`
`npm or yarn install`
`sls deploy`


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
