### PR TITLE
fixes #4438. get log defaults to 10 minute instead of yesterday

### DIFF
--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -87,6 +87,11 @@ class AwsLogs {
       } else {
         params.startTime = moment.utc(this.options.startTime).valueOf();
       }
+    } else {
+      params.startTime = moment().subtract(10, 'm').valueOf();
+      if (this.options.tail) {
+        params.startTime = moment().subtract(10, 's').valueOf();
+      }
     }
 
     return this.provider

--- a/lib/plugins/aws/logs/index.test.js
+++ b/lib/plugins/aws/logs/index.test.js
@@ -157,10 +157,11 @@ describe('AwsLogs', () => {
 
   describe('#showLogs()', () => {
     let clock;
+    const fakeTime = new Date(Date.UTC(2016, 9, 1)).getTime();
 
     beforeEach(() => {
-      // new Date() => return the fake Date 'Sat Sep 01 2016 00:00:00'
-      clock = sinon.useFakeTimers(new Date(Date.UTC(2016, 9, 1)).getTime());
+      // set the fake Date 'Sat Sep 01 2016 00:00:00'
+      clock = sinon.useFakeTimers(fakeTime);
     });
 
     afterEach(() => {
@@ -209,7 +210,7 @@ describe('AwsLogs', () => {
               interleaved: true,
               logStreamNames: logStreamNamesMock,
               filterPattern: 'error',
-              startTime: 1475269200000,
+              startTime: fakeTime - (3 * 60 * 60 * 1000), // -3h
             }
           )).to.be.equal(true);
           awsLogs.provider.request.restore();
@@ -258,6 +259,99 @@ describe('AwsLogs', () => {
               logStreamNames: logStreamNamesMock,
               startTime: 1287532800000, // '2010-10-20'
               filterPattern: 'error',
+            }
+          )).to.be.equal(true);
+
+          awsLogs.provider.request.restore();
+        });
+    });
+
+    it('should call filterLogEvents API with latest 10 minutes if startTime not given', () => {
+      const replyMock = {
+        events: [
+          {
+            logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+            timestamp: 1469687512311,
+            message: 'test',
+          },
+          {
+            logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+            timestamp: 1469687512311,
+            message: 'test',
+          },
+        ],
+      };
+      const logStreamNamesMock = [
+        '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+        '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+      ];
+      const filterLogEventsStub = sinon.stub(awsLogs.provider, 'request').resolves(replyMock);
+      awsLogs.serverless.service.service = 'new-service';
+      awsLogs.options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+      };
+
+      return awsLogs.showLogs(logStreamNamesMock)
+        .then(() => {
+          expect(filterLogEventsStub.calledOnce).to.be.equal(true);
+          expect(filterLogEventsStub.calledWithExactly(
+            'CloudWatchLogs',
+            'filterLogEvents',
+            {
+              logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+              interleaved: true,
+              logStreamNames: logStreamNamesMock,
+              startTime: fakeTime - (10 * 60 * 1000), // fakeTime - 10 minutes
+            }
+          )).to.be.equal(true);
+
+          awsLogs.provider.request.restore();
+        });
+    });
+
+    it('should call filterLogEvents API which starts 10 seconds in the past if tail given', () => {
+      const replyMock = {
+        events: [
+          {
+            logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+            timestamp: 1469687512311,
+            message: 'test',
+          },
+          {
+            logStreamName: '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+            timestamp: 1469687512311,
+            message: 'test',
+          },
+        ],
+      };
+      const logStreamNamesMock = [
+        '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+        '2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba',
+      ];
+      const filterLogEventsStub = sinon.stub(awsLogs.provider, 'request').resolves(replyMock);
+      awsLogs.serverless.service.service = 'new-service';
+      awsLogs.options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+        tail: true,
+      };
+
+      return awsLogs.showLogs(logStreamNamesMock)
+        .then(() => {
+          expect(filterLogEventsStub.calledOnce).to.be.equal(true);
+          expect(filterLogEventsStub.calledWithExactly(
+            'CloudWatchLogs',
+            'filterLogEvents',
+            {
+              logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+              interleaved: true,
+              logStreamNames: logStreamNamesMock,
+              startTime: fakeTime - (10 * 1000), // fakeTime - 10 minutes
             }
           )).to.be.equal(true);
 


### PR DESCRIPTION
if not given logs range, it will only get the last 10 minutes.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4438 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Modified log options.startTime to be 10 minutes in the past instead of 1 day in the past.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
get logs on aws.
Also modified the test.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Make sure code coverage hasn't dropped
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below
- [ ] Fix linting errors
- [ ] Write documentation
- [ ] Provide verification config / commands / resources

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
