### PR TITLE
Fix for #3069 - Failing to handle schedule event body params due to f…

### DIFF
--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -61,6 +61,20 @@ class AwsCompileScheduledEvents {
               }
 
               if (Input && typeof Input === 'object') {
+                if (_.has(Input, 'body') && typeof Input.body === 'string') {
+                  try {
+                    Input.body = JSON.parse(Input.body);
+                  } catch (error) {
+                    const errorMessage = [
+                      'The body of the schedule event associated with',
+                      ` ${functionName} was passed as a string`,
+                      ' but it failed to parse to a JSON object.',
+                      ' Please check the docs for more info.',
+                    ].join('');
+                    throw new this.serverless.classes
+                      .Error(errorMessage);
+                  }
+                }
                 Input = JSON.stringify(Input);
               }
               if (Input && typeof Input === 'string') {

--- a/lib/plugins/aws/package/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.test.js
@@ -287,6 +287,46 @@ describe('AwsCompileScheduledEvents', () => {
       expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
     });
 
+    it('should not throw an error when Input body is a valid JSON string', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                input: {
+                  body: '{ "functionId": "..." }',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).not.to.throw(Error);
+    });
+
+    it('should throw an error when Input body is an invalid JSON string', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                input: {
+                  body: 'an invalid input body',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+    });
+
     it('should not create corresponding resources when scheduled events are not given', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
…ailures in stringifying an already stringified...string.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3069

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

The author of the bug has a good description of the issue seen.

During processing of the Input body, first checking if it is a string, then parsing it to JSON so it is provided correctly to the scheduleTemplate as valid JSON. 

## How can we verify it:

Clone my fix test, which uses the reporters example:

`git@github.com:shanehandley/serverless-fix-3069.git`

Install:

`npm install`

Execute:

`./node_modules/serverless/bin/serverless package`

The function should execute without error.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
