### PR TITLE
Expose non-errors in informative way

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const { inspect } = require('util');
 const version = require('./../../package.json').version;
 // raven implementation examples https://www.npmjs.com/browse/depended/raven
 const errorReporter = require('../utils/sentry').raven;
@@ -91,7 +92,7 @@ module.exports.logError = e => {
       process.exit(1);
     });
   } catch (errorHandlingError) {
-    throw new Error(e);
+    throw new Error(inspect(e));
   }
 };
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const chalk = require('chalk');
 const version = require('./../../package.json').version;
 // raven implementation examples https://www.npmjs.com/browse/depended/raven

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -141,7 +141,7 @@ describe('Error', () => {
         thrownError = e;
       }
 
-      expect(thrownError.message).to.equal('INVALID INPUT');
+      expect(thrownError.message).to.equal("'INVALID INPUT'");
     });
   });
 


### PR DESCRIPTION
Currently when non-error object is thrown, it's simply stringified, so it can be displayed as:

```
  Error --------------------------------------------------
 
  [object Object]
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
 
  Stack Trace --------------------------------------------
 
Error: [object Object]
    at module.exports.logError (/Users/medikoo/npm-packages/serverless/lib/classes/Error.js:93:11)
    at /Users/medikoo/npm-packages/serverless/bin/serverless.js:69:9
    at processImmediate (internal/timers.js:439:21)
    at process.topLevelDomainCallback (domain.js:126:23)
From previous event:
    at /Users/medikoo/npm-packages/serverless/bin/serverless.js:65:6
    at Object.<anonymous> (/Users/medikoo/npm-packages/serverless/bin/serverless.js:71:7)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11
 ```

Which hides real value being thrown, This patch fixes that and ensures real rejection objects are reported (e.g. Azure for some reason throws objects with meta data, and that patch ensures they're revealed)

After a patch we get reports as:

```
  Error --------------------------------------------------
 
  {
  Message: 'An error has occurred.',
  ExceptionMessage: "Runtime keys are stored on blob storage. This API doesn't support this " +
    'configuration. Please change Environment variable ' +
    "AzureWebJobsSecretStorageType value to 'Files'. For more info, visit " +
    'https://aka.ms/funcsecrets',
  ExceptionType: 'System.InvalidOperationException',
  StackTrace: '   at ' +
    'Kudu.Core.Functions.FunctionManager.<GetKeyObjectFromFile>d__9`1.MoveNext() ' +
    'in C:\\Kudu ' +
    'Files\\Private\\src\\master\\Kudu.Core\\Functions\\FunctionManager.cs:line 141\r' +
    '\n--- End of stack trace from previous location where exception was thrown ' +
    '---\r' +
    '\n   at ' +
    'System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r' +
    '\n   at ' +
    'System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task ' +
    'task)\r' +
    '\n   at ' +
    'Kudu.Core.Functions.FunctionManager.<GetMasterKeyAsync>d__11.MoveNext() ' +
    'in C:\\Kudu ' +
    'Files\\Private\\src\\master\\Kudu.Core\\Functions\\FunctionManager.cs:line 213\r' +
    '\n--- End of stack trace from previous location where exception was thrown ' +
    '---\r' +
    '\n   at ' +
    'System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)\r' +
    '\n   at ' +
    'System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task ' +
    'task)\r' +
    '\n   at ' +
    'Kudu.Services.Functions.FunctionController.<GetMasterKey>d__11.MoveNext() ' +
    'in C:\\Kudu ' +
    'Files\\Private\\src\\master\\Kudu.Services\\Functions\\FunctionController.cs:line ' +
    '121'
}
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
 
  Stack Trace -------------------
```


**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
