### PR TITLE
Update bucket conf to default AES256 encryption.

### DIFF
--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -66,7 +66,8 @@ The Serverless Framework translates all syntax in `serverless.yml` to a single A
   ```
 
 * You can specify your own S3 bucket which should be used to store all the deployment artifacts.
-  The `deploymentBucket` config which is nested under `provider` lets you e.g. set the `name` or the `serverSideEncryption` method for this bucket
+  The `deploymentBucket` config which is nested under `provider` lets you e.g. set the `name` or the `serverSideEncryption` method for this bucket. If you don't provide your own bucket, Serverless
+  will create a bucket which uses default AES256 encryption.
 
 * You can specify your own S3 prefix which should be used to store all the deployment artifacts.
   The `deploymentPrefix` config which is nested under `provider` lets you set the prefix under which the deployment artifacts will be stored. If not specified, defaults to `serverless`.

--- a/lib/plugins/aws/package/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/package/lib/core-cloudformation-template.json
@@ -3,7 +3,21 @@
   "Description": "The AWS CloudFormation template for this Serverless application",
   "Resources": {
     "ServerlessDeploymentBucket": {
-      "Type" : "AWS::S3::Bucket"
+      "Type" : "AWS::S3::Bucket",
+      "Properties" : {
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        },
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        }
+      }
     }
   },
   "Outputs": {

--- a/lib/plugins/aws/package/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/package/lib/core-cloudformation-template.json
@@ -5,9 +5,6 @@
     "ServerlessDeploymentBucket": {
       "Type" : "AWS::S3::Bucket",
       "Properties" : {
-        "VersioningConfiguration": {
-          "Status": "Enabled"
-        },
         "BucketEncryption": {
           "ServerSideEncryptionConfiguration": [
             {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -54,29 +54,26 @@ module.exports = {
         });
     }
 
-    const mergeProperties = [];
-
     if (isS3TransferAccelerationEnabled && isS3TransferAccelerationSupported) {
       // enable acceleration via CloudFormation
-      mergeProperties.push({
-        AccelerateConfiguration: {
-          AccelerationStatus: 'Enabled',
-        },
-      });
+      Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.ServerlessDeploymentBucket.Properties, {
+          AccelerateConfiguration: {
+            AccelerationStatus: 'Enabled',
+          },
+        });
       // keep track of acceleration status via CloudFormation Output
       this.serverless.service.provider.compiledCloudFormationTemplate
         .Outputs.ServerlessDeploymentBucketAccelerated = { Value: true };
     } else if (isS3TransferAccelerationDisabled && isS3TransferAccelerationSupported) {
       // explicitly disable acceleration via CloudFormation
-      mergeProperties.push({
-        AccelerateConfiguration: {
-          AccelerationStatus: 'Suspended',
-        },
-      });
+      Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources.ServerlessDeploymentBucket.Properties, {
+          AccelerateConfiguration: {
+            AccelerationStatus: 'Suspended',
+          },
+        });
     }
-
-    Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate
-      .Resources.ServerlessDeploymentBucket.Properties, ...mergeProperties);
 
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();
 

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -15,13 +15,13 @@ module.exports = {
 
     this.serverless.service.provider
       .compiledCloudFormationTemplate = this.serverless.utils.readFileSync(
-      path.join(this.serverless.config.serverlessPath,
-        'plugins',
-        'aws',
-        'package',
-        'lib',
-        'core-cloudformation-template.json')
-    );
+        path.join(this.serverless.config.serverlessPath,
+          'plugins',
+          'aws',
+          'package',
+          'lib',
+          'core-cloudformation-template.json')
+      );
 
     const bucketName = this.serverless.service.provider.deploymentBucket;
     const isS3TransferAccelerationSupported = this.provider.isS3TransferAccelerationSupported();
@@ -54,26 +54,29 @@ module.exports = {
         });
     }
 
+    const mergeProperties = [];
+
     if (isS3TransferAccelerationEnabled && isS3TransferAccelerationSupported) {
       // enable acceleration via CloudFormation
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.ServerlessDeploymentBucket.Properties = {
-          AccelerateConfiguration: {
-            AccelerationStatus: 'Enabled',
-          },
-        };
+      mergeProperties.push({
+        AccelerateConfiguration: {
+          AccelerationStatus: 'Enabled',
+        },
+      });
       // keep track of acceleration status via CloudFormation Output
       this.serverless.service.provider.compiledCloudFormationTemplate
-      .Outputs.ServerlessDeploymentBucketAccelerated = { Value: true };
+        .Outputs.ServerlessDeploymentBucketAccelerated = { Value: true };
     } else if (isS3TransferAccelerationDisabled && isS3TransferAccelerationSupported) {
       // explicitly disable acceleration via CloudFormation
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources.ServerlessDeploymentBucket.Properties = {
-          AccelerateConfiguration: {
-            AccelerationStatus: 'Suspended',
-          },
-        };
+      mergeProperties.push({
+        AccelerateConfiguration: {
+          AccelerationStatus: 'Suspended',
+        },
+      });
     }
+
+    Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources.ServerlessDeploymentBucket.Properties, ...mergeProperties);
 
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();
 

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -109,9 +109,23 @@ describe('#generateCoreTemplate()', () => {
       expect(
         awsPlugin.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ServerlessDeploymentBucket
-        ).to.be.deep.equal({
-          Type: 'AWS::S3::Bucket',
-        });
+      ).to.be.deep.equal({
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          VersioningConfiguration: {
+            Status: 'Enabled',
+          },
+          BucketEncryption: {
+            ServerSideEncryptionConfiguration: [
+              {
+                ServerSideEncryptionByDefault: {
+                  SSEAlgorithm: 'AES256',
+                },
+              },
+            ],
+          },
+        },
+      });
     })
   );
 
@@ -156,6 +170,18 @@ describe('#generateCoreTemplate()', () => {
             AccelerateConfiguration: {
               AccelerationStatus: 'Suspended',
             },
+            VersioningConfiguration: {
+              Status: 'Enabled',
+            },
+            BucketEncryption: {
+              ServerSideEncryptionConfiguration: [
+                {
+                  ServerSideEncryptionByDefault: {
+                    SSEAlgorithm: 'AES256',
+                  },
+                },
+              ],
+            },
           },
         });
       });
@@ -172,6 +198,20 @@ describe('#generateCoreTemplate()', () => {
         const template = serverless.service.provider.coreCloudFormationTemplate;
         expect(template.Resources.ServerlessDeploymentBucket).to.be.deep.equal({
           Type: 'AWS::S3::Bucket',
+          Properties: {
+            VersioningConfiguration: {
+              Status: 'Enabled',
+            },
+            BucketEncryption: {
+              ServerSideEncryptionConfiguration: [
+                {
+                  ServerSideEncryptionByDefault: {
+                    SSEAlgorithm: 'AES256',
+                  },
+                },
+              ],
+            },
+          },
         });
       });
   });

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -112,9 +112,6 @@ describe('#generateCoreTemplate()', () => {
       ).to.be.deep.equal({
         Type: 'AWS::S3::Bucket',
         Properties: {
-          VersioningConfiguration: {
-            Status: 'Enabled',
-          },
           BucketEncryption: {
             ServerSideEncryptionConfiguration: [
               {
@@ -170,9 +167,6 @@ describe('#generateCoreTemplate()', () => {
             AccelerateConfiguration: {
               AccelerationStatus: 'Suspended',
             },
-            VersioningConfiguration: {
-              Status: 'Enabled',
-            },
             BucketEncryption: {
               ServerSideEncryptionConfiguration: [
                 {
@@ -199,9 +193,6 @@ describe('#generateCoreTemplate()', () => {
         expect(template.Resources.ServerlessDeploymentBucket).to.be.deep.equal({
           Type: 'AWS::S3::Bucket',
           Properties: {
-            VersioningConfiguration: {
-              Status: 'Enabled',
-            },
             BucketEncryption: {
               ServerSideEncryptionConfiguration: [
                 {

--- a/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
+++ b/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
@@ -73,6 +73,20 @@ describe('mergeCustomProviderResources', () => {
             FakeResource2: {
               FakePropKey: 'FakePropValue',
             },
+            Properties: {
+              VersioningConfiguration: {
+                Status: 'Enabled',
+              },
+              BucketEncryption: {
+                ServerSideEncryptionConfiguration: [
+                  {
+                    ServerSideEncryptionByDefault: {
+                      SSEAlgorithm: 'AES256',
+                    },
+                  },
+                ],
+              },
+            },
           },
         },
       };

--- a/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
+++ b/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
@@ -74,9 +74,6 @@ describe('mergeCustomProviderResources', () => {
               FakePropKey: 'FakePropValue',
             },
             Properties: {
-              VersioningConfiguration: {
-                Status: 'Enabled',
-              },
               BucketEncryption: {
                 ServerSideEncryptionConfiguration: [
                   {


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/serverless/serverless/issues/5797

## How did you implement it:

Trivial change to the default bucket policy.

## How can we verify it:

Trivial change. Creating a simple Hello World function, and checking that the deployment bucket creating has default server-side encryption and versioning enabled via the AWS console would do it.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
