### PR TITLE
Add Windows support for spawning mvn

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -233,7 +233,7 @@ class AwsInvokeLocal {
           'package',
           '-f',
           path.join(javaBridgePath, 'pom.xml'),
-        ]);
+        ], { shell: true });
 
         this.serverless.cli
           .log('Building Java bridge, first invocation might take a bit longer.');


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

On Windows machines, attempting to invoke a Java lambda locally causes the following error:
`Error: spawn mvn ENOENT`

Closes #4680 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Added a fix suggested from here: https://github.com/nodejs/node-v0.x-archive/issues/2318
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Invoke a Java function locally on Windows (Win10 in our case) on a fresh install of serverless. The fix should also be compatible on other OSes. We have a team of a few devs (on a mix of Windows and OSX machines) that have been using this fix for a few months now without issue.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
