### PR TITLE
Fix bug where code attempts to parse nonexistent data / context objects

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -74,9 +74,14 @@ class AwsInvokeLocal {
       }
     }).then(() => {
       try {
+        // unless asked to preserve raw input, attempt to parse any provided objects
         if (!this.options.raw) {
-          this.options.data = JSON.parse(this.options.data);
-          this.options.context = JSON.parse(this.options.context);
+          if (this.options.data) {
+            this.options.data = JSON.parse(this.options.data);
+          }
+          if (this.options.context) {
+            this.options.context = JSON.parse(this.options.context);
+          }
         }
       } catch (exception) {
         // do nothing if it's a simple string or object already

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -134,6 +134,23 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
+    it('should parse context if it is a json string', () => {
+      awsInvokeLocal.options.context = '{"key": "value"}';
+
+      return awsInvokeLocal.extendedValidate().then(() => {
+        expect(awsInvokeLocal.options.context).to.deep.equal({ key: 'value' });
+      });
+    });
+
+    it('should skip parsing context if "raw" requested', () => {
+      awsInvokeLocal.options.context = '{"key": "value"}';
+      awsInvokeLocal.options.raw = true;
+
+      return awsInvokeLocal.extendedValidate().then(() => {
+        expect(awsInvokeLocal.options.context).to.deep.equal('{"key": "value"}');
+      });
+    });
+
     it('it should parse file if relative file path is provided', () => {
       serverless.config.servicePath = testUtils.getTmpDirPath();
       const data = {


### PR DESCRIPTION
## What did you implement:

Closes #5511

This is a bug where the invoke local handler attempts to parse the JSON strings supplied via `--data` and `--context` whether or not they were actually provided.  This currently manifests as the inability to pass a `--context` param unless a `--data` param is also supplied.  Currently, if the `--data` param is not supplied, but the `--context` param is, the context JSON string will not be properly parsed and will be passed to the function as a string instead of correctly parsed to an object.

## How did you implement it:

I added a simple existence check before parsing both the `data` and `context` options.  Now, if one or both do not exist, serverless will not attempt to parse them.  This feels a lot more intentional than the previous behavior which relied on routinely throwing and silently swallowing errors.

I used full `if` statements for the sake of straightforward readability, but I'm happy to change them to ternaries if that's more in line with the project's style.

## How can we verify it:

I added new tests to specifically cover this case.  I verified that the tests are failing in the current build and are passing in this PR.

If you'd like to manually validate this, here is an example of an `invoke` command which does not currently function as expected in master, but will function as expected in this PR.

```
serverless invoke local -f hello --context '{ "foo": "bar" }'
```

In master, `typeof context` would currently be `string` as the context object will not be properly parsed.  After this PR, `typeof context` will be `object` as expected.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
