### PR TITLE
Create an HttpsProxyAgent for plugin list if necessary

### DIFF
--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -2,6 +2,8 @@
 
 const fetch = require('node-fetch');
 const BbPromise = require('bluebird');
+const HttpsProxyAgent = require('https-proxy-agent');
+const url = require('url');
 const path = require('path');
 const chalk = require('chalk');
 const _ = require('lodash');
@@ -49,7 +51,20 @@ module.exports = {
 
   getPlugins() {
     const endpoint = 'https://raw.githubusercontent.com/serverless/plugins/master/plugins.json';
-    return fetch(endpoint).then((result) => result.json()).then((json) => json);
+
+    // Use HTTPS Proxy (Optional)
+    const proxy = process.env.proxy
+      || process.env.HTTP_PROXY
+      || process.env.http_proxy
+      || process.env.HTTPS_PROXY
+      || process.env.https_proxy;
+
+    const options = {};
+    if (proxy) {
+      options.agent = new HttpsProxyAgent(url.parse(proxy));
+    }
+
+    return fetch(endpoint, options).then((result) => result.json()).then((json) => json);
   },
 
   display(plugins) {


### PR DESCRIPTION
## What did you implement:

Closes #5480

## How did you implement it:

Create an `HttpsProxyAgent` to pass to `fetch` if any relevant env vars are set

## How can we verify it:

run `sls plugins list` with an `https_proxy` env var set.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
