### PR TITLE
Don't use py3.5+ only subprocess.run in python invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -74,8 +74,11 @@ if __name__ == '__main__':
 
     input = json.load(sys.stdin)
     if sys.platform != 'win32':
-        tty = subprocess.run('tty', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if tty.returncode == 0:
+        try:
+            subprocess.check_call('tty', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except (OSError, subprocess.CalledProcessError):
+            pass
+        else:
             sys.stdin = open('/dev/tty')
 
     context = FakeLambdaContext(**input.get('context', {}))


### PR DESCRIPTION


## What did you implement:

Fixes #5499

invoke local was changed in #5355 to check for a tty by calling the `tty` executable, but it was implemented with `subprocess.run` which was added in Python 3.5 so it doesn't work with Python 2.7 projects

## How did you implement it:

Switched to the older `subprocess.check_call`

## How can we verify it:

```
npm i -g serverless/serverless#fix-py27-invoke-local
sls create -t aws-python
sls invoke local -f hello
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
