### PR TITLE
Fix and improve ESlint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,9 @@ module.exports = {
     "react/require-extension": "off",
     "import/no-extraneous-dependencies": "off"
   },
+  "parserOptions": {
+    "sourceType": "script", // Override ESM implied by airbnb
+  },
   "env": {
     "mocha": true,
     "jest": true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,10 @@ module.exports = {
   "rules": {
     "func-names": "off",
     "global-require": "off", // Interfers with optional and eventual circular references
+    "react/require-extension": "off", // Forced by airbnb, not applicable (also deprecated)
     "strict": ["error", "safe"], // airbnb implies we're transpiling with babel, we're not
 
     // doesn't work in node v4 :(
-    "react/require-extension": "off",
     "import/no-extraneous-dependencies": "off"
   },
   "parserOptions": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,9 @@ module.exports = {
   "rules": {
     "func-names": "off",
     "global-require": "off", // Interfers with optional and eventual circular references
-    "strict": ["error", "safe"],
+    "strict": ["error", "safe"], // airbnb implies we're transpiling with babel, we're not
 
     // doesn't work in node v4 :(
-    "prefer-rest-params": "off",
     "react/require-extension": "off",
     "import/no-extraneous-dependencies": "off"
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,11 +5,9 @@ module.exports = {
   "rules": {
     "func-names": "off",
     "global-require": "off", // Interfers with optional and eventual circular references
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js",  "**/scripts/**", "**/tests/**"]}],
     "react/require-extension": "off", // Forced by airbnb, not applicable (also deprecated)
     "strict": ["error", "safe"], // airbnb implies we're transpiling with babel, we're not
-
-    // doesn't work in node v4 :(
-    "import/no-extraneous-dependencies": "off"
   },
   "parserOptions": {
     "sourceType": "script", // airbnb assumes ESM, while we're CJS

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,9 +5,9 @@ module.exports = {
   "rules": {
     "func-names": "off",
     "global-require": "off", // Interfers with optional and eventual circular references
+    "strict": ["error", "safe"],
 
     // doesn't work in node v4 :(
-    "strict": "off",
     "prefer-rest-params": "off",
     "react/require-extension": "off",
     "import/no-extraneous-dependencies": "off"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     "import/no-extraneous-dependencies": "off"
   },
   "parserOptions": {
-    "sourceType": "script", // Override ESM implied by airbnb
+    "sourceType": "script", // airbnb assumes ESM, while we're CJS
   },
   "env": {
     "mocha": true,

--- a/lib/plugins/aws/lib/getServiceState.js
+++ b/lib/plugins/aws/lib/getServiceState.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 
 module.exports = {

--- a/lib/utils/fs/readFileIfExists.js
+++ b/lib/utils/fs/readFileIfExists.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fileExists = require('./fileExists');
 const readFile = require('./readFile');
 const BbPromise = require('bluebird');

--- a/lib/utils/log/consoleLog.js
+++ b/lib/utils/log/consoleLog.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const consoleLog = function () {
-  console.log(arguments); // eslint-disable-line no-console
+const consoleLog = function (...args) {
+  console.log(args); // eslint-disable-line no-console
 };
 
 module.exports = consoleLog;

--- a/lib/utils/log/fileLog.js
+++ b/lib/utils/log/fileLog.js
@@ -4,11 +4,10 @@ const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
 
-const fileLog = function () {
+const fileLog = function (...args) {
   // TODO BRN: This does not guarentee order, is not multi process safe,
   // TODO BRN: and is not guarenteed to complete before exit.
-  fs.appendFileSync(path.join(process.cwd(), 'sls.log'),
-    _.join(Array.prototype.slice.call(arguments)) + '\n'); // eslint-disable-line prefer-template
+  fs.appendFileSync(path.join(process.cwd(), 'sls.log'), `${_.join(args)}\n`);
 };
 
 module.exports = fileLog;

--- a/lib/utils/log/log.js
+++ b/lib/utils/log/log.js
@@ -9,8 +9,8 @@ const loggers = [
   fileLog,
 ];
 
-const log = function () {
-  _.each(loggers, (logger) => logger.apply(null, arguments)); // eslint-disable-line prefer-spread
+const log = function (...args) {
+  _.each(loggers, (logger) => logger(...args));
 };
 
 module.exports = log;

--- a/lib/utils/renameService.js
+++ b/lib/utils/renameService.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const fse = require('fs-extra');
 

--- a/lib/utils/sentry.js
+++ b/lib/utils/sentry.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const raven = require('raven');
 const ci = require('ci-info');
 const configUtils = require('./config');

--- a/lib/utils/userStats.js
+++ b/lib/utils/userStats.js
@@ -13,8 +13,8 @@ const TRACK_URL = 'https://serverless.com/api/framework/track';
 const IDENTIFY_URL = 'https://serverless.com/api/framework/identify';
 const DEBUG = false;
 
-function debug() {
-  if (DEBUG) console.log(arguments);
+function debug(...args) {
+  if (DEBUG) console.log(args);
 }
 
 /* note tracking swallows errors */

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // timeout is set to 5 minutes
 // eslint-disable-next-line no-undef
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;


### PR DESCRIPTION
It's about basic fixes and improvements (as otherwise bigger refactor into serverless projects common config is pending)

- Fix parsing option, with so far setting ESLint treated our modules as ESM, and disallowed certain syntax which is perfectly valid in CJS
- Fix configuration of `strict` rule, so it correctly enforces usage of `'use strict'` (having that, fixed few modules in which it was missing)
- Turn on `prefer-rest-aparams` rule (and fixed few modules which didn't obey)
- Configure `import/no-extraneous-dependencies` rules, so it works for us.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
