### PR TITLE
Websockets: Support more route characters

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -181,7 +181,12 @@ module.exports = {
   },
 
   getNormalizedWebsocketsRouteKey(route) {
-    return route.replace('$', 'S');
+    return route
+      .replace('$', 'S') // dollar sign
+      .replace('/', 'SL') // slash
+      .replace('-', 'D')  // dash
+      .replace('_', 'U')  // underscore
+      .replace('.', 'P'); // period
   },
 
   getWebsocketsRouteLogicalId(route) {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -183,10 +183,10 @@ module.exports = {
   getNormalizedWebsocketsRouteKey(route) {
     return route
       .replace('$', 'S') // dollar sign
-      .replace('/', 'SL') // slash
-      .replace('-', 'D')  // dash
-      .replace('_', 'U')  // underscore
-      .replace('.', 'P'); // period
+      .replace('/', 'Slash')
+      .replace('-', 'Dash')
+      .replace('_', 'Underscore')
+      .replace('.', 'Period');
   },
 
   getWebsocketsRouteLogicalId(route) {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -259,6 +259,18 @@ describe('#naming()', () => {
     it('should return a normalized version of the route key', () => {
       expect(sdk.naming.getNormalizedWebsocketsRouteKey('$connect'))
         .to.equal('Sconnect');
+
+      expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo/bar'))
+        .to.equal('fooSLbar');
+
+      expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo-bar'))
+        .to.equal('fooDbar');
+
+      expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo_bar'))
+        .to.equal('fooUbar');
+
+      expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo.bar'))
+        .to.equal('fooPbar');
     });
   });
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -261,16 +261,16 @@ describe('#naming()', () => {
         .to.equal('Sconnect');
 
       expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo/bar'))
-        .to.equal('fooSLbar');
+        .to.equal('fooSlashbar');
 
       expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo-bar'))
-        .to.equal('fooDbar');
+        .to.equal('fooDashbar');
 
       expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo_bar'))
-        .to.equal('fooUbar');
+        .to.equal('fooUnderscorebar');
 
       expect(sdk.naming.getNormalizedWebsocketsRouteKey('foo.bar'))
-        .to.equal('fooPbar');
+        .to.equal('fooPeriodbar');
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5858

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Replace special characters with alphanumeric ones, as we've done with other logical IDs

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

```yml
functions:
  hello:
    handler: handler.hello
    events:
      - websocket: 'echo'
      - websocket: 'echo/echo'
      - websocket: 'echo-echo'
      - websocket: 'echo_echo'
      - websocket: 'echo.echo'
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
