### PR TITLE
Fix race condition when loading config file

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -55,27 +55,26 @@ class Serverless {
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();
 
-    // make the serverless config file available to the PluginManager
-    this.pluginManager.loadConfigFile();
+    // load config file
+    return this.pluginManager.loadConfigFile().then(() => {
+      // set the options and commands which were processed by the CLI
+      this.pluginManager.setCliOptions(this.processedInput.options);
+      this.pluginManager.setCliCommands(this.processedInput.commands);
 
-    // set the options and commands which were processed by the CLI
-    this.pluginManager.setCliOptions(this.processedInput.options);
-    this.pluginManager.setCliCommands(this.processedInput.commands);
+      // Check if update is available
+      updateNotifier({ pkg }).notify();
 
-    // Check if update is available
-    updateNotifier({ pkg }).notify();
+      return this.service.load(this.processedInput.options);
+    }).then(() => {
+      // load all plugins
+      this.pluginManager.loadAllPlugins(this.service.plugins);
 
-    return this.service.load(this.processedInput.options)
-      .then(() => {
-        // load all plugins
-        this.pluginManager.loadAllPlugins(this.service.plugins);
-
-        // give the CLI the plugins and commands so that it can print out
-        // information such as options when the user enters --help
-        this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
-        this.cli.setLoadedCommands(this.pluginManager.getCommands());
-        return this.pluginManager.updateAutocompleteCacheFile();
-      });
+      // give the CLI the plugins and commands so that it can print out
+      // information such as options when the user enters --help
+      this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
+      this.cli.setLoadedCommands(this.pluginManager.getCommands());
+      return this.pluginManager.updateAutocompleteCacheFile();
+    });
   }
 
   run() {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -42,9 +42,11 @@ class PluginManager {
   }
 
   loadConfigFile() {
-    getServerlessConfigFile(this.serverless.config.servicePath).then((serverlessConfigFile) => {
-      this.serverlessConfigFile = serverlessConfigFile;
-    });
+    return getServerlessConfigFile(this.serverless.config.servicePath)
+      .then((serverlessConfigFile) => {
+        this.serverlessConfigFile = serverlessConfigFile;
+        return;
+      });
   }
 
   setCliOptions(options) {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This PR fixes a race condition issue caused by #5636, in which the loading of the config file is not awaited and as a result could sometime cause the "must be in a service directory" error even when you are running inside a service.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
