### PR TITLE
Highlight skipping of deployments

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -321,8 +321,18 @@ class CLI {
     process.stdout.write(chalk.yellow('.'));
   }
 
-  log(message, entity) {
-    this.consoleLog(`${entity || 'Serverless'}: ${chalk.yellow(`${message}`)}`);
+  log(message, entity, opts) {
+    const underline = opts ? opts.underline : false;
+    const bold = opts ? opts.bold : false;
+    const color = opts ? opts.color : null;
+
+    let print = chalk.yellow;
+
+    if (color) print = chalk.keyword(color);
+    if (underline) print = print.underline;
+    if (bold) print = print.bold;
+
+    this.consoleLog(`${entity || 'Serverless'}: ${print(message)}`);
   }
 
   consoleLog(message) {

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -547,6 +547,65 @@ describe('CLI', () => {
     });
   });
 
+  describe('#log', () => {
+    let consoleLogSpy;
+
+    beforeEach(() => {
+      cli = new CLI(serverless);
+      consoleLogSpy = sinon.spy(cli, 'consoleLog');
+    });
+
+    afterEach(() => {
+      cli.consoleLog.restore();
+    });
+
+    it('should log messages', () => {
+      const msg = 'Hello World!';
+
+      cli.log(msg);
+
+      expect(consoleLogSpy.callCount).to.equal(1);
+      expect(consoleLogSpy.firstCall.args[0]).to.equal('Serverless: Hello World!');
+    });
+
+    it('should support different entities', () => {
+      const msg = 'Hello World!';
+      const entity = 'Entity';
+
+      cli.log(msg, entity);
+
+      expect(consoleLogSpy.callCount).to.equal(1);
+      expect(consoleLogSpy.firstCall.args[0]).to.equal('Entity: Hello World!');
+    });
+
+    // NOTE: Here we're just testing that it won't break
+    it('should support logging options', () => {
+      const msg = 'Hello World!';
+      const opts = {
+        color: 'orange',
+        bold: true,
+        underline: true,
+      };
+
+      cli.log(msg, 'Serverless', opts);
+
+      expect(consoleLogSpy.callCount).to.equal(1);
+      expect(consoleLogSpy.firstCall.args[0]).to.equal('Serverless: Hello World!');
+    });
+
+    it('should ignore invalid logging options', () => {
+      const msg = 'Hello World!';
+      const opts = {
+        invalid: 'option',
+      };
+
+      cli.log(msg, 'Serverless', opts);
+
+      expect(consoleLogSpy.callCount).to.equal(1);
+      expect(consoleLogSpy.firstCall.args[0]).to.equal('Serverless: Hello World!');
+    });
+  });
+
   describe('Integration tests', function () {
     this.timeout(0);
     const that = this;

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -124,7 +124,7 @@ module.exports = {
           const message = [
             'Service files not changed. Skipping deployment...',
           ].join('');
-          this.serverless.cli.log(message);
+          this.serverless.cli.log(message, 'Serverless', { color: 'orange' });
         }
       });
     }


### PR DESCRIPTION
## What did you implement:

Closes #6069 

Higghlights the log message when deployment are skipped.

## How did you implement it:

I extended the `log` funciton to support `options` which can be passed in to e.g. underline or colorize the log output.

I looked into our Enterprise plugin and decided to **use the color `orange`** here which is used for warnings. This way the Serverless Framework CLI is consistent with what we're doing with our Enterprise plugin.

Here's how it looks like:

<img width="580" alt="Bildschirmfoto 2019-05-01 um 11 16 22" src="https://user-images.githubusercontent.com/1606004/57012080-fc4bb600-6c04-11e9-9d8e-d1f850538ecc.png">


Alternatively I tested a way to print out the message in bold. Here's how that would look like:

<img width="582" alt="Bildschirmfoto 2019-05-01 um 11 18 02" src="https://user-images.githubusercontent.com/1606004/57012087-01a90080-6c05-11e9-99c2-55664a65850e.png">

Again. I've implemented the color `orange` to make it consistent with our Enterprise plugin. However I'm open to change it to be e.g. bold.

## How can we verify it:

Just deploy a service and then re-deploy it.

## Todos:

- [x] Write tests
- [x] Make sure code coverage hasn't dropped
- [x] Fix linting errors
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO