### PR TITLE
Suppress confusing warning "A valid undefined..." 

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -815,8 +815,10 @@ class Variables {
       } else if (variableString.match(this.ssmRefSyntax)) {
         varType = 'SSM parameter';
       }
-      logWarning(`A valid ${varType} to satisfy the declaration '${
-        variableString}' could not be found.`);
+      if (!_.isUndefined(varType)) {
+        logWarning(`A valid ${varType} to satisfy the declaration '${
+          variableString}' could not be found.`);
+      }
     }
     return valueToPopulate;
   }

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1854,6 +1854,21 @@ module.exports = {
       varProxy.warnIfNotFound('self:service', 'a-valid-value');
       expect(logWarningSpy).to.not.have.been.calledOnce;
     });
+    describe('when variable string does not match any of syntax', () => {
+      // These situation happen when deep variable population fails
+      it('should do nothing if variable has null value.', () => {
+        varProxy.warnIfNotFound('', null);
+        expect(logWarningSpy).to.not.have.been.calledOnce;
+      });
+      it('should do nothing if variable has undefined value.', () => {
+        varProxy.warnIfNotFound('', undefined);
+        expect(logWarningSpy).to.not.have.been.calledOnce;
+      });
+      it('should do nothing if variable has empty object value.', () => {
+        varProxy.warnIfNotFound('', {});
+        expect(logWarningSpy).to.not.have.been.calledOnce;
+      });
+    });
     it('should log if variable has null value.', () => {
       varProxy.warnIfNotFound('self:service', null);
       expect(logWarningSpy).to.have.been.calledOnce;


### PR DESCRIPTION
## What did you implement:

Closes #4953 
Closes #5353
Closes #5717 

## How did you implement it:

`Variable#warnIfNotFound(variableString, valueToPopulate)` outputs a confuging warning `A valid undefined ...` when `variableString` does not match any of variable syntaxes.
Such situation can happen when deep variable resolution fails.

This PR suppress warnings when `variableString` does not match any of variable syntaxes, since a root cause of deep variable resolution failure is warned in other call of `#warnIfNotFound`.


## How can we verify it:

1. `npm i -g exoego/serverless#valid-undefined`
2. `sls print` over the below severless.yml
```
provider:
  name: aws
  stage: ${env:NODE_ENV}
  vpc:
    securityGroupIds: ${self:custom.config.stage.vpc.securityGroupIds}

custom:
  config:
    stage: ${file(config/${self:provider.stage}.yml)}
```
3.  Warnings
    * should contains `A valid file to satisfy the declaration 'file(config/.yml)' could not be found.`
    * should NOT contains `A valid undefined to satisfy the declaration 'deep:3.vpc.securityGroupIds' could not be found`

## Todos:

- [x] Write tests
- [x] <del>Write documentation</del> N/A
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
