### PR TITLE
edit Serverless license info so that GitHub recognizes it

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,11 +1,4 @@
-The MIT License (MIT)
-
 Copyright (c) 2018 Serverless, Inc. http://www.serverless.com
-
-The following license applies to all parts of this software except as
-documented below:
-
-====
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,10 +17,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-====
-
-All files located in the node_modules and external directories are
-externally maintained libraries used by this software which have their
-own licenses; we recommend you read them, as their terms may differ from
-the terms above.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Serverless is an MIT open-source project, actively maintained by a full-time, ve
 * [Contributing](#contributing)
 * [Community](#community)
 * [Consultants](#consultants)
+* [Licensing](#licensing)
 * [Previous Version 0.5.x](#v.5)
 
 ## <a name="quick-start"></a>Quick Start
@@ -360,6 +361,12 @@ These consultants use the Serverless Framework and can help you build your serve
 * [OneSpeed](https://onespeed.io/)
 * [Seraro](http://www.seraro.com/) - Who also runs Atlanta Serverless Meetup  (https://www.meetup.com/Atlanta-CABI-Camp-Cloud-AI-Blockchain-IOT) and Delhi Serverless Meetup (https://www.meetup.com/Delhi-NCR-Serverless-Architecture-Meetup/)
 ----
+
+## <a name="licensing"></a>Licensing
+
+Serverless is licensed under the [MIT License](./LICENSE.txt).
+
+All files located in the node_modules and external directories are externally maintained libraries used by this software which have their own licenses; we recommend you read them, as their terms may differ from the terms in the MIT License.
 
 # <a name="v.5"></a>Previous Serverless Version 0.5.x
 


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in https://landscape.cncf.io/selected=serverless)

## What did you implement:
GitHub uses a library called Licensee to identify a project's license type. It shows this information in the status bar and via the API if it can unambiguously identify the license.

This commit makes changes that allow Licensee to successfully identify the license type of Serverless as MIT.

## How did you implement it:
I updated the LICENSE file so that it contains only the full text of the MIT license. The info that pertains to 3rd-party software licensing has now been moved to a "Licensing" section in the README.

## How can we verify it:
- Install [Licensee](https://github.com/benbalter/licensee/)
- From within the `licensee` directory, run `licensee detect https://github.com/serverless/serverless`. 

Below is the output I get. As you can see, Licensee currently reports `Other` as the specific license type for `LICENSE.txt` and `Other` for the overall repository.
```
License:        Other
Matched files:  LICENSE.txt, package.json
LICENSE.txt:
  Content hash:  698f452fa025987ad794c921792cf0602c8ec08f
  Attribution:   Copyright (c) 2018 Serverless, Inc. http://www.serverless.com
  License:       Other
  Closest licenses:
    MIT similarity:      85.85%
    NCSA similarity:     74.89%
    BSL-1.0 similarity:  63.79%
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     MIT License
```

Here is the output I get when I run `licensee detect` on my local clone of Serverless (on the branch that contains my proposed changes).
```
License:        MIT License
Matched files:  LICENSE.txt, package.json
LICENSE.txt:
  Content hash:  46cdc03462b9af57968df67b450cc4372ac41f53
  Attribution:   Copyright (c) 2018 Serverless, Inc. http://www.serverless.com
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT License
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     MIT License
```

## Todos:
- [ ] Write tests (N/A)
- [x] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
