### PR TITLE
Enable download template from a private github repo using personal access token

### DIFF
--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -64,7 +64,7 @@ function parseGitHubURL(url) {
   // validate if given url is a valid GitHub url
   validateUrl(url, 'github.com', 'GitHub', owner, repo);
 
-  const downloadUrl = `https://github.com/${owner}/${repo}/archive/${branch}.zip`;
+  const downloadUrl = `https://${url.auth ? `${url.auth}@`:''}github.com/${owner}/${repo}/archive/${branch}.zip`;
 
   return {
     owner,

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -64,7 +64,7 @@ function parseGitHubURL(url) {
   // validate if given url is a valid GitHub url
   validateUrl(url, 'github.com', 'GitHub', owner, repo);
 
-  const downloadUrl = `https://${url.auth ? `${url.auth}@`:''}github.com/${owner}/${repo}/archive/${branch}.zip`;
+  const downloadUrl = `https://${url.auth ? `${url.auth}@` : ''}github.com/${owner}/${repo}/archive/${branch}.zip`;
 
   return {
     owner,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4566

* When doing a `serverless create`, we can specify a `template-url` to fetch the template from a private github git repo HTTPS url using a personal access token. For instance:

```
mkdir mine
cd mine
npm init -f
npm install serverless --save-dev
SLS_DEBUG="*" npx serverless create --template-url https://x-access-token:${GITHUB_AUTH_TOKEN}@github.com/${PRIVATEFORKOWNER}/serverless/tree/master/lib/plugins/create/templates/aws-nodejs --name 'mine' --path mine
```
## How did you implement it:

When `URL.parse(inputUrl.replace(/\/$/, ''))` is [invoked](https://github.com/serverless/serverless/blob/master/lib/utils/downloadTemplateFromRepo.js#L148), it saves the auth portion of the url object if found, but this [is discarded](https://github.com/serverless/serverless/blob/master/lib/utils/downloadTemplateFromRepo.js#L124) when reconstructed using the existing template string.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
1. Make a private github repo, and push the `serverless/serverless` repo to it.
2. You can manually check your personal access tokens out here https://github.com/settings/tokens and create a new one with "repo" scope. Save it somewhere because you can't get it again (but you can delete and recreate it). In your shell, export this value as the environment variable GITHUB_AUTH_TOKEN.
3. Do this:
```
export GITHUB_AUTH_TOKEN='replacemewithyourtoken'
export PRIVATEFORKOWNER='replacewithyourgithubuser'
mkdir mine
cd mine
npm init -f
npm install serverless --save-dev
SLS_DEBUG="*" npx serverless create --template-url https://x-access-token:${GITHUB_AUTH_TOKEN}@github.com/${PRIVATEFORKOWNER}/serverless/tree/master/lib/plugins/create/templates/aws-nodejs --name 'mine' --path mine
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
