### PR TITLE
fix makeDeepVariable replacement

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -785,7 +785,7 @@ class Variables {
       index = this.deep.push(variable) - 1;
     }
     const variableContainer = variable.match(this.variableSyntax)[0];
-    const variableString = this.cleanVariable(variableContainer);
+    const variableString = this.cleanVariable(variableContainer).replace(/\s/g, '');
     return variableContainer
       .replace(/\s/g, '')
       .replace(variableString, `deep:${index}`);

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -945,6 +945,23 @@ module.exports = {
           return serverless.variables.populateObject(service.custom)
             .should.become(expected);
         });
+        it('should still work with a default file name in double or single quotes', () => {
+          makeTempFile(asyncFileName, asyncContent);
+          service.custom = {
+            val1: '${self:custom.val0}', // eslint-disable-line no-template-curly-in-string
+            val2: '${self:custom.val1}', // eslint-disable-line no-template-curly-in-string
+            val3: `\${file(\${self:custom.nonexistent, "${asyncFileName}"}):str}`,
+            val0: `\${file(\${self:custom.nonexistent, '${asyncFileName}'}):str}`,
+          };
+          const expected = {
+            val1: 'my-async-value-1',
+            val2: 'my-async-value-1',
+            val3: 'my-async-value-1',
+            val0: 'my-async-value-1',
+          };
+          return serverless.variables.populateObject(service.custom)
+            .should.become(expected);
+        });
         it('should populate any given variable only once regardless of ordering or reference count',
           () => {
             makeTempFile(asyncFileName, asyncContent);
@@ -997,8 +1014,8 @@ module.exports = {
           () => {
             const fileName = `./node_modules/@scoped-org/${asyncFileName}`;
             makeTempFile(
-                fileName,
-                asyncContent
+              fileName,
+              asyncContent
             );
             service.custom = {
               val0: `\${file(${fileName}):str}`,
@@ -1007,8 +1024,8 @@ module.exports = {
               val0: 'my-async-value-1',
             };
             return serverless.variables
-                .populateObject(service.custom)
-                .should.become(expected);
+              .populateObject(service.custom)
+              .should.become(expected);
           });
         const selfFileName = 'self.yml';
         const selfContent = `foo: baz


### PR DESCRIPTION
## What did you implement:

Closes #5807 

## How did you implement it:

https://github.com/serverless/serverless/commit/5ed78b8024eead58452012b9e74f0dfdc20ec3a7 added preservation of white space in a single-quote literal. This caused `makeDeepVariable` to not replace the `variableString` properly with the `deep:0` syntax because white space was only being removed from the variableContainer. 

To fix I just added the removal of white space from `variableString` as well. 

## How can we verify it:

I added a new test for the case for it. The sample in #5807 works as well now. 

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
