### PR TITLE
Allow Fn::Join in stream event arns

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -44,6 +44,17 @@ functions:
           type: kinesis
           arn:
             Fn::ImportValue: MyExportedKinesisStreamArnId
+      - stream
+          type: kinesis
+          arn:
+            Fn::Join:
+              - ":"
+              - - arn
+                - aws
+                - kinesis
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - MyOtherKinesisStream
 ```
 
 ## Setting the BatchSize and StartingPosition

--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -54,7 +54,7 @@ functions:
                 - kinesis
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
-                - MyOtherKinesisStream
+                - stream/MyOtherKinesisStream
 ```
 
 ## Setting the BatchSize and StartingPosition

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -75,9 +75,9 @@ class AwsCompileStreamEvents {
                     || _.has(event.stream.arn, 'Fn::Join'))) {
                   const errorMessage = [
                     `Bad dynamic ARN property on stream event in function "${functionName}"`,
-                    ' If you use a dynamic "arn" (such as with Fn::GetAtt or Fn::ImportValue)',
-                    ' there must only be one key (either Fn::GetAtt or Fn::ImportValue) in the arn',
-                    ' object. Please check the docs for more info.',
+                    ' If you use a dynamic "arn" (such as with Fn::GetAtt, Fn::Join',
+                    ' or Fn::ImportValue) there must only be one key (either Fn::GetAtt, Fn::Join',
+                    ' or Fn::ImportValue) in the arn object. Please check the docs for more info.',
                   ].join('');
                   throw new this.serverless.classes
                     .Error(errorMessage);
@@ -112,7 +112,11 @@ class AwsCompileStreamEvents {
                 return EventSourceArn['Fn::ImportValue'];
               } else if (EventSourceArn['Fn::Join']) {
                 // [0] is the used delimiter, [1] is the array with values
-                return EventSourceArn['Fn::Join'][1].slice(-1).pop();
+                const name = EventSourceArn['Fn::Join'][1].slice(-1).pop();
+                if (name.split('/').length) {
+                  return name.split('/').pop();
+                }
+                return name;
               }
               return EventSourceArn.split('/')[1];
             }());

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -70,8 +70,9 @@ class AwsCompileStreamEvents {
                     .Error(errorMessage);
                 }
                 if (Object.keys(event.stream.arn).length !== 1
-                    || !(_.has(event.stream.arn, 'Fn::ImportValue')
-                          || _.has(event.stream.arn, 'Fn::GetAtt'))) {
+                  || !(_.has(event.stream.arn, 'Fn::ImportValue')
+                    || _.has(event.stream.arn, 'Fn::GetAtt')
+                    || _.has(event.stream.arn, 'Fn::Join'))) {
                   const errorMessage = [
                     `Bad dynamic ARN property on stream event in function "${functionName}"`,
                     ' If you use a dynamic "arn" (such as with Fn::GetAtt or Fn::ImportValue)',
@@ -109,6 +110,9 @@ class AwsCompileStreamEvents {
                 return EventSourceArn['Fn::GetAtt'][0];
               } else if (EventSourceArn['Fn::ImportValue']) {
                 return EventSourceArn['Fn::ImportValue'];
+              } else if (EventSourceArn['Fn::Join']) {
+                // [0] is the used delimiter, [1] is the array with values
+                return EventSourceArn['Fn::Join'][1].slice(-1).pop();
               }
               return EventSourceArn.split('/')[1];
             }());

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -533,25 +533,26 @@ describe('AwsCompileStreamEvents', () => {
         expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
       });
 
-      it('fails if keys other than Fn::GetAtt/ImportValue/Join are used for dynamic stream ARN', () => {
-        awsCompileStreamEvents.serverless.service.functions = {
-          first: {
-            events: [
-              {
-                stream: {
-                  type: 'dynamodb',
-                  arn: {
-                    'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'],
-                    batchSize: 1,
+      it('fails if keys other than Fn::GetAtt/ImportValue/Join are used for dynamic stream ARN',
+        () => {
+          awsCompileStreamEvents.serverless.service.functions = {
+            first: {
+              events: [
+                {
+                  stream: {
+                    type: 'dynamodb',
+                    arn: {
+                      'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'],
+                      batchSize: 1,
+                    },
                   },
                 },
-              },
-            ],
-          },
-        };
+              ],
+            },
+          };
 
-        expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
-      });
+          expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
+        });
 
       it('should add the necessary IAM role statements', () => {
         awsCompileStreamEvents.serverless.service.functions = {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -337,21 +337,21 @@ describe('AwsCompileStreamEvents', () => {
           .Properties.EventSourceArn
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0]
-          .stream.arn
+            .stream.arn
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbFoo
           .Properties.BatchSize
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0]
-          .stream.batchSize
+            .stream.batchSize
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbFoo
           .Properties.StartingPosition
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0]
-          .stream.startingPosition
+            .stream.startingPosition
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbFoo
@@ -372,7 +372,7 @@ describe('AwsCompileStreamEvents', () => {
           .Properties.EventSourceArn
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[1]
-          .stream.arn
+            .stream.arn
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbBar
@@ -401,7 +401,7 @@ describe('AwsCompileStreamEvents', () => {
           .Properties.EventSourceArn
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[2]
-          .stream
+            .stream
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingDynamodbBaz
@@ -433,13 +433,30 @@ describe('AwsCompileStreamEvents', () => {
                   type: 'kinesis',
                 },
               },
+              {
+                stream: {
+                  arn: {
+                    'Fn::Join': [
+                      ':', [
+                        'arn', 'aws', 'kinesis', {
+                          Ref: 'AWS::Region',
+                        }, {
+                          Ref: 'AWS::AccountId',
+                        },
+                        'MyStream',
+                      ],
+                    ],
+                  },
+                  type: 'kinesis',
+                },
+              },
             ],
           },
         };
 
         awsCompileStreamEvents.compileStreamEvents();
 
-        // dynamodb version
+        // dynamodb with Fn::GetAtt
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbSomeDdbTable.Properties.EventSourceArn
@@ -468,12 +485,35 @@ describe('AwsCompileStreamEvents', () => {
             ],
           }
         );
-        // and now kinesis
+
+        // kinesis with Fn::ImportValue
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingKinesisForeignKinesis.Properties.EventSourceArn
         ).to.deep.equal(
           { 'Fn::ImportValue': 'ForeignKinesis' }
+        );
+
+        // kinesis with Fn::Join
+        expect(awsCompileStreamEvents.serverless.service
+          .provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingKinesisMyStream.Properties.EventSourceArn
+        ).to.deep.equal(
+          {
+            'Fn::Join': [
+              ':', [
+                'arn',
+                'aws',
+                'kinesis',
+                {
+                  Ref: 'AWS::Region',
+                }, {
+                  Ref: 'AWS::AccountId',
+                },
+                'MyStream',
+              ],
+            ],
+          }
         );
       });
 
@@ -493,7 +533,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
       });
 
-      it('fails if keys other than Fn::GetAtt/ImportValue are used for dynamic stream ARN', () => {
+      it('fails if keys other than Fn::GetAtt/ImportValue/Join are used for dynamic stream ARN', () => {
         awsCompileStreamEvents.serverless.service.functions = {
           first: {
             events: [
@@ -594,21 +634,21 @@ describe('AwsCompileStreamEvents', () => {
           .Properties.EventSourceArn
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0]
-          .stream.arn
+            .stream.arn
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisFoo
           .Properties.BatchSize
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0]
-          .stream.batchSize
+            .stream.batchSize
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisFoo
           .Properties.StartingPosition
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0]
-          .stream.startingPosition
+            .stream.startingPosition
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisFoo
@@ -629,7 +669,7 @@ describe('AwsCompileStreamEvents', () => {
           .Properties.EventSourceArn
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[1]
-          .stream.arn
+            .stream.arn
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBar
@@ -658,7 +698,7 @@ describe('AwsCompileStreamEvents', () => {
           .Properties.EventSourceArn
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[2]
-          .stream
+            .stream
         );
         expect(awsCompileStreamEvents.serverless.service
           .provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBaz

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -443,7 +443,7 @@ describe('AwsCompileStreamEvents', () => {
                         }, {
                           Ref: 'AWS::AccountId',
                         },
-                        'MyStream',
+                        'stream/MyStream',
                       ],
                     ],
                   },
@@ -510,7 +510,7 @@ describe('AwsCompileStreamEvents', () => {
                 }, {
                   Ref: 'AWS::AccountId',
                 },
-                'MyStream',
+                'stream/MyStream',
               ],
             ],
           }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6047 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I added `Fn::Join` as an allowed dynamic ARN builder for stream type events. This only required adding `Fn::Join` to the conditionals checking valid input, and returning the array of elements to join as the stream name.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Deploying any Serverless config with a stream event using `Fn::Join` should work:
```yml
service: my-service

provider:
  name: aws
  runtime: nodejs8.10
  region: us-east-1

functions:
  my-function:
    handler: handler.myHandler
    events:
      - stream:
          type: kinesis
          arn:
            Fn::Join:
              - ":"
              - - arn
                - aws
                - kinesis
                - Ref: AWS::Region
                - Ref: AWS::AccountId
                - stream/my-stream
```

## Todos:

- [X] Write tests
- [X] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
