### PR TITLE
[docs] Remove redundant link to same docs page

### DIFF
--- a/docs/providers/aws/guide/quick-start.md
+++ b/docs/providers/aws/guide/quick-start.md
@@ -76,5 +76,3 @@ If at any point, you no longer need your service, you can run the following comm
 ```bash
 serverless remove
 ```
-
-Check out the [Serverless Framework Guide](./README.md) for more information.


### PR DESCRIPTION
In the [AWS Quickstart ](https://serverless.com/framework/docs/providers/aws/guide/quick-start/) docs page there is a link at the bottom that reads _Check out the Serverless Framework Guide for more information_. Yet this link simply redirects to the same Quick Start docs page.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
