### PR TITLE
AWS: Add fallback support in ${cf} and ${s3}

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -451,14 +451,19 @@ class Variables {
    *  in the given variable strings string.
    */
   overwrite(variableStrings, variableMatch, propertyString) {
+    // A sentinel to rid rejected Promises, so any of resolved value can be used as fallback.
+    const FAIL_TOKEN = {};
     const variableValues = variableStrings.map(variableString =>
-      this.getValueFromSource(variableString, propertyString));
+      this.getValueFromSource(variableString, propertyString)
+        .catch(unused => FAIL_TOKEN)); // eslint-disable-line no-unused-vars
+
     const validValue = value => (
       value !== null &&
       typeof value !== 'undefined' &&
       !(typeof value === 'object' && _.isEmpty(value))
     );
     return BbPromise.all(variableValues)
+      .then(values => values.filter(v => v !== FAIL_TOKEN))
       .then(values => {
         let deepPropertyString = variableMatch;
         let deepProperties = 0;

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -124,6 +124,130 @@ describe('Variables', () => {
           });
       });
   });
+
+  describe('fallback', () => {
+    it('should fallback if ${self} syntax fail to populate but fallback is provided', () => {
+      serverless.variables.service.custom = {
+        settings: '${self:nonExistent, "fallback"}',
+      };
+      return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+        expect(result.custom).to.be.deep.eql({
+          settings: 'fallback',
+        });
+      });
+    });
+
+    it('should fallback if ${opt} syntax fail to populate but fallback is provided', () => {
+      serverless.variables.service.custom = {
+        settings: '${opt:nonExistent, "fallback"}',
+      };
+      return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+        expect(result.custom).to.be.deep.eql({
+          settings: 'fallback',
+        });
+      });
+    });
+
+    it('should fallback if ${env} syntax fail to populate but fallback is provided', () => {
+      serverless.variables.service.custom = {
+        settings: '${env:nonExistent, "fallback"}',
+      };
+      return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+        expect(result.custom).to.be.deep.eql({
+          settings: 'fallback',
+        });
+      });
+    });
+
+    describe('file syntax', () => {
+      it('should fallback if file does not exist but fallback is provided', () => {
+        serverless.variables.service.custom = {
+          settings: '${file(~/config.yml):xyz, "fallback"}',
+        };
+
+        const fileExistsStub = sinon.stub(serverless.utils, 'fileExistsSync').returns(false);
+        const realpathSync = sinon.stub(fse, 'realpathSync').returns(`${os.homedir()}/config.yml`);
+
+        return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+          expect(result.custom).to.be.deep.eql({
+            settings: 'fallback',
+          });
+        }).finally(() => {
+          fileExistsStub.restore();
+          realpathSync.restore();
+        });
+      });
+
+      it('should fallback if file exists but given key not found and fallback is provided', () => {
+        serverless.variables.service.custom = {
+          settings: '${file(~/config.yml):xyz, "fallback"}',
+        };
+
+        const fileExistsStub = sinon.stub(serverless.utils, 'fileExistsSync').returns(true);
+        const realpathSync = sinon.stub(fse, 'realpathSync').returns(`${os.homedir()}/config.yml`);
+        const readFileSyncStub = sinon.stub(serverless.utils, 'readFileSync').returns({
+          test: 1,
+          test2: 'test2',
+        });
+
+        return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+          expect(result.custom).to.be.deep.eql({
+            settings: 'fallback',
+          });
+        }).finally(() => {
+          fileExistsStub.restore();
+          realpathSync.restore();
+          readFileSyncStub.restore();
+        });
+      });
+    });
+
+    describe('aws-specific syntax', () => {
+      let awsProvider;
+      let requestStub;
+      beforeEach(() => {
+        awsProvider = new AwsProvider(serverless, {});
+        requestStub = sinon.stub(awsProvider, 'request', () =>
+          BbPromise.reject(new serverless.classes.Error('Not found.', 400)));
+      });
+      afterEach(() => {
+        requestStub.restore();
+      });
+      it('should fallback if ${s3} syntax fail to populate but fallback is provided', () => {
+        serverless.variables.service.custom = {
+          settings: '${s3:bucket/key, "fallback"}',
+        };
+        return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+          expect(result.custom).to.be.deep.eql({
+            settings: 'fallback',
+          });
+        });
+      });
+
+      it('should fallback if ${cf} syntax fail to populate but fallback is provided', () => {
+        serverless.variables.service.custom = {
+          settings: '${cf:stack.value, "fallback"}',
+        };
+        return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+          expect(result.custom).to.be.deep.eql({
+            settings: 'fallback',
+          });
+        });
+      });
+
+      it('should fallback if ${ssm} syntax fail to populate but fallback is provided', () => {
+        serverless.variables.service.custom = {
+          settings: '${ssm:/path/param, "fallback"}',
+        };
+        return serverless.variables.populateService().should.be.fulfilled.then((result) => {
+          expect(result.custom).to.be.deep.eql({
+            settings: 'fallback',
+          });
+        });
+      });
+    });
+  });
+
   describe('#prepopulateService', () => {
     // TL;DR: call populateService to test prepopulateService (note addition of 'pre')
     //

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -245,6 +245,13 @@ describe('Variables', () => {
           });
         });
       });
+
+      it('should throw an error if fallback fails too', () => {
+        serverless.variables.service.custom = {
+          settings: '${s3:bucket/key, ${ssm:/path/param}}',
+        };
+        return serverless.variables.populateService().should.be.rejected;
+      });
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Closes #4940.
Closes #5756.


## How did you implement it:

`${cf}` and `${s3}` will throw error if AWS request fails.
This behavior is supposed to be expected since it can prevent deploying broken service.
However, current implementation of fallback (`Variable#overwrite`) requires all of Promises is fulfilled.

After this PR, `#overwrite` rid rejected promises, so first fulfilled value can be fallback.   

Note: I think this change makes it easier to fix #3367, #5057, #5369 and #5757.

## How can we verify it:

1. `npm install -g exoego/serverless#default-values`
2. `sls deploy` below

```yml
service: aws-nodejs

provider:
  name: aws
  runtime: nodejs8.10

functions:
  hello:
    handler: handler.hello

custom:
  envVar: ${env:hoge, 'fallback'}
  optVar: ${opt:hoge, 'fallback'}
  selfVar: ${self:custom.xxx, 'fallback'}
  fileVar: ${file(./not-found):nooo, 'fallback'}
  cfVar: ${cf:no-such-stuck-exists.UNDEFINED_KEY, 'fallback'} 
  s3Var: ${s3:no/such/key, 'fallback'}
  ssmVar: ${ssm:/path/to/service/myParam, 'fallback'}
```

## Todos:

- [x] Write tests
- [x] <del>Write documentation</del> N/A
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
