### PR TITLE
Replace \ with / in paths on windows before passing to nanomatch

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -197,14 +197,17 @@ module.exports = {
       nodir: true,
     }).then(allFilePaths => {
       const filePathStates = allFilePaths.reduce((p, c) => Object.assign(p, { [c]: true }), {});
-      patterns.forEach(p => {
-        const exclude = p.startsWith('!');
-        const pattern = exclude ? p.slice(1) : p;
-        nanomatch(allFilePaths, [pattern], { dot: true })
-          .forEach(key => {
-            filePathStates[key] = !exclude;
-          });
-      });
+      patterns
+        // nanomatch only does / style path delimiters, so convert them if on windows
+        .map(p => (process.platform === 'win32' ? p.replace(/\\/g, '/') : p))
+        .forEach(p => {
+          const exclude = p.startsWith('!');
+          const pattern = exclude ? p.slice(1) : p;
+          nanomatch(allFilePaths, [pattern], { dot: true })
+            .forEach(key => {
+              filePathStates[key] = !exclude;
+            });
+        });
       const filePaths = _.toPairs(filePathStates).filter(r => r[1] === true).map(r => r[0]);
       if (filePaths.length !== 0) return filePaths;
       throw new this.serverless.classes.Error('No file matches include / exclude patterns');


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

fixes #5745 because nanomatch only supports / as a path separator

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
replace `\` with `/` on windows before passing patterns into nanomatch
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
on windows:
```
npm i -g serverless/serverless#sls-5745
sls create -t aws-nodejs
sls plugin install -n serverless-offline
sls package
```
then if you check `.serverless/aws-nodejs.zip`, it should not contain the dev dependencies
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- n/a ~~Write documentation~~
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
