### PR TITLE
Update http.md

### DIFF
--- a/docs/providers/azure/events/http.md
+++ b/docs/providers/azure/events/http.md
@@ -42,7 +42,7 @@ functions:
         x-azure-settings:
             name: req #<string>, default - "req", specifies which name it's available on `context.bindings`
             methods: #<array> [GET, POST, PUT, DELETE], default - all
-                - GET
+                - get
             route: example/hello #<string>, default - <function name>
             authLevel: anonymous #<enum - anonymous|function (default)|admin>
 ```


### PR DESCRIPTION
The values for the events properties must be in lowercase. The display values will appear in Capital letters in Azure Portal.

## What did you implement:
Change the value for the event property methods from **GET** to **get** as the properties values must be in lowercase, otherwise the binding property won't be set.

## How did you implement it:
Replace GET with get

## How can we verify it:
If you deploy using GET in the serverless file the methods property in the bindings for the httpTrigger will not be set to GET.
If deploying using get instead, methods property will be set as expected.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
