### PR TITLE
Fix validation after API Gateway deployment

### DIFF
--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -733,7 +733,7 @@ describe('Service', () => {
             }));
       }
 
-      it(`should not throw an error if http event is absent and 
+      it(`should not throw an error if http event is absent and
             stage contains only alphanumeric, underscore and hyphen`, () => {
         const SUtils = new Utils();
         const serverlessYml = {

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -338,6 +338,20 @@ class Utils {
     return _.get(globalConfig, `users[${currentId}].dashboard.accessKey`, false) ||
       _.get(globalConfig, `users[${currentId}].dashboard.accessKeys[${username}]`, false);
   }
+
+  isEventUsed(functions, eventName) {
+    return _.reduce(functions, (accum, func) => {
+      const events = func.events || [];
+      if (events.length) {
+        events.forEach(event => {
+          if (Object.keys(event)[0] === eventName) {
+            accum = true; // eslint-disable-line no-param-reassign
+          }
+        });
+      }
+      return accum;
+    }, false);
+  }
 }
 
 module.exports = Utils;

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -913,4 +913,21 @@ describe('Utils', () => {
       expect(res).to.equal('d45hb04rd4cc3ssk3y');
     });
   });
+
+  describe('#isEventUsed()', () => {
+    it('should return true if the event is used and false otherwise', () => {
+      const functions = {
+        create: {
+          events: [
+            {
+              schedule: 'rate(5 minutes)',
+            },
+          ],
+        },
+      };
+
+      expect(utils.isEventUsed(functions, 'schedule')).to.equal(true);
+      expect(utils.isEventUsed(functions, 'http')).to.equal(false);
+    });
+  });
 });

--- a/lib/plugins/aws/lib/getServiceState.js
+++ b/lib/plugins/aws/lib/getServiceState.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+module.exports = {
+  getServiceState() {
+    const stateFileName = this.provider.naming.getServiceStateFileName();
+    const servicePath = this.serverless.config.servicePath;
+    const packageDirName = this.options.package || '.serverless';
+
+    const stateFilePath = path.join(servicePath, packageDirName, stateFileName);
+    return this.serverless.utils.readFileSync(stateFilePath);
+  },
+};

--- a/lib/plugins/aws/lib/getServiceState.test.js
+++ b/lib/plugins/aws/lib/getServiceState.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const Serverless = require('../../../Serverless');
+const AwsProvider = require('../provider/awsProvider');
+const getServiceState = require('./getServiceState');
+
+describe('#getServiceState()', () => {
+  let serverless;
+  let readFileSyncStub;
+  const options = {};
+  const awsPlugin = {};
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    serverless.config.servicePath = 'my-service';
+    awsPlugin.serverless = serverless;
+    awsPlugin.provider = new AwsProvider(serverless, options);
+    awsPlugin.options = options;
+    Object.assign(awsPlugin, getServiceState);
+
+    readFileSyncStub = sinon
+      .stub(awsPlugin.serverless.utils, 'readFileSync').returns();
+  });
+
+  afterEach(() => {
+    awsPlugin.serverless.utils.readFileSync.restore();
+  });
+
+  it('should use the default state file path if the "package" option is not used', () => {
+    awsPlugin.getServiceState();
+    expect(readFileSyncStub).to.be
+      .calledWithExactly('my-service/.serverless/serverless-state.json');
+  });
+
+  it('should use the argument-based state file path if the "package" option is used ', () => {
+    options.package = 'some-package-path';
+
+    awsPlugin.getServiceState();
+    expect(readFileSyncStub).to.be
+      .calledWithExactly('my-service/some-package-path/serverless-state.json');
+  });
+});

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -80,6 +80,7 @@ class AwsCompileApigEvents {
           return BbPromise.resolve();
         }
 
+        this.state = state;
         return updateStage.call(this);
       },
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -72,9 +72,11 @@ class AwsCompileApigEvents {
 
       // TODO should be removed once AWS fixes the CloudFormation problems using a separate Stage
       'after:deploy:deploy': () => {
+        const getServiceState = require('../../../../lib/getServiceState').getServiceState;
         const updateStage = require('./lib/hack/updateStage').updateStage;
 
-        if (this.validated.events.length === 0) {
+        const state = getServiceState.call(this);
+        if (!this.serverless.utils.isEventUsed(state.service.functions, 'http')) {
           return BbPromise.resolve();
         }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -6,6 +6,7 @@ const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileApigEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
 const validate = require('../../../../lib/validate');
+const getServiceState = require('../../../../lib/getServiceState');
 const updateStage = require('./lib/hack/updateStage');
 const disassociateUsagePlan = require('./lib/hack/disassociateUsagePlan');
 
@@ -116,27 +117,52 @@ describe('AwsCompileApigEvents', () => {
     });
 
     describe('when running the "after:deploy:deploy" promise chain', () => {
+      let getServiceStateStub;
+
+      beforeEach(() => {
+        getServiceStateStub = sinon
+          .stub(getServiceState, 'getServiceState');
+      });
+
+      afterEach(() => {
+        getServiceState.getServiceState.restore();
+      });
+
       it('should run the promise chain in order', () => {
-        awsCompileApigEvents.validated = {
-          events: [
-            {
-              functionName: 'first',
-              http: {
-                path: 'users',
-                method: 'POST',
+        getServiceStateStub.returns({
+          service: {
+            functions: {
+              first: {
+                events: [
+                  {
+                    http: {
+                      path: 'users',
+                      method: 'POST',
+                    },
+                  },
+                ],
               },
             },
-          ],
-        };
-        awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
+          },
+        });
+
+        return awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
           expect(updateStageStub.calledOnce).to.equal(true);
         });
       });
 
       it('should skip the updateStage step when no http events are found', () => {
-        awsCompileApigEvents.validated = { events: [] };
+        getServiceStateStub.returns({
+          service: {
+            functions: {
+              first: {
+                events: [],
+              },
+            },
+          },
+        });
 
-        awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
+        return awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
           expect(updateStageStub.calledOnce).to.equal(false);
         });
       });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -39,7 +39,7 @@ function resolveAccountId() {
 
 function resolveRestApiId() {
   return new BbPromise(resolve => {
-    const apiGateway = this.serverless.service.provider.apiGateway || {};
+    const apiGateway = this.state.service.provider.apiGateway || {};
     if (apiGateway.restApiId) {
       resolve(apiGateway.restApiId);
       return;
@@ -47,7 +47,7 @@ function resolveRestApiId() {
     const resolvefromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(
-          api => api.name === `${this.options.stage}-${this.serverless.service.service}`
+          api => api.name === `${this.options.stage}-${this.state.service.service}`
         );
         if (restApi) return restApi.id;
         if (result.position) return resolvefromAws(result.position);
@@ -111,7 +111,7 @@ function ensureStage() {
 }
 
 function handleTracing() {
-  const tracing = this.serverless.service.provider.tracing;
+  const tracing = this.state.service.provider.tracing;
   const tracingEnabled = tracing && tracing.apiGateway;
 
   let operation = { op: 'replace', path: '/tracingEnabled', value: 'false' };
@@ -122,7 +122,7 @@ function handleTracing() {
 }
 
 function handleLogs() {
-  const provider = this.serverless.service.provider;
+  const provider = this.state.service.provider;
   const logs = provider.logs && provider.logs.restApi;
   const ops = this.apiGatewayStagePatchOperations;
 
@@ -132,7 +132,7 @@ function handleLogs() {
   let operations = [dataTrace, logLevel];
 
   if (logs) {
-    const service = this.serverless.service.service;
+    const service = this.state.service.service;
     const stage = this.options.stage;
     const region = this.options.region;
     const logGroupName = `/aws/api-gateway/${service}-${stage}`;
@@ -167,7 +167,7 @@ function handleLogs() {
 }
 
 function handleTags() {
-  const provider = this.serverless.service.provider;
+  const provider = this.state.service.provider;
   const tagsMerged = Object.assign({}, provider.stackTags, provider.tags);
 
   const tagsToCreate = _.entriesIn(tagsMerged).map(pair => ({
@@ -210,8 +210,8 @@ function applyUpdates() {
 }
 
 function removeLogGroup() {
-  const service = this.serverless.service.service;
-  const provider = this.serverless.service.provider;
+  const service = this.state.service.service;
+  const provider = this.state.service.provider;
   const stage = this.options.stage;
   const logGroupName = `/aws/api-gateway/${service}-${stage}`;
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -27,7 +27,12 @@ describe('#updateStage()', () => {
       .resolves(123456);
     providerRequestStub = sinon.stub(awsProvider, 'request');
 
-    context = { serverless, options, provider: awsProvider };
+    context = {
+      serverless,
+      options,
+      state: serverless,
+      provider: awsProvider,
+    };
 
     providerRequestStub
       .withArgs('APIGateway', 'getRestApis', {


### PR DESCRIPTION
## What did you implement:

Closes #6117 

Fixes the bug where the event validation fails when the packaged service is deployed.

## How did you implement it:

Added a helper method which checks if a given event is used in a service.

## How can we verify it:

Use the following `serverless.yml` file:

```yaml
service: test

provider:
  name: aws
  runtime: nodejs8.10
  versionFunctions: false
  tags:
    foo: bar
    baz: qux
    num: 1234
  tracing:
    apiGateway: true
  logs:
    restApi: true
  apiGateway:
    binaryMediaTypes:
      - '*/*'

functions:
  test:
    handler: handler.hello
    events:
       - http:
           method: GET
           path: hello
```

Run

```
serverless package -p package
```

Comment out the whole `functions` section (with this we check the `after:deploy:deploy` hook will use the correct `serverless-state.json` file to check if API Gateway setup needs to be updated).

Run

```
serverless deploy --package package
```

Validate that the API Gateway setup is updated and you have tracing etc. enabled.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO