### PR TITLE
Add new template for AWS Alexa Typescript

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,10 @@ services:
     image: node:6.10.3
     volumes:
       - ./tmp/serverless-integration-test-aws-nodejs-typescript:/app
+  aws-alexa-typescript:
+    image: node:6.10.3
+    volumes:
+      - ./tmp/serverless-integration-test-aws-alexa-typescript:/app
   aws-nodejs-ecma-script:
     image: node:6.10.3
     volumes:

--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -52,6 +52,7 @@ Most commonly used templates:
 - aws-clojure-gradle
 - aws-nodejs
 - aws-nodejs-typescript
+- aws-alexa-typescript
 - aws-nodejs-ecma-script
 - aws-python
 - aws-python3

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -54,6 +54,7 @@ Here are the available runtimes for AWS Lambda:
 * aws-clojure-gradle
 * aws-nodejs
 * aws-nodejs-typescript
+* aws-alexa-typescript
 * aws-nodejs-ecma-script
 * aws-python
 * aws-python3

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -18,6 +18,7 @@ const validTemplates = [
   'aws-clojurescript-gradle',
   'aws-nodejs',
   'aws-nodejs-typescript',
+  'aws-alexa-typescript',
   'aws-nodejs-ecma-script',
   'aws-python',
   'aws-python3',

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -185,6 +185,43 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "aws-alexa-typescript" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'aws-alexa-typescript';
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(tmpDir);
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('handler.ts');
+        expect(dirContent).to.include('tsconfig.json');
+        expect(dirContent).to.include('package.json');
+        expect(dirContent).to.include('webpack.config.js');
+        expect(dirContent).to.include('.gitignore');
+      });
+    });
+    it('should generate scaffolding for "aws-alexa-typescript" ' +
+      'template and override service name if user passed', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'aws-alexa-typescript';
+      create.options.name = 'my-awesome-service';
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(tmpDir);
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('handler.ts');
+        expect(dirContent).to.include('tsconfig.json');
+        expect(dirContent).to.include('package.json');
+        expect(dirContent).to.include('webpack.config.js');
+        expect(dirContent).to.include('.gitignore');
+
+        // check if the service was renamed
+        const serverlessYmlfileContent = fse
+          .readFileSync(path.join(tmpDir, 'serverless.yml')).toString();
+        expect((/service:\n {2}name: my-awesome-service/)
+          .test(serverlessYmlfileContent)).to.equal(true);
+      });
+    });
+
     it('should generate scaffolding for "aws-nodejs-ecma-script" template', () => {
       process.chdir(tmpDir);
       create.options.template = 'aws-nodejs-ecma-script';

--- a/lib/plugins/create/templates/aws-alexa-typescript/gitignore
+++ b/lib/plugins/create/templates/aws-alexa-typescript/gitignore
@@ -1,0 +1,9 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack

--- a/lib/plugins/create/templates/aws-alexa-typescript/handler.ts
+++ b/lib/plugins/create/templates/aws-alexa-typescript/handler.ts
@@ -1,0 +1,9 @@
+import * as Ask from 'ask-sdk';
+
+export const alexa = Ask.SkillBuilders.custom()
+  .addRequestHandlers({
+    canHandle: handlerInput => true,
+    handle: handlerInput =>
+      handlerInput.responseBuilder.speak('Hello world!').getResponse()
+  })
+  .lambda();

--- a/lib/plugins/create/templates/aws-alexa-typescript/package.json
+++ b/lib/plugins/create/templates/aws-alexa-typescript/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.57",
-    "serverless-alexa-skills": "^0.0.6",
+    "serverless-alexa-skills": "^0.1.0",
     "serverless-webpack": "^5.1.1",
     "source-map-support": "^0.5.6",
     "ts-loader": "^4.2.0",

--- a/lib/plugins/create/templates/aws-alexa-typescript/package.json
+++ b/lib/plugins/create/templates/aws-alexa-typescript/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "aws-alexa-typescript",
+  "version": "1.0.0",
+  "description": "Alexa example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "ask-sdk": "^2.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "^8.0.57",
+    "serverless-alexa-skills": "^0.0.6",
+    "serverless-webpack": "^5.1.1",
+    "source-map-support": "^0.5.6",
+    "ts-loader": "^4.2.0",
+    "typescript": "^2.9.2",
+    "webpack": "^4.5.0"
+  },
+  "author":
+    "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
@@ -11,12 +11,10 @@ provider:
 
 custom:
   alexa:
-    # Step 1: Paste your vendor ID from here: https://developer.amazon.com/mycid.html
-    vendorId: XXXXXXXXXXXXXX
-    # Step 2: Run `sls alexa auth` to authenticate
-    # Step 3: Run `sls alexa create --name "Serverless Alexa Typescript" --locale en-GB --type custom` to create a new skill
+    # Step 1: Run `sls alexa auth` to authenticate
+    # Step 2: Run `sls alexa create --name "Serverless Alexa Typescript" --locale en-GB --type custom` to create a new skill
     skills:
-        # Step 4: Paste the skill id returned by the create command here:
+        # Step 3: Paste the skill id returned by the create command here:
       - id: amzn1.ask.skill.xxxx-xxxx-xxxx-xxxx-xxxx
         manifest:
           publishingInformation:
@@ -26,12 +24,12 @@ custom:
           apis:
             custom:
               endpoint:
-                # Step 5: Deploy your Serverless stack
-                # Step 6: Paste the ARN of your lambda here:
+                # Step 4: Do your first deploy of your Serverless stack
+                # Step 5: Paste the ARN of your lambda here:
                 uri: arn:aws:lambda:[region]:[account-id]:function:[function-name]
-                # Step 7: Run `sls alexa update` to deploy the skill manifest
-                # Step 8: Run `sls alexa build` to build the skill interaction model
-                # Step 9: Enable the skill in the Alexa app to start testing.
+                # Step 6: Run `sls alexa update` to deploy the skill manifest
+                # Step 7: Run `sls alexa build` to build the skill interaction model
+                # Step 8: Enable the skill in the Alexa app to start testing.
           manifestVersion: '1.0'
         models:
           en-GB:

--- a/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
@@ -1,0 +1,50 @@
+service:
+  name: aws-alexa-typescript
+
+plugins:
+  - serverless-webpack
+  - serverless-alexa-skills
+
+provider:
+  name: aws
+  runtime: nodejs8.10
+
+custom:
+  alexa:
+    # Step 1: Paste your vendor ID from here: https://developer.amazon.com/mycid.html
+    vendorId: XXXXXXXXXXXXXX
+    # Step 2: Run `sls alexa auth` to authenticate
+    # Step 3: Run `sls alexa create --name "Serverless Alexa Typescript" --locale en-GB --type custom` to create a new skill
+    skills:
+        # Step 4: Paste the skill id returned by the create command here:
+      - id: amzn1.ask.skill.xxxx-xxxx-xxxx-xxxx-xxxx
+        manifest:
+          publishingInformation:
+            locales:
+              en-GB:
+                name: Serverless Alexa Typescript
+          apis:
+            custom:
+              endpoint:
+                # Step 5: Deploy your Serverless stack
+                # Step 6: Paste the ARN of your lambda here:
+                uri: arn:aws:lambda:[region]:[account-id]:function:[function-name]
+                # Step 7: Run `sls alexa update` to deploy the skill manifest
+                # Step 8: Run `sls alexa build` to build the skill interaction model
+                # Step 9: Enable the skill in the Alexa app to start testing.
+          manifestVersion: '1.0'
+        models:
+          en-GB:
+            interactionModel:
+              languageModel:
+                invocationName: serverless typescript
+                intents:
+                  - name: HelloIntent
+                    samples:
+                      - 'hello'
+
+functions:
+  alexa:
+    handler: handler.alexa
+    events:
+      - alexaSkill: ${self:custom.alexa.skills.0.id}

--- a/lib/plugins/create/templates/aws-alexa-typescript/source-map-install.js
+++ b/lib/plugins/create/templates/aws-alexa-typescript/source-map-install.js
@@ -1,0 +1,1 @@
+require('source-map-support').install();

--- a/lib/plugins/create/templates/aws-alexa-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/aws-alexa-typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "target": "es6",
+    "lib": [
+      "esnext"
+    ],
+    "moduleResolution": "node"
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/lib/plugins/create/templates/aws-alexa-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-alexa-typescript/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+
+const entries = {};
+
+Object.keys(slsw.lib.entries).forEach(
+  key => (entries[key] = ['./source-map-install.js', slsw.lib.entries[key]])
+);
+
+module.exports = {
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: entries,
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      { test: /\.tsx?$/, loader: 'ts-loader' },
+    ],
+  },
+};

--- a/tests/templates/test_all_templates
+++ b/tests/templates/test_all_templates
@@ -25,6 +25,7 @@ integration-test aws-kotlin-jvm-gradle
 integration-test aws-kotlin-jvm-maven
 integration-test aws-kotlin-nodejs-gradle
 integration-test aws-nodejs-typescript
+integration-test aws-alexa-typescript
 integration-test aws-nodejs-ecma-script
 integration-test google-nodejs
 integration-test spotinst-nodejs


### PR DESCRIPTION
## What did you implement:

Added a template for building Alexa skills, based on the `serverless-alexa-skills` plugin.

## How did you implement it:

Adapted from the existing `aws-nodejs-typescript` template:
- Added the `serverless-alexa-skills` plugin.
- Added the `ask-sdk` package.
- Adapted the handler for Alexa.
- Added matching unit and integration tests.

## How can we verify it:

1. Run the additional unit and integration tests.
2. Setup a new project using: `sls create --template-url https://github.com/danielrbradley/serverless/tree/alexa-typescript-template/lib/plugins/create/templates/aws-alexa-typescript`
3. Follow the instructions in the generated `serverless.yml` (you'll need an Amazon developer account)

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
