### PR TITLE
Upgrade to aws-sdk v2.373.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -694,9 +694,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.317.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.317.0.tgz",
-      "integrity": "sha512-X2Cd1Gb9Cf9WVgGOiBSW4TK6q5Mb6AYiGmEA9XikCgur4H8E4TgmgWbBWJnTzxssugclVLVoWQfw3RshNKJksg==",
+      "version": "2.373.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.373.0.tgz",
+      "integrity": "sha512-NZYXwXGtFt9jxaKXc+PJsLPnpbD03t0MAZRxh93g36kbFMuRXtY8CDqHYNQ0ZcrgQpXbCQiz1fxT5/wu5Cu70g==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@serverless/platform-sdk": "^0.3.0",
     "archiver": "^1.1.0",
     "async": "^1.5.2",
-    "aws-sdk": "^2.228.0",
+    "aws-sdk": "^2.373.0",
     "bluebird": "^3.5.0",
     "chalk": "^2.0.0",
     "ci-info": "^1.1.1",


### PR DESCRIPTION
## What did you implement:

Closes #3833

Projects using AWS have some trouble using AWS CLI profiles. While support for profiles is now baked into the serverless framework, the version locked for the `aws-sdk` package has bugs with using profiles. 
## How did you implement it:

Creating/checking the S3 bucket for a new project would fail during `sls deploy`, due to some problem in `aws-sdk`. Updating the `aws-sdk` package avoids the bug.


## How can we verify it:

Using serverless 1.34.1, linked to aws-sdk 2.239.1, sls fails to deploy a project for the first time while using an AWS Profile with MFA. 
![image](https://user-images.githubusercontent.com/141162/49836914-7670c080-fd72-11e8-9437-6da0d16adbc4.png)


After upgrading to aws-sdk 2.373.0, sls succeeds to deploy the project for the first time using the AWS Profile with MFA.
![image](https://user-images.githubusercontent.com/141162/49836985-b637a800-fd72-11e8-9d43-3aa0e413b028.png)


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
