### PR TITLE
restore support for variable refs with spaces in them

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -270,9 +270,9 @@ class Variables {
       (context, contents) => contents.trim()
     );
     if (!cleaned.match(/".*"/)) {
-      cleaned = cleaned.replace(/\s/g, '')
+      cleaned = cleaned.replace(/\s/g, '');
     }
-    return cleaned
+    return cleaned;
   }
   /**
    * @typedef {Object} MatchResult

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -265,10 +265,14 @@ class Variables {
    * @returns {string} The cleaned variable match
    */
   cleanVariable(match) {
-    return match.replace(
+    let cleaned = match.replace(
       this.variableSyntax,
       (context, contents) => contents.trim()
     );
+    if (!cleaned.match(/".*"/)) {
+      cleaned = cleaned.replace(/\s/g, '')
+    }
+    return cleaned
   }
   /**
    * @typedef {Object} MatchResult

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -647,7 +647,7 @@ describe('Variables', () => {
       it('should accept whitespace in variables', () => {
         service.custom = {
           val0: '${self: custom.val}',
-          val: 'foobar'
+          val: 'foobar',
         };
         const expected = {
           val: 'foobar',

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -644,6 +644,18 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);
       });
+      it('should accept whitespace in variables', () => {
+        service.custom = {
+          val0: '${self: custom.val}',
+          val: 'foobar'
+        };
+        const expected = {
+          val: 'foobar',
+          val0: 'foobar',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
       it('should handle deep variables regardless of custom variableSyntax', () => {
         service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._\\\'",\\-\\/\\(\\)]+?)}}';
         serverless.variables.loadVariableSyntax();


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Restores ability to have spaces in variable refs which was broken by #5571

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
if the variable being cleaned isn't surrounded by `"` white space is stripped as it was before

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
make a config file with a variable reference with a space in it
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
