### PR TITLE
Remove invalid log

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -249,7 +249,6 @@ class AwsInvokeLocal {
   }
 
   invokeLocalNodeJs(handlerPath, handlerName, event, customContext) {
-    this.serverless.cli.log('INVOKING INVOKE');
     let lambda;
     let pathToHandler;
     let hasResponded = false;


### PR DESCRIPTION
When running one of the SLS commands I spotted wierd log `Serverless: INVOKING INVOKE`

![screen shot 2018-10-11 at 15 26 37](https://user-images.githubusercontent.com/122434/46807521-659fd080-cd6a-11e8-887d-7992819b1fc2.png)

It feels as something committed in by mistake

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

/cc @lewisf 
