### PR TITLE
Avoid args being rounded and converted to numbers

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -34,7 +34,22 @@ class CLI {
       inputArray = process.argv.slice(2);
     }
 
-    const argv = minimist(inputArray);
+    const valuesToIgnore = _.takeWhile(inputArray, (item) => !item.startsWith('-'));
+    const valuesToConvert = _.difference(inputArray, valuesToIgnore);
+    const valuesToB64 = valuesToConvert.map((x, i) => {
+      if ((i % 2) !== 0) {
+        return Buffer.from(x).toString('base64');
+      }
+      return x;
+    });
+    const valuesToParse = _.concat(valuesToIgnore, valuesToB64);
+    const argvToParse = minimist(valuesToParse);
+    const argv = _.mapValues(argvToParse, (x) => {
+      if (_.isString(x)) {
+        return Buffer.from(x, 'base64').toString();
+      }
+      return x;
+    });
 
     const commands = [].concat(argv._);
     const options = _.omit(argv, ['_']);

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -48,11 +48,18 @@ class CLI {
       return arg;
     };
 
+    // get all the commands
     const valuesToIgnore = _.takeWhile(inputArray, (item) => !item.startsWith('-'));
+    // get all the options
     const valuesToConvert = _.difference(inputArray, valuesToIgnore);
+    // encode all the options values to base64
     const valuesToB64 = _.map(valuesToConvert, toBase64Helper);
+    // concat commands with values on base64
     const valuesToParse = _.concat(valuesToIgnore, valuesToB64);
+
     const argvToParse = minimist(valuesToParse);
+
+    // decode all values to utf8 strings
     const argv = _.mapValues(argvToParse, decodedArgsHelper);
 
     const commands = [].concat(argv._);

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -34,22 +34,26 @@ class CLI {
       inputArray = process.argv.slice(2);
     }
 
+    const toBase64Helper = (value, index) => {
+      if ((index % 2) !== 0) {
+        return new Buffer(value).toString('base64');
+      }
+      return value;
+    };
+
+    const decodedArgsHelper = (arg) => {
+      if (_.isString(arg)) {
+        return new Buffer(arg, 'base64').toString();
+      }
+      return arg;
+    };
+
     const valuesToIgnore = _.takeWhile(inputArray, (item) => !item.startsWith('-'));
     const valuesToConvert = _.difference(inputArray, valuesToIgnore);
-    const valuesToB64 = valuesToConvert.map((x, i) => {
-      if ((i % 2) !== 0) {
-        return Buffer.from(x).toString('base64');
-      }
-      return x;
-    });
+    const valuesToB64 = _.map(valuesToConvert, toBase64Helper);
     const valuesToParse = _.concat(valuesToIgnore, valuesToB64);
     const argvToParse = minimist(valuesToParse);
-    const argv = _.mapValues(argvToParse, (x) => {
-      if (_.isString(x)) {
-        return Buffer.from(x, 'base64').toString();
-      }
-      return x;
-    });
+    const argv = _.mapValues(argvToParse, decodedArgsHelper);
 
     const commands = [].concat(argv._);
     const options = _.omit(argv, ['_']);

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -36,7 +36,7 @@ class CLI {
 
     const toBase64Helper = (value, index) => {
       if ((index % 2) !== 0) {
-        return new Buffer(value).toString('base64');
+        return new Buffer(value.toString()).toString('base64');
       }
       return value;
     };

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -362,6 +362,15 @@ describe('CLI', () => {
       expect(inputToBeProcessed).to.deep.equal(expectedObject);
     });
 
+    it('should only return numbers like strings when numbers are given on options', () => {
+      cli = new CLI(serverless, ['-f', 'function1', '-k', 123]);
+      const inputToBeProcessed = cli.processInput();
+
+      const expectedObject = { commands: [], options: { f: 'function1', k: '123' } };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
+    });
+
     it('should return commands and options when both are given', () => {
       cli = new CLI(serverless, ['deploy', 'functions', '-f', 'function1']);
       const inputToBeProcessed = cli.processInput();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5050 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

After the CLI get the args, before the pass to the 'minimist' I'm handling the string values and encode their to a base64 string like a workaround. After the minimist process, I get again the values and decoded again to get the original values.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

If we test the CLI with numbers and numbers like strings always they going to be treated as strings:

![image](https://user-images.githubusercontent.com/2708687/46568271-86e66400-c907-11e8-8be3-4eeeea353971.png)
![image](https://user-images.githubusercontent.com/2708687/46568282-ab424080-c907-11e8-84fc-651de034a525.png)

Also, there is a **unit test** added:
> "should only return numbers like strings when numbers are given on options"

If we only executed it, we'll we have:
![image](https://user-images.githubusercontent.com/2708687/46568325-74b8f580-c908-11e8-8f9d-eb51d52d24ab.png)

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
