### PR TITLE
During Overwrite, Pause on Deep Variables

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -453,8 +453,21 @@ class Variables {
       !(typeof value === 'object' && _.isEmpty(value))
     );
     return BbPromise.all(variableValues)
-      .then(values => // find and resolve first valid value, undefined if none
-        BbPromise.resolve(values.find(validValue)));
+      .then(values => {
+        let deepPropertyString = propertyString;
+        let deepProperties = 0;
+        values.forEach((value, index) => {
+          if (_.isString(value) && value.match(this.deepRefSyntax)) {
+            deepProperties += 1;
+            deepPropertyString = deepPropertyString.replace(
+              variableStrings[index],
+              this.cleanVariable(value));
+          }
+        });
+        return deepProperties > 0 ?
+          BbPromise.resolve(deepPropertyString) : // return deep variable replacement of original
+          BbPromise.resolve(values.find(validValue));// resolve first valid value, else undefined
+      });
   }
   /**
    * Given any variable string, return the value it should be populated with.

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -586,6 +586,20 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);
       });
+      it('should handle overrides that are populated by unresolvable deep variables', () => {
+        service.custom = {
+          val0: 'foo',
+          val1: '${self:custom.val0}',
+          val2: '${self:custom.val1.notAnAttribute, "fallback"}',
+        };
+        const expected = {
+          val0: 'foo',
+          val1: 'foo',
+          val2: 'fallback',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
       it('should handle deep variables regardless of custom variableSyntax', () => {
         service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
         serverless.variables.loadVariableSyntax();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When a overwrite (defaulting variable) statement is evaluated and a term is populated with a variable, that variable is replaced with a deep variable reference.  This deep variable reference can be mistaken for a valid value, even if it will later fail to resolve.  However, the current logic takes it as the valid result of the overwrite and loses the overwrite context.  This change fixes this error/bug by identifying the case and retaining the context until all deep variables are resolved.

Fixes #5027 ([confirmed](https://github.com/serverless/serverless/issues/5027#issuecomment-407578504))
Possibly #5011 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

When evaluating overwrite values, identify deep values among them and if found pause population.

This avoids taking a deep value as a valid term within an overwrite (defaulting) variable statement that will later resolve to undefined but, as a deep variable string, is valid in immediate evaluation.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

See additional unit test that failed prior to fix.  Alternatively take @dougmoscrop 's configuration from #5027 and verify using his steps.

## Todos:

- [x] Write tests
- [N/A] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
