### PR TITLE
Fix service name in template install message

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -119,10 +119,11 @@ class Create {
         this.options.name,
         this.options.path
       )
-        .then(dirName => {
+        .then(serviceName => {
           const message = [
-            `Successfully installed "${dirName}" `,
-            `${this.options.name && this.options.name !== dirName ? `as "${dirName}"` : ''}`,
+            `Successfully installed "${serviceName}" `,
+            `${this.options.name &&
+              this.options.name !== serviceName ? `as "${this.options.name}"` : ''}`,
           ].join('');
 
           this.serverless.cli.log(message);

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -9,16 +9,18 @@ const Serverless = require('../../Serverless');
 const sinon = require('sinon');
 const testUtils = require('../../../tests/utils');
 const walkDirSync = require('../../utils/fs/walkDirSync');
-const download = require('./../../utils/downloadTemplateFromRepo');
+const download = require('../../utils/downloadTemplateFromRepo');
 
 describe('Create', () => {
   let create;
+  let logSpy;
 
   before(() => {
     const serverless = new Serverless();
     const options = {};
     create = new Create(serverless, options);
     create.serverless.cli = new serverless.classes.CLI();
+    logSpy = sinon.spy(create.serverless.cli, 'log');
   });
 
   describe('#constructor()', () => {
@@ -50,6 +52,56 @@ describe('Create', () => {
 
     afterEach(() => {
       process.chdir(cwd);
+    });
+
+    describe('downloading templates', () => {
+      let downloadStub;
+
+      beforeEach(() => {
+        create.options = {};
+        downloadStub = sinon.stub(download, 'downloadTemplateFromRepo');
+      });
+
+      afterEach(() => {
+        download.downloadTemplateFromRepo.restore();
+      });
+
+      it('should reject if download fails', () => {
+        downloadStub.rejects(new Error('Wrong'));
+        create.options['template-url'] = 'https://github.com/serverless/serverless';
+
+        return create.create().catch((error) => {
+          expect(error).to.match(/Wrong/);
+          expect(downloadStub).to.have.been.calledOnce; // eslint-disable-line
+        });
+      });
+
+      it('should resolve if download succeeds', () => {
+        downloadStub.resolves('serverless');
+        create.options['template-url'] = 'https://github.com/serverless/serverless';
+
+        return create.create().then(() => {
+          const installationMessage =
+            logSpy.args.filter(arg => arg[0].includes('installed "serverless"'));
+
+          expect(downloadStub).to.have.been.calledOnce; // eslint-disable-line
+          expect(installationMessage[0]).to.have.lengthOf(1);
+        });
+      });
+
+      it('should resolve if download succeeds and display the desired service name', () => {
+        downloadStub.resolves('serverless');
+        create.options['template-url'] = 'https://github.com/serverless/serverless';
+        create.options.name = 'sls';
+
+        return create.create().then(() => {
+          const installationMessage =
+            logSpy.args.filter(arg => arg[0].includes('installed "serverless" as "sls"'));
+
+          expect(downloadStub).to.have.been.calledOnce; // eslint-disable-line
+          expect(installationMessage[0]).to.have.lengthOf(1);
+        });
+      });
     });
 
     it('should throw error if user passed unsupported template', () => {
@@ -838,31 +890,6 @@ describe('Create', () => {
       process.chdir(tmpDir);
 
       expect(() => create.create()).to.throw(Error);
-    });
-
-    it('should reject if download fails', (done) => {
-      sinon.stub(download, 'downloadTemplateFromRepo');
-
-      create.options = {};
-      create.options['template-url'] = 'https://github.com/serverless/serverless';
-
-      download.downloadTemplateFromRepo.rejects(new Error('Wrong'));
-
-      create
-        .create()
-        .catch(() => download.downloadTemplateFromRepo.restore())
-        .then(() => done());
-    });
-
-    it('should resolve if download succeeds', () => {
-      sinon.stub(download, 'downloadTemplateFromRepo');
-
-      create.options = {};
-      create.options['template-url'] = 'https://github.com/serverless/serverless';
-
-      download.downloadTemplateFromRepo.resolves();
-
-      return create.create().catch(() => download.downloadTemplateFromRepo.restore());
     });
 
     it('should copy "aws-nodejs" template from local path', () => {

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -3,8 +3,7 @@
 const BbPromise = require('bluebird');
 
 const userStats = require('../../utils/userStats');
-const downloadTemplateFromRepo = require('../../utils/downloadTemplateFromRepo')
-  .downloadTemplateFromRepo;
+const download = require('../../utils/downloadTemplateFromRepo');
 
 class Install {
   constructor(serverless, options) {
@@ -38,7 +37,7 @@ class Install {
   }
 
   install() {
-    return downloadTemplateFromRepo(this.options.url, this.options.name)
+    return download.downloadTemplateFromRepo(this.options.url, this.options.name)
       .then(serviceName => {
         const message = [
           `Successfully installed "${serviceName}" `,

--- a/lib/plugins/install/install.js
+++ b/lib/plugins/install/install.js
@@ -39,10 +39,11 @@ class Install {
 
   install() {
     return downloadTemplateFromRepo(this.options.url, this.options.name)
-      .then(dirName => {
+      .then(serviceName => {
         const message = [
-          `Successfully installed "${dirName}" `,
-          `${this.options.name && this.options.name !== dirName ? `as "${dirName}"` : ''}`,
+          `Successfully installed "${serviceName}" `,
+          `${this.options.name &&
+            this.options.name !== serviceName ? `as "${this.options.name}"` : ''}`,
         ].join('');
         userStats.track('service_installed', {
           data: { // will be updated with core analtyics lib

--- a/lib/plugins/install/install.test.js
+++ b/lib/plugins/install/install.test.js
@@ -5,6 +5,7 @@ const Serverless = require('../../Serverless');
 const Install = require('./install.js');
 const sinon = require('sinon');
 const testUtils = require('../../../tests/utils');
+const download = require('../../utils/downloadTemplateFromRepo');
 const fse = require('fs-extra');
 const path = require('path');
 
@@ -12,6 +13,7 @@ describe('Install', () => {
   let install;
   let serverless;
   let cwd;
+  let logSpy;
 
   let servicePath;
 
@@ -27,6 +29,8 @@ describe('Install', () => {
     serverless = new Serverless();
     install = new Install(serverless);
     serverless.init();
+    install.serverless.cli = new serverless.classes.CLI();
+    logSpy = sinon.spy(install.serverless.cli, 'log');
   });
 
   afterEach(() => {
@@ -35,23 +39,38 @@ describe('Install', () => {
   });
 
   describe('#constructor()', () => {
+    let installStub;
+
+    beforeEach(() => {
+      installStub = sinon
+        .stub(install, 'install').resolves();
+    });
+
+    afterEach(() => {
+      install.install.restore();
+    });
+
     it('should have commands', () => expect(install.commands).to.be.not.empty);
 
     it('should have hooks', () => expect(install.hooks).to.be.not.empty);
 
-    it('should run promise chain in order for "install:install" hook', () => {
-      const installStub = sinon
-        .stub(install, 'install').resolves();
-
-      return install.hooks['install:install']().then(() => {
+    it('should run promise chain in order for "install:install" hook', () => install
+      .hooks['install:install']().then(() => {
         expect(installStub.calledOnce).to.be.equal(true);
-
-        install.install.restore();
-      });
-    });
+      }));
   });
 
   describe('#install()', () => {
+    let downloadStub;
+
+    beforeEach(() => {
+      downloadStub = sinon.stub(download, 'downloadTemplateFromRepo');
+    });
+
+    afterEach(() => {
+      download.downloadTemplateFromRepo.restore();
+    });
+
     it('should throw an error if the passed URL option is not a valid URL', () => {
       install.options = { url: 'invalidUrl' };
 
@@ -71,6 +90,33 @@ describe('Install', () => {
       fse.mkdirsSync(serviceDirName);
 
       expect(() => install.install()).to.throw(Error);
+    });
+
+    it('should succeed if template can be downloaded and installed', () => {
+      install.options = { url: 'https://github.com/johndoe/remote-service' };
+      downloadStub.resolves('remote-service');
+
+      return install.install().then(() => {
+        const installationMessage =
+          logSpy.args.filter(arg => arg[0].includes('installed "remote-service"'));
+
+        expect(downloadStub).to.have.been.calledOnce; // eslint-disable-line
+        expect(installationMessage[0]).to.have.lengthOf(1);
+      });
+    });
+
+    it('should succeed and print out the desired service name', () => {
+      install.options = { url: 'https://github.com/johndoe/remote-service' };
+      install.options.name = 'remote';
+      downloadStub.resolves('remote-service');
+
+      return install.install().then(() => {
+        const installationMessage =
+          logSpy.args.filter(arg => arg[0].includes('installed "remote-service" as "remote"'));
+
+        expect(downloadStub).to.have.been.calledOnce; // eslint-disable-line
+        expect(installationMessage[0]).to.have.lengthOf(1);
+      });
     });
   });
 });

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -217,9 +217,9 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
       fse.removeSync(downloadServicePath);
     }
   }).then(() => {
-    if (!renamed) return BbPromise.resolve();
+    if (renamed) renameService(dirName, servicePath);
 
-    return renameService(dirName, servicePath);
+    return BbPromise.resolve(serviceName);
   });
 }
 

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -92,12 +92,13 @@ describe('downloadTemplateFromRepo', () => {
             writeFileSync(slsYml, 'service: service-name');
           }));
 
-      return downloadTemplateFromRepo(url, name).then(() => {
+      return downloadTemplateFromRepo(url, name).then((serviceName) => {
         expect(downloadStub.calledOnce).to.equal(true);
         expect(downloadStub.args[0][1]).to.contain(name);
         expect(downloadStub.args[0][0]).to.equal(`${url}/archive/master.zip`);
         const yml = readFileSync(path.join(newServicePath, 'serverless.yml'));
         expect(yml.service).to.equal(name);
+        expect(serviceName).to.equal('service-to-be-downloaded');
       });
     });
 
@@ -116,10 +117,11 @@ describe('downloadTemplateFromRepo', () => {
             writeFileSync(slsYml, 'service: service-name');
           }));
 
-      return downloadTemplateFromRepo(url, name).then(() => {
+      return downloadTemplateFromRepo(url, name).then((serviceName) => {
         expect(downloadStub.calledOnce).to.equal(true);
         const yml = readFileSync(path.join(newServicePath, 'serverless.yml'));
         expect(yml.service).to.equal(name);
+        expect(serviceName).to.equal('rest-api-with-dynamodb');
       });
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5802.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
I had `downloadTemplateFromRepo()` return the service name instead of the final directory name, so that `create.js` and `install.js` can correctly display the service name both when creating / installing a service by default and when a service name is explicitly specified.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
### With default service name
`serverless install --url https://github.com/mnylen/serverless-python-fake-context-timeout-issue` should output:
```
Serverless: Downloading and installing "serverless-python-fake-context-timeout-issue"...
Serverless: Successfully installed "serverless-python-fake-context-timeout-issue"
```
### With user-specified service name
`serverless install --url https://github.com/mnylen/serverless-python-fake-context-timeout-issue --name timeout` should output:
```
Serverless: Downloading and installing "serverless-python-fake-context-timeout-issue"...
Serverless: Successfully installed "serverless-python-fake-context-timeout-issue" as "timeout"
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
