### PR TITLE
#5993: Ability to pass args for docker run command during invoke local docker

### DIFF
--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -31,6 +31,7 @@ serverless invoke local --function functionName
 * `--env` or `-e` String representing an environment variable to set when invoking your function, in the form `<name>=<value>`. Can be repeated for more than one environment variable.
 * `--docker` Enable docker support for NodeJS/Python/Ruby/Java. Enabled by default for other
   runtimes.
+* `--docker-arg` Pass additional arguments to docker run command when `--docker` is option used. e.g. `--docker-arg '-p 9229:9229' --docker-arg '-v /var:/host_var'`
 
 ## Environment
 

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -343,12 +343,10 @@ class AwsInvokeLocal {
 
   getDockerArgsFromOptions() {
     const dockerArgOptions = this.options['docker-arg'];
-    const dockerArgsFromOptions = _
-      .concat(dockerArgOptions || [])
-      .flatMap((dockerArgOption) => {
-        const splitItems = dockerArgOption.split(' ');
-        return [splitItems[0], splitItems.slice(1).join(' ')];
-      });
+    const dockerArgsFromOptions = _.flatMap(_.concat(dockerArgOptions || []), (dockerArgOption) => {
+      const splitItems = dockerArgOption.split(' ');
+      return [splitItems[0], splitItems.slice(1).join(' ')];
+    });
     return dockerArgsFromOptions;
   }
 

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -328,15 +328,28 @@ class AwsInvokeLocal {
       .then((results) => new BbPromise((resolve, reject) => {
         const imageName = results[2];
         const artifactPath = results[3];
-        const dockerArgs = [
-          'run', '--rm', '-v', `${artifactPath}:/var/task`, imageName,
-          handler, JSON.stringify(this.options.data),
-        ];
+        const dockerArgsFromOptions = this.getDockerArgsFromOptions();
+        const dockerArgs = _.concat([
+          'run', '--rm', '-v', `${artifactPath}:/var/task`,
+        ], dockerArgsFromOptions, [
+          imageName, handler, JSON.stringify(this.options.data),
+        ]);
         const docker = spawn('docker', dockerArgs);
         docker.stdout.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
         docker.stderr.on('data', (buf) => this.serverless.cli.consoleLog(buf.toString()));
         docker.on('exit', error => (error ? reject(error) : resolve(imageName)));
       }));
+  }
+
+  getDockerArgsFromOptions() {
+    const dockerArgOptions = this.options['docker-arg'];
+    const dockerArgsFromOptions = _
+      .concat(dockerArgOptions || [])
+      .flatMap((dockerArgOption) => {
+        const splitItems = dockerArgOption.split(' ');
+        return [splitItems[0], splitItems.slice(1).join(' ')];
+      });
+    return dockerArgsFromOptions;
   }
 
   invokeLocalPython(runtime, handlerPath, handlerName, event, context) {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1161,6 +1161,7 @@ describe('AwsInvokeLocal', () => {
           runtime: 'nodejs8.10',
         },
         data: {},
+        'docker-arg': '-p 9292:9292',
       };
     });
 
@@ -1190,11 +1191,47 @@ describe('AwsInvokeLocal', () => {
           '--rm',
           '-v',
           'servicePath:/var/task',
+          '-p',
+          '9292:9292',
           'sls-docker',
           'handler.hello',
           '{}',
         ]]);
       })
     );
+  });
+
+  describe('#getDockerArgsFromOptions', () => {
+    it('returns empty list when docker-arg option is absent', () => {
+      delete awsInvokeLocal.options['docker-arg'];
+
+      const dockerArgsFromOptions = awsInvokeLocal.getDockerArgsFromOptions();
+
+      expect(dockerArgsFromOptions).to.eql([]);
+    });
+
+    it('returns arg split by space when single docker-arg option is present', () => {
+      awsInvokeLocal.options['docker-arg'] = '-p 9229:9229';
+
+      const dockerArgsFromOptions = awsInvokeLocal.getDockerArgsFromOptions();
+
+      expect(dockerArgsFromOptions).to.eql(['-p', '9229:9229']);
+    });
+
+    it('returns args split by space when multiple docker-arg options are present', () => {
+      awsInvokeLocal.options['docker-arg'] = ['-p 9229:9229', '-v /var/logs:/host-var-logs'];
+
+      const dockerArgsFromOptions = awsInvokeLocal.getDockerArgsFromOptions();
+
+      expect(dockerArgsFromOptions).to.eql(['-p', '9229:9229', '-v', '/var/logs:/host-var-logs']);
+    });
+
+    it('returns arg split only by first space when docker-arg option has multiple space', () => {
+      awsInvokeLocal.options['docker-arg'] = '-v /My Docs:/docs';
+
+      const dockerArgsFromOptions = awsInvokeLocal.getDockerArgsFromOptions();
+
+      expect(dockerArgsFromOptions).to.eql(['-v', '/My Docs:/docs']);
+    });
   });
 });

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -88,6 +88,9 @@ class Invoke {
                 shortcut: 'e',
               },
               docker: { usage: 'Flag to turn on docker use for node/python/ruby/java' },
+              'docker-arg': {
+                usage: 'Arguments to docker run command. e.g. --docker-arg "-p 9229:9229"',
+              },
             },
 
           },


### PR DESCRIPTION

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5993 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added new option `--docker-arg` to pass additional arguments to docker run command used in `invoke local --docker`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

`serverless.yml`
```yml
service: debuggable-lambda

provider:
  name: aws
  runtime: nodejs8.10

functions:
  hello:
    handler: handler.hello
```

`handler.js`
```js
'use strict';

require('inspector').open(9229, "0.0.0.0", true);

module.exports.hello = async (event) => {
  debugger;
  let var_to_debug = "hello"
  return var_to_debug;
};
```
`.vscode/launch.json`
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node",
            "request": "attach",
            "name": "Attach",
            "port": 9229,
            "localRoot": "${workspaceFolder}",
            "remoteRoot": "/var/task"
        }       
    ]
}
```

## Example steps to debug with Visual Studio Code

* Run below commands
```sh
# Create above files in dir called debuggable-lambda
cd debuggable-lambda
# Open code in Visual Studio Code
code .
npm install -g github:endeepak/serverless#feature/5993_invoke_local_docker_arg
serverless invoke local -f hello --docker --docker-arg='-p 9229:9229'
```

* In Visual Studio Code -> Debug(Left Side Panel) -> Run Attach (Tool Bar)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
