### PR TITLE
Fix documentation section anchor

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -17,7 +17,7 @@ layout: Doc
   - [Example "LAMBDA-PROXY" event (default)](#example-lambda-proxy-event-default)
   - [HTTP Endpoint with Extended Options](#http-endpoint-with-extended-options)
   - [Enabling CORS](#enabling-cors)
-  - [HTTP Endpoints with `AWS_IAM` Authorizers](#http-endpoints-with-awsiam-authorizers)
+  - [HTTP Endpoints with `AWS_IAM` Authorizers](#http-endpoints-with-aws_iam-authorizers)
   - [HTTP Endpoints with Custom Authorizers](#http-endpoints-with-custom-authorizers)
   - [Catching Exceptions In Your Lambda Function](#catching-exceptions-in-your-lambda-function)
   - [Setting API keys for your Rest API](#setting-api-keys-for-your-rest-api)


### PR DESCRIPTION
Section anchor of `HTTP Endpoints with AWS_IAM Authorizers` doesn't match.