### PR TITLE
Make use of join operator first argument in sns docs

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -69,12 +69,11 @@ functions:
       - sns:
           arn:
             Fn::Join:
-              - ""
-              - - "arn:aws:sns:"
+              - ":"
+              - - "arn:aws:sns"
                 - Ref: "AWS::Region"
-                - ":"
                 - Ref: "AWS::AccountId"
-                - ":MyCustomTopic"
+                - "MyCustomTopic"
           topicName: MyCustomTopic
 ```
 


### PR DESCRIPTION
Uses join operator first argument so lines containing only ":" can be removed.

I've tested it on a real sls file and it works.