### PR TITLE
Fix error log output

### DIFF
--- a/lib/plugins/aws/invokeLocal/fixture/handlerWithInitializationError.js
+++ b/lib/plugins/aws/invokeLocal/fixture/handlerWithInitializationError.js
@@ -1,0 +1,3 @@
+'use strict';
+
+throw new Error('Initialization failed');

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -9,7 +9,7 @@ const validate = require('../lib/validate');
 const chalk = require('chalk');
 const stdin = require('get-stdin');
 const spawn = require('child_process').spawn;
-
+const inspect = require('util').inspect;
 
 class AwsInvokeLocal {
   constructor(serverless, options) {
@@ -268,7 +268,7 @@ class AwsInvokeLocal {
       );
       lambda = handlersContainer[handlerName];
     } catch (error) {
-      this.serverless.cli.consoleLog(chalk.red(JSON.stringify(error, null, 4)));
+      this.serverless.cli.consoleLog(chalk.red(inspect(error)));
       throw new Error(`Exception encountered when loading ${pathToHandler}`);
     }
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -503,6 +503,20 @@ describe('AwsInvokeLocal', () => {
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorType": "Error"');
     });
 
+    it('should log Error object if handler crashes at initialization', () => {
+      awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+      try {
+        awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithInitializationError', 'withError');
+      } catch (error) {
+        if (!error.message.startsWith('Exception encountered when loading')) {
+          throw error;
+        }
+      }
+
+      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('Initialization failed');
+    });
+
     it('should log error when called back', () => {
       awsInvokeLocal.serverless.config.servicePath = __dirname;
 


### PR DESCRIPTION

## What did you implement:

I addressed regression introduced with #4912 as since then due to following line:

https://github.com/serverless/serverless/blob/011a6510491f94c4d766d1aa50a9fa8e3dd958d9/lib/plugins/aws/invokeLocal/index.js#L271

errors are logged as `{}` (errors do not have JSON representation), example of log I received:

![screen shot 2018-10-11 at 16 36 24](https://user-images.githubusercontent.com/122434/46811859-dbf50080-cd73-11e8-8037-aa11fdf959b4.png)

Proposed patch ensures that errors are logged properly (with stack trace and all it's properties) and in red (as proposed with #4912)

/cc @lewisf

## How did you implement it:

I used Node.js native `util.inspect`

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
