### PR TITLE
set env vars from --env last in invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -20,9 +20,10 @@ class AwsInvokeLocal {
     Object.assign(this, validate);
 
     this.hooks = {
-      'invoke:local:invoke': () => BbPromise.bind(this)
+      'before:invoke:local:loadEnvVars': () => BbPromise.bind(this)
         .then(this.extendedValidate)
-        .then(this.loadEnvVars)
+        .then(this.loadEnvVars),
+      'invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.invokeLocal),
     };
   }

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -44,23 +44,31 @@ describe('AwsInvokeLocal', () => {
     it('should set the provider variable to an instance of AwsProvider', () =>
       expect(awsInvokeLocal.provider).to.be.instanceof(AwsProvider));
 
-    it('should run promise chain in order', () => {
-      const validateStub = sinon
-        .stub(awsInvokeLocal, 'extendedValidate').resolves();
-      const loadEnvVarsStub = sinon
-        .stub(awsInvokeLocal, 'loadEnvVars').resolves();
+    it('should run invoke:local:invoke promise chain in order', () => {
       const invokeLocalStub = sinon
         .stub(awsInvokeLocal, 'invokeLocal').resolves();
 
 
       return awsInvokeLocal.hooks['invoke:local:invoke']().then(() => {
-        expect(validateStub.calledOnce).to.be.equal(true);
+        expect(invokeLocalStub.callCount).to.be.equal(1);
+
+        awsInvokeLocal.invokeLocal.restore();
+      });
+    });
+
+    it('should run before:invoke:local:loadEnvVars promise chain in order', () => {
+      const validateStub = sinon
+        .stub(awsInvokeLocal, 'extendedValidate').resolves();
+      const loadEnvVarsStub = sinon
+        .stub(awsInvokeLocal, 'loadEnvVars').resolves();
+
+
+      return awsInvokeLocal.hooks['before:invoke:local:loadEnvVars']().then(() => {
+        expect(validateStub.callCount).to.be.equal(1);
         expect(loadEnvVarsStub.calledAfter(validateStub)).to.be.equal(true);
-        expect(invokeLocalStub.calledAfter(loadEnvVarsStub)).to.be.equal(true);
 
         awsInvokeLocal.extendedValidate.restore();
         awsInvokeLocal.loadEnvVars.restore();
-        awsInvokeLocal.invokeLocal.restore();
       });
     });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

fixes #5563

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
call invoke local's env var setting code before invoke's env var setting code (which is what handles the `--env` option)
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
`serverless.yml`:
```yaml
service: test
provider:
  name: aws
  runtime: nodejs8.10
functions:
  test:
    handler: handler.test
    environment:
      FOOBAR=foo
```
`handler.js`:
```javascript
module.exports.test = () => process.env.foobar
```

then
```
sls invoke -f hello --env FOOBAR=bar
```
with master will print `foo` with this branch will print `bar`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
