### PR TITLE
add PRIVATE endpointType

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -472,7 +472,7 @@ Clients connecting to this Rest API will then need to set any of these API keys 
 
 API Gateway [supports regional endpoints](https://aws.amazon.com/about-aws/whats-new/2017/11/amazon-api-gateway-supports-regional-api-endpoints/) for associating your API Gateway REST APIs with a particular region. This can reduce latency if your requests originate from the same region as your REST API and can be helpful in building multi-region applications.
 
-By default, the Serverless Framework deploys your REST API using the EDGE endpoint configuration. If you would like to use the REGIONAL configuration, set the `endpointType` parameter in your `provider` block.
+By default, the Serverless Framework deploys your REST API using the EDGE endpoint configuration. If you would like to use the REGIONAL or PRIVATE configuration, set the `endpointType` parameter in your `provider` block.
 
 Here's an example configuration for setting the endpoint configuration for your service Rest API:
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -15,7 +15,7 @@ module.exports = {
     let endpointType = 'EDGE';
 
     if (this.serverless.service.provider.endpointType) {
-      const validEndpointTypes = ['REGIONAL', 'EDGE'];
+      const validEndpointTypes = ['REGIONAL', 'EDGE', 'PRIVATE'];
       endpointType = this.serverless.service.provider.endpointType;
 
       if (typeof endpointType !== 'string') {
@@ -24,7 +24,7 @@ module.exports = {
 
 
       if (!_.includes(validEndpointTypes, endpointType.toUpperCase())) {
-        const message = 'endpointType must be one of "REGIONAL" or "EDGE". ' +
+        const message = 'endpointType must be one of "REGIONAL" or "EDGE" or "PRIVATE". ' +
                         `You provided ${endpointType}.`;
         throw new this.serverless.classes.Error(message);
       }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -81,6 +81,16 @@ describe('#compileRestApi()', () => {
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
   });
 
+  it('should compile if endpointType property is REGIONAL', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = 'REGIONAL';
+    expect(() => awsCompileApigEvents.compileRestApi()).to.not.throw(Error);
+  });
+
+  it('should compile if endpointType property is PRIVATE', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = 'PRIVATE';
+    expect(() => awsCompileApigEvents.compileRestApi()).to.not.throw(Error);
+  });
+
   it('throw error if endpointType property is not EDGE or REGIONAL', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw('endpointType must be one of');


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added `PRIVATE` [endpointType](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html) for API Gateway

Closes #5063 #5052

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added `PRIVATE` to `validEndpointTypes` const variable with more specific tests.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

```yaml:serverless.yml
service: private-endpoint-test
provider:
  name: aws
  runtime: nodejs6.10
  endpointType: private

functions:
  helloWorld:
    handler: handler.hello
    events:
      - http:
          path: hello
          method: get
```

```shell
$ aws --region us-east-1 apigateway get-rest-apis 

{
    "items": [
        {
            "id": "gxq77iec19",
            "name": "dev-private-gw-test",
            "createdDate": 1530087544,
            "apiKeySource": "HEADER",
            "endpointConfiguration": {
                "types": [
                    "PRIVATE"
                ]
            }
        }
    ]
}
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO