### PR TITLE
feat(log): Log AWS SDK calls in debug mode

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -131,6 +131,11 @@ class AwsProvider {
 
     Object.assign(this.naming, naming);
 
+    // Activate AWS SDK loggin
+    if (process.env.SLS_DEBUG) {
+      AWS.config.logger = this.serverless.cli;
+    }
+
     // Use HTTPS Proxy (Optional)
     const proxy = process.env.proxy
       || process.env.HTTP_PROXY

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -58,6 +58,21 @@ describe('AwsProvider', () => {
       expect(awsProvider.provider).to.equal(awsProvider);
     });
 
+    it('should have no AWS logger', () => {
+      expect(awsProvider.sdk.config.logger).to.be.undefined;
+    });
+
+    it('should set AWS logger', () => {
+      const BK_SLS_DEBUG = process.env.SLS_DEBUG;
+      process.env.SLS_DEBUG = 'true';
+      const newAwsProvider = new AwsProvider(serverless, options);
+
+      expect(typeof newAwsProvider.sdk.config.logger).to.not.equal('undefined');
+
+      // reset env
+      process.env.SLS_DEBUG = BK_SLS_DEBUG;
+    });
+
     it('should set AWS proxy', () => {
       process.env.proxy = 'http://a.b.c.d:n';
       const newAwsProvider = new AwsProvider(serverless, options);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Logging AWS SDK calls when SLS_DEBUG is activated.

Closes #5603 

## How did you implement it:

Configure the AWS.config.logger when SLS_DEBUG environment is activated.
In that case the AWS.config.logger will simply use the serverless.cli.log function to log AWS SDK calls.

Based on the official AWS documentation for logging :
https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/logging-sdk-calls.html

## How can we verify it:

In any serverless projects :
```
SLS_DEBUG=true serverless deploy
```

The console output should show the AWS SDK calls made by serverless :
```
...
Serverless: Invoke aws:deploy:deploy
Serverless: [AWS cloudformation 200 0.653s 0 retries] describeStacks({ StackName: 'aws-nodejs-dev' })
Serverless: [AWS cloudformation 200 0.416s 0 retries] describeStackResource({ StackName: 'aws-nodejs-dev',
  LogicalResourceId: 'ServerlessDeploymentBucket' })
Serverless: Uploading CloudFormation file to S3...
Serverless: [AWS s3 200 0.539s 0 retries] putObject({ Body:
   <Buffer 7b 22 41 57 53 54 65 6d 70 6c 61 74 65 46 6f 72 6d 61 74 56 65 72 73 69 6f 6e 22 3a 22 32 30 31 30 2d 30 39 2d 30 39 22 2c 22 44 65 73 63 72 69 70 74 ... 2008 more bytes>,
  Bucket: 'aws-nodejs-dev-serverlessdeploymentbucket-1xxxx1l3xgitw',
  Key:
   'serverless/aws-nodejs/dev/1544952584628-2018-12-16T09:29:44.628Z/compiled-cloudformation-template.json',
  ContentType: 'application/json',
  Metadata:
   { filesha256: 'xZIKLb/bwT/oy2xNWi6mYZmtWIag3ummNB7fzfIiplU=' } })
Serverless: Uploading artifacts...
...
```

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
