### PR TITLE
Attempt to fix inline editior

### DIFF
--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -146,12 +146,12 @@ For example you define different profiles in `~/.aws/credentials`
 
 ```ini
 [profileName1]
-aws_access_key_id=***************
-aws_secret_access_key=***************
+aws_access_key_id=****************
+aws_secret_access_key=****************
 
 [profileName2]
-aws_access_key_id=***************
-aws_secret_access_key=***************
+aws_access_key_id=****************
+aws_secret_access_key=****************
 ```
 
 Now you can switch per project (/ API) by executing once when you start your project:


### PR DESCRIPTION
In the 'Use an existing AWS Profile` section, the inline editor on serverless.com is broken by the sample code. While I can't be sure, it may be due to the unbalanced use of special character asterisk.

Issue: https://imgur.com/a/UgzpkJ4

The attemped fix is change the number of asterisks to an even number (15->16) to see if that helps. other options would be to escape them.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
