### PR TITLE
Support color output in tests

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,8 +6,6 @@ process.on('unhandledRejection', err => {
   throw err;
 });
 
-if (!process.env.FORCE_COLOR) process.env.FORCE_COLOR = '0';
-
 if (process.argv.length <= 2) {
   process.argv.push(
     '!(node_modules)/**/*.test.js',

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -7,6 +7,7 @@ const os = require('os');
 const fse = require('fs-extra');
 const exec = require('child_process').exec;
 const path = require('path');
+const stripAnsi = require('strip-ansi');
 const Serverless = require('../../lib/Serverless');
 const testUtils = require('../../tests/utils');
 
@@ -542,8 +543,9 @@ describe('CLI', () => {
 
     it('should display container subcommand', () => {
       cli.displayCommandUsage(mycommand, 'mycommand');
-
-      expect(consoleLogStub.calledWith(sinon.match('mycommand subcmd .'))).to.equal(true);
+      expect(stripAnsi(consoleLogStub.firstCall.args[0]).startsWith('mycommand subcmd .')).to.equal(
+        true
+      );
     });
   });
 
@@ -565,7 +567,7 @@ describe('CLI', () => {
       cli.log(msg);
 
       expect(consoleLogSpy.callCount).to.equal(1);
-      expect(consoleLogSpy.firstCall.args[0]).to.equal('Serverless: Hello World!');
+      expect(stripAnsi(consoleLogSpy.firstCall.args[0])).to.equal('Serverless: Hello World!');
     });
 
     it('should support different entities', () => {
@@ -575,7 +577,7 @@ describe('CLI', () => {
       cli.log(msg, entity);
 
       expect(consoleLogSpy.callCount).to.equal(1);
-      expect(consoleLogSpy.firstCall.args[0]).to.equal('Entity: Hello World!');
+      expect(stripAnsi(consoleLogSpy.firstCall.args[0])).to.equal('Entity: Hello World!');
     });
 
     // NOTE: Here we're just testing that it won't break
@@ -590,7 +592,7 @@ describe('CLI', () => {
       cli.log(msg, 'Serverless', opts);
 
       expect(consoleLogSpy.callCount).to.equal(1);
-      expect(consoleLogSpy.firstCall.args[0]).to.equal('Serverless: Hello World!');
+      expect(stripAnsi(consoleLogSpy.firstCall.args[0])).to.equal('Serverless: Hello World!');
     });
 
     it('should ignore invalid logging options', () => {
@@ -602,7 +604,7 @@ describe('CLI', () => {
       cli.log(msg, 'Serverless', opts);
 
       expect(consoleLogSpy.callCount).to.equal(1);
-      expect(consoleLogSpy.firstCall.args[0]).to.equal('Serverless: Hello World!');
+      expect(stripAnsi(consoleLogSpy.firstCall.args[0])).to.equal('Serverless: Hello World!');
     });
   });
 

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -7,6 +7,7 @@ const path = require('path');
 const mockRequire = require('mock-require');
 const EventEmitter = require('events');
 const fse = require('fs-extra');
+const stripAnsi = require('strip-ansi');
 const AwsInvokeLocal = require('./index');
 const AwsProvider = require('../provider/awsProvider');
 const Serverless = require('../../../Serverless');
@@ -598,8 +599,7 @@ describe('AwsInvokeLocal', () => {
       awsInvokeLocal.serverless.config.servicePath = __dirname;
 
       awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
-
-      const logMessageContent = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
+      const logMessageContent = JSON.parse(stripAnsi(serverless.cli.consoleLog.lastCall.args[0]));
 
       expect(logMessageContent.errorMessage).to.equal('failed');
       expect(logMessageContent.errorType).to.equal('Error');

--- a/package-lock.json
+++ b/package-lock.json
@@ -976,6 +976,17 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
           }
         },
         "supports-color": {
@@ -2288,6 +2299,17 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
           }
         },
         "debug": {
@@ -2318,6 +2340,17 @@
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.0",
             "through": "^2.3.6"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
           }
         },
         "ms": {
@@ -4053,6 +4086,14 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -7707,6 +7748,16 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -7718,11 +7769,20 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -7852,6 +7912,23 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
           }
         },
         "is-fullwidth-code-point": {
@@ -8536,6 +8613,17 @@
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "proxyquire": "^1.7.10",
     "sinon": "^1.17.5",
     "sinon-bluebird": "^3.1.0",
-    "sinon-chai": "^2.9.0"
+    "sinon-chai": "^2.9.0",
+    "strip-ansi": "^5.2.0"
   },
   "dependencies": {
     "archiver": "^1.1.0",


### PR DESCRIPTION
## What did you implement:

As we test CLI output of some comment we have disabled color output for whole test run.

As having color output is convenient, I've updated those few tests to work as expected with colors on

## How did you implement it:

I ensured we test non-colored output with help of [strip-ansi](https://www.npmjs.com/package/strip-ansi) package

## How can we verify it:

Run tests

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
