### PR TITLE
updated docs example links from github to serverless

### DIFF
--- a/docs/providers/aws/examples/README.md
+++ b/docs/providers/aws/examples/README.md
@@ -14,18 +14,17 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 
 | Example | Runtime  |
 |:--------------------------- |:-----|
-| [Aws Auth0 Api Gateway](https://github.com/serverless/examples/tree/master/aws-node-auth0-custom-authorizers-api) <br/> Demonstration of protecting API gateway endpoints with auth0 | nodeJS |
-| [Env Variables Encrypted In A File](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file) <br/> Serverless example managing secrets in an encrypted file | nodeJS |
-| [Serverless Node Env Variables](https://github.com/serverless/examples/tree/master/aws-node-env-variables) <br/> This example demonstrates how to use environment variables for AWS Lambdas. | nodeJS |
-| [Fetch File And Store In S3](https://github.com/serverless/examples/tree/master/aws-node-fetch-file-and-store-in-s3) <br/> Fetch an image from remote source (URL) and then upload the image to a S3 bucket. | nodeJS |
-| [Function Compiled With Babel](https://github.com/serverless/examples/tree/master/aws-node-function-compiled-with-babel) <br/> Demonstrating how to compile all your code with Babel | nodeJS |
-| [Serverless Rest With Dynamodb](https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb) <br/> Serverless CRUD service exposing a REST HTTP interface | nodeJS |
-| [Serverless Aws Cron Job Example](https://github.com/serverless/examples/tree/master/aws-node-scheduled-cron) <br/> Example of creating a function that runs as a cron job using the serverless `schedule` event | nodeJS |
-| [Aws Node Serve Dynamic Html Via Http Endpoint](https://github.com/serverless/examples/tree/master/aws-node-serve-dynamic-html-via-http-endpoint) <br/> Hookup an AWS API Gateway endpoint to a Lambda function to render HTML on a `GET` request | nodeJS |
-| [Aws Node Serve Dynamic Html Via Http Endpoint](https://github.com/serverless/examples/tree/master/aws-node-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint | nodeJS |
-| [Single Page App Via Cloudfront](https://github.com/serverless/examples/tree/master/aws-node-single-page-app-via-cloudfront) <br/> Demonstrating how to deploy a Single Page Application with Serverless | nodeJS |
-| [Serverless Single Page App Plugin](https://github.com/serverless/examples/tree/master/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin) <br/> A plugin to simplify deploying Single Page Application using S3 and CloudFront | nodeJS |
-| [Serverless Data Pipeline](https://github.com/serverless/examples/tree/master/aws-node-text-analysis-via-sns-post-processing) <br/> Example demonstrates how to setup a simple data processing pipeline | nodeJS |
-| [Aws Python Simple Http Endpoint](https://github.com/serverless/examples/tree/master/aws-python-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with python | python |
+| [Aws Auth0 Api Gateway](https://serverless.com/examples/aws-node-auth0-custom-authorizers-api/) <br/> Demonstration of protecting API gateway endpoints with auth0 | nodeJS |
+| [Env Variables Encrypted In A File](https://serverless.com/examples/aws-node-env-variables-encrypted-in-a-file/) <br/> Serverless example managing secrets in an encrypted file | nodeJS |
+| [Serverless Node Env Variables](https://serverless.com/examples/aws-node-env-variables/) <br/> This example demonstrates how to use environment variables for AWS Lambdas. | nodeJS |
+| [Fetch File And Store In S3](https://serverless.com/examples/aws-node-fetch-file-and-store-in-s3/) <br/> Fetch an image from remote source (URL) and then upload the image to a S3 bucket. | nodeJS |
+| [Function Compiled With Babel](https://serverless.com/examples/aws-node-function-compiled-with-babel/) <br/> Demonstrating how to compile all your code with Babel | nodeJS |
+| [Serverless Rest With Dynamodb](https://serverless.com/examples/aws-node-rest-api-with-dynamodb/) <br/> Serverless CRUD service exposing a REST HTTP interface | nodeJS |
+| [Serverless Aws Cron Job Example](https://serverless.com/examples/aws-node-scheduled-cron/) <br/> Example of creating a function that runs as a cron job using the serverless `schedule` event | nodeJS |
+| [Aws Node Serve Dynamic Html Via Http Endpoint](https://serverless.com/examples/aws-node-serve-dynamic-html-via-http-endpoint/) <br/> Hookup an AWS API Gateway endpoint to a Lambda function to render HTML on a `GET` request | nodeJS |
+| [Aws Node Serve Dynamic Html Via Http Endpoint](https://serverless.com/examples/aws-node-simple-http-endpoint/) <br/> Example demonstrates how to setup a simple HTTP GET endpoint | nodeJS |
+| [Single Page App Via Cloudfront](https://serverless.com/examples/aws-node-single-page-app-via-cloudfront/) <br/> Demonstrating how to deploy a Single Page Application with Serverless | nodeJS |
+| [Serverless Data Pipeline](https://serverless.com/examples/aws-node-text-analysis-via-sns-post-processing/) <br/> Example demonstrates how to setup a simple data processing pipeline | nodeJS |
+| [Aws Python Simple Http Endpoint](https://serverless.com/examples/aws-python-simple-http-endpoint/) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with python | python |
 
 If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/azure/examples/README.md
+++ b/docs/providers/azure/examples/README.md
@@ -14,6 +14,6 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 
 | Example | Runtime  |
 |:--------------------------- |:-----|
-| [azure Node Simple](https://github.com/serverless/examples/tree/master/azure-node-simple-http-endpoint) <br/> Boilerplate project repository for Azure provider with Serverless Framework. | nodeJS |
+| [azure Node Simple](https://serverless.com/examples/azure-node-simple-http-endpoint/) <br/> Boilerplate project repository for Azure provider with Serverless Framework. | nodeJS |
 
 If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/google/examples/README.md
+++ b/docs/providers/google/examples/README.md
@@ -14,6 +14,6 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 
 | Example | Runtime  |
 |:--------------------------- |:-----|
-| [Google Node Simple](https://github.com/serverless/examples/tree/master/google-node-simple-http-endpoint) <br/> Boilerplate project repository for Google Cloud provider with Serverless Framework. | nodeJS |
+| [Google Node Simple](https://serverless.com/examples/google-node-simple-http-endpoint/) <br/> Boilerplate project repository for Google Cloud provider with Serverless Framework. | nodeJS |
 
 If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/openwhisk/examples/README.md
+++ b/docs/providers/openwhisk/examples/README.md
@@ -14,10 +14,10 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 
 | Example                                  | Runtime |
 | :--------------------------------------- | :------ |
-| [OpenWhisk Node Simple](https://github.com/serverless/examples/tree/master/openwhisk-node-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | nodeJS  |
-| [OpenWhisk Python Simple](https://github.com/serverless/examples/tree/master/openwhisk-python-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | python |
-| [OpenWhisk PHP Simple](https://github.com/serverless/examples/tree/master/openwhisk-php-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | php |
-| [OpenWhisk Ruby Simple](https://github.com/serverless/examples/tree/master/openwhisk-ruby-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | ruby |
-| [OpenWhisk Swift Simple](https://github.com/serverless/examples/tree/master/openwhisk-swift-simple) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | swift |
+| [OpenWhisk Node Simple](https://serverless.com/examples/openwhisk-node-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | nodeJS  |
+| [OpenWhisk Python Simple](https://serverless.com/examples/openwhisk-python-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | python |
+| [OpenWhisk PHP Simple](https://serverless.com/examples/openwhisk-php-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | php |
+| [OpenWhisk Ruby Simple](https://serverless.com/examples/openwhisk-ruby-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | ruby |
+| [OpenWhisk Swift Simple](https://serverless.com/examples/openwhisk-swift-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework. | swift |
 
 If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)


### PR DESCRIPTION
## What did you implement:

Examples listed in our docs were pointing to Github and in this PR, I've updated them to point to sls website instead since we now have Examples Explorer

## How did you implement it:

Updated links in respective .md files

## How can we verify it:

Since this a content update, please refer to the changed files to confirm if the updated links were referenced correctly.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
