### PR TITLE
Require provider.credentials vars to be resolved before s3/ssm/cf vars

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -106,6 +106,10 @@ class Variables {
           value: this.service.provider.profile,
           path: 'serverless.service.provider.profile',
         }),
+        _.assign({ name: 'credentials' }, {
+          value: this.service.provider.credentials,
+          path: 'serverless.service.provider.credentials',
+        }),
       ];
       return this.disableDepedentServices(() => {
         const prepopulations = requiredConfigs.map(config =>

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -102,14 +102,31 @@ class Variables {
       const requiredConfigs = [
         _.assign({ name: 'region' }, provider.getRegionSourceValue()),
         _.assign({ name: 'stage' }, provider.getStageSourceValue()),
-        _.assign({ name: 'profile' }, {
+        {
+          name: 'profile',
           value: this.service.provider.profile,
           path: 'serverless.service.provider.profile',
-        }),
-        _.assign({ name: 'credentials' }, {
+        },
+        {
+          name: 'credentials',
           value: this.service.provider.credentials,
           path: 'serverless.service.provider.credentials',
-        }),
+        },
+        {
+          name: 'credentials.accessKeyId',
+          value: _.get(this, 'service.provider.credentials.accessKeyId'),
+          path: 'serverless.service.provider.credentials.accessKeyId',
+        },
+        {
+          name: 'credentials.secretAccessKey',
+          value: _.get(this, 'service.provider.credentials.secretAccessKey'),
+          path: 'serverless.service.provider.credentials.secretAccessKey',
+        },
+        {
+          name: 'credentials.sessionToken',
+          value: _.get(this, 'service.provider.credentials.sessionToken'),
+          path: 'serverless.service.provider.credentials.sessionToken',
+        },
       ];
       return this.disableDepedentServices(() => {
         const prepopulations = requiredConfigs.map(config =>

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -148,6 +148,10 @@ describe('Variables', () => {
       { name: 'region', getter: (provider) => provider.getRegion() },
       { name: 'stage', getter: (provider) => provider.getStage() },
       { name: 'profile', getter: (provider) => provider.getProfile() },
+      {
+        name: 'credentials',
+        getter: (provider) => provider.serverless.service.provider.credentials,
+      },
     ];
     describe('basic population tests', () => {
       prepopulatedProperties.forEach((property) => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -10,6 +10,7 @@ const path = require('path');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const YAML = require('js-yaml');
+const _ = require('lodash');
 
 const AwsProvider = require('../plugins/aws/provider/awsProvider');
 const fse = require('../utils/fs/fse');
@@ -152,11 +153,26 @@ describe('Variables', () => {
         name: 'credentials',
         getter: (provider) => provider.serverless.service.provider.credentials,
       },
+      {
+        name: 'credentials.accessKeyId',
+        getter: (provider) => provider.serverless.service.provider.credentials.accessKeyId,
+      },
+      {
+        name: 'credentials.secretAccessKey',
+        getter: (provider) => provider.serverless.service.provider.credentials.secretAccessKey,
+      },
+      {
+        name: 'credentials.sessionToken',
+        getter: (provider) => provider.serverless.service.provider.credentials.sessionToken,
+      },
     ];
     describe('basic population tests', () => {
       prepopulatedProperties.forEach((property) => {
         it(`should populate variables in ${property.name} values`, () => {
-          awsProvider.serverless.service.provider[property.name] = '${self:foobar, "default"}';
+          _.set(
+            awsProvider.serverless.service.provider,
+            property.name,
+            '${self:foobar, "default"}');
           return serverless.variables.populateService().should.be.fulfilled
             .then(() => expect(property.getter(awsProvider)).to.be.eql('default'));
         });
@@ -172,7 +188,7 @@ describe('Variables', () => {
       prepopulatedProperties.forEach(property => {
         dependentConfigs.forEach(config => {
           it(`should reject ${config.name} variables in ${property.name} values`, () => {
-            awsProvider.serverless.service.provider[property.name] = config.value;
+            _.set(awsProvider.serverless.service.provider, property.name, config.value);
             return serverless.variables.populateService()
               .should.be.rejectedWith('Variable dependency failure');
           });


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Require provider.credentials vars to be resolved before s3/ssm/cf vars, similar to long standing region/stage and new profile preresolve.

test uses the service definition instead of `getCredentials` because
`getCredentials` is much more complex than `getStage`/`getProfile`/`getRegion`
and we only need to test that the config is updated, not all the
credential setting logic

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

added `credentials` in the prepopulate step of variable system
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Create an SSM var called `sls-5763` containing the value `sls-5763`
Create a service with the following config, replacing the key id & secret key of course:
```yaml
service: sls-5763
custom:
  creds:
    sls-5763:
      accessKeyId: YOURACCESSKEYID
      secretAccessKey: YOURSECRETACCESSKEY
provider:
  credentials: ${self:custom.creds.${ssm:sls-5763}}
  name: aws
  runtime: nodejs8.10
functions:
  hello:
    handler: handler.hello
```
then when you run `sls print` with the stable version of serverless you'll get:
```
$ sls print
 Serverless Information ----------------------------------

  ##########################################################################################
  # 2501: 2 of 3 promises have settled
  # 2501: 1 unsettled promises:
  # 2501:   ssm:sls-4638 waited on by: ${self:custom.creds.${ssm:sls-4638}} ${ssm:sls-4638}
  # This can result from latent connections but may represent a cyclic variable dependency
  ##########################################################################################


 Serverless Information ----------------------------------

  ##########################################################################################
  # 5006: 2 of 3 promises have settled
  # 5006: 1 unsettled promises:
  # 5006:   ssm:sls-4638 waited on by: ${self:custom.creds.${ssm:sls-4638}} ${ssm:sls-4638}
  # This can result from latent connections but may represent a cyclic variable dependency
  ##########################################################################################


 Serverless Information ----------------------------------

  ##########################################################################################
  # 7507: 2 of 3 promises have settled
  # 7507: 1 unsettled promises:
  # 7507:   ssm:sls-4638 waited on by: ${self:custom.creds.${ssm:sls-4638}} ${ssm:sls-4638}
  # This can result from latent connections but may represent a cyclic variable dependency
  ##########################################################################################
^C
```

then install this branch with `npm i -g serverless/serverless#credentials-preresolve` and you should get:
```
$ sls print

  Error --------------------------------------------------

  Variable dependency failure: variable 'ssm:sls-4638' references service SSM but using that service requires a concrete value to be ca
lled.

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information -----------------------------
     OS:                     darwin
     Node Version:           10.15.0
     Serverless Version:     1.36.3
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- n/a ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
