### PR TITLE
Provide multi origin cors values

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -231,6 +231,37 @@ functions:
             allowCredentials: false
 ```
 
+To allow multipe origins, you can use the following configuration and provide an array in the `origins` field rather than using `origin`:
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          path: hello
+          method: get
+          cors:
+            origins:
+              - http://example.com
+              - http://*.amazonaws.com
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+            allowCredentials: false
+```
+
+Please note that since you can't send multiple values for [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), this configuration uses a response template to check if the request origin matches one of your provided `origins` like so:
+
+```
+#set($origin = $input.params("Origin")
+#if($origin == "http://example.com" || $origin == "http://*.amazonaws.com") #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end
+```
+
 Configuring the `cors` property sets  [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers), [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods),[Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) headers in the CORS preflight response.
 
 To enable the `Access-Control-Max-Age` preflight response header, set the `maxAge` property in the `cors` object:

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -11,18 +11,26 @@ module.exports = {
       const corsMethodLogicalId = this.provider.naming
         .getMethodLogicalId(resourceName, 'options');
 
-      // TODO remove once "origins" config is deprecated
       let origin = config.origin;
-      if (config.origins && config.origins.length) {
-        origin = config.origins.join(',');
+      let origins = (config.origins && config.origins.length) ? config.origins : undefined;
+
+      if (origins && origins.length === 1) {
+        origin = origins[0];
+        origins = undefined;
       }
 
-      const preflightHeaders = {
-        'Access-Control-Allow-Origin': `'${origin}'`,
-        'Access-Control-Allow-Headers': `'${config.headers.join(',')}'`,
-        'Access-Control-Allow-Methods': `'${config.methods.join(',')}'`,
-        'Access-Control-Allow-Credentials': `'${config.allowCredentials}'`,
-      };
+      if (!origin && !origins) {
+        const errorMessage = 'must specify either origin or origins';
+        throw new this.serverless.classes.Error(errorMessage);
+      }
+
+      const preflightHeaders = _.assign(
+        origin && !origins ? { 'Access-Control-Allow-Origin': `'${origin}'` } : {}
+        , {
+          'Access-Control-Allow-Headers': `'${config.headers.join(',')}'`,
+          'Access-Control-Allow-Methods': `'${config.methods.join(',')}'`,
+          'Access-Control-Allow-Credentials': `'${config.allowCredentials}'`,
+        });
 
       // Enable CORS Max Age usage if set
       if (_.has(config, 'maxAge')) {
@@ -61,7 +69,8 @@ module.exports = {
                 'application/json': '{statusCode:200}',
               },
               ContentHandling: 'CONVERT_TO_TEXT',
-              IntegrationResponses: this.generateCorsIntegrationResponses(preflightHeaders),
+              IntegrationResponses:
+                this.generateCorsIntegrationResponses(preflightHeaders, origins),
             },
             ResourceId: resourceRef,
             RestApiId: this.provider.getApiGatewayRestApiId(),
@@ -89,7 +98,7 @@ module.exports = {
     ];
   },
 
-  generateCorsIntegrationResponses(preflightHeaders) {
+  generateCorsIntegrationResponses(preflightHeaders, origins) {
     const responseParameters = _.mapKeys(preflightHeaders,
       (value, header) => `method.response.header.${header}`);
 
@@ -98,9 +107,20 @@ module.exports = {
         StatusCode: '200',
         ResponseParameters: responseParameters,
         ResponseTemplates: {
-          'application/json': '',
+          'application/json':
+            origins && origins.length ? this.generateCorsResponseTemplate(origins) : '',
         },
       },
     ];
+  },
+
+  generateCorsResponseTemplate(origins) {
+    return (
+      '\'#set($origin = $input.params("Origin") ' +
+      `#if(${origins
+        .map((o, i, a) => `$origin == "${o}"${i < a.length - 1 ? ' || ' : ''}`)
+        .join('')}` +
+      ') #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end\''
+    );
   },
 };

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -71,7 +71,7 @@ describe('#compileCors()', () => {
         cacheControl: 'max-age=600, s-maxage=600',
       },
       'users/create': {
-        origins: ['*', 'http://example.com'],
+        origins: ['http://localhost:3000', 'http://example.com'],
         headers: ['*'],
         methods: ['OPTIONS', 'POST'],
         allowCredentials: true,
@@ -100,7 +100,14 @@ describe('#compileCors()', () => {
           .Resources.ApiGatewayMethodUsersCreateOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Origin']
-      ).to.equal('\'*,http://example.com\'');
+      ).to.equal(undefined);
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreateOptions
+          .Properties.Integration.IntegrationResponses[0]
+          .ResponseTemplates['application/json']
+      ).to.equal('\'#set($origin = $input.params("Origin") #if($origin == "http://localhost:3000" || $origin == "http://example.com") #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end\'');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Provide support for using multiple origins in cors configuration. This PR generates a response template which transforms any matched origin and sets the `Access-Control-Allow-Origin` header to that matched origin

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Created an extra function in the cors library to generate a valid response template script

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Create a new template and use the following configuration:

```yml
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: hello
          method: get
          cors:
            origins:
              - http://localhost:3000
              - http://localhost:3001
            headers:
              - Content-Type
              - X-Amz-Date
              - Authorization
              - X-Api-Key
              - X-Amz-Security-Token
              - X-Amz-User-Agent
            allowCredentials: false
```

Try accessing the requested resource from localhost:3000 and localhost:3001

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
