### PR TITLE
Update variables.md

### DIFF
--- a/docs/providers/spotinst/guide/variables.md
+++ b/docs/providers/spotinst/guide/variables.md
@@ -26,7 +26,7 @@ Also you are able to enter in environment variables in the serverless.yml file. 
 functions:
   test:
     handler: handler.main
-    environmentVariables:
+    environments:
       key: value
 ```
 


### PR DESCRIPTION
## What did you implement:

Fix documentation

Fix documentation for environment variables of functions

Does not work with `environmenVariables` but works with `environments`


## How did you implement it:

GitHub web editor

## How can we verify it:

Try deploy a function with 
```yaml
functions:
  test:
    handler: handler.main
    environmentVariables:
      key: value
```
Notice the absence of environment variable named key.

Try deploy a function with 
```yaml
functions:
  test:
    handler: handler.main
    environments:
      key: value
```
It should work as intended
## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
