### PR TITLE
Deterministic resourceId to fix state diffing on Platform

### DIFF
--- a/lib/plugins/platform/platform.js
+++ b/lib/plugins/platform/platform.js
@@ -4,7 +4,6 @@
 
 const BbPromise = require('bluebird');
 const path = require('path');
-const uuid = require('uuid');
 const _ = require('lodash');
 const fs = require('fs');
 const fsExtra = require('../../utils/fs/fse');
@@ -304,7 +303,7 @@ class Platform {
       const physicalId = _.find(this.cfResources, r => r.LogicalResourceId === key)
         .PhysicalResourceId;
       const resource = {
-        resourceId: uuid.v4(),
+        resourceId: key.toLowerCase(),
         id: physicalId,
         name: key,
         type: value.Type,


### PR DESCRIPTION
Makes the `resourceId` deterministic in order to corralte old and new state items in the backend and fix issues with resource diffing.

Here's a screenshot how resource diffing looks like before and after applying the fix (note both deployments are just service-updates and no fresh deployments):

**Before (there are tons of other resource additions and removals...):**

<img width="1440" alt="bildschirmfoto 2018-08-13 um 12 04 40" src="https://user-images.githubusercontent.com/1606004/44025728-2d924256-9ef1-11e8-9c01-4a0b90fefc97.png">

**After:**

<img width="1440" alt="bildschirmfoto 2018-08-13 um 12 01 20" src="https://user-images.githubusercontent.com/1606004/44025738-34aaff92-9ef1-11e8-97fc-86b91ea45828.png">