### PR TITLE
Invoke local override env

### DIFF
--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -28,6 +28,7 @@ serverless invoke local --function functionName
 - `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
 - `--contextPath` or `-x`, The path to a json file holding input context to be passed to the invoked function. This path is relative to the root directory of the service.
 - `--context` or `-c`, String data to be passed as a context to your function. Same like with `--data`, context included in `--contextPath` will overwrite the context you passed with `--context` flag.
+* `--env` or `-e` String representing an environment variable to set when invoking your function, in the form `<name>=<value>`. Can be repeated for more than one environment variable.
 
 ## Environment
 
@@ -93,6 +94,16 @@ serverless invoke local --function functionName --context "hello world"
 serverless invoke local --function functionName --contextPath lib/context.json
 ```
 This example will pass the json context in the `lib/context.json` file (relative to the root of the service) while invoking the specified/deployed function.
+
+### Local function invocation, setting environment variables
+
+```bash
+serverless invoke local -f functionName -e VAR1=value1
+
+# Or more than one variable
+
+serverless invoke local -f functionName -e VAR1=value1 -e VAR2=value2
+```
 
 ### Limitations
 

--- a/docs/providers/google/cli-reference/invoke-local.md
+++ b/docs/providers/google/cli-reference/invoke-local.md
@@ -28,6 +28,7 @@ serverless invoke -f functionName
 * `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
 * `--contextPath` or `-x`, The path to a json file holding input context to be passed to the invoked function. This path is relative to the root directory of the service.
 * `--context` or `-c`, String data to be passed as a context to your function. Same like with `--data`, context included in `--contextPath` will overwrite the context you passed with `--context` flag.
+* `--env` or `-e` String representing an environment variable to set when invoking your function, in the form `<name>=<value>`. Can be repeated for more than one environment variable.
 
 > Keep in mind that if you pass both `--path` and `--data`, the data included in the `--path` file will overwrite the data you passed with the `--data` flag.
 
@@ -53,4 +54,14 @@ serverless invoke local -f functionName -p path/to/file.json
 # OR
 
 serverless invoke local -f functionName -p path/to/file.yaml
+```
+
+### Local function invocation, setting environment variables
+
+```bash
+serverless invoke local -f functionName -e VAR1=value1
+
+# Or more than one variable
+
+serverless invoke local -f functionName -e VAR1=value1 -e VAR2=value2
 ```

--- a/docs/providers/openwhisk/cli-reference/invoke-local.md
+++ b/docs/providers/openwhisk/cli-reference/invoke-local.md
@@ -25,6 +25,7 @@ __*Please note that only the JavaScript and Python runtimes are supported with t
 - `--function` or `-f` The name of the function in your service that you want to invoke locally. **Required**.
 - `--path` or `-p` The path to a json file holding input data to be passed to the invoked function. This path is relative to the root directory of the service. The json file should have event and context properties to hold your mocked event and context data.
 - `--data` or `-d` String data to be passed as an event to your function. Keep in mind that if you pass both `--path` and `--data`, the data included in the `--path` file will overwrite the data you passed with the `--data` flag.
+* `--env` or `-e` String representing an environment variable to set when invoking your function, in the form `<name>=<value>`. Can be repeated for more than one environment variable.
 
 ## Examples
 
@@ -59,6 +60,16 @@ serverless invoke local --function functionName --path lib/data.json
 ```
 
 This example will pass the json data in the `lib/data.json` file (relative to the root of the service) while invoking the specified/deployed function.
+
+### Local function invocation, setting environment variables
+
+```bash
+serverless invoke local -f functionName -e VAR1=value1
+
+# Or more than one variable
+
+serverless invoke local -f functionName -e VAR1=value1 -e VAR2=value2
+```
 
 ### Limitations
 

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -5,8 +5,9 @@ const _ = require('lodash');
 const userStats = require('../../utils/userStats');
 
 class Invoke {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options || {};
 
     this.commands = {
       invoke: {
@@ -81,6 +82,10 @@ class Invoke {
                 usage: 'Path to JSON or YAML file holding context data',
                 shortcut: 'x',
               },
+              env: {
+                usage: 'Override environment variables. e.g. --env VAR1=val1 --env VAR2=val2',
+                shortcut: 'e',
+              },
             },
           },
         },
@@ -113,6 +118,13 @@ class Invoke {
     };
 
     _.merge(process.env, defaultEnvVars);
+
+    // Turn zero or more --env options into an array
+    //   ...then split --env NAME=value and put into process.env.
+    Array.concat(this.options.env || []).forEach(itm => {
+      let split_itm = itm.split('=');
+      process.env[split_itm[0]] = split_itm[1] || '';
+    });
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -121,10 +121,11 @@ class Invoke {
 
     // Turn zero or more --env options into an array
     //   ...then split --env NAME=value and put into process.env.
-    Array.concat(this.options.env || []).forEach(itm => {
-      const splitItm = itm.split('=');
-      process.env[splitItm[0]] = splitItm[1] || '';
-    });
+    _.concat(this.options.env || [])
+      .forEach(itm => {
+        const splitItm = _.split(itm, '=');
+        process.env[splitItm[0]] = splitItm[1] || '';
+      });
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -122,8 +122,8 @@ class Invoke {
     // Turn zero or more --env options into an array
     //   ...then split --env NAME=value and put into process.env.
     Array.concat(this.options.env || []).forEach(itm => {
-      let split_itm = itm.split('=');
-      process.env[split_itm[0]] = split_itm[1] || '';
+      const splitItm = itm.split('=');
+      process.env[splitItm[0]] = splitItm[1] || '';
     });
 
     return BbPromise.resolve();

--- a/lib/plugins/invoke/invoke.test.js
+++ b/lib/plugins/invoke/invoke.test.js
@@ -41,6 +41,20 @@ describe('Invoke', () => {
         return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled
         .then(() => expect(process.env.IS_LOCAL).to.equal('true'));
       });
+
+      it('should accept a single env option', () => {
+        invoke.options = { env: 'NAME=value' };
+        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled
+        .then(() => expect(process.env.NAME).to.equal('value'));
+      });
+
+      it('should accept multiple env options', () => {
+        invoke.options = { env: ['NAME1=val1', 'NAME2=val2'] };
+
+        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled
+        .then(() => expect(process.env.NAME1).to.equal('val1'))
+        .then(() => expect(process.env.NAME2).to.equal('val2'));
+      });
     });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #5096 
 - sls invoke local should make it possible to override environment variables

## How did you implement it:

- Added --env option to `sls invoke local` to override environment vars in lib/plugins/invoke/invoke.js
  - Usage: --env NAME1=val1 --env NAME2=val2 ...

## How can we verify it:

Run:
`npm run test lib/plugins/invoke/`
`sls invoke local -f helloWorld ---env NAME1=val1 --env NAME2=val2`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
