### PR TITLE
change behaviour on initial stack create failed

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -18,7 +18,7 @@ module.exports = {
 
     const params = {
       StackName: stackName,
-      OnFailure: 'ROLLBACK',
+      OnFailure: 'DELETE',
       Capabilities: [
         'CAPABILITY_IAM',
         'CAPABILITY_NAMED_IAM',

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -17,8 +17,9 @@ module.exports = {
     ];
     const loggedEvents = [];
     const region = this.provider.getRegion();
-    const baseCfUrl = `https://${region}.console.aws.amazon.com/cloudformation/home`
-    const cfQueryString = `region=${region}#/stack/detail?stackId=${encodeURIComponent(cfData.StackId)}`
+    const baseCfUrl = `https://${region}.console.aws.amazon.com/cloudformation/home`;
+    const encodedStackId = `${encodeURIComponent(cfData.StackId)}`;
+    const cfQueryString = `region=${region}#/stack/detail?stackId=${encodedStackId}`;
     const stackUrl = `${baseCfUrl}?${cfQueryString}`;
 
     let monitoredSince = null;
@@ -77,7 +78,7 @@ module.exports = {
                     // Keep track of first failed event
                     if (eventStatus
                       && (eventStatus.endsWith('FAILED')
-                      || eventStatus === 'UPDATE_ROLLBACK_IN_PROGRESS')
+                        || eventStatus === 'UPDATE_ROLLBACK_IN_PROGRESS')
                       && stackLatestError === null) {
                       stackLatestError = event;
                     }
@@ -103,7 +104,7 @@ module.exports = {
                 });
                 // Handle stack create/update/delete failures
                 if ((stackLatestError && !this.options.verbose)
-                || (stackStatus
+                  || (stackStatus
                     && (stackStatus.endsWith('ROLLBACK_COMPLETE')
                       || stackStatus === 'DELETE_FAILED')
                     && this.options.verbose)) {

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -110,7 +110,8 @@ module.exports = {
                     && this.options.verbose)) {
                   // empty console.log for a prettier output
                   if (!this.options.verbose) this.serverless.cli.consoleLog('');
-                  this.serverless.cli.log(`Operation failed! View the full error output: ${stackUrl}`);
+                  this.serverless.cli.log('Operation failed!');
+                  this.serverless.cli.log(`View the full error output: ${stackUrl}`);
                   let errorMessage = 'An error occurred: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;
                   errorMessage += `${stackLatestError.ResourceStatusReason}.`;

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -16,6 +16,8 @@ module.exports = {
       'DELETE_COMPLETE',
     ];
     const loggedEvents = [];
+    const region = this.provider.getRegion();
+    const stackUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stack/detail?stackId=${cfData.StackId}`;
 
     let monitoredSince = null;
     let stackStatus = null;
@@ -105,7 +107,7 @@ module.exports = {
                     && this.options.verbose)) {
                   // empty console.log for a prettier output
                   if (!this.options.verbose) this.serverless.cli.consoleLog('');
-                  this.serverless.cli.log('Operation failed!');
+                  this.serverless.cli.log(`Operation failed! View the full error output: ${stackUrl}`);
                   let errorMessage = 'An error occurred: ';
                   errorMessage += `${stackLatestError.LogicalResourceId} - `;
                   errorMessage += `${stackLatestError.ResourceStatusReason}.`;

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -78,7 +78,7 @@ module.exports = {
                     // Keep track of first failed event
                     if (eventStatus
                       && (eventStatus.endsWith('FAILED')
-                        || eventStatus === 'UPDATE_ROLLBACK_IN_PROGRESS')
+                      || eventStatus === 'UPDATE_ROLLBACK_IN_PROGRESS')
                       && stackLatestError === null) {
                       stackLatestError = event;
                     }
@@ -104,7 +104,7 @@ module.exports = {
                 });
                 // Handle stack create/update/delete failures
                 if ((stackLatestError && !this.options.verbose)
-                  || (stackStatus
+                || (stackStatus
                     && (stackStatus.endsWith('ROLLBACK_COMPLETE')
                       || stackStatus === 'DELETE_FAILED')
                     && this.options.verbose)) {

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -17,7 +17,9 @@ module.exports = {
     ];
     const loggedEvents = [];
     const region = this.provider.getRegion();
-    const stackUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stack/detail?stackId=${encodeURIComponent(cfData.StackId)}`;
+    const baseCfUrl = `https://${region}.console.aws.amazon.com/cloudformation/home`
+    const cfQueryString = `region=${region}#/stack/detail?stackId=${encodeURIComponent(cfData.StackId)}`
+    const stackUrl = `${baseCfUrl}?${cfQueryString}`;
 
     let monitoredSince = null;
     let stackStatus = null;

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -17,7 +17,7 @@ module.exports = {
     ];
     const loggedEvents = [];
     const region = this.provider.getRegion();
-    const stackUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stack/detail?stackId=${cfData.StackId}`;
+    const stackUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stack/detail?stackId=${encodeURIComponent(cfData.StackId)}`;
 
     let monitoredSince = null;
     let stackStatus = null;


### PR DESCRIPTION
## What did you implement:

Closes #5630

## How did you implement it:

Change stack creation failed behaviour to `DELETE`.

## How can we verify it:

Deploy a failing stack to confirm. e.g trigger a lambda with a nonexistent sns resource.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO