### PR TITLE
Replace blocking fs.readFileSync with non blocking fs.readFile in checkForChanges.js

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -109,23 +109,24 @@ module.exports = {
       // create hashes for all the zip files
       const zipFiles = globby.sync(['**.zip'], { cwd: serverlessDirPath, dot: true, silent: true });
       const zipFilePaths = zipFiles.map((zipFile) => path.join(serverlessDirPath, zipFile));
-      const zipFileHashes = zipFilePaths.map((zipFilePath) => {
-        // TODO refactor to be async (use util function to compute checksum async)
-        const zipFile = fs.readFileSync(zipFilePath);
-        return crypto.createHash('sha256').update(zipFile).digest('base64');
+
+      const readFile = BbPromise.promisify(fs.readFile);
+      const zipFileHashesPromises = zipFilePaths.map(zipFilePath => readFile(zipFilePath)
+        .then(zipFile => crypto.createHash('sha256').update(zipFile).digest('base64')));
+
+      return BbPromise.all(zipFileHashesPromises).then(zipFileHashes => {
+        const localHashes = zipFileHashes;
+        localHashes.push(localCfHash);
+
+        if (_.isEqual(remoteHashes.sort(), localHashes.sort())) {
+          this.serverless.service.provider.shouldNotDeploy = true;
+
+          const message = [
+            'Service files not changed. Skipping deployment...',
+          ].join('');
+          this.serverless.cli.log(message);
+        }
       });
-
-      const localHashes = zipFileHashes;
-      localHashes.push(localCfHash);
-
-      if (_.isEqual(remoteHashes.sort(), localHashes.sort())) {
-        this.serverless.service.provider.shouldNotDeploy = true;
-
-        const message = [
-          'Service files not changed. Skipping deployment...',
-        ].join('');
-        this.serverless.cli.log(message);
-      }
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -278,7 +278,7 @@ describe('checkForChanges', () => {
   describe('#checkIfDeploymentIsNecessary()', () => {
     let normalizeCloudFormationTemplateStub;
     let globbySyncStub;
-    let readFileSyncStub;
+    let readFileStub;
 
     beforeEach(() => {
       normalizeCloudFormationTemplateStub = sinon
@@ -286,22 +286,22 @@ describe('checkForChanges', () => {
         .returns();
       globbySyncStub = sinon
         .stub(globby, 'sync');
-      readFileSyncStub = sinon
-        .stub(fs, 'readFileSync')
-        .returns();
+      readFileStub = sinon
+        .stub(fs, 'readFile')
+        .yields(null, undefined);
     });
 
     afterEach(() => {
       normalizeFiles.normalizeCloudFormationTemplate.restore();
       globby.sync.restore();
-      fs.readFileSync.restore();
+      fs.readFile.restore();
     });
 
     it('should resolve if no input is provided', () => expect(awsDeploy
       .checkIfDeploymentIsNecessary()).to.be.fulfilled.then(() => {
         expect(normalizeCloudFormationTemplateStub).to.not.have.been.called;
         expect(globbySyncStub).to.not.have.been.called;
-        expect(readFileSyncStub).to.not.have.been.called;
+        expect(readFileStub).to.not.have.been.called;
         expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
       })
     );
@@ -313,7 +313,7 @@ describe('checkForChanges', () => {
         .to.be.fulfilled.then(() => {
           expect(normalizeCloudFormationTemplateStub).to.not.have.been.called;
           expect(globbySyncStub).to.not.have.been.called;
-          expect(readFileSyncStub).to.not.have.been.called;
+          expect(readFileStub).to.not.have.been.called;
           expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
         });
     });
@@ -333,7 +333,7 @@ describe('checkForChanges', () => {
         .to.be.fulfilled.then(() => {
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
           expect(globbySyncStub).to.have.been.calledOnce;
-          expect(readFileSyncStub).to.have.been.calledOnce;
+          expect(readFileStub).to.have.been.calledOnce;
           expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -346,7 +346,7 @@ describe('checkForChanges', () => {
               silent: true,
             }
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/my-service.zip')
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
@@ -367,7 +367,7 @@ describe('checkForChanges', () => {
         .to.be.fulfilled.then(() => {
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
           expect(globbySyncStub).to.have.been.calledOnce;
-          expect(readFileSyncStub).to.have.been.calledOnce;
+          expect(readFileStub).to.have.been.calledOnce;
           expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -380,7 +380,7 @@ describe('checkForChanges', () => {
               silent: true,
             }
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/my-service.zip')
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
@@ -403,7 +403,7 @@ describe('checkForChanges', () => {
         .to.be.fulfilled.then(() => {
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
           expect(globbySyncStub).to.have.been.calledOnce;
-          expect(readFileSyncStub).to.have.been.calledTwice;
+          expect(readFileStub).to.have.been.calledTwice;
           expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -416,10 +416,10 @@ describe('checkForChanges', () => {
               silent: true,
             }
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/func1.zip')
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/func2.zip')
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
@@ -440,7 +440,7 @@ describe('checkForChanges', () => {
         .to.be.fulfilled.then(() => {
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
           expect(globbySyncStub).to.have.been.calledOnce;
-          expect(readFileSyncStub).to.have.been.calledOnce;
+          expect(readFileStub).to.have.been.calledOnce;
           expect(awsDeploy.serverless.cli.log).to.have.been.calledOnce;
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -453,7 +453,7 @@ describe('checkForChanges', () => {
               silent: true,
             }
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/my-service.zip')
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
@@ -477,7 +477,7 @@ describe('checkForChanges', () => {
         .to.be.fulfilled.then(() => {
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
           expect(globbySyncStub).to.have.been.calledOnce;
-          expect(readFileSyncStub).to.have.been.calledTwice;
+          expect(readFileStub).to.have.been.calledTwice;
           expect(awsDeploy.serverless.cli.log).to.have.been.calledOnce;
           expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
@@ -490,10 +490,10 @@ describe('checkForChanges', () => {
               silent: true,
             }
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/func1.zip')
           );
-          expect(readFileSyncStub).to.have.been.calledWithExactly(
+          expect(readFileStub).to.have.been.calledWith(
             path.join('my-service/.serverless/func2.zip')
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes: N/A

This PR implements a TODO that was left in `checkForChanges.js` > `checkIfDeploymentIsNecessary` which makes reading the zipFiles asynchronously, therefore should make checkForChanges run a bit faster, specially considering there is already a costly blocking operation after the read to compute the checksum per zipFile.

## How did you implement it:

Simply replaced blocking `fs.readFileSync` with non blocking `fs.readFile`. 

## How can we verify it:

N/A

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
