### PR TITLE
Websockets: fix passing log group ARN

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -34,7 +34,7 @@ module.exports = {
       Object.assign(stageResource.Properties, {
         AccessLogSettings: {
           DestinationArn: {
-            'Fn::GetAtt': [logGroupLogicalId, 'Arn'],
+            'Fn::Sub': `arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:\${${logGroupLogicalId}}`,
           },
           Format: [
             '$context.identity.sourceIp',

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -81,7 +81,8 @@ describe('#compileStage()', () => {
             Description: 'Serverless Websockets',
             AccessLogSettings: {
               DestinationArn: {
-                'Fn::GetAtt': [logGroupLogicalId, 'Arn'],
+                'Fn::Sub':
+                  'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${WebsocketsLogGroup}',
               },
               Format: [
                 '$context.identity.sourceIp',


### PR DESCRIPTION
The log group ARN contains a trailing ":*" that seems to cause
deployment to fail. Instead, generate the ARN with the trailing
wildcard.
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6304 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Construct the log group ARN using Fn::Sub.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

See issue referenced above.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_Note: Run `npm run test-ci` to run all validation checks on proposed changes_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] ~~Write documentation~~
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
