### PR TITLE
Add SQS To Event List

### DIFF
--- a/docs/providers/aws/README.md
+++ b/docs/providers/aws/README.md
@@ -91,6 +91,7 @@ If you have any questions, [search the forums](https://forum.serverless.com?utm_
         <li><a href="./events/s3.md">S3</a></li>
         <li><a href="./events/schedule.md">Schedule</a></li>
         <li><a href="./events/sns.md">SNS</a></li>
+        <li><a href="./events/sqs.md">SQS</a></li>
         <li><a href="./events/alexa-skill.md">Alexa Skill</a></li>
         <li><a href="./events/alexa-smart-home.md">Alexa Smart Home</a></li>
         <li><a href="./events/iot.md">IoT</a></li>


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes 

The events page for AWS is missing a link to SQS

## How did you implement it:

Added SQS Link

## How can we verify it:

click the link 😄 

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
