### PR TITLE
Make local ruby pry work

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -276,8 +276,8 @@ class AwsInvokeLocal {
       const ruby = spawn(runtime,
         [path.join(__dirname, 'invoke.rb'), handlerPath, handlerName],
         { env: process.env }, { shell: true });
-      ruby.stdout.on('data', (buf) => process.stdout.write(buf.toString()));
-      ruby.stderr.on('data', (buf) => process.stderr.write(buf.toString()));
+      ruby.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
+      ruby.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
       ruby.stdin.write(input);
       ruby.stdin.end();
       ruby.on('close', () => resolve());

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -276,8 +276,8 @@ class AwsInvokeLocal {
       const ruby = spawn(runtime,
         [path.join(__dirname, 'invoke.rb'), handlerPath, handlerName],
         { env: process.env }, { shell: true });
-      ruby.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
-      ruby.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
+      ruby.stdout.on('data', (buf) => process.stdout.write(buf.toString()));
+      ruby.stderr.on('data', (buf) => process.stderr.write(buf.toString()));
       ruby.stdin.write(input);
       ruby.stdin.end();
       ruby.on('close', () => resolve());

--- a/lib/plugins/aws/invokeLocal/invoke.rb
+++ b/lib/plugins/aws/invokeLocal/invoke.rb
@@ -42,6 +42,11 @@ class FakeLambdaContext
   end
 end
 
+
+def attach_tty
+  $stdin.reopen "/dev/tty", "a+" unless Gem.win_platform? || $stdin.tty? || !File.exist?("/dev/tty")
+end
+
 if __FILE__ == $0
   unless ARGV[0] && ARGV[1]
     puts "Usage: invoke.rb <handler_path> <handler_name>"
@@ -60,7 +65,7 @@ if __FILE__ == $0
   handler_method, handler_class = handler_name.split(".").reverse
   handler_class ||= "Kernel"
 
-  $stdin.reopen "/dev/tty", "a+" unless Gem.win_platform? || $stdin.tty?
+  attach_tty
 
   context = FakeLambdaContext.new(**input.fetch('context', {}))
   result = Object.const_get(handler_class).send(handler_method, event: input['event'], context: context)

--- a/lib/plugins/aws/invokeLocal/invoke.rb
+++ b/lib/plugins/aws/invokeLocal/invoke.rb
@@ -60,6 +60,8 @@ if __FILE__ == $0
   handler_method, handler_class = handler_name.split(".").reverse
   handler_class ||= "Kernel"
 
+  $stdin.reopen "/dev/tty", "a+" unless Gem.win_platform? || $stdin.tty?
+
   context = FakeLambdaContext.new(**input.fetch('context', {}))
   result = Object.const_get(handler_class).send(handler_method, event: input['event'], context: context)
 

--- a/lib/plugins/aws/invokeLocal/invoke.rb
+++ b/lib/plugins/aws/invokeLocal/invoke.rb
@@ -44,7 +44,11 @@ end
 
 
 def attach_tty
-  $stdin.reopen "/dev/tty", "a+" unless Gem.win_platform? || $stdin.tty? || !File.exist?("/dev/tty")
+  unless Gem.win_platform? || $stdin.tty? || !File.exist?("/dev/tty")
+    $stdin.reopen "/dev/tty", "a+"
+  end
+rescue
+  puts "tty unavailable"
 end
 
 if __FILE__ == $0


### PR DESCRIPTION
Make local ruby debugging work

This follows a similar change for local python invocation at https://github.com/serverless/serverless/blob/ad5decb080a7aa92cac1bc0f8632e3e57b99fe46/lib/plugins/aws/invokeLocal/invoke.py#L76-L82

A handler such as the following will now pause at the breakpoint:

```ruby
require 'json'
require 'pry'

def hello(event:, context:)
  binding.pry # breakpoint
  { statusCode: 200, body: JSON.generate('Go Serverless v1.0! Your function executed successfully!') }
end
```

FWIW: I put this PR up for feedback rather than to expecting to get it merged, especially w.r.t. e30e24222bd9cd584e