### PR TITLE
Allow hyphens in stage name

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -19,7 +19,7 @@ const constants = {
   providerName: 'aws',
 };
 
-const validAPIGatewayStageNamePattern = /^[a-zA-Z0-9_]+$/;
+const validAPIGatewayStageNamePattern = /^[-a-zA-Z0-9_]+$/;
 
 PromiseQueue.configure(BbPromise.Promise);
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -19,7 +19,7 @@ const constants = {
   providerName: 'aws',
 };
 
-const validAPIGatewayStageNamePattern = /^[-a-zA-Z0-9_]+$/;
+const validAPIGatewayStageNamePattern = /^[-:a-zA-Z0-9_{}$.]+$/;
 
 PromiseQueue.configure(BbPromise.Promise);
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -208,7 +208,8 @@ class AwsProvider {
         if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {
           throw new Error([
             `Invalid stage name ${stage}: `,
-            'it should contains only [-a-zA-Z0-9] or Serverless variables for AWS provider if http event are present '
+            'it should contains only [-a-zA-Z0-9] or Serverless variables for AWS provider',
+            'if http event are present',
           ].join(''));
         }
       });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -208,8 +208,7 @@ class AwsProvider {
         if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {
           throw new Error([
             `Invalid stage name ${stage}: `,
-            'it should contains only [a-zA-Z0-9] for AWS provider if http event are present ',
-            'since API Gateway stage name cannot contains hyphens.',
+            'it should contains only [-a-zA-Z0-9] or Serverless variables for AWS provider if http event are present '
           ].join(''));
         }
       });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -136,9 +136,10 @@ describe('AwsProvider', () => {
 
         expect(() => new AwsProvider(serverless, config)).not.to.throw(Error);
       });
-      it('should throw an error if stage contains hyphen and http events are present', () => {
+
+      it('should throw an error if stage contains % and http events are present', () => {
         const config = {
-          stage: 'config-stage',
+          stage: 'config%stage',
         };
         serverless = new Serverless(config);
 
@@ -146,7 +147,7 @@ describe('AwsProvider', () => {
           service: 'new-service',
           provider: {
             name: 'aws',
-            stage: 'config-stage',
+            stage: 'config%stage',
           },
           functions: {
             first: {
@@ -163,7 +164,7 @@ describe('AwsProvider', () => {
         };
         serverless.service = new serverless.classes.Service(serverless, serverlessYml);
 
-        expect(() => new AwsProvider(serverless, config)).not.to.throw(Error);
+        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
       });
     });
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -107,6 +107,36 @@ describe('AwsProvider', () => {
         expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
       });
 
+      it('should not throw an error if stage contains a variable and http events are present', () => {
+        const config = {
+          stage: 'config-${opt:env}',
+        };
+        serverless = new Serverless(config);
+        const serverlessYml = {
+          service: 'new-service',
+          provider: {
+            name: 'aws',
+            stage: 'config-${opt:env}',
+          },
+          functions: {
+            first: {
+              events: [
+                {
+                  http: {
+                    path: 'foo',
+                    method: 'GET',
+                  },
+                },
+              ],
+            },
+          },
+        };
+        serverless.service = new serverless.classes.Service(serverless, serverlessYml);
+
+        expect(() => new AwsProvider(serverless, config)).not.to.throw(Error);
+        
+      });
+
       it('should throw an error if stage contains hyphen and http events are present', () => {
         const config = {
           stage: 'config-stage',
@@ -134,7 +164,7 @@ describe('AwsProvider', () => {
         };
         serverless.service = new serverless.classes.Service(serverless, serverlessYml);
 
-        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
+        expect(() => new AwsProvider(serverless, config)).not.to.throw(Error);
       });
     });
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -107,7 +107,8 @@ describe('AwsProvider', () => {
         expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
       });
 
-      it('should not throw an error if stage contains a variable and http events are present', () => {
+      it('should not throw an error if stage contains a variable and http events are present',
+      () => {
         const config = {
           stage: 'config-${opt:env}',
         };
@@ -134,9 +135,7 @@ describe('AwsProvider', () => {
         serverless.service = new serverless.classes.Service(serverless, serverlessYml);
 
         expect(() => new AwsProvider(serverless, config)).not.to.throw(Error);
-        
       });
-
       it('should throw an error if stage contains hyphen and http events are present', () => {
         const config = {
           stage: 'config-stage',


### PR DESCRIPTION
## What did you implement:

Closes #5655

If your stage is a variable, you'll get an error indicating that the stage name is invalid

## How did you implement it:
It looks like the variable resolution is happening later in the cloudformation compilation, therefore at this stage, we should allow variable syntax like ${}. In addition, hyphens are allowed in stage names.

## How can we verify it:
Just set stage name to be a variable. For example
```
service:
  name: test-stack

custom:
  env: test

provider:
  name: aws
  stage: ${self:custom.env}
  runtime: nodejs8.10

functions:
  tracerTest:
    memorySize: 512
    handler: tracer-test.handler
    events:
      - http:
          method: get
          path: whatever
```
## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped 
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
