### PR TITLE
Add google go template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,10 @@ services:
     image: node:6.9.1
     volumes:
       - ./tmp/serverless-integration-test-google-nodejs:/app
+  google-nodejs:
+    image: golang:1.11
+    volumes:
+      - ./tmp/serverless-integration-test-google-go:/app
   spotinst-nodejs:
     image: node:4.8
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
     image: golang:1.11
     volumes:
       - ./tmp/serverless-integration-test-google-go:/app
+      - ./tmp/serverless-integration-test-google-go:/go/src/app
   spotinst-nodejs:
     image: node:4.8
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     image: node:6.9.1
     volumes:
       - ./tmp/serverless-integration-test-google-nodejs:/app
-  google-nodejs:
+  google-go:
     image: golang:1.11
     volumes:
       - ./tmp/serverless-integration-test-google-go:/app

--- a/docs/providers/google/cli-reference/create.md
+++ b/docs/providers/google/cli-reference/create.md
@@ -41,6 +41,7 @@ To see a list of available templates run `serverless create --help`
 Most commonly used templates:
 
 - google-nodejs
+- google-go
 
 ## Examples
 

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -42,6 +42,7 @@ const validTemplates = [
   'fn-nodejs',
   'fn-go',
   'google-nodejs',
+  'google-go',
   'kubeless-python',
   'kubeless-nodejs',
   'openwhisk-java-maven',

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -567,6 +567,20 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "google-go" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'google-go';
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(tmpDir);
+        expect(dirContent).to.include('fn.go');
+        expect(dirContent).to.include('fn_test.go');
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('Makefile');
+        expect(dirContent).to.include('.gitignore');
+      });
+    });
+
     it('should generate scaffolding for "kubeless-python" template', () => {
       process.chdir(tmpDir);
       create.options.template = 'kubeless-python';

--- a/lib/plugins/create/templates/google-go/.gitignore
+++ b/lib/plugins/create/templates/google-go/.gitignore
@@ -1,0 +1,12 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/lib/plugins/create/templates/google-go/Makefile
+++ b/lib/plugins/create/templates/google-go/Makefile
@@ -1,0 +1,10 @@
+.PHONY: gomodgen deploy delete
+
+gomodgen:
+	GO111MODULE=on go mod init
+
+deploy:
+	gcloud functions deploy hello --entry-point Hello --runtime go111 --trigger-http
+
+delete:
+	gcloud functions delete hello --entry-point Hello --runtime go111 --trigger-http

--- a/lib/plugins/create/templates/google-go/fn.go
+++ b/lib/plugins/create/templates/google-go/fn.go
@@ -1,0 +1,14 @@
+package hello
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func Hello(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		name = "someone"
+	}
+	fmt.Fprintf(w, "Hello, %s!", name)
+}

--- a/lib/plugins/create/templates/google-go/fn_test.go
+++ b/lib/plugins/create/templates/google-go/fn_test.go
@@ -13,7 +13,7 @@ func TestHello(t *testing.T) {
 		wantStatus int
 		wantString string
 	}{
-		"name specified":     {"toshi0607", http.StatusOK, "Hello, toshi0607!"},
+		"name specified":     {"jdoe", http.StatusOK, "Hello, jdoe!"},
 		"name not specified": {"", http.StatusOK, "Hello, someone!"},
 	}
 

--- a/lib/plugins/create/templates/google-go/fn_test.go
+++ b/lib/plugins/create/templates/google-go/fn_test.go
@@ -1,0 +1,44 @@
+package hello
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHello(t *testing.T) {
+	tests := map[string]struct {
+		name       string
+		wantStatus int
+		wantString string
+	}{
+		"name specified":     {"toshi0607", http.StatusOK, "Hello, toshi0607!"},
+		"name not specified": {"", http.StatusOK, "Hello, someone!"},
+	}
+
+	for name, te := range tests {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			q := r.URL.Query()
+			q.Add("name", te.name)
+			r.URL.RawQuery = q.Encode()
+
+			Hello(w, r)
+
+			rw := w.Result()
+			defer rw.Body.Close()
+			if s := rw.StatusCode; s != te.wantStatus {
+				t.Fatalf("got: %d, want: %d", s, te.wantStatus)
+			}
+			b, err := ioutil.ReadAll(rw.Body)
+			if err != nil {
+				t.Fatal("failed to read res body")
+			}
+			if s := string(b); s != te.wantString {
+				t.Fatalf("got: %s, want: %s", s, te.wantString)
+			}
+		})
+	}
+}

--- a/lib/plugins/create/templates/google-go/serverless.yml
+++ b/lib/plugins/create/templates/google-go/serverless.yml
@@ -1,0 +1,44 @@
+service: gcf-go111 # NOTE: Don't put the word "google" in here
+
+provider:
+  name: google
+  runtime: go111
+  project: my-project
+  # the path to the credentials file needs to be absolute
+  credentials: ~/.gcloud/keyfile.json
+
+plugins:
+  - serverless-google-cloudfunctions
+
+# needs more granular excluding in production as only the serverless provider npm
+# package should be excluded (and not the whole node_modules directory)
+package:
+  exclude:
+    - .gitignore
+    - .git/**
+
+functions:
+  first:
+    handler: http
+    events:
+      - http: path
+
+  # NOTE: the following uses an "event" event (pubSub event in this case).
+  # Please create the corresponding resources in the Google Cloud
+  # before deploying this service through Serverless
+
+  #second:
+  #  handler: event
+  #  events:
+  #    - event:
+  #        eventType: providers/cloud.pubsub/eventTypes/topic.publish
+  #        resource: projects/*/topics/my-topic
+
+# you can define resources, templates etc. the same way you would in a
+# Google Cloud deployment configuration
+#resources:
+#  resources:
+#    - type: storage.v1.bucket
+#      name: my-serverless-service-bucket
+#  imports:
+#    - path: my_template.jinja

--- a/lib/plugins/create/templates/google-go/serverless.yml
+++ b/lib/plugins/create/templates/google-go/serverless.yml
@@ -4,6 +4,9 @@ provider:
   name: google
   runtime: go111
   project: my-project
+  # The GCF credentials can be a little tricky to set up. Luckily we've documented this for you here:
+  # https://serverless.com/framework/docs/providers/google/guide/credentials/
+  #
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 

--- a/lib/plugins/create/templates/google-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/google-nodejs/serverless.yml
@@ -4,6 +4,9 @@ provider:
   name: google
   runtime: nodejs
   project: my-project
+  # The GCF credentials can be a little tricky to set up. Luckily we've documented this for you here:
+  # https://serverless.com/framework/docs/providers/google/guide/credentials/
+  #
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 

--- a/tests/templates/test_all_templates
+++ b/tests/templates/test_all_templates
@@ -30,6 +30,7 @@ integration-test aws-nodejs-typescript
 integration-test aws-alexa-typescript
 integration-test aws-nodejs-ecma-script
 integration-test google-nodejs
+integration-test google-go
 integration-test spotinst-nodejs
 integration-test spotinst-python
 integration-test spotinst-ruby


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

close #5724

Cloud Functions Go runtime has bees released! 🎉 So I wrote a template for it.

## How did you implement it:

I added template, list of template and tests.

## How can we verify it:

```
# Go 1.11 is necessary
# $GOPATH should be set

$ cd $GOPATH/src/github.com/[your repo]
$ serverless create -t google-go -p sample-app
$ cd sample-app
$ make gomodgen
```
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
