### PR TITLE
validate if serverless.yml exists when running sls info command

### DIFF
--- a/lib/plugins/info/info.js
+++ b/lib/plugins/info/info.js
@@ -2,10 +2,16 @@
 
 const BbPromise = require('bluebird');
 const userStats = require('../../utils/userStats');
+const validate = require('../lib/validate');
 
 class Info {
   constructor(serverless) {
     this.serverless = serverless;
+
+    Object.assign(
+      this,
+      validate
+    );
 
     this.commands = {
       info: {
@@ -31,6 +37,7 @@ class Info {
     };
 
     this.hooks = {
+      'before:info:info': () => BbPromise.bind(this).then(this.validate),
       'after:info:info': () => BbPromise.bind(this).then(this.track),
     };
   }

--- a/lib/plugins/info/info.test.js
+++ b/lib/plugins/info/info.test.js
@@ -3,6 +3,7 @@
 const expect = require('chai').expect;
 const Info = require('./info');
 const Serverless = require('../../Serverless');
+const sinon = require('sinon');
 
 describe('Info', () => {
   let info;
@@ -15,5 +16,22 @@ describe('Info', () => {
 
   describe('#constructor()', () => {
     it('should have commands', () => expect(info.commands).to.be.not.empty);
+  });
+
+  describe('"before:info:info" hook', () => {
+    let validateStub;
+
+    beforeEach(() => {
+      validateStub = sinon.stub(info, 'validate').resolves();
+    });
+
+    afterEach(() => {
+      info.validate.restore();
+    });
+
+    it('should run the validation', () =>
+      expect(info.hooks['before:info:info']())
+      .to.be.fulfilled.then(() => expect(validateStub).to.be.called)
+    );
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

#2116 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

add lib/validate related to 
https://github.com/serverless/serverless/blob/master/lib/plugins/remove/remove.js

## How can we verify it:

### run

command
```
bin/serverless info
```

result
```

  Error --------------------------------------------------

  This command can only be run in a Serverless service directory

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information -----------------------------
     OS:                     darwin
     Node Version:           8.10.0
     Serverless Version:     1.32.0
```


### test
npm test

before
```
  1681 passing (20s)
  1 pending
```

```
=============================== Coverage summary ===============================
Statements   : 92.73% ( 5545/5980 )
Branches     : 87.28% ( 2546/2917 )
Functions    : 92.76% ( 500/539 )
Lines        : 92.94% ( 5462/5877 )
================================================================================
```

after
```
  1682 passing (20s)
  1 pending
```

```
=============================== Coverage summary ===============================
Statements   : 92.73% ( 5548/5983 )
Branches     : 87.28% ( 2546/2917 )
Functions    : 92.76% ( 500/539 )
Lines        : 92.94% ( 5465/5880 )
================================================================================
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
