### PR TITLE
Create plugin: Bump NodeJS runtime version to 8.10

### DIFF
--- a/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
@@ -19,7 +19,7 @@ service: aws-kotlin-nodejs-gradle # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 # you can overwrite defaults here
 #  stage: dev

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 functions:
   first:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -19,7 +19,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 # you can overwrite defaults here
 #  stage: dev

--- a/lib/plugins/create/templates/hello-world/serverless.yml
+++ b/lib/plugins/create/templates/hello-world/serverless.yml
@@ -10,7 +10,7 @@ service: serverless-hello-world
 # The `provider` block defines where your service will be deployed
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 # The `functions` block defines what code to deploy
 functions:

--- a/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
@@ -17,7 +17,7 @@ service: capitalize
 
 provider:
   name: kubeless
-  runtime: nodejs6
+  runtime: nodejs8.10
 
 plugins:
   - serverless-kubeless

--- a/lib/plugins/create/templates/spotinst-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/spotinst-nodejs/serverless.yml
@@ -21,7 +21,7 @@ provider:
 
 functions:
   hello:
-    runtime: nodejs8.3
+    runtime: nodejs8.10
     handler: handler.main
     memory: 128
     timeout: 30


### PR DESCRIPTION


## What did you implement:
I changed the NodeJS runtime version to 8.10 in all templates.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Changed the `provider.runtime` property to `nodejs8.10`
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
- Checkout to this branch locally
- Create a project directory and change into it
- `(path to serverless bin of this repository) create --template aws-nodejs-ecma-script` and change any of the handlers to use NodeJS 8 features (e.g. async/await)
- Deploy
- Verify that the function is working correctly.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO