### PR TITLE
Update getting started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,11 +6,11 @@ menuOrder: 0
 menuItems:
   - {menuText: AWS Guide, path: /framework/docs/providers/aws/guide/quick-start}
   - {menuText: Azure Functions Guide, path: /framework/docs/providers/azure/guide/quick-start}
-  - {menuText: Fn Guide, path: /framework/docs/providers/fn/guide/quick-start}
-  - {menuText: OpenWhisk Guide, path: /framework/docs/providers/openwhisk/guide/quick-start}
+  - {menuText: Apache OpenWhisk Guide, path: /framework/docs/providers/openwhisk/guide/quick-start}
   - {menuText: Google Functions Guide, path: /framework/docs/providers/google/guide/quick-start}
   - {menuText: Kubeless Guide, path: /framework/docs/providers/kubeless/guide/quick-start}
   - {menuText: Spotinst Guide, path: /framework/docs/providers/spotinst/guide/quick-start}
+  - {menuText: Fn Guide, path: /framework/docs/providers/fn/guide/quick-start}
   - {menuText: Cloudflare Workers Guide, path: /framework/docs/providers/cloudflare/guide/quick-start}
 -->
 
@@ -30,84 +30,92 @@ Next up, it's time to choose where you'd like your serverless service to run.
 ## Choose your compute provider
 
 <div class="docsSections">
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/aws/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/aws-black.png" width="250" draggable="false"/>
-      </a>
+  <a href="/framework/docs/providers/aws/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/aws-black.png" width="250"
+          draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Amazon Web Services<br />Quick Start Guide</span>
+      </div>
     </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/aws/guide/quick-start">Amazon Web Services<br/>Quick Start Guide</a>
+  </a>
+  <a href="/framework/docs/providers/azure/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/azure-black.png" width="250"
+          draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Azure Functions<br />Quick Start Guide</span>
+      </div>
     </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/azure/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/azure-black.png" width="250" draggable="false"/>
-      </a>
+  </a>
+  <a href="/framework/docs/providers/openwhisk/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/openwhisk-black.png" width="250"
+          draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Apache OpenWhisk<br />Quick Start Guide</span>
+      </div>
     </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/azure/guide/quick-start">Azure Functions<br/>Quick Start Guide</a>
+  </a>
+  <a href="/framework/docs/providers/google/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/gcf-black.png" width="250"
+          draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Google Cloud Functions<br />Quick Start Guide</span>
+      </div>
     </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/openwhisk/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/openwhisk-black.png" width="250" draggable="false"/>
-      </a>
+  </a>
+  <a href="/framework/docs/providers/kubeless/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/kubeless-logos-black.png"
+          width="250" draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Kubeless<br />Quick Start Guide</span>
+      </div>
     </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/openwhisk/guide/quick-start">Apache OpenWhisk <br/>Quick Start Guide</a>
+  </a>
+  <a href="/framework/docs/providers/spotinst/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/spotinst-logos-black-small.png"
+          width="250" draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Spotinst<br />Quick Start Guide</span>
+      </div>
     </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/google/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/images/gcf-black.png" width="250" draggable="false"/>
-      </a>
+  </a>
+  <a href="/framework/docs/providers/fn/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/fn-logo-black.png" width="250"
+          draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Fn<br />Quick Start Guide</span>
+      </div>
     </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/google/guide/quick-start">Google Cloud Functions<br/>Quick Start Guide</a>
+  </a>
+  <a href="/framework/docs/providers/cloudflare/guide/quick-start">
+    <div class="docsSection">
+      <div class="docsSectionHeader">
+        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/cloudflare/cf-logo-v-dark-gray.png"
+          width="250" draggable="false" />
+      </div>
+      <div style="text-align:center;">
+        <span>Cloudflare Workers<br />Quick Start Guide</span>
+      </div>
     </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/kubeless/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/kubeless-logos-black.png" width="250" draggable="false"/>
-      </a>
-    </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/kubeless/guide/quick-start">Kubeless<br/>Quick Start Guide</a>
-    </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/spotinst/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/spotinst-logos-black-small.png" width="250" draggable="false"/>
-      </a>
-    </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/spotinst/guide/quick-start">Spotinst<br/>Quick Start Guide</a>
-    </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/fn/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/fn-logo-black.png" width="250" draggable="false"/>
-      </a>
-    </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/fn/guide/quick-start">Fn<br/>Quick Start Guide</a>
-    </div>
-  </div>
-  <div class="docsSection">
-    <div class="docsSectionHeader">
-      <a href="/framework/docs/providers/cloudflare/guide/quick-start">
-        <img src="https://s3-us-west-2.amazonaws.com/assets.site.serverless.com/docs/cloudflare/cf-logo-v-dark-gray.png" width="250" draggable="false"/>
-      </a>
-    </div>
-    <div style="text-align:center;">
-      <a href="/framework/docs/providers/cloudflare/guide/quick-start">Cloudflare Workers<br/>Quick Start Guide</a>
-    </div>
-  </div>
+  </a>
 </div>


### PR DESCRIPTION
Made two changes:

1. Improves link hitboxes by having the `a` tag wrap the whole `docsSection` instead of just the image and title. Currently hovering over the `docsSection` makes it change colour, but not actually become clickable which I thought was weird behavior.
2. Orders `menuItem`s in same order as main page content.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5893

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Wrap whole `docsSection` in `a` tag.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Try rending the markdown to HTML, and try clicking various parts.

## Todos:

- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
