### PR TITLE
Update spawn API with {shell=true}

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -174,7 +174,8 @@ class AwsInvokeLocal {
 
     return new BbPromise(resolve => {
       const python = spawn(runtime,
-        ['-u', path.join(__dirname, 'invoke.py'), handlerPath, handlerName], { env: process.env }, { shell: true });
+        ['-u', path.join(__dirname, 'invoke.py'), handlerPath, handlerName], 
+        { env: process.env }, { shell: true });
       python.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       python.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       python.stdin.write(input);

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -174,7 +174,7 @@ class AwsInvokeLocal {
 
     return new BbPromise(resolve => {
       const python = spawn(runtime,
-        ['-u', path.join(__dirname, 'invoke.py'), handlerPath, handlerName], { env: process.env });
+        ['-u', path.join(__dirname, 'invoke.py'), handlerPath, handlerName], { env: process.env }, { shell: true });
       python.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       python.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       python.stdin.write(input);
@@ -191,7 +191,7 @@ class AwsInvokeLocal {
         `-DhandlerName=${handlerName}`,
         '-jar',
         path.join(__dirname, 'java', 'target', 'invoke-bridge-1.0.jar'),
-      ]);
+      ], { shell: true });
 
       this.serverless.cli.log([
         'In order to get human-readable output,',
@@ -234,7 +234,7 @@ class AwsInvokeLocal {
           'package',
           '-f',
           path.join(javaBridgePath, 'pom.xml'),
-        ]);
+        ], { shell: true });
 
         this.serverless.cli
           .log('Building Java bridge, first invocation might take a bit longer.');

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -174,7 +174,7 @@ class AwsInvokeLocal {
 
     return new BbPromise(resolve => {
       const python = spawn(runtime,
-        ['-u', path.join(__dirname, 'invoke.py'), handlerPath, handlerName], 
+        ['-u', path.join(__dirname, 'invoke.py'), handlerPath, handlerName],
         { env: process.env }, { shell: true });
       python.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       python.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));


### PR DESCRIPTION
## What did you implement:

#5030 & #4789

## How did you implement it:

Added shell=true option to spawn API which is by default set to false. 

## How can we verify it:

Run Invoke local command in windows machine.

Example : sls invoke local -f hello --data '{"a":"bar"}'

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
