### PR TITLE
Fix broken shared API functionality

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -30,7 +30,7 @@ module.exports = {
                   ':',
                   { Ref: 'AWS::AccountId' },
                   ':',
-                  { Ref: this.provider.naming.getRestApiLogicalId() },
+                  this.provider.getApiGatewayRestApiId(),
                   '/*/*',
                 ],
               ],

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -70,6 +70,61 @@ describe('#awsCompilePermissions()', () => {
     });
   });
 
+  it('should create limited permission resource scope to REST API with restApiId provided', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      restApiId: 'xxxxx',
+    };
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'foo/bar',
+          method: 'post',
+        },
+      },
+    ];
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.permissionMapping = [
+      {
+        lambdaLogicalId: 'FirstLambdaFunction',
+        resourceName: 'FooBar',
+        event: {
+          http: {
+            path: 'foo/bar',
+            method: 'post',
+          },
+          functionName: 'First',
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compilePermissions().then(() => {
+      expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstLambdaPermissionApiGateway
+        .Properties.FunctionName['Fn::GetAtt'][0]).to.equal('FirstLambdaFunction');
+
+      const deepObj = {
+        'Fn::Join': ['',
+          [
+            'arn:',
+            { Ref: 'AWS::Partition' },
+            ':execute-api:',
+            { Ref: 'AWS::Region' },
+            ':',
+            { Ref: 'AWS::AccountId' },
+            ':',
+            'xxxxx',
+            '/*/*',
+          ],
+        ],
+      };
+
+      expect(awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.FirstLambdaPermissionApiGateway
+        .Properties.SourceArn).to.deep.equal(deepObj);
+    });
+  });
+
   it('should create permission resources for authorizers', () => {
     awsCompileApigEvents.validated.events = [
       {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -14,9 +14,7 @@ module.exports = {
           Properties: {
             ApiStages: [
               {
-                ApiId: {
-                  Ref: this.provider.naming.getRestApiLogicalId(),
-                },
+                ApiId: this.provider.getApiGatewayRestApiId(),
                 Stage: this.provider.getStage(),
               },
             ],

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -151,4 +151,20 @@ describe('#compileUsagePlan()', () => {
       ).to.equal('first-service-dev');
     });
   });
+
+  it('should compile custom usage plan resource with restApiId provided', () => {
+    serverless.service.provider.apiKeys = ['1234567890'];
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      restApiId: 'xxxxx',
+    };
+
+    return awsCompileApigEvents.compileUsagePlan().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[
+          awsCompileApigEvents.provider.naming.getUsagePlanLogicalId()
+          ].Properties.ApiStages[0].ApiId
+      ).to.equal('xxxxx');
+    });
+  });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4923

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Used wrong function for generating CF, so I have fixed a correct one and added test case so as not to introduce this regression in the future.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Run `sls deploy` with the following serverless.yml

``` yaml
service: shared-api

provider:
  name: aws
  runtime: nodejs6.10
  apiKeys:
    - myFirstKeyss
  usagePlan:
    quota:
      limit: 5000
      offset: 2
      period: MONTH
    throttle:
      burstLimit: 200
      rateLimit: 100
  apiGateway:
    restApiId: xxxxxxxx # Specify your restApiId
    restApiRootResourceId: yyyyyyyyy # Specify your restApiRootResourceId

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: /hello
          method: get

```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
