### PR TITLE
Updating services.md > Invoking Serverless locally

### DIFF
--- a/docs/providers/openwhisk/guide/services.md
+++ b/docs/providers/openwhisk/guide/services.md
@@ -196,5 +196,10 @@ To execute the locally installed Serverless executable you have to reference the
 
 Example:
 ```
-node ./node_modules/serverless/bin/serverless deploy
+node node_modules/.bin/serverless deploy
+```
+
+Or with npx (bundled with npm >= 5.2.0)
+```
+npx serverless deploy
 ```


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Changed the services documention of openwish

Here is an easier way to invoke a local serverless installation.

- executables have symlinks in `node_modules/.bin` folder
- npx is an easier way to invoke these local executables: (ref: https://blog.scottlogic.com/2018/04/05/npx-the-npm-package-runner.html)

Thanks for serverless framework 👍

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

instead of calling the local installation with
`node ./node_modules/serverless/bin/serverless deploy`

We can use

`node node_modules/.bin/serverless deploy`

Or we can use

`npx serverless deploy`

(this is bundled by default with npm 5.2.0 and later

## How can we verify it:

run it locally 👍 

doc about npx: https://blog.scottlogic.com/2018/04/05/npx-the-npm-package-runner.html

https://github.com/npm/npm/releases/tag/v5.2.0

## Todos:

- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below
- [ ] change this block in other providers documentation if it is accepted

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
