### PR TITLE
Update referencing of rest api resources

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -932,7 +932,7 @@ provider:
     restApiId: xxxxxxxxxx
     restApiRootResourceId: xxxxxxxxxx
     restApiResources:
-      /posts: xxxxxxxxxx
+      /posts: 'xxxxxxxxxx'
 
 functions:
   ...
@@ -946,7 +946,7 @@ provider:
     restApiId: xxxxxxxxxx
     restApiRootResourceId: xxxxxxxxxx
     restApiResources:
-      /posts: xxxxxxxxxx
+      /posts: 'xxxxxxxxxx'
 
 functions:
   ...
@@ -963,8 +963,8 @@ provider:
     restApiId: xxxxxxxxxx
     # restApiRootResourceId: xxxxxxxxxx # Optional
     restApiResources:
-      /posts: xxxxxxxxxx
-      /categories: xxxxxxxxx
+      /posts: 'xxxxxxxxxx'
+      /categories: 'xxxxxxxxx'
 
 
 functions:


### PR DESCRIPTION
Update referencing of rest api resources. Deploying without apostrophe (') results with Invalid Resource identifier specified (Service: AmazonApiGateway; Status Code: 404; Error Code: NotFoundException

## How did you implement it:
Add apostrophe (') on restApiResources.

## How can we verify it:
```yaml
service: service-a
provider:
  name: aws
  runtime: nodejs6.10
  region: ap-southeast-1
  apiGateway: 
    restApiId: xxxxxxxxxx #Existing Rest API Id
    restApiRootResourceId: xxxxxxxxxx #Existing Root Resource Id
    restApiResources:
      /posts: xxxxxx
```
This will result an error
An error occurred: ApiGatewayResourceXXX - Invalid Resource identifier specified (Service: AmazonApiGateway; Status Code: 404; Error Code: NotFoundException; Request ID: xxxxxxxxxx).


## Solution
```yaml
service: service-a
provider:
  name: aws
  runtime: nodejs6.10
  region: ap-southeast-1
  apiGateway: 
    restApiId: xxxxxxxxxx #Existing Rest API Id
    restApiRootResourceId: xxxxxxxxxx #Existing Root Resource Id
    restApiResources:
      /posts: 'xxxxxx' #Add apostrophe (')
```

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
