### PR TITLE
Ensure integration tests do not fail when run concurrently

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     "func-names": "off",
     "global-require": "off", // Interfers with optional and eventual circular references
     "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js",  "**/scripts/**", "**/tests/**"]}],
+    "no-param-reassign": "off",
     "no-use-before-define": "off",
     "react/require-extension": "off", // Forced by airbnb, not applicable (also deprecated)
     "strict": ["error", "safe"], // airbnb implies we're transpiling with babel, we're not

--- a/tests/integration-all/api-gateway/service/serverless.yml
+++ b/tests/integration-all/api-gateway/service/serverless.yml
@@ -1,12 +1,12 @@
-service: aws-nodejs # NOTE: update this with your service name
+service: CHANGE_TO_UNIQUE_PER_RUN
 
 provider:
   name: aws
   runtime: nodejs10.x
   versionFunctions: false
   apiKeys:
-    - name: api-key-1
-      value: 0p3ns3s4m3-0p3ns3s4m3-0p3ns3s4m3
+    - name: CHANGE_TO_UNIQUE_PER_RUN
+      value: CHANGE_TO_UNIQUE_PER_RUN
 
 functions:
   # core functions

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -25,7 +25,9 @@ describe('AWS - API Gateway Integration Test', () => {
   beforeAll(() => {
     tmpDirPath = getTmpDirPath();
     serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
-    serviceName = createTestService(tmpDirPath, { templateDir: path.join(__dirname, 'service') });
+    const serverlessConfig =
+      createTestService(tmpDirPath, { templateDir: path.join(__dirname, 'service') });
+    serviceName = serverlessConfig.service;
     StackName = `${serviceName}-${stage}`;
     deployService();
     // create an external REST API

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -20,6 +20,7 @@ describe('AWS - API Gateway Integration Test', () => {
   let serverlessFilePath;
   let restApiId;
   let restApiRootResourceId;
+  let apiKey;
   const stage = 'dev';
 
   beforeAll(() => {
@@ -28,8 +29,11 @@ describe('AWS - API Gateway Integration Test', () => {
     const serverlessConfig = createTestService(tmpDirPath, {
       templateDir: path.join(__dirname, 'service'),
       serverlessConfigHook:
-        // Ensure unique API key name for each test (to avoid collision among concurrent CI runs)
-        config => (config.provider.apiKeys[0].name = `${config.service}-api-key-1`),
+        // Ensure unique API key for each test (to avoid collision among concurrent CI runs)
+        config => {
+          apiKey = `${config.service}-api-key-1`;
+          config.provider.apiKeys[0] = { name: apiKey, value: apiKey };
+        },
     });
     serviceName = serverlessConfig.service;
     stackName = `${serviceName}-${stage}`;
@@ -196,8 +200,6 @@ describe('AWS - API Gateway Integration Test', () => {
     });
 
     it('should succeed if correct API key is given', () => {
-      const apiKey = '0p3ns3s4m3-0p3ns3s4m3-0p3ns3s4m3';
-
       return fetch(testEndpoint, { headers: { 'X-API-Key': apiKey } })
         .then(response => response.json())
         .then((json) => {

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -25,7 +25,7 @@ describe('AWS - API Gateway Integration Test', () => {
   beforeAll(() => {
     tmpDirPath = getTmpDirPath();
     serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
-    serviceName = createTestService('aws-nodejs', tmpDirPath, path.join(__dirname, 'service'));
+    serviceName = createTestService(tmpDirPath, { templateDir: path.join(__dirname, 'service') });
     StackName = `${serviceName}-${stage}`;
     deployService();
     // create an external REST API

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -25,8 +25,12 @@ describe('AWS - API Gateway Integration Test', () => {
   beforeAll(() => {
     tmpDirPath = getTmpDirPath();
     serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
-    const serverlessConfig =
-      createTestService(tmpDirPath, { templateDir: path.join(__dirname, 'service') });
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      serverlessConfigHook:
+        // Ensure unique API key name for each test (to avoid collision among concurrent CI runs)
+        config => (config.provider.apiKeys[0].name = `${config.service}-api-key-1`),
+    });
     serviceName = serverlessConfig.service;
     stackName = `${serviceName}-${stage}`;
     deployService();

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -15,7 +15,7 @@ const CF = new AWS.CloudFormation({ region });
 describe('AWS - API Gateway Integration Test', () => {
   let serviceName;
   let endpoint;
-  let StackName;
+  let stackName;
   let tmpDirPath;
   let serverlessFilePath;
   let restApiId;
@@ -28,7 +28,7 @@ describe('AWS - API Gateway Integration Test', () => {
     const serverlessConfig =
       createTestService(tmpDirPath, { templateDir: path.join(__dirname, 'service') });
     serviceName = serverlessConfig.service;
-    StackName = `${serviceName}-${stage}`;
+    stackName = `${serviceName}-${stage}`;
     deployService();
     // create an external REST API
     const externalRestApiName = `${stage}-${serviceName}-ext-api`;
@@ -55,7 +55,7 @@ describe('AWS - API Gateway Integration Test', () => {
   });
 
   beforeEach(() => {
-    return CF.describeStacks({ StackName }).promise()
+    return CF.describeStacks({ StackName: stackName }).promise()
       .then((result) => _.find(result.Stacks[0].Outputs,
         { OutputKey: 'ServiceEndpoint' }).OutputValue)
       .then((endpointOutput) => {

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -79,8 +79,7 @@ function createTestService(tmpDir, options = {
   process.env.COGNITO_USER_POOL_1 = `${serviceName}-1`;
   process.env.COGNITO_USER_POOL_2 = `${serviceName}-2`;
 
-  // return the name of the CloudFormation stack
-  return serviceName;
+  return serverlessConfig;
 }
 
 function getFunctionLogs(functionName) {

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -51,6 +51,7 @@ function createTestService(tmpDir, options = {
   // Either templateName or templateDir have to be provided
   templateName: null, // Template name to use (e.g. 'aws-nodejs')
   templateDir: null, // Path to prepared service template
+  serverlessConfigHook: null, // Eventual hook to furhter customize serverless config
 }) {
   const serviceName = getServiceName();
 
@@ -70,6 +71,7 @@ function createTestService(tmpDir, options = {
   const serverlessFilePath = path.join(tmpDir, 'serverless.yml');
   const serverlessConfig = readYamlFile(serverlessFilePath);
   serverlessConfig.service = serviceName;
+  if (options.serverlessConfigHook) options.serverlessConfigHook(serverlessConfig);
   writeYamlFile(serverlessFilePath, serverlessConfig);
 
   process.env.TOPIC_1 = `${serviceName}-1`;

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -51,7 +51,7 @@ function createTestService(tmpDir, options = {
   // Either templateName or templateDir have to be provided
   templateName: null, // Generic template to use (e.g. 'aws-nodejs')
   templateDir: null, // Path to custom pre-prepared service template
-  serverlessConfigHook: null, // Eventual hook that allows serverless config customization
+  serverlessConfigHook: null, // Eventual hook that allows to customize serverless config
 }) {
   const serviceName = getServiceName();
 

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -49,9 +49,9 @@ function replaceEnv(values) {
 
 function createTestService(tmpDir, options = {
   // Either templateName or templateDir have to be provided
-  templateName: null, // Template name to use (e.g. 'aws-nodejs')
-  templateDir: null, // Path to prepared service template
-  serverlessConfigHook: null, // Eventual hook to furhter customize serverless config
+  templateName: null, // Generic template to use (e.g. 'aws-nodejs')
+  templateDir: null, // Path to custom pre-prepared service template
+  serverlessConfigHook: null, // Eventual hook that allows serverless config customization
 }) {
   const serviceName = getServiceName();
 

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -67,9 +67,9 @@ function createTestService(tmpDir, options = {
     throw new Error("Either 'templateName' or 'templateDir' options have to be provided");
   }
 
-  // Ensure unique service name
   const serverlessFilePath = path.join(tmpDir, 'serverless.yml');
   const serverlessConfig = readYamlFile(serverlessFilePath);
+  // Ensure unique service name
   serverlessConfig.service = serviceName;
   if (options.serverlessConfigHook) options.serverlessConfigHook(serverlessConfig);
   writeYamlFile(serverlessFilePath, serverlessConfig);


### PR DESCRIPTION
- Improved`createTestService` shape, so it accepts service config customization hook
- Ensure unique pre-prepared API key among different integration test runs (without that, another test cannot run if previous haven't cleaned up yet). This should address integration test fails as observed on master, e.g.: https://travis-ci.org/serverless/serverless/jobs/544767262
- Turned off `no-param-reassign` as it seems unjustified, and prevents on spot arguments handling

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
