### PR TITLE
Cloudflare config should be under provider property

### DIFF
--- a/docs/providers/cloudflare/guide/functions.md
+++ b/docs/providers/cloudflare/guide/functions.md
@@ -23,12 +23,12 @@ All of the Cloudflare Workers in your serverless service can be found in `server
  
 service:
     name: hello-world
-    config:
-      accountId: CLOUDFLARE_ACCOUNT_ID 
-      zoneId: CLOUDFLARE_ZONE_ID 
 
 provider:
   name: cloudflare
+  config:
+    accountId: CLOUDFLARE_ACCOUNT_ID 
+    zoneId: CLOUDFLARE_ZONE_ID 
 
 plugins:
   - serverless-cloudflare-workers
@@ -69,12 +69,12 @@ If you have an Enterprise Cloudflare account, you can add multiple Cloudflare Wo
  
 service:
     name: hello-world
-    config:
-      accountId: CLOUDFLARE_ACCOUNT_ID 
-      zoneId: CLOUDFLARE_ZONE_ID 
 
 provider:
   name: cloudflare
+  config:
+    accountId: CLOUDFLARE_ACCOUNT_ID 
+    zoneId: CLOUDFLARE_ZONE_ID 
 
 plugins:
   - serverless-cloudflare-workers

--- a/docs/providers/cloudflare/guide/services.md
+++ b/docs/providers/cloudflare/guide/services.md
@@ -79,12 +79,12 @@ You can see the name of the service, the provider configuration and the first fu
  
 service:
     name: hello-world
-    config:
-      accountId: CLOUDFLARE_ACCOUNT_ID 
-      zoneId: CLOUDFLARE_ZONE_ID 
 
 provider:
   name: cloudflare
+  config:
+    accountId: CLOUDFLARE_ACCOUNT_ID 
+    zoneId: CLOUDFLARE_ZONE_ID 
 
 plugins:
   - serverless-cloudflare-workers


### PR DESCRIPTION
## What did you implement:

As detailed in cloudflare/serverless-cloudflare-workers#1 the provider specific configuration is usually set under the `provider` property. cloudflare/serverless-cloudflare-workers#2 made the change.

## How did you implement it:

Documentation change to stay consistent with [template](https://github.com/serverless/serverless/blob/master/lib/plugins/create/templates/cloudflare-workers/serverless.yml#L6-L8).

## How can we verify it:

Compare documentation change to [template](https://github.com/serverless/serverless/blob/master/lib/plugins/create/templates/cloudflare-workers/serverless.yml#L6-L8).

## Todos:

- [ ] Write tests
- [x] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO