### PR TITLE
#5110 null error on undefined AWS SSM variables

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -692,7 +692,7 @@ class Variables {
       .then(response => BbPromise.resolve(response.Parameter.Value))
       .catch((err) => {
         if (err.providerError.code !== 'ParameterNotFound') {
-           return BbPromise.reject(new this.serverless.classes.Error(err.message));
+          return BbPromise.reject(new this.serverless.classes.Error(err.message));
         }
         
         return BbPromise.resolve(undefined);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -691,8 +691,7 @@ class Variables {
       { useCache: true }) // Use request cache
       .then(response => BbPromise.resolve(response.Parameter.Value))
       .catch((err) => {
-        const expectedErrorMessage = `Parameter ${param} not found.`;
-        if (err.message !== expectedErrorMessage) {
+        if (err.message && err.message !== `Parameter ${param} not found.`) {
           return BbPromise.reject(new this.serverless.classes.Error(err.message));
         }
         return BbPromise.resolve(undefined);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -691,7 +691,7 @@ class Variables {
       { useCache: true }) // Use request cache
       .then(response => BbPromise.resolve(response.Parameter.Value))
       .catch((err) => {
-        if (err.providerError.code !== 'ParameterNotFound') {
+        if (_.get(err, 'providerError.code') !== 'ParameterNotFound') {
           return BbPromise.reject(new this.serverless.classes.Error(err.message));
         }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -691,9 +691,10 @@ class Variables {
       { useCache: true }) // Use request cache
       .then(response => BbPromise.resolve(response.Parameter.Value))
       .catch((err) => {
-        if (err.message && err.message !== `Parameter ${param} not found.`) {
-          return BbPromise.reject(new this.serverless.classes.Error(err.message));
+        if (err.providerError.code !== 'ParameterNotFound') {
+           return BbPromise.reject(new this.serverless.classes.Error(err.message));
         }
+        
         return BbPromise.resolve(undefined);
       });
   }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -694,7 +694,7 @@ class Variables {
         if (err.providerError.code !== 'ParameterNotFound') {
           return BbPromise.reject(new this.serverless.classes.Error(err.message));
         }
-        
+
         return BbPromise.resolve(undefined);
       });
   }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -691,7 +691,7 @@ class Variables {
       { useCache: true }) // Use request cache
       .then(response => BbPromise.resolve(response.Parameter.Value))
       .catch((err) => {
-        if (_.get(err, 'providerError.code') !== 'ParameterNotFound') {
+        if (err.statusCode !== 400) {
           return BbPromise.reject(new this.serverless.classes.Error(err.message));
         }
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -830,9 +830,10 @@ module.exports = {
       const awsProvider = new AwsProvider(serverless, options);
       const param = '/some/path/to/invalidparam';
       const property = `\${ssm:${param}}`;
-      const error = new Error(`Parameter ${param} not found.`, 123);
+      const error = new serverless.classes.Error(`Parameter ${param} not found.`, 400);
       const requestStub = sinon.stub(awsProvider, 'request', () => BbPromise.reject(error));
       const warnIfNotFoundSpy = sinon.spy(serverless.variables, 'warnIfNotFound');
+
       return serverless.variables.populateProperty(property)
         .should.become(undefined)
         .then(() => {
@@ -1638,7 +1639,7 @@ module.exports = {
     });
 
     it('should return undefined if SSM parameter does not exist', () => {
-      const error = new Error(`Parameter ${param} not found.`);
+      const error = new serverless.classes.Error(`Parameter ${param} not found.`, 400);
       const requestStub = sinon.stub(awsProvider, 'request', () => BbPromise.reject(error));
       return serverless.variables.getValueFromSsm(`ssm:${param}`)
         .should.become(undefined)


### PR DESCRIPTION
Ignore null errors to allow resolution instead of rejection on undefined SSM variables.

Reported to affect all versions from 1.26 through 1.28.


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5119

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Null check.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Using one of the affected releases try a SSM variable in a region that does not have the variable defined.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
