### PR TITLE
Add support for existing S3 buckets

### DIFF
--- a/docs/providers/aws/events/s3.md
+++ b/docs/providers/aws/events/s3.md
@@ -114,3 +114,23 @@ resources:
           Ref: AWS::AccountId
         SourceArn: 'arn:aws:s3:::my-custom-bucket-name'
 ```
+
+## Using existing buckets
+
+Sometimes you might want to attach Lambda functions to existing S3 buckets. In that case you just need to set the `existing` event configuration property to `true`. All the other config parameters can also be used on existing buckets:
+
+**NOTE:** Using the `existing` config will add an additional Lambda function and IAM Role to your stack. The Lambda function backs-up the Custom S3 Resource which is used to support existing S3 buckets.
+
+```yaml
+functions:
+  users:
+    handler: users.handler
+    events:
+      - s3:
+          bucket: legacy-photos
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: uploads/
+            - suffix: .jpg
+          existing: true
+```

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const path = require('path');
+const createZipFile = require('../../../utils/fs/createZipFile');
+
+function addCustomResourceToService(resourceName, iamRoleStatements) {
+  let FunctionName;
+  let Handler;
+  let customResourceFunctionLogicalId;
+
+  const Statement = iamRoleStatements;
+  const customResourcesRoleLogicalId = this.provider.naming.getCustomResourcesRoleLogicalId();
+  const srcDirPath = path.join(__dirname, 'resources');
+  const destDirPath = path.join(
+    this.serverless.config.servicePath,
+    '.serverless',
+    this.provider.naming.getCustomResourcesArtifactDirectoryName()
+  );
+  const zipFilePath = `${destDirPath}.zip`;
+  this.serverless.utils.writeFileDir(zipFilePath);
+
+  if (resourceName === 's3') {
+    FunctionName = `${this.serverless.service.service}-${
+      this.options.stage
+    }-${this.provider.naming.getCustomResourceS3HandlerFunctionName()}`;
+    Handler = 's3/handler.handler';
+    customResourceFunctionLogicalId = this.provider.naming.getCustomResourceS3HandlerFunctionLogicalId();
+  }
+
+  return createZipFile(srcDirPath, zipFilePath).then(outputFilePath => {
+    let S3Bucket = {
+      Ref: this.provider.naming.getDeploymentBucketLogicalId(),
+    };
+    if (this.serverless.service.package.deploymentBucket) {
+      S3Bucket = this.serverless.service.package.deploymentBucket;
+    }
+    const s3Folder = this.serverless.service.package.artifactDirectoryName;
+    const s3FileName = outputFilePath.split(path.sep).pop();
+    const S3Key = `${s3Folder}/${s3FileName}`;
+
+    const customResourceRole = {
+      [customResourcesRoleLogicalId]: {
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: {
+                  Service: ['lambda.amazonaws.com'],
+                },
+                Action: ['sts:AssumeRole'],
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: {
+                'Fn::Join': [
+                  '-',
+                  [
+                    this.provider.getStage(),
+                    this.provider.serverless.service.service,
+                    'custom-resources-lambda',
+                  ],
+                ],
+              },
+              PolicyDocument: {
+                Version: '2012-10-17',
+                Statement,
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const customResourceFunction = {
+      [customResourceFunctionLogicalId]: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket,
+            S3Key,
+          },
+          FunctionName,
+          Handler,
+          MemorySize: 1024,
+          Role: {
+            'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+          },
+          Runtime: 'nodejs10.x',
+          Timeout: 6,
+        },
+        DependsOn: [customResourcesRoleLogicalId],
+      },
+    };
+
+    Object.assign(
+      this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+      customResourceFunction,
+      customResourceRole
+    );
+  });
+}
+
+module.exports = {
+  addCustomResourceToService,
+};

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const chai = require('chai');
+const AwsProvider = require('../provider/awsProvider');
+const Serverless = require('../../../Serverless');
+const { createTmpDir } = require('../../../../tests/utils/fs');
+const { addCustomResourceToService } = require('./index.js');
+
+const expect = chai.expect;
+chai.use(require('chai-as-promised'));
+
+describe('#addCustomResourceToService()', () => {
+  let tmpDirPath;
+  let serverless;
+  let provider;
+  let context;
+  const iamRoleStatements = [
+    {
+      Effect: 'Allow',
+      Resource: 'arn:aws:lambda:*:*:function:custom-resource-func',
+      Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+    },
+  ];
+
+  beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    tmpDirPath = createTmpDir();
+    serverless = new Serverless();
+    provider = new AwsProvider(serverless, options);
+    serverless.setProvider('aws', provider);
+    serverless.service.service = 'some-service';
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+    };
+    serverless.config.servicePath = tmpDirPath;
+    serverless.service.package.artifactDirectoryName = 'artifact-dir-name';
+    context = {
+      serverless,
+      provider,
+      options,
+    };
+  });
+
+  describe('when using the custom S3 resouce', () => {
+    it('should add the custom resource to the service', () => {
+      return expect(
+        addCustomResourceToService.call(context, 's3', iamRoleStatements)
+      ).to.be.fulfilled.then(() => {
+        const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+        const customResourcesZipFilePath = path.join(
+          tmpDirPath,
+          '.serverless',
+          'custom-resources.zip'
+        );
+
+        expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
+        expect(Resources).to.deep.equal({
+          CustomDashresourceDashexistingDashs3LambdaFunction: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {
+              Code: {
+                S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+                S3Key: 'artifact-dir-name/custom-resources.zip',
+              },
+              FunctionName: 'some-service-dev-custom-resource-existing-s3',
+              Handler: 's3/handler.handler',
+              MemorySize: 1024,
+              Role: { 'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'] },
+              Runtime: 'nodejs10.x',
+              Timeout: 6,
+            },
+            DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
+          },
+          IamRoleCustomResourcesLambdaExecution: {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+              AssumeRolePolicyDocument: {
+                Statement: [
+                  {
+                    Action: ['sts:AssumeRole'],
+                    Effect: 'Allow',
+                    Principal: {
+                      Service: ['lambda.amazonaws.com'],
+                    },
+                  },
+                ],
+                Version: '2012-10-17',
+              },
+              Policies: [
+                {
+                  PolicyDocument: {
+                    Statement: [
+                      {
+                        Effect: 'Allow',
+                        Resource: 'arn:aws:lambda:*:*:function:custom-resource-func',
+                        Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+                      },
+                    ],
+                    Version: '2012-10-17',
+                  },
+                  PolicyName: {
+                    'Fn::Join': ['-', ['dev', 'some-service', 'custom-resources-lambda']],
+                  },
+                },
+              ],
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/lib/plugins/aws/customResources/resources/README.md
+++ b/lib/plugins/aws/customResources/resources/README.md
@@ -1,0 +1,3 @@
+# Serverless Custom CloudFormation Resources
+
+This directory contains the Lambda functions for the Serverless Custom CloudFormation Resources.

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { addPermission, removePermission } = require('./lib/permissions');
+const { updateConfiguration, removeConfiguration } = require('./lib/bucket');
+const { getEnvironment, getLambdaArn, handlerWrapper } = require('../utils');
+
+function handler(event, context) {
+  if (event.RequestType === 'Create') {
+    return create(event, context);
+  } else if (event.RequestType === 'Update') {
+    return update(event, context);
+  } else if (event.RequestType === 'Delete') {
+    return remove(event, context);
+  }
+  throw new Error(`Unhandled RequestType ${event.RequestType}`);
+}
+
+function create(event, context) {
+  const { Region, AccountId } = getEnvironment(context);
+  const { FunctionName, BucketName, BucketConfig } = event.ResourceProperties;
+
+  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+
+  return addPermission({
+    functionName: FunctionName,
+    bucketName: BucketName,
+    region: Region,
+  }).then(() =>
+    updateConfiguration({
+      lambdaArn,
+      region: Region,
+      functionName: FunctionName,
+      bucketName: BucketName,
+      bucketConfig: BucketConfig,
+    })
+  );
+}
+
+function update(event, context) {
+  const { Region, AccountId } = getEnvironment(context);
+  const { FunctionName, BucketName, BucketConfig } = event.ResourceProperties;
+
+  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+
+  return updateConfiguration({
+    lambdaArn,
+    region: Region,
+    functionName: FunctionName,
+    bucketName: BucketName,
+    bucketConfig: BucketConfig,
+  });
+}
+
+function remove(event, context) {
+  const { Region } = getEnvironment(context);
+  const { FunctionName, BucketName } = event.ResourceProperties;
+
+  return removePermission({
+    functionName: FunctionName,
+    bucketName: BucketName,
+    region: Region,
+  }).then(() =>
+    removeConfiguration({
+      region: Region,
+      functionName: FunctionName,
+      bucketName: BucketName,
+    })
+  );
+}
+
+module.exports = {
+  handler: handlerWrapper(handler, 'CustomResouceExistingS3'),
+};

--- a/lib/plugins/aws/customResources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/bucket.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const crypto = require('crypto');
+const AWS = require('aws-sdk');
+
+function generateId(functionName, bucketConfig) {
+  const md5 = crypto
+    .createHash('md5')
+    .update(JSON.stringify(bucketConfig))
+    .digest('hex');
+  return `${functionName}-${md5}`;
+}
+
+function createFilter(config) {
+  const rules = config.Rules;
+  if (rules && rules.length) {
+    const FilterRules = rules.map(rule => {
+      const key = Object.keys(rule)[0];
+      const Name = key.toLowerCase();
+      const Value = rule[key].toLowerCase();
+      return {
+        Name,
+        Value,
+      };
+    });
+    return {
+      Key: {
+        FilterRules,
+      },
+    };
+  }
+  return undefined;
+}
+
+function getConfiguration(config) {
+  const { bucketName, region } = config;
+  const s3 = new AWS.S3({ region });
+  const Bucket = bucketName;
+  const payload = {
+    Bucket,
+  };
+  return s3
+    .getBucketNotificationConfiguration(payload)
+    .promise()
+    .then(data => data);
+}
+
+function updateConfiguration(config) {
+  const { lambdaArn, functionName, bucketName, bucketConfig, region } = config;
+  const s3 = new AWS.S3({ region });
+  const Bucket = bucketName;
+
+  return getConfiguration(config).then(NotificationConfiguration => {
+    // remove configurations for this specific function
+    NotificationConfiguration.LambdaFunctionConfigurations = NotificationConfiguration.LambdaFunctionConfigurations.filter(
+      conf => !conf.Id.startsWith(functionName)
+    );
+
+    // add the event to the existing NotificationConfiguration
+    const Events = [bucketConfig.Event];
+    const LambdaFunctionArn = lambdaArn;
+    const Id = generateId(functionName, bucketConfig);
+    const Filter = createFilter(bucketConfig);
+    NotificationConfiguration.LambdaFunctionConfigurations.push({
+      Events,
+      LambdaFunctionArn,
+      Filter,
+      Id,
+    });
+
+    const payload = {
+      Bucket,
+      NotificationConfiguration,
+    };
+    return s3.putBucketNotificationConfiguration(payload).promise();
+  });
+}
+
+function removeConfiguration(config) {
+  const { functionName, bucketName, region } = config;
+  const s3 = new AWS.S3({ region });
+  const Bucket = bucketName;
+
+  return getConfiguration(config).then(NotificationConfiguration => {
+    // remove configurations for this specific function
+    NotificationConfiguration.LambdaFunctionConfigurations = NotificationConfiguration.LambdaFunctionConfigurations.filter(
+      conf => !conf.Id.startsWith(functionName)
+    );
+
+    const payload = {
+      Bucket,
+      NotificationConfiguration,
+    };
+    return s3.putBucketNotificationConfiguration(payload).promise();
+  });
+}
+
+module.exports = {
+  updateConfiguration,
+  removeConfiguration,
+};

--- a/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+
+function getStatementId(functionName, bucketName) {
+  const normalizedBucketName = bucketName.replace(/[.:*]/g, '');
+  const id = `${functionName}-${normalizedBucketName}`;
+  if (id.length < 100) {
+    return id;
+  }
+  return id.substring(0, 100);
+}
+
+function addPermission(config) {
+  const { functionName, bucketName, region } = config;
+  const lambda = new AWS.Lambda({ region });
+  const partition = region && /^cn-/.test(region) ? 'aws-cn' : 'aws';
+  const payload = {
+    Action: 'lambda:InvokeFunction',
+    FunctionName: functionName,
+    Principal: 's3.amazonaws.com',
+    StatementId: getStatementId(functionName, bucketName),
+    SourceArn: `arn:${partition}:s3:::${bucketName}`,
+  };
+  return lambda.addPermission(payload).promise();
+}
+
+function removePermission(config) {
+  const { functionName, bucketName, region } = config;
+  const lambda = new AWS.Lambda({ region });
+  const payload = {
+    FunctionName: functionName,
+    StatementId: getStatementId(functionName, bucketName),
+  };
+  return lambda.removePermission(payload).promise();
+}
+
+module.exports = {
+  getStatementId,
+  addPermission,
+  removePermission,
+};

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const https = require('https');
+const url = require('url');
+
+const logger = console;
+
+function response(event, context, status, data = {}, err) {
+  const reason = err ? err.message : '';
+  const { StackId, RequestId, LogicalResourceId, PhysicalResourceId, ResponseURL } = event;
+
+  const body = JSON.stringify({
+    StackId,
+    RequestId,
+    LogicalResourceId,
+    PhysicalResourceId,
+    Status: status,
+    Reason: reason && `${reason} See details in CloudWatch Log: ${context.logStreamName}`,
+    Data: data,
+  });
+
+  logger.log(body);
+
+  const parsedUrl = url.parse(ResponseURL);
+  const options = {
+    hostname: parsedUrl.hostname,
+    port: 443,
+    path: parsedUrl.path,
+    method: 'PUT',
+    headers: {
+      'Content-Type': '',
+      'Content-Length': body.length,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(options, resp => {
+      logger.log(`STATUS: ${resp.statusCode}`);
+      logger.log(`HEADERS: ${JSON.stringify(resp.headers)}`);
+      return resolve(data);
+    });
+
+    request.on('error', error => {
+      logger.log(`sendResponse Error:\n${error}`);
+      return reject(error);
+    });
+
+    request.on('end', () => {
+      logger.log('end');
+      return resolve();
+    });
+
+    request.write(body);
+    request.end();
+  });
+}
+
+function getLambdaArn(region, accountId, functionName) {
+  return `arn:aws:lambda:${region}:${accountId}:function:${functionName}`;
+}
+
+function getEnvironment(context) {
+  const arn = context.invokedFunctionArn.match(
+    /^arn:aws.*:lambda:(\w+-\w+-\d+):(\d+):function:(.*)$/
+  );
+  return {
+    LambdaArn: arn[0],
+    Region: arn[1],
+    AccountId: arn[2],
+    LambdaName: arn[3],
+  };
+}
+
+function handlerWrapper(handler, PhysicalResourceId) {
+  return (event, context, callback) => {
+    // extend the `event` object to include the PhysicalResourceId
+    event = Object.assign({}, event, { PhysicalResourceId });
+    return Promise.resolve(handler(event, context, callback))
+      .then(
+        result => response(event, context, 'SUCCESS', result),
+        error => response(event, context, 'FAILED', {}, error)
+      )
+      .then(result => callback(null, result), callback);
+  };
+}
+
+module.exports = {
+  logger,
+  response,
+  getEnvironment,
+  getLambdaArn,
+  handlerWrapper,
+};

--- a/lib/plugins/aws/customResources/resources/utils.test.js
+++ b/lib/plugins/aws/customResources/resources/utils.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { expect } = require('chai');
+const { getLambdaArn, getEnvironment } = require('./utils');
+
+describe('#getLambdaArn()', () => {
+  it('should return the Lambda arn', () => {
+    const region = 'us-east-1';
+    const accountId = '123456';
+    const functionName = 'some-function';
+    const arn = getLambdaArn(region, accountId, functionName);
+
+    expect(arn).to.equal('arn:aws:lambda:us-east-1:123456:function:some-function');
+  });
+});
+
+describe('#getEnvironment()', () => {
+  it('should return an object with information about the execution environment', () => {
+    const context = {
+      invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456:function:some-function',
+    };
+    const env = getEnvironment(context);
+
+    expect(env).to.deep.equal({
+      LambdaArn: 'arn:aws:lambda:us-east-1:123456:function:some-function',
+      Region: 'us-east-1',
+      AccountId: '123456',
+      LambdaName: 'some-function',
+    });
+  });
+});

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -14,7 +14,8 @@ module.exports = {
   uploadArtifacts() {
     return BbPromise.bind(this)
       .then(this.uploadCloudFormationFile)
-      .then(this.uploadFunctionsAndLayers);
+      .then(this.uploadFunctionsAndLayers)
+      .then(this.uploadCustomResources);
   },
 
   uploadCloudFormationFile() {
@@ -127,6 +128,21 @@ module.exports = {
       },
       { concurrency: NUM_CONCURRENT_UPLOADS }
     );
+  },
+
+  uploadCustomResources() {
+    const artifactFilePath = path.join(
+      this.serverless.config.servicePath,
+      '.serverless',
+      `${this.provider.naming.getCustomResourcesArtifactDirectoryName()}.zip`
+    );
+
+    if (this.serverless.utils.fileExistsSync(artifactFilePath)) {
+      this.serverless.cli.log('Uploading custom CloudFormation resources...');
+      return this.uploadZipFile(artifactFilePath);
+    }
+
+    return BbPromise.resolve();
   },
 };
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -4,6 +4,7 @@
 
 const sinon = require('sinon');
 const fs = require('fs');
+const fse = require('fs-extra');
 const path = require('path');
 const chai = require('chai');
 const proxyquire = require('proxyquire');
@@ -11,7 +12,7 @@ const normalizeFiles = require('../../lib/normalizeFiles');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
-const { getTmpDirPath } = require('../../../../../tests/utils/fs');
+const { getTmpDirPath, createTmpDir } = require('../../../../../tests/utils/fs');
 
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
@@ -329,6 +330,55 @@ describe('uploadArtifacts', () => {
       return awsDeploy.uploadFunctionsAndLayers().then(() => {
         const expected = 'Uploading service new-service.zip file to S3 (1 KB)...';
         expect(awsDeploy.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);
+      });
+    });
+  });
+
+  describe('#uploadCustomResources()', () => {
+    let uploadStub;
+    let serviceDirPath;
+
+    beforeEach(() => {
+      uploadStub = sinon.stub(awsDeploy.provider, 'request').resolves();
+      serviceDirPath = createTmpDir();
+      serverless.config.servicePath = serviceDirPath;
+    });
+
+    afterEach(() => {
+      uploadStub.restore();
+    });
+
+    it('should not attempt to upload a custom resources if the artifact does not exist', () => {
+      return expect(awsDeploy.uploadCustomResources()).to.eventually.be.fulfilled.then(() => {
+        expect(uploadStub).not.to.be.calledOnce;
+      });
+    });
+
+    it('should upload the custom resources .zip file to the S3 bucket', () => {
+      const customResourcesFilePath = path.join(
+        serviceDirPath,
+        '.serverless',
+        'custom-resources.zip'
+      );
+      fse.ensureFileSync(customResourcesFilePath);
+
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(0)
+        .returns('local-hash-zip-file');
+
+      return expect(awsDeploy.uploadCustomResources()).to.eventually.be.fulfilled.then(() => {
+        expect(uploadStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
+          Bucket: awsDeploy.bucketName,
+          Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/custom-resources.zip`,
+          Body: sinon.match.object.and(sinon.match.has('path', customResourcesFilePath)),
+          ContentType: 'application/zip',
+          Metadata: {
+            filesha256: 'local-hash-zip-file',
+          },
+        });
       });
     });
   });

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -451,4 +451,24 @@ module.exports = {
   getLambdaAlbPermissionLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlb`;
   },
+
+  // Custom Resources
+  getCustomResourcesArtifactDirectoryName() {
+    return 'custom-resources';
+  },
+  getCustomResourcesRoleLogicalId() {
+    return 'IamRoleCustomResourcesLambdaExecution';
+  },
+  // S3
+  getCustomResourceS3HandlerFunctionName() {
+    return 'custom-resource-existing-s3';
+  },
+  getCustomResourceS3HandlerFunctionLogicalId() {
+    return this.getLambdaLogicalId(
+      `${this.getNormalizedFunctionName(this.getCustomResourceS3HandlerFunctionName())}`
+    );
+  },
+  getCustomResourceS3ResourceLogicalId(functionName, idx) {
+    return `${this.getNormalizedFunctionName(functionName)}CustomS3${idx}`;
+  },
 };

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -721,4 +721,44 @@ describe('#naming()', () => {
       );
     });
   });
+
+  describe('#getCustomResourcesArtifactDirectoryName()', () => {
+    it('should return the custom resources artifact directory name', () => {
+      expect(sdk.naming.getCustomResourcesArtifactDirectoryName()).to.equal('custom-resources');
+    });
+  });
+
+  describe('#getCustomResourcesRoleLogicalId()', () => {
+    it('should return the custom resources role logical id', () => {
+      expect(sdk.naming.getCustomResourcesRoleLogicalId()).to.equal(
+        'IamRoleCustomResourcesLambdaExecution'
+      );
+    });
+  });
+
+  describe('#getCustomResourceS3HandlerFunctionName()', () => {
+    it('should return the nane of the S3 custom resouce handler function', () => {
+      expect(sdk.naming.getCustomResourceS3HandlerFunctionName()).to.equal(
+        'custom-resource-existing-s3'
+      );
+    });
+  });
+
+  describe('#getCustomResourceS3HandlerFunctionLogicalId()', () => {
+    it('should return the logical id of the S3 custom resouce handler function', () => {
+      expect(sdk.naming.getCustomResourceS3HandlerFunctionLogicalId()).to.equal(
+        'CustomDashresourceDashexistingDashs3LambdaFunction'
+      );
+    });
+  });
+
+  describe('#getCustomResourceS3ResourceLogicalId()', () => {
+    it('should return the logical id of the S3 custom resouce', () => {
+      const functionName = 'my-function';
+      const index = 1;
+      expect(sdk.naming.getCustomResourceS3ResourceLogicalId(functionName, index)).to.equal(
+        'MyDashfunctionCustomS31'
+      );
+    });
+  });
 });

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -1,18 +1,25 @@
 'use strict';
 
 const _ = require('lodash');
+const BbPromise = require('bluebird');
+const { addCustomResourceToService } = require('../../../../customResources');
 
 class AwsCompileS3Events {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'package:compileEvents': this.compileS3Events.bind(this),
+      'package:compileEvents': () => {
+        return BbPromise.bind(this)
+          .then(this.newS3Buckets)
+          .then(this.existingS3Buckets);
+      },
     };
   }
 
-  compileS3Events() {
+  newS3Buckets() {
     const bucketsLambdaConfigurations = {};
     const s3EnabledFunctions = [];
     this.serverless.service.getAllFunctions().forEach(functionName => {
@@ -21,6 +28,9 @@ class AwsCompileS3Events {
       if (functionObj.events) {
         functionObj.events.forEach(event => {
           if (event.s3) {
+            // return immediately if it's an existing S3 event since we treat them differently
+            if (event.s3.existing) return null;
+
             let bucketName;
             let notificationEvent = 's3:ObjectCreated:*';
             let filter = {};
@@ -107,6 +117,8 @@ class AwsCompileS3Events {
             const s3EnabledFunction = { functionName, bucketName };
             s3EnabledFunctions.push(s3EnabledFunction);
           }
+
+          return null;
         });
       }
     });
@@ -182,6 +194,87 @@ class AwsCompileS3Events {
         permissionCFResource
       );
     });
+  }
+
+  existingS3Buckets() {
+    const { service } = this.serverless;
+    const { provider } = service;
+    const { compiledCloudFormationTemplate } = provider;
+    const iamRoleStatements = [];
+
+    service.getAllFunctions().forEach(functionName => {
+      let funcUsesExistingS3Bucket = false;
+      const functionObj = service.getFunction(functionName);
+      const FunctionName = functionObj.name;
+
+      if (functionObj.events) {
+        functionObj.events.forEach((event, idx) => {
+          if (event.s3 && _.isObject(event.s3) && event.s3.existing) {
+            let rules = null;
+            idx = idx += 1;
+            const bucket = event.s3.bucket;
+            const notificationEvent = event.s3.event || 's3:ObjectCreated:*';
+            funcUsesExistingS3Bucket = true;
+
+            rules = _.map(event.s3.rules, rule => {
+              const key = Object.keys(rule)[0];
+              const value = rule[key];
+              return {
+                [_.startCase(key)]: value,
+              };
+            });
+
+            const eventFunctionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+            const customResourceFunctionLogicalId = this.provider.naming.getCustomResourceS3HandlerFunctionLogicalId();
+            const customS3ResourceLogicalId = this.provider.naming.getCustomResourceS3ResourceLogicalId(
+              functionName,
+              idx
+            );
+
+            const customS3Resource = {
+              [customS3ResourceLogicalId]: {
+                Type: 'Custom::S3',
+                Version: 1.0,
+                DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                Properties: {
+                  ServiceToken: {
+                    'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
+                  },
+                  FunctionName,
+                  BucketName: bucket,
+                  BucketConfig: {
+                    Event: notificationEvent,
+                    Rules: rules,
+                  },
+                },
+              },
+            };
+
+            _.merge(compiledCloudFormationTemplate.Resources, customS3Resource);
+
+            iamRoleStatements.push({
+              Effect: 'Allow',
+              Resource: `arn:aws:s3:::${bucket}`,
+              Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+            });
+          }
+        });
+      }
+
+      if (funcUsesExistingS3Bucket) {
+        iamRoleStatements.push({
+          Effect: 'Allow',
+          Resource: `arn:aws:lambda:*:*:function:${FunctionName}`,
+          Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+        });
+      }
+    });
+
+    if (iamRoleStatements.length) {
+      return addCustomResourceToService.call(this, 's3', iamRoleStatements);
+    }
+
+    return null;
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -1,9 +1,16 @@
 'use strict';
 
-const expect = require('chai').expect;
+/* eslint-disable no-unused-expressions */
+
+const sinon = require('sinon');
+const chai = require('chai');
 const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileS3Events = require('./index');
 const Serverless = require('../../../../../../Serverless');
+const customResources = require('../../../../customResources');
+
+const { expect } = chai;
+chai.use(require('sinon-chai'));
 
 describe('AwsCompileS3Events', () => {
   let serverless;
@@ -22,7 +29,7 @@ describe('AwsCompileS3Events', () => {
       expect(awsCompileS3Events.provider).to.be.instanceof(AwsProvider));
   });
 
-  describe('#compileS3Events()', () => {
+  describe('#newS3Buckets()', () => {
     it('should throw an error if s3 event type is not a string or an object', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {
@@ -34,7 +41,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+      expect(() => awsCompileS3Events.newS3Buckets()).to.throw(Error);
     });
 
     it('should throw an error if the "bucket" property is not given', () => {
@@ -50,7 +57,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+      expect(() => awsCompileS3Events.newS3Buckets()).to.throw(Error);
     });
 
     it('should throw an error if the "rules" property is not an array', () => {
@@ -68,7 +75,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+      expect(() => awsCompileS3Events.newS3Buckets()).to.throw(Error);
     });
 
     it('should throw an error if the "rules" property is invalid', () => {
@@ -86,7 +93,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      expect(() => awsCompileS3Events.compileS3Events()).to.throw(Error);
+      expect(() => awsCompileS3Events.newS3Buckets()).to.throw(Error);
     });
 
     it('should create corresponding resources when S3 events are given', () => {
@@ -107,7 +114,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      awsCompileS3Events.compileS3Events();
+      awsCompileS3Events.newS3Buckets();
 
       expect(
         awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -152,7 +159,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      awsCompileS3Events.compileS3Events();
+      awsCompileS3Events.newS3Buckets();
 
       expect(
         awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -185,7 +192,7 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      awsCompileS3Events.compileS3Events();
+      awsCompileS3Events.newS3Buckets();
 
       expect(
         awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -220,11 +227,106 @@ describe('AwsCompileS3Events', () => {
         },
       };
 
-      awsCompileS3Events.compileS3Events();
+      awsCompileS3Events.newS3Buckets();
 
       expect(
         awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate.Resources
       ).to.deep.equal({});
+    });
+  });
+
+  describe('#existingS3Buckets()', () => {
+    let addCustomResourceToServiceStub;
+
+    beforeEach(() => {
+      addCustomResourceToServiceStub = sinon
+        .stub(customResources.addCustomResourceToService, 'call')
+        .resolves();
+    });
+
+    afterEach(() => {
+      customResources.addCustomResourceToService.call.restore();
+    });
+
+    it('should create the necessary resources for the most minimal configuration', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileS3Events.existingS3Buckets();
+
+      const {
+        Resources,
+      } = awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate;
+
+      expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+      expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
+      expect(Resources.FirstCustomS31).to.deep.equal({
+        Type: 'Custom::S3',
+        Version: 1,
+        DependsOn: ['FirstLambdaFunction', 'CustomDashresourceDashexistingDashs3LambdaFunction'],
+        Properties: {
+          ServiceToken: {
+            'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
+          },
+          FunctionName: 'first',
+          BucketName: 'existing-s3-bucket',
+          BucketConfig: { Event: 's3:ObjectCreated:*', Rules: [] },
+        },
+      });
+    });
+
+    it('should create the necessary resources for a service using different config parameters', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          name: 'second',
+          events: [
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectCreated:Put',
+                rules: [{ prefix: 'uploads' }, { suffix: '.jpg' }],
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileS3Events.existingS3Buckets();
+
+      const {
+        Resources,
+      } = awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate;
+
+      expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+      expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
+      expect(Resources.FirstCustomS31).to.deep.equal({
+        Type: 'Custom::S3',
+        Version: 1,
+        DependsOn: ['FirstLambdaFunction', 'CustomDashresourceDashexistingDashs3LambdaFunction'],
+        Properties: {
+          ServiceToken: {
+            'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
+          },
+          FunctionName: 'second',
+          BucketName: 'existing-s3-bucket',
+          BucketConfig: {
+            Event: 's3:ObjectCreated:Put',
+            Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpg' }],
+          },
+        },
+      });
     });
   });
 });

--- a/lib/utils/fs/createZipFile.js
+++ b/lib/utils/fs/createZipFile.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const archiver = require('archiver');
+const BbPromise = require('bluebird');
+const walkDirSync = require('../fs/walkDirSync');
+
+function createZipFile(srcDirPath, outputFilePath) {
+  const files = walkDirSync(srcDirPath).map(file => ({
+    input: file,
+    output: file.replace(path.join(srcDirPath, path.sep), ''),
+  }));
+
+  return new BbPromise((resolve, reject) => {
+    const output = fs.createWriteStream(outputFilePath);
+    const archive = archiver('zip', {
+      zlib: { level: 9 },
+    });
+
+    output.on('open', () => {
+      archive.pipe(output);
+
+      files.forEach(file => {
+        // TODO: update since this is REALLY slow
+        if (fs.lstatSync(file.input).isFile()) {
+          archive.append(fs.createReadStream(file.input), { name: file.output });
+        }
+      });
+
+      archive.finalize();
+    });
+
+    archive.on('error', err => reject(err));
+    output.on('close', () => resolve(outputFilePath));
+  });
+}
+
+module.exports = createZipFile;

--- a/lib/utils/fs/createZipFile.test.js
+++ b/lib/utils/fs/createZipFile.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+const chai = require('chai');
+const createZipFile = require('./createZipFile');
+const { createTmpFile, listZipFiles } = require('../../../tests/utils/fs');
+
+// Configure chai
+chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+const expect = require('chai').expect;
+
+describe('#createZipFile()', () => {
+  it('should create a zip file with the source directory content', () => {
+    const toZipFilePath = createTmpFile('foo.json');
+    const zipFilePath = createTmpFile('package.zip');
+
+    const srcDirPath = toZipFilePath
+      .split(path.sep)
+      .slice(0, -1)
+      .join(path.sep);
+
+    return createZipFile(srcDirPath, zipFilePath)
+      .then(listZipFiles)
+      .then(files => expect(files).to.deep.equal(['foo.json']));
+  });
+});

--- a/tests/integration-all/s3/service/core.js
+++ b/tests/integration-all/s3/service/core.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { log } = require('./utils');
+
+function minimal(event, context, callback) {
+  const functionName = 'minimal';
+  const response = { message: `Hello from S3! - (${functionName})`, event };
+  const message = [
+    event.Records[0].eventSource,
+    event.Records[0].eventName,
+    ' ',
+    response.message,
+  ].join('');
+  log(functionName, message);
+  return callback(null, response);
+}
+
+function extended(event, context, callback) {
+  const functionName = 'extended';
+  const response = { message: `Hello from S3! - (${functionName})`, event };
+  const message = [
+    event.Records[0].eventSource,
+    event.Records[0].eventName,
+    ' ',
+    response.message,
+  ].join('');
+  log(functionName, message);
+  return callback(null, response);
+}
+
+function existing(event, context, callback) {
+  const functionName = 'existing';
+  const response = { message: `Hello from S3! - (${functionName})`, event };
+  const message = [
+    event.Records[0].eventSource,
+    event.Records[0].eventName,
+    ' ',
+    response.message,
+  ].join('');
+  log(functionName, message);
+  return callback(null, response);
+}
+
+module.exports = { minimal, extended, existing };

--- a/tests/integration-all/s3/service/serverless.yml
+++ b/tests/integration-all/s3/service/serverless.yml
@@ -1,0 +1,31 @@
+service: CHANGE_TO_UNIQUE_PER_RUN
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+
+functions:
+  minimal:
+    handler: core.minimal
+    events:
+      - s3: CHANGE_TO_UNIQUE_PER_RUN
+  extended:
+    handler: core.extended
+    events:
+      - s3:
+          bucket: CHANGE_TO_UNIQUE_PER_RUN
+          event: s3:ObjectRemoved:*
+          rules:
+            - prefix: photos/
+            - suffix: .jpg
+  existing:
+    handler: core.existing
+    events:
+      - s3:
+          bucket: CHANGE_TO_UNIQUE_PER_RUN
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: files/
+            - suffix: .txt
+          existing: true

--- a/tests/integration-all/s3/service/utils.js
+++ b/tests/integration-all/s3/service/utils.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const logger = console;
+
+function getMarkers(functionName) {
+  return {
+    start: `--- START ${functionName} ---`,
+    end: `--- END ${functionName} ---`,
+  };
+}
+
+function log(functionName, message) {
+  const markers = getMarkers(functionName);
+  logger.log(markers.start);
+  logger.log(message);
+  logger.log(markers.end);
+}
+
+module.exports = {
+  getMarkers,
+  log,
+};

--- a/tests/integration-all/s3/tests.js
+++ b/tests/integration-all/s3/tests.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const path = require('path');
+const { expect } = require('chai');
+
+const { getTmpDirPath } = require('../../utils/fs');
+const { createBucket, createAndRemoveInBucket, deleteBucket } = require('../../utils/s3');
+const {
+  createTestService,
+  deployService,
+  removeService,
+  waitForFunctionLogs,
+} = require('../../utils/misc');
+const { getMarkers } = require('./service/utils');
+
+describe('AWS - S3 Integration Test', () => {
+  let serviceName;
+  let stackName;
+  let tmpDirPath;
+  let bucketMinimalSetup;
+  let bucketExtendedSetup;
+  let bucketExistingSetup;
+  const stage = 'dev';
+
+  beforeAll(() => {
+    tmpDirPath = getTmpDirPath();
+    console.info(`Temporary path: ${tmpDirPath}`);
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      serverlessConfigHook:
+        // Ensure unique S3 bucket names for each test (to avoid collision among concurrent CI runs)
+        config => {
+          bucketMinimalSetup = `${config.service}-s3-minimal`;
+          bucketExtendedSetup = `${config.service}-s3-extended`;
+          bucketExistingSetup = `${config.service}-s3-existing`;
+          config.functions.minimal.events[0].s3 = bucketMinimalSetup;
+          config.functions.extended.events[0].s3.bucket = bucketExtendedSetup;
+          config.functions.existing.events[0].s3.bucket = bucketExistingSetup;
+        },
+    });
+    serviceName = serverlessConfig.service;
+    stackName = `${serviceName}-${stage}`;
+    // create an external S3 bucket
+    // NOTE: deployment can only be done once the S3 bucket is created
+    console.info(`Creating S3 bucket "${bucketExistingSetup}"...`);
+    return createBucket(bucketExistingSetup).then(() => {
+      console.info(`Deploying "${stackName}" service...`);
+      deployService();
+    });
+  });
+
+  afterAll(() => {
+    console.info('Removing service...');
+    removeService();
+    console.info(`Deleting S3 bucket "${bucketExistingSetup}"...`);
+    return deleteBucket(bucketExistingSetup);
+  });
+
+  describe('Minimal Setup', () => {
+    it('should invoke function when an object is created', () => {
+      const functionName = 'minimal';
+      const markers = getMarkers(functionName);
+      const expectedMessage = `Hello from S3! - (${functionName})`;
+
+      return createAndRemoveInBucket(bucketMinimalSetup)
+        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(/aws:s3/g.test(logs)).to.equal(true);
+          expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
+          expect(logs.includes(expectedMessage)).to.equal(true);
+        });
+    });
+  });
+
+  describe('Extended Setup', () => {
+    it('should invoke function when an object is removed', () => {
+      const functionName = 'extended';
+      const markers = getMarkers(functionName);
+      const expectedMessage = `Hello from S3! - (${functionName})`;
+
+      return createAndRemoveInBucket(bucketExtendedSetup, { prefix: 'photos/', suffix: '.jpg' })
+        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(/aws:s3/g.test(logs)).to.equal(true);
+          expect(/ObjectRemoved:Delete/g.test(logs)).to.equal(true);
+          expect(logs.includes(expectedMessage)).to.equal(true);
+        });
+    });
+  });
+
+  describe('Existing Setup', () => {
+    it('should invoke function when an object is created', () => {
+      const functionName = 'existing';
+      const markers = getMarkers(functionName);
+      const expectedMessage = `Hello from S3! - (${functionName})`;
+
+      return createAndRemoveInBucket(bucketExistingSetup, { prefix: 'files/', suffix: '.txt' })
+        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(/aws:s3/g.test(logs)).to.equal(true);
+          expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
+          expect(logs.includes(expectedMessage)).to.equal(true);
+        });
+    });
+  });
+});

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -94,6 +94,20 @@ function getFunctionLogs(functionName) {
   return logsString;
 }
 
+function waitForFunctionLogs(functionName, startMarker, endMarker) {
+  let logs;
+  return new BbPromise(resolve => {
+    const interval = setInterval(() => {
+      logs = getFunctionLogs(functionName);
+      if (logs && logs.includes(startMarker) && logs.includes(endMarker)) {
+        clearInterval(interval);
+        return resolve(logs);
+      }
+      return null;
+    }, 2000);
+  });
+}
+
 function persistentRequest(...args) {
   const func = args[0];
   const funcArgs = args.slice(1);
@@ -159,6 +173,7 @@ module.exports = {
   replaceEnv,
   createTestService,
   getFunctionLogs,
+  waitForFunctionLogs,
   persistentRequest,
   skippedWithNotice,
   skipWithNotice,

--- a/tests/utils/s3/index.js
+++ b/tests/utils/s3/index.js
@@ -3,12 +3,22 @@
 const AWS = require('aws-sdk');
 const { region, persistentRequest } = require('../misc');
 
-function createAndRemoveInBucket(bucketName) {
+function createBucket(bucket) {
   const S3 = new AWS.S3({ region });
 
+  return S3.createBucket({ Bucket: bucket }).promise();
+}
+
+function createAndRemoveInBucket(bucket, opts = {}) {
+  const S3 = new AWS.S3({ region });
+
+  const prefix = opts.prefix || '';
+  const suffix = opts.suffix || '';
+  const fileName = opts.fileName || 'object';
+
   const params = {
-    Bucket: bucketName,
-    Key: 'object',
+    Bucket: bucket,
+    Key: `${prefix}${fileName}${suffix}`,
     Body: 'hello world',
   };
 
@@ -16,7 +26,7 @@ function createAndRemoveInBucket(bucketName) {
     .promise()
     .then(() => {
       delete params.Body;
-      return S3.deleteObject(params);
+      return S3.deleteObject(params).promise();
     });
 }
 
@@ -48,6 +58,7 @@ function deleteBucket(bucket) {
 }
 
 module.exports = {
+  createBucket: persistentRequest.bind(this, createBucket),
   createAndRemoveInBucket: persistentRequest.bind(this, createAndRemoveInBucket),
   emptyBucket: persistentRequest.bind(this, emptyBucket),
   deleteBucket: persistentRequest.bind(this, deleteBucket),


### PR DESCRIPTION
This PR adds support for existing S3 buckets via a custom resource.

## What did you implement:

Refs #4241

## How did you implement it:

Checks the `existing` config property of the `s3` event and swaps out the S3 CloudFormation resource with a custom resource the Serverless Framework provides. The custom resource basically does raw SDK calls to update the existing S3 bucket. This way everything is encapsulated via CloudFormation and the stack won't get out of sync if we implement it via raw SDK calls.

## How can we verify it:

```yaml
service: test

provider:
  name: aws
  runtime: nodejs10.x

functions:
  test:
    handler: handler.hello
    events:
      - s3:
          bucket: existing-s3-bucket
          event: s3:ObjectCreated:*
          rules:
            - prefix: uploads
            - suffix: .jpg
          existing: true
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO