### PR TITLE
[WIP] use path.sep as slash param in nanomatch

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -199,7 +199,7 @@ module.exports = {
       patterns.forEach(p => {
         const exclude = p.startsWith('!');
         const pattern = exclude ? p.slice(1) : p;
-        nanomatch(allFilePaths, [pattern], { dot: true })
+        nanomatch(allFilePaths, [pattern], { dot: true, slash: path.sep })
           .forEach(key => {
             filePathStates[key] = !exclude;
           });


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This should fix #5609 by using \ on windows instead of /

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

set `slash` to `path.sep` in the nanomatch options
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Try packaging a file via include that is above the project root, on windows.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
