### PR TITLE
Lambda Layers - cast account id to string if number provided

### DIFF
--- a/lib/plugins/aws/package/compile/layers/index.js
+++ b/lib/plugins/aws/package/compile/layers/index.js
@@ -56,15 +56,16 @@ class AwsCompileLayers {
 
     if (layerObject.allowedAccounts) {
       layerObject.allowedAccounts.map(account => {
+        let parsedAccount = account;
         // cast to string if account is number
-        if(typeof account == 'number' && !isNaN(account)) {
-          account = `${account}`;
+        if (typeof account === 'number' && !isNaN(account)) {
+          parsedAccount = `${account}`;
         }
         const newPermission = this.cfLambdaLayerPermissionTemplate();
         newPermission.Properties.LayerVersionArn = { Ref: layerLogicalId };
-        newPermission.Properties.Principal = account;
+        newPermission.Properties.Principal = parsedAccount;
         const layerPermLogicalId = this.provider.naming.getLambdaLayerPermissionLogicalId(
-          layerName, account);
+          layerName, parsedAccount);
         newLayerObject[layerPermLogicalId] = newPermission;
         return newPermission;
       });

--- a/lib/plugins/aws/package/compile/layers/index.js
+++ b/lib/plugins/aws/package/compile/layers/index.js
@@ -56,6 +56,10 @@ class AwsCompileLayers {
 
     if (layerObject.allowedAccounts) {
       layerObject.allowedAccounts.map(account => {
+        // cast to string if account is number
+        if(typeof account == 'number' && !isNaN(account)) {
+          account = `${account}`;
+        }
         const newPermission = this.cfLambdaLayerPermissionTemplate();
         newPermission.Properties.LayerVersionArn = { Ref: layerLogicalId };
         newPermission.Properties.Principal = account;

--- a/lib/plugins/aws/package/compile/layers/index.test.js
+++ b/lib/plugins/aws/package/compile/layers/index.test.js
@@ -172,6 +172,75 @@ describe('AwsCompileLayers', () => {
       });
     });
 
+    it('should create a layer resource with permissions per account', () => {
+      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
+      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
+        .split(path.sep).pop();
+      awsCompileLayers.serverless.service.layers = {
+        test: {
+          path: 'layer',
+          allowedAccounts: [1111111, '2222222'],
+        },
+      };
+      const compiledLayer = {
+        Type: 'AWS::Lambda::LayerVersion',
+        Properties: {
+          Content: {
+            S3Key: `${s3Folder}/${s3FileName}`,
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          },
+          LayerName: 'test',
+        },
+      };
+      const compiledLayerOutput = {
+        Description: 'Current Lambda layer version',
+        Value: {
+          Ref: 'TestLambdaLayer',
+        },
+      };
+      const compiledLayerVersionNumber = {
+        Type: 'AWS::Lambda::LayerVersionPermission',
+        Properties: {
+          Action: 'lambda:GetLayerVersion',
+          LayerVersionArn: {
+            Ref: 'TestLambdaLayer',
+          },
+          Principal: '1111111',
+        },
+      };
+
+      const compiledLayerVersionString = {
+        Type: 'AWS::Lambda::LayerVersionPermission',
+        Properties: {
+          Action: 'lambda:GetLayerVersion',
+          LayerVersionArn: {
+            Ref: 'TestLambdaLayer',
+          },
+          Principal: '2222222',
+        },
+      };
+
+      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled
+      .then(() => {
+        expect(
+          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.TestLambdaLayer
+        ).to.deep.equal(compiledLayer);
+        expect(
+          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate
+            .Outputs.TestLambdaLayerQualifiedArn
+        ).to.deep.equal(compiledLayerOutput);
+        expect(
+          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.Test1111111LambdaLayerPermission
+        ).to.deep.equal(compiledLayerVersionNumber);
+        expect(
+          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.Test2222222LambdaLayerPermission
+        ).to.deep.equal(compiledLayerVersionString);
+      });
+    });
+
     it('should create a layer resource with metadata options set', () => {
       const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Cast account to string if passed as a number (according to docs, you are able to do it)
https://serverless.com/framework/docs/providers/aws/guide/layers/

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Change is self-explainatory really, I just make sure that account is a number, if it is - switch it to string
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Provide layers config with account as a number
```
layers:
  test:
    path: testPath
    allowedAccounts:
      - 11111111
```

After triggering there is going to be an error as integer doesn't have replace method:
```
account.replace is not a function
    at Object.getLambdaLayerPermissionLogicalId ({...}/node_modules/serverless/lib/plugins/aws/lib/naming.js:148:15)
```
With this fix, generation is going to pass

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [X] Write tests
- [X] Write documentation **N/A**
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
