### PR TITLE
Add additional Capability when Transform is detected

### DIFF
--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -28,8 +28,9 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    if (this.serverless.service.provider.compiledCloudFormationTemplate && this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
-      params.Capabilities.push('CAPABILITY_AUTO_EXPAND')
+    if (this.serverless.service.provider.compiledCloudFormationTemplate &&
+        this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
     }
 
     if (this.serverless.service.provider.cfnRole) {

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -28,6 +28,10 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
+    if (this.serverless.service.provider.compiledCloudFormationTemplate && this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND')
+    }
+
     if (this.serverless.service.provider.cfnRole) {
       params.RoleARN = this.serverless.service.provider.cfnRole;
     }

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -60,6 +60,19 @@ describe('createStack', () => {
       });
     });
 
+    it('should add CAPABILITY_AUTO_EXPAND if a Transform directive is specified', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {Transform: 'MyMacro'}
+
+      const createStackStub = sandbox
+        .stub(awsDeploy.provider, 'request').resolves();
+      sandbox.stub(awsDeploy, 'monitorStack').resolves();
+
+      return awsDeploy.create().then(() => {
+        expect(createStackStub.args[0][2].Capabilities)
+        .to.contain('CAPABILITY_AUTO_EXPAND');
+      });
+    });
+
     it('should use CloudFormation service role ARN if it is specified', () => {
       awsDeploy.serverless.service.provider.cfnRole = 'arn:aws:iam::123456789012:role/myrole';
 

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -61,7 +61,8 @@ describe('createStack', () => {
     });
 
     it('should add CAPABILITY_AUTO_EXPAND if a Transform directive is specified', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {Transform: 'MyMacro'}
+      awsDeploy.serverless.service.provider
+        .compiledCloudFormationTemplate = { Transform: 'MyMacro' };
 
       const createStackStub = sandbox
         .stub(awsDeploy.provider, 'request').resolves();

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -34,6 +34,10 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
+    if (this.serverless.service.provider.compiledCloudFormationTemplate && this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND')
+    }
+
     if (this.serverless.service.provider.cfnRole) {
       params.RoleARN = this.serverless.service.provider.cfnRole;
     }
@@ -72,6 +76,10 @@ module.exports = {
       TemplateURL: templateUrl,
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
+
+    if (this.serverless.service.provider.compiledCloudFormationTemplate && this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND')
+    }
 
     if (this.serverless.service.provider.cfnRole) {
       params.RoleARN = this.serverless.service.provider.cfnRole;

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -34,8 +34,9 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    if (this.serverless.service.provider.compiledCloudFormationTemplate && this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
-      params.Capabilities.push('CAPABILITY_AUTO_EXPAND')
+    if (this.serverless.service.provider.compiledCloudFormationTemplate &&
+        this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
     }
 
     if (this.serverless.service.provider.cfnRole) {
@@ -77,8 +78,9 @@ module.exports = {
       Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    if (this.serverless.service.provider.compiledCloudFormationTemplate && this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
-      params.Capabilities.push('CAPABILITY_AUTO_EXPAND')
+    if (this.serverless.service.provider.compiledCloudFormationTemplate &&
+        this.serverless.service.provider.compiledCloudFormationTemplate.Transform) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
     }
 
     if (this.serverless.service.provider.cfnRole) {

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -80,7 +80,8 @@ describe('updateStack', () => {
     });
 
     it('should add CAPABILITY_AUTO_EXPAND if a Transform directive is specified', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {Transform: 'MyMacro'}
+      awsDeploy.serverless.service.provider
+        .compiledCloudFormationTemplate = { Transform: 'MyMacro' };
 
       const createStackStub = sinon.stub(awsDeploy.provider, 'request').resolves();
       sinon.stub(awsDeploy, 'monitorStack').resolves();
@@ -88,8 +89,8 @@ describe('updateStack', () => {
       return awsDeploy.createFallback().then(() => {
         expect(createStackStub.args[0][2].Capabilities)
         .to.contain('CAPABILITY_AUTO_EXPAND');
-        awsDeploy.provider.request.restore()
-        awsDeploy.monitorStack.restore()
+        awsDeploy.provider.request.restore();
+        awsDeploy.monitorStack.restore();
       });
     });
 
@@ -190,7 +191,8 @@ describe('updateStack', () => {
     });
 
     it('should add CAPABILITY_AUTO_EXPAND if a Transform directive is specified', () => {
-      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {Transform: 'MyMacro'}
+      awsDeploy.serverless.service.provider
+        .compiledCloudFormationTemplate = { Transform: 'MyMacro' };
 
       return awsDeploy.update().then(() => {
         expect(updateStackStub.args[0][2].Capabilities)

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -79,6 +79,20 @@ describe('updateStack', () => {
       });
     });
 
+    it('should add CAPABILITY_AUTO_EXPAND if a Transform directive is specified', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {Transform: 'MyMacro'}
+
+      const createStackStub = sinon.stub(awsDeploy.provider, 'request').resolves();
+      sinon.stub(awsDeploy, 'monitorStack').resolves();
+
+      return awsDeploy.createFallback().then(() => {
+        expect(createStackStub.args[0][2].Capabilities)
+        .to.contain('CAPABILITY_AUTO_EXPAND');
+        awsDeploy.provider.request.restore()
+        awsDeploy.monitorStack.restore()
+      });
+    });
+
     it('should use CloudFormation service role if it is specified', () => {
       awsDeploy.serverless.service.provider.cfnRole = 'arn:aws:iam::123456789012:role/myrole';
 
@@ -173,6 +187,15 @@ describe('updateStack', () => {
         .rejects(new Error('No updates are to be performed.'));
 
       return awsDeploy.update();
+    });
+
+    it('should add CAPABILITY_AUTO_EXPAND if a Transform directive is specified', () => {
+      awsDeploy.serverless.service.provider.compiledCloudFormationTemplate = {Transform: 'MyMacro'}
+
+      return awsDeploy.update().then(() => {
+        expect(updateStackStub.args[0][2].Capabilities)
+        .to.contain('CAPABILITY_AUTO_EXPAND');
+      });
     });
 
     it('should use CloudFormation service role if it is specified', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5995 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

When creating or updating a stack, it checks the CloudFormation template to see if a `Transform` directive is found.  If it is, it adds the additional capability CAPABILITY_AUTO_EXPAND, which is required when using a CloudFormation Macro via the `Transform` directive.

## How can we verify it:

This serverless.yml should be successfully deployed:
```
service: transform-test

provider:
  name: aws

resources:
  Transform: 'AWS::Serverless-2016-10-31'
  Resources:
    SimpleTable:
      Type: AWS::Serverless::SimpleTable
      Properties:
        PrimaryKey:
          Name: id
          Type: String
        ProvisionedThroughput:
          ReadCapacityUnits: 5
          WriteCapacityUnits: 5
```

## Todos:

(I'm not sure what documentation would be required for this, but I'm happy to add some if necessary...)

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
