### PR TITLE
Use timestamp on temporary directory to make it uniq

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -57,6 +57,12 @@ class Serverless {
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();
 
+    const date = new Date();
+    const dateString = date.toISOString();
+    this.workDir = this.processedInput.options.package
+      ? `.serverless-${dateString}`
+      : '.serverless';
+
     // set the options and commands which were processed by the CLI
     this.pluginManager.setCliOptions(this.processedInput.options);
     this.pluginManager.setCliCommands(this.processedInput.commands);

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -7,6 +7,7 @@ const path = require('path');
 const YAML = require('js-yaml');
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
+const mockDate = require('mockdate');
 
 const YamlParser = require('../lib/classes/YamlParser');
 const PluginManager = require('../lib/classes/PluginManager');
@@ -20,6 +21,7 @@ describe('Serverless', () => {
   let serverless;
 
   beforeEach(() => {
+    mockDate.reset();
     serverless = new Serverless();
   });
 
@@ -146,6 +148,30 @@ describe('Serverless', () => {
         expect(serverless.processedInput).to.not.deep.equal({});
       })
     );
+
+    it('should set default workDir when no path for artifacts is provided', () => serverless.init()
+      .then(() => {
+        expect(serverless.workDir).to.equal('.serverless');
+      })
+    );
+
+    it('should set workDir with timestamp when a path for artifacts is provided', () => {
+      class CustomCLI extends CLI {
+        processInput() {
+          return {
+            options: {
+              package: 'some-path',
+            },
+          };
+        }
+      }
+      serverless.classes.CLI = CustomCLI;
+      mockDate.set(new Date('2018-01-01'));
+
+      return serverless.init().then(() => {
+        expect(serverless.workDir).to.equal('.serverless-2018-01-01T00:00:00.000Z');
+      });
+    });
 
     it('should resolve after loading the service', () => {
       const SUtils = new Utils();

--- a/lib/plugins/aws/common/lib/artifacts.js
+++ b/lib/plugins/aws/common/lib/artifacts.js
@@ -7,13 +7,14 @@ const _ = require('lodash');
 
 module.exports = {
   moveArtifactsToPackage() {
+    const servicePath = this.serverless.config.servicePath;
     const packagePath = this.options.package ||
       this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+      path.join(servicePath || '.', '.serverless');
 
     // Only move the artifacts if it was requested by the user
-    if (this.serverless.config.servicePath && !_.endsWith(packagePath, '.serverless')) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    if (servicePath && !_.endsWith(packagePath, '.serverless')) {
+      const serverlessTmpDirPath = path.join(servicePath, this.serverless.workDir);
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
         if (this.serverless.utils.dirExistsSync(packagePath)) {

--- a/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/lib/plugins/aws/common/lib/artifacts.test.js
@@ -10,14 +10,16 @@ const testUtils = require('../../../../../tests/utils');
 describe('#moveArtifactsToPackage()', () => {
   let serverless;
   let awsCommon;
+  const workingDirectory = 'workingDirectory';
   const moveBasePath = path.join(testUtils.getTmpDirPath(), 'move');
-  const moveServerlessPath = path.join(moveBasePath, '.serverless');
+  const moveServerlessPath = path.join(moveBasePath, workingDirectory);
 
   beforeEach(() => {
     serverless = new Serverless();
     awsCommon = new AWSCommon(serverless, {});
 
     serverless.config.servicePath = moveBasePath;
+    serverless.workDir = workingDirectory;
     if (!serverless.utils.dirExistsSync(moveServerlessPath)) {
       serverless.utils.writeFileDir(moveServerlessPath);
     }

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -78,7 +78,7 @@ module.exports = {
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();
 
     const coreTemplateFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.workDir,
       coreTemplateFileName);
 
     this.serverless.utils.writeFileSync(coreTemplateFilePath,

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -19,6 +19,7 @@ describe('#generateCoreTemplate()', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
+    serverless.workDir = 'workingDirectory';
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless, {});
     awsPlugin.options = {

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.js
@@ -9,7 +9,7 @@ module.exports = {
 
     const compiledTemplateFilePath = path.join(
       this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.workDir,
       compiledTemplateFileName
     );
 

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
@@ -17,6 +17,7 @@ describe('#saveCompiledTemplate()', () => {
     const options = {};
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.workDir = 'workingDirectory';
     awsPackage = new AwsPackage(serverless, options);
     serverless.config.servicePath = 'my-service';
     serverless.service = {
@@ -39,7 +40,7 @@ describe('#saveCompiledTemplate()', () => {
   it('should write the compiled template to disk', () => {
     const filePath = path.join(
       awsPackage.serverless.config.servicePath,
-      '.serverless',
+      'workingDirectory',
       'compiled.json'
     );
 

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -11,7 +11,7 @@ module.exports = {
 
     const serviceStateFilePath = path.join(
       this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.workDir,
       serviceStateFileName
     );
 

--- a/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -17,6 +17,7 @@ describe('#saveServiceState()', () => {
     const options = {};
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.workDir = 'workingDirectory';
     awsPackage = new AwsPackage(serverless, options);
     serverless.config.servicePath = 'my-service';
     serverless.service = {
@@ -44,7 +45,7 @@ describe('#saveServiceState()', () => {
   it('should write the service state file template to disk', () => {
     const filePath = path.join(
       awsPackage.serverless.config.servicePath,
-      '.serverless',
+      'workingDirectory',
       'service-state.json'
     );
 
@@ -71,7 +72,7 @@ describe('#saveServiceState()', () => {
   it('should remove self references correctly', () => {
     const filePath = path.join(
       awsPackage.serverless.config.servicePath,
-      '.serverless',
+      'workingDirectory',
       'service-state.json'
     );
 

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -64,7 +64,7 @@ module.exports = {
     const zip = archiver.create('zip');
     // Create artifact in temp path and move it to the package path (if any) later
     const artifactFilePath = path.join(this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.workDir,
       zipFileName
     );
     this.serverless.utils.writeFileDir(artifactFilePath);

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -22,6 +22,7 @@ chai.use(require('sinon-chai'));
 const expect = require('chai').expect;
 
 describe('zipService', () => {
+  const workingDirectory = 'workingDirectory';
   let tmpDirPath;
   let serverless;
   let packagePlugin;
@@ -32,6 +33,7 @@ describe('zipService', () => {
     serverless = new Serverless();
     serverless.service.service = 'first-service';
     serverless.config.servicePath = tmpDirPath;
+    serverless.workDir = workingDirectory;
     packagePlugin = new Package(serverless, {});
     packagePlugin.serverless.cli = new serverless.classes.CLI();
     params = {
@@ -790,7 +792,7 @@ describe('zipService', () => {
       params.zipFileName = getTestArtifactFileName('whole-service');
 
       return expect(packagePlugin.zip(params)).to.eventually.be
-        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .equal(path.join(serverless.config.servicePath, workingDirectory, params.zipFileName))
       .then(artifact => {
         const data = fs.readFileSync(artifact);
         return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -840,7 +842,7 @@ describe('zipService', () => {
       params.zipFileName = getTestArtifactFileName('file-permissions');
 
       return expect(packagePlugin.zip(params)).to.eventually.be
-        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .equal(path.join(serverless.config.servicePath, workingDirectory, params.zipFileName))
       .then(artifact => {
         const data = fs.readFileSync(artifact);
         return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -872,7 +874,7 @@ describe('zipService', () => {
       ];
 
       return expect(packagePlugin.zip(params)).to.eventually.be
-        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .equal(path.join(serverless.config.servicePath, workingDirectory, params.zipFileName))
       .then(artifact => {
         const data = fs.readFileSync(artifact);
         return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -917,7 +919,7 @@ describe('zipService', () => {
       ];
 
       return expect(packagePlugin.zip(params)).to.eventually.be
-        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .equal(path.join(serverless.config.servicePath, workingDirectory, params.zipFileName))
       .then(artifact => {
         const data = fs.readFileSync(artifact);
         return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -971,7 +973,7 @@ describe('zipService', () => {
       ];
 
       return expect(packagePlugin.zip(params)).to.eventually.be
-        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .equal(path.join(serverless.config.servicePath, workingDirectory, params.zipFileName))
       .then(artifact => {
         const data = fs.readFileSync(artifact);
         return expect(zip.loadAsync(data)).to.be.fulfilled;

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
     "mock-require": "^1.3.0",
+    "mockdate": "^2.0.2",
     "parse-github-url": "^1.0.1",
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.5",


### PR DESCRIPTION
## What did you implement:

Closes #5002 

## How did you implement it:

In order to run the `package` command in parallel, the temporary directory used for the artifacts must exist in a uniq folder for each execution. The uniqueness is defined by a timestamp. It introduces a breaking change since there are plugins that uses the temporary folder (e.g: serverless-webpack).

## How can we verify it:

Execute at least two `package` commands in the same location with different output folders. Each process will create its own temporary folder with the timestamp of when the execution started. The artifacts must be generated without any conflict.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
