### PR TITLE
AWS: Fix ${cf.REGION} syntax causes deployment in wrong region

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -226,7 +226,7 @@ class AwsProvider {
    */
   request(service, method, params, options) {
     const that = this;
-    const credentials = that.getCredentials();
+    const credentials = _.cloneDeep(that.getCredentials());
     // Make sure options is an object (honors wrong calls of request)
     const requestOptions = _.isObject(options) ? options : {};
     const shouldCache = _.get(requestOptions, 'useCache', false);

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -324,6 +324,7 @@ describe('AwsProvider', () => {
           },
         },
       };
+      expect(awsProvider.getCredentials()).to.deep.eql({ region: options.region });
 
       return awsProvider
         .request('CloudFormation',
@@ -332,6 +333,8 @@ describe('AwsProvider', () => {
           { region: 'ap-northeast-1' })
         .then(data => {
           expect(data).to.eql({ region: 'ap-northeast-1' });
+          // Requesting different region should not affect region in credentials
+          expect(awsProvider.getCredentials()).to.deep.eql({ region: options.region });
         });
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #5606 

## How did you implement it:

`${cf.REGION}` syntax changes `region` field of the credentials object returnd by `awsProvider.getCredentials()`, to get stack info in different region.
However, `getCredentias()` returns a reference to mutable credentials.
So the modified region are accidentally used for later AWS request, then a stack is deployed to wrong region which is specified by `${cf.REGION}` syntax.

This PR fixes the issue by add deep-cloning the credentials before changing region.

## How can we verify it:

1. Install custom build of serverless from this PR
`npm i -g exoego/serverless#fix-cf-region-syntax`

2. Create a service to be referenced: `sls create -t aws-nodejs --path my-service`

3. Update serverless.yml of `my-service`
``` yaml
service: my-service
provider:
  name: aws
  runtime: nodejs8.10
  region: ap-northeast-1
  memorySize: 512
functions:
  hello:
    name: ${self:custom.functionPrefix}hello
    handler: handler.hello
custom:
  functionPrefix: "issue5154-"
resources:
  Outputs:
    functionPrefix:
      Value: ${self:custom.functionPrefix}
      Export:
        Name: functionPrefix
    memorySize:
      Value: ${self:provider.memorySize}
      Export:
        Name: memorySize
```

3. Deploy my-service: `sls deploy`
4. Create another service:  `sls create -t aws-nodejs --path another`
5. Update serverless.yml of `another`
```yaml
service: another
provider:
  name: aws
  region: us-east-1
  runtime: nodejs8.10
  memorySize: ${cf.ap-northeast-1:myService-dev.memorySize}
functions:
  hello:
    name: ${cf.ap-northeast-1:myService-dev.functionPrefix}hello-usa
    handler: handler.hello
```
6. Deploy `another` service that reference `my-service`

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
