### PR TITLE
Add a hook for plugins to perform asyncronous initialization.

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -70,7 +70,8 @@ class Serverless {
     }).then(() => {
       // load all plugins
       this.pluginManager.loadAllPlugins(this.service.plugins);
-
+      return this.pluginManager.asyncPluginInit();
+    }).then(() => {
       // give the CLI the plugins and commands so that it can print out
       // information such as options when the user enters --help
       this.cli.setLoadedPlugins(this.pluginManager.getPlugins());

--- a/lib/Serverless.test.js
+++ b/lib/Serverless.test.js
@@ -111,16 +111,20 @@ describe('Serverless', () => {
 
   describe('#init()', () => {
     let loadAllPluginsStub;
+    let asyncPluginInitStub;
     let updateAutocompleteCacheFileStub;
 
     beforeEach(() => {
       loadAllPluginsStub = sinon
         .stub(serverless.pluginManager, 'loadAllPlugins').returns();
+      asyncPluginInitStub = sinon
+        .stub(serverless.pluginManager, 'asyncPluginInit').returns(BbPromise.resolve());
       updateAutocompleteCacheFileStub = sinon
         .stub(serverless.pluginManager, 'updateAutocompleteCacheFile').resolves();
     });
 
     afterEach(() => {
+      serverless.pluginManager.asyncPluginInit.restore();
       serverless.pluginManager.loadAllPlugins.restore();
       serverless.pluginManager.updateAutocompleteCacheFile.restore();
     });
@@ -180,6 +184,7 @@ describe('Serverless', () => {
 
       return serverless.init().then(() => {
         expect(loadAllPluginsStub.calledOnce).to.equal(true);
+        expect(asyncPluginInitStub.calledOnce).to.equal(true);
         expect(updateAutocompleteCacheFileStub.calledOnce).to.equal(true);
       });
     });

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -549,6 +549,10 @@ class PluginManager {
       }
     });
   }
+
+  asyncPluginInit() {
+    return BbPromise.map(this.plugins, plugin => (plugin.asyncInit && plugin.asyncInit()));
+  }
 }
 
 module.exports = PluginManager;

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -29,7 +29,8 @@ describe('PluginManager', () => {
   let pluginManager;
   let serverless;
 
-  class ServicePluginMock1 {}
+  class ServicePluginMock1 {
+  }
 
   class ServicePluginMock2 {}
 
@@ -712,6 +713,18 @@ describe('PluginManager', () => {
 
     afterEach(() => {
       mockRequire.stop('ServicePluginMock1');
+    });
+  });
+  describe('#asyncPluginInit()', function () {
+    this.timeout(5000);
+
+    it('should call async init on plugins that have it', () => {
+      const plugin1 = new ServicePluginMock1();
+      plugin1.asyncInit = sinon.stub().returns(BbPromise.resolve());
+      pluginManager.plugins = [plugin1];
+      return pluginManager.asyncPluginInit().then(() => {
+        expect(plugin1.asyncInit.calledOnce).to.equal(true);
+      });
     });
   });
 


### PR DESCRIPTION
needed for SFE to enable deployment profiles serverless/enterprise-plugin#116

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Added a hook for plugins to perform async initialization too.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
added a check for an `asyncInit` function in plugins, and if it exists, call it expecting a promise.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
install this branch & install the plugin from the pr referenced above & deploy
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
