### PR TITLE
--aws-profile should override profile defined in serverless.yml

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -315,7 +315,7 @@ class AwsProvider {
 
     // add specified credentials, overriding with more specific declarations
     impl.addCredentials(result, this.serverless.service.provider.credentials); // config creds
-    if (this.serverless.service.provider.profile) {
+    if (this.serverless.service.provider.profile && !this.options['aws-profile']) {
       // config profile
       impl.addProfileCredentials(result, this.serverless.service.provider.profile);
     }

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -743,6 +743,25 @@ describe('AwsProvider', () => {
       expect(credentials.credentials.profile).to.equal('notDefault');
     });
 
+    it('should get credentials when profile is provied via --aws-profile option even if profile is defined in serverless.yml', () => { // eslint-disable-line max-len
+      process.env.AWS_PROFILE = 'notDefaultTemporary';
+      newAwsProvider.options['aws-profile'] = 'notDefault';
+
+      serverless.service.provider.profile = 'notDefaultTemporary2';
+
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials.profile).to.equal('notDefault');
+    });
+
+    it('should get credentials when profile is provied via process.env.AWS_PROFILE even if profile is defined in serverless.yml', () => { // eslint-disable-line max-len
+      process.env.AWS_PROFILE = 'notDefault';
+
+      serverless.service.provider.profile = 'notDefaultTemporary';
+
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials.profile).to.equal('notDefault');
+    });
+
     it('should set the signatureVersion to v4 if the serverSideEncryption is aws:kms', () => {
       newAwsProvider.serverless.service.provider.deploymentBucketObject = {
         serverSideEncryption: 'aws:kms',


### PR DESCRIPTION
## What did you implement:

Closes #5515

## How did you implement it:

The option `aws-profile` should override defined profile in `serverless.yml`.

When the profile is defined AND the `--aws-profile` is defined, we don't load the profile from `serverless.yml` but from the option `aws-profile`.

## How can we verify it:

Use that `serverless.yml` file:
```yml
provider:
    name: aws
    runtime: nodejs8.10
    profile: foobar
    region: ${opt:region, 'eu-west-1'}
```

And that `~/.aws/credentials` file:

```ini
[myprofile]
aws_access_key_id = xx
aws_secret_access_key = xx
region = eu-west-1
```

The command `serverless deploy --aws-profile myprofile` should NOT trigger an error about the profile "foobar" which does not exist.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
