### PR TITLE
Support wildcard in API Gateway cors domains

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -257,7 +257,7 @@ functions:
             allowCredentials: false
 ```
 
-Wildcards are accepted, so 
+Wildcards are accepted. The following example will match all sub-domains of example.com over http:
 
 ```yml
     cors:
@@ -265,7 +265,6 @@ Wildcards are accepted, so
         - http://*.example.com
         - http://example2.com
 ```
-will match all sub-domains of example.com, over http
 
 Please note that since you can't send multiple values for [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), this configuration uses a response template to check if the request origin matches one of your provided `origins` and overrides the header with the following code:
 

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -257,6 +257,16 @@ functions:
             allowCredentials: false
 ```
 
+Wildcards are accepted, so 
+
+```yml
+    cors:
+      origins:
+        - http://*.example.com
+        - http://example2.com
+```
+will match all sub-domains of example.com, over http
+
 Please note that since you can't send multiple values for [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), this configuration uses a response template to check if the request origin matches one of your provided `origins` and overrides the header with the following code:
 
 ```

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -117,12 +117,21 @@ module.exports = {
     ];
   },
 
+  regexifyWildcards(orig) {
+    return orig.map((str) => str.replace(/\./g, '[.]')
+      .replace('*', '.*'));
+  },
+
   generateCorsResponseTemplate(origins) {
+    // glob pattern needs to be parsed into a Java regex
+    // escape literal dots, replace wildcard * for .*
+    const regexOrigins = this.regexifyWildcards(origins);
+
     return (
       '#set($origin = $input.params("Origin"))\n' +
       '#if($origin == "") #set($origin = $input.params("origin")) #end\n' +
-      `#if(${origins
-        .map((o, i, a) => `$origin == "${o}"${i < a.length - 1 ? ' || ' : ''}`)
+      `#if(${regexOrigins
+        .map((o, i, a) => `$origin.matches("${o}")${i < a.length - 1 ? ' || ' : ''}`)
         .join('')}` +
       ') #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end'
     );

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -72,7 +72,7 @@ describe('#compileCors()', () => {
         cacheControl: 'max-age=600, s-maxage=600',
       },
       'users/create': {
-        origins: ['http://localhost:3000', 'http://example.com'],
+        origins: ['http://localhost:3000', 'https://*.example.com'],
         headers: ['*'],
         methods: ['OPTIONS', 'POST'],
         allowCredentials: true,
@@ -108,7 +108,7 @@ describe('#compileCors()', () => {
           .Resources.ApiGatewayMethodUsersCreateOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseTemplates['application/json']
-      ).to.equal('#set($origin = $input.params("Origin"))\n#if($origin == "") #set($origin = $input.params("origin")) #end\n#if($origin == "http://localhost:3000" || $origin == "http://example.com") #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end');
+      ).to.equal('#set($origin = $input.params("Origin"))\n#if($origin == "") #set($origin = $input.params("origin")) #end\n#if($origin.matches("http://localhost:3000") || $origin.matches("https://.*[.]example[.]com")) #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -230,7 +230,7 @@ describe('#compileCors()', () => {
           .Resources.ApiGatewayMethodUsersAnyOptions
           .Properties.Integration.IntegrationResponses[0]
           .ResponseTemplates['application/json']
-      ).to.equal('#set($origin = $input.params("Origin"))\n#if($origin == "") #set($origin = $input.params("origin")) #end\n#if($origin == "http://localhost:3000" || $origin == "http://example.com") #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end');
+      ).to.equal('#set($origin = $input.params("Origin"))\n#if($origin == "") #set($origin = $input.params("origin")) #end\n#if($origin.matches("http://localhost:3000") || $origin.matches("http://example[.]com")) #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin) #end');
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
## What did you implement:
Adds support for wildcards in cors domains for API gateway

Closes #6012

## How did you implement it:

Transforms wildcarded domain to Java regex, which can be used in VLT template

## How can we verify it:

Deploy an AWS with one lambda with multiple cors domains with wildcards. Use the following command
```
curl -H "Origin:<testing domain>"  -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: X-Requested-With"  -X OPTIONS --verbose <your api gateway URL>
```
If testing domain satisfies the wildcard, it will be returned in the Acces-Control-Allow-Origin header

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?: ***Yes
***Is it a breaking change?: ***No
