### PR TITLE
Add support for API Gateway payload compression

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -45,6 +45,7 @@ layout: Doc
       - [Note while using authorizers with shared API Gateway](#note-while-using-authorizers-with-shared-api-gateway)
   - [Share Authorizer](#share-authorizer)
   - [Resource Policy](#resource-policy)
+  - [Compression](#compression)
 
 _Are you looking for tutorials on using API Gateway? Check out the following resources:_
 
@@ -1233,4 +1234,15 @@ provider:
           aws:SourceIp:
             - "123.123.123.123"
 
+```
+
+## Compression
+
+API Gateway allows for clients to receive [compressed payloads](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gzip-compression-decompression.html), and supports various [content encodings](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-enable-compression.html#api-gateway-supported-content-encodings).
+
+```yml
+provider:
+  name: aws
+  apiGateway:
+    minimumCompressionSize: 1024
 ```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -55,6 +55,7 @@ provider:
       '/users': xxxxxxxxxx
       '/users/create': xxxxxxxxxx
     apiKeySourceType: HEADER # Source of API key for usage plan. HEADER or AUTHORIZER.
+    minimumCompressionSize: 1024 # Compress response when larger than specified size in bytes (must be between 0 and 10485760)
 
   usagePlan: # Optional usage plan configuration
     quota:

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -81,7 +81,8 @@ module.exports = {
 
       if (!_.isInteger(minimumCompressionSize)) {
         const message =
-          `minimumCompressionSize must be an integer. You provided ${JSON.stringify(minimumCompressionSize)}.`;
+          'minimumCompressionSize must be an integer. ' +
+          `You provided ${JSON.stringify(minimumCompressionSize)}.`;
         return BbPromise.reject(new this.serverless.classes.Error(message));
       }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -81,7 +81,7 @@ module.exports = {
 
       if (!_.isInteger(minimumCompressionSize)) {
         const message =
-          `minimumCompressionSize must be an integer. You provided ${minimumCompressionSize}.`;
+          `minimumCompressionSize must be an integer. You provided ${JSON.stringify(minimumCompressionSize)}.`;
         return BbPromise.reject(new this.serverless.classes.Error(message));
       }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -74,6 +74,31 @@ module.exports = {
       );
     }
 
+    if (!_.isEmpty(this.serverless.service.provider.apiGateway) &&
+      !_.isEmpty(this.serverless.service.provider.apiGateway.minimumCompressionSize)) {
+      const minimumCompressionSize =
+        this.serverless.service.provider.apiGateway.minimumCompressionSize;
+
+      if (!_.isInteger(minimumCompressionSize)) {
+        const message =
+          `minimumCompressionSize must be an integer. You provided ${minimumCompressionSize}.`;
+        return BbPromise.reject(new this.serverless.classes.Error(message));
+      }
+
+      if (minimumCompressionSize < 0 || minimumCompressionSize > 10485760) {
+        const message =
+          'minimumCompressionSize must be between 0 and 10485760. ' +
+          `You provided ${minimumCompressionSize}.`;
+        return BbPromise.reject(new this.serverless.classes.Error(message));
+      }
+
+      _.merge(
+        this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[this.apiGatewayRestApiLogicalId].Properties,
+        { MinimumCompressionSize: minimumCompressionSize }
+      );
+    }
+
     return BbPromise.resolve();
   },
 };

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -75,7 +75,7 @@ module.exports = {
     }
 
     if (!_.isEmpty(this.serverless.service.provider.apiGateway) &&
-      !_.isEmpty(this.serverless.service.provider.apiGateway.minimumCompressionSize)) {
+      !_.isUndefined(this.serverless.service.provider.apiGateway.minimumCompressionSize)) {
       const minimumCompressionSize =
         this.serverless.service.provider.apiGateway.minimumCompressionSize;
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -155,4 +155,32 @@ describe('#compileRestApi()', () => {
     awsCompileApigEvents.serverless.service.provider.apiGateway = { apiKeySourceType: 'Testing' };
     expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
   });
+
+  it('should compile correctly if minimumCompressionSize is an integer', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      minimumCompressionSize: 1024,
+    };
+    expect(() => awsCompileApigEvents.compileRestApi()).to.not.throw(Error);
+  });
+
+  it('should throw error if minimumCompressionSize is not an integer', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      minimumCompressionSize: 'Testing',
+    };
+    expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
+  });
+
+  it('should throw error if minimumCompressionSize is less than 0', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      minimumCompressionSize: -1,
+    };
+    expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
+  });
+
+  it('should throw error if minimumCompressionSize is greater than 10485760', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      minimumCompressionSize: 10485761,
+    };
+    expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
+  });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -176,4 +176,11 @@ describe('#compileRestApi()', () => {
     };
     expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
   });
+
+  it('should throw error if minimumCompressionSize is greater than 10485760', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      minimumCompressionSize: 10485761,
+    };
+    expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
+  });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -176,11 +176,4 @@ describe('#compileRestApi()', () => {
     };
     expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
   });
-
-  it('should throw error if minimumCompressionSize is greater than 10485760', () => {
-    awsCompileApigEvents.serverless.service.provider.apiGateway = {
-      minimumCompressionSize: 10485761,
-    };
-    expect(awsCompileApigEvents.compileRestApi()).to.be.rejectedWith(Error);
-  });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless/serverless/issues/4593

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Modified `/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js` to look for `minimumCompressionSize` in provider configuration and apply to the Cloudformation template for ApiGateway.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. create `serverless.yml`
```yml
service: service-for-verification
provider:
  name: aws
  runtime: nodejs8.10
  apiGateway:
    minimumCompressionSize: 1024
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: hello/
          method: get
```

2. deploy
```bash
sls deploy
```

3. validate cloudformation template
```json
{
  "ApiGatewayRestApi": {
    "Type": "AWS::ApiGateway::RestApi",
    "Properties": {
      "MinimumCompressionSize": 1024
    }
  }
}
``` 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
