### PR TITLE
only use json-cycles when opt-in, for state serialization

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -39,15 +39,15 @@ class Utils {
     return fse.mkdirsSync(path.dirname(filePath));
   }
 
-  writeFileSync(filePath, contents) {
-    return writeFileSync(filePath, contents);
+  writeFileSync(filePath, contents, cycles) {
+    return writeFileSync(filePath, contents, cycles);
   }
 
-  writeFile(filePath, contents) {
+  writeFile(filePath, contents, cycles) {
     const that = this;
     return new BbPromise((resolve, reject) => {
       try {
-        that.writeFileSync(filePath, contents);
+        that.writeFileSync(filePath, contents, cycles);
       } catch (e) {
         reject(e);
       }

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -36,7 +36,7 @@ module.exports = {
       },
     };
 
-    this.serverless.utils.writeFileSync(serviceStateFilePath, state);
+    this.serverless.utils.writeFileSync(serviceStateFilePath, state, true);
 
     return BbPromise.resolve();
   },

--- a/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -63,7 +63,7 @@ describe('#saveServiceState()', () => {
       };
 
       expect(getServiceStateFileNameStub.calledOnce).to.equal(true);
-      expect(writeFileSyncStub.calledWithExactly(filePath, expectedStateFileContent))
+      expect(writeFileSyncStub.calledWithExactly(filePath, expectedStateFileContent, true))
         .to.equal(true);
     });
   });
@@ -97,7 +97,7 @@ describe('#saveServiceState()', () => {
       };
 
       expect(getServiceStateFileNameStub.calledOnce).to.equal(true);
-      expect(writeFileSyncStub.calledWithExactly(filePath, expectedStateFileContent))
+      expect(writeFileSyncStub.calledWithExactly(filePath, expectedStateFileContent, true))
         .to.equal(true);
     });
   });

--- a/lib/utils/fs/writeFile.js
+++ b/lib/utils/fs/writeFile.js
@@ -5,13 +5,17 @@ const path = require('path');
 const jc = require('json-cycle');
 const YAML = require('js-yaml');
 
-function writeFile(filePath, conts) {
+function writeFile(filePath, conts, cycles) {
   let contents = conts || '';
 
   return fse.mkdirsAsync(path.dirname(filePath))
     .then(() => {
       if (filePath.indexOf('.json') !== -1 && typeof contents !== 'string') {
-        contents = jc.stringify(contents, null, 2);
+        if (cycles) {
+          contents = jc.stringify(contents, null, 2);
+        } else {
+          contents = JSON.stringify(contents, null, 2);
+        }
       }
 
       const yamlFileExists = (filePath.indexOf('.yaml') !== -1);

--- a/lib/utils/fs/writeFile.test.js
+++ b/lib/utils/fs/writeFile.test.js
@@ -49,7 +49,7 @@ describe('#writeFile()', function () {
     bar.foo = bar;
     const expected = '{\n  "foo": {\n    "$ref": "$"\n  }\n}';
 
-    return writeFile(tmpFilePath, bar)
+    return writeFile(tmpFilePath, bar, true)
       .then(() =>
         expect(fse.readFileAsync(tmpFilePath, 'utf8')).to.eventually.equal(expected)
       );

--- a/lib/utils/fs/writeFileSync.js
+++ b/lib/utils/fs/writeFileSync.js
@@ -5,13 +5,17 @@ const path = require('path');
 const jc = require('json-cycle');
 const YAML = require('js-yaml');
 
-function writeFileSync(filePath, conts) {
+function writeFileSync(filePath, conts, cycles) {
   let contents = conts || '';
 
   fse.mkdirsSync(path.dirname(filePath));
 
   if (filePath.indexOf('.json') !== -1 && typeof contents !== 'string') {
-    contents = jc.stringify(contents, null, 2);
+    if (cycles) {
+      contents = jc.stringify(contents, null, 2);
+    } else {
+      contents = JSON.stringify(contents, null, 2);
+    }
   }
 
   const yamlFileExists = (filePath.indexOf('.yaml') !== -1);

--- a/lib/utils/fs/writeFileSync.test.js
+++ b/lib/utils/fs/writeFileSync.test.js
@@ -53,7 +53,7 @@ describe('#writeFileSync()', () => {
     bar.foo = bar;
     const expected = '{\n  "foo": {\n    "$ref": "$"\n  }\n}';
 
-    writeFileSync(tmpFilePath, bar);
+    writeFileSync(tmpFilePath, bar, true);
 
     return fse.readFileAsync(tmpFilePath, 'utf8').then((contents) => {
       expect(contents).to.equal(expected);


### PR DESCRIPTION
## What did you implement:

Closes #5014

## How did you implement it:

I made cycle-support opt-in, and enabled it in the one spot I was aware of that needed it, which is the serverless state file.

## How can we verify it:

The example repo I gave on the associated issue has a test that will pass if you use this patch:

- git clone https://github.com/dougmoscrop/serverless-example-json-ref-issue
- `cd serverless-example-json-ref-issue`
- `npm i && npm t` (test will fail)
- (checkout this code and `npm link` from within serverless)
- go back to serverless-example-json-ref-issue and `npm link severless`
- `npm t` will pass

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
