### PR TITLE
Add authorization scopes support for cognito user pool integration

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -279,7 +279,7 @@ functions:
             maxAge: 86400
 ```
 
-If you are using CloudFront or another CDN for your API Gateway, you may want to setup a `Cache-Control` header to allow for OPTIONS request to be cached to avoid the additional hop.  
+If you are using CloudFront or another CDN for your API Gateway, you may want to setup a `Cache-Control` header to allow for OPTIONS request to be cached to avoid the additional hop.
 
 To enable the `Cache-Control` header on preflight response, set the `cacheControl` property in the `cors` object:
 
@@ -446,7 +446,7 @@ functions:
 ```
 
 You can also configure an existing Cognito User Pool as the authorizer, as shown
-in the following example:
+in the following example with optional access token allowed scopes:
 
 ```yml
 functions:
@@ -458,6 +458,8 @@ functions:
           method: post
           authorizer:
             arn: arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ
+            scopes:
+              - my-app/read
 ```
 
 If you are using the default `lambda-proxy` integration, your attributes will be
@@ -1242,7 +1244,7 @@ functions:
     events:
       - http:
           path: /users
-          ...     
+          ...
           authorizer:
             # Provide both type and authorizerId
             type: COGNITO_USER_POOLS # TOKEN or REQUEST or COGNITO_USER_POOLS, same as AWS Cloudformation documentation
@@ -1254,7 +1256,7 @@ functions:
     events:
       - http:
           path: /users/{userId}
-          ...     
+          ...
           # Provide both type and authorizerId
           type: COGNITO_USER_POOLS # TOKEN or REQUEST or COGNITO_USER_POOLS, same as AWS Cloudformation documentation
           authorizerId:

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -26,15 +26,25 @@ module.exports = {
       const authorizerLogicalId = this.provider.naming
         .getAuthorizerLogicalId(http.authorizer.name);
 
-      let authorizationType;
       const authorizerArn = http.authorizer.arn;
+
+      let authorizationType;
       if (typeof authorizerArn === 'string'
         && awsArnRegExs.cognitoIdpArnExpr.test(authorizerArn)) {
         authorizationType = 'COGNITO_USER_POOLS';
-      } else {
-        authorizationType = 'CUSTOM';
+        const cognitoReturn = {
+          Properties: {
+            AuthorizationType: authorizationType,
+            AuthorizerId: { Ref: authorizerLogicalId },
+          },
+          DependsOn: authorizerLogicalId,
+        };
+        if (http.authorizer.scopes) {
+          cognitoReturn.Properties.AuthorizationScopes = http.authorizer.scopes;
+        }
+        return cognitoReturn;
       }
-
+      authorizationType = 'CUSTOM';
       return {
         Properties: {
           AuthorizationType: authorizationType,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -502,6 +502,7 @@ describe('#compileMethods()', () => {
           authorizer: {
             name: 'authorizer',
             arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+            scopes: ['myapp/read', 'myapp/write'],
           },
           integration: 'AWS',
           path: 'users/create',
@@ -515,6 +516,11 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ApiGatewayMethodUsersCreatePost.Properties.AuthorizationType
       ).to.equal('COGNITO_USER_POOLS');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.ApiGatewayMethodUsersCreatePost.Properties.AuthorizationScopes
+      ).to.contain('myapp/read');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -220,6 +220,7 @@ module.exports = {
     let identityValidationExpression;
     let claims;
     let authorizerId;
+    let scopes;
 
     if (typeof authorizer === 'string') {
       if (authorizer.toUpperCase() === 'AWS_IAM') {
@@ -258,6 +259,7 @@ module.exports = {
       resultTtlInSeconds = Number.parseInt(authorizer.resultTtlInSeconds, 10);
       resultTtlInSeconds = Number.isNaN(resultTtlInSeconds) ? 300 : resultTtlInSeconds;
       claims = authorizer.claims || [];
+      scopes = authorizer.scopes;
 
       identitySource = authorizer.identitySource;
       identityValidationExpression = authorizer.identityValidationExpression;
@@ -295,6 +297,7 @@ module.exports = {
       identitySource,
       identityValidationExpression,
       claims,
+      scopes,
     };
   },
 


### PR DESCRIPTION
## What did you implement:

Closes #4661 

Adds support for authorization scopes for COGNITO_USER_POOLS authorizer

## How did you implement it:

Add property to http event authorizer

## How can we verify it:

Package a function containing the additional properties

```
      - http:
          path: /my/api
          method: get
          authorizer:
            arn:arn:aws:cognito-idp:ap-southeast-2:XXXXXXX:userpool/ap-southeast-2_mypool
            scopes:
              - myscope/read
              - aws.cognito.signin.user.admin
```

Verify the AuthorizationScopes:  property is present in the generated cloudformation.


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
