### PR TITLE
Adding CLI options for overriding individual packaging

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -28,6 +28,8 @@ serverless deploy
 - `--conceal` Hides secrets from the output (e.g. API Gateway key values).
 - `--aws-s3-accelerate` Enables S3 Transfer Acceleration making uploading artifacts much faster. You can read more about it [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html). It requires additional `s3:PutAccelerateConfiguration` permissions. **Note: When using Transfer Acceleration, additional data transfer charges may apply.**
 - `--no-aws-s3-accelerate` Explicitly disables S3 Transfer Acceleration). It also requires additional `s3:PutAccelerateConfiguration` permissions.
+- `--individually` Override package configuration in `serverless.yml` and explicitly package functions individually.
+- `--no-individually` Override package configuration in `serverless.yml` and disables individual packaging.
 
 ## Artifacts
 

--- a/docs/providers/aws/cli-reference/package.md
+++ b/docs/providers/aws/cli-reference/package.md
@@ -22,6 +22,8 @@ serverless package
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--package` or `-p` path to the custom packaging directory you want.
+- `--individually` Override package configuration in `serverless.yml` and explicitly package functions individually.
+- `--no-individually` Override package configuration in `serverless.yml` and disables individual packaging.
 
 ## Examples
 

--- a/docs/providers/kubeless/cli-reference/deploy.md
+++ b/docs/providers/kubeless/cli-reference/deploy.md
@@ -27,6 +27,8 @@ This is the simplest deployment usage possible. With this command Serverless wil
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--package` or `-p` The path of a previously packaged deployment to get deployed (skips packaging step).
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.
+- `--individually` Override package configuration in `serverless.yml` and explicitly package functions individually.
+- `--no-individually` Override package configuration in `serverless.yml` and disables individual packaging.
 
 ## Artifacts
 

--- a/docs/providers/openwhisk/cli-reference/deploy.md
+++ b/docs/providers/openwhisk/cli-reference/deploy.md
@@ -22,6 +22,8 @@ serverless deploy
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.
+- `--individually` Override package configuration in `serverless.yml` and explicitly package functions individually.
+- `--no-individually` Override package configuration in `serverless.yml` and disables individual packaging.
 
 ## Artifacts
 

--- a/docs/providers/spotinst/cli-reference/deploy.md
+++ b/docs/providers/spotinst/cli-reference/deploy.md
@@ -21,3 +21,5 @@ serverless deploy -v
 ## Options
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--individually` Override package configuration in `serverless.yml` and explicitly package functions individually.
+- `--no-individually` Override package configuration in `serverless.yml` and disables individual packaging.

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -52,6 +52,12 @@ class Deploy {
           'aws-s3-accelerate': {
             usage: 'Enables S3 Transfer Acceleration making uploading artifacts much faster.',
           },
+          individually: {
+            usage: 'Enable individual packaging',
+          },
+          'no-individually': {
+            usage: 'Disable individual packaging',
+          },
         },
         commands: {
           function: {

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -42,10 +42,14 @@ module.exports = {
   packageService() {
     this.serverless.cli.log('Packaging service...');
     let shouldPackageService = false;
+    const shouldOverridePackageIndividually = !_.isUndefined(this.options.individually);
     const allFunctions = this.serverless.service.getAllFunctions();
     let packagePromises = _.map(allFunctions, functionName => {
       const functionObject = this.serverless.service.getFunction(functionName);
       functionObject.package = functionObject.package || {};
+      const shouldPackageIndividually = shouldOverridePackageIndividually
+        ? this.options.individually
+        : functionObject.package.individually || this.serverless.service.package.individually;
       if (functionObject.package.disable) {
         this.serverless.cli.log(`Packaging disabled for function: "${functionName}"`);
         return BbPromise.resolve();
@@ -53,8 +57,7 @@ module.exports = {
       if (functionObject.package.artifact) {
         return BbPromise.resolve();
       }
-      if (functionObject.package.individually || this.serverless.service
-          .package.individually) {
+      if (shouldPackageIndividually) {
         return this.packageFunction(functionName);
       }
       shouldPackageService = true;

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -159,6 +159,48 @@ describe('#packageService()', () => {
       .then(() => expect(packageFunctionStub).to.be.calledTwice);
     });
 
+    it('should package all functions if --no-individually option is specified', () => {
+      packagePlugin = new Package(serverless, { individually: false });
+      packagePlugin.serverless.cli = new serverless.classes.CLI();
+      packagePlugin.serverless.service.functions = {
+        first: {
+          handler: 'foo',
+        },
+      };
+      serverless.service.package.individually = true;
+
+      const packageAllStub = sinon
+        .stub(packagePlugin, 'packageAll').resolves();
+
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => expect(packageAllStub).to.be.calledOnce);
+    });
+
+    it('should package functions individually if --individually option is specified', () => {
+      packagePlugin = new Package(serverless, { individually: true });
+      packagePlugin.serverless.cli = new serverless.classes.CLI();
+      packagePlugin.serverless.service.functions = {
+        first: {
+          handler: 'foo',
+        },
+      };
+      serverless.service.package.individually = false;
+      serverless.service.functions = {
+        'test-one': {
+          name: 'test-one',
+        },
+        'test-two': {
+          name: 'test-two',
+        },
+      };
+
+      const packageFunctionStub = sinon
+        .stub(packagePlugin, 'packageFunction').resolves((func) => func.name);
+
+      return expect(packagePlugin.packageService()).to.be.fulfilled
+      .then(() => expect(packageFunctionStub).to.be.calledTwice);
+    });
+
     it('should package single function individually', () => {
       serverless.service.functions = {
         'test-one': {

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -47,6 +47,12 @@ class Package {
             usage: 'Output path for the package',
             shortcut: 'p',
           },
+          individually: {
+            usage: 'Enable individual packaging',
+          },
+          'no-individually': {
+            usage: 'Disable individual packaging',
+          },
         },
         commands: {
           function: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5527 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Added `--individually` and `--no-individually` CLI options for `package` plugin.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

serverless.yml
```yml
package:
  individually: true
```

cli
```bash
sls package --no-individually
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
