### PR TITLE
Assume role and MFA support for Serverless CLI

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -13,12 +13,16 @@ const fs = require('fs');
 const objectHash = require('object-hash');
 const PromiseQueue = require('promise-queue');
 const getS3EndpointForRegion = require('../utils/getS3EndpointForRegion');
+const readline = require('readline');
 
 const constants = {
   providerName: 'aws',
 };
 
 PromiseQueue.configure(BbPromise.Promise);
+
+// Store credentials in this variable to avoid creating them several times (messes up MFA).
+let cachedCredentials = null;
 
 const impl = {
   /**
@@ -78,6 +82,18 @@ const impl = {
       if (process.env.AWS_SHARED_CREDENTIALS_FILE) {
         params.filename = process.env.AWS_SHARED_CREDENTIALS_FILE;
       }
+
+      // Allow AWS SDK to load configuration from ~/.aws/config (e.g. MFA and assumed role settings).
+      process.env.AWS_SDK_LOAD_CONFIG = 'true';
+
+      // Setup a MFA callback for asking the code from the user.
+      params.tokenCodeFn = (mfaSerial, callback) => {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        rl.question(`Enter MFA code for ${mfaSerial}: `, (answer) => {
+          rl.close();
+          callback(null, answer);
+        });
+      };
 
       const profileCredentials = new AWS.SharedIniFileCredentials(params);
       if (!(profileCredentials.accessKeyId
@@ -294,6 +310,10 @@ class AwsProvider {
    * @returns {{region: *}}
    */
   getCredentials() {
+    if (cachedCredentials) {
+      // We have already created the credentials object once, so return it.
+      return cachedCredentials;
+    }
     const result = {};
     const stageUpper = this.getStage() ? this.getStage().toUpperCase() : null;
 
@@ -318,6 +338,8 @@ class AwsProvider {
       result.signatureVersion = 'v4';
     }
 
+    // Store the credentials to avoid creating them again (messes up MFA).
+    cachedCredentials = result;
     return result;
   }
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -21,9 +21,6 @@ const constants = {
 
 PromiseQueue.configure(BbPromise.Promise);
 
-// Store credentials in this variable to avoid creating them several times (messes up MFA).
-let cachedCredentials = null;
-
 const impl = {
   /**
    * Determine whether the given credentials are valid.  It turned out that detecting invalid
@@ -83,7 +80,8 @@ const impl = {
         params.filename = process.env.AWS_SHARED_CREDENTIALS_FILE;
       }
 
-      // Allow AWS SDK to load configuration from ~/.aws/config (e.g. MFA and assumed role settings).
+      // Allow AWS SDK to load configuration from ~/.aws/config
+      // (e.g. MFA and assumed role settings)
       process.env.AWS_SDK_LOAD_CONFIG = 'true';
 
       // Setup a MFA callback for asking the code from the user.
@@ -132,6 +130,8 @@ class AwsProvider {
     this.serverless.setProvider(constants.providerName, this);
     this.requestCache = {};
     this.requestQueue = new PromiseQueue(2, Infinity);
+    // Store credentials in this variable to avoid creating them several times (messes up MFA).
+    this.cachedCredentials = null;
 
     Object.assign(this.naming, naming);
 
@@ -310,9 +310,9 @@ class AwsProvider {
    * @returns {{region: *}}
    */
   getCredentials() {
-    if (cachedCredentials) {
+    if (this.cachedCredentials) {
       // We have already created the credentials object once, so return it.
-      return cachedCredentials;
+      return this.cachedCredentials;
     }
     const result = {};
     const stageUpper = this.getStage() ? this.getStage().toUpperCase() : null;
@@ -339,7 +339,7 @@ class AwsProvider {
     }
 
     // Store the credentials to avoid creating them again (messes up MFA).
-    cachedCredentials = result;
+    this.cachedCredentials = result;
     return result;
   }
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -80,10 +80,6 @@ const impl = {
         params.filename = process.env.AWS_SHARED_CREDENTIALS_FILE;
       }
 
-      // Allow AWS SDK to load configuration from ~/.aws/config
-      // (e.g. MFA and assumed role settings)
-      process.env.AWS_SDK_LOAD_CONFIG = 'true';
-
       // Setup a MFA callback for asking the code from the user.
       params.tokenCodeFn = (mfaSerial, callback) => {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });


### PR DESCRIPTION
## What did you implement:

With these changes Serverless Framework should be compatible with
AWS CLI, so that these instructions for assuming a role work
out-of-the-box:
https://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html

Related to #5048

## How did you implement it:

This sets the AWS_SDK_LOAD_CONFIG environment variable which allows
AWS SDK to read ~/.aws/config, and implements the tokenCodeFn
callback which asks the user to enter a MFA code. Credentials are
also cached to avoid creating the object multiple times, which
makes MFA work properly when multiple requests are made.

## How can we verify it:

Deploy any project using an AWS profile that has role_arn, source_profile and mfa_serial configured in ~/.aws/config.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
