### PR TITLE
Throw an error if plugin is executed outside of a serverless directory

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -57,8 +57,10 @@ class Serverless {
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();
 
+    // make the serverless config file available to the PluginManager
+    this.pluginManager.loadConfigFile();
+
     // set the options and commands which were processed by the CLI
-    this.pluginManager.loadConfig();
     this.pluginManager.setCliOptions(this.processedInput.options);
     this.pluginManager.setCliCommands(this.processedInput.commands);
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -58,6 +58,7 @@ class Serverless {
     this.processedInput = this.cli.processInput();
 
     // set the options and commands which were processed by the CLI
+    this.pluginManager.loadConfig();
     this.pluginManager.setCliOptions(this.processedInput.options);
     this.pluginManager.setCliCommands(this.processedInput.commands);
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -29,7 +29,7 @@ class TerminateHookChain extends Error {
 class PluginManager {
   constructor(serverless) {
     this.serverless = serverless;
-    this.config = null;
+    this.serverlessConfigFile = null;
 
     this.cliOptions = {};
     this.cliCommands = [];
@@ -41,9 +41,9 @@ class PluginManager {
     this.deprecatedEvents = {};
   }
 
-  loadConfig() {
+  loadConfigFile() {
     getServerlessConfigFile(this.serverless.config.servicePath).then((serverlessConfigFile) => {
-      this.config = serverlessConfigFile;
+      this.serverlessConfigFile = serverlessConfigFile;
     });
   }
 
@@ -443,7 +443,7 @@ class PluginManager {
    */
   validateServerlessConfigDependency(command) {
     if ('configDependent' in command && command.configDependent) {
-      if (!this.config) {
+      if (!this.serverlessConfigFile) {
         throw new this.serverless.classes.Error(
           'This command can only be run in a Serverless service directory'
         );
@@ -498,7 +498,7 @@ class PluginManager {
     });
 
     const serverlessConfigFileHash = crypto.createHash('sha256')
-      .update(JSON.stringify(this.config)).digest('hex');
+      .update(JSON.stringify(this.serverlessConfigFile)).digest('hex');
     cacheFile.validationHash = serverlessConfigFileHash;
     const cacheFilePath = getCacheFilePath(this.serverless.config.servicePath);
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -29,6 +29,7 @@ class TerminateHookChain extends Error {
 class PluginManager {
   constructor(serverless) {
     this.serverless = serverless;
+    this.config = null;
 
     this.cliOptions = {};
     this.cliCommands = [];
@@ -38,6 +39,12 @@ class PluginManager {
     this.aliases = {};
     this.hooks = {};
     this.deprecatedEvents = {};
+  }
+
+  loadConfig() {
+    getServerlessConfigFile(this.serverless.config.servicePath).then((serverlessConfigFile) => {
+      this.config = serverlessConfigFile;
+    });
   }
 
   setCliOptions(options) {
@@ -436,19 +443,12 @@ class PluginManager {
    */
   validateServerlessConfigDependency(command) {
     if ('configDependent' in command && command.configDependent) {
-      return getServerlessConfigFile().then((serverlessConfigFile) => {
-        if (!serverlessConfigFile) {
-          const error = new this.serverless.classes.Error(
-            'This command can only be run in a Serverless service directory'
-          );
-          return BbPromise.reject(error);
-        }
-
-        return BbPromise.resolve();
-      });
+      if (!this.config) {
+        throw new this.serverless.classes.Error(
+          'This command can only be run in a Serverless service directory'
+        );
+      }
     }
-
-    return BbPromise.resolve();
   }
 
   validateOptions(command) {
@@ -497,15 +497,12 @@ class PluginManager {
         .concat(Object.keys(command.commands));
     });
 
-    return getServerlessConfigFile(this.serverless.config.servicePath)
-      .then((serverlessConfigFile) => {
-        const serverlessConfigFileHash = crypto.createHash('sha256')
-          .update(JSON.stringify(serverlessConfigFile)).digest('hex');
-        cacheFile.validationHash = serverlessConfigFileHash;
-        const cacheFilePath = getCacheFilePath(this.serverless.config.servicePath);
-        return writeFile(cacheFilePath, cacheFile);
-      })
-      .catch((e) => null);  // eslint-disable-line
+    const serverlessConfigFileHash = crypto.createHash('sha256')
+      .update(JSON.stringify(this.config)).digest('hex');
+    cacheFile.validationHash = serverlessConfigFileHash;
+    const cacheFilePath = getCacheFilePath(this.serverless.config.servicePath);
+
+    return writeFile(cacheFilePath, cacheFile);
   }
 
   convertShortcutsIntoOptions(command) {

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1170,21 +1170,16 @@ describe('PluginManager', () => {
 
   describe('#validateServerlessConfigDependency()', () => {
     let serverlessInstance;
-    let getServerlessConfigFileStub;
     let pluginManagerInstance;
 
     beforeEach(() => {
-      getServerlessConfigFileStub = sinon.stub();
-      PluginManager = proxyquire('./PluginManager.js', {
-        '../utils/getServerlessConfigFile': getServerlessConfigFileStub,
-      });
       serverlessInstance = new Serverless();
       serverlessInstance.config.servicePath = 'my-service';
       pluginManagerInstance = new PluginManager(serverlessInstance);
     });
 
     it('should continue loading if the configDependent property is absent', () => {
-      pluginManagerInstance.config = null;
+      pluginManagerInstance.configFile = null;
 
       pluginManagerInstance.commands = {
         foo: {},
@@ -1196,7 +1191,7 @@ describe('PluginManager', () => {
     });
 
     it('should load if the configDependent property is false and config is null', () => {
-      pluginManagerInstance.config = null;
+      pluginManagerInstance.configFile = null;
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1210,7 +1205,7 @@ describe('PluginManager', () => {
     });
 
     it('should throw an error if configDependent is true and no config is found', () => {
-      pluginManagerInstance.config = null;
+      pluginManagerInstance.configFile = null;
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1224,7 +1219,7 @@ describe('PluginManager', () => {
     });
 
     it('should throw an error if configDependent is true and config is an empty string', () => {
-      pluginManagerInstance.config = '';
+      pluginManagerInstance.configFile = '';
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1238,7 +1233,7 @@ describe('PluginManager', () => {
     });
 
     it('should load if the configDependent property is true and config exists', () => {
-      pluginManagerInstance.config = {
+      pluginManagerInstance.configFile = {
         servicePath: 'foo',
       };
 

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1179,7 +1179,7 @@ describe('PluginManager', () => {
     });
 
     it('should continue loading if the configDependent property is absent', () => {
-      pluginManagerInstance.configFile = null;
+      pluginManagerInstance.serverlessConfigFile = null;
 
       pluginManagerInstance.commands = {
         foo: {},
@@ -1191,7 +1191,7 @@ describe('PluginManager', () => {
     });
 
     it('should load if the configDependent property is false and config is null', () => {
-      pluginManagerInstance.configFile = null;
+      pluginManagerInstance.serverlessConfigFile = null;
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1205,7 +1205,7 @@ describe('PluginManager', () => {
     });
 
     it('should throw an error if configDependent is true and no config is found', () => {
-      pluginManagerInstance.configFile = null;
+      pluginManagerInstance.serverlessConfigFile = null;
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1219,7 +1219,7 @@ describe('PluginManager', () => {
     });
 
     it('should throw an error if configDependent is true and config is an empty string', () => {
-      pluginManagerInstance.configFile = '';
+      pluginManagerInstance.serverlessConfigFile = '';
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1233,7 +1233,7 @@ describe('PluginManager', () => {
     });
 
     it('should load if the configDependent property is true and config exists', () => {
-      pluginManagerInstance.configFile = {
+      pluginManagerInstance.serverlessConfigFile = {
         servicePath: 'foo',
       };
 

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1195,7 +1195,7 @@ describe('PluginManager', () => {
       expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
     });
 
-    it('should load if the configDependent property has a false value and config is null', () => {
+    it('should load if the configDependent property is false and config is null', () => {
       pluginManagerInstance.config = null;
 
       pluginManagerInstance.commands = {
@@ -1209,7 +1209,7 @@ describe('PluginManager', () => {
       expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
     });
 
-    it('should throw an error if configDependent has a true value and no config is found', () => {
+    it('should throw an error if configDependent is true and no config is found', () => {
       pluginManagerInstance.config = null;
 
       pluginManagerInstance.commands = {
@@ -1223,7 +1223,7 @@ describe('PluginManager', () => {
       expect(() => { pluginManager.validateServerlessConfigDependency(foo); }).to.throw(Error);
     });
 
-    it('should throw an error if configDependent has a true value and config was returned as an empty string', () => {
+    it('should throw an error if configDependent is true and config is an empty string', () => {
       pluginManagerInstance.config = '';
 
       pluginManagerInstance.commands = {
@@ -1237,9 +1237,9 @@ describe('PluginManager', () => {
       expect(() => { pluginManager.validateServerlessConfigDependency(foo); }).to.throw(Error);
     });
 
-    it('should load if the configDependent property has a true value, and config exists', () => {
+    it('should load if the configDependent property is true and config exists', () => {
       pluginManagerInstance.config = {
-        servicePath: 'foo'
+        servicePath: 'foo',
       };
 
       pluginManagerInstance.commands = {
@@ -1252,8 +1252,6 @@ describe('PluginManager', () => {
 
       expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
     });
-
-
   });
 
   describe('#validateOptions()', () => {

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1184,7 +1184,7 @@ describe('PluginManager', () => {
     });
 
     it('should continue loading if the configDependent property is absent', () => {
-      getServerlessConfigFileStub.resolves({ service: 'my-service' });
+      pluginManagerInstance.config = null;
 
       pluginManagerInstance.commands = {
         foo: {},
@@ -1192,11 +1192,11 @@ describe('PluginManager', () => {
 
       const foo = pluginManagerInstance.commands.foo;
 
-      return expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.fulfilled;
+      expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
     });
 
-    it('should load if the configDependent property has a false value', () => {
-      getServerlessConfigFileStub.resolves('');
+    it('should load if the configDependent property has a false value and config is null', () => {
+      pluginManagerInstance.config = null;
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1206,11 +1206,11 @@ describe('PluginManager', () => {
 
       const foo = pluginManagerInstance.commands.foo;
 
-      return expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.fillfilled;
+      expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
     });
 
-    it('should load if the configDependent property has a true value, and config is found', () => {
-      getServerlessConfigFileStub.resolves({ service: 'my-service' });
+    it('should throw an error if configDependent has a true value and no config is found', () => {
+      pluginManagerInstance.config = null;
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1220,15 +1220,11 @@ describe('PluginManager', () => {
 
       const foo = pluginManagerInstance.commands.foo;
 
-      return expect(
-        pluginManagerInstance.validateServerlessConfigDependency(foo)
-      ).to.be.fulfilled.then(() => {
-        expect(getServerlessConfigFileStub).to.have.been.calledOnce;
-      });
+      expect(() => { pluginManager.validateServerlessConfigDependency(foo); }).to.throw(Error);
     });
 
-    it('should error if configDependent has a true value and no config is found', () => {
-      getServerlessConfigFileStub.resolves('');
+    it('should throw an error if configDependent has a true value and config was returned as an empty string', () => {
+      pluginManagerInstance.config = '';
 
       pluginManagerInstance.commands = {
         foo: {
@@ -1238,12 +1234,26 @@ describe('PluginManager', () => {
 
       const foo = pluginManagerInstance.commands.foo;
 
-      return expect(
-        pluginManagerInstance.validateServerlessConfigDependency(foo)
-      ).to.be.rejected.then(() => {
-        expect(getServerlessConfigFileStub).to.have.been.calledOnce;
-      });
+      expect(() => { pluginManager.validateServerlessConfigDependency(foo); }).to.throw(Error);
     });
+
+    it('should load if the configDependent property has a true value, and config exists', () => {
+      pluginManagerInstance.config = {
+        servicePath: 'foo'
+      };
+
+      pluginManagerInstance.commands = {
+        foo: {
+          configDependent: true,
+        },
+      };
+
+      const foo = pluginManagerInstance.commands.foo;
+
+      expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
+    });
+
+
   });
 
   describe('#validateOptions()', () => {


### PR DESCRIPTION
## What did you implement:

This is a revisit of a previous developer experience bug where executing a serverless command in a path with no `serverless.yml` would fail silently. I noticed that this issue has returned in the latest release.

The tests appeared to be passing because the method to validate a plugins config dependency was working, but the rejection was not being caught during execution, possible because of the asynchronous nature of loading the config file in `getServerlessConfigFile`

## How did you implement it:

`getServerlessConfigFile` was being called twice within the pluginManager, so serverless will now ask the PluginManager to load the config file earlier and then store it to lookup during plugin execution, rather than try to load in it's methods as it was previously.

## How can we verify it:

Currently, running `sls info` provides no feedback when running in a directory without a `serverless.yml` will result in a silent failure.

Checking out this commit and try running `./bin/serverless info` in a directory with no `.serverless.yml` will result in an error indicating that it must be executed in a serverless directory.

No documentation has been added as it's N/A.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
