### PR TITLE
version bump to fix regression out of project includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.35.1 (2018-12-17)
+# 1.35.1 (2018-12-18)
  - [fixed regression preventing including files outside working dir](https://github.com/serverless/serverless/pull/5602)
  - [Update ruby template gitignore](https://github.com/serverless/serverless/pull/5599)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.35.1 (2018-12-17)
+ - [fixed regression preventing including files outside working dir](https://github.com/serverless/serverless/pull/5602)
+ - [Update ruby template gitignore](https://github.com/serverless/serverless/pull/5599)
+
+## Meta
+ - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.35.0...v1.35.1)
+
 # 1.35.0 (2018-12-13)
  - [Fix logRetentionInDays regression in AWS](https://github.com/serverless/serverless/pull/5562)
  - [`invoke local` support for Ruby lambdas](https://github.com/serverless/serverless/pull/5559)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -714,9 +714,9 @@
           "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "ieee754": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
# 1.35.1 (2018-12-17)
 - [Update gitignore](https://github.com/serverless/serverless/pull/5599)
 - [fix: fixed regression preventing including files outside working dir](https://github.com/serverless/serverless/pull/5602)

## Meta
 - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.35.0...master)


