### PR TITLE
Fix issues with PR #5631 causing base64 errors

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -34,32 +34,43 @@ class CLI {
       inputArray = process.argv.slice(2);
     }
 
-    const toBase64Helper = (value, index) => {
-      if ((index % 2) !== 0) {
-        return new Buffer(value.toString()).toString('base64');
+    const base64Encode = (valueStr) =>
+      new Buffer(valueStr).toString('base64');
+
+    const toBase64Helper = (value) => {
+      const valueStr = value.toString();
+      if (valueStr.startsWith('-')) {
+        if (valueStr.indexOf('=') !== -1) {
+          // do not encode argument names, since those are parsed by
+          // minimist, and thus need to be there unconverted:
+          const splitted = valueStr.split('=', 2);
+          // splitted[1] values, however, need to be encoded, since we
+          // decode them later back to utf8
+          const encodedValue = base64Encode(splitted[1]);
+          return `${splitted[0]}=${encodedValue}`;
+        }
+        // do not encode plain flags, for the same reason as above
+        return valueStr;
       }
-      return value;
+      return base64Encode(valueStr);
     };
 
     const decodedArgsHelper = (arg) => {
       if (_.isString(arg)) {
         return new Buffer(arg, 'base64').toString();
+      } else if (_.isArray(arg)) {
+        return _.map(arg, decodedArgsHelper);
       }
       return arg;
     };
 
-    // get all the commands
-    const valuesToIgnore = _.takeWhile(inputArray, (item) => !item.startsWith('-'));
-    // get all the options
-    const valuesToConvert = _.difference(inputArray, valuesToIgnore);
     // encode all the options values to base64
-    const valuesToB64 = _.map(valuesToConvert, toBase64Helper);
-    // concat commands with values on base64
-    const valuesToParse = _.concat(valuesToIgnore, valuesToB64);
+    const valuesToParse = _.map(inputArray, toBase64Helper);
 
+    // parse the options with minimist
     const argvToParse = minimist(valuesToParse);
 
-    // decode all values to utf8 strings
+    // decode all values back to utf8 strings
     const argv = _.mapValues(argvToParse, decodedArgsHelper);
 
     const commands = [].concat(argv._);

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -371,6 +371,29 @@ describe('CLI', () => {
       expect(inputToBeProcessed).to.deep.equal(expectedObject);
     });
 
+    it('should not pass base64 values as options', () => {
+      cli = new CLI(serverless, ['--service=foo', 'dynamodb', 'install']);
+      const inputToBeProcessed = cli.processInput();
+
+      /* It used to fail with the following diff, failing to convert base64 back,
+         and unconverting non-base64 values into binary:
+       {
+         "commands": [
+      -    "ZHluYW1vZGI="
+      +    "dynamodb"
+           "install"
+         ]
+         "options": {
+      -    "service": "~�"
+      +    "service": "foo"
+         }
+       }
+      */
+      const expectedObject = { commands: ['dynamodb', 'install'], options: { service: 'foo' } };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
+    });
+
     it('should return commands and options when both are given', () => {
       cli = new CLI(serverless, ['deploy', 'functions', '-f', 'function1']);
       const inputToBeProcessed = cli.processInput();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5491

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Changed the arguments parsing logic to encode all the arguments, which simplifies the decoding later, to avoid errors like the one from #5491.
- Implemented decoding of nested objects, which is required to decode encoded commands.

### Details, why the changes were required:

- Some of values were not converted back from base64, which resulted in spurious errors with base64 strings. (This was caused by nested arrays, like commands, not being converted back, combined with the wrong assumption that commands always occur before options. It is not always true, as the added test case demonstrates.)
- Some other values were converted *from* base64, but they weren't base64 in the first place, which resulted in junk binary data. (This was due to the invalid assumption that only odd-numbered values   need to be converted.)

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Try running for instance `serverless --no-color --verbose info` in any project.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
