### PR TITLE
Fixed principal's host issue in China region

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -19,7 +19,7 @@ module.exports = {
               'Fn::GetAtt': [singlePermissionMapping.lambdaLogicalId, 'Arn'],
             },
             Action: 'lambda:InvokeFunction',
-            Principal: { 'Fn::Join': ['', ['apigateway.', { Ref: 'AWS::URLSuffix' }]] },
+            Principal: 'apigateway.amazonaws.com',
             SourceArn: {
               'Fn::Join': ['',
                 [
@@ -56,7 +56,7 @@ module.exports = {
             Properties: {
               FunctionName: authorizer.arn,
               Action: 'lambda:InvokeFunction',
-              Principal: { 'Fn::Join': ['', ['apigateway.', { Ref: 'AWS::URLSuffix' }]] },
+              Principal: 'apigateway.amazonaws.com',
             },
           },
         });

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
@@ -107,7 +107,7 @@ class AwsCompileCloudWatchEventEvents {
                   "FunctionName": { "Fn::GetAtt": ["${
               lambdaLogicalId}", "Arn"] },
                   "Action": "lambda:InvokeFunction",
-                  "Principal": { "Fn::Join": ["", ["events.", { "Ref": "AWS::URLSuffix" }]] },
+                  "Principal": "events.amazonaws.com",
                   "SourceArn": { "Fn::GetAtt": ["${cloudWatchLogicalId}", "Arn"] }
                 }
               }

--- a/lib/plugins/aws/package/compile/events/cloudWatchLog/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchLog/index.js
@@ -76,7 +76,7 @@ class AwsCompileCloudWatchLogEvents {
               .getCloudWatchLogLogicalId(functionName, cloudWatchLogNumberInFunction);
             const lambdaPermissionLogicalId = this.provider.naming
               .getLambdaCloudWatchLogPermissionLogicalId(functionName,
-              cloudWatchLogNumberInFunction);
+                cloudWatchLogNumberInFunction);
 
             // unescape quotes once when the first quote is detected escaped
             const idxFirstSlash = FilterPattern.indexOf('\\');
@@ -109,7 +109,7 @@ class AwsCompileCloudWatchLogEvents {
                   "logs.",
                   { "Ref": "AWS::Region" },
                   ".",
-                  { "Ref": "AWS::URLSuffix" }
+                  "amazonaws.com"
                   ] ]
                 },
                 "SourceArn": {

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -151,7 +151,7 @@ class AwsCompileCognitoUserPoolEvents {
             ],
           },
           Action: 'lambda:InvokeFunction',
-          Principal: { 'Fn::Join': ['', ['cognito-idp.', { Ref: 'AWS::URLSuffix' }]] },
+          Principal: 'cognito-idp.amazonaws.com',
           SourceArn: {
             'Fn::GetAtt': [
               userPoolLogicalId,
@@ -162,7 +162,7 @@ class AwsCompileCognitoUserPoolEvents {
       };
       const lambdaPermissionLogicalId = this.provider.naming
         .getLambdaCognitoUserPoolPermissionLogicalId(cognitoUserPoolTriggerFunction.functionName,
-        cognitoUserPoolTriggerFunction.poolName, cognitoUserPoolTriggerFunction.triggerSource);
+          cognitoUserPoolTriggerFunction.poolName, cognitoUserPoolTriggerFunction.triggerSource);
       const permissionCFResource = {
         [lambdaPermissionLogicalId]: permissionTemplate,
       };

--- a/lib/plugins/aws/package/compile/events/iot/index.js
+++ b/lib/plugins/aws/package/compile/events/iot/index.js
@@ -80,7 +80,7 @@ class AwsCompileIoTEvents {
                 "Properties": {
                   "FunctionName": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
                   "Action": "lambda:InvokeFunction",
-                  "Principal": { "Fn::Join": ["", [ "iot.", { "Ref": "AWS::URLSuffix" } ]] },
+                  "Principal": "iot.amazonaws.com",
                   "SourceArn": { "Fn::Join": ["",
                     [
                       "arn:",

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -147,7 +147,7 @@ class AwsCompileS3Events {
       _.forEach(dependsOnToCreate, (item) => {
         const lambdaPermissionLogicalId = this.provider.naming
           .getLambdaS3PermissionLogicalId(item.functionName,
-          item.bucketName);
+            item.bucketName);
 
         bucketTemplate.DependsOn.push(lambdaPermissionLogicalId);
       });
@@ -177,7 +177,7 @@ class AwsCompileS3Events {
             ],
           },
           Action: 'lambda:InvokeFunction',
-          Principal: { 'Fn::Join': ['', ['s3.', { Ref: 'AWS::URLSuffix' }]] },
+          Principal: 's3.amazonaws.com',
           SourceArn: {
             'Fn::Join': ['',
               [
@@ -191,7 +191,7 @@ class AwsCompileS3Events {
       };
       const lambdaPermissionLogicalId = this.provider.naming
         .getLambdaS3PermissionLogicalId(s3EnabledFunction.functionName,
-        s3EnabledFunction.bucketName);
+          s3EnabledFunction.bucketName);
       const permissionCFResource = {
         [lambdaPermissionLogicalId]: permissionTemplate,
       };

--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -128,7 +128,7 @@ class AwsCompileScheduledEvents {
                   "FunctionName": { "Fn::GetAtt": ["${
               lambdaLogicalId}", "Arn"] },
                   "Action": "lambda:InvokeFunction",
-                  "Principal": { "Fn::Join": ["", [ "events.", { "Ref": "AWS::URLSuffix" } ]] },
+                  "Principal": "events.amazonaws.com",
                   "SourceArn": { "Fn::GetAtt": ["${scheduleLogicalId}", "Arn"] }
                 }
               }

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -187,7 +187,7 @@ class AwsCompileSNSEvents {
                 Properties: {
                   FunctionName: endpoint,
                   Action: 'lambda:InvokeFunction',
-                  Principal: { 'Fn::Join': ['', ['sns.', { Ref: 'AWS::URLSuffix' }]] },
+                  Principal: 'sns.amazonaws.com',
                   SourceArn: topicArn,
                 },
               },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless/serverless/issues/5365

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Replace `AWS::URLSuffix` in all principal parameters to hardcoded `<service-name>.amazonaws.com`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Deploy a restApi in region `cn-north-1`.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
