### PR TITLE
Add type configuration to aws serverless.yml guide for authorizer

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -181,6 +181,7 @@ functions:
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization
             identityValidationExpression: someRegex
+            type: token # token or request. Determines input to the authorier function, called with the auth token or the entire request event. Defaults to token
       - websocket:
           route: $connect
           authorizer:


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add a small description to docs for providers > aws > guide > serverless.yml
I looked for a while and finally found that the authorizer configuration has a `type` options that defaults to `token` but can be set to `response` to return the entire Api Gateway event to the authorizer, but that is not currently reflected in the serverless.yml documentation, so that's what this attempts to address.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Add a small entry to document that the `type` option exists with `token` and `response` as values, and that it defaults to `token`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
This behavior is already documented somewhat in the Api Gateway events documentation here:
[https://serverless.com/framework/docs/providers/aws/events/apigateway/#http-endpoints-with-custom-authorizers](https://serverless.com/framework/docs/providers/aws/events/apigateway/#http-endpoints-with-custom-authorizers)
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [X] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
