### PR TITLE
Update required Node.js version / Add version check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ matrix:
   include:
     # Linux tests
     - os: linux
-      node_js: "4.4"
-      env: SLS_IGNORE_WARNING=*
-    - os: linux
-      node_js: "5.11"
-      env: SLS_IGNORE_WARNING=*
-    - os: linux
       node_js: "6.2"
       env: SLS_IGNORE_WARNING=*
     - os: linux

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -49,6 +49,10 @@ Any non-backward compatible changes leads to a major version bump. This includes
 
 If we remove a helper function from the serverless object passed down to a plugin then this is a breaking change since some people might rely on it in custom made plugins.
 
+### Node.js versions
+
+The Serverless Framework supports the major cloud providers Node.js runtime versions. Support for old Node.js versions will be removed once Cloud providers announce that such runtimes are not supported anymore.
+
 ### FAQ
 
 1. Is it okay to mark a feature as deprecated in version 1.4.0 and then remove it in 1.8.0

--- a/bin/serverless
+++ b/bin/serverless
@@ -7,20 +7,6 @@ const BbPromise = require('bluebird');
 const logError = require('../lib/classes/Error').logError;
 const uuid = require('uuid');
 const initializeErrorReporter = require('../lib/utils/sentry').initializeErrorReporter;
-const semver = require('semver');
-const packageJson = require('../package.json');
-
-function checkNodeVersion(serverless) {
-  const requiredVersion = packageJson.engines.node;
-  const nodeVersion = process.version;
-  if (!semver.satisfies(nodeVersion, requiredVersion)) {
-    const msg = [
-      `Serverless Framework requires Node.js version ${requiredVersion}. `,
-      `You're running version ${nodeVersion}.`,
-    ].join('');
-    serverless.cli.log(msg);
-  }
-}
 
 Error.stackTraceLimit = Infinity;
 
@@ -54,7 +40,6 @@ const invocationId = uuid.v4();
   serverless.invocationId = invocationId;
 
   return serverless.init()
-    .then(() => checkNodeVersion(serverless))
     .then(() => serverless.run())
     .then(() => process.exit(0))
     .catch((err) => {

--- a/bin/serverless
+++ b/bin/serverless
@@ -7,6 +7,20 @@ const BbPromise = require('bluebird');
 const logError = require('../lib/classes/Error').logError;
 const uuid = require('uuid');
 const initializeErrorReporter = require('../lib/utils/sentry').initializeErrorReporter;
+const semver = require('semver');
+const packageJson = require('../package.json');
+
+function checkNodeVersion(serverless) {
+  const requiredVersion = packageJson.engines.node;
+  const nodeVersion = process.version;
+  if (!semver.satisfies(nodeVersion, requiredVersion)) {
+    const msg = [
+      `Serverless Framework requires Node.js version ${requiredVersion}. `,
+      `You're running version ${nodeVersion}.`,
+    ].join('');
+    serverless.cli.log(msg);
+  }
+}
 
 Error.stackTraceLimit = Infinity;
 
@@ -40,6 +54,7 @@ const invocationId = uuid.v4();
   serverless.invocationId = invocationId;
 
   return serverless.init()
+    .then(() => checkNodeVersion(serverless))
     .then(() => serverless.run())
     .then(() => process.exit(0))
     .catch((err) => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serverless",
   "version": "1.43.0",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "preferGlobal": true,
   "homepage": "https://github.com/serverless/serverless#readme",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "engines": {
     "node": ">=6.0"
   },
+  "engineStrict": true,
   "preferGlobal": true,
   "homepage": "https://github.com/serverless/serverless#readme",
   "description": "Serverless Framework - Build web, mobile and IoT applications with serverless architectures using AWS Lambda, Azure Functions, Google CloudFunctions & more",


### PR DESCRIPTION
## What did you implement:

Closes #6076

Updates the required Node.js version to match the major Cloud providers Node.js runtime requirements.

## How did you implement it:

Updated the version number in the `package.json` file.

## How can we verify it:

Use the Serverless Framework with a Node.js version older than 8.

## Todos:

- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO