### PR TITLE
Improve handling of custom API Gateway options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 1.42.3 (2019-05-14)
+
+- [Update deploy.md](https://github.com/serverless/serverless/pull/6110)
+- [Adding a more specific example of how to package individually](https://github.com/serverless/serverless/pull/6108)
+- [Update Azure Functions Template](https://github.com/serverless/serverless/pull/6106)
+- [Update cloudflare documentation](https://github.com/serverless/serverless/pull/6105)
+- [Azure template update](https://github.com/serverless/serverless/pull/6122)
+- [Remove not used module](https://github.com/serverless/serverless/pull/6095)
+- [Support color output in tests](https://github.com/serverless/serverless/pull/6119)
+- [Fix validation after API Gateway deployment](https://github.com/serverless/serverless/pull/6128)
+- [Improve handling of custom API Gateway options](https://github.com/serverless/serverless/pull/6129)
+
+## Meta
+ - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.42.2...v1.42.3)
+
 # 1.42.2 (2019-05-10)
 
 - [Fix restApiId resolution in post CF deployment phase](https://github.com/serverless/serverless/pull/6111)

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -73,12 +73,13 @@ class AwsCompileApigEvents {
       // TODO should be removed once AWS fixes the CloudFormation problems using a separate Stage
       'after:deploy:deploy': () => {
         const getServiceState = require('../../../../lib/getServiceState').getServiceState;
-        const updateStage = require('./lib/hack/updateStage').updateStage;
 
         const state = getServiceState.call(this);
         if (!this.serverless.utils.isEventUsed(state.service.functions, 'http')) {
           return BbPromise.resolve();
         }
+
+        const updateStage = require('./lib/hack/updateStage').updateStage;
 
         this.state = state;
         return updateStage.call(this);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -39,8 +39,8 @@ module.exports = {
 
           const errorMessage = [
             'Rest API could not be resolved. ',
-            'This mighe be casued by a custom API Gateway setup. ',
-            'With you current setup stage specific configuration such as ',
+            'This might be casued by a custom API Gateway setup. ',
+            'With you current setup stage specific configurations such as ',
             '`tracing`, `logs` and `tags` are not supported',
             '',
             'Please update your configuration or open up an issue if you feel ',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -37,16 +37,17 @@ module.exports = {
             return null;
           }
 
-          throw new Error(`Rest API id could not be resolved
+          const errorMessage = [
+            'Rest API could not be resolved. ',
+            'This mighe be casued by a custom API Gateway setup. ',
+            'With you current setup stage specific configuration such as ',
+            '`tracing`, `logs` and `tags` are not supported',
+            '',
+            'Please update your configuration or open up an issue if you feel ',
+            'that there\'s a way to support your setup.',
+          ].join('');
 
-It's most likely due to custom APIGateway setup.
-In given situation some APIGateway specific options (as \`tracing\`, \`logs\` and \`tags\`)
-could not be applied.
-
-If you feel Rest API Id could be resolved automatically by Serverless framework,
-please report this case to us (so hopefully we can improve it)
-
-Otherwise, please adjust your configuration.`);
+          throw new Error(errorMessage);
         }
         return resolveStage
           .call(this)
@@ -68,16 +69,16 @@ function resolveAccountId() {
 
 function resolveRestApiId() {
   return new BbPromise(resolve => {
-    const apiGateway = this.state.service.provider.apiGateway || {};
-    if (apiGateway.restApiId) {
-      resolve(isRestApiId(apiGateway.restApiId) ? apiGateway.restApiId : null);
+    const provider = this.state.service.provider;
+    const customRestApiId = provider.apiGateway && provider.apiGateway.restApiId;
+    if (customRestApiId) {
+      resolve(isRestApiId(customRestApiId) ? customRestApiId : null);
       return;
     }
+    const apiName = provider.apiName || `${this.options.stage}-${this.serverless.service.service}`;
     const resolvefromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
-        const restApi = result.items.find(
-          api => api.name === `${this.options.stage}-${this.state.service.service}`
-        );
+        const restApi = result.items.find(api => api.name === apiName);
         if (restApi) return restApi.id;
         if (result.position) return resolvefromAws(result.position);
         return null;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -5,6 +5,8 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
+const isRestApiId = RegExp.prototype.test.bind(/^[a-z0-9]{10}$/);
+
 // NOTE --> Keep this file in sync with ../stage.js
 
 // NOTE: This code was written since there are problem setting up dedicated CloudFormation
@@ -41,7 +43,7 @@ function resolveRestApiId() {
   return new BbPromise(resolve => {
     const apiGateway = this.state.service.provider.apiGateway || {};
     if (apiGateway.restApiId) {
-      resolve(apiGateway.restApiId);
+      resolve(isRestApiId(apiGateway.restApiId) ? apiGateway.restApiId : null);
       return;
     }
     const resolvefromAws = position =>

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -27,7 +27,7 @@ module.exports = {
         if (!this.apiGatewayRestApiId) {
           // Could not resolve REST API id automatically
 
-          const provider = this.serverless.service.provider;
+          const provider = this.state.service.provider;
           const isTracingEnabled = provider.tracing && provider.tracing.apiGateway;
           const areLogsEnabled = provider.logs && provider.logs.restApi;
           const hasTags = Boolean(provider.tags);
@@ -75,7 +75,7 @@ function resolveRestApiId() {
       resolve(isRestApiId(customRestApiId) ? customRestApiId : null);
       return;
     }
-    const apiName = provider.apiName || `${this.options.stage}-${this.serverless.service.service}`;
+    const apiName = provider.apiName || `${this.options.stage}-${this.state.service.service}`;
     const resolvefromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(api => api.name === apiName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -23,14 +23,41 @@ module.exports = {
 
     return resolveAccountId.call(this)
       .then(resolveRestApiId.bind(this))
-      .then(resolveStage.bind(this))
-      .then(resolveDeploymentId.bind(this))
-      .then(ensureStage.bind(this))
-      .then(handleTracing.bind(this))
-      .then(handleLogs.bind(this))
-      .then(handleTags.bind(this))
-      .then(applyUpdates.bind(this))
-      .then(removeLogGroup.bind(this));
+      .then(() => {
+        if (!this.apiGatewayRestApiId) {
+          // Could not resolve REST API id automatically
+
+          const provider = this.serverless.service.provider;
+          const isTracingEnabled = provider.tracing && provider.tracing.apiGateway;
+          const areLogsEnabled = provider.logs && provider.logs.restApi;
+          const hasTags = Boolean(provider.tags);
+
+          if (!isTracingEnabled && !areLogsEnabled && !hasTags) {
+            // Do crash if there are no API Gateway customizations to apply
+            return null;
+          }
+
+          throw new Error(`Rest API id could not be resolved
+
+It's most likely, due to custom APIGateway setup.
+In given situation some APIGateway specific options (as \`tracing\`, \`logs\` and \`tags\`)
+could not be applied.
+
+If you feel Rest API Id could be resolved automatically by Serverless framework,
+please report this case to us (so hopefully we can improve it)
+
+Otherwise, please adjust your configuration.`);
+        }
+        return resolveStage
+          .call(this)
+          .then(resolveDeploymentId.bind(this))
+          .then(ensureStage.bind(this))
+          .then(handleTracing.bind(this))
+          .then(handleLogs.bind(this))
+          .then(handleTags.bind(this))
+          .then(applyUpdates.bind(this))
+          .then(removeLogGroup.bind(this));
+      });
   },
 };
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -39,7 +39,7 @@ module.exports = {
 
           throw new Error(`Rest API id could not be resolved
 
-It's most likely, due to custom APIGateway setup.
+It's most likely due to custom APIGateway setup.
 In given situation some APIGateway specific options (as \`tracing\`, \`logs\` and \`tags\`)
 could not be applied.
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -5,7 +5,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
-const isRestApiId = RegExp.prototype.test.bind(/^[a-z0-9]{10}$/);
+const isRestApiId = RegExp.prototype.test.bind(/^[a-z0-9]{3,}$/);
 
 // NOTE --> Keep this file in sync with ../stage.js
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -212,7 +212,7 @@ describe('#updateStage()', () => {
   it('should resolve custom restApiId', () => {
     providerRequestStub
       .withArgs('APIGateway', 'getStage', {
-        restApiId: 'foobar',
+        restApiId: 'foobarfoo1',
         stageName: 'dev',
       })
       .resolves({
@@ -220,9 +220,9 @@ describe('#updateStage()', () => {
           old: 'tag',
         },
       });
-    context.serverless.service.provider.apiGateway = { restApiId: 'foobar' };
+    context.serverless.service.provider.apiGateway = { restApiId: 'foobarfoo1' };
     return updateStage.call(context).then(() => {
-      expect(context.apiGatewayRestApiId).to.equal('foobar');
+      expect(context.apiGatewayRestApiId).to.equal('foobarfoo1');
     });
   });
 
@@ -234,12 +234,12 @@ describe('#updateStage()', () => {
       })
       .resolves({
         items: [],
-        position: 'foobar',
+        position: 'foobarfoo1',
       });
     providerRequestStub
       .withArgs('APIGateway', 'getRestApis', {
         limit: 500,
-        position: 'foobar',
+        position: 'foobarfoo1',
       })
       .resolves({
         items: [{ name: 'dev-my-service', id: 'someRestApiId' }],

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -64,18 +64,18 @@ describe('#updateStage()', () => {
   });
 
   it('should update the stage based on the serverless file configuration', () => {
-    context.serverless.service.provider.tags = {
+    context.state.service.provider.tags = {
       foo: 'bar',
       bar: 'baz',
     };
-    context.serverless.service.provider.stackTags = {
+    context.state.service.provider.stackTags = {
       baz: 'qux',
       num: 123,
     };
-    context.serverless.service.provider.tracing = {
+    context.state.service.provider.tracing = {
       apiGateway: true,
     };
-    context.serverless.service.provider.logs = {
+    context.state.service.provider.logs = {
       restApi: true,
     };
 
@@ -220,7 +220,7 @@ describe('#updateStage()', () => {
           old: 'tag',
         },
       });
-    context.serverless.service.provider.apiGateway = { restApiId: 'foobarfoo1' };
+    context.state.service.provider.apiGateway = { restApiId: 'foobarfoo1' };
     return updateStage.call(context).then(() => {
       expect(context.apiGatewayRestApiId).to.equal('foobarfoo1');
     });
@@ -245,7 +245,7 @@ describe('#updateStage()', () => {
           old: 'tag',
         },
       });
-    context.serverless.service.provider.apiName = 'custom-api-gateway-name';
+    context.state.service.provider.apiName = 'custom-api-gateway-name';
     return updateStage.call(context).then(() => {
       expect(context.apiGatewayRestApiId).to.equal('restapicus');
     });
@@ -279,7 +279,7 @@ describe('#updateStage()', () => {
     'should not apply hack when restApiId could not be resolved and ' +
       'no custom settings are applied',
     () => {
-      context.serverless.service.provider.apiGateway = {
+      context.state.service.provider.apiGateway = {
         restApiId: { 'Fn::ImportValue': 'RestApiId-${self:custom.stage}' },
       };
       return updateStage.call(context).then(() => {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -226,6 +226,31 @@ describe('#updateStage()', () => {
     });
   });
 
+  it('should resolve custom APIGateway name', () => {
+    providerRequestStub
+      .withArgs('APIGateway', 'getRestApis', {
+        limit: 500,
+        position: undefined,
+      })
+      .resolves({
+        items: [{ name: 'custom-api-gateway-name', id: 'restapicus' }],
+      });
+    providerRequestStub
+      .withArgs('APIGateway', 'getStage', {
+        restApiId: 'restapicus',
+        stageName: 'dev',
+      })
+      .resolves({
+        variables: {
+          old: 'tag',
+        },
+      });
+    context.serverless.service.provider.apiName = 'custom-api-gateway-name';
+    return updateStage.call(context).then(() => {
+      expect(context.apiGatewayRestApiId).to.equal('restapicus');
+    });
+  });
+
   it('should resolve expected restApiId when beyond 500 APIs are deployed', () => {
     providerRequestStub
       .withArgs('APIGateway', 'getRestApis', {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -5,6 +5,7 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
+const _ = require('lodash');
 const Serverless = require('../../../../../../../../Serverless');
 const AwsProvider = require('../../../../../../provider/awsProvider');
 const updateStage = require('./updateStage').updateStage;
@@ -30,7 +31,7 @@ describe('#updateStage()', () => {
     context = {
       serverless,
       options,
-      state: serverless,
+      state: _.cloneDeep(serverless),
       provider: awsProvider,
     };
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -249,4 +249,17 @@ describe('#updateStage()', () => {
       expect(context.apiGatewayRestApiId).to.equal('someRestApiId');
     });
   });
+
+  it(
+    'should not apply hack when restAPIId could not be resolved and ' +
+      'no custom settings are applied',
+    () => {
+      context.serverless.service.provider.apiGateway = {
+        restApiId: { 'Fn::ImportValue': 'RestApiId-${self:custom.stage}' },
+      };
+      return updateStage.call(context).then(() => {
+        expect(providerRequestStub.callCount).to.equal(0);
+      });
+    }
+  );
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -276,7 +276,7 @@ describe('#updateStage()', () => {
   });
 
   it(
-    'should not apply hack when restAPIId could not be resolved and ' +
+    'should not apply hack when restApiId could not be resolved and ' +
       'no custom settings are applied',
     () => {
       context.serverless.service.provider.apiGateway = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.42.2",
+  "version": "1.42.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -264,21 +264,6 @@
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
         }
       }
     },
@@ -899,9 +884,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.452.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.452.0.tgz",
-      "integrity": "sha512-l6J2NmUg12xpDKG9YdlPje5+Z+nNvqyWMA85ookzPqwx8RcD28D3vg4K1aGi27/oo/3NsngR3XfKUBPSqUpUMA==",
+      "version": "2.454.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.454.0.tgz",
+      "integrity": "sha512-1vB9DNIwh+mqKD2IZspYTQapCD6f5VnMT5V2VPlXJ1CNcUdFSU8FFyxKmYApNs+S3re1h3fhWDjpwTreS+XLRQ==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -976,17 +961,15 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1589,9 +1572,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2299,17 +2282,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
           }
         },
         "debug": {
@@ -2340,17 +2312,6 @@
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.0",
             "through": "^2.3.6"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
           }
         },
         "ms": {
@@ -2366,6 +2327,15 @@
           "dev": true,
           "requires": {
             "once": "^1.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -6032,9 +6002,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "next-tick": {
@@ -7889,12 +7859,6 @@
             "json-stable-stringify": "^1.0.1"
           }
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -7912,23 +7876,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
           }
         },
         "is-fullwidth-code-point": {
@@ -7947,6 +7894,12 @@
             "strip-ansi": "^4.0.0"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -7956,6 +7909,15 @@
                 "ansi-regex": "^3.0.0"
               }
             }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -8228,9 +8190,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
-      "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.42.2",
+  "version": "1.42.3",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
## What did you implement:

It appears there are cases where we cannot reliably resolve REST API id (as it can be set directly in CloudFormation, and even resolved via CF functions, for which there are no means to resolve reliably locally).

In light of that, hack that applies custom APIGateway settings post CF deployment was updated to 
not apply any settings, if no customizations are found in `serverless.yml` and we cannot resolve REST API id.

Additionally added support for custom `apiName` (before only default resolution was assumed)

Closes #6100 

## How did you implement it:

- Added early exit if there are no APIGateway customizations and REST API id cannot be resolved.
- Added fallback for `provider.apiName` if provided

## How can we verify it:

Deploy a service that resembles documented case, and test whether it deploys as expected.

## Todos:

- [x] Write tests

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
