### PR TITLE
Fix: override wildcard glob pattern (**) in resolveFilePathsFromPatterns

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -207,6 +207,9 @@ module.exports = {
     params.include.forEach((pattern) => {
       patterns.push(pattern);
     });
+    // NOTE: please keep this order of concatenating the include params
+    // rather than doing it the other way round!
+    // see https://github.com/serverless/serverless/pull/5825 for more information
     return globby(['**'].concat(params.include), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -207,7 +207,7 @@ module.exports = {
     params.include.forEach((pattern) => {
       patterns.push(pattern);
     });
-    return globby(params.include.concat(['**']), {
+    return globby(['**'].concat(params.include), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,
       silent: true,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Ability to override [wildcard glob pattern](https://github.com/serverless/serverless/blob/master/lib/plugins/package/lib/packageService.js#L210)  by a negative `params.include` to avoid unnecessary traversal and get much faster glob matching during packaging in some cases.

When `globby` is provided with an array of patterns, it adds all _subsequent_ negative patterns as `ignore` option of a particular task ([source code here](https://github.com/sindresorhus/globby/blob/master/index.js#L34-L41)). However, that is not useful when the wildcard comes the last (as it is now) - `ignore` for the relevant matching task is always empty.

Putting the least specific pattern first makes it possible to override it with a subsequent negative one and avoid unnecessary traversal in e.g. `node_modules`, `.git`, etc.

Related to #4263, #5574.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Put wildcard pattern `**` first in `resolveFilePathsFromPatterns`.

## How can we verify it:

[Minimal example](https://github.com/svlapin/serverless-package-example)

Without this PR:
```bash
svl@sergeys-laptop:~/dev/serverless-package-example$ time ./node_modules/.bin/serverless package 
Serverless: Packaging service...

real	1m28,677s
user	1m32,756s
sys	0m1,412s
```

With this PR:
```bash
svl@sergeys-laptop:~/dev/serverless-package-example$ time ./node_modules/.bin/serverless package 
Serverless: Packaging service...

real	0m0,898s
user	0m1,017s
sys	0m0,090s
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
