### PR TITLE
Fix #4739

### DIFF
--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -196,7 +196,7 @@ describe('Create', () => {
 
         expect(dirContent).to.include('serverless.yml');
         expect(dirContent).to.include('pom.xml');
-        expect(dirContent).to.include(path.join('src', 'main', 'resources', 'log4j.properties'));
+        expect(dirContent).to.include(path.join('src', 'main', 'resources', 'log4j2.xml'));
         expect(dirContent).to.include(path.join('src', 'main', 'java', 'com', 'serverless',
           'Handler.java'));
         expect(dirContent).to.include(path.join('src', 'main', 'java', 'com', 'serverless',

--- a/lib/plugins/create/templates/aws-java-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-java-maven/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
   <version>dev</version>
   <name>hello</name>
-  
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -16,13 +16,18 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-core</artifactId>
+      <artifactId>aws-lambda-java-log4j2</artifactId>
       <version>1.1.0</version>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-log4j</artifactId>
-      <version>1.0.0</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -65,8 +70,22 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <transformers>
+                <transformer
+                  implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                </transformer>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.edwgiz</groupId>
+            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <version>2.8.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/lib/plugins/create/templates/aws-java-maven/src/main/java/com/serverless/ApiGatewayResponse.java
+++ b/lib/plugins/create/templates/aws-java-maven/src/main/java/com/serverless/ApiGatewayResponse.java
@@ -5,7 +5,8 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,7 +48,7 @@ public class ApiGatewayResponse {
 
 	public static class Builder {
 
-		private static final Logger LOG = Logger.getLogger(ApiGatewayResponse.Builder.class);
+		private static final Logger LOG = LogManager.getLogger(ApiGatewayResponse.Builder.class);
 
 		private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/lib/plugins/create/templates/aws-java-maven/src/main/java/com/serverless/Handler.java
+++ b/lib/plugins/create/templates/aws-java-maven/src/main/java/com/serverless/Handler.java
@@ -3,21 +3,19 @@ package com.serverless;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 
 public class Handler implements RequestHandler<Map<String, Object>, ApiGatewayResponse> {
 
-	private static final Logger LOG = Logger.getLogger(Handler.class);
+	private static final Logger LOG = LogManager.getLogger(Handler.class);
 
 	@Override
 	public ApiGatewayResponse handleRequest(Map<String, Object> input, Context context) {
-		BasicConfigurator.configure();
-
-		LOG.info("received: " + input);
+		LOG.info("received: {}", input);
 		Response responseBody = new Response("Go Serverless v1.x! Your function executed successfully!", input);
 		return ApiGatewayResponse.builder()
 				.setStatusCode(200)

--- a/lib/plugins/create/templates/aws-java-maven/src/main/resources/log4j.properties
+++ b/lib/plugins/create/templates/aws-java-maven/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log = .
-log4j.rootLogger = DEBUG, LAMBDA
-
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} <%X{AWSRequestId}> %-5p %c:%L - %m%n

--- a/lib/plugins/create/templates/aws-java-maven/src/main/resources/log4j2.xml
+++ b/lib/plugins/create/templates/aws-java-maven/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
+  <Appenders>
+    <Lambda name="Lambda">
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+      </PatternLayout>
+    </Lambda>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="Lambda" />
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Update aws-java-maven template to use Log4J2 as recommended by AWS

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4739

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Updated pom.xml for the aws-java-maven template to use Log4J2, replaced log4j.properties with log4j2.xml and replaced Logger.getLogger references with LogManager.getLogger. Essentially what https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html describes.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Run the aws-java-maven integration test. Invoke the lambda and verify Cloudwatch log

## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
