### PR TITLE
Use region pseudo parameter

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -88,9 +88,7 @@ module.exports = {
         [
           this.provider.serverless.service.service,
           this.provider.getStage(),
-          {
-            'Ref': 'AWS::Region'
-          },
+          { Ref: 'AWS::Region' },
           'lambdaRole',
         ],
       ],

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -88,7 +88,9 @@ module.exports = {
         [
           this.provider.serverless.service.service,
           this.provider.getStage(),
-          this.provider.getRegion(),
+          {
+            'Ref': 'AWS::Region'
+          },
           'lambdaRole',
         ],
       ],

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -123,7 +123,7 @@ describe('#naming()', () => {
           [
             serverless.service.service,
             sdk.naming.provider.getStage(),
-            sdk.naming.provider.getRegion(),
+            { Ref: 'AWS::Region' },
             'lambdaRole',
           ],
         ],

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
@@ -29,7 +29,11 @@ module.exports = {
             [
               'https://',
               this.provider.getApiGatewayRestApiId(),
-              `.execute-api.${this.provider.getRegion()}.`,
+              '.execute-api.',
+              {
+                'Ref': 'AWS::Region'
+              },
+              '.',
               { Ref: 'AWS::URLSuffix' },
               `/${this.provider.getStage()}`,
             ],

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
@@ -30,9 +30,7 @@ module.exports = {
               'https://',
               this.provider.getApiGatewayRestApiId(),
               '.execute-api.',
-              {
-                'Ref': 'AWS::Region'
-              },
+              { Ref: 'AWS::Region' },
               '.',
               { Ref: 'AWS::URLSuffix' },
               `/${this.provider.getStage()}`,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
@@ -93,7 +93,9 @@ describe('#compileDeployment()', () => {
             [
               'https://',
               { Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId },
-              '.execute-api.us-east-1.',
+              '.execute-api.',
+              { Ref: 'AWS::Region' },
+              '.',
               { Ref: 'AWS::URLSuffix' },
               '/dev',
             ],

--- a/lib/plugins/aws/package/compile/events/websockets/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/deployment.js
@@ -35,7 +35,9 @@ module.exports = {
             [
               'wss://',
               { Ref: this.provider.naming.getWebsocketsApiLogicalId() },
-              `.execute-api.${this.provider.getRegion()}.`,
+              '.execute-api.',
+              { Ref: 'AWS::Region' },
+              '.',
               { Ref: 'AWS::URLSuffix' },
               `/${this.provider.getStage()}`,
             ],

--- a/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
@@ -69,7 +69,11 @@ describe('#compileDeployment()', () => {
                 {
                   Ref: 'WebsocketsApi',
                 },
-                '.execute-api.us-east-1.',
+                '.execute-api.',
+                {
+                  Ref: 'AWS::Region',
+                },
+                '.',
                 {
                   Ref: 'AWS::URLSuffix',
                 },

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -122,7 +122,9 @@ describe('#mergeIamTemplates()', () => {
                 [
                   awsPackage.serverless.service.service,
                   awsPackage.provider.getStage(),
-                  awsPackage.provider.getRegion(),
+                  {
+                    Ref: 'AWS::Region',
+                  },
                   'lambdaRole',
                 ],
               ],


### PR DESCRIPTION
## What did you implement:

I replaced the region name in IAM Roles and ServiceEndpoint with a reference to `AWS::Region` [pseudo parameter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html). With this change to CloudFormation template output could be exported and re-applied in an other region. This is a really small change but could be part of a complete export of produced CloudFormation to be share with other and apply with a click (making deployment bucket public).

## How did you implement it:

Followed the AWS documentation about pseudo parameters: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

## How can we verify it:

Create a new project, go to AWS Console under **CloudFormation -> Stacks -> Your service name**, then open the tab **Template** and you should see the CloudFormation template produced by Serverless.
Search for region name and you should not find any occurrences.

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
