### PR TITLE
#5947: Ensure invoke local docker runs lambda with the dependencies

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -302,10 +302,10 @@ class AwsInvokeLocal {
         Object.keys(zip.files)
           .map(filename => zip.files[filename].async('nodebuffer').then(fileData => {
             if (filename.endsWith(path.sep)) {
+              mkdirp.sync(path.join(
+                '.serverless', 'invokeLocal', 'artifact', filename));
               return BbPromise.resolve();
             }
-            mkdirp.sync(path.join(
-              '.serverless', 'invokeLocal', 'artifact'));
             return fs.writeFileAsync(path.join(
               '.serverless', 'invokeLocal', 'artifact', filename), fileData, {
                 mode: zip.files[filename].unixPermissions,
@@ -319,24 +319,26 @@ class AwsInvokeLocal {
   invokeLocalDocker() {
     const handler = this.options.functionObj.handler;
 
-    return BbPromise.all([
-      this.checkDockerDaemonStatus(),
-      this.checkDockerImage().then(exists => (exists ? {} : this.pullDockerImage())),
-      this.getLayerPaths().then(layerPaths => this.buildDockerImage(layerPaths)),
-      this.extractArtifact(),
-    ])
-      .then((results) => new BbPromise((resolve, reject) => {
-        const imageName = results[2];
-        const artifactPath = results[3];
-        const dockerArgs = [
-          'run', '--rm', '-v', `${artifactPath}:/var/task`, imageName,
-          handler, JSON.stringify(this.options.data),
-        ];
-        const docker = spawn('docker', dockerArgs);
-        docker.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
-        docker.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
-        docker.on('exit', error => (error ? reject(error) : resolve(imageName)));
-      }));
+    return this.serverless.pluginManager.spawn('package').then(() =>
+      BbPromise.all([
+        this.checkDockerDaemonStatus(),
+        this.checkDockerImage().then(exists => (exists ? {} : this.pullDockerImage())),
+        this.getLayerPaths().then(layerPaths => this.buildDockerImage(layerPaths)),
+        this.extractArtifact(),
+      ])
+        .then((results) => new BbPromise((resolve, reject) => {
+          const imageName = results[2];
+          const artifactPath = results[3];
+          const dockerArgs = [
+            'run', '--rm', '-v', `${artifactPath}:/var/task`, imageName,
+            handler, JSON.stringify(this.options.data),
+          ];
+          const docker = spawn('docker', dockerArgs);
+          docker.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
+          docker.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
+          docker.on('exit', error => (error ? reject(error) : resolve(imageName)));
+        }))
+    );
   }
 
   invokeLocalPython(runtime, handlerPath, handlerName, event, context) {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -306,6 +306,8 @@ class AwsInvokeLocal {
                 '.serverless', 'invokeLocal', 'artifact', filename));
               return BbPromise.resolve();
             }
+            mkdirp.sync(path.join(
+              '.serverless', 'invokeLocal', 'artifact'));
             return fs.writeFileAsync(path.join(
               '.serverless', 'invokeLocal', 'artifact', filename), fileData, {
                 mode: zip.files[filename].unixPermissions,

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -302,12 +302,10 @@ class AwsInvokeLocal {
         Object.keys(zip.files)
           .map(filename => zip.files[filename].async('nodebuffer').then(fileData => {
             if (filename.endsWith(path.sep)) {
-              mkdirp.sync(path.join(
-                '.serverless', 'invokeLocal', 'artifact', filename));
               return BbPromise.resolve();
             }
             mkdirp.sync(path.join(
-              '.serverless', 'invokeLocal', 'artifact'));
+              '.serverless', 'invokeLocal', 'artifact', path.dirname(filename)));
             return fs.writeFileAsync(path.join(
               '.serverless', 'invokeLocal', 'artifact', filename), fileData, {
                 mode: zip.files[filename].unixPermissions,

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1118,6 +1118,8 @@ describe('AwsInvokeLocal', () => {
   describe('#invokeLocalDocker()', () => {
     let awsInvokeLocalMocked;
     let spawnStub;
+    let pluginMangerSpawnStub;
+    let pluginMangerSpawnPackageStub;
 
     beforeEach(() => {
       awsInvokeLocal.provider.options.stage = 'dev';
@@ -1162,16 +1164,22 @@ describe('AwsInvokeLocal', () => {
         },
         data: {},
       };
+
+      pluginMangerSpawnStub = sinon
+        .stub(serverless.pluginManager, 'spawn');
+      pluginMangerSpawnPackageStub = pluginMangerSpawnStub.withArgs('package').resolves();
     });
 
 
     afterEach(() => {
       delete require.cache[require.resolve('./index')];
       delete require.cache[require.resolve('child_process')];
+      serverless.pluginManager.spawn.restore();
     });
 
-    it('calls docker', () =>
+    it('calls docker with packaged artifact', () =>
       awsInvokeLocalMocked.invokeLocalDocker().then(() => {
+        expect(pluginMangerSpawnPackageStub.calledOnce).to.equal(true);
         expect(spawnStub.getCall(0).args).to.deep.equal(['docker', ['version']]);
         expect(spawnStub.getCall(1).args).to.deep.equal(['docker',
           ['images', '-q', 'lambci/lambda:nodejs8.10']]);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5947

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- The invoke local command runs `package` command before invoking docker. The `package` command as usual ensures dependencies are included in package
- The `package` command sets the `service.package.artifact` path to generated package path. This way `extractArtifact()` unzips the packaged artifact into docker before running the handler
- During this fix, I noticed an issue with `extractArtifact` where it fails to unzip folder with subfolder. This has been fixed by ensuring subfolder is created before creating the file in the subfolder

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

`serverless.yml`
```yml
service: dependency-bug

provider:
  name: aws
  runtime: python2.7

functions:
  hello:
    handler: handler.hello

plugins:
  - serverless-python-requirements
```

`handler.py`
```py
import os
import dns.resolver

def hello(event, context):
    return "hello"
```

```sh
npm install -g github:endeepak/serverless#bugfix/5947_invoke_local_handle_dependency
# The below command should not raise import error as it used to do before this fix
sls invoke local -f hello --docker 
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
