### PR TITLE
Add support for installing templates and boilerplates from GitLab

### DIFF
--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -62,7 +62,7 @@ function parseGitHubURL(url) {
  * @param {Object} url
  * @returns {Object}
  */
-function parseBitBucketURL(url) {
+function parseBitbucketURL(url) {
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > 4;
   const owner = parts[1];
@@ -71,11 +71,11 @@ function parseBitBucketURL(url) {
   const query = qs.parse(url.query);
   const branch = 'at' in query ? query.at : 'master';
 
-  // validate if given url is a valid GitHub url
+  // validate if given url is a valid Bitbucket url
   if (url.hostname !== 'bitbucket.org' || !owner || !repo) {
     const errorMessage = [
-      'The URL must be a valid GitHub URL in the following format:',
-      ' https://github.com/serverless/serverless',
+      'The URL must be a valid Bitbucket URL in the following format:',
+      ' https://bitbucket.org/serverless/serverless',
     ].join('');
     throw new ServerlessError(errorMessage);
   }
@@ -91,6 +91,57 @@ function parseBitBucketURL(url) {
     '/',
     repo,
     '/get/',
+    branch,
+    '.zip',
+  ].join('');
+
+  return {
+    owner,
+    repo,
+    branch,
+    downloadUrl,
+    isSubdirectory,
+    pathToDirectory,
+  };
+}
+
+/**
+ * @param {Object} url
+ * @returns {Object}
+ */
+function parseGitlabURL(url) {
+  const parts = url.pathname.split('/');
+  const isSubdirectory = parts.length > 4;
+  const owner = parts[1];
+  const repo = parts[2];
+
+  const query = qs.parse(url.query);
+  const branch = isSubdirectory ? parts[4] : 'master';
+
+  // validate if given url is a valid GitLab url
+  if (url.hostname !== 'gitlab.com' || !owner || !repo) {
+    const errorMessage = [
+      'The URL must be a valid GitLab URL in the following format:',
+      ' https://gitlab.com/serverless/serverless',
+    ].join('');
+    throw new ServerlessError(errorMessage);
+  }
+
+  let pathToDirectory = '';
+  for (let i = 5; i <= (parts.length - 1); i++) {
+    pathToDirectory = path.join(pathToDirectory, parts[i]);
+  }
+
+  const downloadUrl = [
+    'https://gitlab.com/',
+    owner,
+    '/',
+    repo,
+    '/-/archive/',
+    branch,
+    '/',
+    repo,
+    '-',
     branch,
     '.zip',
   ].join('');
@@ -129,10 +180,13 @@ function parseRepoURL(inputUrl) {
       return parseGitHubURL(url);
     }
     case 'bitbucket.org': {
-      return parseBitBucketURL(url);
+      return parseBitbucketURL(url);
+    }
+    case 'gitlab.com': {
+      return parseGitlabURL(url);
     }
     default: {
-      const msg = 'The URL you passed is not one of the valid providers: "GitHub", "BitBucket".';
+      const msg = 'The URL you passed is not one of the valid providers: "GitHub", "Bitbucket", or "GitLab".';
       throw new ServerlessError(msg);
     }
   }
@@ -191,5 +245,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
   });
 }
 
-module.exports.downloadTemplateFromRepo = downloadTemplateFromRepo;
-module.exports.parseRepoURL = parseRepoURL;
+module.exports = {
+  downloadTemplateFromRepo,
+  parseRepoURL
+}

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -14,39 +14,57 @@ const dirExistsSync = require('./fs/dirExistsSync');
 const log = require('./log/serverlessLog');
 
 /**
+ * Returns directory path
+ * @param {Number} length
+ * @param {Array} parts
+ * @returns {String} directory path
+ */
+function getPathDirectory(length, parts) {
+  if (!parts) {
+    return '';
+  }
+  return parts
+    .slice(length)
+    .filter(part => part !== '')
+    .join(path.sep);
+}
+
+/**
+ * Validates URL
+ * @param {Object} url
+ * @param {String} hostname
+ * @param {String} service
+ * @param {String} owner
+ * @param {String} repo
+ */
+function validateUrl(url, hostname, service, owner, repo) {
+    // validate if given url is a valid url
+  if (url.hostname !== hostname || !owner || !repo) {
+    const errorMessage = `The URL must be a valid ${
+        service
+      } URL in the following format: https://${
+        hostname
+      }/serverless/serverless`;
+    throw new ServerlessError(errorMessage);
+  }
+}
+
+/**
  * @param {Object} url
  * @returns {Object}
  */
 function parseGitHubURL(url) {
+  const pathLength = 4;
   const parts = url.pathname.split('/');
-  const isSubdirectory = parts.length > 4;
+  const isSubdirectory = parts.length > pathLength;
   const owner = parts[1];
   const repo = parts[2];
-  const branch = isSubdirectory ? parts[4] : 'master';
+  const branch = isSubdirectory ? parts[pathLength] : 'master';
 
   // validate if given url is a valid GitHub url
-  if (url.hostname !== 'github.com' || !owner || !repo) {
-    const errorMessage = [
-      'The URL must be a valid GitHub URL in the following format:',
-      ' https://github.com/serverless/serverless',
-    ].join('');
-    throw new ServerlessError(errorMessage);
-  }
+  validateUrl(url, 'github.com', 'GitHub', owner, repo);
 
-  let pathToDirectory = '';
-  for (let i = 5; i <= (parts.length - 1); i++) {
-    pathToDirectory = path.join(pathToDirectory, parts[i]);
-  }
-
-  const downloadUrl = [
-    'https://github.com/',
-    owner,
-    '/',
-    repo,
-    '/archive/',
-    branch,
-    '.zip',
-  ].join('');
+  const downloadUrl = `https://github.com/${owner}/${repo}/archive/${branch}.zip`;
 
   return {
     owner,
@@ -54,7 +72,7 @@ function parseGitHubURL(url) {
     branch,
     downloadUrl,
     isSubdirectory,
-    pathToDirectory,
+    pathToDirectory: getPathDirectory(pathLength + 1, parts),
   };
 }
 
@@ -63,8 +81,9 @@ function parseGitHubURL(url) {
  * @returns {Object}
  */
 function parseBitbucketURL(url) {
+  const pathLength = 4;
   const parts = url.pathname.split('/');
-  const isSubdirectory = parts.length > 4;
+  const isSubdirectory = parts.length > pathLength;
   const owner = parts[1];
   const repo = parts[2];
 
@@ -72,28 +91,9 @@ function parseBitbucketURL(url) {
   const branch = 'at' in query ? query.at : 'master';
 
   // validate if given url is a valid Bitbucket url
-  if (url.hostname !== 'bitbucket.org' || !owner || !repo) {
-    const errorMessage = [
-      'The URL must be a valid Bitbucket URL in the following format:',
-      ' https://bitbucket.org/serverless/serverless',
-    ].join('');
-    throw new ServerlessError(errorMessage);
-  }
+  validateUrl(url, 'bitbucket.org', 'Bitbucket', owner, repo);
 
-  let pathToDirectory = '';
-  for (let i = 5; i <= (parts.length - 1); i++) {
-    pathToDirectory = path.join(pathToDirectory, parts[i]);
-  }
-
-  const downloadUrl = [
-    'https://bitbucket.org/',
-    owner,
-    '/',
-    repo,
-    '/get/',
-    branch,
-    '.zip',
-  ].join('');
+  const downloadUrl = `https://bitbucket.org/${owner}/${repo}/get/${branch}.zip`;
 
   return {
     owner,
@@ -101,7 +101,7 @@ function parseBitbucketURL(url) {
     branch,
     downloadUrl,
     isSubdirectory,
-    pathToDirectory,
+    pathToDirectory: getPathDirectory(pathLength + 1, parts),
   };
 }
 
@@ -110,41 +110,18 @@ function parseBitbucketURL(url) {
  * @returns {Object}
  */
 function parseGitlabURL(url) {
+  const pathLength = 4;
   const parts = url.pathname.split('/');
-  const isSubdirectory = parts.length > 4;
+  const isSubdirectory = parts.length > pathLength;
   const owner = parts[1];
   const repo = parts[2];
 
-  const query = qs.parse(url.query);
-  const branch = isSubdirectory ? parts[4] : 'master';
+  const branch = isSubdirectory ? parts[pathLength] : 'master';
 
   // validate if given url is a valid GitLab url
-  if (url.hostname !== 'gitlab.com' || !owner || !repo) {
-    const errorMessage = [
-      'The URL must be a valid GitLab URL in the following format:',
-      ' https://gitlab.com/serverless/serverless',
-    ].join('');
-    throw new ServerlessError(errorMessage);
-  }
+  validateUrl(url, 'gitlab.com', 'Bitbucket', owner, repo);
 
-  let pathToDirectory = '';
-  for (let i = 5; i <= (parts.length - 1); i++) {
-    pathToDirectory = path.join(pathToDirectory, parts[i]);
-  }
-
-  const downloadUrl = [
-    'https://gitlab.com/',
-    owner,
-    '/',
-    repo,
-    '/-/archive/',
-    branch,
-    '/',
-    repo,
-    '-',
-    branch,
-    '.zip',
-  ].join('');
+  const downloadUrl = `https://gitlab.com/${owner}/${repo}/-/archive/${branch}/${repo}-${branch}.zip`;
 
   return {
     owner,
@@ -152,7 +129,7 @@ function parseGitlabURL(url) {
     branch,
     downloadUrl,
     isSubdirectory,
-    pathToDirectory,
+    pathToDirectory: getPathDirectory(pathLength + 1, parts),
   };
 }
 
@@ -186,7 +163,8 @@ function parseRepoURL(inputUrl) {
       return parseGitlabURL(url);
     }
     default: {
-      const msg = 'The URL you passed is not one of the valid providers: "GitHub", "Bitbucket", or "GitLab".';
+      const msg =
+        'The URL you passed is not one of the valid providers: "GitHub", "Bitbucket", or "GitLab".';
       throw new ServerlessError(msg);
     }
   }
@@ -247,5 +225,5 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
 
 module.exports = {
   downloadTemplateFromRepo,
-  parseRepoURL
-}
+  parseRepoURL,
+};

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -196,5 +196,31 @@ describe('downloadTemplateFromRepo', () => {
         pathToDirectory: `localstack${path.sep}dashboard`,
       });
     });
+
+    it('should parse a valid GitLab URL ', () => {
+      const output = parseRepoURL('https://gitlab.com/serverless/serverless');
+
+      expect(output).to.deep.eq({
+        owner: 'serverless',
+        repo: 'serverless',
+        branch: 'master',
+        downloadUrl: 'https://gitlab.com/serverless/serverless/-/archive/master/serverless-master.zip',
+        isSubdirectory: false,
+        pathToDirectory: '',
+      });
+    });
+
+    it('should parse a valid GitLab URL with subdirectory', () => {
+      const output = parseRepoURL('https://gitlab.com/serverless/serverless/tree/dev/subdir');
+
+      expect(output).to.deep.eq({
+        owner: 'serverless',
+        repo: 'serverless',
+        branch: 'dev',
+        downloadUrl: 'https://gitlab.com/serverless/serverless/-/archive/dev/serverless-dev.zip',
+        isSubdirectory: true,
+        pathToDirectory: 'subdir',
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This PR adds support for installing templates and service boilerplates from GitLab.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Besides adding the function that handles the Gitlab support, I refactored some parts of the code that are repeated to use helper functions.

## How can we verify it:

`serverless create --template-url https://gitlab.com/laardee/serverless-template-example --name gitlab-example` creates service from root of the repo using master branch
`serverless create --template-url  https://gitlab.com/laardee/serverless-template-example/tree/temp/subdir --name gitlab-example-subdir` creates service from sub directory of the repo using temp branch

`serverless install --url https://gitlab.com/laardee/serverless-template-example --name gitlab-example` installs from root of the repo using master branch
`serverless install --url https://gitlab.com/laardee/serverless-template-example/tree/temp/subdir --name gitlab-example-subdir` installs from sub directory of the repo using temp branch

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
