### PR TITLE
Add stack trace to aws/invokeLocal errors

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -329,6 +329,7 @@ class AwsInvokeLocal {
         errorResult = {
           errorMessage: err.message,
           errorType: err.constructor.name,
+          stackTrace: err.stack.split('\n'),
         };
       } else {
         errorResult = {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -584,6 +584,7 @@ describe('AwsInvokeLocal', () => {
 
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorType": "Error"');
+      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"stackTrace": [');
     });
 
     it('should log Error object if handler crashes at initialization', () => {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -582,9 +582,11 @@ describe('AwsInvokeLocal', () => {
 
       awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
 
-      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
-      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorType": "Error"');
-      expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"stackTrace": [');
+      const logMessageContent = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
+
+      expect(logMessageContent.errorMessage).to.equal('failed');
+      expect(logMessageContent.errorType).to.equal('Error');
+      expect(logMessageContent.stackTrace[0]).to.equal('Error: failed');
     });
 
     it('should log Error object if handler crashes at initialization', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5834.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
I added `err.stack` to the error result that `aws/invokeLocal/index.js#handleError` returns to include a stack trace in the error message. 

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. `serverless create --template aws-nodejs`
2. Add the following handler:
```js
module.exports.testError = async function(data, context) {
    throw new Error('testError');
    return 'unreachable';
};
```
3. `serverless invoke local -s aws-nodejs -l --function testError` should error with a stack trace:
```json
{
    "errorMessage": "testError",
    "errorType": "Error",
    "stackTrace": [
        "Error: testError",
        "    at module.exports.testError (C:\\Users\\user\\Desktop\\test_serverless\\handler.js:17:11)",
        "    at Promise (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\lib\\plugins\\aws\\invokeLocal\\index.js:409:30)",
        "    at new Promise (<anonymous>)",
        "    at AwsInvokeLocal.invokeLocalNodeJs (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\lib\\plugins\\aws\\invokeLocal\\index.js:363:12)",
        "    at AwsInvokeLocal.invokeLocal (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\lib\\plugins\\aws\\invokeLocal\\index.js:137:19)",
        "    at AwsInvokeLocal.tryCatcher (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\util.js:16:23)",
        "    at Promise._settlePromiseFromHandler (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\promise.js:512:31)",
        "    at Promise._settlePromise (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\promise.js:569:18)",
        "    at Promise._settlePromiseCtx (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\promise.js:606:10)",
        "    at _drainQueueStep (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\async.js:142:12)",
        "    at _drainQueue (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\async.js:131:9)",
        "    at Async._drainQueues (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\async.js:147:5)",
        "    at Immediate.Async.drainQueues [as _onImmediate] (C:\\Users\\user\\Documents\\GitHub\\externalProjects\\serverless\\node_modules\\bluebird\\js\\release\\async.js:17:14)",
        "    at runCallback (timers.js:810:20)",
        "    at tryOnImmediate (timers.js:768:5)",
        "    at processImmediate [as _immediateCallback] (timers.js:745:5)"
    ]
}
```

## Todos:

- [X] Write tests
- [ ] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
