### PR TITLE
Use common prefix for log groups permissions at Lambdas' execution roles

### DIFF
--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -83,33 +83,32 @@ module.exports = {
       }
     );
 
-    this.serverless.service.getAllFunctions().forEach((functionName) => {
-      const functionObject = this.serverless.service.getFunction(functionName);
+    const logGroupsPrefix = this.provider.naming
+      .getLogGroupName(`${this.provider.serverless.service.service}-${this.provider.getStage()}`);
 
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[this.provider.naming.getRoleLogicalId()]
-        .Properties
-        .Policies[0]
-        .PolicyDocument
-        .Statement[0]
-        .Resource
-        .push({
-          'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-            `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*`,
-        });
+    this.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources[this.provider.naming.getRoleLogicalId()]
+      .Properties
+      .Policies[0]
+      .PolicyDocument
+      .Statement[0]
+      .Resource
+      .push({
+        'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+          `:log-group:${logGroupsPrefix}*:*`,
+      });
 
-      this.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[this.provider.naming.getRoleLogicalId()]
-        .Properties
-        .Policies[0]
-        .PolicyDocument
-        .Statement[1]
-        .Resource
-        .push({
-          'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-            `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*:*`,
-        });
-    });
+    this.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources[this.provider.naming.getRoleLogicalId()]
+      .Properties
+      .Policies[0]
+      .PolicyDocument
+      .Statement[1]
+      .Resource
+      .push({
+        'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+          `:log-group:${logGroupsPrefix}*:*:*`,
+      });
 
     if (this.serverless.service.provider.iamRoleStatements) {
       // add custom iam role statements

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -50,7 +50,9 @@ describe('#mergeIamTemplates()', () => {
   it('should merge the IamRoleLambdaExecution template into the CloudFormation template',
     () => awsPackage.mergeIamTemplates()
       .then(() => {
-        const qualifiedFunction = awsPackage.serverless.service.getFunction(functionName).name;
+        const canonicalFunctionsPrefix =
+          `${awsPackage.serverless.service.service}-${awsPackage.provider.getStage()}`;
+
         expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
           .Resources[awsPackage.provider.naming.getRoleLogicalId()]
         ).to.deep.equal({
@@ -96,7 +98,7 @@ describe('#mergeIamTemplates()', () => {
                       Resource: [
                         {
                           'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-                            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
+                            + `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*`,
                         },
                       ],
                     },
@@ -108,7 +110,7 @@ describe('#mergeIamTemplates()', () => {
                       Resource: [
                         {
                           'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-                            + `log-group:/aws/lambda/${qualifiedFunction}:*:*`,
+                            + `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*:*`,
                         },
                       ],
                     },
@@ -370,91 +372,6 @@ describe('#mergeIamTemplates()', () => {
             LogGroupName: awsPackage.provider.naming.getLogGroupName(f.func1.name),
           },
         }
-        );
-    });
-  });
-
-  it('should update IamRoleLambdaExecution with a logging resource for the function', () => {
-    const qualifiedFunction = awsPackage.serverless.service.getFunction(functionName).name;
-    return awsPackage.mergeIamTemplates().then(() => {
-      expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[awsPackage.provider.naming.getRoleLogicalId()]
-        .Properties
-        .Policies[0]
-        .PolicyDocument
-        .Statement[0]
-        .Resource
-      ).to.deep.equal([
-        {
-          'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-            + `log-group:/aws/lambda/${qualifiedFunction}:*`,
-        },
-      ]);
-      expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[awsPackage.provider.naming.getRoleLogicalId()]
-        .Properties
-        .Policies[0]
-        .PolicyDocument
-        .Statement[1]
-        .Resource
-      ).to.deep.equal([
-        {
-          'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-            + `log-group:/aws/lambda/${qualifiedFunction}:*:*`,
-        },
-      ]);
-    });
-  });
-
-  it('should update IamRoleLambdaExecution with each function\'s logging resources', () => {
-    awsPackage.serverless.service.functions = {
-      func0: {
-        handler: 'func.function.handler',
-        name: 'func0',
-      },
-      func1: {
-        handler: 'func.function.handler',
-        name: 'func1',
-      },
-    };
-    return awsPackage.mergeIamTemplates().then(() => {
-      expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[awsPackage.provider.naming.getRoleLogicalId()]
-        .Properties
-        .Policies[0]
-        .PolicyDocument
-        .Statement[0]
-        .Resource
-      ).to.deep.equal(
-        [
-          {
-            'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func0:*',
-          },
-          {
-            'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func1:*',
-          },
-        ]
-        );
-      expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate
-        .Resources[awsPackage.provider.naming.getRoleLogicalId()]
-        .Properties
-        .Policies[0]
-        .PolicyDocument
-        .Statement[1]
-        .Resource
-      ).to.deep.equal(
-        [
-          {
-            'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func0:*:*',
-          },
-          {
-            'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:'
-              + 'log-group:/aws/lambda/func1:*:*',
-          },
-        ]
         );
     });
   });


### PR DESCRIPTION
## What did you implement:

Closes #2508, Closes #4686 

Our team has started to hit limitations on some growing services regarding the maximum allowed size for an IAM role, which is 10240 bytes.
```
An error occurred: IamRoleLambdaExecutioncanary - Maximum policy size of 10240 bytes exceeded for role hello-world-service-prod-us-east-1-lambdaRole
```

Checking the CloudFormation's templates I realized that somewhere between 60%-70% of the role policy is this:
```
{
  "Action": [
    "logs:CreateLogStream"
  ],
  "Resource": [
    {
      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/hello-world-service-prod-helloWorld:*"
    }
   ...this repeats for every function on the project
  ]
}
```

and this:
```
{
  "Action": [
    "logs:LogPutEvents"
  ],
  "Resource": [
    {
      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/hello-world-service-prod-helloWorld:*"
    },
    ...this repeats for every function on the project
  ]
}
```

## How did you implement it:

Instead of adding a permission for each log group separately, I simply got their common prefix which is the service name + dash + the current stage and added a wildcard at the end.

On a service with 10 functions, I was able to see a reduction from 7100 bytes to 3100 bytes.

I hope this doesn't have extra complications... looking forward to hearing your thoughts.

## How can we verify it:

Simply package any service and verify that the iamRoleLambdaExecution now only has one entry for the log groups with a wildcard appended, rather than one for each function on the service.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
