### PR TITLE
Changing "runtimes" to "templates"

### DIFF
--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -48,7 +48,7 @@ To create a service, use the `create` command. You must also pass in a runtime (
 serverless create --template aws-nodejs --path myService
 ```
 
-Here are the available runtimes for AWS Lambda:
+Here are the available templates for AWS Lambda:
 
 * aws-clojurescript-gradle
 * aws-clojure-gradle


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The documentation page was describing that there was a list of runtimes, when in fact its a list of templates

## How did you implement it:

Changed:
Here are the available runtimes for AWS Lambda:
to
Here are the available templates for AWS Lambda:

Because these are in fact templates and not actual runtimes in AWS Lambda

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
