### PR TITLE
Add `sls:stage` and `sls:region` variables

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -125,6 +125,14 @@ functions:
       APIG_DEPLOYMENT_ID: ApiGatewayDeployment${sls:instanceId}
 ```
 
+**region**
+
+The region used by the Serverless CLI. The `${sls:region}` variable is a shortcut for `${opt:region, self:provider.region}`
+
+**stage**
+
+The stage used by the Serverless CLI. The `${sls:stage}` variable is a shortcut for `${opt:stage, self:provider.stage}`
+
 ## Referencing Environment Variables
 To reference environment variables, use the `${env:SOME_VAR}` syntax in your `serverless.yml` configuration file.  It is valid to use the empty string in place of `SOME_VAR`.  This looks like "`${env:}`" and the result of declaring this in your `serverless.yml` is to embed the complete `process.env` object (i.e. all the variables defined in your environment).
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -553,8 +553,18 @@ class Variables {
   getValueFromSls(variableString) {
     let valueToPopulate = {};
     const requestedSlsVar = variableString.split(':')[1];
-    if (requestedSlsVar === 'instanceId') {
-      valueToPopulate = this.serverless.instanceId;
+    switch (requestedSlsVar) {
+      case 'instanceId':
+        valueToPopulate = this.serverless.instanceId;
+        break;
+      // Shortcuts for the stage and region
+      case 'stage':
+      case 'region':
+        valueToPopulate = (requestedSlsVar in this.options)
+          ? this.options[requestedSlsVar]
+          : this.getValueFromSelf(`self:provider.${requestedSlsVar}`);
+        break;
+      default:
     }
     return BbPromise.resolve(valueToPopulate);
   }

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1503,11 +1503,50 @@ module.exports = {
   });
 
   describe('#getValueFromSls()', () => {
+    beforeEach(() => {
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}';
+      serverless.variables.loadVariableSyntax();
+      delete serverless.service.provider.variableSyntax;
+    });
     it('should get variable from Serverless Framework provided variables', () => {
       serverless.instanceId = 12345678;
       return serverless.variables.getValueFromSls('sls:instanceId').then((valueToPopulate) => {
         expect(valueToPopulate).to.equal(12345678);
       });
+    });
+    it('should resolve the stage variable from the options', () => {
+      serverless.variables.options = {
+        stage: 'prod',
+      };
+      return serverless.variables.getValueFromSls('sls:stage')
+        .then((valueToPopulate) => {
+          expect(valueToPopulate).to.equal('prod');
+        });
+    });
+    it('should resolve the stage variable from the provider if not defined in the options', () => {
+      serverless.variables.options = {};
+      serverless.variables.service.provider.stage = 'prod';
+      return serverless.variables.getValueFromSls('sls:stage')
+        .then((valueToPopulate) => {
+          expect(valueToPopulate).to.equal('prod');
+        });
+    });
+    it('should resolve the region variable from the options', () => {
+      serverless.variables.options = {
+        region: 'us-west-2',
+      };
+      return serverless.variables.getValueFromSls('sls:region')
+        .then((valueToPopulate) => {
+          expect(valueToPopulate).to.equal('us-west-2');
+        });
+    });
+    it('should resolve the region variable from the provider if not defined in the options', () => {
+      serverless.variables.options = {};
+      serverless.variables.service.provider.region = 'us-west-2';
+      return serverless.variables.getValueFromSls('sls:region')
+        .then((valueToPopulate) => {
+          expect(valueToPopulate).to.equal('us-west-2');
+        });
     });
   });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fix #6031 by adding 2 new variables: `sls:stage` and `sls:region`.

Those variables are shortcuts to:

```
${opt:stage, self:provider.stage}
${opt:region, self:provider.region}
```

## How did you implement it:

To be honest I copied existing code, I am not an expert. Feel free to post comments to suggest improvements.

## How can we verify it:

I added automated tests but testing with a real `serverless.yml` would be great (didn't find those in automated tests).

Here is an example:

```yaml
service: aws-nodejs # NOTE: update this with your service name
provider:
  name: aws
  runtime: nodejs8.10
  stage: customstage
  environment:
    APP_STAGE: ${sls:stage}
functions:
  hello:
    handler: handler.hello
```

The function could be:

```js
module.exports.hello = async (event) => {
  return { stage: process.env.APP_STAGE };
};
```

The result of this function should be `{"stage":"customstage"}`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
