### PR TITLE
Support for Cloudwatch Event InputTransformer

### DIFF
--- a/docs/providers/aws/events/cloudwatch-event.md
+++ b/docs/providers/aws/events/cloudwatch-event.md
@@ -89,6 +89,19 @@ functions:
               state:
                 - pending
           inputPath: '$.stageVariables'
+      - cloudwatchEvent:
+          event:
+            source:
+              - "aws.ec2"
+            detail-type:
+              - "EC2 Instance State-change Notification"
+            detail:
+              state:
+                - pending
+          inputTransformer:
+            inputPathsMap:
+              eventTime: '$.time'
+            inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
 ```
 
 ## Specifying a Description

--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -47,6 +47,13 @@ functions:
           rate: cron(0 12 * * ? *)
           enabled: false
           inputPath: '$.stageVariables'
+      - schedule:
+          rate: rate(2 hours)
+          enabled: true
+          inputTransformer:
+            inputPathsMap:
+              eventTime: '$.time'
+            inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
 ```
 
 ## Specify Name and Description

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -243,13 +243,17 @@ functions:
             detail:
               state:
                 - pending
-          # Note: you can either use "input" or "inputPath"
+          # Note, you can use only one of input, inputPath, or inputTransformer
           input:
             key1: value1
             key2: value2
             stageParams:
               stage: dev
           inputPath: '$.stageVariables'
+          inputTransformer:
+            inputPathsMap:
+              eventTime: '$.time'
+            inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
       - cloudwatchLog:
           logGroup: '/aws/lambda/hello'
           filter: '{$.userIdentity.type = Root}'

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -200,12 +200,17 @@ functions:
           description: a description of my scheduled event's purpose
           rate: rate(10 minutes)
           enabled: false
+          # Note, you can use only one of input, inputPath, or inputTransformer
           input:
             key1: value1
             key2: value2
             stageParams:
               stage: dev
           inputPath: '$.stageVariables'
+          inputTransformer:
+            inputPathsMap:
+              eventTime: '$.time'
+            inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
       - sns:
           topicName: aggregate
           displayName: Data aggregation pipeline

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
@@ -25,6 +25,7 @@ class AwsCompileCloudWatchEventEvents {
             let State;
             let Input;
             let InputPath;
+            let InputTransformer;
             let Description;
             let Name;
 
@@ -45,13 +46,15 @@ class AwsCompileCloudWatchEventEvents {
               }
               Input = event.cloudwatchEvent.input;
               InputPath = event.cloudwatchEvent.inputPath;
+              InputTransformer = event.cloudwatchEvent.inputTransformer;
               Description = event.cloudwatchEvent.description;
               Name = event.cloudwatchEvent.name;
 
-              if (Input && InputPath) {
+              const inputOptions = [Input, InputPath, InputTransformer].filter(i => i);
+              if (inputOptions.length > 1) {
                 const errorMessage = [
-                  'You can\'t set both input & inputPath properties at the',
-                  'same time for cloudwatch events.',
+                  'You can only set one of input, inputPath, or inputTransformer ',
+                  'properties at the same time for cloudwatch events. ',
                   'Please check the AWS docs for more info',
                 ].join('');
                 throw new this.serverless.classes.Error(errorMessage);
@@ -63,6 +66,9 @@ class AwsCompileCloudWatchEventEvents {
               if (Input && typeof Input === 'string') {
                 // escape quotes to favor JSON.parse
                 Input = Input.replace(/\"/g, '\\"'); // eslint-disable-line
+              }
+              if (InputTransformer) {
+                InputTransformer = this.formatInputTransformer(InputTransformer);
               }
             } else {
               const errorMessage = [
@@ -93,6 +99,7 @@ class AwsCompileCloudWatchEventEvents {
                   "Targets": [{
                     ${Input ? `"Input": "${Input.replace(/\\n|\\r/g, '')}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath.replace(/\r?\n/g, '')}",` : ''}
+                    ${InputTransformer ? `"InputTransformer": ${InputTransformer},` : ''}
                     "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
                     "Id": "${cloudWatchId}"
                   }]
@@ -127,6 +134,24 @@ class AwsCompileCloudWatchEventEvents {
         });
       }
     });
+  }
+
+  formatInputTransformer(inputTransformer) {
+    if (!inputTransformer.inputTemplate) {
+      throw new this.serverless.classes.Error(
+        'The inputTemplate key is required when specifying an ' +
+        'inputTransformer for a cloudwatchEvent event'
+      );
+    }
+    const cfmOutput = {
+      // InputTemplate is required
+      InputTemplate: inputTransformer.inputTemplate,
+    };
+    // InputPathsMap is optional
+    if (inputTransformer.inputPathsMap) {
+      cfmOutput.InputPathsMap = inputTransformer.inputPathsMap;
+    }
+    return JSON.stringify(cfmOutput);
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.test.js
@@ -218,6 +218,42 @@ describe('awsCompileCloudWatchEventEvents', () => {
       ).to.equal('{"key":"value"}');
     });
 
+    it('should respect inputTransformer variable', () => {
+      awsCompileCloudWatchEventEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cloudwatchEvent: {
+                event: {
+                  source: ['aws.ec2'],
+                  'detail-type': ['EC2 Instance State-change Notification'],
+                  detail: { state: ['pending'] },
+                },
+                enabled: false,
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
+                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileCloudWatchEventEvents.compileCloudWatchEventEvents();
+
+      expect(awsCompileCloudWatchEventEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.Targets[0].InputTransformer
+      ).to.eql({
+        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+        InputPathsMap: { eventTime: '$.time' },
+      });
+    });
+
+
     it('should respect description variable', () => {
       awsCompileCloudWatchEventEvents.serverless.service.functions = {
         first: {
@@ -319,6 +355,62 @@ describe('awsCompileCloudWatchEventEvents', () => {
                   key: 'value',
                 },
                 inputPath: '$.stageVariables',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileCloudWatchEventEvents.compileCloudWatchEventEvents()).to.throw(Error);
+    });
+
+    it('should throw an error when both Input and InputTransformer are set', () => {
+      awsCompileCloudWatchEventEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cloudwatchEvent: {
+                event: {
+                  source: ['aws.ec2'],
+                  'detail-type': ['EC2 Instance State-change Notification'],
+                  detail: { state: ['pending'] },
+                },
+                enabled: false,
+                input: {
+                  key: 'value',
+                },
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
+                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileCloudWatchEventEvents.compileCloudWatchEventEvents()).to.throw(Error);
+    });
+
+    it('should throw an error when inputTransformer does not have inputTemplate', () => {
+      awsCompileCloudWatchEventEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cloudwatchEvent: {
+                event: {
+                  source: ['aws.ec2'],
+                  'detail-type': ['EC2 Instance State-change Notification'],
+                  detail: { state: ['pending'] },
+                },
+                enabled: false,
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
+                },
               },
             },
           ],

--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -40,6 +40,7 @@ class AwsCompileScheduledEvents {
             let State;
             let Input;
             let InputPath;
+            let InputTransformer;
             let Name;
             let Description;
 
@@ -56,13 +57,15 @@ class AwsCompileScheduledEvents {
               }
               Input = event.schedule.input;
               InputPath = event.schedule.inputPath;
+              InputTransformer = event.schedule.inputTransformer;
               Name = event.schedule.name;
               Description = event.schedule.description;
 
-              if (Input && InputPath) {
+              const inputOptions = [Input, InputPath, InputTransformer].filter(i => i);
+              if (inputOptions.length > 1) {
                 const errorMessage = [
-                  'You can\'t set both input & inputPath properties at the',
-                  'same time for schedule events.',
+                  'You can only set one of input, inputPath, or inputTransformer ',
+                  'properties at the same time for schedule events. ',
                   'Please check the AWS docs for more info',
                 ].join('');
                 throw new this.serverless.classes
@@ -89,6 +92,9 @@ class AwsCompileScheduledEvents {
               if (Input && typeof Input === 'string') {
                 // escape quotes to favor JSON.parse
                 Input = Input.replace(/\"/g, '\\"'); // eslint-disable-line
+              }
+              if (InputTransformer) {
+                InputTransformer = this.formatInputTransformer(InputTransformer);
               }
             } else if (this.validateScheduleSyntax(event.schedule)) {
               ScheduleExpression = event.schedule;
@@ -118,6 +124,7 @@ class AwsCompileScheduledEvents {
                   "Targets": [{
                     ${Input ? `"Input": "${Input}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath}",` : ''}
+                    ${InputTransformer ? `"InputTransformer": ${InputTransformer},` : ''}
                     "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
                     "Id": "${scheduleId}"
                   }]
@@ -157,6 +164,24 @@ class AwsCompileScheduledEvents {
   validateScheduleSyntax(input) {
     return typeof input === 'string' &&
       (rateSyntaxPattern.test(input) || cronSyntaxPattern.test(input));
+  }
+
+  formatInputTransformer(inputTransformer) {
+    if (!inputTransformer.inputTemplate) {
+      throw new this.serverless.classes.Error(
+        'The inputTemplate key is required when specifying an ' +
+        'inputTransformer for a schedule event'
+      );
+    }
+    const cfmOutput = {
+      // InputTemplate is required
+      InputTemplate: inputTransformer.inputTemplate,
+    };
+    // InputPathsMap is optional
+    if (inputTransformer.inputPathsMap) {
+      cfmOutput.InputPathsMap = inputTransformer.inputPathsMap;
+    }
+    return JSON.stringify(cfmOutput);
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/schedule/index.test.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.test.js
@@ -405,6 +405,38 @@ describe('AwsCompileScheduledEvents', () => {
       ).to.equal('{"key":"value"}');
     });
 
+    it('should respect inputTransformer variable', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
+                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileScheduledEvents.compileScheduledEvents();
+
+      expect(awsCompileScheduledEvents.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleSchedule1
+        .Properties.Targets[0].InputTransformer
+      ).to.eql({
+        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+        InputPathsMap: { eventTime: '$.time' },
+      });
+    });
+
+
     it('should throw an error when both Input and InputPath are set', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
@@ -417,6 +449,32 @@ describe('AwsCompileScheduledEvents', () => {
                   key: 'value',
                 },
                 inputPath: '$.stageVariables',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+    });
+
+    it('should throw an error when both Input and InputTransformer are set', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                input: {
+                  key: 'value',
+                },
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
+                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+                },
               },
             },
           ],
@@ -456,6 +514,28 @@ describe('AwsCompileScheduledEvents', () => {
                 enabled: false,
                 input: {
                   body: 'an invalid input body',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(Error);
+    });
+
+    it('should throw an error when inputTransformer does not have inputTemplate', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
                 },
               },
             },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->



<!--
Briefly describe the feature if no issue exists for this PR
-->

Support for specifying the InputTransformer option for cloudwatch events.


<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

The code is pretty self-explanatory, but it simply allows inputTransformer option to be mapped to the [cloudformation InputTransformer spec](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-inputtransformer.html#cfn-events-rule-inputtransformer-inputpathsmap) in both the schedule and cloudwatchEvent events.


```yaml
service: input-transformer-example

provider:
  name: aws
  runtime: nodejs8.10
  region: us-east-1

functions:
  printEvent:
    description: Simply logs the event
    handler: printEvent.handler
    events:
      - schedule:
          name: everyMinute
          rate: rate(1 minute)
          enabled: true
          inputTransformer:
            inputPathsMap:
              eventTime: '$.time'
            inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
```

```
// printEvent.js
module.exports = {
    handler: async (event, config) => console.log(event),
}
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->


- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO