### PR TITLE
Fix array notation in stream ARN

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -29,9 +29,7 @@ functions:
       - stream:
           type: dynamodb
           arn:
-            Fn::GetAtt:
-              - MyDynamoDbTable
-              - StreamArn
+            Fn::GetAtt: [ MyDynamoDbTable, StreamArn ]
       - stream:
           type: dynamodb
           arn:


### PR DESCRIPTION
Fix array notation in stream ARN

## What did you implement:

Just a doc change to actually show people what works for referencing an ARN from a newly created DynamoDB stream

Closes https://github.com/serverless/serverless/issues/5671

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I just changed the docs.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
