### PR TITLE
Convert logging to return a promise so that #5349 no longer causes #5497

### DIFF
--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -62,9 +62,9 @@ class AwsLogs {
   showLogs(logStreamNames) {
     if (!logStreamNames || !logStreamNames.length) {
       if (this.options.tail) {
-        return setTimeout((() => this.getLogStreams()
-          .then(nextLogStreamNames => this.showLogs(nextLogStreamNames))),
-          this.options.interval);
+        return BbPromise.delay(this.options.interval)
+          .then(this.getLogStreams.bind(this))
+          .then(this.showLogs.bind(this));
       }
     }
 
@@ -116,9 +116,9 @@ class AwsLogs {
             this.options.startTime = _.last(results.events).timestamp + 1;
           }
 
-          return setTimeout((() => this.getLogStreams()
-              .then(nextLogStreamNames => this.showLogs(nextLogStreamNames))),
-            this.options.interval);
+          return BbPromise.delay(this.options.interval)
+            .then(this.getLogStreams.bind(this))
+            .then(this.showLogs.bind(this));
         }
 
         return BbPromise.resolve();

--- a/lib/plugins/aws/logs/index.test.js
+++ b/lib/plugins/aws/logs/index.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const bluebird = require('bluebird');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsProvider = require('../provider/awsProvider');
@@ -340,8 +341,10 @@ describe('AwsLogs', () => {
         logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
         tail: true,
       };
+      const bbPromiseDelay = sinon.stub(bluebird, 'delay').rejects();
 
       return awsLogs.showLogs(logStreamNamesMock)
+        .catch(() => true) // Promise.delay has to reject or it'll loop forever
         .then(() => {
           expect(filterLogEventsStub.calledOnce).to.be.equal(true);
           expect(filterLogEventsStub.calledWithExactly(
@@ -356,6 +359,7 @@ describe('AwsLogs', () => {
           )).to.be.equal(true);
 
           awsLogs.provider.request.restore();
+          bbPromiseDelay.restore();
         });
     });
   });


### PR DESCRIPTION
# What did you implement:

Closes #5497

## How did you implement it:

Used bluebird's `Promise.delay` instead of `setTimeout` so that `showLogs` continues to extend the promise chain so that it doesn't return, which would then cause #5349 to exit the process.

## How can we verify it:
```
npm i -g serverless
sls create -t aws-nodejs -p test -n test
cd test
sls deploy
sls invoke
sls logs -t # this will exit immediately, which is the bug
npm i -g serverless/serverless#fix-5497
sls invoke -t # this should not exit
```

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
