### PR TITLE
Provide Consistent Service Path (Fix #5242)

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -475,13 +475,12 @@ class PluginManager {
         .concat(Object.keys(command.commands));
     });
 
-    const servicePath = this.serverless.config.servicePath || 'x';
-    return getServerlessConfigFile(servicePath)
+    return getServerlessConfigFile(this.serverless.config.servicePath)
       .then((serverlessConfigFile) => {
         const serverlessConfigFileHash = crypto.createHash('sha256')
           .update(JSON.stringify(serverlessConfigFile)).digest('hex');
         cacheFile.validationHash = serverlessConfigFileHash;
-        const cacheFilePath = getCacheFilePath(servicePath);
+        const cacheFilePath = getCacheFilePath(this.serverless.config.servicePath);
         return writeFile(cacheFilePath, cacheFile);
       })
       .catch((e) => null);  // eslint-disable-line

--- a/lib/plugins/lib/validate.js
+++ b/lib/plugins/lib/validate.js
@@ -5,7 +5,7 @@ const getServerlessConfigFile = require('../../utils/getServerlessConfigFile');
 
 module.exports = {
   validate() {
-    return getServerlessConfigFile(process.cwd()).then((result) => {
+    return getServerlessConfigFile(this.serverless.config.servicePath).then((result) => {
       const isRunInService = !!result;
 
       if (!isRunInService) {

--- a/lib/plugins/lib/validate.test.js
+++ b/lib/plugins/lib/validate.test.js
@@ -39,7 +39,8 @@ describe('#validate()', () => {
 
     return expect(serverlessPlugin.validate()).to.be.fulfilled.then(() => {
       expect(getServerlessConfigFileStub).to.have.been.calledOnce;
-      expect(getServerlessConfigFileStub).to.have.been.calledWithExactly(process.cwd());
+      expect(getServerlessConfigFileStub).to.have.been
+        .calledWithExactly(serverless.config.servicePath);
     });
   });
 });

--- a/lib/plugins/print/print.js
+++ b/lib/plugins/print/print.js
@@ -94,7 +94,7 @@ class Print {
     // the codebase.  Avoiding that, this method must read the serverless.yml file itself, adorn it
     // as the Service class would and then populate it, reversing the adornments thereafter in
     // preparation for printing the service for the user.
-    return getServerlessConfigFile(process.cwd())
+    return getServerlessConfigFile(this.serverless.config.servicePath)
       .then((svc) => {
         const service = svc;
         this.adorn(service);

--- a/lib/utils/autocomplete.js
+++ b/lib/utils/autocomplete.js
@@ -40,27 +40,22 @@ const cacheFileValid = (serverlessConfigFile, validationHash) => {
 };
 
 const autocomplete = () => {
-  let servicePath = process.cwd();
+  const servicePath = process.cwd();
   return getServerlessConfigFile(servicePath)
-    .then((serverlessConfigFile) => {
-      if (!serverlessConfigFile) {
-        servicePath = 'x';
-      }
-      return getCacheFile(servicePath)
-        .then((cacheFile) => {
-          if (!cacheFile || !cacheFileValid(serverlessConfigFile, cacheFile.validationHash)) {
-            const serverless = new Serverless();
-            return serverless.init().then(() => getCacheFile(servicePath));
-          }
-          return cacheFile;
-        })
-        .then((cacheFile) => {
-          if (!cacheFile || !cacheFileValid(serverlessConfigFile, cacheFile.validationHash)) {
-            return;
-          }
-          return getSuggestions(cacheFile.commands); // eslint-disable-line consistent-return
-        });
-    });
+    .then((serverlessConfigFile) => getCacheFile(servicePath)
+      .then((cacheFile) => {
+        if (!cacheFile || !cacheFileValid(serverlessConfigFile, cacheFile.validationHash)) {
+          const serverless = new Serverless();
+          return serverless.init().then(() => getCacheFile(servicePath));
+        }
+        return cacheFile;
+      })
+      .then((cacheFile) => {
+        if (!cacheFile || !cacheFileValid(serverlessConfigFile, cacheFile.validationHash)) {
+          return;
+        }
+        return getSuggestions(cacheFile.commands); // eslint-disable-line consistent-return
+      }));
 };
 
 module.exports = autocomplete;

--- a/lib/utils/getCacheFilePath.js
+++ b/lib/utils/getCacheFilePath.js
@@ -4,7 +4,8 @@ const homedir = require('os').homedir();
 const path = require('path');
 const crypto = require('crypto');
 
-const getCacheFilePath = function (servicePath) {
+const getCacheFilePath = function (srvcPath) {
+  const servicePath = srvcPath || process.cwd();
   const servicePathHash = crypto.createHash('sha256').update(servicePath).digest('hex');
   return path.join(homedir, '.serverless', 'cache', servicePathHash, 'autocomplete.json');
 };

--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -6,7 +6,8 @@ const path = require('path');
 const fileExists = require('./fs/fileExists');
 const readFile = require('./fs/readFile');
 
-const getServerlessConfigFile = _.memoize((servicePath) => {
+const getServerlessConfigFile = _.memoize((srvcPath) => {
+  const servicePath = srvcPath || process.cwd();
   const jsonPath = path.join(servicePath, 'serverless.json');
   const ymlPath = path.join(servicePath, 'serverless.yml');
   const yamlPath = path.join(servicePath, 'serverless.yaml');

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -81,6 +81,7 @@ describe('#getServerlessConfigFile()', () => {
     const cwd = process.cwd();
     process.chdir(tmpDirPath);
     return expect(getServerlessConfigFile()).to.be.fulfilled
+      .then(result => result)
       .catch((ex) => {
         process.chdir(cwd);
         throw ex

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -84,10 +84,10 @@ describe('#getServerlessConfigFile()', () => {
       .then(result => result)
       .catch((ex) => {
         process.chdir(cwd);
-        throw ex
+        throw ex;
       })
       .then((result) => {
-        expect(result).to.deep.equal({service: 'my-yml-service'});
+        expect(result).to.deep.equal({ service: 'my-yml-service' });
       });
-  })
+  });
 });

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -73,4 +73,20 @@ describe('#getServerlessConfigFile()', () => {
     return expect(getServerlessConfigFile(tmpDirPath))
       .to.be.rejectedWith('serverless.js must export plain object');
   });
+
+  it('should look in the current working directory if servicePath is undefined', () => {
+    const serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
+
+    writeFileSync(serverlessFilePath, 'service: my-yml-service');
+    const cwd = process.cwd();
+    process.chdir(tmpDirPath);
+    return expect(getServerlessConfigFile()).to.be.fulfilled
+      .catch((ex) => {
+        process.chdir(cwd);
+        throw ex
+      })
+      .then((result) => {
+        expect(result).to.deep.equal({service: 'my-yml-service'});
+      });
+  })
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -780,7 +780,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -889,7 +889,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -918,7 +918,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -1571,7 +1571,7 @@
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -1579,7 +1579,7 @@
     },
     "commander": {
       "version": "2.8.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "requires": {
         "graceful-readlink": ">= 1.0.0"
@@ -2425,7 +2425,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2438,7 +2438,7 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
@@ -2705,7 +2705,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "~1.3.5",
@@ -2836,7 +2836,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "requires": {
         "extend": "^3.0.0",
@@ -3769,7 +3769,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -4036,7 +4036,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -4172,7 +4172,7 @@
     },
     "inquirer": {
       "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -4198,7 +4198,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -4438,7 +4438,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
@@ -5359,7 +5359,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -5416,7 +5416,7 @@
         },
         "es6-promise": {
           "version": "3.0.2",
-          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
           "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
           "dev": true
         },
@@ -5428,7 +5428,7 @@
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
@@ -5572,7 +5572,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -5680,7 +5680,7 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
@@ -5927,7 +5927,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -5953,7 +5953,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -5961,7 +5961,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -5987,7 +5987,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -6358,7 +6358,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opn": {
@@ -6381,7 +6381,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -6878,7 +6878,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -7511,7 +7511,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "seek-bzip": {
@@ -7658,7 +7658,7 @@
     },
     "sinon": {
       "version": "1.17.7",
-      "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
@@ -8109,7 +8109,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -8145,7 +8145,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8277,7 +8277,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {
@@ -8877,7 +8877,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fix #5242

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Do this by first supplying the `servicePath` in `~/lib/plugins/lib/validate.js` and `~/lib/plugins/print.js` in a consistent manner with the code in `~/lib/classes/PluginManager.js`.  Then, provide a default of `process.cwd()` for `servicePath` in `getCacheFilePath` and `getServerlessConfigFile`.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

As per #5242, this bug impacts the execution of Serverless with a `servicePath` that is not the current working directory.  One could re-create this circumstance.

I have offered a new test to validate this behavior in `getServerlessConfigFile.test.js`, the corresponding change in `getCacheFilePath.js` seemed too trivial to warrant the code.  Can provide that too if desired.

Paging @eahefnawy as per discussion in issue #5242 

## Todos:

- [x] Write tests
- [n/a] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
