### PR TITLE
Support setting both proxy and ca file for awsprovider AWS config agent

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -143,8 +143,9 @@ class AwsProvider {
       || process.env.HTTPS_PROXY
       || process.env.https_proxy;
 
+    const proxyOptions = {};
     if (proxy) {
-      AWS.config.httpOptions.agent = new HttpsProxyAgent(url.parse(proxy));
+      Object.assign(proxyOptions, url.parse(proxy));
     }
 
     const ca = process.env.ca
@@ -171,12 +172,18 @@ class AwsProvider {
     }
 
     if (caCerts.length > 0) {
-      const caOptions = {
+      Object.assign(proxyOptions, {
         rejectUnauthorized: true,
         ca: caCerts,
-      };
+      });
+    }
+
+    // Passes also certifications
+    if (proxy) {
+      AWS.config.httpOptions.agent = new HttpsProxyAgent(proxyOptions);
+    } else if (proxyOptions.ca) {
       // Update the agent -- http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-registering-certs.html
-      AWS.config.httpOptions.agent = new https.Agent(caOptions);
+      AWS.config.httpOptions.agent = new https.Agent(proxyOptions);
     }
 
     // Configure the AWS Client timeout (Optional).  The default is 120000 (2 minutes)

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -142,6 +142,15 @@ describe('AwsProvider', () => {
         expect(typeof newAwsProvider.sdk.config.httpOptions.agent).to.not.equal('undefined');
       });
 
+      it('should set AWS ca single and proxy', () => {
+        process.env.ca = '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----';
+        process.env.proxy = 'http://a.b.c.d:n';
+
+        const newAwsProvider = new AwsProvider(serverless, options);
+
+        expect(typeof newAwsProvider.sdk.config.httpOptions.agent).to.not.equal('undefined');
+      });
+
       it('should set AWS ca multiple', () => {
         const certContents = '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----';
         process.env.ca = `${certContents},${certContents}`;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5561

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

I tested with https://www.charlesproxy.com/ proxy.

I setup proxy to localhost:8888 and downloaded charles root certificate from the help menu.
 Then ran command
 `env https_cafile=charles-ssl-proxying-certificate.pem  proxy='http://localhost:8888' ../bin/serverless deploy`

with a sample project. It gives forbidden   `ServerlessError: The security token included in the request is invalid.` since I tested with invalid key(to not accidently deploying)

![image](https://user-images.githubusercontent.com/16050765/55108144-98047680-50db-11e9-8353-80cfed6d45ad.png)

So the https connection with proxy and custom certificate seems to work.




<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
