### PR TITLE
Add option to configure duplicate-handlers warnings

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -230,7 +230,9 @@ class Service {
           this.serverless.cli.log(warnMessage);
         });
     };
-    warnOnDuplicateHandlers();
+    if (_.isObject(this.serviceObject) && this.serviceObject.warnDuplicateHandlers) {
+      warnOnDuplicateHandlers();
+    }
 
     const provider = this.serverless.getProvider('aws');
     if (provider) {

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -724,10 +724,82 @@ describe('Service', () => {
       });
     });
 
-    it('should warn if multiple functions have same handler', () => {
+    it('should *NOT* warn by default even if multiple functions have same handler', () => {
       const SUtils = new Utils();
       const serverlessYml = {
         service: 'testService',
+        provider: 'testProvider',
+        functions: {
+          functionA: {
+            handler: 'foo.functionA',
+            events: [],
+          },
+          functionB: {
+            handler: 'foo.functionA',
+            events: [],
+          },
+        },
+      };
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+
+      class CustomCLI extends CLI {}
+      const consoleLogStub = sinon.stub(CustomCLI.prototype, 'log');
+      serverless.cli = new CustomCLI(serverless);
+
+      return expect(serverless.service.load()).to.eventually.be.fulfilled
+        .then(() => {
+          serverless.service.validate();
+          expect(consoleLogStub.callCount).to.equal(0);
+        });
+    });
+
+    it('should *NOT* warn if multiple functions have same handler ' +
+      'and warnDuplicateHandlers is explicitly falsy', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: {
+          name: 'testService',
+          warnDuplicateHandlers: '', // falsy
+        },
+        provider: 'testProvider',
+        functions: {
+          functionA: {
+            handler: 'foo.functionA',
+            events: [],
+          },
+          functionB: {
+            handler: 'foo.functionA',
+            events: [],
+          },
+        },
+      };
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'),
+        YAML.dump(serverlessYml));
+
+      const serverless = new Serverless({ servicePath: tmpDirPath });
+
+      class CustomCLI extends CLI {}
+      const consoleLogStub = sinon.stub(CustomCLI.prototype, 'log');
+      serverless.cli = new CustomCLI(serverless);
+
+      return expect(serverless.service.load()).to.eventually.be.fulfilled
+        .then(() => {
+          serverless.service.validate();
+          expect(consoleLogStub.callCount).to.equal(0);
+        });
+    });
+
+    it('should warn if multiple functions have same handler ' +
+       'and warnDuplicateHandlers is explicitly truthy', () => {
+      const SUtils = new Utils();
+      const serverlessYml = {
+        service: {
+          name: 'testService',
+          warnDuplicateHandlers: 'true', // truthy, so it can be passed from variable
+        },
         provider: 'testProvider',
         functions: {
           functionA: {


### PR DESCRIPTION
## What did you implement:
Closes #5689

## How did you implement it:

* Add a option `warnDuplicateHandlers` to configure duplicate-handlers warnings
* `warnDuplicateHandlers` is `false` by default, to reclaim a previous behavior before v1.36.0
   * I believe this makes it easy for users to upgrade serverless from older versions without no changes to their `serverless.yml`


## How can we verify it:

1. `sls install -g exoego/serverless#allow-duplicate-handlers`
2. Prepare the below yml.
```yml
service: 
  name myservice
  warnDuplicateHandlers: ${opt:foo, ''}
provider:
  name: aws
  runtime: nodejs8.10
functions:
  function1:
    handler: lib/proxy.handler
  function2:
    handler: lib/proxy.handler
```
3. `sls package`, then it should NOT print duplicate handlers warnings.
4. `sls package --foo=1`, the it should print warnings.


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
