### PR TITLE
Fix CloudFormation template normalization

### DIFF
--- a/lib/plugins/aws/lib/normalizeFiles.js
+++ b/lib/plugins/aws/lib/normalizeFiles.js
@@ -7,7 +7,11 @@ module.exports = {
     const normalizedTemplate = _.cloneDeep(template);
 
     // reset all the S3Keys for AWS::Lambda::Function resources
-    _.forEach(normalizedTemplate.Resources, (value) => {
+    _.forEach(normalizedTemplate.Resources, (value, key) => {
+      if (key.startsWith('ApiGatewayDeployment')) {
+        delete Object.assign(normalizedTemplate.Resources,
+          { ApiGatewayDeployment: normalizedTemplate.Resources[key] })[key];
+      }
       if (value.Type && value.Type === 'AWS::Lambda::Function') {
         const newVal = value;
         newVal.Properties.Code.S3Key = '';

--- a/lib/plugins/aws/lib/normalizeFiles.js
+++ b/lib/plugins/aws/lib/normalizeFiles.js
@@ -6,7 +6,6 @@ module.exports = {
   normalizeCloudFormationTemplate(template) {
     const normalizedTemplate = _.cloneDeep(template);
 
-    // reset all the S3Keys for AWS::Lambda::Function resources
     _.forEach(normalizedTemplate.Resources, (value, key) => {
       if (key.startsWith('ApiGatewayDeployment')) {
         delete Object.assign(normalizedTemplate.Resources,

--- a/lib/plugins/aws/lib/normalizeFiles.test.js
+++ b/lib/plugins/aws/lib/normalizeFiles.test.js
@@ -35,6 +35,64 @@ describe('normalizeFiles', () => {
       });
     });
 
+    it('should reset the S3 content keys for Lambda layer versions', () => {
+      const input = {
+        Resources: {
+          MyLambdaLayer: {
+            Type: 'AWS::Lambda::LayerVersion',
+            Properties: {
+              Content: {
+                S3Key: 'some-s3-key-for-the-layer',
+              },
+            },
+          },
+        },
+      };
+
+      const result = normalizeFiles.normalizeCloudFormationTemplate(input);
+
+      expect(result).to.deep.equal({
+        Resources: {
+          MyLambdaLayer: {
+            Type: 'AWS::Lambda::LayerVersion',
+            Properties: {
+              Content: {
+                S3Key: '',
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should remove the API Gateway Deployment random id', () => {
+      const input = {
+        Resources: {
+          ApiGatewayDeploymentR4ND0M: {
+            Type: 'AWS::ApiGateway::Deployment',
+            Properties: {
+              RestApiId: 'rest-api-id',
+              StageName: 'dev',
+            },
+          },
+        },
+      };
+
+      const result = normalizeFiles.normalizeCloudFormationTemplate(input);
+
+      expect(result).to.deep.equal({
+        Resources: {
+          ApiGatewayDeployment: {
+            Type: 'AWS::ApiGateway::Deployment',
+            Properties: {
+              RestApiId: 'rest-api-id',
+              StageName: 'dev',
+            },
+          },
+        },
+      });
+    });
+
     it('should keep other resources untouched', () => {
       const input = {
         Resources: {


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5873 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

normalizeCloudFormationTemplate() now removes timestamp suffix from ApiGatewayDeployment resource name. 
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
