### PR TITLE
AWS: Fix stage name is validated before variable resolution

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -10,6 +10,8 @@ const fse = require('../utils/fs/fse');
 const logWarning = require('./Error').logWarning;
 const PromiseTracker = require('./PromiseTracker');
 
+const validAPIGatewayStageNamePattern = /^[a-zA-Z0-9_]+$/;
+
 /**
  * Maintainer's notes:
  *
@@ -108,6 +110,19 @@ class Variables {
           this.populateValue(config.value, true) // populate
             .then(populated => _.assign(config, { populated })));
         return this.assignProperties(provider, prepopulations);
+      }).then(() => {
+        const stage = provider.getStage();
+        this.serverless.service.getAllFunctions().forEach(funcName => {
+          _.forEach(this.serverless.service.getAllEventsInFunction(funcName), event => {
+            if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {
+              throw new this.serverless.classes.Error([
+                `Invalid stage name ${stage}: `,
+                'it should contains only [a-zA-Z0-9] for AWS provider if http event are present ',
+                'since API Gateway stage name cannot contains hyphens.',
+              ].join(''));
+            }
+          });
+        });
       });
     }
     return BbPromise.resolve();

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -207,6 +207,68 @@ describe('Variables', () => {
         });
       });
     });
+    describe('stage name validation', () => {
+      it('should throw an error if http event is present and stage contains hyphen', () => {
+        const serverlessYml = {
+          service: 'new-service',
+          provider: {
+            name: 'aws',
+            stage: 'my-stage',
+          },
+          functions: {
+            first: {
+              events: [
+                {
+                  http: {
+                    path: 'foo',
+                    method: 'GET',
+                  },
+                },
+              ],
+            },
+          },
+        };
+        serverless.service = new serverless.classes.Service(serverless, serverlessYml);
+
+        return serverless.variables.populateService().should.be
+          .rejectedWith(serverless.classes.Error, [
+            'Invalid stage name my-stage: it should contains only [a-zA-Z0-9]',
+            'for AWS provider if http event are present',
+            'since API Gateway stage name cannot contains hyphens.',
+          ].join(' '));
+      });
+
+      it(`should throw an error after variable population
+            if http event is present and stage contains hyphen`, () => {
+        const serverlessYml = {
+          service: 'new-service',
+          provider: {
+            name: 'aws',
+            stage: '${opt:stage, "default-stage"}',
+          },
+          functions: {
+            first: {
+              events: [
+                {
+                  http: {
+                    path: 'foo',
+                    method: 'GET',
+                  },
+                },
+              ],
+            },
+          },
+        };
+        serverless.service = new serverless.classes.Service(serverless, serverlessYml);
+
+        return serverless.variables.populateService().should.be
+          .rejectedWith(serverless.classes.Error, [
+            'Invalid stage name default-stage: it should contains only [a-zA-Z0-9]',
+            'for AWS provider if http event are present',
+            'since API Gateway stage name cannot contains hyphens.',
+          ].join(' '));
+      });
+    });
   });
 
   describe('#getProperties', () => {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -19,8 +19,6 @@ const constants = {
   providerName: 'aws',
 };
 
-const validAPIGatewayStageNamePattern = /^[a-zA-Z0-9_]+$/;
-
 PromiseQueue.configure(BbPromise.Promise);
 
 const impl = {
@@ -201,19 +199,6 @@ class AwsProvider {
         }
       }
     }
-
-    const stage = this.getStage();
-    this.serverless.service.getAllFunctions().forEach(funcName => {
-      _.forEach(this.serverless.service.getAllEventsInFunction(funcName), event => {
-        if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {
-          throw new Error([
-            `Invalid stage name ${stage}: `,
-            'it should contains only [a-zA-Z0-9] for AWS provider if http event are present ',
-            'since API Gateway stage name cannot contains hyphens.',
-          ].join(''));
-        }
-      });
-    });
   }
 
   /**

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -90,51 +90,43 @@ describe('AwsProvider', () => {
       delete process.env.AWS_CLIENT_TIMEOUT;
     });
 
-    describe('validation on construction', () => {
-      it('should not throw an error if stage name contains only alphanumeric', () => {
-        const config = {
-          stage: 'configStage',
-        };
-        serverless = new Serverless(config);
-        expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
-      });
+    describe('stage name validation', () => {
+      const stages = [
+        'myStage',
+        'my-stage',
+        'my_stage',
+        '${opt:stage, \'prod\'}',
+      ];
+      stages.forEach(stage => {
+        it(`should not throw an error before variable population 
+            even if http event is present and stage is ${stage}`, () => {
+          const config = {
+            stage,
+          };
+          serverless = new Serverless(config);
 
-      it('should not throw an error if stage contains hyphen but http events are absent', () => {
-        const config = {
-          stage: 'config-stage',
-        };
-        serverless = new Serverless(config);
-        expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
-      });
-
-      it('should throw an error if stage contains hyphen and http events are present', () => {
-        const config = {
-          stage: 'config-stage',
-        };
-        serverless = new Serverless(config);
-
-        const serverlessYml = {
-          service: 'new-service',
-          provider: {
-            name: 'aws',
-            stage: 'config-stage',
-          },
-          functions: {
-            first: {
-              events: [
-                {
-                  http: {
-                    path: 'foo',
-                    method: 'GET',
-                  },
-                },
-              ],
+          const serverlessYml = {
+            service: 'new-service',
+            provider: {
+              name: 'aws',
+              stage,
             },
-          },
-        };
-        serverless.service = new serverless.classes.Service(serverless, serverlessYml);
-
-        expect(() => new AwsProvider(serverless, config)).to.throw(Error);
+            functions: {
+              first: {
+                events: [
+                  {
+                    http: {
+                      path: 'foo',
+                      method: 'GET',
+                    },
+                  },
+                ],
+              },
+            },
+          };
+          serverless.service = new serverless.classes.Service(serverless, serverlessYml);
+          expect(() => new AwsProvider(serverless, config)).to.not.throw(Error);
+        });
       });
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #5655, #5674, #5683, #5684 and PR #5658 

## How did you implement it:

Move the validation to after `${variable}` are resolved.

## How can we verify it:

(WIP)

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
