### PR TITLE
AWS: Validate rate/cron syntax before Deploy

### DIFF
--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -2,6 +2,9 @@
 
 const _ = require('lodash');
 
+const rateSyntaxPattern =/^rate\((?:1 (?:minute|hour|day)|(?:1\d+|[2-9]\d*) (?:minute|hour|day)s)\)$/;
+const cronSyntaxPattern =/^cron\(\S+ \S+ \S+ \S+ \S+ \S+\)$/;
+
 class AwsCompileScheduledEvents {
   constructor(serverless) {
     this.serverless = serverless;
@@ -28,14 +31,14 @@ class AwsCompileScheduledEvents {
             let Name;
             let Description;
 
-            // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
-              if (!event.schedule.rate) {
+              if (!this.validateScheduleSyntax(event.schedule.rate)) {
                 const errorMessage = [
-                  `Missing "rate" property for schedule event in function ${functionName}`,
-                  ' The correct syntax is: schedule: rate(10 minutes)',
+                  `"rate" property for schedule event is missing or invalid in function ${functionName}`,
+                  ' The correct syntax is: schedule: rate(10 minutes) or cron(0 12 * * ? *)',
                   ' OR an object with "rate" property.',
-                  ' Please check the docs for more info.',
+                  ' Please check the docs for more info:',
+                  ' https://serverless.com/framework/docs/providers/aws/events/schedule/'
                 ].join('');
                 throw new this.serverless.classes
                   .Error(errorMessage);
@@ -81,15 +84,16 @@ class AwsCompileScheduledEvents {
                 // escape quotes to favor JSON.parse
                 Input = Input.replace(/\"/g, '\\"'); // eslint-disable-line
               }
-            } else if (typeof event.schedule === 'string') {
+            } else if (typeof event.schedule === 'string' && this.validateScheduleSyntax(event.schedule)) {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';
             } else {
               const errorMessage = [
-                `Schedule event of function ${functionName} is not an object nor a string`,
-                ' The correct syntax is: schedule: rate(10 minutes)',
+                `Schedule event of function ${functionName} is not an object nor a string.`,
+                ' The correct syntax is: schedule: rate(10 minutes) or cron(0 12 * * ? *)',
                 ' OR an object with "rate" property.',
-                ' Please check the docs for more info.',
+                ' Please check the docs for more info:',
+                ' https://serverless.com/framework/docs/providers/aws/events/schedule/'
               ].join('');
               throw new this.serverless.classes
                 .Error(errorMessage);
@@ -148,6 +152,10 @@ class AwsCompileScheduledEvents {
         });
       }
     });
+  }
+
+  validateScheduleSyntax(input) {
+    return rateSyntaxPattern.test(input) || cronSyntaxPattern.test(input);
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -2,8 +2,10 @@
 
 const _ = require('lodash');
 
-const rateSyntaxPattern =/^rate\((?:1 (?:minute|hour|day)|(?:1\d+|[2-9]\d*) (?:minute|hour|day)s)\)$/;
-const cronSyntaxPattern =/^cron\(\S+ \S+ \S+ \S+ \S+ \S+\)$/;
+const rateSyntaxPattern =
+  /^rate\((?:1 (?:minute|hour|day)|(?:1\d+|[2-9]\d*) (?:minute|hour|day)s)\)$/;
+const cronSyntaxPattern =
+  /^cron\(\S+ \S+ \S+ \S+ \S+ \S+\)$/;
 
 class AwsCompileScheduledEvents {
   constructor(serverless) {
@@ -13,6 +15,16 @@ class AwsCompileScheduledEvents {
     this.hooks = {
       'package:compileEvents': this.compileScheduledEvents.bind(this),
     };
+  }
+
+  buildValidationErrorMessage(functionName) {
+    return [
+      `"rate" property for schedule event is missing or invalid in function ${functionName}.`,
+      ' The correct syntax is: `schedule: rate(10 minutes)`, `schedule: cron(0 12 * * ? *)`',
+      ' OR an object with "rate" property.',
+      ' Please check the docs for more info:',
+      ' https://serverless.com/framework/docs/providers/aws/events/schedule/',
+    ].join('');
   }
 
   compileScheduledEvents() {
@@ -33,13 +45,7 @@ class AwsCompileScheduledEvents {
 
             if (typeof event.schedule === 'object') {
               if (!this.validateScheduleSyntax(event.schedule.rate)) {
-                const errorMessage = [
-                  `"rate" property for schedule event is missing or invalid in function ${functionName}`,
-                  ' The correct syntax is: schedule: rate(10 minutes) or cron(0 12 * * ? *)',
-                  ' OR an object with "rate" property.',
-                  ' Please check the docs for more info:',
-                  ' https://serverless.com/framework/docs/providers/aws/events/schedule/'
-                ].join('');
+                const errorMessage = this.buildValidationErrorMessage(functionName);
                 throw new this.serverless.classes
                   .Error(errorMessage);
               }
@@ -84,17 +90,11 @@ class AwsCompileScheduledEvents {
                 // escape quotes to favor JSON.parse
                 Input = Input.replace(/\"/g, '\\"'); // eslint-disable-line
               }
-            } else if (typeof event.schedule === 'string' && this.validateScheduleSyntax(event.schedule)) {
+            } else if (this.validateScheduleSyntax(event.schedule)) {
               ScheduleExpression = event.schedule;
               State = 'ENABLED';
             } else {
-              const errorMessage = [
-                `Schedule event of function ${functionName} is not an object nor a string.`,
-                ' The correct syntax is: schedule: rate(10 minutes) or cron(0 12 * * ? *)',
-                ' OR an object with "rate" property.',
-                ' Please check the docs for more info:',
-                ' https://serverless.com/framework/docs/providers/aws/events/schedule/'
-              ].join('');
+              const errorMessage = this.buildValidationErrorMessage(functionName);
               throw new this.serverless.classes
                 .Error(errorMessage);
             }
@@ -155,7 +155,8 @@ class AwsCompileScheduledEvents {
   }
 
   validateScheduleSyntax(input) {
-    return rateSyntaxPattern.test(input) || cronSyntaxPattern.test(input);
+    return typeof input === 'string' &&
+      (rateSyntaxPattern.test(input) || cronSyntaxPattern.test(input));
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.test.js
@@ -54,126 +54,134 @@ describe('AwsCompileScheduledEvents', () => {
     });
 
     describe('rate syntax validation: rate(value unit)', () => {
-      it('should throw an error if the value equal to 1 but the unit is plural in schedule string', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: 'rate(1 days)',
-              },
-            ],
-          },
-        };
-
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
-      });
-
-      it('should throw an error if the value equal to 1 but the unit is plural in schedule object', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'rate(1 days)',
+      describe('schedule string', () => {
+        it('should throw an error if the value is 1 but the unit is plural', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: 'rate(1 days)',
                 },
-              },
-            ],
-          },
-        };
+              ],
+            },
+          };
 
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
-      });
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
 
-      it('should throw an error if the value is greater than 1 but the unit is not plural in schedule string', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: 'rate(5 minute)',
-              },
-            ],
-          },
-        };
-
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
-      });
-
-      it('should throw an error if the value is greater than 1 but the unit is not plural in schedule object', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'rate(5 minute)',
+        it('should throw an error if the value is >1 but the unit is not plural', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: 'rate(5 minute)',
                 },
-              },
-            ],
-          },
-        };
+              ],
+            },
+          };
 
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
+      });
+
+      describe('schedule object', () => {
+        it('should throw an error if the value is 1 but the unit is plural', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: {
+                    rate: 'rate(1 days)',
+                  },
+                },
+              ],
+            },
+          };
+
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
+
+        it('should throw an error if the value is >1 but the unit is not plural', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: {
+                    rate: 'rate(5 minute)',
+                  },
+                },
+              ],
+            },
+          };
+
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
       });
     });
 
-    describe('cron syntax validation: cron(Minutes Hours DayOfMonth Month DayOfWeek Year)', () => {
-      it('should throw an error if number of fields is less than 6 in schedule string', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: 'cron(0 12 * * ?)',
-              },
-            ],
-          },
-        };
-
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
-      });
-
-      it('should throw an error if number of fields is less than 6 in schedule object', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'cron(0 12 * * ?)',
+    describe('cron syntax validation: cron(* * * * * 2018)', () => {
+      describe('schedule string', () => {
+        it('should throw an error if number of fields is less than 6', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: 'cron(0 12 * * ?)',
                 },
-              },
-            ],
-          },
-        };
+              ],
+            },
+          };
 
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
-      });
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
 
-      it('should throw an error if number of fields is greater than 6 in schedule string', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: 'cron(0 12 * * ? * *)',
-              },
-            ],
-          },
-        };
-
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
-      });
-
-      it('should throw an error if number of fields is greater than 6 in schedule object', () => {
-        awsCompileScheduledEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'cron(0 12 * * ? * *)',
+        it('should throw an error if number of fields is greater than 6', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: 'cron(0 12 * * ? * *)',
                 },
-              },
-            ],
-          },
-        };
+              ],
+            },
+          };
 
-        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
+      });
+
+      describe('schedule object', () => {
+        it('should throw an error if number of fields is less than 6', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: {
+                    rate: 'cron(0 12 * * ?)',
+                  },
+                },
+              ],
+            },
+          };
+
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
+
+        it('should throw an error if number of fields is greater than 6', () => {
+          awsCompileScheduledEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  schedule: {
+                    rate: 'cron(0 12 * * ? * *)',
+                  },
+                },
+              ],
+            },
+          };
+
+          expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+        });
       });
     });
 

--- a/lib/plugins/aws/package/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.test.js
@@ -53,6 +53,68 @@ describe('AwsCompileScheduledEvents', () => {
       expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
     });
 
+    describe('rate syntax validation: rate(value unit)', () => {
+      it('should throw an error if the value equal to 1 but the unit is plural in schedule string', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: 'rate(1 days)',
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if the value equal to 1 but the unit is plural in schedule object', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(1 days)',
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if the value is greater than 1 but the unit is not plural in schedule string', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: 'rate(5 minute)',
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if the value is greater than 1 but the unit is not plural in schedule object', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(5 minute)',
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+    });
+
     it('should create corresponding resources when schedule events are given', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/package/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.test.js
@@ -115,6 +115,68 @@ describe('AwsCompileScheduledEvents', () => {
       });
     });
 
+    describe('cron syntax validation: cron(Minutes Hours DayOfMonth Month DayOfWeek Year)', () => {
+      it('should throw an error if number of fields is less than 6 in schedule string', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: 'cron(0 12 * * ?)',
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if number of fields is less than 6 in schedule object', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'cron(0 12 * * ?)',
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if number of fields is greater than 6 in schedule string', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: 'cron(0 12 * * ? * *)',
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if number of fields is greater than 6 in schedule object', () => {
+        awsCompileScheduledEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'cron(0 12 * * ? * *)',
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+      });
+    });
+
     it('should create corresponding resources when schedule events are given', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
@@ -133,6 +195,9 @@ describe('AwsCompileScheduledEvents', () => {
             },
             {
               schedule: 'rate(10 minutes)',
+            },
+            {
+              schedule: 'cron(5,35 12 ? * 6l 2002-2005)',
             },
           ],
         },
@@ -160,6 +225,10 @@ describe('AwsCompileScheduledEvents', () => {
       expect(awsCompileScheduledEvents.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstLambdaPermissionEventsRuleSchedule3.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstLambdaPermissionEventsRuleSchedule4.Type
       ).to.equal('AWS::Lambda::Permission');
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #3306

## How did you implement it:

* Add validation to `compileScheduledEvents` so users can find error before deploy.
    * Note: `cron` validation checks only number of fields, since it requires [very complex regex](https://gist.github.com/dkandalov/a2aed17cfdeb65243022) to validate full cron syntax.
* Polish error message: include `cron` syntax and a link to doc.

## How can we verify it:

Run test.


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO