### PR TITLE
Updating Node.js runtime version

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 functions:
   first:


### PR DESCRIPTION
Node.js 6.10 is deprecated for AWS Lambda.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Updated Node.js runtime version to 8.10 (6.10 is being phased out).

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Changed the serverless.yml file.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

`sls create -t aws-nodejs-ecma-script -p nodetest`

Then confirm serverless.yml is using `nodejs8.10`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
