### PR TITLE
Fix Travis CI deploy config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ git:
   depth: 1 # No need for commits history
 
 branches:
-  only: master # Do not build PR branches
+  only:
+    - master # Do not build PR branches
+    - /^v\d+\.\d+\.\d+$/ # Ensure to build release tags
 
 env: SLS_IGNORE_WARNING=* # Default env
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ jobs:
         - npm run integration-test-cleanup
 
     - stage: Deploy
+      node_js: 12
       script: skip
       deploy:
         provider: npm

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "mocha": {
-    "R": "tests/mocha-reporter",
+    "reporter": "tests/mocha-reporter",
     "timeout": 5000
   },
   "jest": {


### PR DESCRIPTION
Fix regression introduced with https://github.com/serverless/serverless/pull/6178

Setting _branches_ to `only: master` prevented all tag builds. It's also noted in Travis CI [documentation](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches) that it's expected behavior:

> Note that safelisting also prevents tagged commits from being built. If you consistently tag your builds in the format v1.3 you can safelist them all with regular expressions, for example /^v\d+\.\d+(\.\d+)?(-\S*)?$/.

This patch ensures that release tags are whitelisted, and that deploy job runs with latest Node.js version (if not specified Travis tries to install project with its default which is v0.10).

Additionally fix mocha config property name. Current setting works, but it was not intended to work -> https://github.com/mochajs/mocha/issues/3936#issuecomment-499656526

--- 

_For a meantime I've workaround v1.45.0 release with temporary patch in context of a branch -> https://travis-ci.org/serverless/serverless/builds/544643104_

--- 

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO