### PR TITLE
docs menu sidebar - added [Getting Started] above [Providers]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@ title: Serverless Framework Documentation
 menuText: Docs
 layout: Doc
 menuItems:
+  - {menuText: "Getting Started", path: /framework/docs/getting-started/}
   - {menuText: Providers, path: /framework/docs/providers}
   - {menuText: "- AWS", path: /framework/docs/providers/aws/}
   - {menuText: "- Azure", path: /framework/docs/providers/azure/}


### PR DESCRIPTION
## What did you implement:

Right now, in the main docs sidebar (https://serverless.com/framework/docs/), [Getting Started] menu item appears below [Providers]. This PR moves [Getting Started] to the top

## How did you implement it:

By adding [Getting Started] as the first menuItem in the respective file's frontmatter

## How can we verify it:

Run a serverless/site build with this branch to see the new menu order

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
