### PR TITLE
Fix tagging API Gateway stage fails if tag contains special characters like space

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -17,6 +17,8 @@ module.exports = {
     // this array is used to gather all the patch operations we need to
     // perform on the stage
     this.apiGatewayStagePatchOperations = [];
+    this.apiGatewayTagResourceParams = [];
+    this.apiGatewayUntagResourceParams = [];
     this.apiGatewayStageState = {};
     this.apiGatewayDeploymentId = null;
     this.apiGatewayRestApiId = null;
@@ -57,6 +59,8 @@ module.exports = {
           .then(handleLogs.bind(this))
           .then(handleTags.bind(this))
           .then(applyUpdates.bind(this))
+          .then(addTags.bind(this))
+          .then(removeTags.bind(this))
           .then(removeLogGroup.bind(this));
       });
   },
@@ -198,30 +202,41 @@ function handleLogs() {
 
 function handleTags() {
   const provider = this.state.service.provider;
-  const tagsMerged = Object.assign({}, provider.stackTags, provider.tags);
+  const tagsMerged = _.mapValues(Object.assign({}, provider.stackTags, provider.tags),
+      v => String(v));
+  const currentTags = this.apiGatewayStageState.tags || {};
+  const tagKeysToBeRemoved = Object.keys(currentTags)
+    .filter(currentKey => !_.isString(tagsMerged[currentKey]));
 
-  const tagsToCreate = _.entriesIn(tagsMerged).map(pair => ({
-    key: String(pair[0]),
-    value: String(pair[1]),
-  }));
-  if (tagsToCreate) {
-    tagsToCreate.forEach((tag) => {
-      const operation = { op: 'replace', path: `/variables/${tag.key}`, value: tag.value };
-      this.apiGatewayStagePatchOperations.push(operation);
+  const restApiId = this.apiGatewayRestApiId;
+  const stageName = this.options.stage;
+  const region = this.options.region;
+  const resourceArn = `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+
+  if (tagKeysToBeRemoved.length > 0) {
+    this.apiGatewayUntagResourceParams.push({
+      resourceArn,
+      tagKeys: tagKeysToBeRemoved,
     });
   }
-
-  if (this.apiGatewayStageState.variables) {
-    const stateTagKeys = Object.keys(this.apiGatewayStageState.variables);
-    const newTagKeys = Object.keys(tagsMerged);
-    const tagsToRemove = _.difference(stateTagKeys, newTagKeys);
-    if (tagsToRemove) {
-      tagsToRemove.forEach((tagKey) => {
-        const operation = { op: 'remove', path: `/variables/${tagKey}` };
-        this.apiGatewayStagePatchOperations.push(operation);
-      });
-    }
+  if (!_.isEqual(currentTags, tagsMerged) && _.size(tagsMerged) > 0) {
+    this.apiGatewayTagResourceParams.push({
+      resourceArn,
+      tags: tagsMerged,
+    });
   }
+}
+
+function addTags() {
+  const requests = this.apiGatewayTagResourceParams.map(tagResourceParam =>
+    this.provider.request('APIGateway', 'tagResource', tagResourceParam));
+  return BbPromise.all(requests);
+}
+
+function removeTags() {
+  const requests = this.apiGatewayUntagResourceParams.map(untagResourceParam =>
+    this.provider.request('APIGateway', 'untagResource', untagResourceParam));
+  return BbPromise.all(requests);
 }
 
 function applyUpdates() {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -49,7 +49,7 @@ describe('#updateStage()', () => {
         stageName: 'dev',
       })
       .resolves({
-        variables: {
+        tags: {
           old: 'tag',
         },
       });
@@ -66,11 +66,11 @@ describe('#updateStage()', () => {
 
   it('should update the stage based on the serverless file configuration', () => {
     context.state.service.provider.tags = {
-      foo: 'bar',
-      bar: 'baz',
+      'Containing Space': 'bar',
+      bar: 'high-priority',
     };
     context.state.service.provider.stackTags = {
-      baz: 'qux',
+      bar: 'low-priority',
       num: 123,
     };
     context.state.service.provider.tracing = {
@@ -87,15 +87,10 @@ describe('#updateStage()', () => {
         { op: 'replace', path: '/accessLogSettings/format', value: 'requestId: $context.requestId, ip: $context.identity.sourceIp, caller: $context.identity.caller, user: $context.identity.user, requestTime: $context.requestTime, httpMethod: $context.httpMethod, resourcePath: $context.resourcePath, status: $context.status, protocol: $context.protocol, responseLength: $context.responseLength' },
         { op: 'replace', path: '/*/*/logging/dataTrace', value: 'true' },
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' },
-        { op: 'replace', path: '/variables/baz', value: 'qux' },
-        { op: 'replace', path: '/variables/num', value: '123' },
-        { op: 'replace', path: '/variables/foo', value: 'bar' },
-        { op: 'replace', path: '/variables/bar', value: 'baz' },
-        { op: 'remove', path: '/variables/old' },
       ];
 
       expect(providerGetAccountIdStub).to.be.calledOnce;
-      expect(providerRequestStub.args).to.have.length(3);
+      expect(providerRequestStub.args).to.have.length(5);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
       expect(providerRequestStub.args[0][2]).to.deep.equal({
@@ -112,16 +107,34 @@ describe('#updateStage()', () => {
         stageName: 'dev',
         patchOperations,
       });
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('tagResource');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
+        resourceArn: 'arn:aws:apigateway:us-east-1::/restapis/someRestApiId/stages/dev',
+        tags: {
+          'Containing Space': 'bar',
+          bar: 'high-priority',
+          num: '123',
+        },
+      });
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('untagResource');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
+        resourceArn: 'arn:aws:apigateway:us-east-1::/restapis/someRestApiId/stages/dev',
+        tagKeys: ['old'],
+      });
     });
   });
 
-  it('should perform default actions if settings are not configure', () =>
-    updateStage.call(context).then(() => {
+  it('should perform default actions if settings are not configure', () => {
+    context.state.service.provider.tags = {
+      old: 'tag',
+    };
+    return updateStage.call(context).then(() => {
       const patchOperations = [
         { op: 'replace', path: '/tracingEnabled', value: 'false' },
         { op: 'replace', path: '/*/*/logging/dataTrace', value: 'false' },
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' },
-        { op: 'remove', path: '/variables/old' },
       ];
 
       expect(providerGetAccountIdStub).to.be.calledOnce;
@@ -147,7 +160,8 @@ describe('#updateStage()', () => {
       expect(providerRequestStub.args[3][2]).to.deep.equal({
         logGroupName: '/aws/api-gateway/my-service-dev',
       });
-    }));
+    });
+  });
 
   it('should create a new stage and proceed as usual if none can be found', () => {
     providerRequestStub.withArgs('APIGateway', 'getStage', {


### PR DESCRIPTION
## What did you implement:

Closes #6133
Closes #6170

## How did you implement it:

Use [tagResource](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html#tagResource-property) and [untagResource](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html#untagResource-property) that can use tag containing space. 

## How can we verify it:

The following should deploy successfully where API GW stage are tagged with `bar bar` & `foo`.


```yaml
service: fix-6133

provider:
  name: aws
  runtime: nodejs10.x
  region: us-east-1
  tags:
    foo: XXX
  stackTags:
    bar bar: ZZZ

functions:
  hello:
    handler: handler.hello
    events:
      - http: GET hello
```

## Todos:

- [x] Write tests
- N/A Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** NO
