### PR TITLE
Set reserved concurrency in cfn template even if zero

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -298,7 +298,7 @@ class AwsCompileFunctions {
       delete newFunction.Properties.VpcConfig;
     }
 
-    if (functionObject.reservedConcurrency) {
+    if (functionObject.reservedConcurrency || functionObject.reservedConcurrency === 0) {
       if (_.isInteger(functionObject.reservedConcurrency)) {
         newFunction.Properties.ReservedConcurrentExecutions = functionObject.reservedConcurrency;
       } else {

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1929,6 +1929,47 @@ describe('AwsCompileFunctions', () => {
         });
     });
 
+    it('should set function declared reserved concurrency limit even if it is zero', () => {
+      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
+        .split(path.sep).pop();
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+          reservedConcurrency: 0,
+        },
+      };
+      const compiledFunction = {
+        Type: 'AWS::Lambda::Function',
+        DependsOn: [
+          'FuncLogGroup',
+          'IamRoleLambdaExecution',
+        ],
+        Properties: {
+          Code: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          FunctionName: 'new-service-dev-func',
+          Handler: 'func.function.handler',
+          MemorySize: 1024,
+          ReservedConcurrentExecutions: 0,
+          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+          Runtime: 'nodejs4.3',
+          Timeout: 6,
+        },
+      };
+
+      return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          expect(
+            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+              .Resources.FuncLambdaFunction
+          ).to.deep.equal(compiledFunction);
+        });
+    });
+
     it('should throw an informative error message if non-integer reserved concurrency limit set ' +
       'on function', () => {
       awsCompileFunctions.serverless.service.functions = {


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
fixes #5402


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
change the check to be for truthyness or `=== 0`
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
1. make service with a lambda with zero concurrency
2. `sls package`
3. check that it is set in the cfn template inside `.serverless`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
