### PR TITLE
Update serverless.yml.md

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -25,9 +25,9 @@ frameworkVersion: ">=1.0.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: nodejs6.10
-  stage: dev # Set the default stage used. Default is dev
-  region: us-east-1 # Overwrite the default region used. Default is us-east-1
+  runtime: nodejs8.10
+  stage: ${opt:stage, 'dev'} # Set the default stage used. Default is dev
+  region: ${opt:region, 'us-east-1'} # Overwrite the default region used. Default is us-east-1
   stackName: custom-stack-name # Use a custom name for the CloudFormation stack
   apiName: custom-api-name # Use a custom name for the API Gateway API
   profile: production # The default profile to use with this service


### PR DESCRIPTION
In https://serverless.com/framework/docs/providers/aws/guide/deploying/ the documentation states that you can deploy to different environments / regions by passing them to the --stage or --region flags, however this doesn't work out of the box because the sample documentation / serverless.yml file hardcodes the stage & region and is not set up to use the ones passed to the CLI.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
