### PR TITLE
Add Ability to Run CLI in Parallel

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -50,6 +50,39 @@ class Serverless {
     this.serverlessDirPath = path.join(os.homedir(), '.serverless');
   }
 
+  /**
+   * Determine where the artifact is being created
+   * order is
+   * 1. command line switch (--package)
+   * 2. serverless.yml
+   * 3. default (local directory)
+   * 4. user home directory
+   */
+  getArtifactPath() {
+    const serviceLocalPath = this.config && this.config.servicePath ?
+      path.join(this.config.servicePath, '.serverless') : undefined;
+
+    const packageSwitch = this.processedInput && this.processedInput.options ?
+      this.processedInput.options.package : undefined;
+
+    const servicePackagePath = this.service && this.service.package ?
+      this.service.package.path : undefined;
+
+    return packageSwitch ||
+      servicePackagePath ||
+      serviceLocalPath ||
+      this.serverlessDirPath;
+  }
+
+
+  /**
+   * Flag indicating user passed a package path
+   */
+  userProvidedPackagePath() {
+    return !!(this.processedInput && this.processedInput.options &&
+      this.processedInput.options.package);
+  }
+
   init() {
     // create a new CLI instance
     this.cli = new this.classes.CLI(this);

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -283,4 +283,52 @@ describe('Serverless', () => {
       expect(semverRegex().test(serverless.getVersion())).to.equal(true);
     });
   });
+
+  describe('#getArtifactPath()', () => {
+    it('should return user home dir artifact path', () => {
+      expect(serverless.getArtifactPath()).to.match(/\.serverless/);
+    });
+    it('should return service artifact path', () => {
+      serverless.config = {
+        servicePath: 'servicePath',
+      };
+      expect(serverless.getArtifactPath()).to.equal(path.join('servicePath', '.serverless'));
+    });
+    it('should return artifact path from serverless.yml', () => {
+      serverless.service = {
+        package: {
+          path: '1/2/3/4',
+        },
+      };
+      expect(serverless.getArtifactPath()).to.equal('1/2/3/4');
+    });
+    it('should return artifact path from command line', () => {
+      serverless.processedInput = {
+        options: {
+          package: '5/6/7/8',
+        },
+      };
+      serverless.service = {
+        package: {
+          path: '1/2/3/4',
+        },
+      };
+      expect(serverless.getArtifactPath()).to.equal('5/6/7/8');
+    });
+  });
+
+  describe('#userProvidedPackagePath', () => {
+    it('should return false', () => {
+      expect(serverless.userProvidedPackagePath()).to.be.equal(false);
+    });
+
+    it('should return true', () => {
+      serverless.processedInput = {
+        options: {
+          package: '5/6/7/8',
+        },
+      };
+      expect(serverless.userProvidedPackagePath()).to.be.equal(true);
+    });
+  });
 });

--- a/lib/plugins/aws/common/lib/artifacts.js
+++ b/lib/plugins/aws/common/lib/artifacts.js
@@ -34,18 +34,19 @@ module.exports = {
       path.join(this.serverless.config.servicePath || '.', '.serverless');
 
     // Only move the artifacts if it was requested by the user
-    if (this.serverless.config.servicePath && !_.endsWith(packagePath, '.serverless')) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    if (!this.serverless.userProvidedPackagePath()) {
+      if (this.serverless.config.servicePath && !_.endsWith(packagePath, '.serverless')) {
+        const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
 
-      if (this.serverless.utils.dirExistsSync(packagePath)) {
-        if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
-          fse.removeSync(serverlessTmpDirPath);
+        if (this.serverless.utils.dirExistsSync(packagePath)) {
+          if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
+            fse.removeSync(serverlessTmpDirPath);
+          }
+          this.serverless.utils.writeFileDir(serverlessTmpDirPath);
+          this.serverless.utils.copyDirContentsSync(packagePath, serverlessTmpDirPath);
         }
-        this.serverless.utils.writeFileDir(serverlessTmpDirPath);
-        this.serverless.utils.copyDirContentsSync(packagePath, serverlessTmpDirPath);
       }
     }
-
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/lib/plugins/aws/common/lib/artifacts.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const path = require('path');
 const fse = require('fs-extra');
 const AWSCommon = require('../index');
@@ -177,6 +178,34 @@ describe('#moveArtifactsToTemp()', () => {
     return awsCommon.moveArtifactsToTemp().then(() => {
       expect(serverless.utils.dirExistsSync(moveServerlessPath)).to.be.equal(true);
       expect(serverless.utils.fileExistsSync(testFileSource)).to.be.equal(true);
+    });
+  });
+
+  it('should not moveArtifactsToTemp', (done) => {
+    sinon.stub(serverless, 'userProvidedPackagePath').returns(true);
+    const dirExistsSyncStub = sinon.stub(serverless.utils, 'dirExistsSync');
+
+    awsCommon.moveArtifactsToTemp().then(() => {
+      expect(dirExistsSyncStub.calledOnce).to.be.equal(false);
+      done();
+    });
+  });
+
+  it('should moveArtifactsToTemp', (done) => {
+    serverless.config = {
+      servicePath: 'a/b/c',
+    };
+    serverless.service = {
+      package: {
+        path: 'a/b/c',
+      },
+    };
+    sinon.stub(serverless, 'userProvidedPackagePath').returns(false);
+    const dirExistsSyncStub = sinon.stub(serverless.utils, 'dirExistsSync');
+
+    awsCommon.moveArtifactsToTemp().then(() => {
+      expect(dirExistsSyncStub.calledOnce).to.be.equal(true);
+      done();
     });
   });
 });

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -12,7 +12,6 @@ const validateTemplate = require('./lib/validateTemplate');
 const createDeployment = require('./lib/createDeployment');
 const updateStack = require('../lib/updateStack');
 const existsDeploymentBucket = require('./lib/existsDeploymentBucket');
-const path = require('path');
 
 class AwsDeploy {
   constructor(serverless, options) {
@@ -21,8 +20,7 @@ class AwsDeploy {
     this.provider = this.serverless.getProvider('aws');
     this.servicePath = this.serverless.config.servicePath || '';
     this.packagePath = this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.servicePath, '.serverless');
+      serverless.getArtifactPath();
 
     Object.assign(
       this,

--- a/lib/plugins/aws/deploy/lib/createDeployment.js
+++ b/lib/plugins/aws/deploy/lib/createDeployment.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
 const platform = require('@serverless/platform-sdk');
 const BbPromise = require('bluebird');
 const getAccessKey = require('../../../../utils/getAccessKey');
+const fs = require('fs');
 
 module.exports = {
   createDeployment() {
     const serverlessStateFilePath = path.join(
-      this.serverless.config.servicePath, '.serverless', 'serverless-state.json');
+      this.serverless.getArtifactPath(), 'serverless-state.json');
     const serverlessStateFileContent = JSON.parse(fs.readFileSync(serverlessStateFilePath, 'utf8'));
 
     return getAccessKey(this.serverless.service.tenant).then(accessKey => {

--- a/lib/plugins/aws/deploy/lib/createDeployment.test.js
+++ b/lib/plugins/aws/deploy/lib/createDeployment.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai');
+const sinon = require('sinon');
+const path = require('path');
+const AwsProvider = require('../../provider/awsProvider');
+const AwsDeploy = require('../index');
+const Serverless = require('../../../../Serverless');
+const testUtils = require('../../../../../tests/utils');
+const platform = require('@serverless/platform-sdk');
+const fs = require('fs');
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
+
+describe('createDeployment', () => {
+  let awsDeploy;
+  let serverless;
+  const tmpDirPath = testUtils.getTmpDirPath();
+
+  const serverlessYmlPath = path.join(tmpDirPath, 'serverless.yml');
+  const serverlessYml = {
+    service: 'first-service',
+    provider: 'aws',
+    functions: {
+      first: {
+        handler: 'sample.handler',
+      },
+    },
+  };
+  const stateFileMock = {
+    service: serverlessYml,
+    package: {
+      individually: true,
+      artifactDirectoryName: 'some/path',
+      artifact: '',
+    },
+  };
+
+  beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
+    serverless.config.servicePath = tmpDirPath;
+    awsDeploy = new AwsDeploy(serverless, options);
+    awsDeploy.serverless.service.service = `service-${(new Date()).getTime().toString()}`;
+    awsDeploy.serverless.cli = {
+      log: sinon.spy(),
+    };
+  });
+
+
+  describe('#createDeployment', () => {
+    let fileExistsSyncStub;
+    let platformStub;
+    let getArtifactPathSpy;
+    let fsStub;
+
+    beforeEach(() => {
+      fileExistsSyncStub = sinon
+        .stub(awsDeploy.serverless.utils, 'fileExistsSync');
+      awsDeploy.serverless.service.package.individually = false;
+      platformStub = sinon.stub(platform, 'createDeployment').resolves({ id: 'abc123' });
+      getArtifactPathSpy = sinon.spy(serverless, 'getArtifactPath');
+      stateFileMock.service.functions = {};
+      fileExistsSyncStub.returns(true);
+      fsStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify(stateFileMock));
+    });
+
+    afterEach(() => {
+      fileExistsSyncStub.restore();
+      platformStub.restore();
+      getArtifactPathSpy.restore();
+      fsStub.restore();
+    });
+
+    it('should call createDeployment', () => {
+      process.env.SERVERLESS_ACCESS_KEY = 'abc123';
+
+      awsDeploy.serverless.service.tenant = 'aws';
+      awsDeploy.serverless.service.app = 'myService';
+
+      awsDeploy.createDeployment()
+        .then(() => {
+          expect(getArtifactPathSpy.calledOnce).to.equal(true);
+          expect(platformStub.calledOnce).to.equal(true);
+        });
+      process.env.SERVERLESS_ACCESS_KEY = undefined;
+    });
+
+    it('should not create a deployment', () => {
+      awsDeploy.createDeployment()
+        .then(() => {
+          expect(getArtifactPathSpy.calledOnce).to.equal(true);
+          expect(platformStub.calledOnce).to.equal(false);
+        });
+    });
+  });
+});

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -9,9 +9,8 @@ module.exports = {
   extendedValidate() {
     // Restore state
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
-    const serviceStateFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless',
-      serviceStateFileName);
+    const serviceStateFilePath = path.join(
+      this.serverless.getArtifactPath(), serviceStateFileName);
     if (!this.serverless.utils.fileExistsSync(serviceStateFilePath)) {
       throw new this.serverless.classes
         .Error(`No ${serviceStateFileName} file found in the package path you provided.`);
@@ -27,7 +26,7 @@ module.exports = {
     // only restore the default artifact path if the user is not using a custom path
     if (!_.isEmpty(state.package.artifact) && this.serverless.service.artifact) {
       this.serverless.service.package.artifact = path
-        .join(this.serverless.config.servicePath, '.serverless', state.package.artifact);
+        .join(this.serverless.getArtifactPath(), state.package.artifact);
     }
 
     // Check function's attached to API Gateway timeout

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -10,7 +10,7 @@ const BbPromise = require('bluebird');
 const filesize = require('filesize');
 const normalizeFiles = require('../../lib/normalizeFiles');
 
-const NUM_CONCURRENT_UPLOADS = 3;
+const NUM_CONCURRENT_UPLOADS = 4;
 
 module.exports = {
   uploadArtifacts() {
@@ -102,7 +102,6 @@ module.exports = {
         return artifactFilePath;
       })
     );
-
     return BbPromise.map(artifactFilePaths, (artifactFilePath) => {
       const stats = fs.statSync(artifactFilePath);
       this.serverless.cli.log(`Uploading service .zip file to S3 (${filesize(stats.size)})...`);

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -83,8 +83,7 @@ class AwsCompileFunctions {
         artifactFileName = functionArtifactFileName;
       }
 
-      artifactFilePath = path.join(this.serverless.config.servicePath
-        , '.serverless', artifactFileName);
+      artifactFilePath = path.join(this.serverless.getArtifactPath(), artifactFileName);
     }
 
     if (this.serverless.service.package.deploymentBucket) {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -77,8 +77,7 @@ module.exports = {
 
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();
 
-    const coreTemplateFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless',
+    const coreTemplateFilePath = path.join(this.serverless.getArtifactPath(),
       coreTemplateFileName);
 
     this.serverless.utils.writeFileSync(coreTemplateFilePath,

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.js
@@ -8,9 +8,7 @@ module.exports = {
     const compiledTemplateFileName = this.provider.naming.getCompiledTemplateFileName();
 
     const compiledTemplateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      compiledTemplateFileName
+      this.serverless.getArtifactPath(), compiledTemplateFileName
     );
 
     this.serverless.utils.writeFileSync(compiledTemplateFilePath,

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -10,9 +10,7 @@ module.exports = {
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
 
     const serviceStateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      serviceStateFileName
+      this.serverless.getArtifactPath(), serviceStateFileName
     );
 
     const artifact = _.last(

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -63,8 +63,7 @@ module.exports = {
 
     const zip = archiver.create('zip');
     // Create artifact in temp path and move it to the package path (if any) later
-    const artifactFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless',
+    const artifactFilePath = path.join(this.serverless.getArtifactPath(),
       zipFileName
     );
     this.serverless.utils.writeFileDir(artifactFilePath);

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const path = require('path');
 const validate = require('../lib/validate');
 const zipService = require('./lib/zipService');
 const packageService = require('./lib/packageService');
@@ -11,9 +10,7 @@ class Package {
     this.serverless = serverless;
     this.options = options;
     this.servicePath = this.serverless.config.servicePath || '';
-    this.packagePath = this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.servicePath || '.', '.serverless');
+    this.packagePath = this.options.package || serverless.getArtifactPath();
 
     Object.assign(
       this,


### PR DESCRIPTION
This change allows the CLI to be run in parallel when running
'package' and 'deploy'.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
The ability to run 'package' and 'deploy' cli commands in parallel to support building and deploying to multiple regions.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
When --package is passed on the command line with the package command, the cli uses this directory to create the supporting files necessary for deployment.
When --package is passed on the command line with the deploy command, the cli uses the artifacts in this directory to deploy.
When --package is passed on the command line, the .serverless directory is no longer used as a staging directory.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

./node_modules/serverless/bin/serverless package --package location/us-east-1 --region us-east-1 --stage development &
./node_modules/serverless/bin/serverless package --package location/us-east-2 --region us-east-2 --stage development &
./node_modules/serverless/bin/serverless package --package location//us-west-1 --region us-west-1 --stage development &
./node_modules/serverless/bin/serverless package --package location/us-west-2 --region us-west-2 --stage development &

wait

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
