### PR TITLE
fix use of cors: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 1.42.0 (2019-05-09)
+- [Fix bug with `cors: true`](https://github.com/serverless/serverless/pull/6104)
+
+# 1.42.0 (2019-05-09)
 
 - [Update cors.md](https://github.com/serverless/serverless/pull/6027)
 - [Add tags to AWS APIGateway Stage](https://github.com/serverless/serverless/pull/5851)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.42.0 (2019-05-09)
+# 1.42.1 (2019-05-09)
 - [Fix bug with `cors: true`](https://github.com/serverless/serverless/pull/6104)
 
 # 1.42.0 (2019-05-09)

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -74,8 +74,6 @@ class AwsCompileApigEvents {
       'after:deploy:deploy': () => {
         const updateStage = require('./lib/hack/updateStage').updateStage;
 
-        this.validated = this.validate();
-
         if (this.validated.events.length === 0) {
           return BbPromise.resolve();
         }

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -116,12 +116,8 @@ describe('AwsCompileApigEvents', () => {
     });
 
     describe('when running the "after:deploy:deploy" promise chain', () => {
-      afterEach(() => {
-        awsCompileApigEvents.validate.restore();
-      });
-
       it('should run the promise chain in order', () => {
-        const validateStub = sinon.stub(awsCompileApigEvents, 'validate').returns({
+        awsCompileApigEvents.validated = {
           events: [
             {
               functionName: 'first',
@@ -131,21 +127,16 @@ describe('AwsCompileApigEvents', () => {
               },
             },
           ],
-        });
-
+        };
         awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
-          expect(validateStub.calledOnce).to.equal(true);
-          expect(updateStageStub.calledAfter(validateStub)).to.equal(true);
+          expect(updateStageStub.calledOnce).to.equal(true);
         });
       });
 
       it('should skip the updateStage step when no http events are found', () => {
-        const validateStub = sinon.stub(awsCompileApigEvents, 'validate').returns({
-          events: [],
-        });
+        awsCompileApigEvents.validated = { events: [] };
 
         awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
-          expect(validateStub.calledOnce).to.equal(true);
           expect(updateStageStub.calledOnce).to.equal(false);
         });
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Fixed the use of `cors: true` in http event configs
Closes #6098
Closes #6102

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Validate fails when called a second time with `cors: true` and I don't see
why it has to be called again. the service config doesn't change during a deploy
and it's already saved on `this.validated`.

But maybe there's a reason `this.validate()` has to also be called after deployment. @pmuens this was added in your PR.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
```
npm i -g serverless
sls create -t aws-nodejs
# in serverless.yml uncomment an http event config and add `cors: true`
sls deploy # this should give the origin/origins error
npm i -g serverless/serverless#sls-6098
sls deploy # no error
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- ~~Write documentation~~
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
