### PR TITLE
Use naming to get stackName

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.js
@@ -9,7 +9,7 @@ module.exports = {
 
     if (apiKeys && apiKeys.length) {
       this.serverless.cli.log('Removing usage plan association...');
-      const stackName = `${this.serverless.service.service}-${this.provider.getStage()}`;
+      const stackName = `${this.provider.naming.getStackName()}`;
       return BbPromise.all([
         this.provider.request('CloudFormation',
           'describeStackResource',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.test.js
@@ -69,7 +69,7 @@ describe('#disassociateUsagePlan()', () => {
         'CloudFormation',
         'describeStackResource',
         {
-          StackName: `${serverless.service.service}-${awsProvider.getStage()}`,
+          StackName: `${awsProvider.naming.getStackName()}`,
           LogicalResourceId: 'ApiGatewayRestApi',
         }
       )).to.be.equal(true);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Updated `disassociateUsagePlan.js` to use naming service for determining stack name rather than directly appending stage to the service name.
Closes #6283

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Utilized the naming service for retrieving the stack name rather than directly appending stage to the service name.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
Before pulling down changes, in a directory with:

serverless.yml:
```
service:
  name: my-test-service

frameworkVersion: ">=1.0.0 <2.0.0"

provider:
  name: aws
  runtime: python3.7
  stage: myStage
  region: us-west-2
  stackName: ${self:service.name}
  apiKeys:
  - statusCheckKey

  apiName: ${self:provider.stackName}
  endpointType: regional


functions:
  hello:
    handler: handler.hello
    events:
    - http:
        method: post
        path: "/hello
```
handler.py
```
import json


def hello(event, context):
    body = {
        "message": "Go Serverless v1.0! Your function executed successfully!",
        "input": event
    }

    response = {
        "statusCode": 200,
        "body": json.dumps(body)
    }

    return response
```
run `sls deploy`, followed by `sls remove`. Verify that you receive a failure indicating
```
Serverless: Removing usage plan association...
 
  Serverless Error ---------------------------------------
 
  Stack 'my-test-service-myStage' does not exist
```
Pull down the change and run `sls deploy`, followed by `sls remove`. Verify that `sls remove` succeeds

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
