### PR TITLE
Convert reservedConcurrency to integer to allow use env var

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -299,8 +299,11 @@ class AwsCompileFunctions {
     }
 
     if (functionObject.reservedConcurrency || functionObject.reservedConcurrency === 0) {
-      if (_.isInteger(functionObject.reservedConcurrency)) {
-        newFunction.Properties.ReservedConcurrentExecutions = functionObject.reservedConcurrency;
+      // Try convert reservedConcurrency to integer
+      const reservedConcurrency = _.parseInt(functionObject.reservedConcurrency);
+
+      if (_.isInteger(reservedConcurrency)) {
+        newFunction.Properties.ReservedConcurrentExecutions = reservedConcurrency;
       } else {
         const errorMessage = [
           'You should use integer as reservedConcurrency value on function: ',

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1976,7 +1976,7 @@ describe('AwsCompileFunctions', () => {
         func: {
           handler: 'func.function.handler',
           name: 'new-service-dev-func',
-          reservedConcurrency: '1',
+          reservedConcurrency: 'a',
         },
       };
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5698 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Converting reservedConcurrency variable to integer

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Store serverless.yaml
```
service: env-test

provider:
  name: aws
  runtime: nodejs6.10

functions:
    cronFunc:
        handler: handler.cronFunc
        reservedConcurrency: '${env:CONCURRENCY}'
```

then compile
```env CONCURRENCY=10 serverless package```

see 
```"ReservedConcurrentExecutions": 10```
for example using
```cat .serverless/serverless-state.json```


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO

