### PR TITLE
Fix integration test

### DIFF
--- a/tests/simple-suite/tests.js
+++ b/tests/simple-suite/tests.js
@@ -69,7 +69,7 @@ describe('Service Lifecyle Integration Test', () => {
     let timestamp;
     const listDeploys = execSync(`${serverlessExec} deploy list`);
     const output = listDeploys.toString();
-    const match = output.match(new RegExp('Timestamp: (.+)'));
+    const match = output.match(new RegExp('Datetime: (.+)'));
     if (match) {
       timestamp = match[1];
     }


### PR DESCRIPTION
rollback was using a unix timestamp, but  expects an ISO8601 timestamp it seems


## What did you implement:

Fix simple integration test


## How did you implement it:
rollback was using a unix timestamp, but  expects an ISO8601 timestamp it seems

## How can we verify it:

run `npm run simple-integration-test`

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~
- [ ] ~~Fix linting errors~~
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
