### PR TITLE
Use Buffer.from() instead of new Buffer() which it's deprecated

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -35,7 +35,7 @@ class CLI {
     }
 
     const base64Encode = (valueStr) =>
-      new Buffer(valueStr).toString('base64');
+      Buffer.from(valueStr).toString('base64');
 
     const toBase64Helper = (value) => {
       const valueStr = value.toString();
@@ -57,7 +57,7 @@ class CLI {
 
     const decodedArgsHelper = (arg) => {
       if (_.isString(arg)) {
-        return new Buffer(arg, 'base64').toString();
+        return Buffer.from(arg, 'base64').toString();
       } else if (_.isArray(arg)) {
         return _.map(arg, decodedArgsHelper);
       }

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1748,7 +1748,7 @@ describe('PluginManager', () => {
         'plugins:\n  - local-plugin\n  - parent-plugin');
 
       const output = execSync(serverlessExec);
-      const stringifiedOutput = (new Buffer(output, 'base64').toString());
+      const stringifiedOutput = (Buffer.from(output, 'base64').toString());
       expect(stringifiedOutput).to.contain('SynchronousPluginMock');
       expect(stringifiedOutput).to.contain('PromisePluginMock');
     });

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -520,7 +520,7 @@ describe('AwsDeployFunction', () => {
 
     it('should log artifact size', () => {
       // awnY7Oi280gp5kTCloXzsqJCO4J766x6hATWqQsN/uM= <-- hash of the local zip file
-      readFileSyncStub.returns(new Buffer('my-service.zip content'));
+      readFileSyncStub.returns(Buffer.from('my-service.zip content'));
 
       return awsDeployFunction.deployFunction().then(() => {
         const expected = 'Uploading function: first (1 KB)...';

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -76,7 +76,7 @@ class AwsInvoke {
       FunctionName: this.options.functionObj.name,
       InvocationType: invocationType,
       LogType: this.options.log,
-      Payload: new Buffer(JSON.stringify(this.options.data || {})),
+      Payload: Buffer.from(JSON.stringify(this.options.data || {})),
     };
 
     return this.provider.request('Lambda', 'invoke', params);
@@ -94,7 +94,7 @@ class AwsInvoke {
     if (invocationReply.LogResult) {
       this.consoleLog(chalk
         .gray('--------------------------------------------------------------------'));
-      const logResult = new Buffer(invocationReply.LogResult, 'base64').toString();
+      const logResult = Buffer.from(invocationReply.LogResult, 'base64').toString();
       logResult.split('\n').forEach(line => this.consoleLog(formatLambdaLogEvent(line)));
     }
 

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -202,7 +202,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'RequestResponse',
             LogType: 'None',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
           }
         )).to.be.equal(true);
         awsInvoke.provider.request.restore();
@@ -221,7 +221,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'RequestResponse',
             LogType: 'Tail',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
           }
         )).to.be.equal(true);
         awsInvoke.provider.request.restore();
@@ -240,7 +240,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'OtherType',
             LogType: 'None',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
           }
         )).to.be.equal(true);
         awsInvoke.provider.request.restore();

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2080,7 +2080,7 @@ describe('AwsCompileFunctions', () => {
       });
 
       it('should throw for object type Buffer', () => {
-        const role = new Buffer('Foo');
+        const role = Buffer.from('Foo');
         const resource = { Properties: {} };
 
         expect(() =>

--- a/lib/plugins/aws/rollbackFunction/index.test.js
+++ b/lib/plugins/aws/rollbackFunction/index.test.js
@@ -217,7 +217,7 @@ describe('AwsRollbackFunction', () => {
 
     it('should restore the provided function', () => {
       awsRollbackFunction.options.function = 'hello';
-      const zipBuffer = new Buffer('');
+      const zipBuffer = Buffer.from('');
 
       return awsRollbackFunction.restoreFunction(zipBuffer).then(() => {
         expect(updateFunctionCodeStub.calledOnce).to.equal(true);

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -77,7 +77,7 @@ describe('zipService', () => {
     });
 
     it('should keep the file content as is', () => {
-      const buf = new Buffer([10, 20, 30, 40, 50]);
+      const buf = Buffer.from([10, 20, 30, 40, 50]);
       const filePath = path.join(servicePath, 'bin-file');
 
       fs.writeFileSync(filePath, buf);
@@ -98,7 +98,7 @@ describe('zipService', () => {
     });
 
     it('should keep the file content as is', () => {
-      const buf = new Buffer([10, 20, 30, 40, 50]);
+      const buf = Buffer.from([10, 20, 30, 40, 50]);
       const filePath = path.join(servicePath, 'bin-file');
 
       fs.writeFileSync(filePath, buf);

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/tests.js
@@ -41,7 +41,7 @@ describe('AWS - API Gateway (Integration: Lambda Proxy): API keys test', () => {
 
   beforeAll(() => {
     const info = execSync(`${Utils.serverlessExec} info`);
-    const stringifiedOutput = (new Buffer(info, 'base64').toString());
+    const stringifiedOutput = (Buffer.from(info, 'base64').toString());
     // some regex magic to extract the first API key value from the info output
     apiKey = stringifiedOutput.match(/(api keys:\n)(\s*)(.+):(\s*)(.+)/)[5];
   });

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/tests.js
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/tests.js
@@ -52,7 +52,7 @@ describe('AWS - API Gateway (Integration: Lambda): API keys test', () => {
   it('should expose the API key(s) with its values when running the info command', () => {
     const info = execSync(`${Utils.serverlessExec} info`);
 
-    const stringifiedOutput = (new Buffer(info, 'base64').toString());
+    const stringifiedOutput = (Buffer.from(info, 'base64').toString());
 
     // some regex magic to extract the first API key value from the info output
     apiKey = stringifiedOutput.match(/(api keys:\n)(\s*)(.+):(\s*)(.+)/)[5];

--- a/tests/integration/aws/general/environment-variables/tests.js
+++ b/tests/integration/aws/general/environment-variables/tests.js
@@ -15,7 +15,7 @@ describe('AWS - General: Environment variables test', () => {
   it('should expose environment variables', () => {
     const invoked = execSync(`${Utils.serverlessExec} invoke --function hello --noGreeting true`);
 
-    const result = JSON.parse(new Buffer(invoked, 'base64').toString());
+    const result = JSON.parse(Buffer.from(invoked, 'base64').toString());
 
     expect(result.environment_variables.provider_level_variable_1)
       .to.be.equal('provider_level_1');

--- a/tests/integration/aws/general/nested-handlers/tests.js
+++ b/tests/integration/aws/general/nested-handlers/tests.js
@@ -15,7 +15,7 @@ describe('AWS - General: Nested handlers test', () => {
   it('should invoke the nested handler function from AWS', () => {
     const invoked = execSync(`${Utils.serverlessExec} invoke --function hello --noGreeting true`);
 
-    const result = JSON.parse(new Buffer(invoked, 'base64').toString());
+    const result = JSON.parse(Buffer.from(invoked, 'base64').toString());
     expect(result.message).to.be.equal('Go Serverless v1.0! Your function executed successfully!');
   });
 

--- a/tests/integration/general/custom-plugins/tests.js
+++ b/tests/integration/general/custom-plugins/tests.js
@@ -24,7 +24,7 @@ describe('General: Custom plugins test', () => {
     const pluginExecution = execSync(`${Utils.serverlessExec} greet`);
 
     // note: the result will return a newline at the end
-    const result = new Buffer(pluginExecution, 'base64').toString();
+    const result = Buffer.from(pluginExecution, 'base64').toString();
 
     expect(result).to.equal('Hello from the greeter plugin!');
   });

--- a/tests/integration/general/local-plugins/tests.js
+++ b/tests/integration/general/local-plugins/tests.js
@@ -13,13 +13,13 @@ describe('General: Local plugins test', () => {
 
   it('should successfully run the one command', () => {
     const pluginExecution = execSync(`${Utils.serverlessExec} one`);
-    const result = new Buffer(pluginExecution, 'base64').toString();
+    const result = Buffer.from(pluginExecution, 'base64').toString();
     expect(/plugin one ran successfully/g.test(result)).to.equal(true);
   });
 
   it('should successfully run the two command', () => {
     const pluginExecution = execSync(`${Utils.serverlessExec} two`);
-    const result = new Buffer(pluginExecution, 'base64').toString();
+    const result = Buffer.from(pluginExecution, 'base64').toString();
     expect(/plugin two ran successfully/g.test(result)).to.equal(true);
   });
 });

--- a/tests/simple-suite/tests.js
+++ b/tests/simple-suite/tests.js
@@ -39,7 +39,7 @@ describe('Service Lifecyle Integration Test', () => {
 
   it('should invoke function from aws', () => {
     const invoked = execSync(`${serverlessExec} invoke --function hello --noGreeting true`);
-    const result = JSON.parse(new Buffer(invoked, 'base64').toString());
+    const result = JSON.parse(Buffer.from(invoked, 'base64').toString());
     // parse it once again because the body is stringified to be LAMBDA-PROXY ready
     const message = JSON.parse(result.body).message;
     expect(message).to.be.equal('Go Serverless v1.0! Your function executed successfully!');
@@ -61,7 +61,7 @@ describe('Service Lifecyle Integration Test', () => {
 
   it('should invoke updated function from aws', () => {
     const invoked = execSync(`${serverlessExec} invoke --function hello --noGreeting true`);
-    const result = JSON.parse(new Buffer(invoked, 'base64').toString());
+    const result = JSON.parse(Buffer.from(invoked, 'base64').toString());
     expect(result.message).to.be.equal('Service Update Succeeded');
   });
 
@@ -79,7 +79,7 @@ describe('Service Lifecyle Integration Test', () => {
     execSync(`${serverlessExec} rollback -t ${timestamp}`);
 
     const invoked = execSync(`${serverlessExec} invoke --function hello --noGreeting true`);
-    const result = JSON.parse(new Buffer(invoked, 'base64').toString());
+    const result = JSON.parse(Buffer.from(invoked, 'base64').toString());
     // parse it once again because the body is stringified to be LAMBDA-PROXY ready
     const message = JSON.parse(result.body).message;
     expect(message).to.be.equal('Go Serverless v1.0! Your function executed successfully!');

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -154,7 +154,7 @@ module.exports = {
 
         const params = {
           topic,
-          payload: new Buffer(message),
+          payload: Buffer.from(message),
         };
 
         return IotData.publishPromised(params);
@@ -207,7 +207,7 @@ module.exports = {
 
   getFunctionLogs(functionName) {
     const logs = execSync(`${serverlessExec} logs --function ${functionName} --noGreeting true`);
-    const logsString = new Buffer(logs, 'base64').toString();
+    const logsString = Buffer.from(logs, 'base64').toString();
     process.stdout.write(logsString);
     return logsString;
   },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes https://github.com/serverless/serverless/issues/5394

According to the Node.js official documents, `new Buffer()` is deprecated because there are security vulnerabilities in it.

`Buffer.from()` support Node.js v4.x, so I have converted `new Buffer()` to `Buffer.from()` in order to be more secure.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I searched for all invocations of Buffer constructor (which it's deprecated) in the code and changed it to the more secure call `Buffer.from()`, ensuring no breaking changes.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Search for Buffer constructor calls in all Node.js code, there aren't anymore. I have replaced all calls to `Buffer.from()`

Running tests and executing the project gave successful results. 

Verification commands: 
- `npm run test`
- `npm run test-bare`
- `npm run lint`
- `npm run simple-integration-test`
- `npm run complex-integration-test`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
