### PR TITLE
fix: Implement context.log function for invoke local command on Python environment.

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -45,6 +45,10 @@ class FakeLambdaContext(object):
     def log_stream_name(self):
         return strftime('%Y/%m/%d') +'/[$' + self.version + ']58419525dade4d17a495dceeeed44708'
 
+    @property
+    def log(self):
+        return sys.stdout.write
+
 logging.basicConfig()
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4544

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Add context.log function into FakeLambdaContext which class is used while running a handler by 'invoke local' command.
I implement context.log function as redirect function to standard output.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

You can reproduce this problem as blow.

Prepare the source code like this.

```
❯ cat handler.py
import json

def hello(event, context):
    body = {
        "message": "Go Serverless v1.0! Your function executed successfully!",
        "input": event
    }

    response = {
        "statusCode": 200,
        "body": json.dumps(body)
    }

    context.log('log function experimental invoking.')

    return response
```

and execute it by `invoke local`, then you can see the exception.

```
❯ sls invoke local -t -f hello
Traceback (most recent call last):
  File "/Users/aki/.nodebrew/node/v8.11.3/lib/node_modules/serverless/lib/plugins/aws/invokeLocal/invoke.py", line 67, in <module>

    result = handler(input['event'], context)
  File "./handler.py", line 14, in hello
    context.log('log function experimental invoking.')
AttributeError: 'FakeLambdaContext' object has no attribute 'log'
```

But when you execute same command by the new implementation.

```
~/Projects/webii/serverless-4544-verify-python
❯ ../serverless/bin/serverless invoke local -t -f hello
log function experimental invoking.
{
    "body": "{\"input\": {}, \"message\": \"Go Serverless v1.0! Your function executed successfully!\"}",
    "statusCode": 200
}
```

`log function experimental invoking` is the output of context.log.
So now that function works correctly.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
  - There are no test code for `invoke.py`, and I don't have the knowledge for creating new one. Sorry.
- [ ] Write documentation
  - context.log function is not documented at the [AWS official document](https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/python-context-object.html#python-context-object-methods), but it's [implicitly existing](https://gist.github.com/gene1wood/c0d37dfcb598fc133a8c) in the real AWS Lambda environment. So because of that, I think this function shouldn't be written in the document of Serverless framework as well.
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
