### PR TITLE
Enchancement/kotlin jvm maven updates

### DIFF
--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-lambda-java-log4j</artifactId>
+            <artifactId>aws-lambda-java-log4j2</artifactId>
             <version>1.1.0</version>
         </dependency>
         <dependency>
@@ -104,6 +104,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.edwgiz</groupId>
+                        <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+                        <version>2.8.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
@@ -14,6 +14,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.9.8</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -33,17 +45,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
     </dependencies>
 

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
@@ -8,7 +8,8 @@
     <name>hello</name>
 
     <properties>
-        <kotlin.version>1.1.4-3</kotlin.version>
+        <kotlin.version>1.3.21</kotlin.version>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
@@ -35,12 +35,22 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.11.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.11.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -79,6 +89,11 @@
                 <version>2.3</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <transformers>
+                        <transformer
+                                implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        </transformer>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/ApiGatewayResponse.kt
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/ApiGatewayResponse.kt
@@ -2,7 +2,8 @@ package com.serverless
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import java.nio.charset.StandardCharsets
 import java.util.*
 
@@ -24,7 +25,7 @@ class ApiGatewayResponse(
     }
 
     class Builder {
-        var LOG: Logger = Logger.getLogger(ApiGatewayResponse.Builder::class.java)
+        var LOG: Logger = LogManager.getLogger(ApiGatewayResponse.Builder::class.java)
         var objectMapper: ObjectMapper = ObjectMapper()
 
         var statusCode: Int = 200

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/Handler.kt
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/kotlin/com/serverless/Handler.kt
@@ -2,13 +2,11 @@ package com.serverless
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
-import org.apache.log4j.BasicConfigurator
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import java.util.*
 
 class Handler:RequestHandler<Map<String, Any>, ApiGatewayResponse> {
     override fun handleRequest(input:Map<String, Any>, context:Context):ApiGatewayResponse {
-        BasicConfigurator.configure()
         LOG.info("received: " + input.keys.toString())
 
         val responseBody = Response("Go Serverless v1.x! Your Kotlin function executed successfully!", input)
@@ -19,6 +17,6 @@ class Handler:RequestHandler<Map<String, Any>, ApiGatewayResponse> {
         }
     }
     companion object {
-        private val LOG = Logger.getLogger(Handler::class.java)
+        private val LOG = LogManager.getLogger(Handler::class.java)
     }
 }

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/resources/log4j2.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## What did you implement:

Closes #5871. Where the Kotlin module is out of date and can be improved to use standard pom.xml techniques.

## How did you implement it:
Updated the `pom.xml` file and added a `log4j2.xml`, to enable logging.

## How can we verify it:
Blocked by #5870. Currently we cannot, integration testing is broken and must be resolved first

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
