### PR TITLE
Fixed typo "disonnect"

### DIFF
--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -36,7 +36,7 @@ This code will setup a websocket with a `$disconnect` route key:
 
 ```yml
 functions:
-  disonnectHandler:
+  disconnectHandler:
     handler: handler.disconnectHandler
     events:
       - websocket:


### PR DESCRIPTION
The PR template said not to delete it, but I did. Sorry. This is just a 1 character change, a typo in the docs. Surely I don't have to fill all that out? Seems code-PR oriented.