### PR TITLE
AWS API Gateway request body validation

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -24,6 +24,7 @@ layout: Doc
     - [Setting API keys for your Rest API](#setting-api-keys-for-your-rest-api)
     - [Configuring endpoint types](#configuring-endpoint-types)
     - [Request Parameters](#request-parameters)
+    - [Request Schema Validation](#request-schema-validation)
     - [Setting source of API key for metering requests](#setting-source-of-api-key-for-metering-requests)
   - [Lambda Integration](#lambda-integration)
     - [Example "LAMBDA" event (before customization)](#example-lambda-event-before-customization)
@@ -639,6 +640,47 @@ functions:
             parameters:
               paths:
                 id: true
+```
+
+### Request Schema Validators
+
+To use request schema validation with API gateway, add the [JSON Schema](https://json-schema.org/)
+for your content type. Since JSON Schema is represented in JSON, it's easier to include it from a
+file.
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          request:
+            schema:
+              application/json: ${file(create_request.json)}
+```
+
+A sample schema contained in `create_request.json` might look something like this:
+
+```json
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "username"
+  ],
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "The Foo Schema",
+      "default": "",
+      "pattern": "^[a-zA-Z0-9]+$"
+    }
+  }
+}
 ```
 
 ### Setting source of API key for metering requests

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -683,6 +683,9 @@ A sample schema contained in `create_request.json` might look something like thi
 }
 ```
 
+**NOTE:** schema validators are only applied to content types you specify. Other content types are
+not blocked.
+
 ### Setting source of API key for metering requests
 
 API Gateway provide a feature for metering your API's requests and you can choice [the source of key](https://docs.aws.amazon.com/apigateway/api-reference/resource/rest-api/#apiKeySource) which is used for metering. If you want to acquire that key from the request's X-API-Key header, set option like this:

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -242,6 +242,13 @@ module.exports = {
   getMethodLogicalId(resourceId, methodName) {
     return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}`;
   },
+  getValidatorLogicalId(resourceId, methodName) {
+    return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}Validator`;
+  },
+  getModelLogicalId(resourceId, methodName, contentType) {
+    return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}${_.startCase(
+      contentType).replace(' ', '')}Model`;
+  },
   getApiKeyLogicalId(apiKeyNumber, apiKeyName) {
     if (apiKeyName) {
       return `ApiGatewayApiKey${this.normalizeName(apiKeyName)}${apiKeyNumber}`;

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -243,10 +243,10 @@ module.exports = {
     return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}`;
   },
   getValidatorLogicalId(resourceId, methodName) {
-    return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}Validator`;
+    return `${this.getMethodLogicalId(resourceId, methodName)}Validator`;
   },
   getModelLogicalId(resourceId, methodName, contentType) {
-    return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}${_.startCase(
+    return `${this.getMethodLogicalId(resourceId, methodName)}${_.startCase(
       contentType).replace(' ', '')}Model`;
   },
   getApiKeyLogicalId(apiKeyNumber, apiKeyName) {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -390,6 +390,22 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getValidatorLogicalId()', () => {
+    it('', () => {
+      expect(sdk.naming.getValidatorLogicalId(
+        'ResourceId', 'get'
+      )).to.equal('ApiGatewayMethodResourceIdGetValidator');
+    });
+  });
+
+  describe('#getModelLogicalId()', () => {
+    it('', () => {
+      expect(sdk.naming.getModelLogicalId(
+        'ResourceId', 'get', 'application/json'
+      )).to.equal('ApiGatewayMethodResourceIdGetApplicationJsonModel');
+    });
+  });
+
   describe('#getApiKeyLogicalId(keyIndex)', () => {
     it('should produce the given index with ApiGatewayApiKey as a prefix', () => {
       expect(sdk.naming.getApiKeyLogicalId(1)).to.equal('ApiGatewayApiKey1');

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -68,7 +68,9 @@ module.exports = {
       this.apiGatewayMethodLogicalIds.push(methodLogicalId);
 
       if (event.http.request && event.http.request.schema) {
-        for (const [contentType, schema] of _.entries(event.http.request.schema)) {
+        for (const requestSchema of _.entries(event.http.request.schema)) {
+          const contentType = requestSchema[0];
+          const schema = requestSchema[1];
           template.Properties.RequestValidatorId = { Ref: `${methodLogicalId}Validator` };
           template.Properties.RequestModels = {
             [contentType]: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -67,34 +67,38 @@ module.exports = {
 
       this.apiGatewayMethodLogicalIds.push(methodLogicalId);
 
-      if (event.http.schema) {
-        template.Properties.RequestValidatorId = { Ref: `${methodLogicalId}Validator` };
-        template.Properties.RequestModels = {
-          'application/json': { Ref: `${methodLogicalId}Model` },
-        };
+      if (event.http.request && event.http.request.schema) {
+        for (const [contentType, schema] of _.entries(event.http.request.schema)) {
+          template.Properties.RequestValidatorId = { Ref: `${methodLogicalId}Validator` };
+          template.Properties.RequestModels = {
+            [contentType]: {
+              Ref: `${methodLogicalId}${_.startCase(contentType).replace(' ', '')}Model`,
+            },
+          };
 
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
-          [`${methodLogicalId}Model`]: {
-            Type: 'AWS::ApiGateway::Model',
-            Properties: {
-              RestApiId: {
-                Ref: 'ApiGatewayRestApi',
+          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+            [`${methodLogicalId}${_.startCase(contentType).replace(' ', '')}Model`]: {
+              Type: 'AWS::ApiGateway::Model',
+              Properties: {
+                RestApiId: {
+                  Ref: 'ApiGatewayRestApi',
+                },
+                ContentType: contentType,
+                Schema: schema,
               },
-              ContentType: 'application/json',
-              Schema: event.http.schema,
             },
-          },
-          [`${methodLogicalId}Validator`]: {
-            Type: 'AWS::ApiGateway::RequestValidator',
-            Properties: {
-              RestApiId: {
-                Ref: 'ApiGatewayRestApi',
+            [`${methodLogicalId}Validator`]: {
+              Type: 'AWS::ApiGateway::RequestValidator',
+              Properties: {
+                RestApiId: {
+                  Ref: 'ApiGatewayRestApi',
+                },
+                ValidateRequestBody: true,
+                ValidateRequestParameters: true,
               },
-              ValidateRequestBody: true,
-              ValidateRequestParameters: false,
             },
-          },
-        });
+          });
+        }
       }
 
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -67,6 +67,36 @@ module.exports = {
 
       this.apiGatewayMethodLogicalIds.push(methodLogicalId);
 
+      if (event.http.schema) {
+        template.Properties.RequestValidatorId = { Ref: `${methodLogicalId}Validator` };
+        template.Properties.RequestModels = {
+          'application/json': { Ref: `${methodLogicalId}Model` },
+        };
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          [`${methodLogicalId}Model`]: {
+            Type: 'AWS::ApiGateway::Model',
+            Properties: {
+              RestApiId: {
+                Ref: 'ApiGatewayRestApi',
+              },
+              ContentType: 'application/json',
+              Schema: event.http.schema,
+            },
+          },
+          [`${methodLogicalId}Validator`]: {
+            Type: 'AWS::ApiGateway::RequestValidator',
+            Properties: {
+              RestApiId: {
+                Ref: 'ApiGatewayRestApi',
+              },
+              ValidateRequestBody: true,
+              ValidateRequestParameters: false,
+            },
+          },
+        });
+      }
+
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [methodLogicalId]: template,
       });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -30,6 +30,8 @@ module.exports = {
 
       const methodLogicalId = this.provider.naming
         .getMethodLogicalId(resourceName, event.http.method);
+      const validatorLogicalId = this.provider.naming
+        .getValidatorLogicalId(resourceName, event.http.method);
       const lambdaLogicalId = this.provider.naming
         .getLambdaLogicalId(event.functionName);
 
@@ -71,29 +73,29 @@ module.exports = {
         for (const requestSchema of _.entries(event.http.request.schema)) {
           const contentType = requestSchema[0];
           const schema = requestSchema[1];
-          template.Properties.RequestValidatorId = { Ref: `${methodLogicalId}Validator` };
-          template.Properties.RequestModels = {
-            [contentType]: {
-              Ref: `${methodLogicalId}${_.startCase(contentType).replace(' ', '')}Model`,
-            },
-          };
+
+          const modelLogicalId = this.provider.naming
+            .getModelLogicalId(resourceName, event.http.method, contentType);
+
+          template.Properties.RequestValidatorId = { Ref: validatorLogicalId };
+          template.Properties.RequestModels = { [contentType]: { Ref: modelLogicalId } };
 
           _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
-            [`${methodLogicalId}${_.startCase(contentType).replace(' ', '')}Model`]: {
+            [modelLogicalId]: {
               Type: 'AWS::ApiGateway::Model',
               Properties: {
                 RestApiId: {
-                  Ref: 'ApiGatewayRestApi',
+                  Ref: this.provider.naming.getRestApiLogicalId(),
                 },
                 ContentType: contentType,
                 Schema: schema,
               },
             },
-            [`${methodLogicalId}Validator`]: {
+            [validatorLogicalId]: {
               Type: 'AWS::ApiGateway::RequestValidator',
               Properties: {
                 RestApiId: {
-                  Ref: 'ApiGatewayRestApi',
+                  Ref: this.provider.naming.getRestApiLogicalId(),
                 },
                 ValidateRequestBody: true,
                 ValidateRequestParameters: true,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -65,18 +65,7 @@ describe('#compileMethods()', () => {
           path: 'users/create',
           method: 'post',
           integration: 'AWS',
-          request: {
-            schema: {
-              'application/json': {foo: 'bar'}
-            },
-          },
-          response: {
-            statusCodes: {
-              200: {
-                pattern: '',
-              },
-            },
-          },
+          request: { schema: { 'application/json': { foo: 'bar' } } },
         },
       },
     ];
@@ -87,7 +76,7 @@ describe('#compileMethods()', () => {
       ).to.deep.equal({
         Type: 'AWS::ApiGateway::RequestValidator',
         Properties: {
-          RestApiId: { Ref: "ApiGatewayRestApi" },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
           ValidateRequestBody: true,
           ValidateRequestParameters: true,
         },
@@ -98,9 +87,9 @@ describe('#compileMethods()', () => {
       ).to.deep.equal({
         Type: 'AWS::ApiGateway::Model',
         Properties: {
-          RestApiId: { Ref: "ApiGatewayRestApi" },
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
           ContentType: 'application/json',
-          Schema: {foo: 'bar'},
+          Schema: { foo: 'bar' },
         },
       });
       expect(
@@ -112,7 +101,7 @@ describe('#compileMethods()', () => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersCreatePost.Properties.RequestValidatorId
-      ).to.deep.equal({Ref: 'ApiGatewayMethodUsersCreatePostValidator'});
+      ).to.deep.equal({ Ref: 'ApiGatewayMethodUsersCreatePostValidator' });
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -57,6 +57,65 @@ describe('#compileMethods()', () => {
     };
   });
 
+  it('should have request validators/models defined when they are set', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          integration: 'AWS',
+          request: {
+            schema: {
+              'application/json': {foo: 'bar'}
+            },
+          },
+          response: {
+            statusCodes: {
+              200: {
+                pattern: '',
+              },
+            },
+          },
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePostValidator
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::RequestValidator',
+        Properties: {
+          RestApiId: { Ref: "ApiGatewayRestApi" },
+          ValidateRequestBody: true,
+          ValidateRequestParameters: true,
+        },
+      });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePostApplicationJsonModel
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::Model',
+        Properties: {
+          RestApiId: { Ref: "ApiGatewayRestApi" },
+          ContentType: 'application/json',
+          Schema: {foo: 'bar'},
+        },
+      });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.RequestModels
+      ).to.deep.equal({
+        'application/json': { Ref: 'ApiGatewayMethodUsersCreatePostApplicationJsonModel' },
+      });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.RequestValidatorId
+      ).to.deep.equal({Ref: 'ApiGatewayMethodUsersCreatePostValidator'});
+    });
+  });
+
   it('should have request parameters defined when they are set', () => {
     awsCompileApigEvents.validated.events = [
       {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -98,7 +98,9 @@ module.exports = {
             if (http.request) {
               const keys = Object.keys(http.request);
               const allowedKeys =
-                http.integration === 'AWS_PROXY' ? ['parameters'] : ['parameters', 'uri'];
+                http.integration === 'AWS_PROXY'
+                  ? ['parameters', 'schema']
+                  : ['parameters', 'uri', 'schema'];
 
               if (!_.isEmpty(_.difference(keys, allowedKeys))) {
                 const requestWarningMessage = [


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Added support for JSONSchema request body validation with API Gateway, Closing #3464. Reading the various docs for request validation(notably with CloudFormation), I couldn't quite understand how parameter or header validation would work. Any input regarding this implementation or how param/header validation would work is greatly appreciated.

Closes #3464

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
When you add a `schema` containing JSON schema to an HTTP event, the following are added:
* `AWS::ApiGateway::Model` with the schema specified
* `AWS::ApiGateway::RequestValidator` with `ValidateRequestBody: true` and attached to the `AWS::ApiGateway::RestApi` that serverless generates
* attach the model above to the `AWS::ApiGateway::Method` for the event

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
1. Install serverless from this branch: `npm i -g serverless/serverless#sls-3464`
2. Create a `serverless.yml` containing this:
```yaml
service: request-schema-test
provider:
  name: aws
  runtime: nodejs8.10
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: users/create
          method: post
          request:
            schema:
              application/json: ${file(create_request.json)}
```
3. Create a `create_request.json` containing the following json schema:
```json
{
  "definitions": {},
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "title": "The Root Schema",
  "required": [
    "username"
  ],
  "properties": {
    "username": {
      "type": "string",
      "title": "The Foo Schema",
      "default": "",
      "pattern": "^[a-zA-Z0-9]+$"
    }
  }
}
```
4. deploy! `sls deploy`
5. Test a valid body:
```
$ curl -X POST https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/users/create -H 'Content-Type: applica
tion/json' --data-binary '{"username":"fobar"}'
{"message":"Go Serverless v1.0! Your function executed successfully!","input":{"resource":"/users/create","path":"/users/create","httpM
ethod":"POST","headers":{"Accept":"*/*","CloudFront-Forwarded-Proto":"https","CloudFront-Is-Desktop-Viewer":"true","CloudFront-Is-Mobil
e-Viewer":"false","CloudFront-Is-SmartTV-Viewer":"false","CloudFront-Is-Tablet-Viewer":"false","CloudFront-Viewer-Country":"US","conten
t-type":"application/json","Host":"l9g362zco2.execute-api.us-east-1.amazonaws.com","User-Agent":"curl/7.54.0","Via":"2.0 170a9cb5b4951d
3141f3cdf6b50b780c.cloudfront.net (CloudFront)","X-Amz-Cf-Id":"hC0MNvDYecp6TysdX_LbcHU7U4NMdl8AcAmLNQW7fFMWJtLKsW0bLw==","X-Amzn-Trace-
Id":"Root=1-5c9a2fbf-844aa8f755339602ea3fdc6a","X-Forwarded-For":"96.86.1.5, 70.132.59.151","X-Forwarded-Port":"443","X-Forwarded-Proto
":"https"},"multiValueHeaders":{"Accept":["*/*"],"CloudFront-Forwarded-Proto":["https"],"CloudFront-Is-Desktop-Viewer":["true"],"CloudF
ront-Is-Mobile-Viewer":["false"],"CloudFront-Is-SmartTV-Viewer":["false"],"CloudFront-Is-Tablet-Viewer":["false"],"CloudFront-Viewer-Co
untry":["US"],"content-type":["application/json"],"Host":["l9g362zco2.execute-api.us-east-1.amazonaws.com"],"User-Agent":["curl/7.54.0"
],"Via":["2.0 170a9cb5b4951d3141f3cdf6b50b780c.cloudfront.net (CloudFront)"],"X-Amz-Cf-Id":["hC0MNvDYecp6TysdX_LbcHU7U4NMdl8AcAmLNQW7fF
MWJtLKsW0bLw=="],"X-Amzn-Trace-Id":["Root=1-5c9a2fbf-844aa8f755339602ea3fdc6a"],"X-Forwarded-For":["96.86.1.5, 70.132.59.151"],"X-Forwa
rded-Port":["443"],"X-Forwarded-Proto":["https"]},"queryStringParameters":null,"multiValueQueryStringParameters":null,"pathParameters":
null,"stageVariables":null,"requestContext":{"resourceId":"54yhea","resourcePath":"/users/create","httpMethod":"POST","extendedRequestI
d":"XJxl5FjTIAMF3EQ=","requestTime":"26/Mar/2019:13:57:19 +0000","path":"/dev/users/create","accountId":"490103061721","protocol":"HTTP
/1.1","stage":"dev","domainPrefix":"l9g362zco2","requestTimeEpoch":1553608639379,"requestId":"1234deb3-4fcf-11e9-b124-6949ca7fd2f1","id
entity":{"cognitoIdentityPoolId":null,"accountId":null,"cognitoIdentityId":null,"caller":null,"sourceIp":"96.86.1.5","accessKey":null,"
cognitoAuthenticationType":null,"cognitoAuthenticationProvider":null,"userArn":null,"userAgent":"curl/7.54.0","user":null},"domainName"
:"l9g362zco2.execute-api.us-east-1.amazonaws.com","apiId":"l9g362zco2"},"body":"{\"username\":\"fobar\"}","isBase64Encoded":false}}
```
6. Test an invalid body:
```
$ curl -X POST https://l9g362zco2.execute-api.us-east-1.amazonaws.com/dev/users/create -H 'Content-Type: applica
tion/json' --data-binary '{"username":"fo-bar"}'
{"message": "Invalid request body"}
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
