### PR TITLE
aws-csharp create template uses handler-specific artifact

### DIFF
--- a/lib/plugins/create/templates/aws-csharp/build.cmd
+++ b/lib/plugins/create/templates/aws-csharp/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp2.1 --output-package bin/release/netcoreapp2.1/deploy-package.zip
+dotnet lambda package --configuration release --framework netcoreapp2.1 --output-package bin/release/netcoreapp2.1/hello.zip

--- a/lib/plugins/create/templates/aws-csharp/build.sh
+++ b/lib/plugins/create/templates/aws-csharp/build.sh
@@ -8,4 +8,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp2.1 --output-package bin/release/netcoreapp2.1/deploy-package.zip
+dotnet lambda package --configuration release --framework netcoreapp2.1 --output-package bin/release/netcoreapp2.1/hello.zip

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -45,6 +45,9 @@ provider:
 #  environment:
 #    variable1: value1
 
+package:
+  individually: true
+
 functions:
   hello:
     handler: CsharpHandlers::AwsDotnetCsharp.Handler::Hello

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -45,16 +45,16 @@ provider:
 #  environment:
 #    variable1: value1
 
-# you can add packaging information here
-package:
-  artifact: bin/release/netcoreapp2.1/deploy-package.zip
-#  exclude:
-#    - exclude-me.js
-#    - exclude-me-dir/**
-
 functions:
   hello:
     handler: CsharpHandlers::AwsDotnetCsharp.Handler::Hello
+
+    # you can add packaging information here
+    package:
+      artifact: bin/release/netcoreapp2.1/hello.zip
+    #  exclude:
+    #    - exclude-me.js
+    #    - exclude-me-dir/**
 
 #    The following are a few example events you can configure
 #    NOTE: Please make sure to change your handler code to work with those events


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

**The problem:**

* The template for aws-csharp creates an artifact (using `build.sh`) called `deploy-package.zip`.
* Serverless uploads all artifacts to the same prefix in the S3 bucket.
* To create a second artifact for a second function the basename of the artifact needs to be changed to something else.
* If you use the same basename (in another directory), you get an unexplained error during the deployment:

```
  An error occurred: HelloLambdaVersionGtHPSWSbQu5erGQ1qsmWTuL5axFax9OvH53cRMS4yHA - CodeSHA256 (buSKlTnYj3iptkvZOp+HzA1my2aAHCfzE9YYl0jQrqE=) is different from current CodeSHA256 in $LATEST (+5nQZZsPn2CzTTHHeZPKO6Kqt6XJJxVOboMVKg6pSHg=). Please try again with the CodeSHA256 in $LATEST. (Service: AWSLambda; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: 6823784f-d5d7-11e8-8c3b-bdc8b24e0fb1).
```

This error is confusing, and it took me a lot of time to realize that the problem is with the basename of the artifact.

**Solution:** In the template use a more specific artifact name (e.g. `hello.zip` for the hello function), so that the user understands it cannot be a generic and duplicate name (e.g. `deploy-package.zip`).

## How did you implement it:

- Changed aws-csharp template's `build.sh` to create a zip file called `hello.zip` (like the function's name).
- Changed aws-csharp template's `serverless.yml` to use a function-specific artifact.

## How can we verify it:

```bash
serverless create --tempate aws-csharp
```

## Todos:

- Write tests
- Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
