### PR TITLE
Allow Fn::Join in SQS arn builder

### DIFF
--- a/docs/providers/aws/events/sqs.md
+++ b/docs/providers/aws/events/sqs.md
@@ -34,6 +34,16 @@ functions:
       - sqs:
           arn:
             Fn::ImportValue: MyExportedQueueArnId
+      - sqs:
+          arn:
+            Fn::Join:
+              - ":"
+              - - arn
+                - aws
+                - sqs
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - MyOtherQueue
 ```
 
 ## Setting the BatchSize

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -49,7 +49,8 @@ class AwsCompileSQSEvents {
                 // for dynamic arns (GetAtt/ImportValue)
                 if (Object.keys(event.sqs.arn).length !== 1
                     || !(_.has(event.sqs.arn, 'Fn::ImportValue')
-                          || _.has(event.sqs.arn, 'Fn::GetAtt'))) {
+                          || _.has(event.sqs.arn, 'Fn::GetAtt')
+                            || _.has(event.sqs.arn, 'Fn::Join'))) {
                   const errorMessage = [
                     `Bad dynamic ARN property on sqs event in function "${functionName}"`,
                     ' If you use a dynamic "arn" (such as with Fn::GetAtt or Fn::ImportValue)',

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -85,6 +85,9 @@ class AwsCompileSQSEvents {
                 return EventSourceArn['Fn::GetAtt'][0];
               } else if (EventSourceArn['Fn::ImportValue']) {
                 return EventSourceArn['Fn::ImportValue'];
+              } else if (EventSourceArn['Fn::Join']) {
+                // [0] is the used delimiter, [1] is the array with values
+                return EventSourceArn['Fn::Join'][1].slice(-1).pop();
               }
               return EventSourceArn.split(':').pop();
             }());

--- a/lib/plugins/aws/package/compile/events/sqs/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.test.js
@@ -391,18 +391,29 @@ describe('AwsCompileSQSEvents', () => {
                   arn: { 'Fn::ImportValue': 'ForeignQueue' },
                 },
               },
+              {
+                sqs: {
+                  arn: {
+                    'Fn::Join': [
+                      ':', [
+                        'arn', 'aws', 'sqs', {
+                          Ref: 'AWS::Region',
+                        },
+                        {
+                          Ref: 'AWS::AccountId',
+                        },
+                        'MyQueue',
+                      ],
+                    ],
+                  },
+                },
+              },
             ],
           },
         };
 
         awsCompileSQSEvents.compileSQSEvents();
 
-        expect(awsCompileSQSEvents.serverless.service
-          .provider.compiledCloudFormationTemplate.Resources
-          .FirstEventSourceMappingSQSSomeQueue.Properties.EventSourceArn
-        ).to.deep.equal(
-          { 'Fn::GetAtt': ['SomeQueue', 'Arn'] }
-        );
         expect(awsCompileSQSEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution
           .Properties.Policies[0].PolicyDocument.Statement[0]
@@ -424,8 +435,31 @@ describe('AwsCompileSQSEvents', () => {
               {
                 'Fn::ImportValue': 'ForeignQueue',
               },
+              {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn',
+                    'aws',
+                    'sqs',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'MyQueue',
+                  ],
+                ],
+              },
             ],
           }
+        );
+        expect(awsCompileSQSEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSSomeQueue.Properties.EventSourceArn
+        ).to.deep.equal(
+          { 'Fn::GetAtt': ['SomeQueue', 'Arn'] }
         );
         expect(awsCompileSQSEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources
@@ -433,9 +467,30 @@ describe('AwsCompileSQSEvents', () => {
         ).to.deep.equal(
           { 'Fn::ImportValue': 'ForeignQueue' }
         );
+        expect(awsCompileSQSEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSMyQueue.Properties.EventSourceArn
+        ).to.deep.equal(
+          {
+            'Fn::Join': [
+              ':',
+              [
+                'arn',
+                'aws',
+                'sqs',
+                {
+                  Ref: 'AWS::Region',
+                },
+                {
+                  Ref: 'AWS::AccountId',
+                },
+                'MyQueue',
+              ],
+            ],
+          });
       });
 
-      it('fails if keys other than Fn::GetAtt/ImportValue are used for dynamic queue ARN', () => {
+      it('fails if keys other than Fn::GetAtt/ImportValue/Join are used for dynamic ARNs', () => {
         awsCompileSQSEvents.serverless.service.functions = {
           first: {
             events: [


### PR DESCRIPTION
## What did you implement:

Closes #5345 

## How did you implement it:

Allowed `Fn::Join` to be used in the dynamic ARN builder for SQS events.

## How can we verify it:

Install this branch:

```
npm install git://github.com/serverless/serverless.git#SQSFnJoin
```

Try to deploy an SQS trigger that uses `Fn::Join`:

```yml
service: myservice

custom:
  region: eu-central-1
  mySQSQueue:
    Fn::Join:
      - ":"
      - - arn
        - aws
        - sqs
        - Ref: AWS::Region
        - Ref: AWS::AccountId
        - ${env:MY_SQS_QUEUE}

provider:
  name: aws
  runtime: nodejs8.10
  region: ${self:custom.region}

functions:
  fun:
    handler: handler.myhandler
    events:
      - sqs:
          arn: ${self:custom.mySQSQueue}
          batchSize: 10
```

Make sure it works.

@AndreaAdvanon Can you try this branch and confirm it solves your problem? Also make sure it doesn't cause any issues with CloudFormation.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
