### PR TITLE
Fixed that create command didn't use the service name given as -n option

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -224,16 +224,8 @@ class Create {
     // rename the service if the user has provided a path via options and is creating a service
     if ((boilerplatePath || serviceName) && notPlugin) {
       const newServiceName = serviceName || boilerplatePath.split(path.sep).pop();
-      const serverlessYmlFilePath = path
-        .join(this.serverless.config.servicePath, 'serverless.yml');
 
-      let serverlessYmlFileContent = fse
-        .readFileSync(serverlessYmlFilePath).toString();
-
-      serverlessYmlFileContent = serverlessYmlFileContent
-        .replace(/service: .+/, `service: ${newServiceName}`);
-
-      fse.writeFileSync(serverlessYmlFilePath, serverlessYmlFileContent);
+      renameService(newServiceName, this.serverless.config.servicePath);
     }
 
     userStats.track('service_created', {

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -115,6 +115,28 @@ describe('Create', () => {
         expect(dirContent).to.include('.gitignore');
       });
     });
+    it('should generate scaffolding for "aws-nodejs-typescript" ' +
+      'template and override service name if user passed', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'aws-nodejs-typescript';
+      create.options.name = 'my-awesome-service';
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(tmpDir);
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('handler.ts');
+        expect(dirContent).to.include('tsconfig.json');
+        expect(dirContent).to.include('package.json');
+        expect(dirContent).to.include('webpack.config.js');
+        expect(dirContent).to.include('.gitignore');
+
+        // check if the service was renamed
+        const serverlessYmlfileContent = fse
+          .readFileSync(path.join(tmpDir, 'serverless.yml')).toString();
+        expect((/service:\n {2}name: my-awesome-service/)
+          .test(serverlessYmlfileContent)).to.equal(true);
+      });
+    });
 
     it('should generate scaffolding for "aws-nodejs-ecma-script" template', () => {
       process.chdir(tmpDir);

--- a/lib/utils/renameService.js
+++ b/lib/utils/renameService.js
@@ -24,6 +24,11 @@ function renameService(name, servicePath) {
         const fractions = match.split('#');
         fractions[0] = `service: ${name}`;
         return fractions.join(' #');
+      })
+      .replace(/service\s*:\n {2}name:.+/gi, (match) => {
+        const fractions = match.split('#');
+        fractions[0] = `service:\n  name: ${name}`;
+        return fractions.join(' #');
       });
 
   fse.writeFileSync(serviceFile, serverlessYml);

--- a/lib/utils/renameService.test.js
+++ b/lib/utils/renameService.test.js
@@ -92,6 +92,50 @@ describe('renameService', () => {
     expect(serviceYml).to.equal(newServiceYml);
   });
 
+  it('should set new name of service in serverless.yml and name in package.json', () => {
+    const defaultServiceYml =
+      'service:\n  name: service-name\n\nprovider:\n  name: aws\n';
+    const newServiceYml =
+      'service:\n  name: new-service-name\n\nprovider:\n  name: aws\n';
+
+    const defaultServiceName = 'service-name';
+    const newServiceName = 'new-service-name';
+
+    const packageFile = path.join(servicePath, 'package.json');
+    const serviceFile = path.join(servicePath, 'serverless.yml');
+
+    serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    fse.writeFileSync(serviceFile, defaultServiceYml);
+
+    renameService(newServiceName, servicePath);
+    const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
+    const packageJson = serverless.utils.readFileSync(packageFile);
+    expect(serviceYml).to.equal(newServiceYml);
+    expect(packageJson.name).to.equal(newServiceName);
+  });
+
+  it('should set new name of service in commented serverless.yml and name in package.json', () => {
+    const defaultServiceYml =
+      '# comment\nservice:\n  name: service-name #comment\n\nprovider:\n  name: aws\n# comment';
+    const newServiceYml =
+      '# comment\nservice:\n  name: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+
+    const defaultServiceName = 'service-name';
+    const newServiceName = 'new-service-name';
+
+    const packageFile = path.join(servicePath, 'package.json');
+    const serviceFile = path.join(servicePath, 'serverless.yml');
+
+    serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    fse.writeFileSync(serviceFile, defaultServiceYml);
+
+    renameService(newServiceName, servicePath);
+    const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
+    const packageJson = serverless.utils.readFileSync(packageFile);
+    expect(serviceYml).to.equal(newServiceYml);
+    expect(packageJson.name).to.equal(newServiceName);
+  });
+
   it('should fail to set new service name in serverless.yml', () => {
     const defaultServiceYml =
       '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5070 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

- **-t** option didn't use RenameService, so I changed to use RenameService.
- RenameService didn't care nested name under service statement so I fixed it.
- I added test for aws-nodejs-typescript's service name.

## How can we verify it:
```
hiromi@hiromi-Matebook:~/git/oos/some-project$ ../serverless/bin/serverless create -t aws-nodejs-typescript -n some-project
Serverless: Generating boilerplate...
 _______                             __
|   _   .-----.----.--.--.-----.----|  .-----.-----.-----.
|   |___|  -__|   _|  |  |  -__|   _|  |  -__|__ --|__ --|
|____   |_____|__|  \___/|_____|__| |__|_____|_____|_____|
|   |   |             The Serverless Application Framework
|       |                           serverless.com, v1.27.0
 -------'

Serverless: Successfully generated boilerplate for template: "aws-nodejs-typescript"

hiromi@hiromi-Matebook:~/git/oos/some-project$
hiromi@hiromi-Matebook:~/git/oos/some-project$ cat serverless.yml 
service:
  name: some-project

# Add the serverless-webpack plugin
plugins:
  - serverless-webpack

provider:
  name: aws
  runtime: nodejs8.10

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          method: get
          path: hello
hiromi@hiromi-Matebook:~/git/oos/some-project$ 

```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
```
=============================== Coverage summary ===============================
Statements   : 90.43% ( 5668/6268 )
Branches     : 86.07% ( 2503/2908 )
Functions    : 90.43% ( 501/554 )
Lines        : 90.69% ( 5589/6163 )
================================================================================

```
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
