### PR TITLE
Fix logRetentionInDays regression in AWS

### DIFF
--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -32,10 +32,9 @@ module.exports = {
       };
 
       if (_.has(this.serverless.service.provider, 'logRetentionInDays')) {
-        if (_.isInteger(this.serverless.service.provider.logRetentionInDays) &&
-          this.serverless.service.provider.logRetentionInDays > 0) {
-          newLogGroup[logGroupLogicalId].Properties.RetentionInDays
-            = this.serverless.service.provider.logRetentionInDays;
+        const RetentionInDays = parseInt(this.serverless.service.provider.logRetentionInDays);
+        if (_.isInteger(RetentionInDays) && RetentionInDays > 0) {
+          newLogGroup[logGroupLogicalId].Properties.RetentionInDays = RetentionInDays;
         } else {
           const errorMessage = 'logRetentionInDays should be an integer over 0';
           throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -33,11 +33,12 @@ module.exports = {
 
       if (_.has(this.serverless.service.provider, 'logRetentionInDays')) {
         const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;
-        const retentionInDays = parseInt(rawRetentionInDays);
+        const retentionInDays = parseInt(rawRetentionInDays, 10);
         if (_.isInteger(retentionInDays) && retentionInDays > 0) {
           newLogGroup[logGroupLogicalId].Properties.RetentionInDays = retentionInDays;
         } else {
-          const errorMessage = `logRetentionInDays should be an integer over 0 but ${rawRetentionInDays}`;
+          const errorMessage =
+            `logRetentionInDays should be an integer over 0 but ${rawRetentionInDays}`;
           throw new this.serverless.classes.Error(errorMessage);
         }
       }

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -32,11 +32,12 @@ module.exports = {
       };
 
       if (_.has(this.serverless.service.provider, 'logRetentionInDays')) {
-        const RetentionInDays = parseInt(this.serverless.service.provider.logRetentionInDays);
-        if (_.isInteger(RetentionInDays) && RetentionInDays > 0) {
-          newLogGroup[logGroupLogicalId].Properties.RetentionInDays = RetentionInDays;
+        const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;
+        const retentionInDays = parseInt(rawRetentionInDays);
+        if (_.isInteger(retentionInDays) && retentionInDays > 0) {
+          newLogGroup[logGroupLogicalId].Properties.RetentionInDays = retentionInDays;
         } else {
-          const errorMessage = 'logRetentionInDays should be an integer over 0';
+          const errorMessage = `logRetentionInDays should be an integer over 0 but ${rawRetentionInDays}`;
           throw new this.serverless.classes.Error(errorMessage);
         }
       }

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -296,20 +296,22 @@ describe('#mergeIamTemplates()', () => {
 
   it('should add RetentionInDays to a CloudWatch LogGroup resource if logRetentionInDays is given'
     , () => {
-      awsPackage.serverless.service.provider.logRetentionInDays = 5;
-      const normalizedName = awsPackage.provider.naming.getLogGroupLogicalId(functionName);
-      return awsPackage.mergeIamTemplates().then(() => {
-        expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources[normalizedName]
-        ).to.deep.equal(
-          {
-            Type: 'AWS::Logs::LogGroup',
-            Properties: {
-              LogGroupName: awsPackage.provider.naming.getLogGroupName(functionName),
-              RetentionInDays: 5,
-            },
-          }
+      [5, "5"].forEach((logRetentionInDays) => {
+        awsPackage.serverless.service.provider.logRetentionInDays = logRetentionInDays;
+        const normalizedName = awsPackage.provider.naming.getLogGroupLogicalId(functionName);
+        return awsPackage.mergeIamTemplates().then(() => {
+          expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources[normalizedName]
+          ).to.deep.equal(
+            {
+              Type: 'AWS::Logs::LogGroup',
+              Properties: {
+                LogGroupName: awsPackage.provider.naming.getLogGroupName(functionName),
+                RetentionInDays: 5,
+              },
+            }
           );
+        });
       });
     });
 

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -296,7 +296,7 @@ describe('#mergeIamTemplates()', () => {
 
   it('should add RetentionInDays to a CloudWatch LogGroup resource if logRetentionInDays is given'
     , () => {
-      [5, "5"].forEach((logRetentionInDays) => {
+      [5, '5'].forEach((logRetentionInDays) => {
         awsPackage.serverless.service.provider.logRetentionInDays = logRetentionInDays;
         const normalizedName = awsPackage.provider.naming.getLogGroupLogicalId(functionName);
         return awsPackage.mergeIamTemplates().then(() => {


### PR DESCRIPTION
## What did you implement:

Closes #5534 

## How did you implement it:

Parsing `logRetentionInDays` as Integer.
If it is a numeric string like `"42"`, it is accepeted as integer.

## How can we verify it:

I think the test code is  sufficient to verify, since it is just fixing trivial regression of type mis-handling.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
