### PR TITLE
Kubeless: warn about bad label values

### DIFF
--- a/docs/providers/kubeless/guide/functions.md
+++ b/docs/providers/kubeless/guide/functions.md
@@ -176,6 +176,8 @@ Using the `labels` configuration makes it possible to add `key` / `value` labels
 
 Those labels will appear in deployments, services and pods and will make it easier to group functions by label or find functions with a common label.
 
+Note that variable types are interpolated by the Serverless Framework in `serverless.yml`. Specifying a value that can be interpolated as anything other than a string (for example, `true`) is not supported and will cause issues for your `kubeless` deployment.
+
 ```yml
 provider:
   name: kubeless


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add warning for `Kubeless` function labels.

Added a warning in the documentation about using values that can be interpolated into variable types that are not strings by the serverless framework. Values for labels that are not strings are not supported in kubeless/kubernetes and basically break the kubeless deployment with a `ReadString: Labels: expected ...` forever because the pods will fail to start. This is serious because it seems the only way to recover is to remove the `kubeless` namespace in kubernetes (and as a result all the related primitives) and then redeploy `kubeless`. This was tested on kubeless `v1.0.0-alpha2`.

## How did you implement it:

text edit

## How can we verify it:

You can verify the issue exists as follows:

Attempt to deploy to a k8s cluster running kubeless with a function that has a `label` section in its `serverless.yml` that contains a value that can be interpolated as something other than a string. For example,

```
service: kubeless-issue-001

provider:
  name: kubeless
  runtime: nodejs8
  namespace: functions

plugins:
  - serverless-kubeless

functions:
  echo:
    handler: handler.echo
    labels:
      willbreak: true
```
And then `serverless deploy -v`.

You will see that the pod cannot be started though the function is deployed due to a ReadString error if you run `kubectl logs -n kubeless $(kubectl get pods -n kubeless -l kubeless=controller -o=name)`.

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
