### PR TITLE
Skip trimming of white spaces inside quoted part. See issue #4624

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -19,7 +19,7 @@ class Service {
     this.provider = {
       stage: 'dev',
       region: 'us-east-1',
-      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -31,7 +31,7 @@ describe('Service', () => {
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
         region: 'us-east-1',
-        variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+        variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}',
       });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);
@@ -792,7 +792,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -10,6 +10,8 @@ const fse = require('../utils/fs/fse');
 const logWarning = require('./Error').logWarning;
 const PromiseTracker = require('./PromiseTracker');
 
+const whiteSpaceRegExp = /\s/;
+
 /**
  * Maintainer's notes:
  *
@@ -265,10 +267,30 @@ class Variables {
    * @returns {string} The cleaned variable match
    */
   cleanVariable(match) {
-    return match.replace(
+    return this.removeWhiteSpaces(match.replace(
       this.variableSyntax,
       (context, contents) => contents.trim()
-    ).replace(/\s/g, '');
+    ));
+  }
+  /**
+   * Removes white spaces from the string except inside ' characters.
+   * @param {*} str The string to trim.
+   */
+  removeWhiteSpaces(str) {
+    let insideQuotes = false;
+    let trimmed = '';
+    for (let i = 0; i < str.length; i++) {
+      const c = str.charAt(i);
+      if (c === '\'') { // Check if quote, flipping flag
+        insideQuotes = !insideQuotes;
+        trimmed += c;
+      } else if (insideQuotes) {  // Allow white space inside quotes
+        trimmed += c;
+      } else if (!whiteSpaceRegExp.test(c)) {  // Trim white spaces outside of quotes
+        trimmed += c;
+      }
+    }
+    return trimmed;
   }
   /**
    * @typedef {Object} MatchResult
@@ -744,9 +766,8 @@ class Variables {
     }
     const variableContainer = variable.match(this.variableSyntax)[0];
     const variableString = this.cleanVariable(variableContainer);
-    return variableContainer
-      .replace(/\s/g, '')
-      .replace(variableString, `deep:${index}`);
+    const foo = this.removeWhiteSpaces(variableContainer);
+    return foo.replace(variableString, `deep:${index}`);
   }
   appendDeepVariable(variable, subProperty) {
     return `${variable.slice(0, variable.length - 1)}.${subProperty}}`;

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -47,8 +47,8 @@ describe('Variables', () => {
 
   describe('#loadVariableSyntax()', () => {
     it('should set variableSyntax', () => {
-      // eslint-disable-next-line no-template-curly-in-string
-      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
+      // eslint-disable-next-line no-template-curly-in-string, max-len
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}}';
       serverless.variables.loadVariableSyntax();
       expect(serverless.variables.variableSyntax).to.be.a('RegExp');
     });
@@ -294,8 +294,8 @@ describe('Variables', () => {
       });
       beforeEach(() => {
         service = makeDefault();
-        // eslint-disable-next-line no-template-curly-in-string
-        service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}'; // default
+        // eslint-disable-next-line no-template-curly-in-string, max-len
+        service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}'; // default
         serverless.variables.service = service;
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
@@ -327,6 +327,19 @@ describe('Variables', () => {
           expect(result).to.eql(expected);
         })).to.be.fulfilled;
       });
+
+      it('should properly handle hard-coded argument', () => {
+        service.custom = {
+          val0: '${env:VAR, \'a(0 * ?)\'}',
+        };
+        const expected = {
+          val0: 'a(0 * ?)',
+        };
+        return expect(serverless.variables.populateObject(service.custom).then((result) => {
+          expect(result).to.eql(expected);
+        })).to.be.fulfilled;
+      });
+
       it('should properly populate an overwrite with a default value that is a string', () => {
         service.custom = {
           val0: 'my value', // eslint-disable-next-line no-template-curly-in-string
@@ -601,7 +614,7 @@ describe('Variables', () => {
           .should.become(expected);
       });
       it('should handle deep variables regardless of custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)\\*\\?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -618,7 +631,7 @@ describe('Variables', () => {
           .should.become(expected);
       });
       it('should handle deep variables regardless of recursion into custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)\\*\\?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -639,7 +652,7 @@ describe('Variables', () => {
           .should.become(expected);
       });
       it('should handle deep variables in complex recursions of custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)\\*\\?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -1204,7 +1217,8 @@ module.exports = {
 
   describe('#getValueFromSelf()', () => {
     beforeEach(() => {
-      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}';
+      // eslint-disable-next-line max-len
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}}';
       serverless.variables.loadVariableSyntax();
       delete serverless.service.provider.variableSyntax;
     });

--- a/lib/plugins/print/print.js
+++ b/lib/plugins/print/print.js
@@ -54,7 +54,7 @@ class Print {
     service.provider = _.merge({
       stage: 'dev',
       region: 'us-east-1',
-      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)\\*\\?]+?)}',
     }, service.provider);
   }
   strip(svc) {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4624 

## How did you implement it:

PR adds * and ? characters to the variable syntax which allows cron syntax.
White spaces were removed from variables which is disable inside quotes in the PR. 

## How can we verify it:

Examples:

`
service: serverless-dynamodb-backup
  
provider:
  name: aws
  runtime: nodejs6.10
  environment:
    LAMBDA_SCHEDULE: ${env:LAMBDA_SCHEDULE, 'cron(0 0 * * ? *)'}
functions:
    cronFunc:
        handler: handler.cronFunc
        events:
           - schedule:
              rate: ${self:provider.environment.LAMBDA_SCHEDULE}
              enabled: true
`
sls package returns correctly LAMBDA_SCHEDULE default value(cron(0 0 * * ? *)). If one sets "export LAMBDA_SCHEDULE=foo" then foo is printed in serverless-state.json


***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
