### PR TITLE
Python3.7 support!!!

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./tmp/serverless-integration-test-aws-python:/app
   aws-python3:
-    image: python:3.6
+    image: python:3.7
     volumes:
       - ./tmp/serverless-integration-test-aws-python3:/app
   aws-java-maven:

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -129,7 +129,7 @@ class AwsInvokeLocal {
         this.options.context);
     }
 
-    if (runtime === 'python2.7' || runtime === 'python3.6') {
+    if (['python2.7', 'python3.6', 'python3.7'].includes(runtime)) {
       const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents.slice(0, -1).join('.');
       const handlerName = handlerComponents.pop();

--- a/lib/plugins/create/templates/aws-python3/serverless.yml
+++ b/lib/plugins/create/templates/aws-python3/serverless.yml
@@ -19,7 +19,7 @@ service: aws-python3 # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.7
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
AWS now supports Python3.7 in Lambda!
https://aws.amazon.com/blogs/compute/python-3-7-runtime-now-available-in-aws-lambda/

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Updated the python3 template to use the python3.7 runtime & invoke local to support it too.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

* replaced string in python3 template
* changed check for python runtime in invoke local

## How can we verify it:

```
npm i -g serverless/serverless#python3.7
sls create -t aws-python3 -n py37 -p py37
cd py37
sls deploy
sls invoke local -f hello
sls invoke -f hello
```

## Todos:

- [ ] ~~Write tests~~
- [ ] ~~Write documentation~~
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
