### PR TITLE
Clarify docs for the http key for GCF

### DIFF
--- a/docs/providers/google/events/http.md
+++ b/docs/providers/google/events/http.md
@@ -22,7 +22,7 @@ It might be helpful to read the Google Cloud Functions [HTTP docs](https://cloud
 
 ### HTTP endpoint
 
-This setup specifies that the `first` function should be run when someone accesses the Functions API endpoint via a `GET` request. You can get the URL for the endpoint by running the `serverless info` command after deploying your service.
+This setup specifies that the `first` function should be run when someone accesses the Functions API endpoint. You can get the URL for the endpoint by running the `serverless info` command after deploying your service.
 
 Here's an example:
 
@@ -33,7 +33,7 @@ functions:
   first:
     handler: http
     events:
-      - http: path
+      - http: foo # the value of this key is ignored. It is the presence of the http key that matters to serverless.
 ```
 
 ```javascript
@@ -44,5 +44,12 @@ exports.first = (request, response) => {
   response.status(200).send('Hello World!');
 };
 ```
+
+### Differences from other providers
+
+The configuration for Google Cloud Functions is a bit different than some other providers:
+
+* Your deployed endpoint from above will accept GET, POST, and all other HTTP verbs. If you want to disallow certain verbs, [you can do that within the method body](https://cloud.google.com/functions/docs/writing/http#handling_http_methods).
+* All Google Cloud Functions are deployed as just the handler name at the root of the URL pathname. In the example above, this means your function is deployed to `https://YOUR_URL/http`. As a result, you cannot configure nested routes such as `http/hello` in your `serverless.yml` file. Instead, Google passes all URLs that appear to be subdirectories of your URL to your handler function so that you can determine the appropriate behavior. The complete path is still available as `req.path` and can be parsed to provide nested routes, path/URL parameters, and more.
 
 **Note:** See the documentation about the [function handlers](../guide/functions.md) to learn how your handler signature should look like to work with this type of event.


### PR DESCRIPTION
## What did you implement:

This adds a few notes to better explain what you can and cannot do within `serverless.yml` when using GCF. I hope this will address a few common questions for newcomers around HTTP verbs and path configuration in the place they are most likely to find them.

Revisions to this are more than welcome - explaining the URL configuration clearly and concisely was a challenge.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
