### PR TITLE
remove default region value in provider object

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -20,7 +20,6 @@ class Service {
     this.serviceObject = null;
     this.provider = {
       stage: 'dev',
-      region: 'us-east-1',
       variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}',
     };
     this.custom = {};


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

the current default is using AWS region naming syntax,
this mean other cloud provider would have to add extra code
to set their default value.

Instead, region default should be left to each provider.
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
one line code change

## How can we verify it:

1. Install this branch
1. Run `sls deploy` in 3 different scenario:
    * set region as a flag
    * set region in `serverless.yml`
    * don't set region in flag or `serverless.yml`

## Todos:

- [x ] Write tests
- [x ] Write documentation
- [x ] Fix linting errors
- [x ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x ] Enable "Allow edits from maintainers" for this PR
- [x ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
