### PR TITLE
Fixed problem of v1.28.0 related environment value 

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -164,9 +164,9 @@ class AwsDeployFunction {
             const errorMessage = 'Invalid characters in environment variable';
             throw new this.serverless.classes.Error(errorMessage);
           }
+
           if (!_.isString(params.Environment.Variables[key])) {
-            const errorMessage = `Environment variable ${key} must contain strings`;
-            throw new this.serverless.classes.Error(errorMessage);
+             params.Environment.Variables[key] = _.toString(params.Environment.Variables[key])
           }
         });
       }

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -166,7 +166,7 @@ class AwsDeployFunction {
           }
 
           if (!_.isString(params.Environment.Variables[key])) {
-             params.Environment.Variables[key] = _.toString(params.Environment.Variables[key])
+            params.Environment.Variables[key] = _.toString(params.Environment.Variables[key]);
           }
         });
       }

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -353,19 +353,35 @@ describe('AwsDeployFunction', () => {
       expect(() => awsDeployFunction.updateFunctionConfiguration()).to.throw(Error);
     });
 
-    it('should fail when using non-string values as environment variables', () => {
-      options.functionObj = {
-        name: 'first',
-        description: 'change',
-        environment: {
-          COUNTER: 6,
-        },
-      };
+    it('should transform to string values when using non-string values as environment variables',
+      () => {
+        options.functionObj = {
+          name: 'first',
+          description: 'change',
+          environment: {
+            COUNTER: 6,
+          },
+        };
 
-      awsDeployFunction.options = options;
-
-      expect(() => awsDeployFunction.updateFunctionConfiguration()).to.throw(Error);
-    });
+        awsDeployFunction.options = options;
+        return expect(awsDeployFunction.updateFunctionConfiguration()).to.be.fulfilled
+          .then(() => {
+            expect(updateFunctionConfigurationStub.calledOnce).to.be.equal(true);
+            expect(updateFunctionConfigurationStub.calledWithExactly(
+              'Lambda',
+              'updateFunctionConfiguration',
+              {
+                FunctionName: 'first',
+                Description: 'change',
+                Environment: {
+                  Variables: {
+                    COUNTER: '6',
+                  },
+                },
+              }
+            )).to.be.equal(true);
+          });
+      });
 
     it('should inherit provider-level config', () => {
       options.functionObj = {

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -259,13 +259,6 @@ class AwsCompileFunctions {
             invalidEnvVar = `Invalid characters in environment variable ${key}`;
             return false;   // break loop with lodash
           }
-          const value = newFunction.Properties.Environment.Variables[key];
-          const isCFRef = _.isObject(value) &&
-            !_.some(value, (v, k) => k !== 'Ref' && !_.startsWith(k, 'Fn::'));
-          if (!isCFRef && !_.isString(value)) {
-            invalidEnvVar = `Environment variable ${key} must contain string`;
-            return false;
-          }
         }
       );
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -259,6 +259,15 @@ class AwsCompileFunctions {
             invalidEnvVar = `Invalid characters in environment variable ${key}`;
             return false;   // break loop with lodash
           }
+          const value = newFunction.Properties.Environment.Variables[key];
+          if (_.isObject(value)) {
+            const isCFRef = _.isObject(value) &&
+              !_.some(value, (v, k) => k !== 'Ref' && !_.startsWith(k, 'Fn::'));
+            if (!isCFRef) {
+              invalidEnvVar = `Environment variable ${key} must contain string`;
+              return false;
+            }
+          }
         }
       );
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1456,7 +1456,7 @@ describe('AwsCompileFunctions', () => {
       return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
     });
 
-    it('should throw an error if environment variable is not a string', () => {
+    it('should accept an environment variable with a not-string value', () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -1467,7 +1467,13 @@ describe('AwsCompileFunctions', () => {
         },
       };
 
-      return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(Error);
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+      .then(() => {
+        expect(awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate
+          .Resources.FuncLambdaFunction.Properties.Environment.Variables.counter
+        ).to.equal(18);
+      });
     });
 
     it('should accept an environment variable with CF ref and functions', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5094

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Fixed the bug by transforming env var to string when setting num value
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
You can do `sls deploy` and `sls deploy function -f hello` with following yml file and will success both of them.

```yaml
service: sls-test

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    environment:
      AWS_ACCOUNT_ID: 1234567890
``` 

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
