### PR TITLE
don't check call tty on macs

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -75,7 +75,8 @@ if __name__ == '__main__':
     input = json.load(sys.stdin)
     if sys.platform != 'win32':
         try:
-            subprocess.check_call('tty', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if sys.platform != 'darwin':
+                subprocess.check_call('tty', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except (OSError, subprocess.CalledProcessError):
             pass
         else:


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

In #5354/#5355 a call to `tty` was called to ensure it was available to prevent issues in CI systems. However, when I merged it, I didn't have a mac and saw no issue with this. When I joined the team at serverless, I got a mac so I could better test the UX that our many mac users experience. I've found that this tty call doesn't work on macs, so I'm disabling this check on macOs since there shouldn't be odd environments like CI to consider on a mac;

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
skip call to `tty` when `sys.platform == 'darwin'`
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
On a mac (no changes on other OSes)
```
sls create -t aws-python3
echo -e 'def hello(event, context):\n    import pdb;pdb.set_trace()' > handler.py
sls invoke local -f hello
--Return--

> /Users/dschep/code/tmp/handler.py(2)hello()->None
-> import pdb;pdb.set_trace()
(Pdb)
```
on master it raises `bdb.BdbQuit`

## Todos:

- n/a ~~Write tests~~
- n/a ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
