### PR TITLE
Tests: Fix stub configuration

### DIFF
--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -207,7 +207,7 @@ describe('zipService', () => {
       });
 
       it('should return excludes and includes if an error is thrown in the global scope', () => {
-        globbySyncStub.rejects();
+        globbySyncStub.throws();
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be
           .fulfilled.then((updatedParams) => {


### PR DESCRIPTION
_Addresses #6116 (not closing yet as there are some further steps to make)_

Stub for sync function was configured to return rejected promise instead of throwing an error.

That theoretically produces unhandled rejection, still [`sinon-blubird` doesn't create real promises for `rejects()`](https://github.com/toddbluhm/sinon-bluebird/blob/2c496d62948460fe20ce43e5f7e19284629dbb4d/index.js#L12-L13), that's why it came unnoticed on our side.

With [Sinon upgrade](https://github.com/serverless/serverless/pull/6206) this issue will be eminent.

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO