### PR TITLE
AWS: Tell S3 bucket name and how to recover if deployment bucket does not exist

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -49,7 +49,7 @@ module.exports = {
       return BbPromise.reject(new this.serverless.classes.Error([
         `The serverless deployment bucket "${params.Bucket}" does not exist.`,
         `Create it manually if you want to reuse the CloudFormation stack "${stackName}",`,
-        'or delete the stack then run "sls deploy".',
+        'or delete the stack if it is no longer required.',
       ].join(' ')));
     }).then((result) => {
       if (result && result.Contents && result.Contents.length) {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -41,7 +41,17 @@ module.exports = {
     return this.provider.request('S3',
       'listObjectsV2',
       params
-    ).then((result) => {
+    ).catch((reason) => {
+      if (!_.includes(reason.message, 'The specified bucket does not exist')) {
+        return BbPromise.reject(reason);
+      }
+      const stackName = this.provider.naming.getStackName();
+      return BbPromise.reject(new this.serverless.classes.Error([
+        `The serverless deployment bucket "${params.Bucket}" does not exist.`,
+        `Create it manually if you want to reuse the CloudFormation stack "${stackName}",`,
+        'or delete the stack then run "sls deploy".',
+      ].join(' ')));
+    }).then((result) => {
       if (result && result.Contents && result.Contents.length) {
         const objects = result.Contents;
 

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -135,6 +135,23 @@ describe('checkForChanges', () => {
       });
     });
 
+    it('should translate error if rejected due to missing bucket', () => {
+      listObjectsV2Stub
+        .rejects(new serverless.classes.Error('The specified bucket does not exist'));
+
+      return expect(awsDeploy.getMostRecentObjects()).to.be.rejectedWith([
+        `The serverless deployment bucket "${awsDeploy.bucketName}" does not exist.`,
+        'Create it manually if you want to reuse the CloudFormation stack "my-service-dev",',
+        'or delete the stack then run "sls deploy".',
+      ].join(' '));
+    });
+
+    it('should throw original error if rejected not due to missing bucket', () => {
+      listObjectsV2Stub
+        .rejects(new serverless.classes.Error('Other reason'));
+      return expect(awsDeploy.getMostRecentObjects()).to.be.rejectedWith('Other reason');
+    });
+
     it('should resolve if result array is empty', () => {
       const serviceObjects = {
         Contents: [],

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -142,7 +142,7 @@ describe('checkForChanges', () => {
       return expect(awsDeploy.getMostRecentObjects()).to.be.rejectedWith([
         `The serverless deployment bucket "${awsDeploy.bucketName}" does not exist.`,
         'Create it manually if you want to reuse the CloudFormation stack "my-service-dev",',
-        'or delete the stack then run "sls deploy".',
+        'or delete the stack if it is no longer required.',
       ].join(' '));
     });
 


### PR DESCRIPTION
## What did you implement:

Closes #5699

## How did you implement it:

Translate the "The specified bucket does not exist" error into more detailed error containing below:

* Bucket name
* stack name
* Possible recovery operation.


## How can we verify it:

1. `npm i -g exoego/serverless#fix-5699;`
1. `sls deploy` anything
1. Delete the deployment bucket manually.
1. `sls deploy`
1. Verify that new error message is shown.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
