### PR TITLE
Fix Travis configuration for branch/tag runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,15 @@ jobs:
         - SLS_IGNORE_WARNING=*
         - FORCE_COLOR=1 # TTY is lost as processes are combined '&&'
       # Combine with '&&' to not continue on fail
-      script: npm run lint-updated && npm test
+      script:
+        - |
+          if [ $TRAVIS_PULL_REQUEST = false ]
+          then
+            npm run lint
+          else
+            npm run lint-updated
+          fi &&
+          npm test
     - name: "Unit Tests - Windows - Node.js v12"
       os: windows
       node_js: 12


### PR DESCRIPTION
Issue observed at e.g. https://github.com/serverless/serverless/tree/v1.45.1

`lint-updated` crashes on tags and non-master branch runs, as master branch then is not retrieved by Travis.

Reconfigured so all files are linted in non PR cases.

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
