### PR TITLE
Added calculating ApiGatewayDeploymentLogicalId

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const crypto = require('crypto');
 
 /**
  * A centralized naming object that provides naming standards for the AWS provider plugin.  The
@@ -169,7 +170,43 @@ module.exports = {
     }
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;
   },
-  generateApiGatewayDeploymentLogicalId() {
+  hashString(resource) {
+    return crypto
+      .createHash('md5')
+      .update(resource)
+      .digest('hex');
+  },
+  getApiGatewayDeploymentLogicalId() {
+    let hashPostfix = '';
+    if (this.provider.serverless.service.provider.apiName &&
+      _.isString(this.provider.serverless.service.provider.apiName)) {
+      hashPostfix = this.hashString(this.provider.serverless.service.provider.apiName);
+    }
+    if (this.provider.serverless.service.provider.apiGateway &&
+        !_.isEmpty(this.provider.serverless.service.provider.apiGateway)) {
+      hashPostfix = this.hashString(hashPostfix +
+        JSON.stringify(this.provider.serverless.service.provider.apiGateway));
+    }
+    if (this.provider.serverless.service.functions &&
+        !_.isEmpty(this.provider.serverless.service.functions)) {
+      _.values(this.provider.serverless.service.functions).forEach((funct) => {
+        funct.events.forEach((event) => {
+          if (event.http) {
+            hashPostfix = this.hashString(hashPostfix +
+              JSON.stringify(event.http));
+          }
+        });
+      });
+    }
+    if (this.provider.serverless.service.provider.apiKeys &&
+        !_.isEmpty(this.provider.serverless.service.provider.apiKeys)) {
+      _.values(this.provider.serverless.service.provider.apiKeys).forEach((k) => {
+        hashPostfix = this.hashString(hashPostfix + k);
+      });
+    }
+    if (hashPostfix.length > 0) {
+      return `ApiGatewayDeployment${hashPostfix}`;
+    }
     return `ApiGatewayDeployment${(new Date()).getTime().toString()}`;
   },
   getRestApiLogicalId() {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -235,11 +235,84 @@ describe('#naming()', () => {
     });
   });
 
-  describe('#generateApiGatewayDeploymentLogicalId()', () => {
+  describe('#getApiGatewayDeploymentLogicalId()', () => {
     it('should return ApiGatewayDeployment with a date based suffix', () => {
-      expect(sdk.naming.generateApiGatewayDeploymentLogicalId()
+      expect(sdk.naming.getApiGatewayDeploymentLogicalId()
         .match(/ApiGatewayDeployment(.*)/).length)
         .to.be.greaterThan(1);
+    });
+    it('should return ApiGatewayDeployment with a hash suffix', () => {
+      serverless.service.provider.apiName = 'app-dev-testApi';
+      expect(sdk.naming.getApiGatewayDeploymentLogicalId()
+        .match(/ApiGatewayDeployment(.*)/).length)
+        .to.be.greaterThan(1);
+    });
+    it('should return same ApiGatewayDeployment when apiName does not change', () => {
+      serverless.service.provider.apiName = 'app-dev-testApi';
+      expect(sdk.naming.getApiGatewayDeploymentLogicalId())
+        .to.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return different ApiGatewayDeployment when apiName change', () => {
+      serverless.service.provider.apiName = 'app-dev-testApi';
+      const deploymentName = sdk.naming.getApiGatewayDeploymentLogicalId();
+      serverless.service.provider.apiName = 'app-dev-testApi1';
+      expect(deploymentName)
+        .to.not.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return same ApiGatewayDeployment when apiGateway object does not change', () => {
+      serverless.service.provider.apiGateway = { restApiId: 'app-dev-testApi' };
+      expect(sdk.naming.getApiGatewayDeploymentLogicalId())
+        .to.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return different ApiGatewayDeployment when apiGateway object change', () => {
+      serverless.service.provider.apiGateway = { restApiId: 'app-dev-testApi' };
+      const deploymentName = sdk.naming.getApiGatewayDeploymentLogicalId();
+      serverless.service.provider.apiGateway.restApiId = 'app-dev-testApi1';
+      expect(deploymentName)
+        .to.not.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return different ApiGatewayDeployment when apiKeys list change', () => {
+      serverless.service.provider.apiKeys = ['app-dev-testApi', 'app-dev-testApi1'];
+      const deploymentName = sdk.naming.getApiGatewayDeploymentLogicalId();
+      serverless.service.provider.apiKeys = ['app-dev-testApi', 'app-dev-testApi2'];
+      expect(deploymentName)
+        .to.not.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return same ApiGatewayDeployment when http event object does not change', () => {
+      serverless.service.functions =
+      {
+        httpFunction: {
+          desc: 'api access',
+          events: [{ http: { method: 'get' } }],
+        },
+      };
+      expect(sdk.naming.getApiGatewayDeploymentLogicalId())
+        .to.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return same ApiGatewayDeployment when http event object does not change', () => {
+      serverless.service.functions =
+      {
+        httpFunction: {
+          desc: 'api access',
+          events: [{ http: { method: 'get' } }],
+        },
+      };
+      const deploymentName = sdk.naming.getApiGatewayDeploymentLogicalId();
+      serverless.service.functions =
+      {
+        httpFunction: {
+          desc: 'api access',
+          events: [{ http: { method: 'post' } }],
+        },
+      };
+      expect(deploymentName)
+        .to.not.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
+    });
+    it('should return different ApiGatewayDeployment when apiKeys list does not change', () => {
+      serverless.service.provider.apiKeys = ['app-dev-testApi', 'app-dev-testApi1'];
+      const deploymentName = sdk.naming.getApiGatewayDeploymentLogicalId();
+      expect(deploymentName)
+        .to.equal(sdk.naming.getApiGatewayDeploymentLogicalId());
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
@@ -6,7 +6,7 @@ const BbPromise = require('bluebird');
 module.exports = {
   compileDeployment() {
     this.apiGatewayDeploymentLogicalId = this.provider.naming
-      .generateApiGatewayDeploymentLogicalId();
+      .getApiGatewayDeploymentLogicalId();
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.apiGatewayDeploymentLogicalId]: {


### PR DESCRIPTION
## What did you implement:

Fixes #5783

ApiGatewayDeploymentLogicalId shouldn't be regenerated when no changes to api gateway config were made

## How did you implement it:

Added calculating hash postfix for ApiGatewayDeploymentLogicalId based on API Gateway config from `serverless.yml`

## How can we verify it:

* Tests cases were added.
* Change `apiName` or `apiGateway` section or any `http` function event and see taht name was regenerated.
* Run deployment twice without any changes and see there's `Serverless: Service files not changed. Skipping deployment...` info and no deployment

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
