### PR TITLE
more faithfully represent aws lambda python runtime context

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 import sys
-from time import time
+from time import strftime, time
 from importlib import import_module
 
 class FakeLambdaContext(object):
@@ -43,7 +43,7 @@ class FakeLambdaContext(object):
 
     @property
     def log_stream_name(self):
-        return '2018/09/12/[$' + self.version + ']58419525dade4d17a495dceeeed44708'
+        return strftime('%Y/%m/%d') +'/[$' + self.version + ']58419525dade4d17a495dceeeed44708'
 
 logging.basicConfig()
 

--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -31,12 +31,19 @@ class FakeLambdaContext(object):
 
     @property
     def memory_limit_in_mb(self):
-        return 1024
+        return '1024'
 
     @property
     def aws_request_id(self):
         return '1234567890'
 
+    @property
+    def log_group_name(self):
+        return '/aws/lambda/' + self.name
+
+    @property
+    def log_stream_name(self):
+        return '2018/09/12/[$' + self.version + ']58419525dade4d17a495dceeeed44708'
 
 logging.basicConfig()
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5283

<!--
Briefly describe the feature if no issue exists for this PR
-->

Brought the python fake local invoke context up to greater parity with aws python runtime context based on the investigation in missing attributes and attribute value type mismatches mentioned in https://github.com/serverless/serverless/issues/5283#issuecomment-420510817

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I added two new property methods to invoke.py for the two attributes I was missing and corrected the value type of `memory_limit_in_mb` to match that of the aws lambda python runtime

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

You can essentially follow the same experiment here https://github.com/serverless/serverless/issues/5283#issuecomment-420510817

you can take the off the shelf aws lambda python3.6 runtime template and change it to output the attrs and value types defined on the context object

```python
def hello(event, context):
    return [(attr, str(type(getattr(context, attr)))) for attr in dir(context) if not attr.startswith('__')]
```

the compare the output of `serverless invoke local -f hello` vs `serverless invoke -f hello` ( after deploying it of course )

you should see that the value type of `memory_limit_in_mb` is now consistent and the attributes `log_group_name` and `log_stream_name` now exist in both contexts

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
