### PR TITLE
Bump aws-nodejs template node version to 8.10, update serverless.yml

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -19,7 +19,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
Update the aws-nodejs template to use the latest NodeJS version supported by aws which is currently 8.10

## What did you implement:

Bump the default NodeJS version provided in the serverless.yaml for the aws-nodejs template

## How did you implement it:

updated the serverless.yaml file

## How can we verify it:
sls create -t aws-nodejs and verify the generated serverless.yaml has   runtime: nodejs8.10

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
