### PR TITLE
Resolve profile before performing aws-sdk dependent actions

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -102,6 +102,10 @@ class Variables {
       const requiredConfigs = [
         _.assign({ name: 'region' }, provider.getRegionSourceValue()),
         _.assign({ name: 'stage' }, provider.getStageSourceValue()),
+        _.assign({ name: 'profile' }, {
+          value: this.service.provider.profile,
+          path: 'serverless.service.provider.profile',
+        }),
       ];
       return this.disableDepedentServices(() => {
         const prepopulations = requiredConfigs.map(config =>

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -147,11 +147,12 @@ describe('Variables', () => {
     const prepopulatedProperties = [
       { name: 'region', getter: (provider) => provider.getRegion() },
       { name: 'stage', getter: (provider) => provider.getStage() },
+      { name: 'profile', getter: (provider) => provider.getProfile() },
     ];
     describe('basic population tests', () => {
       prepopulatedProperties.forEach((property) => {
         it(`should populate variables in ${property.name} values`, () => {
-          awsProvider.options[property.name] = '${self:foobar, "default"}';
+          awsProvider.serverless.service.provider[property.name] = '${self:foobar, "default"}';
           return serverless.variables.populateService().should.be.fulfilled
             .then(() => expect(property.getter(awsProvider)).to.be.eql('default'));
         });
@@ -167,7 +168,7 @@ describe('Variables', () => {
       prepopulatedProperties.forEach(property => {
         dependentConfigs.forEach(config => {
           it(`should reject ${config.name} variables in ${property.name} values`, () => {
-            awsProvider.options[property.name] = config.value;
+            awsProvider.serverless.service.provider[property.name] = config.value;
             return serverless.variables.populateService()
               .should.be.rejectedWith('Variable dependency failure');
           });
@@ -175,7 +176,7 @@ describe('Variables', () => {
             serverless.variables.service.custom = {
               settings: config.value,
             };
-            awsProvider.options.region = '${self:custom.settings.region}';
+            awsProvider.serverless.service.provider.region = '${self:custom.settings.region}';
             return serverless.variables.populateService()
               .should.be.rejectedWith('Variable dependency failure');
           });
@@ -196,8 +197,8 @@ describe('Variables', () => {
             { name: 'getValueFromS3', original: serverless.variables.getValueFromS3 },
             { name: 'getValueFromSsm', original: serverless.variables.getValueFromSsm },
           ];
-          awsProvider.options.region = combination.region;
-          awsProvider.options.state = combination.state;
+          awsProvider.serverless.service.provider.region = combination.region;
+          awsProvider.serverless.service.provider.state = combination.state;
           return serverless.variables.populateService().should.be.fulfilled
             .then(() => {
               dependentMethods.forEach((method) => {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -410,6 +410,7 @@ class AwsProvider {
 
   getProfileSourceValue() {
     const values = this.getValues(this, [
+      ['options', 'aws-profile'],
       ['options', 'profile'],
       ['serverless', 'config', 'profile'],
       ['serverless', 'service', 'provider', 'profile'],


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

closes #4311
closes #4725


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

* added profile to list of variables that must resolve to a constant before SSM (and cfn & s3) variables are attempted to be resolved.
* updated `AwsProvider` to check the `aws-profile` option instead of `profile` since that's what's actually implemented(afaik).
* updated `getProfileSourceValue` return value to be more like that of the `getStageSourceValue` and `getRegionSourceValue`
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
set `profile` to a variable and try to `sls print` with stable install and then again with this branch
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- n/a ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
