### PR TITLE
Removing the context parameter from aws-nodejs template

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs/handler.js
+++ b/lib/plugins/create/templates/aws-nodejs/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports.hello = async (event, context) => {
+module.exports.hello = async (event) => {
   return {
     statusCode: 200,
     body: JSON.stringify({


### PR DESCRIPTION
AWS no longer adds the 'context' parameter by default to Node 8 functions created through AWS's console. 

In order to keep **_Serverless_** consistent with AWS, I think it's worth removing the 'context' parameter from the aws-nodejs template as well. 

If this PR is accepted, I can go ahead and modify the other Node templates by removing the mentioned parameter from them.

The tests have passed so I assume nobody ever used this parameter anyways.

EDIT: The parameter is still passed to the function, it's just that most developers never use it. If one wants to use it, then the the argument should be added back manually. My point here is just to have the templates create the same code that AWS's console would.

Thanks!