### PR TITLE
Fix error when using websockets and role ARN

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -27,20 +27,21 @@ module.exports = {
       .Resources[this.provider.naming.getRoleLogicalId()];
 
     if (defaultRoleResource) {
-      // insert policy that allows functions to postToConnection
-      const websocketsPolicy = {
-        Effect: 'Allow',
-        Action: ['execute-api:ManageConnections'],
-        Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
-      };
-
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[this.provider.naming.getRoleLogicalId()]
-        .Properties
+      // insert policy that allows functions to postToConnection if policy is in resources
+      const role = this.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources[this.provider.naming.getRoleLogicalId()]
+      if (role) {
+        const websocketsPolicy = {
+          Effect: 'Allow',
+          Action: ['execute-api:ManageConnections'],
+          Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
+        };
+        role.Properties
         .Policies[0]
         .PolicyDocument
         .Statement
         .push(websocketsPolicy);
+      }
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -29,7 +29,7 @@ module.exports = {
     if (defaultRoleResource) {
       // insert policy that allows functions to postToConnection if policy is in resources
       const role = this.serverless.service.provider.compiledCloudFormationTemplate
-      .Resources[this.provider.naming.getRoleLogicalId()]
+      .Resources[this.provider.naming.getRoleLogicalId()];
       if (role) {
         const websocketsPolicy = {
           Effect: 'Allow',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Closes: https://github.com/serverless/serverless/issues/5906


<!--
Briefly describe the feature if no issue exists for this PR
-->
Verify the role is in resources when building the cloudformation, before adding a policy. It fails currently if your websocket functions use an arn for their role because it tries to inject an additional policy into something that doesn't exist.

## How did you implement it:
Skip adding a policy to the role if the role is not in resources.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Create a simple serverless.yml that uses websockets. Then add an arn as the role and try to deploy. It fails now, but with this change it succeeds.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
