### PR TITLE
Allow to set custom log group name for each function

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -215,7 +215,8 @@ class AwsInvokeLocal {
     const context = {
       name: this.options.functionObj.name,
       version: 'LATEST',
-      logGroupName: this.provider.naming.getLogGroupName(this.options.functionObj.name),
+      logGroupName: this.provider.naming
+        .getLogGroupName(this.options.functionObj.logGroupName || this.options.functionObj.name),
       timeout,
     };
     const input = JSON.stringify({
@@ -304,13 +305,14 @@ class AwsInvokeLocal {
 
 
     const startTime = new Date();
+    const logGroupName = this.options.functionObj.logGroupName || this.options.functionObj.name;
     const timeout = Number(this.options.functionObj.timeout)
       || Number(this.serverless.service.provider.timeout)
       || 6;
     let context = {
       awsRequestId: 'id',
       invokeid: 'id',
-      logGroupName: this.provider.naming.getLogGroupName(this.options.functionObj.name),
+      logGroupName: this.provider.naming.getLogGroupName(logGroupName),
       logStreamName: '2015/09/22/[HEAD]13370a84ca4ed8b77c427af260',
       functionVersion: 'HEAD',
       isDefaultFunctionVersion: true,

--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -26,10 +26,11 @@ class AwsLogs {
     this.validate();
 
     // validate function exists in service
-    const lambdaName = this.serverless.service.getFunction(this.options.function).name;
+    const lambdaFn = this.serverless.service.getFunction(this.options.function);
+    const logGroupName = lambdaFn.logGroupName || lambdaFn.name;
 
     this.options.interval = this.options.interval || 1000;
-    this.options.logGroupName = this.provider.naming.getLogGroupName(lambdaName);
+    this.options.logGroupName = this.provider.naming.getLogGroupName(logGroupName);
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/aws/logs/index.test.js
+++ b/lib/plugins/aws/logs/index.test.js
@@ -90,6 +90,18 @@ describe('AwsLogs', () => {
       expect(awsLogs.options.logGroupName).to.deep.equal(awsLogs.provider.naming
         .getLogGroupName('customName'));
     }));
+
+    it('it should set custom log group name', () => {
+      serverless.service.functions = {
+        first: {
+          logGroupName: 'my-log-group',
+        },
+      };
+      awsLogs.extendedValidate().then(() => {
+        expect(awsLogs.options.logGroupName).to.deep.equal(awsLogs.provider.naming
+          .getLogGroupName('my-log-group'));
+      });
+    });
   });
 
   describe('#getLogStreams()', () => {

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -304,7 +304,8 @@ class AwsCompileFunctions {
       }
     }
 
-    newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)]
+    const logGroupName = functionObject.logGroupName || functionName;
+    newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(logGroupName)]
       .concat(newFunction.DependsOn || []);
 
     const functionLogicalId = this.provider.naming

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -21,12 +21,13 @@ module.exports = {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionObject = this.serverless.service.getFunction(functionName);
       const logGroupLogicalId = this.provider.naming
-        .getLogGroupLogicalId(functionName);
+        .getLogGroupLogicalId(functionObject.logGroupName || functionName);
       const newLogGroup = {
         [logGroupLogicalId]: {
           Type: 'AWS::Logs::LogGroup',
           Properties: {
-            LogGroupName: this.provider.naming.getLogGroupName(functionObject.name),
+            LogGroupName: this.provider.naming
+              .getLogGroupName(functionObject.logGroupName || functionObject.name),
           },
         },
       };
@@ -84,7 +85,7 @@ module.exports = {
 
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionObject = this.serverless.service.getFunction(functionName);
-
+      const logGroupName = functionObject.logGroupName || functionObject.name;
       this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.provider.naming.getRoleLogicalId()]
         .Properties
@@ -94,7 +95,7 @@ module.exports = {
         .Resource
         .push({
           'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-            `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*`,
+            `:log-group:${this.provider.naming.getLogGroupName(logGroupName)}:*`,
         });
 
       this.serverless.service.provider.compiledCloudFormationTemplate
@@ -106,7 +107,7 @@ module.exports = {
         .Resource
         .push({
           'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-            `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*:*`,
+            `:log-group:${this.provider.naming.getLogGroupName(logGroupName)}:*:*`,
         });
     });
 

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -313,6 +313,31 @@ describe('#mergeIamTemplates()', () => {
       });
     });
 
+  it('should add LogGroupName to a CloudWatch LogGroup if logGroupName on function is given'
+    , () => {
+      awsPackage.serverless.service.functions = {
+        functionWithCustomLogGroupName: {
+          name: 'name-without-stage',
+          logGroupName: 'custom-log-group-name',
+        },
+      };
+      const normalizedName = awsPackage.provider.naming
+        .getLogGroupLogicalId('custom-log-group-name');
+      return awsPackage.mergeIamTemplates().then(() => {
+        expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[normalizedName]
+        ).to.deep.equal(
+          {
+            Type: 'AWS::Logs::LogGroup',
+            Properties: {
+              LogGroupName: awsPackage.provider.naming
+                .getLogGroupName('custom-log-group-name'),
+            },
+          }
+        );
+      });
+    });
+
   it('should throw error if RetentionInDays is 0 or not an integer'
     , () => {
       awsPackage.serverless.service.provider.logRetentionInDays = 0;


### PR DESCRIPTION
In our use-case we call some lambdas from our service code directly. It makes things much more easier for us to access these lambdas using an `alias` using the `serverless-aws-alias` plugin. We've set our function-name to a static value not including the stage. This results in a `CREATE_FAILED` of the lambda log group (the function name is currently used) 

## What did you implement:
Allow to set custom log group name for each function

## How did you implement it:
Falling back to current `functionName` (logical id) and `function.name` (name) if custom `logGroupName` is not present on the `functionObj`

## How can we verify it:
Unit Test

Examples:
```yml
functions:
  my-function:
    name: custom-name-without-stage
    logGroupName: my-function-logs-${self:provider.stage}
```

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
