### PR TITLE
Issue #5502 Support for native async/await in AWS Lambda for aws-nodejs-typescript template 

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
@@ -1,13 +1,17 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
-    "target": "es6",
     "lib": [
-      "esnext"
+      "es2017"
     ],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
   },
   "exclude": [
     "node_modules"
   ]
 }
+

--- a/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/tsconfig.json
@@ -14,4 +14,3 @@
     "node_modules"
   ]
 }
-


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5502 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Changed the plugins/create/templates/aws-nodejs-typescript/tsconfig.json to contain es2017 for lib and target

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Run _serverless create --template aws-nodejs-typescript_ which should now target es2017 instead of es6

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [n/a] Write tests
- [n/a] Write documentation
- [n/a] Fix linting errors
- [n/a] Make sure code coverage hasn't dropped
- [n/a] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
