### PR TITLE
Fix CORS race condition

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -23,6 +23,9 @@ class AwsCompileApigEvents {
     this.options = options;
     this.provider = this.serverless.getProvider('aws');
 
+    // used for the generated method logical ids (GET, PATCH, PUT, DELETE, OPTIONS, ...)
+    this.apiGatewayMethodLogicalIds = [];
+
     Object.assign(
       this,
       validate,

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -75,6 +75,9 @@ describe('AwsCompileApigEvents', () => {
     it('should set the provider variable to be an instanceof AwsProvider', () =>
       expect(awsCompileApigEvents.provider).to.be.instanceof(AwsProvider));
 
+    it('should setup an empty array to gather the method logical ids', () =>
+      expect(awsCompileApigEvents.apiGatewayMethodLogicalIds).to.deep.equal([]));
+
     it('should run "package:compileEvents" promise chain in order', () => {
       const validateStub = sinon
         .stub(awsCompileApigEvents, 'validate').returns({

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -4,7 +4,6 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 
 module.exports = {
-
   compileCors() {
     _.forEach(this.validated.corsPreflight, (config, path) => {
       const resourceName = this.getResourceName(path);
@@ -40,6 +39,8 @@ module.exports = {
           preflightHeaders['Access-Control-Allow-Methods']
             .replace('ANY', 'DELETE,GET,HEAD,PATCH,POST,PUT');
       }
+
+      this.apiGatewayMethodLogicalIds.push(corsMethodLogicalId);
 
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [corsMethodLogicalId]: {
@@ -97,5 +98,4 @@ module.exports = {
       },
     ];
   },
-
 };

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -33,13 +33,13 @@ describe('#compileCors()', () => {
       },
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    awsCompileApigEvents.apiGatewayMethodLogicalIds = [];
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayResources = {
       'users/create': {
         name: 'UsersCreate',
         resourceLogicalId: 'ApiGatewayResourceUsersCreate',
       },
-
       'users/list': {
         name: 'UsersList',
         resourceLogicalId: 'ApiGatewayResourceUsersList',
@@ -251,5 +251,30 @@ describe('#compileCors()', () => {
 
     expect(() => awsCompileApigEvents.compileCors())
       .to.throw(Error, 'maxAge should be an integer over 0');
+  });
+
+  it('should add the methods resource logical id to the array of method logical ids', () => {
+    awsCompileApigEvents.validated.corsPreflight = {
+      'users/create': {
+        origins: ['*', 'http://example.com'],
+        headers: ['*'],
+        methods: ['OPTIONS', 'POST'],
+        allowCredentials: true,
+        maxAge: 86400,
+      },
+      'users/any': {
+        origins: ['http://example.com'],
+        headers: ['*'],
+        methods: ['OPTIONS', 'ANY'],
+        allowCredentials: false,
+      },
+    };
+    return awsCompileApigEvents.compileCors().then(() => {
+      expect(awsCompileApigEvents.apiGatewayMethodLogicalIds)
+        .to.deep.equal([
+          'ApiGatewayMethodUsersCreateOptions',
+          'ApiGatewayMethodUsersAnyOptions',
+        ]);
+    });
   });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -4,9 +4,7 @@ const BbPromise = require('bluebird');
 const _ = require('lodash');
 
 module.exports = {
-
   compileMethods() {
-    this.apiGatewayMethodLogicalIds = [];
     this.permissionMapping = [];
 
     this.validated.events.forEach((event) => {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -34,6 +34,7 @@ describe('#compileMethods()', () => {
     };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.validated = {};
+    awsCompileApigEvents.apiGatewayMethodLogicalIds = [];
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayResources = {
       'users/create': {
@@ -609,7 +610,7 @@ describe('#compileMethods()', () => {
     });
   });
 
-  it('should create methodLogicalIds array', () => {
+  it('should update the method logical ids array', () => {
     awsCompileApigEvents.validated.events = [
       {
         functionName: 'First',
@@ -628,6 +629,10 @@ describe('#compileMethods()', () => {
     ];
     return awsCompileApigEvents.compileMethods().then(() => {
       expect(awsCompileApigEvents.apiGatewayMethodLogicalIds.length).to.equal(2);
+      expect(awsCompileApigEvents.apiGatewayMethodLogicalIds).to.deep.equal([
+        'ApiGatewayMethodUsersCreatePost',
+        'ApiGatewayMethodUsersListGet',
+      ]);
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #5100 

This closes the bug where large API Gateways ran into deployment issues when using CORS.

## How did you implement it:

The CORS Method resource logical ids are now included in the `DependsOn` block of the API Gateway deployment resource.

## How can we verify it:

Hard to actually reproduce this bug since it's a race condition. Developers affected by #5100 should try this PR and see if it resolves the issue.

Re-deploying a service via `serverless deploy` should be enough to test this fix.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO