### PR TITLE
Add step to populate ~/.wskprops file to OpenWhisk docs.

### DIFF
--- a/docs/providers/openwhisk/guide/credentials.md
+++ b/docs/providers/openwhisk/guide/credentials.md
@@ -70,11 +70,17 @@ For example....
 ibmcloud login -a api.ng.bluemix.net -o user@email_host.com -s dev
 ```
 
-#### regions
+After logging into the CLI, run the following command to populate the `~/.wskprops` file with credentials needed to run `serverless` commands:
+
+```
+ibmcloud wsk property get --auth
+```
+
+#### Regions
 
 Cloud Functions is available with the following regions US-South (`api.ng.bluemix.net`), London (`api.eu-gb.bluemix.net`), Frankfurt (` api.eu-de.bluemix.net`). Use the appropriate [API endpoint](https://console.bluemix.net/docs/overview/ibm-cloud.html#ov_intro_reg) to target Cloud Functions in that region.
 
-#### organisations and spaces
+#### Organisations and Spaces
 
 Organisations and spaces for your account can be viewed on this page: [https://console.bluemix.net/account/organizations](https://console.bluemix.net/account/organizations)
 
@@ -133,7 +139,13 @@ You can configure the Serverless Framework to use your OpenWhisk credentials in 
 
 #### IBM Cloud Functions
 
-Provided you have logged into the IBM Cloud CLI, authenticated credentials will be already stored in the `~/.wskprops` file. If this file is available, the provider plugin will automatically read those credentials and you don't need to do anything else!
+After logging into the CLI, run the following command to populate the `~/.wskprops` file with credentials needed to run `serverless` commands:
+
+```
+ibmcloud wsk property get --auth
+```
+
+With this file available, the provider plugin will automatically read those credentials and you don't need to do anything else!
 
 #### Environment Variables Setup
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4777 by adding documentation to run a required command.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Added docs.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Set up IBM Cloud CLI on a dev machine and attempt to deploy the OpenWhisk template without performing the added step. Note that it will fail, claiming you need to set an `OW_APIHOST` env var.

## Todos:

- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
