### PR TITLE
Make function tags inherit provider tags

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -305,6 +305,28 @@ functions:
       foo: bar
 ```
 
+Or if you want to apply tags configuration to all functions in your service, you can add the configuration to the higher level `provider` object. Tags configured at the function level are merged with those at the provider level, so your function with specific tags will get the tags defined at the provider level. If a tag with the same key is defined at both the function and provider levels, the function-specific value overrides the provider-level default value. For exemple:
+
+```yml
+# serverless.yml
+service: service-name
+provider:
+  name: aws
+  tags:
+    foo: bar
+    baz: qux
+
+functions:
+  hello:
+    # this function will inherit the service level tags config above
+    handler: handler.hello
+  users:
+    # this function will overwrite the foo tag and inherit the baz tag
+    handler: handler.users
+    tags:
+      foo: quux
+```
+
 Real-world use cases where tagging your functions is helpful include:
 
 - Cost estimations (tag functions with an environment tag: `environment: Production`)

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -96,6 +96,9 @@ provider:
       - subnetId2
   notificationArns: # List of existing Amazon SNS topics in the same region where notifications about stack events are sent.
     - 'arn:aws:sns:us-east-1:XXXXXX:mytopic'
+  tags: # Optional service wide function tags
+    foo: bar
+    baz: qux
 
 package: # Optional deployment packaging configuration
   include: # Specify the directories and files which should be included in the deployment package

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -127,9 +127,14 @@ class AwsCompileFunctions {
       newFunction.Properties.Description = functionObject.description;
     }
 
-    if (functionObject.tags && typeof functionObject.tags === 'object') {
+    if (functionObject.tags || this.serverless.service.provider.tags) {
+      const tags = Object.assign(
+        {},
+        this.serverless.service.provider.tags,
+        functionObject.tags
+      );
       newFunction.Properties.Tags = [];
-      _.forEach(functionObject.tags, (Value, Key) => {
+      _.forEach(tags, (Value, Key) => {
         newFunction.Properties.Tags.push({ Key, Value });
       });
     }

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -522,7 +522,104 @@ describe('AwsCompileFunctions', () => {
       });
     });
 
-    it('should create a function resource with tags', () => {
+    it('should create a function resource with provider level tags', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+        },
+      };
+
+      awsCompileFunctions.serverless.service.provider.tags = {
+        foo: 'bar',
+        baz: 'qux',
+      };
+
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Tags: [
+            { Key: 'foo', Value: 'bar' },
+            { Key: 'baz', Value: 'qux' },
+          ],
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
+    });
+
+    it('should create a function resource with function level tags', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          tags: {
+            foo: 'bar',
+            baz: 'qux',
+          },
+        },
+      };
+
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+          Tags: [
+            { Key: 'foo', Value: 'bar' },
+            { Key: 'baz', Value: 'qux' },
+          ],
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FuncLambdaFunction
+        ).to.deep.equal(compiledFunction);
+      });
+    });
+
+    it('should create a function resource with provider and function level tags', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
         .split(path.sep).pop();

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -537,6 +537,11 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
+      awsCompileFunctions.serverless.service.provider.tags = {
+        foo: 'quux',
+        corge: 'uier',
+      };
+
       const compiledFunction = {
         Type: 'AWS::Lambda::Function',
         DependsOn: [
@@ -556,6 +561,7 @@ describe('AwsCompileFunctions', () => {
           Timeout: 6,
           Tags: [
             { Key: 'foo', Value: 'bar' },
+            { Key: 'corge', Value: 'uier' },
             { Key: 'baz', Value: 'qux' },
           ],
         },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This PR makes functions tags inherit from provider tags. Same behavior as `environment`. 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Merge provider tags with function tags
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Given the following `serverless.yml`, `hello` should be deployed with the tag `foo` equal to `quux` and `baz` equal to `qux`

```yml
service: xxx
provider:
  name: aws
  runtime: nodejs8.10
  tags:
    foo: bar
    baz: qux

functions:
  hello:
    handler: handler.hello
    tags:
      foo: quux
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
