### PR TITLE
Fix #5664 - Rollback fails due to a timestamp parsing error

### DIFF
--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -65,7 +65,13 @@ class AwsRollback {
           return BbPromise.reject(`${msg} ${hint}`);
         }
 
-        const date = new Date(this.options.timestamp);
+        let date = new Date(this.options.timestamp);
+
+        // The if below is added due issues#5664 - Check it for more details
+        if (date instanceof Date === false || isNaN(date.valueOf())) {
+          date = new Date(Number(this.options.timestamp));
+        }
+
         const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
         const exists = _.some(deployments, (deployment) => (
           _.some(deployment, {

--- a/lib/plugins/aws/rollback/index.test.js
+++ b/lib/plugins/aws/rollback/index.test.js
@@ -14,21 +14,28 @@ describe('AwsRollback', () => {
   let serverless;
   let provider;
 
-  beforeEach(() => {
+  const createInstance = (options) => {
     serverless = new Serverless();
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-      timestamp: 1476779096930,
-    };
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'rollback';
+
     spawnStub = sinon.stub(serverless.pluginManager, 'spawn');
+
     awsRollback = new AwsRollback(serverless, options);
     awsRollback.serverless.cli = new serverless.classes.CLI();
     const prefix = provider.getDeploymentPrefix();
     s3Key = `${prefix}/${serverless.service.service}/${provider.getStage()}`;
+  };
+
+  beforeEach(() => {
+    createInstance({
+      stage: 'dev',
+      region: 'us-east-1',
+      timestamp: 1476779096930,
+    });
+
+    return Promise.resolve();
   });
 
   afterEach(() => {
@@ -80,6 +87,39 @@ describe('AwsRollback', () => {
   });
 
   describe('#setStackToUpdate()', () => {
+    it('should resolve with the correct path when the timestamp argument is passed as a string', () => {
+      createInstance({
+        stage: 'dev',
+        region: 'us-east-1',
+        timestamp: '1476779096930',
+      });
+
+      const s3Objects = [
+        {
+          // eslint-disable-next-line max-len
+          Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/compiled-cloudformation-template.json',
+        },
+        {
+          Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/test.zip',
+        },
+      ];
+      const s3Response = {
+        Contents: s3Objects,
+      };
+
+      sinon.stub(awsRollback.provider, 'request')
+        .resolves(s3Response);
+
+      return awsRollback.setStackToUpdate()
+        .then(() => {
+          expect(awsRollback.serverless.service.package.artifactDirectoryName)
+            .to.be.equal('serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z');
+
+          awsRollback.provider.request.restore();
+        });
+    });
+
+
     it('should reject in case no deployments are available', () => {
       const s3Response = {
         Contents: [],

--- a/lib/plugins/aws/rollback/index.test.js
+++ b/lib/plugins/aws/rollback/index.test.js
@@ -87,7 +87,7 @@ describe('AwsRollback', () => {
   });
 
   describe('#setStackToUpdate()', () => {
-    it('should resolve with the correct path when the timestamp argument is passed as a string', () => {
+    it('should resolve when the timestamp argument is passed as a string', () => {
       createInstance({
         stage: 'dev',
         region: 'us-east-1',


### PR DESCRIPTION
When running sls rollback -t 1546961025152 the timestamp was being parsed as a string inside a Date Object.
This would return an Invalid Date, therefore, failing to convert the timestamp into a valid date.

In here we are checking to see if the date is already a valid one, otherwise convert the timestamp to a number and try again.
We are checking first because most cases we don't want to convert to numbers.

Fix #5664

Ps: We could add another check, if the date is still invalid, throw an Error, but that's not the scope of the issue.

## What did you implement:

Closes #5664 

## How did you implement it:

When running `sls rollback -t 1546961025152` the timestamp was being parsed as a string inside a Date Object.
This would return an Invalid Date, therefore, failing to convert the timestamp into a valid date.

In here we are checking to see if the date is already a valid one, otherwise convert the timestamp to a number and try again.
We are checking first because most cases we don't want to convert to numbers.

## How can we verify it:

Check #5664 

Ps: Can someone guide me on how to write the tests for this? I couldn't figure out for myself.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
