### PR TITLE
Added ability to create custom stack names and API names

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -28,6 +28,8 @@ provider:
   runtime: nodejs6.10
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
+  stackName: custom-stack-name # Use a custom name for the CloudFormation stack
+  apiName: custom-api-name # Use a custom name for the API Gateway API
   profile: production # The default profile to use with this service
   memorySize: 512 # Overwrite the default memory size. Default is 1024
   timeout: 10 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -46,7 +46,8 @@ module.exports = {
 
   // Stack
   getStackName() {
-    if (_.isString(this.provider.serverless.service.provider.stackName)) {
+    if (this.provider.serverless.service.provider.stackName &&
+        _.isString(this.provider.serverless.service.provider.stackName)) {
       return `${this.provider.serverless.service.provider.stackName}`;
     }
     return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
@@ -148,7 +149,8 @@ module.exports = {
 
   // API Gateway
   getApiGatewayName() {
-    if (_.isString(this.provider.serverless.service.provider.apiName)) {
+    if (this.provider.serverless.service.provider.apiName &&
+        _.isString(this.provider.serverless.service.provider.apiName)) {
       return `${this.provider.serverless.service.provider.apiName}`;
     }
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -46,6 +46,10 @@ module.exports = {
 
   // Stack
   getStackName() {
+    if (this.provider.serverless.service.provider.stackName &&
+        this.provider.serverless.service.provider.stackName.length > 0) {
+      return `${this.provider.serverless.service.provider.stackName}`;
+    }
     return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
   },
 
@@ -145,6 +149,10 @@ module.exports = {
 
   // API Gateway
   getApiGatewayName() {
+    if (this.provider.serverless.service.provider.apiName &&
+        this.provider.serverless.service.provider.apiName.length > 0) {
+      return `${this.provider.serverless.service.provider.apiName}`;
+    }
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;
   },
   generateApiGatewayDeploymentLogicalId() {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -46,8 +46,7 @@ module.exports = {
 
   // Stack
   getStackName() {
-    if (this.provider.serverless.service.provider.stackName &&
-        this.provider.serverless.service.provider.stackName.length > 0) {
+    if (_.isString(this.provider.serverless.service.provider.stackName)) {
       return `${this.provider.serverless.service.provider.stackName}`;
     }
     return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
@@ -149,8 +148,7 @@ module.exports = {
 
   // API Gateway
   getApiGatewayName() {
-    if (this.provider.serverless.service.provider.apiName &&
-        this.provider.serverless.service.provider.apiName.length > 0) {
+    if (_.isString(this.provider.serverless.service.provider.apiName)) {
       return `${this.provider.serverless.service.provider.apiName}`;
     }
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -94,10 +94,17 @@ describe('#naming()', () => {
   });
 
   describe('#getStackName()', () => {
-    it('should use the service name and stage from the service and config', () => {
+    it('should use the service name & stage if custom stack name not provided', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getStackName()).to.equal(`${serverless.service.service}-${
         sdk.naming.provider.getStage()}`);
+    });
+
+    it('should use the custom stack name if provided', () => {
+      serverless.service.provider.stackName = 'app-dev-testApp';
+      serverless.service.service = 'myService';
+      serverless.service.provider.stage = sdk.naming.provider.getStage();
+      expect(sdk.naming.getStackName()).to.equal('app-dev-testApp');
     });
   });
 
@@ -214,10 +221,17 @@ describe('#naming()', () => {
   });
 
   describe('#getApiGatewayName()', () => {
-    it('should return the composition of stage and service name', () => {
+    it('should return the composition of stage & service name if custom name not provided', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getApiGatewayName())
         .to.equal(`${sdk.naming.provider.getStage()}-${serverless.service.service}`);
+    });
+
+    it('should return the custom api name if provided', () => {
+      serverless.service.provider.apiName = 'app-dev-testApi';
+      serverless.service.service = 'myService';
+      serverless.service.provider.stage = sdk.naming.provider.getStage();
+      expect(sdk.naming.getApiGatewayName()).to.equal('app-dev-testApi');
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
I implemented a feature that allows developers to customize their CloudFormation stack name and AWS API Gateway API name if they do not want to use the default of `${stage}-${service-name}`.

Closes #2638 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
I added a check to see if certain properties were defined in the YAML, and if so, use it for the stack name or API name. If the properties are not defined, use the default as it has been

## How can we verify it:
__You will need to replace anything inside `<` and `>` in the config below__
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
### serverless.yml
```
service:
    name: ${self:custom.service.name}

# Add the serverless-webpack plugin
plugins:
    - serverless-webpack
    - serverless-dynamodb-local
    - serverless-offline
    - serverless-reqvalidator-plugin
    - serverless-aws-documentation
    - serverless-domain-manager
    - serverless-prune-plugin

provider:
    name: aws
    runtime: nodejs6.10
    memorySize: 512
    timeout: 10
    stackName: ${self:custom.service.label}
    apiName: ${self:custom.service.label}
    region: ${opt:region, 'us-east-1'}
    stage: ${opt:stage, 'dev'}
    versionFunctions: ${self:custom.lambda.versioning.${self:provider.stage}, 'false'}
    stackTags: # Optional CF stack tags
        ENV: ${self:provider.stage}
    deploymentBucket:
        name: www.${self:provider.region, 'us-east-1'}.${self:custom.domain}

functions:
    <FunctionName>:
        handler: index.submit
        name: ${self:custom.service.label}
        description: Manages database records
        onError: <ARN>
        tags:
            ENV: ${self:provider.stage}
        environment:
            ENV: ${self:provider.stage}
            TABLE_NAME: ${self:custom.service.label}
        events:
            - http:
                method: post
                path: /test-endpoint
                cors: true
        package:
            include:
                - index.js
        role: <ARN>

resources:
    Resources:
        <TableName>:
            Type: AWS::DynamoDB::Table
            Properties:
                TableName: ${self:custom.service.label}
                AttributeDefinitions:
                    - AttributeName: id
                      AttributeType: S
                KeySchema:
                    - AttributeName: id
                      KeyType: HASH
                SSESpecification:
                    SSEEnabled: true
                Tags:
                    - Key: "ENV"
                      Value: ${self:provider.stage}
                ProvisionedThroughput:
                    ReadCapacityUnits: ${self:custom.dynamodb.ReadCapacityUnits.${self:provider.stage}, 1}
                    WriteCapacityUnits: ${self:custom.dynamodb.WriteCapacityUnits.${self:provider.stage}, 1}
custom:
    domain: <domain>
    appName: '<App Name>'
    prefix: app-
    service:
        label: ${self:custom.prefix}${self:custom.stagePrefix.${self:provider.stage}, ''}test-service
        name: ${self:custom.prefix}test-service
    stagePrefix:
        dev: ${self:provider.stage}-
        staging: ${self:provider.stage}-
        prod: ''
    dynamodb:
        ReadCapacityUnits:
            dev: 1
            staging: 3
            prod: 3
        WriteCapacityUnits:
            dev: 1
            staging: 3
            prod: 5
    lambda:
        versioning:
            dev: false
            staging: true
            prod: true
    prune:
        automatic: ${self:custom.lambda.versioning.${self:provider.stage}, 'false'}
        number: 5
    api:
        domain:
            dev: api.${self:provider.stage}.${self:custom.domain}
            staging: api.${self:provider.stage}.${self:custom.domain}
            prod: api.${self:custom.domain}
    sslCert:
        dev:
            arn: <ARN>
            name: '*.${self:provider.stage}.${self:custom.domain}'
        staging:
            arn: <ARN>
            name: '*.${self:provider.stage}.${self:custom.domain}'
        prod:
            arn: <ARN>
            name: '*.${self:custom.domain}'
    customDomain:
        domainName: ${self:custom.api.domain.${self:provider.stage, 'dev'}}
        basePath: 'v1'
        stage: ${self:provider.stage}
        createRoute53Record: true
        certificateName: ${self:custom.sslCert.${self:provider.stage}.name}
        endpointType: edge
```

## Todos:

- [X] Write tests
- [ ] Write documentation
- [X] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
