### PR TITLE
Fix ResourceLimitExceeded for cloudwatchLog event

### DIFF
--- a/docs/providers/aws/events/cloudwatch-log.md
+++ b/docs/providers/aws/events/cloudwatch-log.md
@@ -40,22 +40,6 @@ functions:
           filter: '{$.userIdentity.type = Root}'
 ```
 
-## Current gotchas
-
-There's currently one gotcha you might face if you use this event definition.
-
-The deployment will fail with an error that a resource limit exceeded if you replace the `logGroup` name of one function with the `logGroup` name of another function in your `serverless.yml` file and run `serverless deploy` (see below for an in-depth example).
-
-This is caused by the fact that CloudFormation tries to attach the new subscription filter before detaching the old one. CloudWatch Logs only support one subscription filter per log group as you can read in the documentation about [CloudWatch Logs Limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).
-
-You're able to pass an option on your `serverless.yml` file in order to allow the `serverless` CLI to delete the resources manually using `aws-sdk`, to circumvent the problem. With this option enabled, the ResourceLimitExceeded won't trigger because the subscription filter is going to be deleted before it during the `serverless deploy` call. Note that enabling this option may lead on inconsistencies on your CloudFormation stack as deleting resources managed by a CloudFormation stack manually is, acknowledged, a bad practice.
-
-```yml
-provider:
-  cloudWatchLogs:
-    forceUpdateSubscriptionFilters: true
-```
-
 ### Example
 
 Update your `serverless.yml` file as follows and run `serverless deploy`.

--- a/docs/providers/aws/events/cloudwatch-log.md
+++ b/docs/providers/aws/events/cloudwatch-log.md
@@ -48,7 +48,13 @@ The deployment will fail with an error that a resource limit exceeded if you rep
 
 This is caused by the fact that CloudFormation tries to attach the new subscription filter before detaching the old one. CloudWatch Logs only support one subscription filter per log group as you can read in the documentation about [CloudWatch Logs Limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).
 
-Please keep this gotcha in mind when using this event. We will fix it in an upcoming release.
+You're able to pass an option on your `serverless.yml` file in order to allow the `serverless` CLI to delete the resources manually using `aws-sdk`, to circumvent the problem. With this option enabled, the ResourceLimitExceeded won't trigger because the subscription filter is going to be deleted before it during the `serverless deploy` call. Note that enabling this option may lead on inconsistencies on your CloudFormation stack as deleting resources managed by a CloudFormation stack manually is, acknowledged, a bad practice.
+
+```yml
+provider:
+  cloudWatchLogs:
+    forceUpdateSubscriptionFilters: true
+```
 
 ### Example
 

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -13,13 +13,21 @@ module.exports = {
     this.serverless.service.provider.shouldNotDeploy = false;
 
     if (this.options.force) {
-      return BbPromise.resolve();
+      return this.checkLogGroupSubscriptionFilterResourceLimitExceeded();
     }
 
     return BbPromise.bind(this)
       .then(this.getMostRecentObjects)
       .then(this.getObjectMetadata)
-      .then(this.checkIfDeploymentIsNecessary);
+      .then(this.checkIfDeploymentIsNecessary)
+      .then(() => {
+        if (this.serverless.service.provider.shouldNotDeploy) {
+          return BbPromise.resolve();
+        }
+
+        // perform the subscription filter checking only if a deployment is required
+        return this.checkLogGroupSubscriptionFilterResourceLimitExceeded();
+      });
   },
 
   getMostRecentObjects() {
@@ -111,5 +119,127 @@ module.exports = {
     }
 
     return BbPromise.resolve();
+  },
+
+  /**
+   * @description Cloudwatch imposes a hard limit of 1 subscription filter per log group.
+   * If we change a cloudwatchLog event entry to add a subscription filter to a log group
+   * that already had one before, it will throw an error because CloudFormation firstly
+   * tries to create and replace the new subscription filter (therefore hitting the limit)
+   * before deleting the old one. This precompile process aims to delete existent
+   * subscription filters of functions that a new filter was provided, by checking the
+   * current ARN with the new one that will be generated.
+   * See: https://git.io/fpKCM
+  */
+  checkLogGroupSubscriptionFilterResourceLimitExceeded() {
+    const region = this.provider.getRegion();
+    const serviceName = this.serverless.service.getServiceName();
+    const stage = this.provider.getStage();
+    const cloudWatchLogsSdk = new this.provider.sdk.CloudWatchLogs({ region });
+
+    return this.provider.getAccountId()
+      .then(accountId =>
+        Promise.all(this.serverless.service.getAllFunctions().map((functionName) => {
+          const functionObj = this.serverless.service.getFunction(functionName);
+
+          if (!functionObj.events) {
+            return BbPromise.resolve();
+          }
+
+          const promises = functionObj.events.map((event) => {
+            if (!event.cloudwatchLog) {
+              return BbPromise.resolve();
+            }
+
+            let logGroupName;
+
+            /*
+              it isn't necessary to run sanity checks here as they already happened during the
+              compile step
+            */
+            if (typeof event.cloudwatchLog === 'object') {
+              logGroupName = event.cloudwatchLog.logGroup.replace(/\r?\n/g, '');
+            } else {
+              logGroupName = event.cloudwatchLog.replace(/\r?\n/g, '');
+            }
+
+            /*
+              return a new promise that will check the resource limit exceeded and will fix it if
+              the option is enabled
+            */
+            return this.fixLogGroupSubscriptionFilters({
+              cloudWatchLogsSdk,
+              accountId,
+              logGroupName,
+              functionName,
+              region,
+              serviceName,
+              stage,
+            });
+          });
+
+          return Promise.all(promises);
+        })));
+  },
+
+  fixLogGroupSubscriptionFilters(params) {
+    const cloudWatchLogsSdk = params.cloudWatchLogsSdk;
+    const accountId = params.accountId;
+    const logGroupName = params.logGroupName;
+    const functionName = params.functionName;
+    const region = params.region;
+    const serviceName = params.serviceName;
+    const stage = params.stage;
+
+    return cloudWatchLogsSdk.describeSubscriptionFilters({ logGroupName }).promise()
+      .then((response) => {
+        const subscriptionFilter = response.subscriptionFilters[0];
+
+        // log group doesn't have any subscription filters currently
+        if (!subscriptionFilter) {
+          return false;
+        }
+
+        const oldDestinationArn = subscriptionFilter.destinationArn;
+        const filterName = subscriptionFilter.filterName;
+        const newDestinationArn =
+          `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-${stage}-${functionName}`;
+
+        // everything is fine, just return
+        if (oldDestinationArn === newDestinationArn) {
+          return false;
+        }
+
+        const shouldDeleteSubscriptionFilter =
+          _.get(
+            this.serverless.service.provider,
+            ['cloudWatchLogs', 'forceUpdateSubscriptionFilters'],
+            false
+          );
+
+        /*
+          We only run the deletion in case of the user has authorized, as removing resources
+          outside CloudFormation may lead to inconsistencies
+        */
+        if (shouldDeleteSubscriptionFilter) {
+          /*
+            If the destinations functions' ARNs doesn't match, we need to delete the current
+            subscription filter to prevent the resource limit exceeded error to happen
+          */
+          return cloudWatchLogsSdk
+            .deleteSubscriptionFilter({ logGroupName, filterName }).promise();
+        }
+
+        const warning = 'An inconsistency was found on your event.cloudWatchLog subscription filters. You may face errors regarding ResourceLimitExceeded from CloudFormation during deployment. Check https://serverless.com/framework/docs/providers/aws/events/cloudwatch-log/#current-gotchas for more details.';
+
+        this.serverless.cli.log(`WARNING: ${warning}\n`);
+
+        return false;
+      })
+      /*
+        it will throw when trying to get subscription filters of a log group that was just added
+        to the serverless.yml (therefore not created in AWS yet), we can safely ignore this error
+      */
+      .catch(() => undefined);
   },
 };

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -210,31 +210,12 @@ module.exports = {
           return false;
         }
 
-        const shouldDeleteSubscriptionFilter =
-          _.get(
-            this.serverless.service.provider,
-            ['cloudWatchLogs', 'forceUpdateSubscriptionFilters'],
-            false
-          );
-
         /*
-          We only run the deletion in case of the user has authorized, as removing resources
-          outside CloudFormation may lead to inconsistencies
+          If the destinations functions' ARNs doesn't match, we need to delete the current
+          subscription filter to prevent the resource limit exceeded error to happen
         */
-        if (shouldDeleteSubscriptionFilter) {
-          /*
-            If the destinations functions' ARNs doesn't match, we need to delete the current
-            subscription filter to prevent the resource limit exceeded error to happen
-          */
-          return cloudWatchLogsSdk
-            .deleteSubscriptionFilter({ logGroupName, filterName }).promise();
-        }
-
-        const warning = 'An inconsistency was found on your event.cloudWatchLog subscription filters. You may face errors regarding ResourceLimitExceeded from CloudFormation during deployment. Check https://serverless.com/framework/docs/providers/aws/events/cloudwatch-log/#current-gotchas for more details.';
-
-        this.serverless.cli.log(`WARNING: ${warning}\n`);
-
-        return false;
+        return cloudWatchLogsSdk
+          .deleteSubscriptionFilter({ logGroupName, filterName }).promise();
       })
       /*
         it will throw when trying to get subscription filters of a log group that was just added

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -540,30 +540,6 @@ describe('checkForChanges', () => {
       });
     });
 
-    it('should not call delete when option is not set', () => {
-      awsDeploy.serverless.service.functions = {
-        first: {
-          events: [
-            { cloudwatchLog: '/aws/lambda/hello1' },
-          ],
-        },
-      };
-
-      describeSubscriptionFiltersResponse = {
-        subscriptionFilters: [
-          {
-            destinationArn:
-              `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-not-first`,
-            filterName: 'dummy-filter',
-          },
-        ],
-      };
-
-      return awsDeploy.checkForChanges().then(() => {
-        expect(deleteSubscriptionFilterStub).to.not.have.been.called;
-      });
-    });
-
     it('should work normally when there are functions without events', () => {
       awsDeploy.serverless.service.functions = {
         first: {},
@@ -586,9 +562,7 @@ describe('checkForChanges', () => {
 
     describe('option to force update is set', () => {
       beforeEach(() => {
-        awsDeploy.serverless.service.provider.cloudWatchLogs = {
-          forceUpdateSubscriptionFilters: true,
-        };
+        awsDeploy.serverless.service.provider.cloudWatchLogs = {};
       });
 
       afterEach(() => {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -7,6 +7,7 @@ const path = require('path');
 const globby = require('globby');
 const sinon = require('sinon');
 const chai = require('chai');
+const BbPromise = require('bluebird');
 const proxyquire = require('proxyquire');
 const normalizeFiles = require('../../lib/normalizeFiles');
 const AwsProvider = require('../../provider/awsProvider');
@@ -60,6 +61,7 @@ describe('checkForChanges', () => {
     let getMostRecentObjectsStub;
     let getObjectMetadataStub;
     let checkIfDeploymentIsNecessaryStub;
+    let checkLogGroupSubscriptionFilterResourceLimitExceededStub;
 
     beforeEach(() => {
       getMostRecentObjectsStub = sinon
@@ -68,12 +70,15 @@ describe('checkForChanges', () => {
         .stub(awsDeploy, 'getObjectMetadata').resolves();
       checkIfDeploymentIsNecessaryStub = sinon
         .stub(awsDeploy, 'checkIfDeploymentIsNecessary').resolves();
+      checkLogGroupSubscriptionFilterResourceLimitExceededStub = sinon
+        .stub(awsDeploy, 'checkLogGroupSubscriptionFilterResourceLimitExceeded').resolves();
     });
 
     afterEach(() => {
       awsDeploy.getMostRecentObjects.restore();
       awsDeploy.getObjectMetadata.restore();
       awsDeploy.checkIfDeploymentIsNecessary.restore();
+      awsDeploy.checkLogGroupSubscriptionFilterResourceLimitExceeded.restore();
     });
 
     it('should run promise chain in order', () => expect(awsDeploy.checkForChanges())
@@ -81,6 +86,8 @@ describe('checkForChanges', () => {
         expect(getMostRecentObjectsStub).to.have.been.calledOnce;
         expect(getObjectMetadataStub).to.have.been.calledAfter(getMostRecentObjectsStub);
         expect(checkIfDeploymentIsNecessaryStub).to.have.been.calledAfter(getObjectMetadataStub);
+        expect(checkLogGroupSubscriptionFilterResourceLimitExceededStub).to.have.been
+          .calledAfter(checkIfDeploymentIsNecessaryStub);
 
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(false);
       })
@@ -474,6 +481,185 @@ describe('checkForChanges', () => {
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
         });
+    });
+  });
+
+  describe('#checkLogGroupSubscriptionFilterResourceLimitExceeded', () => {
+    let CloudWatchLogsStub;
+    let deleteSubscriptionFilterStub;
+    const accountId = '123456789';
+    const serviceName = 'my-service';
+    const region = 'us-east-1';
+    let describeSubscriptionFiltersResponse = {};
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+
+      CloudWatchLogsStub = class {
+        constructor() {
+          this.deleteSubscriptionFilter = deleteSubscriptionFilterStub = sinon.spy(() => ({
+            promise: () => BbPromise.resolve(),
+          }));
+
+          this.describeSubscriptionFilters = sinon.spy(() => ({
+            promise: () => BbPromise.resolve(describeSubscriptionFiltersResponse),
+          }));
+        }
+      };
+
+      provider.sdk.CloudWatchLogs = CloudWatchLogsStub;
+
+      sandbox.stub(provider, 'getAccountId')
+        .returns(BbPromise.resolve(accountId));
+
+      sandbox.stub(awsDeploy.serverless.service, 'getServiceName')
+        .returns(serviceName);
+
+      sandbox.stub(awsDeploy, 'getMostRecentObjects').resolves();
+      sandbox.stub(awsDeploy, 'getObjectMetadata').resolves();
+      sandbox.stub(awsDeploy, 'checkIfDeploymentIsNecessary').resolves();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should not call checkLogGroup if deployment is not required', () => {
+      awsDeploy.checkIfDeploymentIsNecessary.restore();
+
+      sandbox.stub(awsDeploy, 'checkIfDeploymentIsNecessary', () => new Promise((resolve) => {
+        awsDeploy.serverless.service.provider.shouldNotDeploy = true;
+        resolve();
+      }));
+
+      const spy = sinon.spy(awsDeploy, 'checkLogGroupSubscriptionFilterResourceLimitExceeded');
+
+      return awsDeploy.checkForChanges().then(() => {
+        expect(spy).to.not.have.been.called;
+      });
+    });
+
+    it('should not call delete when option is not set', () => {
+      awsDeploy.serverless.service.functions = {
+        first: {
+          events: [
+            { cloudwatchLog: '/aws/lambda/hello1' },
+          ],
+        },
+      };
+
+      describeSubscriptionFiltersResponse = {
+        subscriptionFilters: [
+          {
+            destinationArn:
+              `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-not-first`,
+            filterName: 'dummy-filter',
+          },
+        ],
+      };
+
+      return awsDeploy.checkForChanges().then(() => {
+        expect(deleteSubscriptionFilterStub).to.not.have.been.called;
+      });
+    });
+
+    it('should work normally when there are functions without events', () => {
+      awsDeploy.serverless.service.functions = {
+        first: {},
+      };
+
+      expect(awsDeploy.checkForChanges()).to.be.fulfilled;
+    });
+
+    it('should work normally when there are functions events that are not cloudWwatchLog', () => {
+      awsDeploy.serverless.service.functions = {
+        first: {
+          events: [
+            { dummyEvent: 'test' },
+          ],
+        },
+      };
+
+      expect(awsDeploy.checkForChanges()).to.be.fulfilled;
+    });
+
+    describe('option to force update is set', () => {
+      beforeEach(() => {
+        awsDeploy.serverless.service.provider.cloudWatchLogs = {
+          forceUpdateSubscriptionFilters: true,
+        };
+      });
+
+      afterEach(() => {
+        awsDeploy.serverless.service.provider.cloudWatchLogs = undefined;
+      });
+
+      it('should not call delete if there are no subscriptionFilters', () => {
+        awsDeploy.serverless.service.functions = {
+          first: {
+            events: [
+              { cloudwatchLog: '/aws/lambda/hello1' },
+            ],
+          },
+        };
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [],
+        };
+
+        return awsDeploy.checkForChanges().then(() => {
+          expect(deleteSubscriptionFilterStub).to.not.have.been.called;
+        });
+      });
+
+      it('should not call delete if there is a subFilter and the ARNs are the same', () => {
+        awsDeploy.serverless.service.functions = {
+          first: {
+            events: [
+              { cloudwatchLog: '/aws/lambda/hello1' },
+            ],
+          },
+        };
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [
+            {
+              destinationArn:
+                `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-first`,
+              filterName: 'dummy-filter',
+            },
+          ],
+        };
+
+        return awsDeploy.checkForChanges().then(() => {
+          expect(deleteSubscriptionFilterStub).to.not.have.been.called;
+        });
+      });
+
+      it('should call delete if there is a subFilter but the ARNs are not the same', () => {
+        awsDeploy.serverless.service.functions = {
+          first: {
+            events: [
+              { cloudwatchLog: '/aws/lambda/hello1' },
+            ],
+          },
+        };
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [
+            {
+              destinationArn:
+                `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-not-first`,
+              filterName: 'dummy-filter',
+            },
+          ],
+        };
+
+        return awsDeploy.checkForChanges().then(() => {
+          expect(deleteSubscriptionFilterStub).to.have.been.called;
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #3447

## How did you implement it:

As per CloudFormation nature, it won't delete a resource before trying to create a new one firstly, and the problem come up once it tries to create a new subscription filter, as it will hit CloudWatch's hard limit of 1 subscription filter per log group (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html). The unique option to make it work is to manually delete the resource and then run the CF update again -- since the resource is gone CF is going to be able to create the new one, and also delete the old as its definition is not on template anymore. The idea is to delete the subscription filter whenever the destination function ARN is different from the one that was just configured at `serverless.yml`.

I haven't added UT at all because I'd like to know firstly if this implementation makes sense. It worked for all situations that were pointed out by @ztmdsbt on #3447. 

## How can we verify it:

1. Create a project with `serverless.yml` with the following configuration: https://gist.github.com/rdsedmundo/556d8b6ed7fc119f13b8c54bf47595fa. `handler.js` content can be whatever, e.g just a hello world:
```
'use strict';

module.exports.hello = async (event, context) => {
  return { message: 'Go Serverless v1.0! Your function executed successfully!', event };
};
```
2. Change `cloudwatchLog` log group interchangeably (set test-1 for the first function, then test-2 to the 3rd, etc), change function definitions orders (add hello first, then hello2 at the end, etc), create new functions at the beginning of the function definitions, at the middle, etc.
3. If you're using the version from this PR you won't face the "ResourceLimitExceeded" error as we got on `master` (reference: https://serverless.com/framework/docs/providers/aws/events/cloudwatch-log#current-gotchas).

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
