### PR TITLE
#5945: Invoke local docker to pass env vars to lambda container

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -103,6 +103,12 @@ class AwsInvokeLocal {
     });
   }
 
+  getConfiguredEnvVars() {
+    const providerEnvVars = this.serverless.service.provider.environment || {};
+    const functionEnvVars = this.options.functionObj.environment || {};
+    return _.merge(providerEnvVars, functionEnvVars);
+  }
+
   loadEnvVars() {
     const lambdaName = this.options.functionObj.name;
     const memorySize = Number(this.options.functionObj.memorySize)
@@ -130,10 +136,9 @@ class AwsInvokeLocal {
       lambdaDefaultEnvVars.AWS_PROFILE = profileOverride;
     }
 
-    const providerEnvVars = this.serverless.service.provider.environment || {};
-    const functionEnvVars = this.options.functionObj.environment || {};
+    const configuredEnvVars = this.getConfiguredEnvVars();
 
-    _.merge(process.env, lambdaDefaultEnvVars, providerEnvVars, functionEnvVars);
+    _.merge(process.env, lambdaDefaultEnvVars, configuredEnvVars);
 
     return BbPromise.resolve();
   }
@@ -315,6 +320,16 @@ class AwsInvokeLocal {
         this.serverless.config.servicePath, '.serverless', 'invokeLocal', 'artifact'));
   }
 
+  getEnvVarsFromOptions() {
+    const envVarsFromOptions = {};
+    // Get the env vars from command line options in the form of --env KEY=value
+    _.concat(this.options.env || [])
+    .forEach(itm => {
+      const splitItm = _.split(itm, '=');
+      envVarsFromOptions[splitItm[0]] = splitItm.slice(1, splitItm.length).join('=') || '';
+    });
+    return envVarsFromOptions;
+  }
 
   invokeLocalDocker() {
     const handler = this.options.functionObj.handler;
@@ -328,10 +343,17 @@ class AwsInvokeLocal {
       .then((results) => new BbPromise((resolve, reject) => {
         const imageName = results[2];
         const artifactPath = results[3];
-        const dockerArgs = [
-          'run', '--rm', '-v', `${artifactPath}:/var/task`, imageName,
-          handler, JSON.stringify(this.options.data),
-        ];
+        const configuredEnvVars = this.getConfiguredEnvVars();
+        const envVarsFromOptions = this.getEnvVarsFromOptions();
+        const envVars = _.merge(configuredEnvVars, envVarsFromOptions);
+        const envVarsDockerArgs = _.flatMap(envVars,
+          (value, key) => ['--env', `${key}=${value}`]
+        );
+        const dockerArgs = _.concat([
+          'run', '--rm', '-v', `${artifactPath}:/var/task`,
+        ], envVarsDockerArgs, [
+          imageName, handler, JSON.stringify(this.options.data),
+        ]);
         const docker = spawn('docker', dockerArgs);
         docker.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
         docker.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1151,6 +1151,9 @@ describe('AwsInvokeLocal', () => {
       serverless.setProvider('aws', new AwsProvider(serverless, options));
       awsInvokeLocalMocked = new AwsInvokeLocalMocked(serverless, options);
 
+      serverless.service.provider.environment = {
+        providerVar: 'providerValue',
+      };
       awsInvokeLocalMocked.options = {
         stage: 'dev',
         function: 'first',
@@ -1159,8 +1162,12 @@ describe('AwsInvokeLocal', () => {
           name: 'hello',
           timeout: 4,
           runtime: 'nodejs8.10',
+          environment: {
+            functionVar: 'functionValue',
+          },
         },
         data: {},
+        env: 'commandLineEnvVar=commandLineEnvVarValue',
       };
     });
 
@@ -1190,11 +1197,59 @@ describe('AwsInvokeLocal', () => {
           '--rm',
           '-v',
           'servicePath:/var/task',
+          '--env',
+          'providerVar=providerValue',
+          '--env',
+          'functionVar=functionValue',
+          '--env',
+          'commandLineEnvVar=commandLineEnvVarValue',
           'sls-docker',
           'handler.hello',
           '{}',
         ]]);
       })
     );
+  });
+
+  describe('#getEnvVarsFromOptions', () => {
+    it('returns empty object when env option is not set', () => {
+      delete awsInvokeLocal.options.env;
+
+      const envVarsFromOptions = awsInvokeLocal.getEnvVarsFromOptions();
+
+      expect(envVarsFromOptions).to.be.eql({});
+    });
+
+    it('returns empty object when env option empty', () => {
+      awsInvokeLocal.options.env = '';
+
+      const envVarsFromOptions = awsInvokeLocal.getEnvVarsFromOptions();
+
+      expect(envVarsFromOptions).to.be.eql({});
+    });
+
+    it('returns key value for option separated by =', () => {
+      awsInvokeLocal.options.env = 'SOME_ENV_VAR=some-value';
+
+      const envVarsFromOptions = awsInvokeLocal.getEnvVarsFromOptions();
+
+      expect(envVarsFromOptions).to.be.eql({ SOME_ENV_VAR: 'some-value' });
+    });
+
+    it('returns key with empty value for option without =', () => {
+      awsInvokeLocal.options.env = 'SOME_ENV_VAR';
+
+      const envVarsFromOptions = awsInvokeLocal.getEnvVarsFromOptions();
+
+      expect(envVarsFromOptions).to.be.eql({ SOME_ENV_VAR: '' });
+    });
+
+    it('returns key with single value for option multiple =s', () => {
+      awsInvokeLocal.options.env = 'SOME_ENV_VAR=value1=value2';
+
+      const envVarsFromOptions = awsInvokeLocal.getEnvVarsFromOptions();
+
+      expect(envVarsFromOptions).to.be.eql({ SOME_ENV_VAR: 'value1=value2' });
+    });
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5945

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
- The environment variables configured at provider level, service level and from command line options are passed to docker container using `--env` option for `docker run` command

## How can we verify it:

`serverless.yml`
```yml
service: env-var-bug

provider:
  name: aws
  runtime: python2.7
  environment:
    SOME_ENV_VAR: some-value

functions:
  hello:
    handler: handler.hello
```

`handler.py`
```py
import os

def hello(event, context):
    return os.environ['SOME_ENV_VAR']
```

```sh
npm install -g github:endeepak/serverless#bugfix/5945_invoke_local_docker_env_vars
sls invoke local -f hello --docker
# should not fail and show output -> "some-value"
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
