### PR TITLE
feat: add file option to cli

### DIFF
--- a/docs/providers/aws/examples/hello-world/csharp/README.md
+++ b/docs/providers/aws/examples/hello-world/csharp/README.md
@@ -25,6 +25,7 @@ Commands
 * Pass "--verbose" to this command to get in-depth plugin info
 * Pass "--no-color" to disable CLI colors
 * Pass "--help" after any <command> for contextual help
+* Pass "--file <file>" to specify the config that should be used
 ```
 
 ## 1. Create a service

--- a/docs/providers/aws/examples/hello-world/fsharp/README.md
+++ b/docs/providers/aws/examples/hello-world/fsharp/README.md
@@ -23,6 +23,7 @@ Commands
 * Pass "--verbose" to this command to get in-depth plugin info
 * Pass "--no-color" to disable CLI colors
 * Pass "--help" after any <command> for contextual help
+* Pass "--file <file>" to specify the config that should be used
 ```
 
 ## 1. Create a service

--- a/docs/providers/aws/examples/hello-world/go/README.md
+++ b/docs/providers/aws/examples/hello-world/go/README.md
@@ -23,6 +23,7 @@ Commands
 * Pass "--verbose" to this command to get in-depth plugin info
 * Pass "--no-color" to disable CLI colors
 * Pass "--help" after any <command> for contextual help
+* Pass "--file <file>" to specify the config that should be used
 ```
 
 You should also have [go](https://golang.org/doc/install) and [make](https://www.gnu.org/software/make/)

--- a/docs/providers/aws/examples/hello-world/node/README.md
+++ b/docs/providers/aws/examples/hello-world/node/README.md
@@ -23,6 +23,7 @@ Commands
 * Pass "--verbose" to this command to get in-depth plugin info
 * Pass "--no-color" to disable CLI colors
 * Pass "--help" after any <command> for contextual help
+* Pass "--file <file>" to specify the config that should be used
 ```
 
 ## 1. Create a service

--- a/docs/providers/aws/examples/hello-world/python/README.md
+++ b/docs/providers/aws/examples/hello-world/python/README.md
@@ -23,6 +23,7 @@ Commands
 * Pass "--verbose" to this command to get in-depth plugin info
 * Pass "--no-color" to disable CLI colors
 * Pass "--help" after any <command> for contextual help
+* Pass "--file <file>" to specify the config that should be used
 ```
 
 ## 1. Create a service

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -165,6 +165,7 @@ class CLI {
     this.consoleLog(chalk.dim('* Pass "--verbose" to this command to get in-depth plugin info'));
     this.consoleLog(chalk.dim('* Pass "--no-color" to disable CLI colors'));
     this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
+    this.consoleLog(chalk.dim('* Pass "--file <path>" to specify the config that should be used'));
 
     this.consoleLog('');
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -426,6 +426,15 @@ describe('CLI', () => {
 
       expect(inputToBeProcessed).to.deep.equal(expectedObject);
     });
+
+    it('should be able to parse --file foobars.yml', () => {
+      cli = new CLI(serverless, ['--file', 'foobars.yml']);
+      const inputToBeProcessed = cli.processInput();
+
+      const expectedObject = { commands: [], options: { file: 'foobars.yml' } };
+
+      expect(inputToBeProcessed).to.deep.equal(expectedObject);
+    });
   });
 
   describe('Integration tests', function () {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -55,6 +55,10 @@ class Service {
       'serverless.js',
     ];
 
+    if (options.file) {
+      serviceFilenames.unshift(options.file);
+    }
+
     const serviceFilePaths = _.map(serviceFilenames, filename => path.join(servicePath, filename));
     const serviceFileIndex = _.findIndex(serviceFilePaths,
       filename => this.serverless.utils.fileExistsSync(filename)
@@ -68,7 +72,7 @@ class Service {
       serviceFilenames[serviceFileIndex] :
       _.first(serviceFilenames);
 
-    if (serviceFilename === 'serverless.js') {
+    if (serviceFilename.endsWith('.js')) {
       return BbPromise.try(() => {
         // use require to load serverless.js file
         // eslint-disable-next-line global-require


### PR DESCRIPTION


## What did you implement:

Closes #4473

## How did you implement it:

Add a `--file <filepath>` option to the serverless cli

## How can we verify it:

Use the serverless CLI with the file option:

**e.g.** `sls --file=serverless-3.yml`

## Todos:

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
