### PR TITLE
add support for command type='container'

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -137,7 +137,7 @@ class CLI {
   displayCommandUsage(commandObject, command, indents) {
     const dotsLength = 30;
 
-    // check if command has lifecycleEvents (can be executed)
+    // check if command has lifecycleEvents (can be executed) and it's not a container command
     if (commandObject.lifecycleEvents && commandObject.type !== 'container') {
       const usage = commandObject.usage;
       const dots = _.repeat('.', dotsLength - command.length);

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -138,7 +138,7 @@ class CLI {
     const dotsLength = 30;
 
     // check if command has lifecycleEvents (can be executed)
-    if (commandObject.lifecycleEvents) {
+    if (commandObject.lifecycleEvents && commandObject.type !== 'container') {
       const usage = commandObject.usage;
       const dots = _.repeat('.', dotsLength - command.length);
       const indent = _.repeat('  ', indents || 0);

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -514,6 +514,7 @@ describe('CLI', () => {
   });
 
   describe('#displayCommandUsage', () => {
+    let consoleLogStub;
     const mycommand = {
       type: 'container',
       commands: {
@@ -524,14 +525,25 @@ describe('CLI', () => {
       },
     };
 
-    it('should not display container command', () => {
+    beforeEach(() => {
       cli = new CLI(serverless);
-      cli.consoleLog = sinon.stub();
+      consoleLogStub = sinon.stub(cli, 'consoleLog').returns();
+    });
 
+    afterEach(() => {
+      cli.consoleLog.restore();
+    });
+
+    it('should not display container command', () => {
       cli.displayCommandUsage(mycommand, 'mycommand');
 
-      expect(cli.consoleLog.calledOnce).to.equal(true);
-      expect(cli.consoleLog.calledWith(sinon.match('mycommand subcmd'))).to.equal(true);
+      expect(consoleLogStub.calledWith(sinon.match('mycommand .'))).to.equal(false);
+    });
+
+    it('should display container subcommand', () => {
+      cli.displayCommandUsage(mycommand, 'mycommand');
+
+      expect(consoleLogStub.calledWith(sinon.match('mycommand subcmd .'))).to.equal(true);
     });
   });
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -513,6 +513,28 @@ describe('CLI', () => {
     });
   });
 
+  describe('#displayCommandUsage', () => {
+    const mycommand = {
+      type: 'container',
+      commands: {
+        subcmd: {
+          usage: 'Subcmd usage',
+          lifecycleEvents: ['event1', 'event2'],
+        },
+      },
+    };
+
+    it('should not display container command', () => {
+      cli = new CLI(serverless);
+      cli.consoleLog = sinon.stub();
+
+      cli.displayCommandUsage(mycommand, 'mycommand');
+
+      expect(cli.consoleLog.calledOnce).to.equal(true);
+      expect(cli.consoleLog.calledWith(sinon.match('mycommand subcmd'))).to.equal(true);
+    });
+  });
+
   describe('Integration tests', function () {
     this.timeout(0);
     const that = this;

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -346,9 +346,16 @@ class PluginManager {
     // Check if the command references an alias
     const aliasCommandTarget = this.getAliasCommandTarget(commandsArray);
     const commandOrAlias = aliasCommandTarget ? _.split(aliasCommandTarget, ':') : commandsArray;
+
     return _.reduce(commandOrAlias, (current, name, index) => {
-      if (name in current.commands &&
-         (allowEntryPoints || current.commands[name].type !== 'entrypoint')) {
+      const commandExists = name in current.commands;
+      const isNotContainer = commandExists && current.commands[name].type !== 'container';
+      const isNotEntrypoint = commandExists && current.commands[name].type !== 'entrypoint';
+      const remainingIterationsLeft = index < commandOrAlias.length - 1;
+
+      if (commandExists
+        && (isNotContainer || remainingIterationsLeft)
+        && (isNotEntrypoint || allowEntryPoints)) {
         return current.commands[name];
       }
       const commandName = commandOrAlias.slice(0, index + 1).join(' ');

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -377,6 +377,41 @@ describe('PluginManager', () => {
     }
   }
 
+  class ContainerPluginMock {
+    constructor() {
+      this.commands = {
+        // not a public command because its declared as a Container
+        mycontainer: {
+          type: 'container',
+          commands: {
+            // public command because its children of a container
+            mysubcmd: {
+              lifecycleEvents: [
+                'event1',
+                'event2',
+              ],
+            },
+          },
+        },
+      };
+
+      this.hooks = {
+        'mycontainer:mysubcmd:event1': this.eventOne.bind(this),
+        'mycontainer:mysubcmd:event2': this.eventTwo.bind(this),
+      };
+
+      this.callResult = '';
+    }
+
+    eventOne() {
+      this.callResult += '>mysubcmdEvent1';
+    }
+
+    eventTwo() {
+      this.callResult += '>mysubcmdEvent2';
+    }
+  }
+
   class DeprecatedLifecycleEventsPluginMock {
     constructor() {
       this.hooks = {
@@ -1121,10 +1156,24 @@ describe('PluginManager', () => {
         .to.not.throw(serverless.classes.Error);
     });
 
+    it('should find container children commands', () => {
+      pluginManager.addPlugin(ContainerPluginMock);
+
+      expect(() => pluginManager.validateCommand(['mycontainer', 'mysubcmd']))
+        .to.not.throw(serverless.classes.Error);
+    });
+
     it('should throw on entrypoints', () => {
       pluginManager.addPlugin(EntrypointPluginMock);
 
       expect(() => pluginManager.validateCommand(['myep', 'mysubep']))
+        .to.throw(/command ".*" not found/);
+    });
+
+    it('should throw on container', () => {
+      pluginManager.addPlugin(ContainerPluginMock);
+
+      expect(() => pluginManager.validateCommand(['mycontainer']))
         .to.throw(/command ".*" not found/);
     });
   });
@@ -1332,6 +1381,22 @@ describe('PluginManager', () => {
       const commandsArray = ['myep'];
 
       expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
+    });
+
+    it('should throw an error when the given command is a container', () => {
+      pluginManager.addPlugin(ContainerPluginMock);
+
+      const commandsArray = ['mycontainer'];
+
+      expect(() => { pluginManager.run(commandsArray); }).to.throw(Error);
+    });
+
+    it('should NOT throw an error when the given command is a child of a container', () => {
+      pluginManager.addPlugin(ContainerPluginMock);
+
+      const commandsArray = ['mycontainer', 'mysubcmd'];
+
+      expect(() => { pluginManager.run(commandsArray); }).to.not.throw(Error);
     });
 
     it('should throw an error when the given command is a child of an entrypoint', () => {
@@ -1586,6 +1651,29 @@ describe('PluginManager', () => {
           .to.be.rejectedWith('Terminating mycmd:mysubcmd')
           .then(() => {
             expect(pluginManager.plugins[0].callResult).to.equal('>subInitialize>subFinalize');
+          });
+      });
+    });
+
+    describe('when invoking a container', () => {
+      it('should fail', () => {
+        pluginManager.addPlugin(ContainerPluginMock);
+
+        const commandsArray = ['mycontainer'];
+
+        return expect(
+          () => pluginManager.spawn(commandsArray)
+        ).to.throw(/command ".*" not found/);
+      });
+
+      it('should spawn nested commands', () => {
+        pluginManager.addPlugin(ContainerPluginMock);
+
+        const commandsArray = ['mycontainer', 'mysubcmd'];
+
+        return pluginManager.spawn(commandsArray)
+          .then(() => {
+            expect(pluginManager.plugins[0].callResult).to.equal('>mysubcmdEvent1>mysubcmdEvent2');
           });
       });
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes: #5806

## How did you implement it:

- Added a new command type "container", which can be used when you want nested commands but the top level command on its own doesn't do anything. 
- Note this is different from the `entrypoint` command type which hides its children commands.
- "container" commands cannot be invoked, only its children. 
- "container" commands will not be displayed on the CLI, only its children. 

## How can we verify it:

**ServerlessCustomPlugin.js**
```
class ServerlessCustomPlugin {
  constructor(serverless, options) {
    this.serverless = serverless;
    this.options = options;

    this.commands = {
      mycommand: {
        type: 'container',
        commands: {
          foo: {
            usage: 'Child foo command',
            lifecycleEvents: ['foo1']
          },

          bar: {
            usage: 'Child bar command',
            lifecycleEvents: ['bar1']
          }
        }
      }
    };

    this.hooks = {
      'mycommand:foo:foo1': this.fooOne.bind(this),
      'mycommand:bar:bar1': this.barOne.bind(this)
    };
  }

  fooOne() {
    console.log('Hello foo1');
  }

  barOne() {
    console.log('Hello bar1');
  }
}

module.exports = ServerlessCustomPlugin;
```

As seen below, `mycommand` is not displayed on the CLI, only its children: 

![image](https://user-images.githubusercontent.com/1122442/52522454-942caa00-2c7d-11e9-977e-f23273b681ef.png)

Also, when trying to invoke it directly fails:

![image](https://user-images.githubusercontent.com/1122442/52522500-0ef5c500-2c7e-11e9-89cc-a1016ae0a81b.png)

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
