### PR TITLE
Add template for provided runtime with the bash sample from AWS

### DIFF
--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -57,6 +57,7 @@ Most commonly used templates:
 - aws-python
 - aws-python3
 - aws-ruby
+- aws-provided
 - aws-kotlin-jvm-maven
 - aws-kotlin-jvm-gradle
 - aws-kotlin-nodejs-gradle

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -59,6 +59,7 @@ Here are the available runtimes for AWS Lambda:
 * aws-python
 * aws-python3
 * aws-ruby
+* aws-provided
 * aws-kotlin-jvm-maven
 * aws-kotlin-nodejs-gradle
 * aws-groovy-gradle

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -36,6 +36,7 @@ const validTemplates = [
   'aws-go-dep',
   'aws-go-mod',
   'aws-ruby',
+  'aws-provided',
   'azure-nodejs',
   'cloudflare-workers',
   'cloudflare-workers-enterprise',

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -958,5 +958,21 @@ describe('Create', () => {
           .to.be.equal(true);
       });
     });
+
+    it('should generate scaffolding for "aws-provided" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'aws-provided';
+
+      return create.create().then(() => {
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'serverless.yml')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'handler.sh')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, '.gitignore')))
+          .to.be.equal(true);
+        expect(create.serverless.utils.fileExistsSync(path.join(tmpDir, 'bootstrap')))
+          .to.be.equal(true);
+      });
+    });
   });
 });

--- a/lib/plugins/create/templates/aws-provided/bootstrap
+++ b/lib/plugins/create/templates/aws-provided/bootstrap
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# Initialization - load function handler
+source $LAMBDA_TASK_ROOT/"$(echo $_HANDLER | cut -d. -f1).sh"
+
+# Processing
+while true
+do
+  HEADERS="$(mktemp)"
+  # Get an event
+  EVENT_DATA=$(curl -sS -LD "$HEADERS" -X GET "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
+  REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
+
+  # Execute the handler function from the script
+  RESPONSE=$($(echo "$_HANDLER" | cut -d. -f2) "$EVENT_DATA")
+
+  # Send the response
+  curl -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/response"  -d "$RESPONSE"
+done

--- a/lib/plugins/create/templates/aws-provided/gitignore
+++ b/lib/plugins/create/templates/aws-provided/gitignore
@@ -1,0 +1,2 @@
+.serverless
+node_modules

--- a/lib/plugins/create/templates/aws-provided/handler.sh
+++ b/lib/plugins/create/templates/aws-provided/handler.sh
@@ -1,0 +1,7 @@
+function hello () {
+  EVENT_DATA=$1
+  echo "$EVENT_DATA" 1>&2;
+  RESPONSE="{\"body\": {\"input\": $EVENT_DATA, \"msg\": \"Wecome to serverless!\"}}"
+
+  echo $RESPONSE
+}

--- a/lib/plugins/create/templates/aws-provided/serverless.yml
+++ b/lib/plugins/create/templates/aws-provided/serverless.yml
@@ -1,0 +1,104 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: aws-provided # NOTE: update this with your service name
+
+# You can pin your service to only deploy with a specific Serverless version
+# Check out our docs for more details
+# frameworkVersion: "=X.X.X"
+
+provider:
+  name: aws
+  runtime: provided
+
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
+
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "/*"
+
+# you can define service wide environment variables here
+#  environment:
+#    variable1: value1
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.py
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.py
+#    - exclude-me-dir/**
+
+functions:
+  hello:
+    handler: handler.hello
+
+#    The following are a few example events you can configure
+#    NOTE: Please make sure to change your handler code to work with those events
+#    Check the event documentation for details
+#    events:
+#      - http:
+#          path: users/create
+#          method: get
+#      - s3: ${env:BUCKET}
+#      - schedule: rate(10 minutes)
+#      - sns: greeter-topic
+#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
+#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
+#      - iot:
+#          sql: "SELECT * FROM 'some_topic'"
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - "aws.ec2"
+#            detail-type:
+#              - "EC2 Instance State-change Notification"
+#            detail:
+#              state:
+#                - pending
+#      - cloudwatchLog: '/aws/lambda/hello'
+#      - cognitoUserPool:
+#          pool: MyUserPool
+#          trigger: PreSignUp
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+# you can add CloudFormation resource templates here
+#resources:
+#  Resources:
+#    NewResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: my-new-bucket
+#  Outputs:
+#     NewOutput:
+#       Description: "Description for the output"
+#       Value: "Some output value"

--- a/tests/templates/test_all_templates
+++ b/tests/templates/test_all_templates
@@ -23,6 +23,7 @@ integration-test aws-nodejs
 integration-test aws-python
 integration-test aws-python3
 integration-test aws-ruby
+integration-test aws-provided
 integration-test aws-kotlin-jvm-gradle
 integration-test aws-kotlin-jvm-maven
 integration-test aws-kotlin-nodejs-gradle


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added an `aws-provided` template including AWS's bash example of using the Runtime API

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

* added template to create plugin 
* added to list of templates(todo)
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
```
npm i -g serverless/serverless#provided-template
sls create -t aws-provided
sls deploy
sls invoke -f hello
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
