### PR TITLE
Fix duplicate packaging issue

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -226,15 +226,10 @@ module.exports = {
       patterns.push(pattern);
     });
 
-    // This strips "./" from the beginning of an includes pattern to avoid
-    // duplication of paths. See https://github.com/serverless/serverless/issues/5748
-    const strippedIncludes = params.include.map((pattern) => {
-      return path.normalize(pattern);
-    });
     // NOTE: please keep this order of concatenating the include params
     // rather than doing it the other way round!
     // see https://github.com/serverless/serverless/pull/5825 for more information
-    return globby(['**'].concat(strippedIncludes), {
+    return globby(['**'].concat(params.include), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,
       silent: true,

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -229,7 +229,7 @@ module.exports = {
     // This strips "./" from the beginning of an includes pattern to avoid
     // duplication of paths. See https://github.com/serverless/serverless/issues/5748
     const strippedIncludes = params.include.map((pattern) => {
-      return pattern.replace(/^.\//, '');
+      return path.normalize(pattern);
     });
     // NOTE: please keep this order of concatenating the include params
     // rather than doing it the other way round!

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -225,10 +225,16 @@ module.exports = {
     params.include.forEach((pattern) => {
       patterns.push(pattern);
     });
+
+    // This strips "./" from the beginning of an includes pattern to avoid
+    // duplication of paths. See https://github.com/serverless/serverless/issues/5748
+    const strippedIncludes = params.include.map((pattern) => {
+      return pattern.replace(/^.\//, '');
+    });
     // NOTE: please keep this order of concatenating the include params
     // rather than doing it the other way round!
     // see https://github.com/serverless/serverless/pull/5825 for more information
-    return globby(['**'].concat(params.include), {
+    return globby(['**'].concat(strippedIncludes), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,
       silent: true,

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -3,16 +3,18 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
+const fse = require('fs-extra');
 const chai = require('chai');
 const sinon = require('sinon');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
 const serverlessConfigFileUtils = require('../../../../lib/utils/getServerlessConfigFile');
+const { createTmpDir } = require('../../../../tests/utils/fs');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
-const expect = require('chai').expect;
+const { expect } = require('chai');
 
 describe('#packageService()', () => {
   let serverless;
@@ -174,6 +176,28 @@ describe('#packageService()', () => {
             [serverlessConfigFileName], [localPath], packageExcludes, funcExcludes)
           )
         );
+    });
+  });
+
+  describe('#resolveFilePathsFromPatterns()', () => {
+    let tmpDirPath;
+
+    beforeEach(() => {
+      tmpDirPath = createTmpDir();
+      const filePath = path.join(tmpDirPath, 'bin', 'file');
+      fse.ensureFileSync(filePath);
+    });
+
+    it('should foo', () => {
+      packagePlugin.serverless.config.servicePath = tmpDirPath;
+
+      const params = {
+        exclude: ['./**'],
+        include: ['./bin/**'],
+      };
+
+      return expect(packagePlugin.resolveFilePathsFromPatterns(params)).to.be.fulfilled
+        .then((res) => expect(res).to.deep.equal(['bin/file']));
     });
   });
 
@@ -516,6 +540,7 @@ describe('#packageService()', () => {
       ]));
     });
   });
+
   describe('#packageLayer()', () => {
     const exclude = ['test-exclude'];
     const include = ['test-include'];

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -179,28 +179,6 @@ describe('#packageService()', () => {
     });
   });
 
-  describe('#resolveFilePathsFromPatterns()', () => {
-    let tmpDirPath;
-
-    beforeEach(() => {
-      tmpDirPath = createTmpDir();
-      const filePath = path.join(tmpDirPath, 'bin', 'file');
-      fse.ensureFileSync(filePath);
-    });
-
-    it('should foo', () => {
-      packagePlugin.serverless.config.servicePath = tmpDirPath;
-
-      const params = {
-        exclude: ['./**'],
-        include: ['./bin/**'],
-      };
-
-      return expect(packagePlugin.resolveFilePathsFromPatterns(params)).to.be.fulfilled
-        .then((res) => expect(res).to.deep.equal(['bin/file']));
-    });
-  });
-
   describe('#packageService()', () => {
     it('should package all functions', () => {
       serverless.service.package.individually = false;

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -3,13 +3,11 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
-const fse = require('fs-extra');
 const chai = require('chai');
 const sinon = require('sinon');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
 const serverlessConfigFileUtils = require('../../../../lib/utils/getServerlessConfigFile');
-const { createTmpDir } = require('../../../../tests/utils/fs');
 
 // Configure chai
 chai.use(require('chai-as-promised'));

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -82,27 +82,29 @@ module.exports = {
       output.on('error', (err) => reject(err));
       zip.on('error', (err) => reject(err));
 
-
       output.on('open', () => {
         zip.pipe(output);
 
-        BbPromise.all(files.map(this.getFileContentAndStat.bind(this))).then((contents) => {
-          _.forEach(_.sortBy(contents, ['filePath']), (file) => {
-            const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
-            let mode = file.stat.mode;
-            if (filesToChmodPlusX && _.includes(filesToChmodPlusX, name)
-                && file.stat.mode % 2 === 0) {
-              mode += 1;
-            }
-            zip.append(file.data, {
-              name,
-              mode,
-              date: new Date(0), // necessary to get the same hash when zipping the same content
-            });
-          });
+        const normalizedFiles = _.uniq(files.map(file => path.normalize(file)));
 
-          zip.finalize();
-        }).catch(reject);
+        return BbPromise.all(normalizedFiles.map(this.getFileContentAndStat.bind(this)))
+          .then((contents) => {
+            _.forEach(_.sortBy(contents, ['filePath']), (file) => {
+              const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
+              let mode = file.stat.mode;
+              if (filesToChmodPlusX && _.includes(filesToChmodPlusX, name)
+                  && file.stat.mode % 2 === 0) {
+                mode += 1;
+              }
+              zip.append(file.data, {
+                name,
+                mode,
+                date: new Date(0), // necessary to get the same hash when zipping the same content
+              });
+            });
+
+            zip.finalize();
+          }).catch(reject);
       });
     });
   },

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -1036,6 +1036,30 @@ describe('zipService', () => {
         });
     });
 
+    it('should include files only once', () => {
+      params.zipFileName = getTestArtifactFileName('include-outside-working-dir');
+      serverless.config.servicePath = path.join(serverless.config.servicePath, 'lib');
+      params.exclude = [
+        './**',
+      ];
+      params.include = [
+        '.././bin/**',
+      ];
+
+      return expect(packagePlugin.zip(params)).to.eventually.be
+        .equal(path.join(serverless.config.servicePath, '.serverless', params.zipFileName))
+        .then(artifact => {
+          const data = fs.readFileSync(artifact);
+          return expect(zip.loadAsync(data)).to.be.fulfilled;
+        }).then(unzippedData => {
+          const unzippedFileData = unzippedData.files;
+          expect(Object.keys(unzippedFileData).sort()).to.deep.equal([
+            'bin/binary-444',
+            'bin/binary-777',
+          ]);
+        });
+    });
+
     it('should throw an error if no files are matched', () => {
       params.exclude = ['**/**'];
       params.include = [];

--- a/tests/utils/fs/index.js
+++ b/tests/utils/fs/index.js
@@ -19,6 +19,12 @@ function getTmpFilePath(fileName) {
   return path.join(getTmpDirPath(), fileName);
 }
 
+function createTmpDir() {
+  const dirPath = getTmpDirPath();
+  fse.ensureDirSync(dirPath);
+  return dirPath;
+}
+
 function createTmpFile(name) {
   const filePath = getTmpFilePath(name);
   fse.ensureFileSync(filePath);
@@ -50,6 +56,7 @@ module.exports = {
   tmpDirCommonPath,
   getTmpDirPath,
   getTmpFilePath,
+  createTmpDir,
   createTmpFile,
   replaceTextInFile,
   readYamlFile,


### PR DESCRIPTION
## What did you implement:

Closes #5748 

Basically, if your `include` items have `./` before them, it would grab the same file twice

```
package:
 exclude:
   - ./**
 include:
   - ./bin/**
```

This would grab `./bin/file` as well as `bin/file`.

## How did you implement it:

As a fix, I'm stripping the `./` from the start of the pattern before adding the include patterns to globby.

## How can we verify it:

Using the `aws-go` template, have a serverless.yml with the following:

```yml
service: golang-package # NOTE: update this with your service name

provider:
  name: aws
  runtime: go1.x
package:
 exclude:
   - ./**
 include:
   - ./bin/**

functions:
  hello:
    handler: bin/hello
    events:
      - http:
          path: hello
          method: get
```

Run `sls package` with the current Framework, and your zipfile in `.serverless/golang-package.zip` should have a duplicated file.

Checkout this branch and run `sls package` again. It should have just one file.

## Todos:

- [x] Write tests
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
