### PR TITLE
Tests: Fix mocha config

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -934,7 +934,8 @@ describe('AwsInvokeLocal', () => {
     });
 
     describe('context.remainingTimeInMillis', () => {
-      it('should become lower over time', () => {
+      it('should become lower over time', function () {
+        this.timeout(3000); // On Windows it tends to timeout with 2000
         awsInvokeLocal.serverless.config.servicePath = __dirname;
 
         return awsInvokeLocal.invokeLocalRuby(
@@ -948,7 +949,9 @@ describe('AwsInvokeLocal', () => {
     });
 
     describe('calling a class method', () => {
-      it('should execute', () => {
+      it('should execute', function () {
+        this.timeout(3000); // On Windows it tends to timeout with 2000
+
         awsInvokeLocal.serverless.config.servicePath = __dirname;
 
         return awsInvokeLocal.invokeLocalRuby(

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "mocha": {
     "require": "sinon-bluebird",
-    "-R": "tests/mocha-reporter"
+    "R": "tests/mocha-reporter"
   },
   "jest": {
     "testRegex": "(\\.|/)(tests)\\.js$",

--- a/tests/mocha-reporter.js
+++ b/tests/mocha-reporter.js
@@ -47,7 +47,7 @@ module.exports = class ServerlessSpec extends Spec {
         // Timeout '5' to ensure no false positives, with '1' there are observable rare scenarios
         // of possibly a garbage collector delaying process exit being picked up
         // On Node.js v8+ '2' seems safe, while v6 needs '5'
-      }, 5).unref()
+      }, 6).unref()
     );
   }
 };

--- a/tests/mocha-reporter.js
+++ b/tests/mocha-reporter.js
@@ -36,6 +36,12 @@ BbPromise.prototype._ensurePossibleRejectionHandled = function () {
 };
 /* eslint-enable */
 
+if (process.version[1] < 8) {
+  // Async leaks detector is not reliable in Node.js v6
+  module.exports = Spec;
+  return;
+}
+
 module.exports = class ServerlessSpec extends Spec {
   constructor(runner) {
     super(runner);
@@ -44,10 +50,10 @@ module.exports = class ServerlessSpec extends Spec {
         // If tests end with any orphaned async call then this callback will be invoked
         // It's a signal there's some promise chain (or in general async flow) miconfiguration
         throw new Error('Test ended with unfinished async jobs');
-        // Timeout '5' to ensure no false positives, with '1' there are observable rare scenarios
+        // Timeout '2' to ensure no false positives, with '1' there are observable rare scenarios
         // of possibly a garbage collector delaying process exit being picked up
-        // On Node.js v8+ '2' seems safe, while v6 needs '5'
-      }, 6).unref()
+      }, 2).unref()
     );
   }
 };
+


### PR DESCRIPTION
Fix regression introduced with #6169

_**Note**: To support used syntax, https://github.com/serverless/serverless/pull/6188 needs to merged first_

By mistake param was named `-R` not `R`. Unfortunately mocha silently ignored that error (proposed an improvement at: https://github.com/mochajs/mocha/issues/3936)

This patch brings back correct Mocha setup

Additionally async leaks detector was turned off in Node.js v6 testing, as proven to produce there false positives

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
