### PR TITLE
Migrate node-typescript-template to webpack v4 and exclude node_modules

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -15,7 +15,8 @@
     "serverless-webpack": "^5.1.1",
     "ts-loader": "^4.2.0",
     "typescript": "^2.8.1",
-    "webpack": "^4.5.0"
+    "webpack": "^4.16.0",
+    "webpack-cli": "^3.0.8"
   },
   "author":
     "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require('path');
 const slsw = require('serverless-webpack');
 
-const entries = {};
+const entries = ['./source-map-install.js'];
 
 Object.keys(slsw.lib.entries).forEach(
-  key => (entries[key] = ['./source-map-install.js', slsw.lib.entries[key]])
-);
+  key => entries.push(slsw.lib.entries[key])
+)
+
 
 module.exports = {
   mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
@@ -23,7 +24,7 @@ module.exports = {
   module: {
     rules: [
       // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
-      { test: /\.tsx?$/, loader: 'ts-loader' },
+      { test: /\.tsx?$/, loader: 'ts-loader', exclude: '/node_modules/' },
     ],
   },
 };


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When migrating to Webpack v4 currently you get an error saying 

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.entry should be one of these:
   object { <key>: non-empty string | [non-empty string] } | non-empty string | [non-empty string] | function
   -> The entry point(s) of the compilation.
   Details:
    * configuration.entry should not be empty.
      -> Multiple entry bundles are created. The key is the chunk name. The value can be a string or an array.
    * configuration.entry should be a string.
      -> An entry point without name. The string is resolved to a module which is loaded upon startup.
    * configuration.entry should be an array:
      [non-empty string]
    * configuration.entry should be an instance of function
      -> A Function returning an entry object, an entry string, an entry array or a promise to these things.
```

This fixes it

## How can we verify it:
1. ```npm i -g webpack webpack-cli```
1. ```webpack```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
