### PR TITLE
fix: fixed regression preventing including files outside working dir

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -188,7 +188,7 @@ module.exports = {
     params.include.forEach((pattern) => {
       patterns.push(pattern);
     });
-    return globby(['**'], {
+    return globby(params.include.concat(['**']), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,
       silent: true,

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -1012,6 +1012,30 @@ describe('zipService', () => {
       });
     });
 
+    it('should include files even if outside working dir', () => {
+      params.zipFileName = getTestArtifactFileName('include-outside-working-dir');
+      serverless.config.servicePath = path.join(serverless.config.servicePath, 'lib');
+      params.exclude = [
+        './**',
+      ];
+      params.include = [
+        '../bin/binary-**',
+      ];
+
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .then(artifact => {
+          const data = fs.readFileSync(artifact);
+          return expect(zip.loadAsync(data)).to.be.fulfilled;
+        }).then(unzippedData => {
+          const unzippedFileData = unzippedData.files;
+          expect(Object.keys(unzippedFileData).sort()).to.deep.equal([
+            'bin/binary-444',
+            'bin/binary-777',
+          ]);
+        });
+    });
+
     it('should throw an error if no files are matched', () => {
       params.exclude = ['**/**'];
       params.include = [];


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixed a regression for some users where the `package: include: ` section of their config pointed to files outside the current working directory. The performance impact of this is directly correlated with how many patterns (not files behind those patterns) a user specifies inside their include, and should therefore not be a problem.

Closes #5600 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added the `include` patterns specified by the user to the initial glob matching.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

A test was added for this specific use case, which now passes.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
