### PR TITLE
Added websockets authorizer support

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -30,6 +30,8 @@ provider:
   region: ${opt:region, 'us-east-1'} # Overwrite the default region used. Default is us-east-1
   stackName: custom-stack-name # Use a custom name for the CloudFormation stack
   apiName: custom-api-name # Use a custom name for the API Gateway API
+  websocketsApiName: custom-websockets-api-name # Use a custom name for the websockets API
+  websocketsApiRouteSelectionExpression: $request.body.route # custom route selection expression
   profile: production # The default profile to use with this service
   memorySize: 512 # Overwrite the default memory size. Default is 1024
   timeout: 10 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds
@@ -175,6 +177,12 @@ functions:
             identityValidationExpression: someRegex
       - websocket:
           route: $connect
+          authorizer:
+            # name: auth    NOTE: you can either use "name" or arn" properties
+            arn: arn:aws:lambda:us-east-1:1234567890:function:auth
+            identitySource:
+              - 'route.request.header.Auth'
+              - 'route.request.querystring.Auth'
       - s3:
           bucket: photos
           event: s3:ObjectCreated:*

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -196,6 +196,10 @@ module.exports = {
     return 'WebsocketsDeploymentStage';
   },
 
+  getWebsocketsAuthorizerLogicalId(functionName) {
+    return `${this.getNormalizedAuthorizerName(functionName)}WebsocketsAuthorizer`;
+  },
+
   // API Gateway
   getApiGatewayName() {
     if (this.provider.serverless.service.provider.apiName &&

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -283,6 +283,13 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getWebsocketsAuthorizerLogicalId()', () => {
+    it('should return the websockets authorizer logical id', () => {
+      expect(sdk.naming.getWebsocketsAuthorizerLogicalId('auth'))
+        .to.equal('AuthWebsocketsAuthorizer');
+    });
+  });
+
   describe('#getApiGatewayName()', () => {
     it('should return the composition of stage & service name if custom name not provided', () => {
       serverless.service.service = 'myService';

--- a/lib/plugins/aws/package/compile/events/websockets/index.js
+++ b/lib/plugins/aws/package/compile/events/websockets/index.js
@@ -9,6 +9,7 @@ const compilePermissions = require('./lib/permissions');
 const compileRoutes = require('./lib/routes');
 const compileDeployment = require('./lib/deployment');
 const compileStage = require('./lib/stage');
+const compileAuthorizers = require('./lib/authorizers');
 
 class AwsCompileWebsockets {
   constructor(serverless, options) {
@@ -21,6 +22,7 @@ class AwsCompileWebsockets {
       validate,
       compileApi,
       compileIntegrations,
+      compileAuthorizers,
       compilePermissions,
       compileRoutes,
       compileDeployment,
@@ -38,6 +40,7 @@ class AwsCompileWebsockets {
         return BbPromise.bind(this)
           .then(this.compileApi)
           .then(this.compileIntegrations)
+          .then(this.compileAuthorizers)
           .then(this.compilePermissions)
           .then(this.compileRoutes)
           .then(this.compileDeployment)

--- a/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -35,6 +35,7 @@ describe('AwsCompileWebsocketsEvents', () => {
   describe('#constructor()', () => {
     let compileApiStub;
     let compileIntegrationsStub;
+    let compileAuthorizersStub;
     let compilePermissionsStub;
     let compileRoutesStub;
     let compileDeploymentStub;
@@ -45,6 +46,8 @@ describe('AwsCompileWebsocketsEvents', () => {
         .stub(awsCompileWebsocketsEvents, 'compileApi').resolves();
       compileIntegrationsStub = sinon
         .stub(awsCompileWebsocketsEvents, 'compileIntegrations').resolves();
+      compileAuthorizersStub = sinon
+        .stub(awsCompileWebsocketsEvents, 'compileAuthorizers').resolves();
       compilePermissionsStub = sinon
         .stub(awsCompileWebsocketsEvents, 'compilePermissions').resolves();
       compileRoutesStub = sinon
@@ -58,6 +61,7 @@ describe('AwsCompileWebsocketsEvents', () => {
     afterEach(() => {
       awsCompileWebsocketsEvents.compileApi.restore();
       awsCompileWebsocketsEvents.compileIntegrations.restore();
+      awsCompileWebsocketsEvents.compileAuthorizers.restore();
       awsCompileWebsocketsEvents.compilePermissions.restore();
       awsCompileWebsocketsEvents.compileRoutes.restore();
       awsCompileWebsocketsEvents.compileDeployment.restore();
@@ -91,7 +95,8 @@ describe('AwsCompileWebsocketsEvents', () => {
           expect(validateStub.calledOnce).to.be.equal(true);
           expect(compileApiStub.calledAfter(validateStub)).to.be.equal(true);
           expect(compileIntegrationsStub.calledAfter(compileApiStub)).to.be.equal(true);
-          expect(compilePermissionsStub.calledAfter(compileIntegrationsStub)).to.be.equal(true);
+          expect(compileAuthorizersStub.calledAfter(compileIntegrationsStub)).to.be.equal(true);
+          expect(compilePermissionsStub.calledAfter(compileAuthorizersStub)).to.be.equal(true);
           expect(compileRoutesStub.calledAfter(compilePermissionsStub)).to.be.equal(true);
           expect(compileDeploymentStub.calledAfter(compileRoutesStub)).to.be.equal(true);
           expect(compileStageStub.calledAfter(compileDeploymentStub)).to.be.equal(true);

--- a/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+
+module.exports = {
+  compileAuthorizers() {
+    this.validated.events.forEach(event => {
+      const websocketsAuthorizerLogicalId = this.provider.naming
+        .getWebsocketsAuthorizerLogicalId(event.authorizer.name);
+
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+        [websocketsAuthorizerLogicalId]: {
+          Type: 'AWS::ApiGatewayV2::Authorizer',
+          Properties: {
+            ApiId: {
+              Ref: this.websocketsApiLogicalId,
+            },
+            Name: event.authorizer.name,
+            AuthorizerType: 'REQUEST',
+            AuthorizerUri: event.authorizer.uri,
+            IdentitySource: event.authorizer.identitySource,
+          },
+        },
+      });
+    });
+
+    return BbPromise.resolve();
+  },
+};

--- a/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
@@ -6,6 +6,9 @@ const BbPromise = require('bluebird');
 module.exports = {
   compileAuthorizers() {
     this.validated.events.forEach(event => {
+      if (!event.authorizer) {
+        return;
+      }
       const websocketsAuthorizerLogicalId = this.provider.naming
         .getWebsocketsAuthorizerLogicalId(event.authorizer.name);
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const expect = require('chai').expect;
+const AwsCompileWebsocketsEvents = require('../index');
+const Serverless = require('../../../../../../../Serverless');
+const AwsProvider = require('../../../../../provider/awsProvider');
+
+describe('#compileAuthorizers()', () => {
+  let awsCompileWebsocketsEvents;
+
+  beforeEach(() => {
+    const serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+
+    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
+
+    awsCompileWebsocketsEvents.websocketsApiLogicalId
+      = awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+  });
+
+  it('should create an authorizer resource for routes with authorizer definition', () => {
+    awsCompileWebsocketsEvents.validated = {
+      events: [
+        {
+          functionName: 'First',
+          route: '$connect',
+          authorizer: {
+            name: 'auth',
+            uri: {
+              'Fn::Join': ['',
+                [
+                  'arn:',
+                  { Ref: 'AWS::Partition' },
+                  ':apigateway:',
+                  { Ref: 'AWS::Region' },
+                  ':lambda:path/2015-03-31/functions/',
+                  { 'Fn::GetAtt': ['AuthLambdaFunction', 'Arn'] },
+                  '/invocations',
+                ],
+              ],
+            },
+            identitySource: ['route.request.header.Auth'],
+          },
+        },
+      ],
+    };
+
+    return awsCompileWebsocketsEvents.compileAuthorizers().then(() => {
+      const resources = awsCompileWebsocketsEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources;
+
+      expect(resources).to.deep.equal({
+        AuthWebsocketsAuthorizer: {
+          Type: 'AWS::ApiGatewayV2::Authorizer',
+          Properties: {
+            ApiId: {
+              Ref: 'WebsocketsApi',
+            },
+            Name: 'auth',
+            AuthorizerType: 'REQUEST',
+            AuthorizerUri: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':apigateway:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':lambda:path/2015-03-31/functions/',
+                  {
+                    'Fn::GetAtt': [
+                      'AuthLambdaFunction',
+                      'Arn',
+                    ],
+                  },
+                  '/invocations',
+                ],
+              ],
+            },
+            IdentitySource: ['route.request.header.Auth'],
+          },
+        },
+      });
+    });
+  });
+
+  it('should NOT create an authorizer resource for routes with not authorizer definition', () => {
+    awsCompileWebsocketsEvents.validated = {
+      events: [
+        {
+          functionName: 'First',
+          route: '$connect',
+        },
+      ],
+    };
+
+    return awsCompileWebsocketsEvents.compileAuthorizers().then(() => {
+      const resources = awsCompileWebsocketsEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources;
+
+      expect(resources).to.deep.equal({});
+    });
+  });
+});

--- a/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
@@ -28,6 +28,7 @@ module.exports = {
       if (event.authorizer) {
         const websocketsAuthorizerPermissionLogicalId = this.provider.naming
           .getLambdaWebsocketsPermissionLogicalId(event.authorizer.name);
+
         const authorizerPermissionTemplate = {
           [websocketsAuthorizerPermissionLogicalId]: {
             Type: 'AWS::Lambda::Permission',

--- a/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
@@ -24,6 +24,37 @@ module.exports = {
           },
         },
       });
+
+      if (event.authorizer) {
+        const websocketsAuthorizerPermissionLogicalId = this.provider.naming
+          .getLambdaWebsocketsPermissionLogicalId(event.authorizer.name);
+        const authorizerPermissionTemplate = {
+          [websocketsAuthorizerPermissionLogicalId]: {
+            Type: 'AWS::Lambda::Permission',
+            DependsOn: [this.websocketsApiLogicalId],
+            Properties: {
+              Action: 'lambda:InvokeFunction',
+              Principal: { 'Fn::Join': ['', ['apigateway.', { Ref: 'AWS::URLSuffix' }]] },
+            },
+          },
+        };
+
+        if (event.authorizer.permission.includes(':')) {
+          authorizerPermissionTemplate[websocketsAuthorizerPermissionLogicalId]
+            .Properties.FunctionName = event.authorizer.permission;
+        } else {
+          authorizerPermissionTemplate[websocketsAuthorizerPermissionLogicalId]
+            .Properties.FunctionName = {
+              'Fn::GetAtt': [event.authorizer.permission, 'Arn'],
+            };
+
+          authorizerPermissionTemplate[websocketsAuthorizerPermissionLogicalId]
+            .DependsOn.push(event.authorizer.permission);
+        }
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+          authorizerPermissionTemplate);
+      }
     });
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
@@ -94,4 +94,80 @@ describe('#compilePermissions()', () => {
       });
     });
   });
+
+  it('should create a permission resource for authorizer function', () => {
+    awsCompileWebsocketsEvents.validated = {
+      events: [
+        {
+          functionName: 'First',
+          route: '$connect',
+          authorizer: {
+            name: 'auth',
+            permission: 'AuthLambdaPermissionWebsockets',
+          },
+        },
+      ],
+    };
+
+    return awsCompileWebsocketsEvents.compilePermissions().then(() => {
+      const resources = awsCompileWebsocketsEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources;
+
+      expect(resources).to.deep.equal({
+        FirstLambdaPermissionWebsockets: {
+          Type: 'AWS::Lambda::Permission',
+          DependsOn: [
+            'WebsocketsApi',
+            'FirstLambdaFunction',
+          ],
+          Properties: {
+            FunctionName: {
+              'Fn::GetAtt': [
+                'FirstLambdaFunction', 'Arn',
+              ],
+            },
+            Action: 'lambda:InvokeFunction',
+            Principal: {
+              'Fn::Join': [
+                '',
+                [
+                  'apigateway.',
+                  {
+                    Ref: 'AWS::URLSuffix',
+                  },
+                ],
+              ],
+            },
+          },
+        },
+        AuthLambdaPermissionWebsockets: {
+          Type: 'AWS::Lambda::Permission',
+          DependsOn: [
+            'WebsocketsApi',
+            'AuthLambdaPermissionWebsockets',
+          ],
+          Properties: {
+            FunctionName: {
+              'Fn::GetAtt': [
+                'AuthLambdaPermissionWebsockets',
+                'Arn',
+              ],
+            },
+            Action: 'lambda:InvokeFunction',
+            Principal: {
+              'Fn::Join': [
+                '',
+                [
+                  'apigateway.',
+                  {
+                    Ref: 'AWS::URLSuffix',
+                  },
+                ],
+              ],
+            },
+          },
+        },
+      });
+    });
+  });
 });

--- a/lib/plugins/aws/package/compile/events/websockets/lib/routes.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/routes.js
@@ -12,7 +12,7 @@ module.exports = {
       const websocketsRouteLogicalId = this.provider.naming
         .getWebsocketsRouteLogicalId(event.route);
 
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      const routeTemplate = {
         [websocketsRouteLogicalId]: {
           Type: 'AWS::ApiGatewayV2::Route',
           Properties: {
@@ -31,7 +31,17 @@ module.exports = {
             },
           },
         },
-      });
+      };
+
+      if (event.authorizer) {
+        routeTemplate[websocketsRouteLogicalId].Properties.AuthorizationType = 'CUSTOM';
+        routeTemplate[websocketsRouteLogicalId].Properties.AuthorizerId = {
+          Ref: this.provider.naming
+            .getWebsocketsAuthorizerLogicalId(event.authorizer.name),
+        };
+      }
+      _.merge(this.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources, routeTemplate);
     });
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
@@ -82,4 +82,50 @@ describe('#compileRoutes()', () => {
       });
     });
   });
+
+  it('should set authorizer property for the connect route', () => {
+    awsCompileWebsocketsEvents.validated = {
+      events: [
+        {
+          functionName: 'First',
+          route: '$connect',
+          authorizer: {
+            name: 'auth',
+          },
+        },
+      ],
+    };
+
+    return awsCompileWebsocketsEvents.compileRoutes().then(() => {
+      const resources = awsCompileWebsocketsEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources;
+
+      expect(resources).to.deep.equal({
+        SconnectWebsocketsRoute: {
+          Type: 'AWS::ApiGatewayV2::Route',
+          Properties: {
+            ApiId: {
+              Ref: 'WebsocketsApi',
+            },
+            RouteKey: '$connect',
+            AuthorizationType: 'CUSTOM',
+            AuthorizerId: {
+              Ref: awsCompileWebsocketsEvents.provider.naming
+                .getWebsocketsAuthorizerLogicalId('auth'),
+            },
+            Target: {
+              'Fn::Join': [
+                '/',
+                [
+                  'integrations', {
+                    Ref: 'FirstWebsocketsIntegration',
+                  },
+                ],
+              ],
+            },
+          },
+        },
+      });
+    });
+  });
 });

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -6,6 +6,11 @@ module.exports = {
   validate() {
     const events = [];
 
+    const getAuthorizerNameFromArn = (arn) => {
+      const splitArn = arn.split(':');
+      return splitArn[splitArn.length - 1];
+    };
+
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       _.forEach(functionObject.events, (event) => {
         // check if we have both, `http` and `websocket` events which is not supported
@@ -20,10 +25,105 @@ module.exports = {
               const errorMessage = 'You need to set the "route" when using the websocket event.';
               throw new this.serverless.classes.Error(errorMessage);
             }
-            events.push({
+
+            const websocketObj = {
               functionName,
               route: event.websocket.route,
-            });
+            };
+
+            // authorizers
+            if (_.isString(event.websocket.authorizer)) {
+              if (event.websocket.authorizer.includes(':')) { // arn
+                websocketObj.authorizer = {
+                  name: getAuthorizerNameFromArn(event.websocket.authorizer),
+                  uri: {
+                    'Fn::Join': ['',
+                      [
+                        'arn:',
+                        { Ref: 'AWS::Partition' },
+                        ':apigateway:',
+                        { Ref: 'AWS::Region' },
+                        ':lambda:path/2015-03-31/functions/',
+                        event.websocket.authorizer,
+                        '/invocations',
+                      ],
+                    ],
+                  },
+                  identitySource: ['route.request.header.Auth'],
+                  permission: event.websocket.authorizer,
+                };
+              } else { // reference function
+                const lambdaLogicalId = this.provider.naming
+                  .getLambdaLogicalId(event.websocket.authorizer);
+                websocketObj.authorizer = {
+                  name: event.websocket.authorizer,
+                  uri: {
+                    'Fn::Join': ['',
+                      [
+                        'arn:',
+                        { Ref: 'AWS::Partition' },
+                        ':apigateway:',
+                        { Ref: 'AWS::Region' },
+                        ':lambda:path/2015-03-31/functions/',
+                        { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] },
+                        '/invocations',
+                      ],
+                    ],
+                  },
+                  identitySource: ['route.request.header.Auth'],
+                  permission: lambdaLogicalId,
+                };
+              }
+            } else if (_.isObject(event.websocket.authorizer)) {
+              websocketObj.authorizer = {};
+              if (event.websocket.authorizer.arn) {
+                websocketObj.authorizer.name =
+                  getAuthorizerNameFromArn(event.websocket.authorizer.arn);
+                websocketObj.authorizer.uri = {
+                  'Fn::Join': ['',
+                    [
+                      'arn:',
+                      { Ref: 'AWS::Partition' },
+                      ':apigateway:',
+                      { Ref: 'AWS::Region' },
+                      ':lambda:path/2015-03-31/functions/',
+                      event.websocket.authorizer.arn,
+                      '/invocations',
+                    ],
+                  ],
+                };
+                websocketObj.authorizer.permission = event.websocket.authorizer.arn;
+              } else if (event.websocket.authorizer.name) {
+                websocketObj.authorizer.name = event.websocket.authorizer.name;
+                const lambdaLogicalId = this.provider.naming
+                  .getLambdaLogicalId(event.websocket.authorizer.name);
+                websocketObj.authorizer.uri = {
+                  'Fn::Join': ['',
+                    [
+                      'arn:',
+                      { Ref: 'AWS::Partition' },
+                      ':apigateway:',
+                      { Ref: 'AWS::Region' },
+                      ':lambda:path/2015-03-31/functions/',
+                      { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] },
+                      '/invocations',
+                    ],
+                  ],
+                };
+                websocketObj.authorizer.permission = lambdaLogicalId;
+              } else {
+                const errorMessage =
+                  'You must specify name or arn properties when using a websocket authorizer';
+                throw new this.serverless.classes.Error(errorMessage);
+              }
+
+              if (!event.websocket.authorizer.identitySource) {
+                websocketObj.authorizer.identitySource = ['route.request.header.Auth'];
+              } else {
+                websocketObj.authorizer.identitySource = event.websocket.authorizer.identitySource;
+              }
+            }
+            events.push(websocketObj);
           // dealing with the simplified string representation
           } else if (_.isString(event.websocket)) {
             events.push({

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
@@ -5,7 +5,7 @@ const AwsCompileWebsocketsEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
 
-describe('#validate()', () => {
+describe.only('#validate()', () => {
   let serverless;
   let awsCompileWebsocketsEvents;
 
@@ -59,6 +59,172 @@ describe('#validate()', () => {
     ]);
   });
 
+  it('should add authorizer config when authorizer is specified as a string', () => {
+    awsCompileWebsocketsEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            websocket: {
+              route: '$connect',
+              authorizer: 'auth',
+            },
+          },
+        ],
+      },
+    };
+    const validated = awsCompileWebsocketsEvents.validate();
+    expect(validated.events).to.deep.equal([
+      {
+        functionName: 'first',
+        route: '$connect',
+        authorizer: {
+          name: 'auth',
+          uri: {
+            'Fn::Join': ['',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':apigateway:',
+                { Ref: 'AWS::Region' },
+                ':lambda:path/2015-03-31/functions/',
+                { 'Fn::GetAtt': ['AuthLambdaFunction', 'Arn'] },
+                '/invocations',
+              ],
+            ],
+          },
+          identitySource: ['route.request.header.Auth'],
+          permission: 'AuthLambdaFunction',
+        },
+      },
+    ]);
+  });
+
+  it('should add authorizer config when authorizer is specified as a string with arn', () => {
+    awsCompileWebsocketsEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            websocket: {
+              route: '$connect',
+              authorizer: 'arn:aws:auth',
+            },
+          },
+        ],
+      },
+    };
+    const validated = awsCompileWebsocketsEvents.validate();
+    expect(validated.events).to.deep.equal([
+      {
+        functionName: 'first',
+        route: '$connect',
+        authorizer: {
+          name: 'auth',
+          uri: {
+            'Fn::Join': ['',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':apigateway:',
+                { Ref: 'AWS::Region' },
+                ':lambda:path/2015-03-31/functions/',
+                'arn:aws:auth',
+                '/invocations',
+              ],
+            ],
+          },
+          identitySource: ['route.request.header.Auth'],
+          permission: 'arn:aws:auth',
+        },
+      },
+    ]);
+  });
+
+  it('should add authorizer config when authorizer is specified as an object', () => {
+    awsCompileWebsocketsEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            websocket: {
+              route: '$connect',
+              authorizer: {
+                name: 'auth',
+                identitySource: ['route.request.header.Auth', 'route.request.querystring.Auth'],
+              },
+            },
+          },
+        ],
+      },
+    };
+    const validated = awsCompileWebsocketsEvents.validate();
+    expect(validated.events).to.deep.equal([
+      {
+        functionName: 'first',
+        route: '$connect',
+        authorizer: {
+          name: 'auth',
+          uri: {
+            'Fn::Join': ['',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':apigateway:',
+                { Ref: 'AWS::Region' },
+                ':lambda:path/2015-03-31/functions/',
+                { 'Fn::GetAtt': ['AuthLambdaFunction', 'Arn'] },
+                '/invocations',
+              ],
+            ],
+          },
+          identitySource: ['route.request.header.Auth', 'route.request.querystring.Auth'],
+          permission: 'AuthLambdaFunction',
+        },
+      },
+    ]);
+  });
+
+  it('should add authorizer config when authorizer is specified as an object with arn', () => {
+    awsCompileWebsocketsEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            websocket: {
+              route: '$connect',
+              authorizer: {
+                arn: 'arn:aws:auth',
+                identitySource: ['route.request.header.Auth', 'route.request.querystring.Auth'],
+              },
+            },
+          },
+        ],
+      },
+    };
+    const validated = awsCompileWebsocketsEvents.validate();
+    expect(validated.events).to.deep.equal([
+      {
+        functionName: 'first',
+        route: '$connect',
+        authorizer: {
+          name: 'auth',
+          uri: {
+            'Fn::Join': ['',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':apigateway:',
+                { Ref: 'AWS::Region' },
+                ':lambda:path/2015-03-31/functions/',
+                'arn:aws:auth',
+                '/invocations',
+              ],
+            ],
+          },
+          identitySource: ['route.request.header.Auth', 'route.request.querystring.Auth'],
+          permission: 'arn:aws:auth',
+        },
+      },
+    ]);
+  });
+
   it('should ignore non-websocket events', () => {
     awsCompileWebsocketsEvents.serverless.service.functions = {
       first: {
@@ -84,6 +250,24 @@ describe('#validate()', () => {
       },
     };
     expect(() => awsCompileWebsocketsEvents.validate()).to.throw(/set the "route"/);
+  });
+
+  it('should reject an authorizer definition without name nor arn', () => {
+    awsCompileWebsocketsEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            websocket: {
+              route: '$connect',
+              authorizer: {
+                identitySource: ['route.request.header.Auth', 'route.request.querystring.Auth'],
+              },
+            },
+          },
+        ],
+      },
+    };
+    expect(() => awsCompileWebsocketsEvents.validate()).to.throw(/You must specify name or arn/);
   });
 
   it('should reject a usage of both, http and websocket event types', () => {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
@@ -5,7 +5,7 @@ const AwsCompileWebsocketsEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
 
-describe.only('#validate()', () => {
+describe('#validate()', () => {
   let serverless;
   let awsCompileWebsocketsEvents;
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5857
Closes #5874 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Using the Authorizer CF template, and mapping it to the Route template, and setting the required permissions.

## How can we verify it:

Using the following service:

```yml
service: websocket-authorizers

provider:
  name: aws
  stage: dev
  runtime: nodejs8.10

functions:
  connect:
    handler: handler.connect
    events:
      - websocket:
          route: $connect
          authorizer:
            name: auth
            identitySource:
              - 'route.request.header.Auth'
              - 'route.request.querystring.Auth'
  default:
    handler: handler.default
    events:
      - websocket:
          route: $default

  auth:
    handler: handler.auth
```

```js
// handler.js
'use strict';

const AWS = require('aws-sdk')

// the following section injects the new ApiGatewayManagementApi service
// into the Lambda AWS SDK, otherwise you'll have to deploy the entire new version of the SDK

/* START ApiGatewayManagementApi injection */
const { Service, apiLoader } = AWS

apiLoader.services['apigatewaymanagementapi'] = {}

const model = {
  metadata: {
    apiVersion: '2018-11-29',
    endpointPrefix: 'execute-api',
    signingName: 'execute-api',
    serviceFullName: 'AmazonApiGatewayManagementApi',
    serviceId: 'ApiGatewayManagementApi',
    protocol: 'rest-json',
    jsonVersion: '1.1',
    uid: 'apigatewaymanagementapi-2018-11-29',
    signatureVersion: 'v4'
  },
  operations: {
    PostToConnection: {
      http: {
        requestUri: '/@connections/{connectionId}',
        responseCode: 200
      },
      input: {
        type: 'structure',
        members: {
          Data: {
            type: 'blob'
          },
          ConnectionId: {
            location: 'uri',
            locationName: 'connectionId'
          }
        },
        required: ['ConnectionId', 'Data'],
        payload: 'Data'
      }
    }
  },
  paginators: {},
  shapes: {}
}

AWS.ApiGatewayManagementApi = Service.defineService('apigatewaymanagementapi', ['2018-11-29'])
Object.defineProperty(apiLoader.services['apigatewaymanagementapi'], '2018-11-29', {
  // eslint-disable-next-line
  get: function get() {
    return model
  },
  enumerable: true,
  configurable: true
})
/* END ApiGatewayManagementApi injection */

module.exports.connect = (event, context, cb) => {
  cb(null, {
    statusCode: 200,
    body: 'Connected.'
  });
};

module.exports.default = async (event, context, cb) => {

  const client = new AWS.ApiGatewayManagementApi({
    apiVersion: '2018-11-29',
    endpoint: `https://${event.requestContext.domainName}/${event.requestContext.stage}`
  });

  await client
    .postToConnection({
      ConnectionId: event.requestContext.connectionId,
      Data: `default route received: ${event.body}`
    })
    .promise();

  cb(null, {
    statusCode: 200,
    body: 'Sent.'
  });
};

module.exports.auth = async (event, context) => {
  return {
    "principalId": "user",
    "policyDocument": {
      "Version": "2012-10-17",
      "Statement": [
        {
          "Action": "execute-api:Invoke",
          "Effect": "Allow",
          "Resource": event.methodArn
        }
      ]
    }
  };
};
```

deploy, then connect to the ws url:

```
wscat -c wss://<ID>.execute-api.us-east-1.amazonaws.com/dev?Auth=foo -H Auth:bar
# connection should SUCCEED because you provided both identity sources: querystring & header

wscat -c wss://<ID>.execute-api.us-east-1.amazonaws.com/dev -H Auth:bar
# connection should FAIL because you ONLY provided the header
# and your serverless.yml clearly states that you need the querystring identity source
# If you remove the `identitySource` from `serverless.yml`, it should SUCCEED
# because using ONLY the header is the default behavior
```




<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
