### PR TITLE
 version bump for #5492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.33.1 (15.11.2018)
+ - [fix issue with `sls deploy --verbose --stage foobar`](https://github.com/serverless/serverless/pull/5492)
+
+## Meta
+ - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.33.0...v1.33.1)
+
+
 # 1.33.0 (15.11.2018)
  - [2116 consistent errors missing config](https://github.com/serverless/serverless/pull/5298)
  - [Update plugin version of google-nodejs template](https://github.com/serverless/serverless/pull/5473)

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -402,6 +402,15 @@ describe('CLI', () => {
 
       expect(inputToBeProcessed).to.deep.equal(expectedObject);
     });
+
+    it('should be able to parse --verbose --stage foobar', () => {
+      cli = new CLI(serverless, ['deploy', '--verbose', '--stage', 'foobar']);
+      const inputToBeProcessed = cli.processInput();
+
+      const expectedObject = { commands: ['deploy'], options: { verbose: true, stage: 'foobar' } };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
+    });
   });
 
   describe('Integration tests', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
patch release for regression causing `sls depoy --verbose --stage foobar` to fail. 