### PR TITLE
Fix typo in link to ALB docs

### DIFF
--- a/docs/providers/aws/README.md
+++ b/docs/providers/aws/README.md
@@ -93,7 +93,7 @@ If you have any questions, [search the forums](https://forum.serverless.com?utm_
         <li><a href="./events/schedule.md">Schedule</a></li>
         <li><a href="./events/sns.md">SNS</a></li>
         <li><a href="./events/sqs.md">SQS</a></li>
-        <li><a href="./evetns/alb.md">ALB</a></li>
+        <li><a href="./events/alb.md">ALB</a></li>
         <li><a href="./events/alexa-skill.md">Alexa Skill</a></li>
         <li><a href="./events/alexa-smart-home.md">Alexa Smart Home</a></li>
         <li><a href="./events/iot.md">IoT</a></li>


### PR DESCRIPTION
"events" was misspelled as "evetns" in the url to alb.md

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixed AWS docs. Link to ALB was broken due to typo.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I updated the URL to correct the typo.

## How can we verify it:

1. Preview the change.
2. Click/tap on the link to the ALB event.
3. Verify that the link correctly takes you to the [AWS Application Load Balancer doc](https://github.com/serverless/serverless/blob/master/docs/providers/aws/events/alb.md).

## Todos:

- [ ] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
