### PR TITLE
Remove prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "integration-test-cleanup": "node scripts/integration-test-cleanup.js",
     "simple-integration-test": "jest --maxWorkers=5 simple-suite",
     "complex-integration-test": "jest --maxWorkers=5 integration",
-    "postinstall": "node ./scripts/postinstall.js",
-    "prepublishOnly": "./scripts/shrinkwrap && node ./scripts/pre-release.js"
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "jest": {
     "testRegex": "(\\.|/)(tests)\\.js$",

--- a/scripts/pre-release.js
+++ b/scripts/pre-release.js
@@ -7,9 +7,11 @@ const path = require('path');
 const trackingConfigFilePath = path.join(process.cwd(), getTrackingConfigFileName());
 
 // don't release without Sentry key!
+/*
 if (!process.env.SENTRY_DSN) {
   throw new Error('SENTRY_DSN env var not set');
 }
+*/
 
 const trackingConfig = {
   sentryDSN: process.env.SENTRY_DSN,

--- a/scripts/pre-release.js
+++ b/scripts/pre-release.js
@@ -7,11 +7,9 @@ const path = require('path');
 const trackingConfigFilePath = path.join(process.cwd(), getTrackingConfigFileName());
 
 // don't release without Sentry key!
-/*
 if (!process.env.SENTRY_DSN) {
   throw new Error('SENTRY_DSN env var not set');
 }
-*/
 
 const trackingConfig = {
   sentryDSN: process.env.SENTRY_DSN,


### PR DESCRIPTION
we dont actually use this and its blocking release now.

Releases just happened to work in the past because node 4 would do the deploy which doesnt
run the prerelease script
