### PR TITLE
Fixes for AWS cors config issues

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -110,7 +110,8 @@ module.exports = {
         ResponseParameters: responseParameters,
         ResponseTemplates: {
           'application/json':
-            Array.isArray(origins) && origins.length ? this.generateCorsResponseTemplate(origins) : '',
+            Array.isArray(origins) && origins.length ?
+              this.generateCorsResponseTemplate(origins) : '',
         },
       },
     ];

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -18,11 +18,11 @@ module.exports = {
         origins = origin.split(',').map(a => a.trim());
       }
 
-      if (origins) {
+      if (origins.length) {
         origin = origins[0];
       }
 
-      if (!origin && !origins) {
+      if (!origin && !origins.length) {
         const errorMessage = 'must specify either origin or origins';
         throw new this.serverless.classes.Error(errorMessage);
       }
@@ -110,7 +110,7 @@ module.exports = {
         ResponseParameters: responseParameters,
         ResponseTemplates: {
           'application/json':
-            Array.isArray(origins) ? this.generateCorsResponseTemplate(origins) : '',
+            Array.isArray(origins) && origins.length ? this.generateCorsResponseTemplate(origins) : '',
         },
       },
     ];

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -18,11 +18,11 @@ module.exports = {
         origins = origin.split(',').map(a => a.trim());
       }
 
-      if (origins.length) {
+      if (!_.isEmpty(origins)) {
         origin = origins[0];
       }
 
-      if (!origin && !origins.length) {
+      if (!origin) {
         const errorMessage = 'must specify either origin or origins';
         throw new this.serverless.classes.Error(errorMessage);
       }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -64,6 +64,7 @@ describe('#compileCors()', () => {
     awsCompileApigEvents.validated.corsPreflight = {
       'users/update': {
         origin: 'http://example.com',
+        origins: [],
         headers: ['*'],
         methods: ['OPTIONS', 'PUT'],
         allowCredentials: false,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -67,6 +67,10 @@ module.exports = {
               cors.maxAge = http.cors.maxAge;
             }
 
+            if (_.has(http.cors, 'cacheControl')) {
+              cors.cacheControl = http.cors.cacheControl;
+            }
+
             corsPreflight[http.path] = cors;
           }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -644,6 +644,7 @@ describe('#validate()', () => {
                 origins: ['acme.com'],
                 methods: ['POST', 'OPTIONS'],
                 maxAge: 86400,
+                cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
               },
             },
           },
@@ -659,6 +660,7 @@ describe('#validate()', () => {
       origins: ['acme.com'],
       allowCredentials: false,
       maxAge: 86400,
+      cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
     });
   });
 
@@ -676,6 +678,7 @@ describe('#validate()', () => {
                 ],
                 allowCredentials: true,
                 maxAge: 10000,
+                cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
               },
             },
           }, {
@@ -723,6 +726,8 @@ describe('#validate()', () => {
       .to.deep.equal(['TestHeader2', 'TestHeader']);
     expect(validated.corsPreflight.users.maxAge)
       .to.equal(86400);
+    expect(validated.corsPreflight.users.cacheControl)
+      .to.equal('max-age=600, s-maxage=600, proxy-revalidate');
     expect(validated.corsPreflight.users.allowCredentials)
       .to.equal(true);
     expect(validated.corsPreflight['users/{id}'].allowCredentials)

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -644,7 +644,7 @@ describe('#validate()', () => {
                 origins: ['acme.com'],
                 methods: ['POST', 'OPTIONS'],
                 maxAge: 86400,
-                cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
+                cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate',
               },
             },
           },
@@ -660,7 +660,7 @@ describe('#validate()', () => {
       origins: ['acme.com'],
       allowCredentials: false,
       maxAge: 86400,
-      cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
+      cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate',
     });
   });
 
@@ -678,7 +678,7 @@ describe('#validate()', () => {
                 ],
                 allowCredentials: true,
                 maxAge: 10000,
-                cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
+                cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate',
               },
             },
           }, {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5779
Closes #5780

* Now checking if `origins` is empty to ensure `origin` is only set where appropriate.
* `validate.js` now copies `cacheControl` into `corsPreflight` so the configured value is available in `compileCors()`.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

See above.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Modified existing unit tests to cover these scenarios and tested with my own stack.  The linked issues describe how to recreate.

## Todos:

- [x] Write tests
- [x] ~~Write documentation~~ N/A - Bug fixes only.
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources (see linked issues)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?: YES
***Is it a breaking change?: NO
