### PR TITLE
Print customized function names correctly in sls info output

### DIFF
--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -40,8 +40,7 @@ module.exports = {
         this.serverless.service.getAllFunctions().forEach((func) => {
           const functionInfo = {};
           functionInfo.name = func;
-          functionInfo.deployedName = `${
-            this.serverless.service.service}-${this.provider.getStage()}-${func}`;
+          functionInfo.deployedName = this.serverless.service.getFunction(func).name;
           this.gatheredData.info.functions.push(functionInfo);
         });
 

--- a/lib/plugins/aws/info/getStackInfo.test.js
+++ b/lib/plugins/aws/info/getStackInfo.test.js
@@ -20,8 +20,8 @@ describe('#getStackInfo()', () => {
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     serverless.service.functions = {
-      hello: {},
-      world: {},
+      hello: { name: 'my-service-dev-hello' },
+      world: { name: 'customized' },
     };
     serverless.service.layers = { test: {} };
     awsInfo = new AwsInfo(serverless, options);
@@ -85,7 +85,7 @@ describe('#getStackInfo()', () => {
           },
           {
             name: 'world',
-            deployedName: 'my-service-dev-world',
+            deployedName: 'customized',
           },
         ],
         layers: [


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Correct function names in `sls info` & `sls deploy` output when customized
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
used `getFunction(funcId).name` in gather info instead of generating the name again.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Create a service with a function that specifies `name: customized` and on deploy you should see that name instead of `SERVICENAME-STAGENAME-FUNCTIONNAME`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- n/a ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
