### PR TITLE
Add stage name validation to AWS provider.

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -19,7 +19,6 @@ const constants = {
   providerName: 'aws',
 };
 
-const validCloudFrontStageNamePattern = /^[a-zA-Z0-9-]+$/;
 const validAPIGatewayStageNamePattern = /^[a-zA-Z0-9_]+$/;
 
 PromiseQueue.configure(BbPromise.Promise);
@@ -204,13 +203,6 @@ class AwsProvider {
     }
 
     const stage = this.getStage();
-    if (!validCloudFrontStageNamePattern.test(stage)) {
-      throw new Error([
-        `Invalid stage name ${stage}: `,
-        'it should contains only [a-zA-Z0-9] and hyphens for AWS provider.',
-      ].join(''));
-    }
-
     this.serverless.service.getAllFunctions().forEach(funcName => {
       _.forEach(this.serverless.service.getAllEventsInFunction(funcName), event => {
         if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -19,7 +19,8 @@ const constants = {
   providerName: 'aws',
 };
 
-const validStageNamePattern = /^[a-zA-Z0-9]+$/;
+const validCloudFrontStageNamePattern = /^[a-zA-Z0-9-]+$/;
+const validAPIGatewayStageNamePattern = /^[a-zA-Z0-9_]+$/;
 
 PromiseQueue.configure(BbPromise.Promise);
 
@@ -203,14 +204,24 @@ class AwsProvider {
     }
 
     const stage = this.getStage();
-    if (!validStageNamePattern.test(stage)) {
+    if (!validCloudFrontStageNamePattern.test(stage)) {
       throw new Error([
         `Invalid stage name ${stage}: `,
-        'it should contains only [a-zA-Z0-9] for AWS provider ',
-        'since API Gateway stage name cannot contain hyphens ',
-        'and CloudFront stack name cannot contain underscores.',
+        'it should contains only [a-zA-Z0-9] and hyphens for AWS provider.',
       ].join(''));
     }
+
+    this.serverless.service.getAllFunctions().forEach(funcName => {
+      _.forEach(this.serverless.service.getAllEventsInFunction(funcName), event => {
+        if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {
+          throw new Error([
+            `Invalid stage name ${stage}: `,
+            'it should contains only [a-zA-Z0-9] for AWS provider if http event are present ',
+            'since API Gateway stage name cannot contains hyphens.',
+          ].join(''));
+        }
+      });
+    });
   }
 
   /**

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -19,6 +19,8 @@ const constants = {
   providerName: 'aws',
 };
 
+const validStageNamePattern = /^[a-zA-Z0-9]+$/;
+
 PromiseQueue.configure(BbPromise.Promise);
 
 const impl = {
@@ -201,7 +203,7 @@ class AwsProvider {
     }
 
     const stage = this.getStage() || '';
-    if (stage.indexOf('-') >= 0 || stage.indexOf('_') >= 0) {
+    if (!validStageNamePattern.test(stage)) {
       throw new Error([
         `Invalid stage name ${stage}: `,
         'it should contains only [a-zA-Z0-9] for AWS provider ',

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -202,7 +202,7 @@ class AwsProvider {
       }
     }
 
-    const stage = this.getStage() || '';
+    const stage = this.getStage();
     if (!validStageNamePattern.test(stage)) {
       throw new Error([
         `Invalid stage name ${stage}: `,

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -206,7 +206,7 @@ class AwsProvider {
         `Invalid stage name ${stage}: `,
         'it should contains only [a-zA-Z0-9] for AWS provider ',
         'since API Gateway stage name cannot contain hyphens ',
-        'and CloudFront stack name cannot contain underscores.'
+        'and CloudFront stack name cannot contain underscores.',
       ].join(''));
     }
   }

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -199,6 +199,16 @@ class AwsProvider {
         }
       }
     }
+
+    const stage = this.getStage() || '';
+    if (stage.indexOf('-') >= 0 || stage.indexOf('_') >= 0) {
+      throw new Error([
+        `Invalid stage name ${stage}: `,
+        'it should contains only [a-zA-Z0-9] for AWS provider ',
+        'since API Gateway stage name cannot contain hyphens ',
+        'and CloudFront stack name cannot contain underscores.'
+      ].join(''));
+    }
   }
 
   /**

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -90,6 +90,24 @@ describe('AwsProvider', () => {
       delete process.env.AWS_CLIENT_TIMEOUT;
     });
 
+    describe('validation on construction', () => {
+      it('should throw an error if stage name contains hyphen', () => {
+        const config = {
+          stage: 'config-stage',
+        };
+        serverless = new Serverless(config);
+        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
+      });
+
+      it('should throw an error if stage name contains underscore', () => {
+        const config = {
+          stage: 'config_stage',
+        };
+        serverless = new Serverless(config);
+        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
+      });
+    });
+
     describe('certificate authority - environment variable', () => {
       afterEach('Environment Variable Cleanup', () => {
         // clear env

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -91,6 +91,14 @@ describe('AwsProvider', () => {
     });
 
     describe('validation on construction', () => {
+      it('should pass if stage name contains only alphanumeric', () => {
+        const config = {
+          stage: 'configStage',
+        };
+        serverless = new Serverless(config);
+        expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
+      });
+
       it('should throw an error if stage name contains hyphen', () => {
         const config = {
           stage: 'config-stage',

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -91,7 +91,7 @@ describe('AwsProvider', () => {
     });
 
     describe('validation on construction', () => {
-      it('should pass if stage name contains only alphanumeric', () => {
+      it('should not throw if stage name contains only alphanumeric', () => {
         const config = {
           stage: 'configStage',
         };

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -106,6 +106,15 @@ describe('AwsProvider', () => {
         serverless = new Serverless(config);
         expect(() => new AwsProvider(serverless, config)).to.throw(Error);
       });
+
+
+      it('should throw an error if stage name contains non-ascii', () => {
+        const config = {
+          stage: '\xe5',
+        };
+        serverless = new Serverless(config);
+        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
+      });
     });
 
     describe('certificate authority - environment variable', () => {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -99,23 +99,6 @@ describe('AwsProvider', () => {
         expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
       });
 
-      it('should throw an error if stage name contains underscore', () => {
-        const config = {
-          stage: 'config_stage',
-        };
-        serverless = new Serverless(config);
-        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
-      });
-
-
-      it('should throw an error if stage name contains non-ascii', () => {
-        const config = {
-          stage: '\xe5',
-        };
-        serverless = new Serverless(config);
-        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
-      });
-
       it('should not throw an error if stage contains hyphen but http events are absent', () => {
         const config = {
           stage: 'config-stage',

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -91,20 +91,12 @@ describe('AwsProvider', () => {
     });
 
     describe('validation on construction', () => {
-      it('should not throw if stage name contains only alphanumeric', () => {
+      it('should not throw an error if stage name contains only alphanumeric', () => {
         const config = {
           stage: 'configStage',
         };
         serverless = new Serverless(config);
         expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
-      });
-
-      it('should throw an error if stage name contains hyphen', () => {
-        const config = {
-          stage: 'config-stage',
-        };
-        serverless = new Serverless(config);
-        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
       });
 
       it('should throw an error if stage name contains underscore', () => {
@@ -121,6 +113,44 @@ describe('AwsProvider', () => {
           stage: '\xe5',
         };
         serverless = new Serverless(config);
+        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
+      });
+
+      it('should not throw an error if stage contains hyphen but http events are absent', () => {
+        const config = {
+          stage: 'config-stage',
+        };
+        serverless = new Serverless(config);
+        expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
+      });
+
+      it('should throw an error if stage contains hyphen and http events are present', () => {
+        const config = {
+          stage: 'config-stage',
+        };
+        serverless = new Serverless(config);
+
+        const serverlessYml = {
+          service: 'new-service',
+          provider: {
+            name: 'aws',
+            stage: 'config-stage',
+          },
+          functions: {
+            first: {
+              events: [
+                {
+                  http: {
+                    path: 'foo',
+                    method: 'GET',
+                  },
+                },
+              ],
+            },
+          },
+        };
+        serverless.service = new serverless.classes.Service(serverless, serverlessYml);
+
         expect(() => new AwsProvider(serverless, config)).to.throw(Error);
       });
     });


### PR DESCRIPTION
## What did you implement:

Closes #4737

## How did you implement it:

Add hyphen validation to `AwsProvider` constructor, so users can get informed about what is invalid stage name before deploy which is time-consuming.

* Hyphen in stage name will be an error only if `http` events are present, since API Gateway does not support hyphen in stage name.
* Why validation in constructor?  Because I think it can raise error in both createStack and updateStack time.

Underscore is already implemented in
https://github.com/serverless/serverless/blob/3c1b4393af2416eff5ce269fd187363512ede/lib/plugins/aws/deploy/lib/createStack.js#L50-L57 so this PR does not touch underscore.

## How can we verify it:

Run test.


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
