### PR TITLE
Make it easier on the eyes of serverless newcomers

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/second.js
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/second.js
@@ -8,7 +8,7 @@ export const hello = (event, context, cb) => {
     body: JSON.stringify({
       message: 'Go Serverless Webpack (Ecma Script) v1.0! Second module!',
       input: event,
-    }),
+    }, null, 2),
   };
   p
     .then(() => cb(null, response))

--- a/lib/plugins/create/templates/aws-nodejs-typescript/handler.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/handler.ts
@@ -7,6 +7,6 @@ export const hello: APIGatewayProxyHandler = async (event, _context) => {
     body: JSON.stringify({
       message: 'Go Serverless Webpack (Typescript) v1.0! Your function executed successfully!',
       input: event,
-    }),
+    }, null, 2),
   };
 }

--- a/lib/plugins/create/templates/aws-nodejs/handler.js
+++ b/lib/plugins/create/templates/aws-nodejs/handler.js
@@ -6,7 +6,7 @@ module.exports.hello = async (event) => {
     body: JSON.stringify({
       message: 'Go Serverless v1.0! Your function executed successfully!',
       input: event,
-    }),
+    }, null, 2),
   };
 
   // Use this code if you don't use the http event with the LAMBDA-PROXY integration


### PR DESCRIPTION
## What did you implement:

Make the first result a javascript developer has with Serverless, easier in the eyes by just adding better formatting to the `JSON.stringify()` function.

## How did you implement it:

Added `JSON.stringify(response, null, 2)` instead of `JSON.stringify(response)`

## How can we verify it:

## Todos:

- [ ] Update tests

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
