### PR TITLE
Update AWS Node.js runtime to version 10

### DIFF
--- a/docs/providers/aws/cli-reference/print.md
+++ b/docs/providers/aws/cli-reference/print.md
@@ -42,7 +42,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   stage: ${opt:stage, "dev"}
 
 functions:
@@ -66,7 +66,7 @@ custom:
   bucketName: test
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   stage: dev # <-- Resolved
 functions:
   hello:

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1220,7 +1220,7 @@ service: my-api
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   stage: dev
   region: eu-west-2
 
@@ -1390,7 +1390,7 @@ Resource policies are policy documents that are used to control the invocation o
 ```yml
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
   resourcePolicy:
     - Effect: Allow

--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -60,7 +60,7 @@ service: serverless-ws-test
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   websocketsApiName: custom-websockets-api-name
   websocketsApiRouteSelectionExpression: $request.body.action # custom routes are selected by the value of the action property in the body
 
@@ -127,7 +127,7 @@ functions:
             identitySource:
               - 'route.request.header.Auth'
               - 'route.request.querystring.Auth'
-            
+
   auth:
     handler: handler.auth
 ```
@@ -147,7 +147,7 @@ functions:
             identitySource:
               - 'route.request.header.Auth'
               - 'route.request.querystring.Auth'
-            
+
   auth:
     handler: handler.auth
 ```
@@ -177,7 +177,7 @@ const sendMessageToClient = (url, connectionId, payload) => new Promise((resolve
 module.exports.defaultHandler = async (event, context) => {
   const domain = event.requestContext.domainName;
   const stage = event.requestContext.stage;
-  const connectionId = event.requestContext.connectionId; 
+  const connectionId = event.requestContext.connectionId;
   const callbackUrlForAWS = util.format(util.format('https://%s/%s', domain, stage)); //construct the needed url
   await sendMessageToClient(callbackUrlForAWS, connectionId, event);
 

--- a/docs/providers/aws/examples/hello-world/node/serverless.yml
+++ b/docs/providers/aws/examples/hello-world/node/serverless.yml
@@ -3,7 +3,7 @@ service: hello-world # Service Name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   helloWorld:

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -131,7 +131,7 @@ You can even set up different profiles for different accounts, which can be used
 service: new-service
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   stage: dev
   profile: devProfile
 ```
@@ -176,7 +176,7 @@ This example `serverless.yml` snippet will load the profile depending upon the s
 service: new-service
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   stage: ${opt:stage, self:custom.defaultStage}
   profile: ${self:custom.profiles.${self:provider.stage}}
 custom:

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -24,7 +24,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   memorySize: 512 # optional, in MB, default is 1024
   timeout: 10 # optional, in seconds, default is 6
   versionFunctions: false # optional, default is true
@@ -59,7 +59,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   functionOne:
@@ -79,7 +79,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   memorySize: 512 # will be inherited by all functions
 
 functions:
@@ -95,7 +95,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   functionOne:
@@ -133,7 +133,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   iamRoleStatements: # permissions for all of your functions can be set here
     - Effect: Allow
       Action: # Gives permission to DynamoDB tables in a specific region
@@ -390,7 +390,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:
@@ -443,7 +443,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   tracing:
     lambda: true
 ```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -25,7 +25,7 @@ frameworkVersion: ">=1.0.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   stage: ${opt:stage, 'dev'} # Set the default stage used. Default is dev
   region: ${opt:region, 'us-east-1'} # Overwrite the default region used. Default is us-east-1
   stackName: custom-stack-name # Use a custom name for the CloudFormation stack
@@ -148,7 +148,7 @@ functions:
     description: My function # The description of your function.
     memorySize: 512 # memorySize for this specific function.
     reservedConcurrency: 5 # optional, reserved concurrency limit for this function. By default, AWS uses account concurrency limit
-    runtime: nodejs6.10 # Runtime for this specific function. Overrides the default which is set on the provider level
+    runtime: nodejs10.x # Runtime for this specific function. Overrides the default which is set on the provider level
     timeout: 10 # Timeout for this specific function.  Overrides the default set above.
     role: arn:aws:iam::XXXXXX:role/role # IAM role which will be used for this function
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic # Optional SNS topic / SQS arn (Ref, Fn::GetAtt and Fn::ImportValue are supported as well) which will be used for the DeadLetterConfig

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -99,7 +99,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
   stackName: my-custom-stack-name-${self:provider.stage} # Overwrite default CloudFormation stack name. Default is ${self:service}-${self:provider.stage}
@@ -229,7 +229,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   memorySize: 512
 
 …
@@ -246,7 +246,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   memorySize: 512
 
 …

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -183,7 +183,7 @@ You can add such custom output to CloudFormation stack. For example:
 service: another-service
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   region: ap-northeast-1
   memorySize: 512
 functions:
@@ -562,7 +562,7 @@ service: new-service
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   variableSyntax: "\\${{([ ~:a-zA-Z0-9._@\\'\",\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
 #  variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml -- e.g. ${AWS::Region}. All other Serverless variables work as usual.
 

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -97,14 +97,14 @@ describe('Service', () => {
       const data = {
         provider: {
           name: 'testProvider',
-          runtime: 'nodejs6.10',
+          runtime: 'nodejs10.x',
         },
       };
 
       const serviceInstance = new Service(serverless, data);
 
       expect(serviceInstance.provider.name).to.be.equal('testProvider');
-      expect(serviceInstance.provider.runtime).to.be.equal('nodejs6.10');
+      expect(serviceInstance.provider.runtime).to.be.equal('nodejs10.x');
     });
   });
 

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -728,7 +728,7 @@ describe('Utils', () => {
         service: 'new-service',
         provider: {
           name: 'aws',
-          runtime: 'nodejs6.10',
+          runtime: 'nodejs10.x',
           stage: 'dev',
           region: 'us-east-1',
           variableSyntax: '\\${foo}',

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -38,7 +38,7 @@ class AwsInvokeLocal {
   getRuntime() {
     return this.options.functionObj.runtime
       || this.serverless.service.provider.runtime
-      || 'nodejs4.3';
+      || 'nodejs10.x';
   }
 
   validateFile(filePath, key) {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -382,7 +382,7 @@ describe('AwsInvokeLocal', () => {
     );
 
     it('should call invokeLocalNodeJs for any node.js runtime version', () => {
-      awsInvokeLocal.options.functionObj.runtime = 'nodejs6.10';
+      awsInvokeLocal.options.functionObj.runtime = 'nodejs10.x';
       return awsInvokeLocal.invokeLocal().then(() => {
         expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
         expect(invokeLocalNodeJsStub.calledWithExactly(
@@ -482,8 +482,8 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
-    it('should call invokeLocalDocker if using --docker option with nodejs8.10', () => {
-      awsInvokeLocal.options.functionObj.runtime = 'nodejs8.10';
+    it('should call invokeLocalDocker if using --docker option with nodejs10.x', () => {
+      awsInvokeLocal.options.functionObj.runtime = 'nodejs10.x';
       awsInvokeLocal.options.functionObj.handler = 'handler.foobar';
       awsInvokeLocal.options.docker = true;
       return awsInvokeLocal.invokeLocal().then(() => {
@@ -1163,7 +1163,7 @@ describe('AwsInvokeLocal', () => {
           handler: 'handler.hello',
           name: 'hello',
           timeout: 4,
-          runtime: 'nodejs8.10',
+          runtime: 'nodejs10.x',
           environment: {
             functionVar: 'functionValue',
           },
@@ -1190,9 +1190,9 @@ describe('AwsInvokeLocal', () => {
         expect(pluginMangerSpawnPackageStub.calledOnce).to.equal(true);
         expect(spawnStub.getCall(0).args).to.deep.equal(['docker', ['version']]);
         expect(spawnStub.getCall(1).args).to.deep.equal(['docker',
-          ['images', '-q', 'lambci/lambda:nodejs8.10']]);
+          ['images', '-q', 'lambci/lambda:nodejs10.x']]);
         expect(spawnStub.getCall(2).args).to.deep.equal(['docker',
-          ['pull', 'lambci/lambda:nodejs8.10']]);
+          ['pull', 'lambci/lambda:nodejs10.x']]);
         expect(spawnStub.getCall(3).args).to.deep.equal(['docker', [
           'build',
           '-t',

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -115,7 +115,7 @@ class AwsCompileFunctions {
       || 6;
     const Runtime = functionObject.runtime
       || this.serverless.service.provider.runtime
-      || 'nodejs4.3';
+      || 'nodejs10.x';
 
     newFunction.Properties.Handler = Handler;
     newFunction.Properties.FunctionName = FunctionName;

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -416,7 +416,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
         },
       };
@@ -460,7 +460,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           VpcConfig: {
             SecurityGroupIds: ['xxx'],
@@ -507,7 +507,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           VpcConfig: {
             SecurityGroupIds: ['xxx'],
@@ -556,7 +556,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Tags: [
             { Key: 'foo', Value: 'bar' },
@@ -604,7 +604,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Tags: [
             { Key: 'foo', Value: 'bar' },
@@ -657,7 +657,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Tags: [
             { Key: 'foo', Value: 'bar' },
@@ -765,7 +765,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: 'arn:aws:sns:region:accountid:foo',
@@ -834,7 +834,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -880,7 +880,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -926,7 +926,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -972,7 +972,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: 'arn:aws:sns:region:accountid:foo',
@@ -1085,7 +1085,7 @@ describe('AwsCompileFunctions', () => {
             Handler: 'func.function.handler',
             MemorySize: 1024,
             Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-            Runtime: 'nodejs4.3',
+            Runtime: 'nodejs10.x',
             Timeout: 6,
             KmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
           },
@@ -1133,7 +1133,7 @@ describe('AwsCompileFunctions', () => {
             Handler: 'func1.function.handler',
             MemorySize: 1024,
             Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-            Runtime: 'nodejs4.3',
+            Runtime: 'nodejs10.x',
             Timeout: 6,
             KmsKeyArn: 'arn:aws:kms:region:accountid:foo/function',
           },
@@ -1154,7 +1154,7 @@ describe('AwsCompileFunctions', () => {
             Handler: 'func2.function.handler',
             MemorySize: 1024,
             Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-            Runtime: 'nodejs4.3',
+            Runtime: 'nodejs10.x',
             Timeout: 6,
             KmsKeyArn: 'arn:aws:kms:region:accountid:foo/service',
           },
@@ -1213,7 +1213,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               KmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
             },
@@ -1267,7 +1267,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               KmsKeyArn: 'arn:aws:kms:region:accountid:foo/bar',
             },
@@ -1338,7 +1338,7 @@ describe('AwsCompileFunctions', () => {
             Handler: 'func.function.handler',
             MemorySize: 1024,
             Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-            Runtime: 'nodejs4.3',
+            Runtime: 'nodejs10.x',
             Timeout: 6,
             TracingConfig: {
               Mode: 'Active',
@@ -1388,7 +1388,7 @@ describe('AwsCompileFunctions', () => {
             Handler: 'func1.function.handler',
             MemorySize: 1024,
             Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-            Runtime: 'nodejs4.3',
+            Runtime: 'nodejs10.x',
             Timeout: 6,
             TracingConfig: {
               Mode: 'Active',
@@ -1411,7 +1411,7 @@ describe('AwsCompileFunctions', () => {
             Handler: 'func2.function.handler',
             MemorySize: 1024,
             Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-            Runtime: 'nodejs4.3',
+            Runtime: 'nodejs10.x',
             Timeout: 6,
             TracingConfig: {
               Mode: 'PassThrough',
@@ -1471,7 +1471,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               TracingConfig: {
                 Mode: 'Active',
@@ -1527,7 +1527,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs4.3',
+              Runtime: 'nodejs10.x',
               Timeout: 6,
               TracingConfig: {
                 Mode: 'PassThrough',
@@ -1581,7 +1581,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Environment: {
             Variables: {
@@ -1631,7 +1631,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Environment: {
             Variables: {
@@ -1680,7 +1680,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Environment: {
             Variables: {
@@ -1732,7 +1732,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Environment: {
             Variables: {
@@ -1846,7 +1846,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 128,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 10,
         },
       };
@@ -1902,7 +1902,7 @@ describe('AwsCompileFunctions', () => {
       });
     });
 
-    it('should default to the nodejs4.3 runtime when no provider runtime is given', () => {
+    it('should default to the nodejs10.x runtime when no provider runtime is given', () => {
       const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
       const s3FileName = awsCompileFunctions.serverless.service.package.artifact
         .split(path.sep).pop();
@@ -1928,7 +1928,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
         },
       };
@@ -2069,12 +2069,12 @@ describe('AwsCompileFunctions', () => {
       const expectedOutputs = {
         FuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
-          Value: { Ref: 'FuncLambdaVersionl6Rjpaz0gycgsEDI51sLed039fH2uR4W8Q2IW8cNo' },
+          Value: { Ref: 'FuncLambdaVersionpcyXz9PqN5xesfBZOOhY7t6jhi8kOCyGDknpfuhJ4' },
         },
         AnotherFuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
           Value: {
-            Ref: 'AnotherFuncLambdaVersion6JZQneYqP4bC0Z3ywMc3XJPyECHK4RMGhpv8iis4E',
+            Ref: 'AnotherFuncLambdaVersionIo6IWr3BPLeAaVjlRwEGEz4vvDzC43h07eOBY0fXyI',
           },
         },
       };
@@ -2103,12 +2103,12 @@ describe('AwsCompileFunctions', () => {
       const expectedOutputs = {
         FuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
-          Value: { Ref: 'FuncLambdaVersionl6Rjpaz0gycgsEDI51sLed039fH2uR4W8Q2IW8cNo' },
+          Value: { Ref: 'FuncLambdaVersionpcyXz9PqN5xesfBZOOhY7t6jhi8kOCyGDknpfuhJ4' },
         },
         AnotherFuncLambdaFunctionQualifiedArn: {
           Description: 'Current Lambda function version',
           Value: {
-            Ref: 'AnotherFuncLambdaVersion6JZQneYqP4bC0Z3ywMc3XJPyECHK4RMGhpv8iis4E',
+            Ref: 'AnotherFuncLambdaVersionIo6IWr3BPLeAaVjlRwEGEz4vvDzC43h07eOBY0fXyI',
           },
         },
       };
@@ -2143,7 +2143,7 @@ describe('AwsCompileFunctions', () => {
           'FuncLambdaFunctionQualifiedArn',
           {
             Description: 'Current Lambda function version',
-            Value: { Ref: 'FuncLambdaVersiona6VymfU25aF6eS2qysm7sHqPyy8RqYUzoTvDeBrrBA' },
+            Value: { Ref: 'FuncLambdaVersionI1xWetHMVQO8bvzGqgmokPl25rtJA0A8g6lZNYdkdg' },
           }
         );
 
@@ -2168,7 +2168,7 @@ describe('AwsCompileFunctions', () => {
       .then(() => {
         expect(
           awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FuncLambdaVersionOKy3yjVllZnozzdvQqHlRN8lBwkZyA6l76TCAEyork
+            .Resources.FuncLambdaVersionBzAYHivcbYLoEZcl7hN9cBrakBNygN0PiUC9UjQVMA
           .Properties.Description
         ).to.equal('Lambda function description');
       });
@@ -2225,7 +2225,7 @@ describe('AwsCompileFunctions', () => {
           MemorySize: 1024,
           ReservedConcurrentExecutions: 5,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
         },
       };
@@ -2266,7 +2266,7 @@ describe('AwsCompileFunctions', () => {
           MemorySize: 1024,
           ReservedConcurrentExecutions: 0,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
         },
       };
@@ -2434,7 +2434,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
         },
       };
@@ -2475,7 +2475,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs4.3',
+          Runtime: 'nodejs10.x',
           Timeout: 6,
           Layers: ['arn:aws:xxx:*:*'],
         },

--- a/lib/plugins/aws/package/compile/layers/index.test.js
+++ b/lib/plugins/aws/package/compile/layers/index.test.js
@@ -292,7 +292,7 @@ describe('AwsCompileLayers', () => {
         test: {
           path: 'layer',
           description: 'desc',
-          compatibleRuntimes: ['nodejs8.10'],
+          compatibleRuntimes: ['nodejs10.x'],
           licenseInfo: 'GPL',
         },
       };
@@ -305,7 +305,7 @@ describe('AwsCompileLayers', () => {
           },
           LayerName: 'test',
           Description: 'desc',
-          CompatibleRuntimes: ['nodejs8.10'],
+          CompatibleRuntimes: ['nodejs10.x'],
           LicenseInfo: 'GPL',
         },
       };

--- a/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 custom:
   alexa:

--- a/lib/plugins/create/templates/aws-clojurescript-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-clojurescript-gradle/serverless.yml
@@ -19,7 +19,7 @@ service: aws-clojurescript-gradle
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 # you can overwrite defaults here
 #  stage: dev

--- a/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
@@ -19,7 +19,7 @@ service: aws-kotlin-nodejs-gradle # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 # you can overwrite defaults here
 #  stage: dev

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   first:

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -19,7 +19,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 # you can overwrite defaults here
 #  stage: dev

--- a/lib/plugins/create/templates/hello-world/serverless.yml
+++ b/lib/plugins/create/templates/hello-world/serverless.yml
@@ -10,7 +10,7 @@ service: serverless-hello-world
 # The `provider` block defines where your service will be deployed
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 # The `functions` block defines what code to deploy
 functions:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/api-keys/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/cors/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/custom-authorizers/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda-proxy/simple-api/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/api-keys/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   apiKeys:
     - WillBeReplacedBeforeDeployment
 

--- a/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/cors/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/custom-authorizers/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
+++ b/tests/integration/aws/api-gateway/integration-lambda/simple-api/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/cloud-watch-event/multiple-events-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/multiple-events-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   cwe1:

--- a/tests/integration/aws/cloud-watch-event/multiple-events-single-function/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/multiple-events-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   cwe1:

--- a/tests/integration/aws/cloud-watch-event/single-event-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/single-event-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   cwe1:

--- a/tests/integration/aws/cloud-watch-event/single-event-single-function/service/serverless.yml
+++ b/tests/integration/aws/cloud-watch-event/single-event-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   cwe1:

--- a/tests/integration/aws/cognito-user-pool/multiple-pools-multiple-events-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/cognito-user-pool/multiple-pools-multiple-events-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   preSignUp1:

--- a/tests/integration/aws/cognito-user-pool/multiple-pools-single-event-single-function/service/serverless.yml
+++ b/tests/integration/aws/cognito-user-pool/multiple-pools-single-event-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   preSignUp:

--- a/tests/integration/aws/cognito-user-pool/single-pool-multiple-events-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/cognito-user-pool/single-pool-multiple-events-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   preSignUp:

--- a/tests/integration/aws/cognito-user-pool/single-pool-single-event-single-function/service/serverless.yml
+++ b/tests/integration/aws/cognito-user-pool/single-pool-single-event-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   preSignUp:

--- a/tests/integration/aws/general/custom-resources/service/serverless.yml
+++ b/tests/integration/aws/general/custom-resources/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/general/environment-variables/service/serverless.yml
+++ b/tests/integration/aws/general/environment-variables/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   environment:
     provider_level_variable_1: provider_level_1
     provider_level_variable_2: provider_level_2

--- a/tests/integration/aws/general/nested-handlers/service/serverless.yml
+++ b/tests/integration/aws/general/nested-handlers/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/general/overwrite-resources/service/serverless.yml
+++ b/tests/integration/aws/general/overwrite-resources/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/general/package/service/serverless.yml
+++ b/tests/integration/aws/general/package/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/iot/multiple-rules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/iot/multiple-rules-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   iot1:

--- a/tests/integration/aws/iot/multiple-rules-single-function/service/serverless.yml
+++ b/tests/integration/aws/iot/multiple-rules-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   iot1:

--- a/tests/integration/aws/iot/single-rule-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/iot/single-rule-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   iot1:

--- a/tests/integration/aws/iot/single-rule-single-function/service/serverless.yml
+++ b/tests/integration/aws/iot/single-rule-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   iot1:

--- a/tests/integration/aws/s3/multiple-events-multiple-functions-multiple-buckets/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-multiple-functions-multiple-buckets/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/s3/multiple-events-multiple-functions-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-multiple-functions-single-bucket/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   create:

--- a/tests/integration/aws/s3/multiple-events-single-function-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/multiple-events-single-function-single-bucket/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/s3/single-event-single-function-single-bucket/service/serverless.yml
+++ b/tests/integration/aws/s3/single-event-single-function-single-bucket/service/serverless.yml
@@ -3,7 +3,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/schedule/multiple-schedules-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/sns/existing-topic/service/serverless.yml
+++ b/tests/integration/aws/sns/existing-topic/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/multiple-topics-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-multiple-functions/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
+++ b/tests/integration/aws/sns/single-topic-single-function/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/general/custom-plugins/service/serverless.yml
+++ b/tests/integration/general/custom-plugins/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:

--- a/tests/integration/general/local-plugins/service/serverless.yml
+++ b/tests/integration/general/local-plugins/service/serverless.yml
@@ -2,7 +2,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
 
 functions:
   hello:


### PR DESCRIPTION
Updates Node.js runtime to version `nodejs10.x`.

See the AWS docs for more information on that matter --> https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

One can verify it by running:

```yml
serverless create -t aws-nodejs -p node-test

cd node-test

serverless deploy

serverless invoke -f hello

serverless remove
```

Closes #6135