### PR TITLE
Add CacheControl headers on the OPTIONS response in AWS API Gateway

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -246,6 +246,31 @@ functions:
             maxAge: 86400
 ```
 
+If you are using CloudFront or another CDN for your API Gateway, you may want to setup a `Cache-Control` header to allow for OPTIONS request to be cached to avoid the additional hop.  
+
+To enable the `Cache-Control` header on preflight response, set the `cacheControl` property in the `cors` object:
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          path: hello
+          method: get
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+            allowCredentials: false
+            cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate' # Caches on browser and proxy for 10 minutes and doesnt allow proxy to serve out of date content
+```
+
 If you want to use CORS with the lambda-proxy integration, remember to include the `Access-Control-Allow-*` headers in your headers object, like this:
 
 ```javascript

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -33,7 +33,7 @@ module.exports = {
           throw new this.serverless.classes.Error(errorMessage);
         }
       }
-      
+
       // Allow Cache-Control header if set
       if (_.has(config, 'cacheControl')) {
         preflightHeaders['Cache-Control'] = `'${config.cacheControl}'`;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -33,6 +33,11 @@ module.exports = {
           throw new this.serverless.classes.Error(errorMessage);
         }
       }
+      
+      // Allow Cache-Control header if set
+      if (_.has(config, 'cacheControl')) {
+        preflightHeaders['Cache-Control'] = `'${config.cacheControl}'`;
+      }
 
       if (_.includes(config.methods, 'ANY')) {
         preflightHeaders['Access-Control-Allow-Methods'] =

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -68,7 +68,7 @@ describe('#compileCors()', () => {
         methods: ['OPTIONS', 'PUT'],
         allowCredentials: false,
         maxAge: 86400,
-        cacheControl: 'max-age=600, s-maxage-600',
+        cacheControl: 'max-age=600, s-maxage=600',
       },
       'users/create': {
         origins: ['*', 'http://example.com'],
@@ -76,7 +76,7 @@ describe('#compileCors()', () => {
         methods: ['OPTIONS', 'POST'],
         allowCredentials: true,
         maxAge: 86400,
-        cacheControl: 'max-age=600, s-maxage-600',
+        cacheControl: 'max-age=600, s-maxage=600',
       },
       'users/delete': {
         origins: ['*'],
@@ -84,7 +84,7 @@ describe('#compileCors()', () => {
         methods: ['OPTIONS', 'DELETE'],
         allowCredentials: false,
         maxAge: 86400,
-        cacheControl: 'max-age=600, s-maxage-600',
+        cacheControl: 'max-age=600, s-maxage=600',
       },
       'users/any': {
         origins: ['http://example.com'],
@@ -135,7 +135,7 @@ describe('#compileCors()', () => {
           .Resources.ApiGatewayMethodUsersCreateOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Cache-Control']
-      ).to.equal('\'max-age=600, s-maxage-600\'');
+      ).to.equal('\'max-age=600, s-maxage=600\'');
 
       // users/update
       expect(
@@ -171,7 +171,7 @@ describe('#compileCors()', () => {
           .Resources.ApiGatewayMethodUsersUpdateOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Cache-Control']
-      ).to.equal('\'max-age=600, s-maxage-600\'');
+      ).to.equal('\'max-age=600, s-maxage=600\'');
 
       // users/delete
       expect(
@@ -214,7 +214,7 @@ describe('#compileCors()', () => {
           .Resources.ApiGatewayMethodUsersDeleteOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Cache-Control']
-      ).to.equal('\'max-age=600, s-maxage-600\'');
+      ).to.equal('\'max-age=600, s-maxage=600\'');
 
       // users/any
       expect(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -68,6 +68,7 @@ describe('#compileCors()', () => {
         methods: ['OPTIONS', 'PUT'],
         allowCredentials: false,
         maxAge: 86400,
+        cacheControl: 'max-age=600, s-maxage-600',
       },
       'users/create': {
         origins: ['*', 'http://example.com'],
@@ -75,6 +76,7 @@ describe('#compileCors()', () => {
         methods: ['OPTIONS', 'POST'],
         allowCredentials: true,
         maxAge: 86400,
+        cacheControl: 'max-age=600, s-maxage-600',
       },
       'users/delete': {
         origins: ['*'],
@@ -82,6 +84,7 @@ describe('#compileCors()', () => {
         methods: ['OPTIONS', 'DELETE'],
         allowCredentials: false,
         maxAge: 86400,
+        cacheControl: 'max-age=600, s-maxage-600',
       },
       'users/any': {
         origins: ['http://example.com'],
@@ -127,6 +130,13 @@ describe('#compileCors()', () => {
           .ResponseParameters['method.response.header.Access-Control-Max-Age']
       ).to.equal('\'86400\'');
 
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreateOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Cache-Control']
+      ).to.equal('\'max-age=600, s-maxage-600\'');
+
       // users/update
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -155,6 +165,13 @@ describe('#compileCors()', () => {
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Max-Age']
       ).to.equal('\'86400\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersUpdateOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Cache-Control']
+      ).to.equal('\'max-age=600, s-maxage-600\'');
 
       // users/delete
       expect(
@@ -191,6 +208,13 @@ describe('#compileCors()', () => {
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Max-Age']
       ).to.equal('\'86400\'');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersDeleteOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Cache-Control']
+      ).to.equal('\'max-age=600, s-maxage-600\'');
 
       // users/any
       expect(


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5326

## How did you implement it:


Added a conditional check when cacheControl property is present on a cors property for a function, it will add the value as the header for the response.  This was only built for AWS API Gateway.

## How can we verify it:

I have modified https://github.com/serverless/examples/tree/master/aws-node-simple-http-endpoint example to include the cors change.  The cacheControl property is the only new thing that I added.

### sample serverless.yml

```

service: serverless-simple-http-endpoint

frameworkVersion: ">=1.1.0 <2.0.0"

provider:
  name: aws
  runtime: nodejs4.3

functions:
  currentTime:
    handler: handler.endpoint
    events:
      - http:
          path: ping
          method: get
          cors:
            origin: '*'
            allowCredentials: true
            cacheControl: 'max-age=600, s-maxage=600'
            maxAge: 600
            headers:
              - Content-Type
              - X-Amz-Date
              - Authorization
              - X-Api-Key
              - X-Amz-Security-Token
              - X-Amz-User-Agent
              - Cache-Control
```

## Todos:

- [X] Write tests
- [x] Write documentation
- [X] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
