### PR TITLE
[WIP] AWS: Attach Lambdas to existing Cognito User Pool

### DIFF
--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -31,7 +31,6 @@ class AwsCompileCognitoUserPoolEvents {
       'before:deploy:deploy': this.ensureAllPreExistingCognitoUserPoolsExists.bind(this),
       'after:deploy:deploy': this.addTriggerFunctionsToPreExistingUserPools.bind(this),
       'before:remove:remove': this.removeTriggerFunctionsFromPreExistingUserPools.bind(this),
-      'after:info:info': this.infoTriggerFunctionsInPreExistingUserPools.bind(this),
     };
   }
 
@@ -146,11 +145,6 @@ class AwsCompileCognitoUserPoolEvents {
       });
     });
     return BbPromise.all(updateLambdaConfigEachPools);
-  }
-
-  infoTriggerFunctionsInPreExistingUserPools() {
-    // TODO implement
-    return BbPromise.resolve('not implemented');
   }
 
   findUserPoolsAndFunctions() {

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -35,7 +35,7 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   ensureAllPreExistingCognitoUserPoolsExists() {
-    const { preExistingUserPools } = this.findUserPoolsAndFunctions();
+    const preExistingUserPools = this.findUserPoolsAndFunctions().preExistingUserPools;
     const preExistingUserPoolIds = preExistingUserPools.map(this.extractPoolId);
     return BbPromise.all(
       preExistingUserPoolIds.map(poolId => this.checkPreExistingCognitoUserPool(poolId))
@@ -84,8 +84,9 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   addTriggerFunctionsToPreExistingUserPools() {
-    const { preExistingUserPools, cognitoUserPoolTriggerFunctions }
-      = this.findUserPoolsAndFunctions();
+    const result = this.findUserPoolsAndFunctions();
+    const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
+    const preExistingUserPools = result.preExistingUserPools;
     const preExistingUserPoolIds = preExistingUserPools.map(this.extractPoolId);
     const updateLambdaConfigEachPools = preExistingUserPoolIds.map(poolId => {
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions,
@@ -99,8 +100,8 @@ class AwsCompileCognitoUserPoolEvents {
         );
       });
       return BbPromise.all(getFunctionArns).then(functions => {
-        const lambdaConfig = _.reduce(functions, (result, value) =>
-          Object.assign({}, result, {
+        const lambdaConfig = _.reduce(functions, (updated, value) =>
+          Object.assign({}, updated, {
             [value.triggerSource]: value.functionArn,
           }), {});
         return this.updateLambdaConfig(poolId, lambdaConfig);
@@ -110,9 +111,9 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   removeTriggerFunctionsFromPreExistingUserPools() {
-    this.serverless.cli.log('removeTriggerFunctionsFromPreExistingUserPools');
-    const { preExistingUserPools, cognitoUserPoolTriggerFunctions }
-      = this.findUserPoolsAndFunctions();
+    const result = this.findUserPoolsAndFunctions();
+    const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
+    const preExistingUserPools = result.preExistingUserPools;
     const preExistingUserPoolIds = preExistingUserPools.map(this.extractPoolId);
     const updateLambdaConfigEachPools = preExistingUserPoolIds.map(poolId => {
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions,
@@ -134,11 +135,10 @@ class AwsCompileCognitoUserPoolEvents {
           return BbPromise.reject(new this.serverless.classes.Error(err.message));
         });
       });
-      return BbPromise.all([
-        this.getLambdaConfig(poolId),
-        ...getFunctionArns,
-      ]).then(result => {
-        const [currentLambdaConfig, ...functions] = result;
+      const promises = _.concat(this.getLambdaConfig(poolId), getFunctionArns);
+      return BbPromise.all(promises).then(results => {
+        const currentLambdaConfig = results[0];
+        const functions = _.drop(results, 1);
         const lambdaConfig = _.omitBy(currentLambdaConfig, (value, key) =>
           _.some(functions, { triggerSource: key, functionArn: value }));
         return this.updateLambdaConfig(poolId, lambdaConfig);
@@ -270,8 +270,10 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   compileCognitoUserPoolEvents() {
-    const { userPools, cognitoUserPoolTriggerFunctions, preExistingUserPools }
-      = this.findUserPoolsAndFunctions();
+    const result = this.findUserPoolsAndFunctions();
+    const userPools = result.userPools;
+    const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
+    const preExistingUserPools = result.preExistingUserPools;
 
     // Generate CloudFormation templates for Cognito User Pool changes
     _.forEach(userPools, (poolName) => {

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -12,6 +12,10 @@ const validTriggerSources = [
   'CreateAuthChallenge',
   'VerifyAuthChallengeResponse',
 ];
+const validPreExistingTypes = [
+  'undefined',
+  'boolean'
+];
 
 class AwsCompileCognitoUserPoolEvents {
   constructor(serverless) {
@@ -57,6 +61,14 @@ class AwsCompileCognitoUserPoolEvents {
                   ].join(' '));
               }
 
+              // Check `cognitoUserPool` preExisting is valid
+              if (!_.includes(validPreExistingTypes, typeof event.cognitoUserPool.preExisting)) {
+                throw new this.serverless.classes
+                  .Error([
+                    `Cognito User Pool pre-existing field is not an undefined nor a boolean`,
+                  ].join(' '));
+              }
+
               // Save trigger functions so we can use them to generate
               // IAM permissions later
               cognitoUserPoolTriggerFunctions.push({
@@ -67,7 +79,10 @@ class AwsCompileCognitoUserPoolEvents {
 
               // Save user pools so we can use them to generate
               // CloudFormation resources later
-              userPools.push(event.cognitoUserPool.pool);
+              userPools.push({
+                poolName: event.cognitoUserPool.pool,
+                preExisting: !!event.cognitoUserPool.preExisting,
+              });
             } else {
               throw new this.serverless.classes
                 .Error([
@@ -80,6 +95,21 @@ class AwsCompileCognitoUserPoolEvents {
         });
       }
     });
+
+    const mixed = Object.entries(_.groupBy(userPools, "poolName")).flatMap(([poolName, group]) => {
+      if (_.uniqBy(group, e => e.preExisting).length === 1) {
+        return [];
+      } else {
+        return [poolName];
+      }
+    });
+    if (!_.isEmpty(mixed)) {
+      throw new this.serverless.classes.Error([
+        `pre-existing fields are mixed (true and false) on these event pools:`,
+        `${mixed.join(' ')}.`,
+        'Must be true-only or false-only on same event pool.',
+      ].join(' '));
+    }
 
     return { cognitoUserPoolTriggerFunctions, userPools };
   }
@@ -123,7 +153,7 @@ class AwsCompileCognitoUserPoolEvents {
     const userPools = result.userPools;
 
     // Generate CloudFormation templates for Cognito User Pool changes
-    _.forEach(userPools, (poolName) => {
+    _.forEach(userPools, ({poolName, preExisting}) => {
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions, { poolName });
       const userPoolCFResource = this.generateTemplateForPool(
         poolName,
@@ -176,7 +206,7 @@ class AwsCompileCognitoUserPoolEvents {
     const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
     const userPools = result.userPools;
 
-    _.forEach(userPools, (poolName) => {
+    _.forEach(userPools, ({poolName, preExisting}) => {
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions, { poolName });
       const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -14,8 +14,10 @@ const validTriggerSources = [
 ];
 const validPreExistingTypes = [
   'undefined',
-  'boolean'
+  'boolean',
 ];
+const cognitoUserPoolIdOrArnPattern =
+  /^(?:arn:aws:cognito-idp:[a-z0-9-]+:[0-9]{12}:userpool\/)?[a-z0-9-]+_[a-zA-Z0-9]{9}$/;
 
 class AwsCompileCognitoUserPoolEvents {
   constructor(serverless) {
@@ -65,8 +67,25 @@ class AwsCompileCognitoUserPoolEvents {
               if (!_.includes(validPreExistingTypes, typeof event.cognitoUserPool.preExisting)) {
                 throw new this.serverless.classes
                   .Error([
-                    `Cognito User Pool pre-existing field is not an undefined nor a boolean`,
+                    'Cognito User Pool pre-existing field is not an undefined nor a boolean.',
                   ].join(' '));
+              }
+
+              if (event.cognitoUserPool.preExisting
+                && !cognitoUserPoolIdOrArnPattern.test(event.cognitoUserPool.pool)) {
+                throw new this.serverless.classes
+                  .Error([
+                    'Cognito User Pool "pool" field must be a pool id or ARN of existing CUP',
+                    'if "preExisting" fields is true.',
+                  ].join(' '));
+              } else if (!event.cognitoUserPool.preExisting
+                && cognitoUserPoolIdOrArnPattern.test(event.cognitoUserPool.pool)) {
+                this.serverless.cli.log([
+                  `Warning: Cognito User Pool "pool" field of a function "${functionName}" seems`,
+                  'an ARN or a pool id of existing user pool',
+                  'but "preExisting" field is missing or false.',
+                  'This may create a new CUP named from the "pool" field.',
+                ].join(' '));
               }
 
               // Save trigger functions so we can use them to generate
@@ -95,21 +114,6 @@ class AwsCompileCognitoUserPoolEvents {
         });
       }
     });
-
-    const mixed = Object.entries(_.groupBy(userPools, "poolName")).flatMap(([poolName, group]) => {
-      if (_.uniqBy(group, e => e.preExisting).length === 1) {
-        return [];
-      } else {
-        return [poolName];
-      }
-    });
-    if (!_.isEmpty(mixed)) {
-      throw new this.serverless.classes.Error([
-        `pre-existing fields are mixed (true and false) on these event pools:`,
-        `${mixed.join(' ')}.`,
-        'Must be true-only or false-only on same event pool.',
-      ].join(' '));
-    }
 
     return { cognitoUserPoolTriggerFunctions, userPools };
   }
@@ -153,7 +157,12 @@ class AwsCompileCognitoUserPoolEvents {
     const userPools = result.userPools;
 
     // Generate CloudFormation templates for Cognito User Pool changes
-    _.forEach(userPools, ({poolName, preExisting}) => {
+    _.forEach(userPools, arg => {
+      const poolName = arg.poolName;
+      const preExisting = arg.preExisting;
+      if (preExisting) {
+        return;
+      }
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions, { poolName });
       const userPoolCFResource = this.generateTemplateForPool(
         poolName,
@@ -206,7 +215,8 @@ class AwsCompileCognitoUserPoolEvents {
     const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
     const userPools = result.userPools;
 
-    _.forEach(userPools, ({poolName, preExisting}) => {
+    _.forEach(userPools, arg => {
+      const poolName = arg.poolName;
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions, { poolName });
       const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -30,7 +30,7 @@ class AwsCompileCognitoUserPoolEvents {
       'after:package:finalize': this.mergeWithCustomResources.bind(this),
       'before:deploy:deploy': this.ensureAllPreExistingCognitoUserPoolsExists.bind(this),
       'after:deploy:deploy': this.addTriggerFunctionsToPreExistingUserPools.bind(this),
-      'after:remove:remove': this.removeTriggerFunctionsFromPreExistingUserPools.bind(this),
+      'before:remove:remove': this.removeTriggerFunctionsFromPreExistingUserPools.bind(this),
       'after:info:info': this.infoTriggerFunctionsInPreExistingUserPools.bind(this),
     };
   }
@@ -67,6 +67,11 @@ class AwsCompileCognitoUserPoolEvents {
       }, {
         useCache: true,
       });
+  }
+
+  getLambdaConfig(UserPoolId) {
+    return this.checkPreExistingCognitoUserPool(UserPoolId)
+      .then((result) => result.UserPool.LambdaConfig);
   }
 
   getLambdaArn(FunctionName) {
@@ -106,8 +111,41 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   removeTriggerFunctionsFromPreExistingUserPools() {
-    // TODO implement
-    return BbPromise.resolve('not implemented');
+    this.serverless.cli.log('removeTriggerFunctionsFromPreExistingUserPools');
+    const { preExistingUserPools, cognitoUserPoolTriggerFunctions }
+      = this.findUserPoolsAndFunctions();
+    const preExistingUserPoolIds = preExistingUserPools.map(this.extractPoolId);
+    const updateLambdaConfigEachPools = preExistingUserPoolIds.map(poolId => {
+      const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions,
+        (func) => poolId === this.extractPoolId(func.poolName));
+      const getFunctionArns = currentPoolTriggerFunctions.map(value => {
+        const stackName = this.provider.naming.getStackName();
+        const functionName = value.functionName;
+        const FunctionName = `${stackName}-${functionName}`;
+        return this.getLambdaArn(FunctionName).then(functionArn =>
+          Object.assign({}, value, { functionArn })
+        ).catch(err => {
+          if (err.statusCode === 404) {
+            this.serverless.cli.log([
+              `A lambda function ${FunctionName} not found.`,
+              `It might be already removed from user pool ${poolId}`,
+            ].join(' '));
+            return BbPromise.resolve(undefined);
+          }
+          return BbPromise.reject(new this.serverless.classes.Error(err.message));
+        });
+      });
+      return BbPromise.all([
+        this.getLambdaConfig(poolId),
+        ...getFunctionArns,
+      ]).then(result => {
+        const [currentLambdaConfig, ...functions] = result;
+        const lambdaConfig = _.omitBy(currentLambdaConfig, (value, key) =>
+          _.some(functions, { triggerSource: key, functionArn: value }));
+        return this.updateLambdaConfig(poolId, lambdaConfig);
+      });
+    });
+    return BbPromise.all(updateLambdaConfigEachPools);
   }
 
   infoTriggerFunctionsInPreExistingUserPools() {

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const BbPromise = require('bluebird');
 
 const validTriggerSources = [
   'PreSignUp',
@@ -17,7 +18,7 @@ const validPreExistingTypes = [
   'boolean',
 ];
 const cognitoUserPoolIdOrArnPattern =
-  /^(?:arn:aws:cognito-idp:[a-z0-9-]+:[0-9]{12}:userpool\/)?[a-z0-9-]+_[a-zA-Z0-9]{9}$/;
+  /^(?:arn:aws:cognito-idp:[a-z0-9-]+:[0-9]{12}:userpool\/)?([a-z0-9-]+_[a-zA-Z0-9]{9})$/;
 
 class AwsCompileCognitoUserPoolEvents {
   constructor(serverless) {
@@ -27,11 +28,96 @@ class AwsCompileCognitoUserPoolEvents {
     this.hooks = {
       'package:compileEvents': this.compileCognitoUserPoolEvents.bind(this),
       'after:package:finalize': this.mergeWithCustomResources.bind(this),
+      'before:deploy:deploy': this.ensureAllPreExistingCognitoUserPoolsExists.bind(this),
+      'after:deploy:deploy': this.addTriggerFunctionsToPreExistingUserPools.bind(this),
+      'after:remove:remove': this.removeTriggerFunctionsFromPreExistingUserPools.bind(this),
+      'after:info:info': this.infoTriggerFunctionsInPreExistingUserPools.bind(this),
     };
+  }
+
+  ensureAllPreExistingCognitoUserPoolsExists() {
+    const { preExistingUserPools } = this.findUserPoolsAndFunctions();
+    const preExistingUserPoolIds = preExistingUserPools.map(this.extractPoolId);
+    return BbPromise.all(
+      preExistingUserPoolIds.map(poolId => this.checkPreExistingCognitoUserPool(poolId))
+    );
+  }
+
+  extractPoolId(poolIdOrArn) {
+    const matched = cognitoUserPoolIdOrArnPattern.exec(poolIdOrArn);
+    return matched && matched[1];
+  }
+
+  checkPreExistingCognitoUserPool(UserPoolId) {
+    return this.provider.request(
+      'CognitoIdentityServiceProvider',
+      'describeUserPool', {
+        UserPoolId,
+      }, {
+        useCache: true,
+      });
+  }
+
+  updateLambdaConfig(UserPoolId, LambdaConfig) {
+    return this.provider.request(
+      'CognitoIdentityServiceProvider',
+      'updateUserPool', {
+        UserPoolId,
+        LambdaConfig,
+      }, {
+        useCache: true,
+      });
+  }
+
+  getLambdaArn(FunctionName) {
+    return this.provider.request(
+      'Lambda',
+      'getFunction', {
+        FunctionName,
+      }, {
+        useCache: true,
+      }).then((result) => result.Configuration.FunctionArn);
+  }
+
+  addTriggerFunctionsToPreExistingUserPools() {
+    const { preExistingUserPools, cognitoUserPoolTriggerFunctions }
+      = this.findUserPoolsAndFunctions();
+    const preExistingUserPoolIds = preExistingUserPools.map(this.extractPoolId);
+    const updateLambdaConfigEachPools = preExistingUserPoolIds.map(poolId => {
+      const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions,
+        (func) => poolId === this.extractPoolId(func.poolName));
+      const getFunctionArns = currentPoolTriggerFunctions.map(value => {
+        const stackName = this.provider.naming.getStackName();
+        const functionName = value.functionName;
+        const FunctionName = `${stackName}-${functionName}`;
+        return this.getLambdaArn(FunctionName).then(functionArn =>
+          Object.assign({}, value, { functionArn })
+        );
+      });
+      return BbPromise.all(getFunctionArns).then(functions => {
+        const lambdaConfig = _.reduce(functions, (result, value) =>
+          Object.assign({}, result, {
+            [value.triggerSource]: value.functionArn,
+          }), {});
+        return this.updateLambdaConfig(poolId, lambdaConfig);
+      });
+    });
+    return BbPromise.all(updateLambdaConfigEachPools);
+  }
+
+  removeTriggerFunctionsFromPreExistingUserPools() {
+    // TODO implement
+    return BbPromise.resolve('not implemented');
+  }
+
+  infoTriggerFunctionsInPreExistingUserPools() {
+    // TODO implement
+    return BbPromise.resolve('not implemented');
   }
 
   findUserPoolsAndFunctions() {
     const userPools = [];
+    const preExistingUserPools = [];
     const cognitoUserPoolTriggerFunctions = [];
 
     // Iterate through all functions declared in `serverless.yml`
@@ -70,24 +156,6 @@ class AwsCompileCognitoUserPoolEvents {
                     'Cognito User Pool pre-existing field is not an undefined nor a boolean.',
                   ].join(' '));
               }
-
-              if (event.cognitoUserPool.preExisting
-                && !cognitoUserPoolIdOrArnPattern.test(event.cognitoUserPool.pool)) {
-                throw new this.serverless.classes
-                  .Error([
-                    'Cognito User Pool "pool" field must be a pool id or ARN of existing CUP',
-                    'if "preExisting" fields is true.',
-                  ].join(' '));
-              } else if (!event.cognitoUserPool.preExisting
-                && cognitoUserPoolIdOrArnPattern.test(event.cognitoUserPool.pool)) {
-                this.serverless.cli.log([
-                  `Warning: Cognito User Pool "pool" field of a function "${functionName}" seems`,
-                  'an ARN or a pool id of existing user pool',
-                  'but "preExisting" field is missing or false.',
-                  'This may create a new CUP named from the "pool" field.',
-                ].join(' '));
-              }
-
               // Save trigger functions so we can use them to generate
               // IAM permissions later
               cognitoUserPoolTriggerFunctions.push({
@@ -96,12 +164,30 @@ class AwsCompileCognitoUserPoolEvents {
                 triggerSource: event.cognitoUserPool.trigger,
               });
 
-              // Save user pools so we can use them to generate
-              // CloudFormation resources later
-              userPools.push({
-                poolName: event.cognitoUserPool.pool,
-                preExisting: !!event.cognitoUserPool.preExisting,
-              });
+              const poolId = this.extractPoolId(event.cognitoUserPool.pool);
+              if (event.cognitoUserPool.preExisting) {
+                if (!_.isString(poolId)) {
+                  throw new this.serverless.classes
+                    .Error([
+                      'Cognito User Pool "pool" field must be a pool id or ARN of existing CUP',
+                      'if "preExisting" fields is true.',
+                    ].join(' '));
+                }
+                preExistingUserPools.push(event.cognitoUserPool.pool);
+              } else {
+                if (_.isString(poolId)) {
+                  this.serverless.cli.log([
+                    `Warning: Cognito User Pool "pool" field of a function "${functionName}" seems`,
+                    'an ARN or a pool id of existing user pool',
+                    'but "preExisting" field is missing or false.',
+                    'This may create a new CUP named from the "pool" field.',
+                  ].join(' '));
+                }
+
+                // Save user pools so we can use them to generate
+                // CloudFormation resources later
+                userPools.push(event.cognitoUserPool.pool);
+              }
             } else {
               throw new this.serverless.classes
                 .Error([
@@ -115,7 +201,7 @@ class AwsCompileCognitoUserPoolEvents {
       }
     });
 
-    return { cognitoUserPoolTriggerFunctions, userPools };
+    return { cognitoUserPoolTriggerFunctions, userPools, preExistingUserPools };
   }
 
   generateTemplateForPool(poolName, currentPoolTriggerFunctions) {
@@ -152,17 +238,11 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   compileCognitoUserPoolEvents() {
-    const result = this.findUserPoolsAndFunctions();
-    const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
-    const userPools = result.userPools;
+    const { userPools, cognitoUserPoolTriggerFunctions, preExistingUserPools }
+      = this.findUserPoolsAndFunctions();
 
     // Generate CloudFormation templates for Cognito User Pool changes
-    _.forEach(userPools, arg => {
-      const poolName = arg.poolName;
-      const preExisting = arg.preExisting;
-      if (preExisting) {
-        return;
-      }
+    _.forEach(userPools, (poolName) => {
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions, { poolName });
       const userPoolCFResource = this.generateTemplateForPool(
         poolName,
@@ -175,6 +255,10 @@ class AwsCompileCognitoUserPoolEvents {
 
     // Generate CloudFormation templates for IAM permissions to allow Cognito to trigger Lambda
     _.forEach(cognitoUserPoolTriggerFunctions, (cognitoUserPoolTriggerFunction) => {
+      if (_.includes(preExistingUserPools, cognitoUserPoolTriggerFunction.poolName)) {
+        return;
+      }
+
       const userPoolLogicalId = this.provider.naming
         .getCognitoUserPoolLogicalId(cognitoUserPoolTriggerFunction.poolName);
       const lambdaLogicalId = this.provider.naming
@@ -215,8 +299,7 @@ class AwsCompileCognitoUserPoolEvents {
     const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
     const userPools = result.userPools;
 
-    _.forEach(userPools, arg => {
-      const poolName = arg.poolName;
+    _.forEach(userPools, poolName => {
       const currentPoolTriggerFunctions = _.filter(cognitoUserPoolTriggerFunctions, { poolName });
       const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
@@ -304,38 +304,180 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
       ).to.deep.equal({});
     });
 
-    describe('pre-existing CUP', () => {
-      it('should throw an error if cognitoUserPool preExisting field is not a boolean', () => {
-        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                cognitoUserPool: {
-                  pool: 'MyUserPool',
-                  trigger: 'PreSignUp',
-                  preExisting: 42,
-                },
+    it('should NOT create user pool resource when pre-existing is true', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'ap-northeast-1_xyz012345',
+                trigger: 'PreSignUp',
+                preExisting: true,
               },
-            ],
-          },
-        };
+            },
+          ],
+        },
+        second: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
+                trigger: 'PreSignUp',
+                preExisting: true,
+              },
+            },
+          ],
+        },
+      };
 
-        expect(() => {
-          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
-        }).to.throw(Error);
+      awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+
+      expect(awsCompileCognitoUserPoolEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+      ).to.deep.equal({});
+    });
+  });
+
+  describe('pre-existing CUP', () => {
+    it('should throw an error if cognitoUserPool preExisting field is not a boolean', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreSignUp',
+                preExisting: 42,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => {
+        awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+      }).to.throw(Error);
+    });
+
+    it('should pass if CUP is pre-existing but and its pool is ARN of pool or a pool id', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'ap-northeast-1_xyz012345',
+                trigger: 'PreSignUp',
+                preExisting: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
+                trigger: 'PreSignUp',
+                preExisting: true,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => {
+        awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+      }).not.to.throw(Error);
+    });
+
+    it('should throw an error if CUP is pre-existing but ' +
+      'its pool is not a user pool idARN of pool nor a pool id', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreSignUp',
+                preExisting: true,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => {
+        awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+      }).to.throw(Error);
+    });
+
+    it('should throw an error if CUP is pre-existing but its pool is a invalid ARN', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'arn:aws:cognito-idp:us-east-1:0123456789:userpool/MyUserPool',
+                trigger: 'PreSignUp',
+                preExisting: true,
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => {
+        awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+      }).to.throw(Error);
+    });
+
+
+    it('should warn if CUP is not pre-existing but its pool is ARN or a pool id', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreSignUp',
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'ap-northeast-1_xyz012345',
+                trigger: 'PreSignUp',
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
+                trigger: 'PreSignUp',
+              },
+            },
+          ],
+        },
+      };
+
+      class CustomCLI extends CLI {}
+      const consoleLogStub = sinon.stub(CustomCLI.prototype, 'log');
+      serverless.cli = new CustomCLI(serverless);
+
+      expect(() => {
+        awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+      }).not.to.throw(Error);
+      expect(consoleLogStub.callCount).to.equal(2); // not 3, since MyUserPool is not ARN or id
+    });
+
+    describe('#beforeDeployPreExistingCognitoUserPools', () => {
+      let requestStub;
+
+      beforeEach(() => {
+        requestStub = sinon.stub(awsCompileCognitoUserPoolEvents.provider, 'request');
+      });
+      afterEach(() => {
+        requestStub.restore();
       });
 
-      it('should pass if CUP is pre-existing but and its pool is ARN of pool or a pool id', () => {
+      it('should reject if any one of the specified pre-existing CUPs do not exist', () => {
         awsCompileCognitoUserPoolEvents.serverless.service.functions = {
           first: {
             events: [
-              {
-                cognitoUserPool: {
-                  pool: 'ap-northeast-1_xyz012345',
-                  trigger: 'PreSignUp',
-                  preExisting: true,
-                },
-              },
               {
                 cognitoUserPool: {
                   pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
@@ -343,23 +485,9 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                   preExisting: true,
                 },
               },
-            ],
-          },
-        };
-
-        expect(() => {
-          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
-        }).not.to.throw(Error);
-      });
-
-      it('should throw an error if CUP is pre-existing but ' +
-        'its pool is not a user pool idARN of pool nor a pool id', () => {
-        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
-          first: {
-            events: [
               {
                 cognitoUserPool: {
-                  pool: 'MyUserPool',
+                  pool: 'us-west-2_wxyz12345',
                   trigger: 'PreSignUp',
                   preExisting: true,
                 },
@@ -368,67 +496,72 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
           },
         };
 
-        expect(() => {
-          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
-        }).to.throw(Error);
+        requestStub
+          .onCall(0).resolves('success')
+          .onCall(1).rejects(new Error('not exist'));
+
+        return awsCompileCognitoUserPoolEvents.ensureAllPreExistingCognitoUserPoolsExists()
+          .should.be.rejectedWith('not exist').then(() => {
+            expect(requestStub.callCount).to.equal(2);
+          });
       });
 
-      it('should throw an error if CUP is pre-existing but its pool is a invalid ARN', () => {
+      it('should success if all of the specified pre-existing CUPs exist', () => {
         awsCompileCognitoUserPoolEvents.serverless.service.functions = {
           first: {
             events: [
-              {
-                cognitoUserPool: {
-                  pool: 'arn:aws:cognito-idp:us-east-1:0123456789:userpool/MyUserPool',
-                  trigger: 'PreSignUp',
-                  preExisting: true,
-                },
-              },
-            ],
-          },
-        };
-
-        expect(() => {
-          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
-        }).to.throw(Error);
-      });
-
-
-      it('should warn if CUP is not pre-existing but its pool is ARN or a pool id', () => {
-        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                cognitoUserPool: {
-                  pool: 'MyUserPool',
-                  trigger: 'PreSignUp',
-                },
-              },
-              {
-                cognitoUserPool: {
-                  pool: 'ap-northeast-1_xyz012345',
-                  trigger: 'PreSignUp',
-                },
-              },
               {
                 cognitoUserPool: {
                   pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
                   trigger: 'PreSignUp',
+                  preExisting: true,
+                },
+              },
+              {
+                cognitoUserPool: {
+                  pool: 'us-west-2_wxyz12345',
+                  trigger: 'PreSignUp',
+                  preExisting: true,
                 },
               },
             ],
           },
         };
 
-        class CustomCLI extends CLI {}
-        const consoleLogStub = sinon.stub(CustomCLI.prototype, 'log');
-        serverless.cli = new CustomCLI(serverless);
+        requestStub.resolves('success');
 
-        expect(() => {
-          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
-        }).not.to.throw(Error);
-        expect(consoleLogStub.callCount).to.equal(2); // not 3, since MyUserPool is not ARN or id
+        return awsCompileCognitoUserPoolEvents.ensureAllPreExistingCognitoUserPoolsExists()
+          .should.be.fulfilled.then(() => {
+            expect(requestStub.callCount).to.equal(2);
+            expect(requestStub).to.have.been.calledWithExactly(
+              'CognitoIdentityServiceProvider',
+              'describeUserPool',
+              {
+                UserPoolId: 'us-east-1_abcd45678',
+              },
+              {
+                useCache: true,
+              });
+            expect(requestStub).to.have.been.calledWithExactly(
+              'CognitoIdentityServiceProvider',
+              'describeUserPool',
+              {
+                UserPoolId: 'us-west-2_wxyz12345',
+              },
+              {
+                useCache: true,
+              });
+          });
       });
+    });
+    describe('#addTriggerFunctionsToPreExistingUserPools', () => {
+      // TODO
+    });
+    describe('#removeTriggerFunctionsFromPreExistingUserPools', () => {
+      // TODO
+    });
+    describe('#infoTriggerFunctionsInPreExistingUserPools', () => {
+      // TODO
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const _ = require('lodash');
+const sinon = require('sinon');
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileCognitoUserPoolEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
+const CLI = require('../../../../../../../lib/classes/CLI');
 
 describe('AwsCompileCognitoUserPoolEvents', () => {
   let serverless;
@@ -318,10 +320,40 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
           },
         };
 
-        expect(() => awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents()).to.throw(Error);
+        expect(() => {
+          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+        }).to.throw(Error);
       });
 
-      it('should throw an error if the same user pool mixes pre-existing (true and not given)', () => {
+      it('should pass if CUP is pre-existing but and its pool is ARN of pool or a pool id', () => {
+        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                cognitoUserPool: {
+                  pool: 'ap-northeast-1_xyz012345',
+                  trigger: 'PreSignUp',
+                  preExisting: true,
+                },
+              },
+              {
+                cognitoUserPool: {
+                  pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
+                  trigger: 'PreSignUp',
+                  preExisting: true,
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => {
+          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+        }).not.to.throw(Error);
+      });
+
+      it('should throw an error if CUP is pre-existing but ' +
+        'its pool is not a user pool idARN of pool nor a pool id', () => {
         awsCompileCognitoUserPoolEvents.serverless.service.functions = {
           first: {
             events: [
@@ -332,20 +364,37 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                   preExisting: true,
                 },
               },
+            ],
+          },
+        };
+
+        expect(() => {
+          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+        }).to.throw(Error);
+      });
+
+      it('should throw an error if CUP is pre-existing but its pool is a invalid ARN', () => {
+        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+          first: {
+            events: [
               {
                 cognitoUserPool: {
-                  pool: 'MyUserPool',
-                  trigger: 'PostConfirmation'
+                  pool: 'arn:aws:cognito-idp:us-east-1:0123456789:userpool/MyUserPool',
+                  trigger: 'PreSignUp',
+                  preExisting: true,
                 },
               },
             ],
           },
         };
 
-        expect(() => awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents()).to.throw(Error);
+        expect(() => {
+          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+        }).to.throw(Error);
       });
 
-      it('should throw an error if the same user pool mixes pre-existing (true and false)', () => {
+
+      it('should warn if CUP is not pre-existing but its pool is ARN or a pool id', () => {
         awsCompileCognitoUserPoolEvents.serverless.service.functions = {
           first: {
             events: [
@@ -353,21 +402,32 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                 cognitoUserPool: {
                   pool: 'MyUserPool',
                   trigger: 'PreSignUp',
-                  preExisting: true,
                 },
               },
               {
                 cognitoUserPool: {
-                  pool: 'MyUserPool',
-                  trigger: 'PostConfirmation',
-                  preExisting:false,
+                  pool: 'ap-northeast-1_xyz012345',
+                  trigger: 'PreSignUp',
+                },
+              },
+              {
+                cognitoUserPool: {
+                  pool: 'arn:aws:cognito-idp:us-east-1:000123456789:userpool/us-east-1_abcd45678',
+                  trigger: 'PreSignUp',
                 },
               },
             ],
           },
         };
 
-        expect(() => awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents()).to.throw(Error);
+        class CustomCLI extends CLI {}
+        const consoleLogStub = sinon.stub(CustomCLI.prototype, 'log');
+        serverless.cli = new CustomCLI(serverless);
+
+        expect(() => {
+          awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents();
+        }).not.to.throw(Error);
+        expect(consoleLogStub.callCount).to.equal(2); // not 3, since MyUserPool is not ARN or id
       });
     });
   });

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
@@ -301,6 +301,75 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
         .compiledCloudFormationTemplate.Resources
       ).to.deep.equal({});
     });
+
+    describe('pre-existing CUP', () => {
+      it('should throw an error if cognitoUserPool preExisting field is not a boolean', () => {
+        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                cognitoUserPool: {
+                  pool: 'MyUserPool',
+                  trigger: 'PreSignUp',
+                  preExisting: 42,
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if the same user pool mixes pre-existing (true and not given)', () => {
+        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                cognitoUserPool: {
+                  pool: 'MyUserPool',
+                  trigger: 'PreSignUp',
+                  preExisting: true,
+                },
+              },
+              {
+                cognitoUserPool: {
+                  pool: 'MyUserPool',
+                  trigger: 'PostConfirmation'
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents()).to.throw(Error);
+      });
+
+      it('should throw an error if the same user pool mixes pre-existing (true and false)', () => {
+        awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                cognitoUserPool: {
+                  pool: 'MyUserPool',
+                  trigger: 'PreSignUp',
+                  preExisting: true,
+                },
+              },
+              {
+                cognitoUserPool: {
+                  pool: 'MyUserPool',
+                  trigger: 'PostConfirmation',
+                  preExisting:false,
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileCognitoUserPoolEvents.compileCognitoUserPoolEvents()).to.throw(Error);
+      });
+    });
   });
 
   describe('#mergeWithCustomResources()', () => {


### PR DESCRIPTION
## What did you implement:

Partially addresses #4241.
Closes #4207.
Closes #5401 

## How did you implement it:

Add `preExisting` field to `cognitoUserPool` event.

If `preExisting` is not given or `false`, then `pool` field is a pool **name*, as same as before this PR.

If `preExisting` is `true`, then `pool` is expected to be a **pool Id** or an **ARN** of an existing user pool
In this case, new Cognito User Pool resource is not created and just referenced.
Lambdas are attached/removed as triggers to CUP via AWS SDK on hooks, not via CloudFormation, since CloudFormation does not support configure pre-existing CUP.

## How can we verify it:

1. `npm install -g exoego/serverless#aws-existing-resources`
2. Prepare serverless.yaml based onf the below
```
service: pre-existing

provider:
  name: aws
  runtime: nodejs8.10
  region: us-east-1

functions:
  hello:
    handler: handler.hello
    events: []
      - cognitoUserPool:
          pool: arn:aws:cognito-idp:REGION_HERE:ACCOUNT_ID_HERE:userpool/POOL_ID_HERE
          trigger: PreSignUp
          preExisting: true
```
3. `sls deploy`
4. Go to the Trigger page of the specified user pool on Cognito Console, then confirm that `PreSignUp` trigger is now `pre-existing-dev-hello` lambda.
5. `sls remove`
6. Refresh the Trigger page, then confirm that `PreSignUp` trigger is now empty.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
