### PR TITLE
Let function package.individually config override service artifact

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -93,7 +93,8 @@ module.exports = {
     }
 
     // use the artifact in service config if provided
-    if (this.serverless.service.package.artifact) {
+    // and if the function is not set to be packaged individually
+    if (this.serverless.service.package.artifact && !funcPackageConfig.individually) {
       const filePath = path.join(this.serverless.config.servicePath,
         this.serverless.service.package.artifact);
       funcPackageConfig.artifact = filePath;

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -387,5 +387,35 @@ describe('#packageService()', () => {
           expect(zipFilesStub).to.not.have.been.called,
         ]));
     });
+
+    it('should call zipService with settings if packaging individually without artifact', () => {
+      const servicePath = 'test';
+      const funcName = 'test-func';
+
+      const zipFileName = 'test-func.zip';
+
+      serverless.config.servicePath = servicePath;
+      serverless.service.functions = {};
+      serverless.service.package = {
+        artifact: 'artifact.zip',
+      };
+      serverless.service.functions[funcName] = {
+        name: `test-proj-${funcName}`,
+        package: { individually: true },
+      };
+
+      return expect(packagePlugin.packageFunction(funcName)).to.eventually.equal(artifactFilePath)
+      .then(() => BbPromise.all([
+        expect(getExcludesStub).to.be.calledOnce,
+        expect(getIncludesStub).to.be.calledOnce,
+        expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
+
+        expect(zipFilesStub).to.be.calledOnce,
+        expect(zipFilesStub).to.have.been.calledWithExactly(
+          files,
+          zipFileName
+        ),
+      ]));
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/FidelLimited/serverless-plugin-warmup/issues/25

<!--
Briefly describe the feature if no issue exists for this PR
-->

The problem that this feature solves is that, if you set a service level artifact, functions marked as `package: individually: true` are not packaged individually as you would expect but use the service artifact instead.

This change simply allows you do to do:

```yml
package:
  artifact: my-app.zip

function:
  ...
  myIndividualFunc:
    ...
    package: 
      individually: true
```

So all the functions will use the `my-app.zip` artifact but `myIndividualFunc` will be packaged normally

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

It's a pretty trivial change. Simply check if the function is set to package individually and, if so, package it individually. :) 

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->



I've added a test that proves that the feature works and doesn't break existing functionality.
It's pretty trivial to verify with a small app:
```yml
service: test

provider:
  name: aws
  runtime: nodejs8.10

package:
  artifact: my-app.zip # This can be an empty zip

functions:
  normalFunc:
    handler: func/handler.func
    events:
      - http:
          path: func
          method: post
  individualFunc:
    handler: func/handler.func
    events:
      - http:
          path: func2
          method: post
    package:
       individually: true
```
running `serverless package` with the above config will create a zip for `func/handler.func` (the func folder needs to exist of course).
At the moment is doesn't and it just tries to use `my-app.zip` instead

## Todos:

- [x] Write tests
- [ ] Write documentation (No docs change needed. this change just make it work as the current docs make it seems like it would work)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
