### PR TITLE
Check if role is in resources

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -27,20 +27,21 @@ module.exports = {
       .Resources[this.provider.naming.getRoleLogicalId()];
 
     if (defaultRoleResource) {
-      // insert policy that allows functions to postToConnection
-      const websocketsPolicy = {
-        Effect: 'Allow',
-        Action: ['execute-api:ManageConnections'],
-        Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
-      };
-
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[this.provider.naming.getRoleLogicalId()]
-        .Properties
+      // insert policy that allows functions to postToConnection if policy is in resources
+      const role = this.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources[this.provider.naming.getRoleLogicalId()]
+      if (role) {
+        const websocketsPolicy = {
+          Effect: 'Allow',
+          Action: ['execute-api:ManageConnections'],
+          Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
+        };
+        role.Properties
         .Policies[0]
         .PolicyDocument
         .Statement
         .push(websocketsPolicy);
+      }
     }
 
     return BbPromise.resolve();


### PR DESCRIPTION
If the role used by websockets lambda is managed it still tries to add a policy. Resulting in this error:
TypeError: Cannot read property 'Properties' of undefined
	at AwsCompileWebsockets.compileApi (/usr/local/lib/node_modules/serverless/lib/plugins/aws/package/compile/events/websockets/lib/api.js:35:8)

I ran into this error because my company is starting to lock down iam permissions and I do not have the iam:CreateRole, so I need to use an existing role.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
