### PR TITLE
Do not print logs if print command is used.

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -81,7 +81,7 @@ class Serverless {
     if (this.cli.displayHelp(this.processedInput)) {
       return BbPromise.resolve();
     }
-    this.cli.suppressLog(this.processedInput);
+    this.cli.suppressLogIfPrintCommand(this.processedInput);
 
     // make sure the command exists before doing anything else
     this.pluginManager.validateCommand(this.processedInput.commands);

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -81,6 +81,7 @@ class Serverless {
     if (this.cli.displayHelp(this.processedInput)) {
       return BbPromise.resolve();
     }
+    this.cli.suppressLog(this.processedInput);
 
     // make sure the command exists before doing anything else
     this.pluginManager.validateCommand(this.processedInput.commands);

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -79,6 +79,30 @@ class CLI {
     return { commands, options };
   }
 
+  suppressLog(processedInput) {
+    const commands = processedInput.commands;
+    const options = processedInput.options;
+
+    // if "-help" or "-h" was entered
+    if (options.help || options.h) {
+      return;
+    }
+
+    // if "print" was NOT entered
+    if (commands.indexOf('print') === -1) {
+      return;
+    }
+
+    // if other command was combined with "print"
+    if (commands.length !== 1) {
+      return;
+    }
+
+    // Make "log" no-op to suppress warnings.
+    // But preserve "consoleLog" which "print" command use to print config.
+    this.log = function() {};
+  }
+
   displayHelp(processedInput) {
     const commands = processedInput.commands;
     const options = processedInput.options;

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -100,7 +100,7 @@ class CLI {
 
     // Make "log" no-op to suppress warnings.
     // But preserve "consoleLog" which "print" command use to print config.
-    this.log = function() {};
+    this.log = function () {};
   }
 
   displayHelp(processedInput) {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -79,7 +79,7 @@ class CLI {
     return { commands, options };
   }
 
-  suppressLog(processedInput) {
+  suppressLogIfPrintCommand(processedInput) {
     const commands = processedInput.commands;
     const options = processedInput.options;
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -72,7 +72,7 @@ describe('CLI', () => {
     });
   });
 
-  describe('#suppressLog()', () => {
+  describe('#suppressLogIfPrintCommand()', () => {
     let logStub;
     let consoleLogStub;
 
@@ -87,7 +87,7 @@ describe('CLI', () => {
       cli.consoleLog = consoleLogStub;
 
       const processedInput = cli.processInput();
-      cli.suppressLog(processedInput);
+      cli.suppressLogIfPrintCommand(processedInput);
       cli.log('logged');
       cli.consoleLog('logged');
 
@@ -101,7 +101,7 @@ describe('CLI', () => {
       cli.consoleLog = consoleLogStub;
 
       const processedInput = cli.processInput();
-      cli.suppressLog(processedInput);
+      cli.suppressLogIfPrintCommand(processedInput);
       cli.log('logged');
       cli.consoleLog('logged');
 
@@ -115,7 +115,7 @@ describe('CLI', () => {
       cli.consoleLog = consoleLogStub;
 
       const processedInput = cli.processInput();
-      cli.suppressLog(processedInput);
+      cli.suppressLogIfPrintCommand(processedInput);
       cli.log('logged');
       cli.consoleLog('logged');
 
@@ -129,7 +129,7 @@ describe('CLI', () => {
       cli.consoleLog = consoleLogStub;
 
       const processedInput = cli.processInput();
-      cli.suppressLog(processedInput);
+      cli.suppressLogIfPrintCommand(processedInput);
       cli.log('logged');
       cli.consoleLog('logged');
 
@@ -143,7 +143,7 @@ describe('CLI', () => {
       cli.consoleLog = consoleLogStub;
 
       const processedInput = cli.processInput();
-      cli.suppressLog(processedInput);
+      cli.suppressLogIfPrintCommand(processedInput);
       cli.log('NOT LOGGED');
       cli.consoleLog('logged');
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -57,6 +57,86 @@ describe('CLI', () => {
     });
   });
 
+  describe('#suppressLog()', () => {
+    let logStub;
+    let consoleLogStub;
+
+    beforeEach(() => {
+      logStub = sinon.stub();
+      consoleLogStub = sinon.stub();
+    });
+
+    it('should do nothing when no command is given', () => {
+      cli = new CLI(serverless, []);
+      cli.log = logStub;
+      cli.consoleLog = consoleLogStub;
+
+      const processedInput = cli.processInput();
+      cli.suppressLog(processedInput);
+      cli.log('logged');
+      cli.consoleLog('logged');
+
+      expect(logStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+
+    it('should do nothing when "print" is given with "-h"', () => {
+      cli = new CLI(serverless, ['print', '-h']);
+      cli.log = logStub;
+      cli.consoleLog = consoleLogStub;
+
+      const processedInput = cli.processInput();
+      cli.suppressLog(processedInput);
+      cli.log('logged');
+      cli.consoleLog('logged');
+
+      expect(logStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+
+    it('should do nothing when "print" is given with "-help"', () => {
+      cli = new CLI(serverless, ['print', '-help']);
+      cli.log = logStub;
+      cli.consoleLog = consoleLogStub;
+
+      const processedInput = cli.processInput();
+      cli.suppressLog(processedInput);
+      cli.log('logged');
+      cli.consoleLog('logged');
+
+      expect(logStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+
+    it('should do nothing when "print" is combined with other command.', () => {
+      cli = new CLI(serverless, ['other', 'print']);
+      cli.log = logStub;
+      cli.consoleLog = consoleLogStub;
+
+      const processedInput = cli.processInput();
+      cli.suppressLog(processedInput);
+      cli.log('logged');
+      cli.consoleLog('logged');
+
+      expect(logStub.calledOnce).to.equal(true);
+      expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+
+    it('should suppress log when "print" is given', () => {
+      cli = new CLI(serverless, ['print', '-myvar', '123']);
+      cli.log = logStub;
+      cli.consoleLog = consoleLogStub;
+
+      const processedInput = cli.processInput();
+      cli.suppressLog(processedInput);
+      cli.log('NOT LOGGED');
+      cli.consoleLog('logged');
+
+      expect(logStub.calledOnce).to.equal(false);
+      expect(consoleLogStub.calledOnce).to.equal(true);
+    });
+  });
+
   describe('#displayHelp()', () => {
     it('should return true when no command is given', () => {
       cli = new CLI(serverless, []);


### PR DESCRIPTION
## What did you implement:

Closes #5676

## How did you implement it:

If `print` command is used, `CLI#log` become no-op.
Therefore logs are suppressed, except printing service definition.

Though duplicate-warnings are getting removed in #5733, 
I think this change is worth to prevent similar "unexpected log while print" issues in future.


## How can we verify it:

1. `npm install -g exoego/serverless#print-no-log`
2. Prepare the below yml.
```yml
service: 
  name: myservice
provider:
  name: aws
  runtime: nodejs8.10
functions:
  function1:
    handler: lib/proxy.handler
  function2:
    handler: lib/proxy.handler
```
3. `sls print`, it should only give yml, no warnings.


## Todos:

- [x] Write tests
- [x] <del>Write documentation</del> N/A
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
