### PR TITLE
`invoke local` support for Ruby lambdas

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ environment:
     - NODEJS_VERSION: "8"
 
 install:
+  # For Ruby invoke local testing
+  - set PATH=C:\Ruby25\bin;%PATH%
   # Get the version of Node.js
   - ps: Install-Product node $Env:NODEJS_VERSION
   # install modules

--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -107,7 +107,7 @@ serverless invoke local -f functionName -e VAR1=value1 -e VAR2=value2
 
 ### Limitations
 
-Currently, `invoke local` only supports the NodeJs, Python & Java runtimes.
+Currently, `invoke local` only supports the NodeJs, Python, Java, & Ruby runtimes.
 
 **Note:** In order to get correct output when using Java runtime, your Response class must implement `toString()` method.
 

--- a/lib/plugins/aws/invokeLocal/fixture/handler.rb
+++ b/lib/plugins/aws/invokeLocal/fixture/handler.rb
@@ -1,0 +1,7 @@
+def withRemainingTime(event:, context:)
+  start = context.get_remaining_time_in_millis()
+  sleep(0.001)
+  stop = context.get_remaining_time_in_millis()
+
+  {"start" => start, "stop" => stop}
+end

--- a/lib/plugins/aws/invokeLocal/fixture/handler.rb
+++ b/lib/plugins/aws/invokeLocal/fixture/handler.rb
@@ -5,3 +5,11 @@ def withRemainingTime(event:, context:)
 
   {"start" => start, "stop" => stop}
 end
+
+module MyModule
+  class MyClass
+    def self.my_class_method(event:, context:)
+      {"foo" => "bar"}
+    end
+  end
+end

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -158,8 +158,20 @@ class AwsInvokeLocal {
         this.options.context);
     }
 
+    if (runtime === 'ruby2.5') {
+      const handlerComponents = handler.split(/\./);
+      const handlerPath = handlerComponents.slice(0, -1).join('.');
+      const handlerName = handlerComponents.pop();
+      return this.invokeLocalRuby(
+        process.platform === 'win32' ? 'ruby.exe' : 'ruby',
+        handlerPath,
+        handlerName,
+        this.options.data,
+        this.options.context);
+    }
+
     throw new this.serverless.classes
-      .Error('You can only invoke Node.js, Python & Java functions locally.');
+      .Error('You can only invoke Node.js, Python, Java & Ruby functions locally.');
   }
 
   invokeLocalPython(runtime, handlerPath, handlerName, event, context) {
@@ -251,6 +263,24 @@ class AwsInvokeLocal {
         mvn.on('close', () => this.callJavaBridge(artifactPath, className, handlerName, input)
           .then(resolve));
       }));
+  }
+
+  invokeLocalRuby(runtime, handlerPath, handlerName, event, context) {
+    const input = JSON.stringify({
+      event: event || {},
+      context,
+    });
+
+    return new BbPromise(resolve => {
+      const ruby = spawn(runtime,
+        [path.join(__dirname, 'invoke.rb'), handlerPath, handlerName],
+        { env: process.env }, { shell: true });
+      ruby.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
+      ruby.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
+      ruby.stdin.write(input);
+      ruby.stdin.end();
+      ruby.on('close', () => resolve());
+    });
   }
 
   invokeLocalNodeJs(handlerPath, handlerName, event, customContext) {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -160,8 +160,8 @@ class AwsInvokeLocal {
 
     if (runtime === 'ruby2.5') {
       const handlerComponents = handler.split(/\./);
-      const handlerPath = handlerComponents.slice(0, -1).join('.');
-      const handlerName = handlerComponents.pop();
+      const handlerPath = handlerComponents[0];
+      const handlerName = handlerComponents.slice(1).join('.');
       return this.invokeLocalRuby(
         process.platform === 'win32' ? 'ruby.exe' : 'ruby',
         handlerPath,

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -431,6 +431,23 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
+    it('should call invokeLocalRuby with class/module info when used', () => {
+      awsInvokeLocal.options.functionObj.runtime = 'ruby2.5';
+      awsInvokeLocal.options.functionObj.handler = 'handler.MyModule::MyClass.hello';
+      return awsInvokeLocal.invokeLocal().then(() => {
+        // NOTE: this is important so that tests on Windows won't fail
+        const runtime = process.platform === 'win32' ? 'ruby.exe' : 'ruby';
+        expect(invokeLocalRubyStub.calledOnce).to.be.equal(true);
+        expect(invokeLocalRubyStub.calledWithExactly(
+          runtime,
+          'handler',
+          'MyModule::MyClass.hello',
+          {},
+          undefined
+        )).to.be.equal(true);
+      });
+    });
+
     it('throw error when using runtime other than Node.js, Python, Java or Ruby', () => {
       awsInvokeLocal.options.functionObj.runtime = 'invalid-runtime';
       expect(() => awsInvokeLocal.invokeLocal()).to.throw(Error);
@@ -1025,6 +1042,20 @@ describe('AwsInvokeLocal', () => {
           'withRemainingTime').then(() => {
             const remainingTimes = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
             expect(remainingTimes.start).to.be.above(remainingTimes.stop);
+          });
+      });
+    });
+
+    describe('calling a class method', () => {
+      it('should execute', () => {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+        return awsInvokeLocal.invokeLocalRuby(
+          'ruby',
+          'fixture/handler',
+          'MyModule::MyClass.my_class_method').then(() => {
+            const result = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
+            expect(result.foo).to.eq('bar');
           });
       });
     });

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -313,6 +313,7 @@ describe('AwsInvokeLocal', () => {
     let invokeLocalNodeJsStub;
     let invokeLocalPythonStub;
     let invokeLocalJavaStub;
+    let invokeLocalRubyStub;
 
     beforeEach(() => {
       invokeLocalNodeJsStub =
@@ -321,6 +322,8 @@ describe('AwsInvokeLocal', () => {
         sinon.stub(awsInvokeLocal, 'invokeLocalPython').resolves();
       invokeLocalJavaStub =
         sinon.stub(awsInvokeLocal, 'invokeLocalJava').resolves();
+      invokeLocalRubyStub =
+        sinon.stub(awsInvokeLocal, 'invokeLocalRuby').resolves();
 
       awsInvokeLocal.serverless.service.service = 'new-service';
       awsInvokeLocal.provider.options.stage = 'dev';
@@ -338,6 +341,7 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.invokeLocalNodeJs.restore();
       awsInvokeLocal.invokeLocalPython.restore();
       awsInvokeLocal.invokeLocalJava.restore();
+      awsInvokeLocal.invokeLocalRuby.restore();
     });
 
     it('should call invokeLocalNodeJs when no runtime is set', () => awsInvokeLocal.invokeLocal()
@@ -411,7 +415,23 @@ describe('AwsInvokeLocal', () => {
         });
     });
 
-    it('throw error when using runtime other than Node.js or Python', () => {
+    it('should call invokeLocalRuby when ruby2.5 runtime is set', () => {
+      awsInvokeLocal.options.functionObj.runtime = 'ruby2.5';
+      return awsInvokeLocal.invokeLocal().then(() => {
+        // NOTE: this is important so that tests on Windows won't fail
+        const runtime = process.platform === 'win32' ? 'ruby.exe' : 'ruby';
+        expect(invokeLocalRubyStub.calledOnce).to.be.equal(true);
+        expect(invokeLocalRubyStub.calledWithExactly(
+          runtime,
+          'handler',
+          'hello',
+          {},
+          undefined
+        )).to.be.equal(true);
+      });
+    });
+
+    it('throw error when using runtime other than Node.js, Python, Java or Ruby', () => {
       awsInvokeLocal.options.functionObj.runtime = 'invalid-runtime';
       expect(() => awsInvokeLocal.invokeLocal()).to.throw(Error);
       delete awsInvokeLocal.options.functionObj.runtime;
@@ -973,6 +993,40 @@ describe('AwsInvokeLocal', () => {
           )).to.be.equal(true);
         })
       );
+    });
+  });
+
+  describe('#invokeLocalRuby', () => {
+    let curdir;
+    beforeEach(() => {
+      curdir = process.cwd();
+      process.chdir(__dirname);
+      awsInvokeLocal.options = {
+        functionObj: {
+          name: '',
+        },
+      };
+
+      sinon.stub(serverless.cli, 'consoleLog');
+    });
+
+    afterEach(() => {
+      serverless.cli.consoleLog.restore();
+      process.chdir(curdir);
+    });
+
+    describe('context.remainingTimeInMillis', () => {
+      it('should become lower over time', () => {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+        return awsInvokeLocal.invokeLocalRuby(
+          'ruby',
+          'fixture/handler',
+          'withRemainingTime').then(() => {
+            const remainingTimes = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
+            expect(remainingTimes.start).to.be.above(remainingTimes.stop);
+          });
+      });
     });
   });
 });

--- a/lib/plugins/aws/invokeLocal/invoke.rb
+++ b/lib/plugins/aws/invokeLocal/invoke.rb
@@ -53,8 +53,7 @@ if __FILE__ == $0
 
   input = JSON.load($stdin) || {}
 
-  $LOAD_PATH << "."
-  require(handler_path)
+  require("./#{handler_path}")
 
   # handler name is either a global method or a static method in a class
   # my_method or MyModule::MyClass.my_method

--- a/lib/plugins/aws/invokeLocal/invoke.rb
+++ b/lib/plugins/aws/invokeLocal/invoke.rb
@@ -1,0 +1,66 @@
+require 'json'
+
+class FakeLambdaContext
+  attr_reader :function_name, :function_version
+
+  def initialize(name: 'Fake', version: 'LATEST', timeout: 6, **options)
+    @function_name = name
+    @function_version = version
+    @created_time = Time.now()
+    @timeout = timeout
+    options.each {|k,v|
+      send(k, v)
+    }
+  end
+
+  def get_remaining_time_in_millis
+    [@timeout*1000 - ((Time.now() - @created_time)*1000).round, 0].max
+  end
+
+  def invoked_function_arn
+    "arn:aws:lambda:serverless:#{function_name}"
+  end
+
+  def memory_limit_in_mb
+    return '1024'
+  end
+
+  def aws_request_id
+    return '1234567890'
+  end
+
+  def log_group_name
+    return "/aws/lambda/#{function_name}"
+  end
+
+  def log_stream_name
+    return Time.now.strftime('%Y/%m/%d') +'/[$' + function_version + ']58419525dade4d17a495dceeeed44708'
+  end
+
+  def log(message)
+    puts message
+  end
+end
+
+if __FILE__ == $0
+  unless ARGV[0] && ARGV[1]
+    puts "Usage: invoke.rb <handler_path> <handler_name>"
+    exit 1
+  end
+
+  handler_path = "#{ARGV[0]}.rb"
+  handler_name = ARGV[1]
+
+  # handler name is either a global method or a static method in a class
+  # my_method or MyModule::MyClass.my_method
+  input = JSON.load($stdin) || {}
+  $LOAD_PATH << "."
+  $LOAD_PATH << "lib"
+  load(handler_path)
+  handler = method(handler_name)
+
+  context = FakeLambdaContext.new(**input.fetch('context', {}))
+  result = handler.call(event: input['event'], context: context)
+
+  puts result.to_json
+end


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Adds Ruby lambda support for `invoke local` 
Closes #5545

## How did you implement it:
I followed the pattern for calling Python lambda's via `invoke local`

## How can we verify it:

```
mkdir aws-ruby-example
cd aws-ruby-example
serverless create --template aws-ruby
serverless invoke local -f hello
```

Here's my result, using a local checkout of this branch:
```
➜  aws-ruby-example ~/work/serverless/bin/serverless invoke local -f hello
{"statusCode":200,"body":"\"Go Serverless v1.0! Your function executed successfully!\""}
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
