### PR TITLE
Fix bug when using websocket events with functions with custom roles

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -23,20 +23,25 @@ module.exports = {
       },
     });
 
-    // insert policy that allows functions to postToConnection
-    const websocketsPolicy = {
-      Effect: 'Allow',
-      Action: ['execute-api:ManageConnections'],
-      Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
-    };
+    const defaultRoleResource = this.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources[this.provider.naming.getRoleLogicalId()];
 
-    this.serverless.service.provider.compiledCloudFormationTemplate
-      .Resources[this.provider.naming.getRoleLogicalId()]
-      .Properties
-      .Policies[0]
-      .PolicyDocument
-      .Statement
-      .push(websocketsPolicy);
+    if (defaultRoleResource) {
+      // insert policy that allows functions to postToConnection
+      const websocketsPolicy = {
+        Effect: 'Allow',
+        Action: ['execute-api:ManageConnections'],
+        Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
+      };
+
+      this.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources[this.provider.naming.getRoleLogicalId()]
+        .Properties
+        .Policies[0]
+        .PolicyDocument
+        .Statement
+        .push(websocketsPolicy);
+    }
 
     return BbPromise.resolve();
   },

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
@@ -77,4 +77,17 @@ describe('#compileApi()', () => {
         },
       });
     }));
+
+  it('should NOT add the websockets policy if role resource does not exist', () => {
+    awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources = {};
+
+    return awsCompileWebsocketsEvents
+      .compileApi().then(() => {
+        const resources = awsCompileWebsocketsEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources;
+
+        expect(resources[roleLogicalId]).to.deep.equal(undefined);
+      });
+  });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5868 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Skip the logic that adds websocket policies to the default role when using custom roles.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

```yml
functions:
  myWebSocket:
    handler: myWebsocket.handler
    role: { "Fn::GetAtt": [ "MyWebSocketLambdaFunctionRole", "Arn" ] }
    events:
      - websocket:
          route: $connect
      - websocket:
          route: $disconnect
      - websocket:
          route: $default

resources:
  Resources:
    MyWebSocketLambdaFunctionRole: 
      Type: "AWS::IAM::Role,
      Properties:
        #custom role policies

```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
