### PR TITLE
Set default maxRetries for AWS provider

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -113,6 +113,7 @@ class AwsProvider {
     this.provider = this; // only load plugin in an AWS service context
     this.serverless = serverless;
     this.sdk = AWS;
+    this.sdk.config.update({ maxRetries: 5 });
     this.serverless.setProvider(constants.providerName, this);
     this.requestCache = {};
     this.requestQueue = new PromiseQueue(2, Infinity);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5142

This configures the AWS provider to retry failed api calls for errors which are retry-able. 

## How did you implement it:

This is a really minor change to the default AWS.config which sets the retry attempts to 5.
This could arguably be exposed via the `serverless.yml` file to enable users to configure this themselves.

## How can we verify it:

This is a difficult one to verify. Our use case if for when we are running multiple serverless cli commands in parallel. I am not sure how to easily simulate this, or even add a test case. But as the change is relatively minor and is following the sdk docs [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#update-property). 

## Todos:

- [x] Write tests (n/a)
- [x] Write documentation (n/a)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
