### PR TITLE
break single general issue template into two specialized templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--
+1. If you have a question and not a bug report please ask first at http://forum.serverless.com
+2. Please check if an issue already exists. This bug may have already been documented
+3. Check out and follow our Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
+4. Fill out the whole template so we have a good overview on the issue
+5. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
+6. Please follow the template, otherwise we'll have to ask you to update it
+-->
+
+# This is a Bug Report
+
+## Description
+
+* What went wrong?
+* What did you expect should have happened?
+* What was the config you used?
+* What stacktrace or error message from your provider did you see?
+
+Similar or dependent issues:
+* #12345
+
+## Additional Data
+
+* ***Serverless Framework Version you're using***:
+* ***Operating System***:
+* ***Stack Trace***:
+* ***Provider Error messages***:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,32 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for serverless framework
+---
+
 <!--
-1. If you have a question and not a bug/feature request please ask it at http://forum.serverless.com
-2. Please check if an issue already exists so there are no duplicates
+1. If you have a question and not a feature request please ask first at http://forum.serverless.com
+2. Please check if an issue already exists. This feature may have already been requested
 3. Check out and follow our Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
 4. Fill out the whole template so we have a good overview on the issue
 5. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
 6. Please follow the template, otherwise we'll have to ask you to update it
 -->
 
-# This is a (Bug Report / Feature Proposal)
+# This is a Feature Proposal
 
 ## Description
 
-For bug reports:
-* What went wrong?
-* What did you expect should have happened?
-* What was the config you used?
-* What stacktrace or error message from your provider did you see?
-
-For feature proposals:
 * What is the use case that should be solved. The more detail you describe this in the easier it is to understand for us.
 * If there is additional config how would it look
 
 Similar or dependent issues:
 * #12345
-
-## Additional Data
-
-* ***Serverless Framework Version you're using***:
-* ***Operating System***:
-* ***Stack Trace***:
-* ***Provider Error messages***:


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

To make less work for contributors, I factored out bug reports and feature requests into two separate gh issue templates. 

Closes #5350

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

The UI for selecting templates feature is [built into github](https://blog.github.com/2018-05-02-issue-template-improvements/). The markdown front matter is what drives that UI.

I took the existing issue template copy and split it into two specialized sets of copy, each for its own singular purpose with minor adjustments.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

I don't think there's a way to see the github UI without merging but the pattern is the same for all repositories.

You can view rendered markdown.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
