### PR TITLE
[Docs] - Add support information for AWS lambda and SQS

### DIFF
--- a/docs/providers/aws/events/sqs.md
+++ b/docs/providers/aws/events/sqs.md
@@ -18,6 +18,8 @@ The ARN for the queue can be specified as a string, the reference to the ARN of 
 
 **Note:** The `sqs` event will hook up your existing SQS Queue to a Lambda function. Serverless won't create a new queue for you.
 
+**IMPORTANT:** AWS is [not supporting FIFO queue](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html) to trigger Lambda function so your queue(s) **must be** a standard queue.
+
 ```yml
 functions:
   compute:


### PR DESCRIPTION
From the AWS docs:
https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

it says:
> Amazon Simple Queue Service supports both Standard and FIFO queues. AWS Lambda supports only standard queues. For more information on the difference, see What Type of Queue Do I Need?

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
