### PR TITLE
Add unit tests for getLocalAccessKey function

### DIFF
--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -829,4 +829,88 @@ describe('Utils', () => {
       });
     });
   });
+
+  describe('#getLocalAccessKey()', () => {
+    let getConfigStub;
+    let getGlobalConfigStub;
+
+    beforeEach(() => {
+      getConfigStub = sinon.stub(configUtils, 'getConfig');
+      getGlobalConfigStub = sinon.stub(configUtils, 'getGlobalConfig');
+    });
+
+    afterEach(() => {
+      configUtils.getConfig.restore();
+      configUtils.getGlobalConfig.restore();
+    });
+
+    it('should return false if a user could not be found globally', () => {
+      getConfigStub.returns({
+        userId: 123456,
+      });
+      getGlobalConfigStub.returns({});
+
+      const res = utils.getLocalAccessKey();
+
+      expect(res).to.equal(false);
+    });
+
+    it('should return false if a user could be found globally but no locally', () => {
+      getConfigStub.returns({});
+      getGlobalConfigStub.returns({
+        users: {
+          123456: {
+            dashboard: {
+              accessKey: 'd45hb04rd4cc3ssk3y',
+            },
+          },
+        },
+      });
+
+      const res = utils.getLocalAccessKey();
+      expect(res).to.equal(false);
+    });
+
+    it('should return false if a user could be found but the dashboard config is missing', () => {
+      getConfigStub.returns({ userId: 123456 });
+      getGlobalConfigStub.returns({
+        users: {
+          123456: {},
+        },
+      });
+
+      const res = utils.getLocalAccessKey();
+      expect(res).to.equal(false);
+    });
+
+    it('should return false if a user could be found but the accessKey config is missing', () => {
+      getConfigStub.returns({ userId: 123456 });
+      getGlobalConfigStub.returns({
+        users: {
+          123456: {
+            dashboard: {},
+          },
+        },
+      });
+
+      const res = utils.getLocalAccessKey();
+      expect(res).to.equal(false);
+    });
+
+    it('should return the users dasboard access key if config can be found', () => {
+      getConfigStub.returns({ userId: 123456 });
+      getGlobalConfigStub.returns({
+        users: {
+          123456: {
+            dashboard: {
+              accessKey: 'd45hb04rd4cc3ssk3y',
+            },
+          },
+        },
+      });
+
+      const res = utils.getLocalAccessKey();
+      expect(res).to.equal('d45hb04rd4cc3ssk3y');
+    });
+  });
 });


### PR DESCRIPTION
Adds test for the `getLocalAccessKey` function in the `Utils` class. This PR is a preparation to merge https://github.com/serverless/serverless/pull/5335