### PR TITLE
AWS: Request cache should add region as key to prevent cross-region cache collision

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -230,7 +230,10 @@ class AwsProvider {
     // Make sure options is an object (honors wrong calls of request)
     const requestOptions = _.isObject(options) ? options : {};
     const shouldCache = _.get(requestOptions, 'useCache', false);
-    const paramsHash = objectHash.sha1(params);
+    const paramsWithRegion = _.merge({}, params, {
+      region: _.get(options, 'region'),
+    });
+    const paramsHash = objectHash.sha1(paramsWithRegion);
     const MAX_TRIES = 4;
     const persistentRequest = (f) => new BbPromise((resolve, reject) => {
       const doCall = (numTry) => {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -223,6 +223,7 @@ class AwsProvider {
    * @param {Object} params - Parameters
    * @param {Object} [options] - Options to modify the request behavior
    * @prop [options.useCache] - Utilize cache to retrieve results
+   * @prop [options.region] - Specify when to request to different region
    */
   request(service, method, params, options) {
     const that = this;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -598,7 +598,7 @@ describe('AwsProvider', () => {
 
         return BbPromise.all(requests)
           .then(results => {
-            expect(_.size(results, 2))
+            expect(_.size(results, 2));
             _.forEach(results, result => {
               expect(result).to.deep.equal(expectedResult);
             });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -565,6 +565,50 @@ describe('AwsProvider', () => {
           });
       });
 
+      it('should request if same service, method and params but different region in option', () => {
+        const expectedResult = { called: true };
+        const sendStub = sinon.stub().yields(null, { called: true });
+        const requestSpy = sinon.spy(awsProvider, 'request');
+        class FakeCF {
+          constructor(credentials) {
+            this.credentials = credentials;
+          }
+
+          describeStacks() {
+            return {
+              send: sendStub,
+            };
+          }
+        }
+        awsProvider.sdk = {
+          CloudFormation: FakeCF,
+        };
+        const executeRequestWithRegion = (region) => awsProvider.request(
+          'CloudFormation',
+          'describeStacks',
+          { StackName: 'same-stack' },
+          {
+            useCache: true,
+            region,
+          }
+        );
+        const requests = [];
+        requests.push(BbPromise.try(() => executeRequestWithRegion('us-east-1')));
+        requests.push(BbPromise.try(() => executeRequestWithRegion('ap-northeast-1')));
+
+        return BbPromise.all(requests)
+          .then(results => {
+            expect(_.size(results, 2))
+            _.forEach(results, result => {
+              expect(result).to.deep.equal(expectedResult);
+            });
+            return expect(sendStub.callCount).to.equal(2);
+          })
+          .finally(() => {
+            requestSpy.restore();
+          });
+      });
+
       it('should resolve to the same response with mutiple parallel requests', () => {
         const expectedResult = { called: true };
         const sendStub = sinon.stub().yields(null, { called: true });


### PR DESCRIPTION
## What did you implement:

Closes #5685

## How did you implement it:

Now AWS Provider's request cache consider `region` as a part of cache key.
So `${cf.REGION:stackA.key1}` and `${cf.ANOTHER-REGION:stackA.key1}` can request separately and does not affect each cache.



## How can we verify it:

1. `npm install -g exoego/serverless#cross-region-same-stack-name`

2. Run `sls deploy` against below: `dev-foo` to `eu-central-1`

```yml
service: foo
provider:
  name: aws
  region: eu-central-1
  stage: dev
  runtime: nodejs8.10
functions:
  hello:
    handler: handler.hello
resources:
  Outputs:
    foo:
      Value: 123
      Export:
        Name: foo
```

2. Run `sls deploy` against below:  `dev-foo` to `us-east-1` (same stack name but different region)

```yml
service: foo
provider:
  name: aws
  region: us-east-1
  stage: dev
  runtime: nodejs8.10
functions:
  hello:
    handler: handler.hello
resources:
  Outputs:
    foo:
      Value: 456
      Export:
        Name: foo
```

3. Run `sls deploy` against below: uses `${cf.REGION}`

```yml
service: bar
provider:
  name: aws
  region: us-east-1
  stage: dev
  runtime: nodejs8.10
functions:
  hello:
    handler: handler.hello
resources:
  Outputs:
    foo1:
      Value: ${cf.eu-central-1:foo-dev.foo}
      Export:
        Name: foo1
    foo2:
      Value: ${cf.us-east-1:foo-dev.foo}
      Export:
        Name: foo2
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
