### PR TITLE
Update handler name when deploy a single function

### DIFF
--- a/docs/providers/aws/cli-reference/deploy-function.md
+++ b/docs/providers/aws/cli-reference/deploy-function.md
@@ -27,7 +27,7 @@ cycles and not production deployments
 - `--function` or `-f` The name of the function which should be deployed
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
-- `--update-config` or `-u` Pushes ONLY Lambda-level configuration changes e.g. timeout or memorySize
+- `--update-config` or `-u` Pushes ONLY Lambda-level configuration changes e.g. handler, timeout or memorySize
 
 ## Examples
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -128,6 +128,10 @@ class AwsDeployFunction {
     if ('description' in functionObj && !_.isObject(functionObj.description)) {
       params.Description = functionObj.description;
     }
+    
+    if ('handler' in functionObj && !_.isObject(functionObj.handler)) {
+      params.Handler = functionObj.handler;
+    }
 
     if ('memorySize' in functionObj && !_.isObject(functionObj.memorySize)) {
       params.MemorySize = functionObj.memorySize;

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -128,7 +128,7 @@ class AwsDeployFunction {
     if ('description' in functionObj && !_.isObject(functionObj.description)) {
       params.Description = functionObj.description;
     }
-    
+
     if ('handler' in functionObj && !_.isObject(functionObj.handler)) {
       params.Handler = functionObj.handler;
     }

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -218,6 +218,7 @@ describe('AwsDeployFunction', () => {
       options.functionObj = {
         awsKmsKeyArn: 'arn:aws:kms:us-east-1:123456789012',
         description: 'desc',
+        handler: 'my_handler',
         environment: {
           VARIABLE: 'value',
         },
@@ -245,6 +246,7 @@ describe('AwsDeployFunction', () => {
             DeadLetterConfig: {
               TargetArn: 'arn:aws:sqs:us-east-1:123456789012:dlq',
             },
+            Handler: 'my_handler',
             Description: 'desc',
             Environment: {
               Variables: {

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -293,6 +293,7 @@ describe('AwsDeployFunction', () => {
       options.functionObj = {
         name: 'first',
         description: 'change',
+        handler: 'my_handler',
         vpc: {
           securityGroupIds: ['xxxxx', {
             ref: 'myVPCRef',
@@ -318,6 +319,7 @@ describe('AwsDeployFunction', () => {
           'updateFunctionConfiguration',
           {
             FunctionName: 'first',
+            Handler: 'my_handler',
             Description: 'change',
           }
         )).to.be.equal(true);
@@ -359,6 +361,7 @@ describe('AwsDeployFunction', () => {
       () => {
         options.functionObj = {
           name: 'first',
+          handler: 'my_handler',
           description: 'change',
           environment: {
             COUNTER: 6,
@@ -374,6 +377,7 @@ describe('AwsDeployFunction', () => {
               'updateFunctionConfiguration',
               {
                 FunctionName: 'first',
+                Handler: 'my_handler',
                 Description: 'change',
                 Environment: {
                   Variables: {
@@ -388,6 +392,7 @@ describe('AwsDeployFunction', () => {
     it('should inherit provider-level config', () => {
       options.functionObj = {
         name: 'first',
+        handler: 'my_handler',
         description: 'change',
       };
 
@@ -410,6 +415,7 @@ describe('AwsDeployFunction', () => {
           'updateFunctionConfiguration',
           {
             FunctionName: 'first',
+            Handler: 'my_handler',
             Description: 'change',
             VpcConfig: {
               SubnetIds: [1234, 12345],


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
In this PR I fixed an issue (or a not implemented feature), according the function handler name of an AWS Lambda, while deploying a single function. (using `deploy -f / --function`)

Former to that fix, when deploying a single function even if you change the code and the handler file / handler method , changing the *handler name* in the `serverless.yml` was not affected.

(BTW other configuration such as memorySize, description,  timeout, etc.. are affected as expected)

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
As done for others configuration ( such as memorySize, description,  timeout, etc..)
while  `updateFunctionConfiguration() {...} ` in [/lib/plugins/aws/deployFunction/index.js](https://github.com/serverless/serverless/blob/cfc2ac81f50427e343673e9ed2e2be6cafa99097/lib/plugins/aws/deployFunction/index.js#L114) - I did implement the same logic to take the handler name from the functionObj and added it to params of the `callUpdateFunctionConfiguration` method
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

1. Deploy a simple sls stack with one function to aws.
2. Change the handler name in the `serverless.yml` (e.g to point on an other method)
3. Deploy this single function using `-f` / `--function` cmd line option.
4. Check in the AWS Lambda console that the new handler name appear in the configuration 

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
