### PR TITLE
Wrong error when S3 bucket name starts with an upper-case character

### DIFF
--- a/lib/plugins/aws/lib/validateS3BucketName.js
+++ b/lib/plugins/aws/lib/validateS3BucketName.js
@@ -14,33 +14,32 @@ module.exports = {
    * @param bucketName
    */
   validateS3BucketName(bucketName) {
-    return BbPromise.resolve()
-      .then(() => {
-        let error;
-        if (!bucketName) {
-          error = 'Bucket name cannot be undefined or empty';
-        } else if (bucketName.length < 3) {
-          error = `Bucket name is shorter than 3 characters. ${bucketName}`;
-        } else if (bucketName.length > 63) {
-          error = `Bucket name is longer than 63 characters. ${bucketName}`;
-        } else if (/^[^a-z0-9]/.test(bucketName)) {
-          error = `Bucket name must start with a letter or number. ${bucketName}`;
-        } else if (/[^a-z0-9]$/.test(bucketName)) {
-          error = `Bucket name must end with a letter or number. ${bucketName}`;
-        } else if (/[A-Z]/.test(bucketName)) {
-          error = `Bucket name cannot contain uppercase letters. ${bucketName}`;
-        } else if (!/^[a-z0-9][a-z.0-9-]+[a-z0-9]$/.test(bucketName)) {
-          error = `Bucket name contains invalid characters, [a-z.0-9-] ${bucketName}`;
-        } else if (/\.{2,}/.test(bucketName)) {
-          error = `Bucket name cannot contain consecutive periods (.) ${bucketName}`;
-        } else if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(bucketName)) {
-          error = `Bucket name cannot look like an IPv4 address. ${bucketName}`;
-        }
+    return BbPromise.resolve().then(() => {
+      let error;
+      if (!bucketName) {
+        error = 'Bucket name cannot be undefined or empty';
+      } else if (bucketName.length < 3) {
+        error = `Bucket name is shorter than 3 characters. ${bucketName}`;
+      } else if (bucketName.length > 63) {
+        error = `Bucket name is longer than 63 characters. ${bucketName}`;
+      } else if (/[A-Z]/.test(bucketName)) {
+        error = `Bucket name cannot contain uppercase letters. ${bucketName}`;
+      } else if (/^[^a-z0-9]/.test(bucketName)) {
+        error = `Bucket name must start with a letter or number. ${bucketName}`;
+      } else if (/[^a-z0-9]$/.test(bucketName)) {
+        error = `Bucket name must end with a letter or number. ${bucketName}`;
+      } else if (!/^[a-z0-9][a-z.0-9-]+[a-z0-9]$/.test(bucketName)) {
+        error = `Bucket name contains invalid characters, [a-z.0-9-] ${bucketName}`;
+      } else if (/\.{2,}/.test(bucketName)) {
+        error = `Bucket name cannot contain consecutive periods (.) ${bucketName}`;
+      } else if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(bucketName)) {
+        error = `Bucket name cannot look like an IPv4 address. ${bucketName}`;
+      }
 
-        if (error) {
-          throw new this.serverless.classes.Error(error);
-        }
-        return true;
-      });
+      if (error) {
+        throw new this.serverless.classes.Error(error);
+      }
+      return true;
+    });
   },
 };

--- a/lib/plugins/aws/lib/validateS3BucketName.js
+++ b/lib/plugins/aws/lib/validateS3BucketName.js
@@ -14,32 +14,33 @@ module.exports = {
    * @param bucketName
    */
   validateS3BucketName(bucketName) {
-    return BbPromise.resolve().then(() => {
-      let error;
-      if (!bucketName) {
-        error = 'Bucket name cannot be undefined or empty';
-      } else if (bucketName.length < 3) {
-        error = `Bucket name is shorter than 3 characters. ${bucketName}`;
-      } else if (bucketName.length > 63) {
-        error = `Bucket name is longer than 63 characters. ${bucketName}`;
-      } else if (/[A-Z]/.test(bucketName)) {
-        error = `Bucket name cannot contain uppercase letters. ${bucketName}`;
-      } else if (/^[^a-z0-9]/.test(bucketName)) {
-        error = `Bucket name must start with a letter or number. ${bucketName}`;
-      } else if (/[^a-z0-9]$/.test(bucketName)) {
-        error = `Bucket name must end with a letter or number. ${bucketName}`;
-      } else if (!/^[a-z0-9][a-z.0-9-]+[a-z0-9]$/.test(bucketName)) {
-        error = `Bucket name contains invalid characters, [a-z.0-9-] ${bucketName}`;
-      } else if (/\.{2,}/.test(bucketName)) {
-        error = `Bucket name cannot contain consecutive periods (.) ${bucketName}`;
-      } else if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(bucketName)) {
-        error = `Bucket name cannot look like an IPv4 address. ${bucketName}`;
-      }
+    return BbPromise.resolve()
+      .then(() => {
+        let error;
+        if (!bucketName) {
+          error = 'Bucket name cannot be undefined or empty';
+        } else if (bucketName.length < 3) {
+          error = `Bucket name is shorter than 3 characters. ${bucketName}`;
+        } else if (bucketName.length > 63) {
+          error = `Bucket name is longer than 63 characters. ${bucketName}`;
+        } else if (/[A-Z]/.test(bucketName)) {
+          error = `Bucket name cannot contain uppercase letters. ${bucketName}`;
+        } else if (/^[^a-z0-9]/.test(bucketName)) {
+          error = `Bucket name must start with a letter or number. ${bucketName}`;
+        } else if (/[^a-z0-9]$/.test(bucketName)) {
+          error = `Bucket name must end with a letter or number. ${bucketName}`;
+        } else if (!/^[a-z0-9][a-z.0-9-]+[a-z0-9]$/.test(bucketName)) {
+          error = `Bucket name contains invalid characters, [a-z.0-9-] ${bucketName}`;
+        } else if (/\.{2,}/.test(bucketName)) {
+          error = `Bucket name cannot contain consecutive periods (.) ${bucketName}`;
+        } else if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(bucketName)) {
+          error = `Bucket name cannot look like an IPv4 address. ${bucketName}`;
+        }
 
-      if (error) {
-        throw new this.serverless.classes.Error(error);
-      }
-      return true;
-    });
+        if (error) {
+          throw new this.serverless.classes.Error(error);
+        }
+        return true;
+      });
   },
 };


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/5406

## How did you implement it:

Moved case sensitivity case.

## How can we verify it:

Set bucket name to e.g. `Bucket` or `buCket`.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
