### PR TITLE
Fix: LogGroup & function name ignores stage flag passed in from CLI tool. #4929

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -56,6 +56,7 @@ class Serverless {
 
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();
+    this.service.provider.stage = this.processedInput.options.stage || this.service.provider.stage;
 
     // set the options and commands which were processed by the CLI
     this.pluginManager.setCliOptions(this.processedInput.options);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4929 

When the serverless.yml has no stage key, and you use the --stage flag, the LogGroup and function name will be named using the default dev stage.

For example we have serverless file like this
```
service: banana

provider:
  name: aws
  runtime: nodejs6.10

functions:
  hello:
    handler: handler.hello
    name: hello-${self:provider.stage}
```

If look you can see that provider does not have stage but function name has reference on `${self:provider.stage}`.
When user deploys it and pass ` --stage` flag in cli it works a little bit strange.
Cloudformation stack will be named OK   but cloudwatch group name  and function name will ignore it and will use always default stage('dev')


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
If `--stage` flag was passed in cli it rewrites default stage 'dev', but it does not rewrite stage which was specified in provider section.



<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO