### PR TITLE
Document changes from #4951

### DIFF
--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -104,6 +104,8 @@ provider:
   runtime: nodejs6.10
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
+  stackName: my-custom-stack-name-${self:provider.stage} # Overwrite default CloudFormation stack name. Default is ${self:service}-${self:provider.stage}
+  apiName: my-custom-api-gateway-name-${self:provider.stage} # Overwrite default API Gateway name. Default is ${self:provider.stage}-${self:service}
   profile: production # The default profile to use with this service
   memorySize: 512 # Overwrite the default memory size. Default is 1024
   deploymentBucket:


### PR DESCRIPTION

## What did you implement:
Add `stackName` and `apiName` to `serveless.yml` example in docs. Documents feature added in #4951.

Was attempting to change my CloudFormation stack name the other day and found the PR adding the feature; however, I noticed there were no official docs for the change.

## How did you implement it:

## How can we verify it:

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
