### PR TITLE
Provide AWS_PROFILE from configuration for invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -102,6 +102,7 @@ class AwsInvokeLocal {
       LAMBDA_TASK_ROOT: '/var/task',
       LAMBDA_RUNTIME_DIR: '/var/runtime',
       AWS_REGION: this.provider.getRegion(),
+      AWS_PROFILE: this.provider.getProfile(),
       AWS_DEFAULT_REGION: this.provider.getRegion(),
       AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
       AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -102,7 +102,6 @@ class AwsInvokeLocal {
       LAMBDA_TASK_ROOT: '/var/task',
       LAMBDA_RUNTIME_DIR: '/var/runtime',
       AWS_REGION: this.provider.getRegion(),
-      AWS_PROFILE: this.provider.getProfile(),
       AWS_DEFAULT_REGION: this.provider.getRegion(),
       AWS_LAMBDA_LOG_GROUP_NAME: this.provider.naming.getLogGroupName(lambdaName),
       AWS_LAMBDA_LOG_STREAM_NAME: '2016/12/02/[$LATEST]f77ff5e4026c45bda9a9ebcec6bc9cad',
@@ -111,6 +110,12 @@ class AwsInvokeLocal {
       AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
     };
+
+    // profile override from config
+    const profileOverride = this.provider.getProfile();
+    if (profileOverride) {
+      lambdaDefaultEnvVars.AWS_PROFILE = profileOverride;
+    }
 
     const providerEnvVars = this.serverless.service.provider.environment || {};
     const functionEnvVars = this.options.functionObj.environment || {};

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -272,6 +272,23 @@ describe('AwsInvokeLocal', () => {
       })
     );
 
+    it('it should load provider profile env', () => {
+      // create a copy of options with profile so as to not impact other tests sharing options
+      const optionsWithProfile = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        profile: 'busta-rhymes',
+      };
+      const awsInvokeLocalWithProfile = new AwsInvokeLocal(serverless, optionsWithProfile);
+      const providerWithProfile = new AwsProvider(serverless, optionsWithProfile);
+      awsInvokeLocalWithProfile.provider = providerWithProfile;
+      awsInvokeLocalWithProfile.loadEnvVars().then(() => {
+        // AWS_PROFILE should be set from provider
+        expect(process.env.AWS_PROFILE).to.be.equal('busta-rhymes');
+      });
+    });
+
     it('it should load function env vars', () => awsInvokeLocal
       .loadEnvVars().then(() => {
         expect(process.env.functionVar).to.be.equal('functionValue');

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -24,6 +24,7 @@ describe('AwsInvokeLocal', () => {
   let serverless;
   let provider;
   let awsInvokeLocal;
+
   beforeEach(() => {
     options = {
       stage: 'dev',
@@ -266,6 +267,10 @@ describe('AwsInvokeLocal', () => {
       };
     });
 
+    afterEach(() => {
+      delete process.env.AWS_PROFILE;
+    });
+
     it('it should load provider env vars', () => awsInvokeLocal
       .loadEnvVars().then(() => {
         expect(process.env.providerVar).to.be.equal('providerValue');
@@ -273,19 +278,9 @@ describe('AwsInvokeLocal', () => {
     );
 
     it('it should load provider profile env', () => {
-      // create a copy of options with profile so as to not impact other tests sharing options
-      const optionsWithProfile = {
-        stage: 'dev',
-        region: 'us-east-1',
-        function: 'first',
-        profile: 'busta-rhymes',
-      };
-      const awsInvokeLocalWithProfile = new AwsInvokeLocal(serverless, optionsWithProfile);
-      const providerWithProfile = new AwsProvider(serverless, optionsWithProfile);
-      awsInvokeLocalWithProfile.provider = providerWithProfile;
-      awsInvokeLocalWithProfile.loadEnvVars().then(() => {
-        // AWS_PROFILE should be set from provider
-        expect(process.env.AWS_PROFILE).to.be.equal('busta-rhymes');
+      serverless.service.provider.profile = 'jdoe';
+      return awsInvokeLocal.loadEnvVars().then(() => {
+        expect(process.env.AWS_PROFILE).to.be.equal('jdoe');
       });
     });
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -425,7 +425,8 @@ class AwsProvider {
       ['serverless', 'config', 'profile'],
       ['serverless', 'service', 'provider', 'profile'],
     ]);
-    return this.firstValue(values);
+    const firstVal = this.firstValue(values);
+    return firstVal ? firstVal.value : null;
   }
   getProfile() {
     return this.getProfileSourceValue();

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -419,6 +419,18 @@ class AwsProvider {
     return regionSourceValue.value || defaultRegion;
   }
 
+  getProfileSourceValue() {
+    const values = this.getValues(this, [
+      ['options', 'profile'],
+      ['serverless', 'config', 'profile'],
+      ['serverless', 'service', 'provider', 'profile'],
+    ]);
+    return this.firstValue(values);
+  }
+  getProfile() {
+    return this.getProfileSourceValue();
+  }
+
   getServerlessDeploymentBucketName() {
     if (this.serverless.service.provider.deploymentBucket) {
       return BbPromise.resolve(this.serverless.service.provider.deploymentBucket);

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -337,7 +337,6 @@ describe('AwsProvider', () => {
           expect(awsProvider.getCredentials()).to.deep.eql({ region: options.region });
         });
     });
-
     it('should retry if error code is 429', (done) => {
       const error = {
         statusCode: 429,

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -990,6 +990,46 @@ describe('AwsProvider', () => {
     });
   });
 
+  describe('#getProfile()', () => {
+    let newAwsProvider;
+
+    it('should prefer options over config or provider', () => {
+      const newOptions = {
+        profile: 'optionsProfile',
+      };
+      const config = {
+        profile: 'configProfile',
+      };
+      serverless = new Serverless(config);
+      serverless.service.provider.profile = 'providerProfile';
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getProfile()).to.equal(newOptions.profile);
+    });
+
+    it('should prefer config over provider in lieu of options', () => {
+      const newOptions = {};
+      const config = {
+        profile: 'configProfile',
+      };
+      serverless = new Serverless(config);
+      serverless.service.provider.profile = 'providerProfile';
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getProfile()).to.equal(config.profile);
+    });
+
+    it('should use provider in lieu of options and config', () => {
+      const newOptions = {};
+      const config = {};
+      serverless = new Serverless(config);
+      serverless.service.provider.profile = 'providerProfile';
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getProfile()).to.equal(serverless.service.provider.profile);
+    });
+  });
+
   describe('#getServerlessDeploymentBucketName()', () => {
     it('should return the name of the serverless deployment bucket', () => {
       const describeStackResourcesStub = sinon


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5661

## How did you implement it:

Exactly like the AWS_REGION environment code.

## How can we verify it:

Create two profiles in .aws/config, make profile1 default
Set provider.profile to profile2
Run `invoke` - see that it runs as profile2
Run `invoke local` - see that it runs as profile1

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
