### PR TITLE
Add multi-region support

### DIFF
--- a/lib/plugins/aws/deploy/lib/createDeployment.js
+++ b/lib/plugins/aws/deploy/lib/createDeployment.js
@@ -13,6 +13,8 @@ module.exports = {
         this.serverless.service.tenant &&
         !this.options.noDeploy) {
         const deploymentData = {
+          provider: this.serverless.service.provider.name,
+          region: this.serverless.service.provider.region,
           tenant: this.serverless.service.tenant,
           app: this.serverless.service.app,
           accessKey,

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -36,7 +36,11 @@ module.exports = {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
 
-    return this.createDeployment().then(() => this.provider.request(
+    const deploymentData = {
+      provider: this.serverless.service.provider.name,
+      region: this.serverless.service.provider.region,
+    };
+    return this.createDeployment(deploymentData).then(() => this.provider.request(
         'CloudFormation',
         'createStack',
         params

--- a/lib/plugins/aws/deploy/lib/validateTemplate.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.js
@@ -25,7 +25,11 @@ module.exports = {
       throw new Error(errorMessage);
     }).then(() => {
       if (!this.serverless.service.deployment || !this.serverless.service.deployment.deploymentId) {
-        return this.createDeployment().catch((error) => {
+        const deploymentData = {
+          provider: this.serverless.service.provider.name,
+          region: this.serverless.service.provider.region,
+        };
+        return this.createDeployment(deploymentData).catch((error) => {
           throw new Error(error);
         });
       }

--- a/lib/plugins/platform/platform.js
+++ b/lib/plugins/platform/platform.js
@@ -437,6 +437,8 @@ class Platform {
         return BbPromise.resolve();
       }
       const data = {
+        provider: this.serverless.service.provider.name,
+        region: this.serverless.service.provider.region,
         name: this.serverless.service.service,
         tenant: this.serverless.service.tenant,
         app: this.serverless.service.app,


### PR DESCRIPTION
Adds multi-region awareness when creating deployments and archiving services.

Platform SDK PR --> https://github.com/serverless/platform-sdk/pull/13