### PR TITLE
Set timout & others on context in python invoke local

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -184,12 +184,14 @@ class AwsInvokeLocal {
   invokeLocalPython(runtime, handlerPath, handlerName, event, context) {
     const input = JSON.stringify({
       event: event || {},
-      context:  Object.assign(
+      context: Object.assign(
         {
           name: this.options.functionObj.name,
           version: 'LATEST',
           logGroupName: this.provider.naming.getLogGroupName(this.options.functionObj.name),
-          timeout,
+          timeout: Number(this.options.functionObj.timeout)
+            || Number(this.serverless.service.provider.timeout)
+            || 6,
         },
         context
       ),

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -184,7 +184,15 @@ class AwsInvokeLocal {
   invokeLocalPython(runtime, handlerPath, handlerName, event, context) {
     const input = JSON.stringify({
       event: event || {},
-      context,
+      context:  Object.assign(
+        {
+          name: this.options.functionObj.name,
+          version: 'LATEST',
+          logGroupName: this.provider.naming.getLogGroupName(this.options.functionObj.name),
+          timeout,
+        },
+        context
+      ),
     });
 
     if (process.env.VIRTUAL_ENV) {


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

closes #5792
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
set the same default context as the java invoke local implementation
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

run @mnylen's example repo in #5792 
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- n/a ~~Write documentation~~
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
