### PR TITLE
handle layers paths with trailing slash and leading ./ or just .

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -132,8 +132,9 @@ module.exports = {
     const zipFileName = `${layerName}.zip`;
 
     return this.resolveFilePathsLayer(layerName)
+      .then(filePaths => filePaths.map(f => path.resolve(path.join(layerObject.path, f))))
       .then(filePaths =>
-        this.zipFiles(filePaths, zipFileName, layerObject.path).then(artifactPath => {
+        this.zipFiles(filePaths, zipFileName, path.resolve(layerObject.path)).then(artifactPath => {
           layerObject.package = {
             artifact: artifactPath,
           };

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -466,7 +466,7 @@ describe('#packageService()', () => {
         expect(zipFilesStub).to.have.been.calledWithExactly(
           files,
           zipFileName,
-          path.resolve('./foobar'),
+          path.resolve('./foobar')
         ),
       ]));
     });

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -418,4 +418,57 @@ describe('#packageService()', () => {
       ]));
     });
   });
+  describe('#packageLayer()', () => {
+    const exclude = ['test-exclude'];
+    const include = ['test-include'];
+    const files = [];
+    const artifactFilePath = '/some/fake/path/test-artifact.zip';
+    let getExcludesStub;
+    let getIncludesStub;
+    let resolveFilePathsFromPatternsStub;
+    let zipFilesStub;
+
+    beforeEach(() => {
+      getExcludesStub = sinon
+        .stub(packagePlugin, 'getExcludes').returns(exclude);
+      getIncludesStub = sinon
+        .stub(packagePlugin, 'getIncludes').returns(include);
+      resolveFilePathsFromPatternsStub = sinon
+        .stub(packagePlugin, 'resolveFilePathsFromPatterns').returns(files);
+      zipFilesStub = sinon
+        .stub(packagePlugin, 'zipFiles').resolves(artifactFilePath);
+    });
+
+    afterEach(() => {
+      packagePlugin.getExcludes.restore();
+      packagePlugin.getIncludes.restore();
+      packagePlugin.resolveFilePathsFromPatterns.restore();
+      packagePlugin.zipFiles.restore();
+    });
+
+    it('should call zipService with settings', () => {
+      const servicePath = 'test';
+      const layerName = 'test-layer';
+
+      const zipFileName = 'test-layer.zip';
+
+      serverless.config.servicePath = servicePath;
+      serverless.service.layers = {};
+      serverless.service.layers[layerName] = { path: './foobar' };
+
+      return expect(packagePlugin.packageLayer(layerName)).to.eventually.equal(artifactFilePath)
+      .then(() => BbPromise.all([
+        expect(getExcludesStub).to.be.calledOnce,
+        expect(getIncludesStub).to.be.calledOnce,
+        expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
+
+        expect(zipFilesStub).to.be.calledOnce,
+        expect(zipFilesStub).to.have.been.calledWithExactly(
+          files,
+          zipFileName,
+          path.resolve('./foobar'),
+        ),
+      ]));
+    });
+  });
 });

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -80,8 +80,7 @@ module.exports = {
       output.on('open', () => {
         zip.pipe(output);
 
-        const filePaths = files.map(file => (prefix ? path.join(prefix, file) : file));
-        BbPromise.all(filePaths.map(this.getFileContentAndStat.bind(this))).then((contents) => {
+        BbPromise.all(files.map(this.getFileContentAndStat.bind(this))).then((contents) => {
           _.forEach(_.sortBy(contents, ['filePath']), (file) => {
             const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
             zip.append(file.data, {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
handle layers paths with trailing slash
closes #5646

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
use `path.resolve` on the layer path before using it as a prefix
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
create a service with a layer with a path ending in `/`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
