### PR TITLE
Add error message when provider does not exist

### DIFF
--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -105,6 +105,11 @@ class Deploy {
     this.hooks = {
       'before:deploy:deploy': () => BbPromise.bind(this)
         .then(() => {
+          const provider = this.serverless.service.provider.name;
+          if (!this.serverless.getProvider(provider)) {
+            const errorMessage = `The specified provider "${provider}" does not exist.`;
+            return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
+          }
           if (this.options.function) {
             // If the user has given a function parameter, spawn a function deploy
             // and terminate execution right afterwards. We did not enter the

--- a/lib/plugins/deploy/deploy.test.js
+++ b/lib/plugins/deploy/deploy.test.js
@@ -20,6 +20,8 @@ describe('Deploy', () => {
     serverless = new Serverless();
     options = {};
     deploy = new Deploy(serverless, options);
+    deploy.serverless.providers = { validProvider: true };
+    deploy.serverless.service.provider.name = 'validProvider';
   });
 
   describe('#constructor()', () => {
@@ -89,6 +91,14 @@ describe('Deploy', () => {
           }
         ),
       ]));
+    });
+
+    it('should throw an error if provider does not exist', () => {
+      deploy.serverless.service.provider.name = 'nonExistentProvider';
+
+      return expect(deploy.hooks['before:deploy:deploy']()).to.be.rejectedWith(
+        'The specified provider "nonExistentProvider" does not exist.'
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5876.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I added a check in the `before:deploy:deploy` hook to check if the specified provider in `serverless.yml` exists, and to throw an error if it does not.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

1. Specify a non-existent provider in `serverless.yml`:
```yaml
provider:
  name: nonExistentProvider
```
2. `serverless deploy` should throw an error:
```
  Serverless Error ---------------------------------------

  The specified provider "nonExistentProvider" does not exist.

```

## Todos:

- [X] Write tests
- [ ] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
