### PR TITLE
Add ip, method, header and query conditions to ALB events

### DIFF
--- a/docs/providers/aws/events/alb.md
+++ b/docs/providers/aws/events/alb.md
@@ -27,6 +27,35 @@ functions:
           listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
           priority: 1
           conditions:
+            path: /hello
+```
+
+## Using different conditions
+
+```yml
+functions:
+  albEventConsumer:
+    handler: handler.hello
+    events:
+      - alb:
+          listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
+          priority: 1
+          conditions:
             host: example.com
             path: /hello
+            method:
+              - POST
+              - PATCH
+            host:
+              - example.com
+              - example2.com
+            header:
+              name: foo
+              values:
+                - bar
+            query:
+              bar: true
+            ip:
+              - fe80:0000:0000:0000:0204:61ff:fe9d:f156/6
+              - 192.168.0.1/0
 ```

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -11,16 +11,51 @@ module.exports = {
       const Conditions = [
         {
           Field: 'path-pattern',
-          Values: [event.conditions.path],
+          Values: event.conditions.path,
         },
       ];
       if (event.conditions.host) {
         Conditions.push({
           Field: 'host-header',
-          Values: [event.conditions.host],
+          Values: event.conditions.host,
         });
       }
-
+      if (event.conditions.method) {
+        Conditions.push({
+          Field: 'http-request-method',
+          HttpRequestMethodConfig: {
+            Values: event.conditions.method,
+          },
+        });
+      }
+      if (event.conditions.header) {
+        Conditions.push({
+          Field: 'http-header',
+          HttpHeaderConfig: {
+            HttpHeaderName: event.conditions.header.name,
+            Values: event.conditions.header.values,
+          },
+        });
+      }
+      if (event.conditions.query) {
+        Conditions.push({
+          Field: 'query-string',
+          QueryStringConfig: {
+            Values: Object.keys(event.conditions.query).map(key => ({
+              Key: key,
+              Value: event.conditions.query[key],
+            })),
+          },
+        });
+      }
+      if (event.conditions.ip) {
+        Conditions.push({
+          Field: 'source-ip',
+          SourceIpConfig: {
+            Values: event.conditions.ip,
+          },
+        });
+      }
       Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [listenerRuleLogicalId]: {
           Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -27,8 +27,8 @@ describe('#compileListenerRules()', () => {
             + '50dc6c495c0c9188/f2f7dc8efc522ab2',
           priority: 1,
           conditions: {
-            host: 'example.com',
-            path: '/hello',
+            host: ['example.com'],
+            path: ['/hello'],
           },
         },
         {
@@ -38,7 +38,7 @@ describe('#compileListenerRules()', () => {
             + '50dc6c495c0c9188/f2f7dc8efc522ab2',
           priority: 2,
           conditions: {
-            path: '/world',
+            path: ['/world'],
           },
         },
       ],

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -2,6 +2,10 @@
 
 const _ = require('lodash');
 
+// eslint-disable-next-line max-len
+const CIDR_IPV6_PATTERN = /^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))$/;
+const CIDR_IPV4_PATTERN = /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$/;
+
 module.exports = {
   validate() {
     const events = [];
@@ -14,13 +18,26 @@ module.exports = {
               listenerArn: event.alb.listenerArn,
               priority: event.alb.priority,
               conditions: {
-                path: event.alb.conditions.path,
+                // concat usage allows the user to provide value as a string or an array
+                path: _.concat(event.alb.conditions.path),
               },
               // the following is data which is not defined on the event-level
               functionName,
             };
             if (event.alb.conditions.host) {
-              albObj.conditions.host = event.alb.conditions.host;
+              albObj.conditions.host = _.concat(event.alb.conditions.host);
+            }
+            if (event.alb.conditions.method) {
+              albObj.conditions.method = _.concat(event.alb.conditions.method);
+            }
+            if (event.alb.conditions.header) {
+              albObj.conditions.header = this.validateHeaderCondition(event, functionName);
+            }
+            if (event.alb.conditions.query) {
+              albObj.conditions.query = this.validateQueryCondition(event, functionName);
+            }
+            if (event.alb.conditions.ip) {
+              albObj.conditions.ip = this.validateIpCondition(event, functionName);
             }
             events.push(albObj);
           }
@@ -31,5 +48,52 @@ module.exports = {
     return {
       events,
     };
+  },
+
+  validateHeaderCondition(event, functionName) {
+    const messageTitle = `Invalid ALB event "header" condition in function "${functionName}".`;
+    if (!_.isObject(event.alb.conditions.header)
+      || !event.alb.conditions.header.name
+      || !event.alb.conditions.header.values) {
+      const errorMessage = [
+        messageTitle,
+        ' You must provide an object with "name" and "values" properties.',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+    if (!_.isArray(event.alb.conditions.header.values)) {
+      const errorMessage = [
+        messageTitle,
+        ' Property "values" must be an array.',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+    return event.alb.conditions.header;
+  },
+
+  validateQueryCondition(event, functionName) {
+    if (!_.isObject(event.alb.conditions.query)) {
+      const errorMessage = [
+        `Invalid ALB event "query" condition in function "${functionName}".`,
+        ' You must provide an object.',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+    return event.alb.conditions.query;
+  },
+
+  validateIpCondition(event, functionName) {
+    const cidrBlocks = _.concat(event.alb.conditions.ip);
+    const allValuesAreCidr = cidrBlocks
+      .every(cidr => CIDR_IPV4_PATTERN.test(cidr) || CIDR_IPV6_PATTERN.test(cidr));
+
+    if (!allValuesAreCidr) {
+      const errorMessage = [
+        `Invalid ALB event "ip" condition in function "${functionName}".`,
+        ' You must provide values in a valid IPv4 or IPv6 CIDR format.',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+    return cidrBlocks;
   },
 };

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -30,6 +30,8 @@ describe('#validate()', () => {
               conditions: {
                 host: 'example.com',
                 path: '/hello',
+                method: 'GET',
+                ip: ['192.168.0.1/1', 'fe80:0000:0000:0000:0204:61ff:fe9d:f156/3'],
               },
             },
           },
@@ -45,6 +47,10 @@ describe('#validate()', () => {
               priority: 2,
               conditions: {
                 path: '/world',
+                method: ['POST', 'GET'],
+                query: {
+                  foo: 'bar',
+                },
               },
             },
           },
@@ -62,8 +68,10 @@ describe('#validate()', () => {
           + '50dc6c495c0c9188/f2f7dc8efc522ab2',
         priority: 1,
         conditions: {
-          host: 'example.com',
-          path: '/hello',
+          host: ['example.com'],
+          path: ['/hello'],
+          method: ['GET'],
+          ip: ['192.168.0.1/1', 'fe80:0000:0000:0000:0204:61ff:fe9d:f156/3'],
         },
       },
       {
@@ -73,9 +81,132 @@ describe('#validate()', () => {
           + '50dc6c495c0c9188/f2f7dc8efc522ab2',
         priority: 2,
         conditions: {
-          path: '/world',
+          path: ['/world'],
+          method: ['POST', 'GET'],
+          query: {
+            foo: 'bar',
+          },
         },
       },
     ]);
+  });
+
+  it('should throw when given an invalid query condition', () => {
+    awsCompileAlbEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            alb: {
+              listenerArn: 'arn:aws:elasticloadbalancing:'
+                + 'us-east-1:123456789012:listener/app/my-load-balancer/'
+                + '50dc6c495c0c9188/f2f7dc8efc522ab2',
+              priority: 1,
+              conditions: {
+                path: '/hello',
+                query: 'ss',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileAlbEvents.validate()).to.throw(Error);
+  });
+
+  it('should throw when given an invalid ip condition', () => {
+    awsCompileAlbEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            alb: {
+              listenerArn: 'arn:aws:elasticloadbalancing:'
+                + 'us-east-1:123456789012:listener/app/my-load-balancer/'
+                + '50dc6c495c0c9188/f2f7dc8efc522ab2',
+              priority: 1,
+              conditions: {
+                path: '/hello',
+                ip: '1.1.1.1',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileAlbEvents.validate()).to.throw(Error);
+  });
+
+  it('should throw when given an invalid header condition', () => {
+    awsCompileAlbEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            alb: {
+              listenerArn: 'arn:aws:elasticloadbalancing:'
+                + 'us-east-1:123456789012:listener/app/my-load-balancer/'
+                + '50dc6c495c0c9188/f2f7dc8efc522ab2',
+              priority: 1,
+              conditions: {
+                path: '/hello',
+                header: ['foo'],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileAlbEvents.validate()).to.throw(Error);
+  });
+
+  describe('#validateIpCondition()', () => {
+    it('should throw if ip is not a valid ipv6 or ipv4 cidr block', () => {
+      const event = { alb: { conditions: { ip: 'fe80:0000:0000:0000:0204:61ff:fe9d:f156/' } } };
+      expect(() => awsCompileAlbEvents.validateIpCondition(event, '')).to.throw(Error);
+    });
+
+    it('should return the value as array if it is a valid ipv6 cidr block', () => {
+      const event = { alb: { conditions: { ip: 'fe80:0000:0000:0000:0204:61ff:fe9d:f156/127' } } };
+      expect(awsCompileAlbEvents.validateIpCondition(event, ''))
+        .to.deep.equal(['fe80:0000:0000:0000:0204:61ff:fe9d:f156/127']);
+    });
+
+    it('should return the value as array if it is a valid ipv4 cidr block', () => {
+      const event = { alb: { conditions: { ip: '192.168.0.1/21' } } };
+      expect(awsCompileAlbEvents.validateIpCondition(event, ''))
+        .to.deep.equal(['192.168.0.1/21']);
+    });
+  });
+
+  describe('#validateQueryCondition()', () => {
+    it('should throw if query is not an object', () => {
+      const event = { alb: { conditions: { query: 'foo' } } };
+      expect(() => awsCompileAlbEvents.validateQueryCondition(event, '')).to.throw(Error);
+    });
+
+    it('should return the value if it is an object', () => {
+      const event = { alb: { conditions: { query: { foo: 'bar' } } } };
+      expect(awsCompileAlbEvents.validateQueryCondition(event, ''))
+        .to.deep.equal({ foo: 'bar' });
+    });
+  });
+
+  describe('#validateHeaderCondition()', () => {
+    it('should throw if header does not have the required properties', () => {
+      const event = { alb: { conditions: { header: { name: 'foo', value: 'bar' } } } };
+      expect(() => awsCompileAlbEvents.validateHeaderCondition(event, '')).to.throw(Error);
+    });
+
+    it('should throw if header.values is not an array', () => {
+      const event = { alb: { conditions: { header: { name: 'foo', values: 'bar' } } } };
+      expect(() => awsCompileAlbEvents.validateHeaderCondition(event, '')).to.throw(Error);
+    });
+
+    it('should return the value if it is valid', () => {
+      const event = { alb: { conditions: { header: { name: 'foo', values: ['bar'] } } } };
+      expect(awsCompileAlbEvents.validateHeaderCondition(event, ''))
+        .to.deep.equal({ name: 'foo', values: ['bar'] });
+    });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #6242

Add the following conditions for ALB events.
- header
- method
- query
- ip

Also allow multiple values for `host` and `path` conditions as @jviolas suggested.

## How did you implement it:

I modified `lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js` and `lib/plugins/aws/package/compile/events/alb/lib/validate.js` so that it supports the remaining conditions.

I added extra validation (especially for `ip` condition) because it's easy to specify a wrong configuration (an IP instead of a valid CIDR block for example). 

I added multiple values support for `host` and `path` conditions by using `_.concat` function in `validate.js`. Though I'm not sure this is the cleanest way of doing that.

## How can we verify it:

I updated @pmuens example from #6073.

Use the following as `handler.js` and `serverless.yml`, then follow instructions below.

```javascript
module.exports.hello = async () => ({
  isBase64Encoded: false,
  statusCode: 200,
  statusDescription: "200 OK",
  headers: { "Content-Type": "application/json" },
  body: "Hello from Lambda"
});
```

```yaml
service: test

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

package:
  excludeDevDependencies: false
  exclude:
    - '**/*'
  include:
    - ./handler.js

functions:
  test:
    handler: handler.hello
    events:
      - alb:
          listenerArn: { Ref: HTTPListener }
          priority: 1
          conditions:
            path: /hello
            query:
              bar: true
            ip:
              - fe80:0000:0000:0000:0204:61ff:fe9d:f156/6
              - 192.168.0.1/0
      - alb:
          listenerArn: { Ref: HTTPListener }
          priority: 2
          conditions:
            path:
             - /hello2
             - /hello3
            header:
              name: foo
              values:
                - bar
  test2:
    handler: handler.hello
    events:
    - alb:
        listenerArn: { Ref: HTTPListener }
        priority: 3
        conditions:
          path: /hello4
          method:
            - POST
            - PATCH
          host:
            - example.com
            - example2.com
custom:
  defaultRegion: us-east-1
  defaultStage: dev
  region: ${opt:region, self:custom.defaultRegion}
  stage: ${opt:stage, self:custom.defaultStage}
  objectPrefix: '${self:service}-${self:custom.stage}'

resources:
  Outputs:
    LoadBalancerDNSName:
      Value: { 'Fn::GetAtt': [ LoadBalancer, 'DNSName' ] }
      Export: { Name: '${self:custom.objectPrefix}-LoadBalancerDNSName' }
  Resources:
    VPC:
      Type: 'AWS::EC2::VPC'
      Properties:
        CidrBlock: 172.31.0.0/16
        EnableDnsHostnames: true
    InternetGateway:
      Type: 'AWS::EC2::InternetGateway'
    VPCGatewayAttachment:
      Type: 'AWS::EC2::VPCGatewayAttachment'
      Properties:
        VpcId: { Ref: VPC }
        InternetGatewayId: { Ref: InternetGateway }
    RouteTable:
      Type: 'AWS::EC2::RouteTable'
      Properties:
        VpcId: { Ref: VPC }
    InternetRoute:
      Type: 'AWS::EC2::Route'
      DependsOn: VPCGatewayAttachment
      Properties:
        DestinationCidrBlock: 0.0.0.0/0
        GatewayId: { Ref: InternetGateway }
        RouteTableId: { Ref: RouteTable }
    SubnetA:
      Type: 'AWS::EC2::Subnet'
      Properties:
        AvailabilityZone: '${self:custom.region}a'
        CidrBlock: 172.31.0.0/20
        MapPublicIpOnLaunch: false
        VpcId: { Ref: VPC }
    SubnetB:
      Type: 'AWS::EC2::Subnet'
      Properties:
        AvailabilityZone: '${self:custom.region}b'
        CidrBlock: 172.31.16.0/20
        MapPublicIpOnLaunch: false
        VpcId: { Ref: VPC }
    SubnetARouteTableAssociation:
      Type: 'AWS::EC2::SubnetRouteTableAssociation'
      Properties:
        SubnetId: { Ref: SubnetA }
        RouteTableId: { Ref: RouteTable }
    SubnetBRouteTableAssociation:
      Type: 'AWS::EC2::SubnetRouteTableAssociation'
      Properties:
        SubnetId: { Ref: SubnetB }
        RouteTableId: { Ref: RouteTable }
    SecurityGroup:
      Type: 'AWS::EC2::SecurityGroup'
      Properties:
        GroupName: 'http-https'
        GroupDescription: 'HTTPS / HTTPS inbound; Nothing outbound'
        VpcId: { Ref: VPC }
        SecurityGroupIngress:
        -
          IpProtocol: tcp
          FromPort: '80'
          ToPort: '80'
          CidrIp: 0.0.0.0/0
        -
          IpProtocol: tcp
          FromPort: '443'
          ToPort: '443'
          CidrIp: 0.0.0.0/0
        SecurityGroupEgress:
        -
          IpProtocol: -1
          FromPort: '1'
          ToPort: '1'
          CidrIp: 127.0.0.1/32
    LoadBalancer:
      Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
      Properties:
        Type: 'application'
        Name: '${self:custom.objectPrefix}'
        IpAddressType: 'ipv4'
        Scheme: 'internet-facing'
        LoadBalancerAttributes:
        - { Key: 'deletion_protection.enabled', Value: false }
        - { Key: 'routing.http2.enabled', Value: false }
        - { Key: 'access_logs.s3.enabled', Value: false }
        SecurityGroups:
        - { Ref: SecurityGroup }
        Subnets:
        - { Ref: SubnetA }
        - { Ref: SubnetB }
    HTTPListener:
      Type: 'AWS::ElasticLoadBalancingV2::Listener'
      Properties:
        LoadBalancerArn: { Ref: LoadBalancer }
        Port: 80
        Protocol: 'HTTP'
        DefaultActions:
        -
          Type: 'fixed-response'
          Order: 1
          FixedResponseConfig:
            StatusCode: 404
            ContentType: 'application/json'
            MessageBody: '{ "not": "found" }'

```

- Run `serverless deploy -v` (or `serverless package` if you just want to check the CloudFormation template).
- Check that the Listener Rule Conditions have been created in the EC2 console first (it's faster to detect problems this way).
- Copy the `LoadBalancerDNSName` output that is printed on the terminal and append the function event `path` to test it. Note that if your HTTP request does not match all the conditions of the event, you will get a 404.
- Change the condition's values to test different combinations. Note that you can add a maximum of 5 conditions for each event. Multiple values for a condition counts as multiple conditions.
- Test `ip` condition by setting its value to a CIDR block matching your IP
- Test `host` condition by adding `Host`header to the request `curl -X GET http://example.com -H 'Host: example.com'`

Other conditions are pretty straightforward to test.

## Todos:

- [x] Write tests
- [x] Write documentation (thanks @pmuens)
- [x] Fix linting errors
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
