### PR TITLE
Add Support for Shorthand CloudFormation Syntax

### DIFF
--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -24,7 +24,7 @@ const functionNames = [
 ];
 
 const yamlType = (name, kind) => {
-  const functionName = ['Ref', 'Condition'].includes(name) ? name : `Fn::${name}`;
+  const functionName = _.includes(['Ref', 'Condition'], name) ? name : `Fn::${name}`;
   return new YAML.Type(`!${name}`, {
     kind,
     construct: data => {

--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const YAML = require('js-yaml');
+const _ = require('lodash');
+
+const functionNames = [
+  'And',
+  'Base64',
+  'Cidr',
+  'Condition',
+  'Equals',
+  'FindInMap',
+  'GetAtt',
+  'GetAZs',
+  'If',
+  'ImportValue',
+  'Join',
+  'Not',
+  'Or',
+  'Ref',
+  'Select',
+  'Split',
+  'Sub',
+];
+
+const yamlType = (name, kind) => {
+  const functionName = ['Ref', 'Condition'].includes(name) ? name : `Fn::${name}`;
+  return new YAML.Type(`!${name}`, {
+    kind,
+    construct: data => {
+      if (name === 'GetAtt') {
+        // special GetAtt dot syntax
+        return { [functionName]: _.isString(data) ? _.split(data, '.', 2) : data };
+      }
+      return { [functionName]: data };
+    },
+  });
+};
+
+const createSchema = () => {
+  const types = _.flatten(
+    _.map(functionNames, functionName =>
+      _.map(['mapping', 'scalar', 'sequence'], kind => yamlType(functionName, kind))
+    )
+  );
+  return YAML.Schema.create(types);
+};
+
+module.exports = {
+  schema: createSchema(),
+};

--- a/lib/plugins/aws/lib/cloudformationSchema.test.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const { schema } = require('./cloudformationSchema');
+
+describe('#cloudformationSchame()', () => {
+  describe('#schema()', () => {
+    it('should contain schema', () => {
+      expect(Object.keys(schema)).to.be.eql([
+        'include',
+        'implicit',
+        'explicit',
+        'compiledImplicit',
+        'compiledExplicit',
+        'compiledTypeMap',
+      ]);
+    });
+  });
+});

--- a/lib/plugins/aws/lib/cloudformationSchema.test.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.test.js
@@ -2,12 +2,12 @@
 
 const expect = require('chai').expect;
 
-const { schema } = require('./cloudformationSchema');
+const cloudformationSchema = require('./cloudformationSchema');
 
 describe('#cloudformationSchame()', () => {
   describe('#schema()', () => {
     it('should contain schema', () => {
-      expect(Object.keys(schema)).to.be.eql([
+      expect(Object.keys(cloudformationSchema.schema)).to.be.eql([
         'include',
         'implicit',
         'explicit',

--- a/lib/utils/fs/parse.js
+++ b/lib/utils/fs/parse.js
@@ -3,39 +3,17 @@
 const jc = require('json-cycle');
 const YAML = require('js-yaml');
 const _ = require('lodash');
+const cloudFormationSchema = require('../../plugins/aws/lib/cloudformationSchema');
 
-const functionNames = [
-  'And',
-  'Base64',
-  'Cidr',
-  'Condition',
-  'Equals',
-  'FindInMap',
-  'GetAtt',
-  'GetAZs',
-  'If',
-  'ImportValue',
-  'Join',
-  'Not',
-  'Or',
-  'Ref',
-  'Select',
-  'Split',
-  'Sub',
-];
-
-const yamlType = (name, kind) => {
-  const functionName = ['Ref', 'Condition'].includes(name) ? name : `Fn::${name}`;
-  return new YAML.Type(`!${name}`, {
-    kind,
-    construct: data => {
-      if (name === 'GetAtt') {
-        // special GetAtt dot syntax
-        return { [functionName]: _.isString(data) ? _.split(data, '.', 2) : data };
-      }
-      return { [functionName]: data };
-    },
-  });
+const loadYaml = (contents, options) => {
+  let data;
+  let error;
+  try {
+    data = YAML.load(contents.toString(), options || {});
+  } catch (exception) {
+    error = exception;
+  }
+  return { data, error };
 };
 
 function parse(filePath, contents) {
@@ -43,15 +21,18 @@ function parse(filePath, contents) {
   if (filePath.endsWith('.json')) {
     return jc.parse(contents);
   } else if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
-    const types = _.flatten(
-      _.map(functionNames, functionName =>
-        _.map(['mapping', 'scalar', 'sequence'], kind => yamlType(functionName, kind))
-      )
-    );
-    return YAML.load(contents.toString(), {
+    const options = {
       filename: filePath,
-      schema: YAML.Schema.create(types),
-    });
+    };
+    let result = loadYaml(contents.toString(), options);
+    if (result.error && result.error.name === 'YAMLException') {
+      _.merge(options, { schema: cloudFormationSchema.schema });
+      result = loadYaml(contents.toString(), options);
+    }
+    if (result.error) {
+      throw result.error;
+    }
+    return result.data;
   }
   return contents.toString().trim();
 }

--- a/lib/utils/fs/parse.js
+++ b/lib/utils/fs/parse.js
@@ -2,13 +2,56 @@
 
 const jc = require('json-cycle');
 const YAML = require('js-yaml');
+const _ = require('lodash');
+
+const functionNames = [
+  'And',
+  'Base64',
+  'Cidr',
+  'Condition',
+  'Equals',
+  'FindInMap',
+  'GetAtt',
+  'GetAZs',
+  'If',
+  'ImportValue',
+  'Join',
+  'Not',
+  'Or',
+  'Ref',
+  'Select',
+  'Split',
+  'Sub',
+];
+
+const yamlType = (name, kind) => {
+  const functionName = ['Ref', 'Condition'].includes(name) ? name : `Fn::${name}`;
+  return new YAML.Type(`!${name}`, {
+    kind,
+    construct: data => {
+      if (name === 'GetAtt') {
+        // special GetAtt dot syntax
+        return { [functionName]: _.isString(data) ? _.split(data, '.', 2) : data };
+      }
+      return { [functionName]: data };
+    },
+  });
+};
 
 function parse(filePath, contents) {
   // Auto-parse JSON
   if (filePath.endsWith('.json')) {
     return jc.parse(contents);
   } else if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
-    return YAML.load(contents.toString(), { filename: filePath });
+    const types = _.flatten(
+      _.map(functionNames, functionName =>
+        _.map(['mapping', 'scalar', 'sequence'], kind => yamlType(functionName, kind))
+      )
+    );
+    return YAML.load(contents.toString(), {
+      filename: filePath,
+      schema: YAML.Schema.create(types),
+    });
   }
   return contents.toString().trim();
 }

--- a/lib/utils/fs/parse.test.js
+++ b/lib/utils/fs/parse.test.js
@@ -111,4 +111,36 @@ describe('#parse()', () => {
       expect(obj).to.eql(shortHandOption.json);
     });
   });
+
+
+  it('should parse YAML without shorthand syntax', () => {
+    const tmpFilePath = 'anything.yml';
+    const fileContents = 'Item:\n  Fn::Join:\n  - ""\n  - - "arn:aws:s3::"\n    - !Ref MyBucket';
+    const obj = parse(tmpFilePath, fileContents);
+    expect(obj).to.eql({
+      Item: {
+        'Fn::Join': [
+          '',
+          [
+            'arn:aws:s3::',
+            {
+              Ref: 'MyBucket',
+            },
+          ],
+        ],
+      },
+    });
+  });
+
+  it('should throw error with invalid shorthand syntax', () => {
+    const tmpFilePath = 'anything.yml';
+    const fileContents = 'Item:\n  !Invalid\n- ""\n- - "arn:aws:s3::"\n  - !Ref MyBucket';
+    let obj;
+    try {
+      obj = parse(tmpFilePath, fileContents);
+    } catch (exception) {
+      expect(exception.name).to.be.equal('YAMLException');
+    }
+    expect(obj).to.be.equal(undefined);
+  });
 });

--- a/lib/utils/fs/parse.test.js
+++ b/lib/utils/fs/parse.test.js
@@ -8,6 +8,82 @@ chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
+const shortHandOptions = [
+  {
+    name: 'Ref',
+    yaml: 'Item: !Ref OtherItem',
+    json: { Item: { Ref: 'OtherItem' } },
+  },
+  {
+    name: 'GetAtt, dot syntax',
+    yaml: 'Item: !GetAtt MyResource.Arn',
+    json: { Item: { 'Fn::GetAtt': ['MyResource', 'Arn'] } },
+  },
+  {
+    name: 'GetAtt, array syntax',
+    yaml: 'Item: !GetAtt\n- MyResource\n- Arn',
+    json: { Item: { 'Fn::GetAtt': ['MyResource', 'Arn'] } },
+  },
+  {
+    name: 'Base64',
+    yaml: 'Item: !Base64 valueToEncode',
+    json: { Item: { 'Fn::Base64': 'valueToEncode' } },
+  },
+  {
+    name: 'Sub, without mapping',
+    yaml: 'Item: !Sub "My.${AWS::Region}"',
+    json: { Item: { 'Fn::Sub': 'My.${AWS::Region}' } },
+  },
+  {
+    name: 'Sub, with mapping',
+    yaml: 'Item: !Sub\n- www.${Domain}\n- { Domain: "serverless.com" }',
+    json: {
+      Item: {
+        'Fn::Sub': [
+          'www.${Domain}',
+          {
+            Domain: 'serverless.com',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'Join, oneliner',
+    yaml: 'Item: !Join ["", ["arn:aws:s3::", { Ref: MyBucket }]]',
+    json: {
+      Item: {
+        'Fn::Join': [
+          '',
+          [
+            'arn:aws:s3::',
+            {
+              Ref: 'MyBucket',
+            },
+          ],
+        ],
+      },
+    },
+  },
+  {
+    name: 'Join, multiline',
+    yaml: 'Item: !Join\n- ""\n- - "arn:aws:s3::"\n  - !Ref MyBucket',
+    json: {
+      Item: {
+        'Fn::Join': [
+          '',
+          [
+            'arn:aws:s3::',
+            {
+              Ref: 'MyBucket',
+            },
+          ],
+        ],
+      },
+    },
+  },
+];
+
 describe('#parse()', () => {
   it('should reconstitute circular references', () => {
     const tmpFilePath = 'anything.json';
@@ -16,5 +92,23 @@ describe('#parse()', () => {
     const obj = parse(tmpFilePath, fileContents);
 
     expect(obj).to.equal(obj.foo);
+  });
+
+  it('should return contents of a non json or yaml file as a string', () => {
+    const tmpFilePath = 'anything.txt';
+    const fileContents = 'serverless';
+
+    const obj = parse(tmpFilePath, fileContents);
+
+    expect(obj).to.equal('serverless');
+  });
+
+  shortHandOptions.forEach(shortHandOption => {
+    it(`should convert shorthand syntax "${shortHandOption.name}"`, () => {
+      const tmpFilePath = 'anything.yml';
+      const fileContents = shortHandOption.yaml;
+      const obj = parse(tmpFilePath, fileContents);
+      expect(obj).to.eql(shortHandOption.json);
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This PR adds support for shorthand CloudFormation syntax, e.g. `!Ref`, `!GetAtt` and !Join.

This should not be a breaking change, least I don't know any cases where `!Something` syntax is used in serverless.yml.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

This feature leverages `js-yaml` module's custom schema.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

```yaml
service: shorthand-cf

provider:
  name: aws
  runtime: nodejs6.10
  iamRoleStatements:
    - Effect: "Allow"
      Action:
        - "kms:Decrypt"
      Resource: !Join
        - ":"
        - - "arn:aws:kms"
          - !Ref AWS::Region
          - !Ref AWS::AccountId
          - ":key/CMK_key_ID"
    - Effect: "Allow"
      Action:
        - "s3:*"
      Resource:
        - !Join
          - ":"
          - - "arn:aws:s3::"
            - !Ref "MyBucket"
        - !Join
          - ":"
          - - "arn:aws:s3::"
            - !Ref "MyBucket"
            - "/*"

functions:
  hello:
    handler: handler.hello

resources:
  Conditions:
    AndCondition: !And 
      - !Not [!Equals ["prod", "${opt:stage, self:provider.stage}"]]
      - !Not [!Equals ["staging", "${opt:stage, self:provider.stage}"]]

  Resources:
    MyBucket:
      Type: AWS::S3::Bucket
      Properties:
        Tags:
          - Key: FruitTag # fruit tag is the most obvious use case
            Value: !Select [ !If [AndCondition, "0", "1"], [ "apples", "grapes" ] ]

  Outputs:
    BucketName:
      Description: "My bucket name"
      Value: !Ref MyBucket
    BucketArn:
      Description: "My Bucket arn"
      Value: !GetAtt MyBucket.Arn
```

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
