### PR TITLE
Add more specific sub command error handling.

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -359,6 +359,20 @@ class PluginManager {
         && (isNotEntrypoint || allowEntryPoints)) {
         return current.commands[name];
       }
+      // if user is using a top level command properly, but sub commands are not
+      if (this.serverless.cli.loadedCommands[commandOrAlias[0]]) {
+        const errorMessage = [`"${name}" is not a valid sub command. Run "serverless `];
+        for (let i = 0; commandOrAlias[i] !== name; i++) {
+          errorMessage.push(`${commandOrAlias[i]}`);
+          if (commandOrAlias[i + 1] !== name) {
+            errorMessage.push(' ');
+          }
+        }
+        errorMessage.push('" to see a more helpful error message for this command.');
+        throw new this.serverless.classes.Error(errorMessage.join(''));
+      }
+
+      // top level command isn't valid. give a suggestion
       const commandName = commandOrAlias.slice(0, index + 1).join(' ');
       const suggestedCommand = getCommandSuggestion(commandName,
         this.serverless.cli.loadedCommands);

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1586,6 +1586,107 @@ describe('PluginManager', () => {
     });
   });
 
+  describe('#getCommand()', () => {
+    beforeEach(() => {
+      pluginManager.addPlugin(SynchronousPluginMock);
+      pluginManager.serverless.cli.loadedCommands = {
+        create: {
+          usage: 'Create new Serverless service',
+          lifecycleEvents: [
+            'create',
+          ],
+          options: {
+            template: {
+              usage: 'Template for the service. Available templates: ", "aws-nodejs", "..."',
+              shortcut: 't',
+            },
+          },
+          key: 'create',
+          pluginName: 'Create',
+        },
+        deploy: {
+          usage: 'Deploy a Serverless service',
+          configDependent: true,
+          lifecycleEvents: [
+            'cleanup',
+            'initialize',
+          ],
+          options: {
+            conceal: {
+              usage: 'Hide secrets from the output (e.g. API Gateway key values)',
+            },
+            stage: {
+              usage: 'Stage of the service',
+              shortcut: 's',
+            },
+          },
+          key: 'deploy',
+          pluginName: 'Deploy',
+          commands: {
+            function: {
+              usage: 'Deploy a single function from the service',
+              lifecycleEvents: [
+                'initialize',
+                'packageFunction',
+                'deploy',
+              ],
+              options: {
+                function: {
+                  usage: 'Name of the function',
+                  shortcut: 'f',
+                  required: true,
+                },
+              },
+              key: 'deploy:function',
+              pluginName: 'Deploy',
+            },
+            list: {
+              usage: 'List deployed version of your Serverless Service',
+              lifecycleEvents: [
+                'log',
+              ],
+              key: 'deploy:list',
+              pluginName: 'Deploy',
+              commands: {
+                functions: {
+                  usage: 'List all the deployed functions and their versions',
+                  lifecycleEvents: [
+                    'log',
+                  ],
+                  key: 'deploy:list:functions',
+                  pluginName: 'Deploy',
+                },
+              },
+            },
+          },
+        },
+      };
+    });
+    it('should give a suggestion for an unknown command', (done) => {
+      try {
+        pluginManager.getCommand(['creet']);
+        done('Test failed. Expected an error to be thrown');
+      } catch (error) {
+        expect(error.name).to.eql('ServerlessError');
+        expect(error.message).to.eql('Serverless command "creet" not found. ' +
+          'Did you mean "create"? Run "serverless help" for a list of all available commands.');
+        done();
+      }
+    });
+
+    it('should not give a suggestion for valid top level command', (done) => {
+      try {
+        pluginManager.getCommand(['deploy', 'function-misspelled']);
+        done('Test failed. Expected an error to be thrown');
+      } catch (error) {
+        expect(error.name).to.eql('ServerlessError');
+        expect(error.message).to.eql('"function-misspelled" is not a valid sub command. '
+          + 'Run "serverless deploy" to see a more helpful error message for this command.');
+        done();
+      }
+    });
+  });
+
   describe('#spawn()', () => {
     it('should throw an error when the given command is not available', () => {
       pluginManager.addPlugin(EntrypointPluginMock);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6035 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Before sending the user to `getCommandSuggestion`, if the previous commands are valid, return a message telling the user how better to self-correct. Admittedly this message is only to tell the user how to run a command that will give him/her a better error message. Most error handling is handled well in the serverless framework. However, for these niche cases, I feel this is a slight improvement. 

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it: 
This is only handled in error cases where the framework is basically saying "We don't know what you want". I couldn't find any tests for this case to modify.
Current handling: 
![image](https://user-images.githubusercontent.com/10850753/56487696-ef0a2b00-6490-11e9-847b-390a7777ece4.png)

With this change:
![image](https://user-images.githubusercontent.com/10850753/56487711-00ebce00-6491-11e9-8d24-76d543436580.png)

This change does not conflict with any other `validation` methods. For example `validateOptions()` still runs as anticipated since this error case is only with commands or aliases.


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
