### PR TITLE
BREAKING-CHANGE Preserver whitespace in variable fallback

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -268,7 +268,7 @@ class Variables {
     return match.replace(
       this.variableSyntax,
       (context, contents) => contents.trim()
-    ).replace(/\s/g, '');
+    );
   }
   /**
    * @typedef {Object} MatchResult

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -634,6 +634,16 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);
       });
+      it('should preserve whitespace in literal fallback', () => {
+        service.custom = {
+          val0: '${self:custom.val, "rate(3 hours)"}',
+        };
+        const expected = {
+          val0: 'rate(3 hours)',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
       it('should handle deep variables regardless of custom variableSyntax', () => {
         service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
         serverless.variables.loadVariableSyntax();


### PR DESCRIPTION
## What did you implement:

Closes #5558 

## How did you implement it:

Remove whitespace cleaning (`.replace(/\s/g, '');`) which seems unnecessary.

I am suprised that removing it break nothing.
I am not sure that it is essentially unnecessary...

## How can we verify it:
`npm test`

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
