### PR TITLE
Missing underscore

### DIFF
--- a/docs/providers/openwhisk/events/messagehub.md
+++ b/docs/providers/openwhisk/events/messagehub.md
@@ -40,7 +40,7 @@ functions:
     index:
         handler: users.main
         events:
-            - messagehub: 
+            - message_hub: 
                 package: /${BLUEMIX_ORG}_${BLUEMIX_SPACE}/Bluemix_${SERVICE_NAME}_Credentials-1
                 topic: my_kafka_topic
  


### PR DESCRIPTION
Looking at the remainder of the documentation it seems that the Message Hub event key should be `message_hub` and not `messagehub`.
