### PR TITLE
Adds FilterPolicy to SNS event

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -95,3 +95,20 @@ functions:
           topicName: aggregate
           displayName: Data aggregation pipeline
 ```
+
+## Setting a filter policy
+
+This event definition creates an SNS topic which subscription uses a filter policy. The filter policy filters out messages that don't have attribute key `pet` with value `dog` or `cat`.
+
+```yml
+functions:
+  pets:
+    handler: pets.handler
+    events:
+      - sns:
+          topicName: pets
+          filterPolicy:
+            pet:
+              - dog
+              - cat
+```

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -135,8 +135,14 @@ class AwsCompileSNSEvents {
                   ],
                 ],
               };
+
               const topicLogicalId = this.provider.naming
                 .getTopicLogicalId(topicName);
+
+              const subscription = {
+                Endpoint: endpoint,
+                Protocol: 'lambda',
+              };
 
               if (!(topicLogicalId in template.Resources)) {
                 _.merge(template.Resources, {
@@ -150,19 +156,26 @@ class AwsCompileSNSEvents {
                 });
               }
 
-              _.merge(template.Resources, {
-                [subscriptionLogicalId]: {
-                  Type: 'AWS::SNS::Subscription',
-                  Properties: {
-                    TopicArn: {
-                      Ref: topicLogicalId,
-                    },
-                    Protocol: 'lambda',
-                    Endpoint: endpoint,
-                    FilterPolicy: event.sns.filterPolicy,
+              if (event.sns.filterPolicy) {
+                _.merge(template.Resources, {
+                  [subscriptionLogicalId]: {
+                    Type: 'AWS::SNS::Subscription',
+                    Properties:
+                      _.merge(subscription, {
+                        TopicArn: {
+                          Ref: topicLogicalId,
+                        },
+                        FilterPolicy: event.sns.filterPolicy,
+                      }),
                   },
-                },
-              });
+                });
+              } else {
+                if (!template.Resources[topicLogicalId].Properties.Subscription) {
+                  template.Resources[topicLogicalId].Properties.Subscription = [];
+                }
+                template.Resources[topicLogicalId]
+                  .Properties.Subscription.push(subscription);
+              }
             }
 
             const lambdaPermissionLogicalId = this.provider.naming

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -105,10 +105,10 @@ class AwsCompileSNSEvents {
               'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
             };
 
-            if (topicArn) {
-              const subscriptionLogicalId = this.provider.naming
-                .getLambdaSnsSubscriptionLogicalId(functionName, topicName);
+            const subscriptionLogicalId = this.provider.naming
+              .getLambdaSnsSubscriptionLogicalId(functionName, topicName);
 
+            if (topicArn) {
               _.merge(template.Resources, {
                 [subscriptionLogicalId]: {
                   Type: 'AWS::SNS::Subscription',
@@ -116,6 +116,7 @@ class AwsCompileSNSEvents {
                     TopicArn: topicArn,
                     Protocol: 'lambda',
                     Endpoint: endpoint,
+                    FilterPolicy: event.sns.filterPolicy,
                   },
                 },
               });
@@ -137,26 +138,31 @@ class AwsCompileSNSEvents {
               const topicLogicalId = this.provider.naming
                 .getTopicLogicalId(topicName);
 
-              const subscription = {
-                Endpoint: endpoint,
-                Protocol: 'lambda',
-              };
-
-              if (topicLogicalId in template.Resources) {
-                template.Resources[topicLogicalId]
-                  .Properties.Subscription.push(subscription);
-              } else {
+              if (!(topicLogicalId in template.Resources)) {
                 _.merge(template.Resources, {
                   [topicLogicalId]: {
                     Type: 'AWS::SNS::Topic',
                     Properties: {
                       TopicName: topicName,
                       DisplayName: displayName,
-                      Subscription: [subscription],
                     },
                   },
                 });
               }
+
+              _.merge(template.Resources, {
+                [subscriptionLogicalId]: {
+                  Type: 'AWS::SNS::Subscription',
+                  Properties: {
+                    TopicArn: {
+                      Ref: topicLogicalId,
+                    },
+                    Protocol: 'lambda',
+                    Endpoint: endpoint,
+                    FilterPolicy: event.sns.filterPolicy,
+                  },
+                },
+              });
             }
 
             const lambdaPermissionLogicalId = this.provider.naming

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -74,16 +74,9 @@ describe('AwsCompileSNSEvents', () => {
         .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic1.Type
       ).to.equal('AWS::SNS::Subscription');
       expect(awsCompileSNSEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic2.Type
-      ).to.equal('AWS::SNS::Subscription');
-      expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate
         .Resources.FirstSnsSubscriptionTopic1.Properties.FilterPolicy
       ).to.eql({ pet: ['dog', 'cat'] });
-      expect(awsCompileSNSEvents.serverless.service
-        .provider.compiledCloudFormationTemplate
-        .Resources.FirstSnsSubscriptionTopic2.Properties.FilterPolicy
-      ).to.equal(undefined);
     });
 
     it('should create corresponding resources when topic is defined in resources', () => {
@@ -135,16 +128,9 @@ describe('AwsCompileSNSEvents', () => {
         .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic1.Type
       ).to.equal('AWS::SNS::Subscription');
       expect(awsCompileSNSEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic2.Type
-      ).to.equal('AWS::SNS::Subscription');
-      expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate
         .Resources.FirstSnsSubscriptionTopic1.Properties.FilterPolicy
       ).to.eql({ pet: ['dog', 'cat'] });
-      expect(awsCompileSNSEvents.serverless.service
-        .provider.compiledCloudFormationTemplate
-        .Resources.FirstSnsSubscriptionTopic2.Properties.FilterPolicy
-      ).to.equal(undefined);
     });
 
     it('should create single SNS topic when the same topic is referenced repeatedly', () => {
@@ -168,16 +154,13 @@ describe('AwsCompileSNSEvents', () => {
 
       expect(Object.keys(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources)
-      ).to.have.length(3);
+      ).to.have.length(2);
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.SNSTopicTopic1.Type
       ).to.equal('AWS::SNS::Topic');
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionTopic1SNS.Type
       ).to.equal('AWS::Lambda::Permission');
-      expect(awsCompileSNSEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic1.Type
-      ).to.equal('AWS::SNS::Subscription');
     });
 
     it('should throw an error when the event an object and the displayName is not given', () => {

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -44,6 +44,9 @@ describe('AwsCompileSNSEvents', () => {
               sns: {
                 topicName: 'Topic 1',
                 displayName: 'Display name for topic 1',
+                filterPolicy: {
+                  pet: ['dog', 'cat'],
+                },
               },
             },
             {
@@ -67,6 +70,20 @@ describe('AwsCompileSNSEvents', () => {
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionTopic2SNS.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic1.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic2.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate
+        .Resources.FirstSnsSubscriptionTopic1.Properties.FilterPolicy
+      ).to.eql({ pet: ['dog', 'cat'] });
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate
+        .Resources.FirstSnsSubscriptionTopic2.Properties.FilterPolicy
+      ).to.equal(undefined);
     });
 
     it('should create single SNS topic when the same topic is referenced repeatedly', () => {
@@ -90,17 +107,16 @@ describe('AwsCompileSNSEvents', () => {
 
       expect(Object.keys(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources)
-      ).to.have.length(2);
+      ).to.have.length(3);
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.SNSTopicTopic1.Type
       ).to.equal('AWS::SNS::Topic');
       expect(awsCompileSNSEvents.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.SNSTopicTopic1
-        .Properties.Subscription.length
-      ).to.equal(2);
-      expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionTopic1SNS.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic1.Type
+      ).to.equal('AWS::SNS::Subscription');
     });
 
     it('should throw an error when the event an object and the displayName is not given', () => {

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -86,6 +86,67 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal(undefined);
     });
 
+    it('should create corresponding resources when topic is defined in resources', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'Topic 1',
+                displayName: 'Display name for topic 1',
+                filterPolicy: {
+                  pet: ['dog', 'cat'],
+                },
+              },
+            },
+            {
+              sns: 'Topic 2',
+            },
+          ],
+        },
+      };
+
+      Object.assign(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources, {
+          SNSTopicTopic2: {
+            Type: 'AWS::SNS::Topic',
+            Properties: {
+              TopicName: 'Topic 2',
+              DisplayName: 'Display name for topic 2',
+            },
+          },
+        });
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.SNSTopicTopic1.Type
+      ).to.equal('AWS::SNS::Topic');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.SNSTopicTopic2.Type
+      ).to.equal('AWS::SNS::Topic');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionTopic1SNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionTopic2SNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic1.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionTopic2.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate
+        .Resources.FirstSnsSubscriptionTopic1.Properties.FilterPolicy
+      ).to.eql({ pet: ['dog', 'cat'] });
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate
+        .Resources.FirstSnsSubscriptionTopic2.Properties.FilterPolicy
+      ).to.equal(undefined);
+    });
+
     it('should create single SNS topic when the same topic is referenced repeatedly', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
@@ -172,6 +233,10 @@ describe('AwsCompileSNSEvents', () => {
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionFooSNS.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate
+        .Resources.FirstSnsSubscriptionFoo.Properties.FilterPolicy
+      ).to.equal(undefined);
     });
 
     it('should create SNS topic when only arn is given as an object property', () => {
@@ -200,6 +265,22 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should throw an error when the arn an object and the value is not a string', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                arn: 123,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => { awsCompileSNSEvents.compileSNSEvents(); }).to.throw(Error);
+    });
+
     it('should create SNS topic when arn and topicName are given as object properties', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
@@ -222,6 +303,40 @@ describe('AwsCompileSNSEvents', () => {
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionBar.Type
       ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionBarSNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
+    it('should create SNS topic when arn, topicName, and filterPolicy are given as object', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'bar',
+                arn: 'arn:aws:sns:region:accountid:bar',
+                filterPolicy: {
+                  pet: ['dog', 'cat'],
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(Object.keys(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources)
+      ).to.have.length(2);
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstSnsSubscriptionBar.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(awsCompileSNSEvents.serverless.service
+        .provider.compiledCloudFormationTemplate
+        .Resources.FirstSnsSubscriptionBar.Properties.FilterPolicy
+      ).to.eql({ pet: ['dog', 'cat'] });
       expect(awsCompileSNSEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstLambdaPermissionBarSNS.Type
       ).to.equal('AWS::Lambda::Permission');


### PR DESCRIPTION
## What did you implement:

Closes #5221

## How did you implement it:

[Inline subscription](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-subscription.html) for the topic doesn't support filter policy, so I changed the subscription to be [separate resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html). 

This increases the resource count in the template, so it can be an issue if someone has a stack which is hitting the limits and updates the a new version.

Option would be to write separate subscription resource only when filter policy exists.

## How can we verify it:

Example setup for creation a subscription with a filter policy
```yml
functions:
  pets:
    handler: pets.handler
    events:
      - sns:
          topicName: pets
          filterPolicy:
            pet:
              - dog
              - cat
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
