### PR TITLE
Fix customVariable syntax use results in failed variable population bug

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -729,7 +729,15 @@ class Variables {
     if (index < 0) {
       index = this.deep.push(variable) - 1;
     }
-    return `\${deep:${index}}`;
+    let variableContainer = variable;
+    let variableString = this.cleanVariable(variableContainer);
+    while (variableString.match(this.variableSyntax)) {
+      variableContainer = variableString;
+      variableString = this.cleanVariable(variableContainer);
+    }
+    return variableContainer
+      .replace(/\s/g, '')
+      .replace(variableString, `deep:${index}`);
   }
   appendDeepVariable(variable, subProperty) {
     return `${variable.slice(0, variable.length - 1)}.${subProperty}}`;

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -586,6 +586,44 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);
       });
+      it('should handle deep variables regardless of custom variableSyntax', () => {
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
+        serverless.variables.loadVariableSyntax();
+        delete service.provider.variableSyntax;
+        service.custom = {
+          my0thStage: 'DEV',
+          my1stStage: '${{self:custom.my0thStage}}',
+          my2ndStage: '${{self:custom.my1stStage}}',
+        };
+        const expected = {
+          my0thStage: 'DEV',
+          my1stStage: 'DEV',
+          my2ndStage: 'DEV',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should handle deep variables regardless of recursion into custom variableSyntax', () => {
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
+        serverless.variables.loadVariableSyntax();
+        delete service.provider.variableSyntax;
+        service.custom = {
+          my0thIndex: '0th',
+          my1stIndex: '1st',
+          my0thStage: 'DEV',
+          my1stStage: '${{self:custom.my${{self:custom.my0thIndex}}Stage}}',
+          my2ndStage: '${{self:custom.my${{self:custom.my1stIndex}}Stage}}',
+        };
+        const expected = {
+          my0thIndex: '0th',
+          my1stIndex: '1st',
+          my0thStage: 'DEV',
+          my1stStage: 'DEV',
+          my2ndStage: 'DEV',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
       describe('file reading cases', () => {
         let tmpDirPath;
         beforeEach(() => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When constructing a deep variable, use the variable syntax present in the given variable string, extracting it from the given string that may contain embedded custom variables (i.e. `${{self:var.${{self:var.foo}}.bar}}`).

Closes #4946

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

extract, repeatedly if embedded variables exist, the used syntax (default or custom) for use, then use shell for deep variable construction.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

See unit tests in `Variables.test.js`.

## Todos:

- [x] Write tests
- [n/a] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
