### PR TITLE
Reference custom ApiGateway for models and request validators if conf…

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -84,9 +84,7 @@ module.exports = {
             [modelLogicalId]: {
               Type: 'AWS::ApiGateway::Model',
               Properties: {
-                RestApiId: {
-                  Ref: this.provider.naming.getRestApiLogicalId(),
-                },
+                RestApiId: this.provider.getApiGatewayRestApiId(),
                 ContentType: contentType,
                 Schema: schema,
               },
@@ -94,9 +92,7 @@ module.exports = {
             [validatorLogicalId]: {
               Type: 'AWS::ApiGateway::RequestValidator',
               Properties: {
-                RestApiId: {
-                  Ref: this.provider.naming.getRestApiLogicalId(),
-                },
+                RestApiId: this.provider.getApiGatewayRestApiId(),
                 ValidateRequestBody: true,
                 ValidateRequestParameters: true,
               },


### PR DESCRIPTION
When using request parameter/body validation, both the Model and the RequestValidator were always referencing the standard RestApiLogicalId, even if a custom one (from e.g. another stack) were defined. This leads to this feature breaking when using a shared RestApi.

This PR fixes this by using the same method to reference the custom defined RestApiId as the Method itself does.

(This issue is currently blocking deployment for us, it would be terrific if this could be reviewed/published in a short timeframe).