### PR TITLE
Preserve whitespaces in single-quote literal fallback

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -294,7 +294,7 @@ class Variables {
       this.variableSyntax,
       (context, contents) => contents.trim()
     );
-    if (!cleaned.match(/".*"/)) {
+    if (!cleaned.match(/".*"|'.*'/)) {
       cleaned = cleaned.replace(/\s/g, '');
     }
     return cleaned;

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -786,12 +786,22 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);
       });
-      it('should preserve whitespace in literal fallback', () => {
+      it('should preserve whitespace in double-quote literal fallback', () => {
         service.custom = {
           val0: '${self:custom.val, "rate(3 hours)"}',
         };
         const expected = {
           val0: 'rate(3 hours)',
+        };
+        return serverless.variables.populateObject(service.custom)
+          .should.become(expected);
+      });
+      it('should preserve whitespace in single-quote literal fallback', () => {
+        service.custom = {
+          val0: '${self:custom.val, \'rate(1 hour)\'}',
+        };
+        const expected = {
+          val0: 'rate(1 hour)',
         };
         return serverless.variables.populateObject(service.custom)
           .should.become(expected);


### PR DESCRIPTION
## What did you implement:

Closes #5398 

## How did you implement it:

In #5594, `cleanVariable` does not clean whitespaces if variable is double-quote string literal.

Atter this PR, it also does not clean whitespace if variable is single-quote string literal.

## How can we verify it:

1. `npm install -g exoego/serverless#single-quote-fallback`
2. `sls deploy` below and confirm it completes successfully.

```
service: aws-nodejs

provider:
  name: aws
  runtime: nodejs8.10

functions:
  hello:
    handler: handler.hello
    events:
      - schedule: ${env:SCHEDULE, 'rate(2 hours)'}
      - schedule: ${env:SCHEDULE, "rate(3 hours)"}
```

## Todos:

- [x] Write tests
- [x] <del>Write documentation<del>
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
