### PR TITLE
Do not set tty on stdin if no tty available

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -77,10 +77,10 @@ if __name__ == '__main__':
         try:
             if sys.platform != 'darwin':
                 subprocess.check_call('tty', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            sys.stdin = open('/dev/tty')
         except (OSError, subprocess.CalledProcessError):
             pass
-        else:
-            sys.stdin = open('/dev/tty')
 
     context = FakeLambdaContext(**input.get('context', {}))
     result = handler(input['event'], context)


### PR DESCRIPTION
## What did you implement?

I am using `serverless` into a Docker container without an attached `tty` (no option `-t`). When I invoke my lambda using AWS SDK (`AWS.lambda().invoke().send()`), I got the following error:

```
Proxy Handler could not detect JSON:     sys.stdin = open('/dev/tty')
OSError: [Errno 6] No such device or address: '/dev/tty'
```

## How did you implement it:

This PR just ignores the opening of the TTY in case there is none. As far as I checked, this is only useful for [some CI issue reasons](https://github.com/serverless/serverless/pull/5760).

## How can we verify it:

Create a basic lambda within a Docker container, and invoke it locally (without API Gateway). 

I can provide a basic repo if required. :)

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
