### PR TITLE
Remove `/tmp/node-dependencies*`

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -222,6 +222,12 @@ function excludeNodeDevDependencies(servicePath) {
 
       return exAndIn;
     })
+    .then(() => {
+      // cleanup
+      fs.unlinkSync(nodeDevDepFile);
+      fs.unlinkSync(nodeProdDepFile);
+      return exAndIn;
+    })
     .catch(() => exAndIn);
   } catch (e) {
     // fail silently


### PR DESCRIPTION
## What did you implement:

Since `node-dependencies*` will remain in `/tmp`, cleanup added.

## How did you implement it:

Add the flow to be deleted last.

## How can we verify it:

File does not remain in `/tmp` after deploy.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
