### PR TITLE
Make ALB event target group names unique

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const crypto = require('crypto');
 
 /**
  * A centralized naming object that provides naming standards for the AWS provider plugin.  The
@@ -380,6 +381,17 @@ module.exports = {
   // ALB
   getAlbTargetGroupLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}AlbTargetGroup`;
+  },
+  getAlbTargetGroupNameTagValue(functionName) {
+    return `${
+      this.provider.serverless.service.service
+    }-${functionName}-${this.provider.getStage()}`;
+  },
+  getAlbTargetGroupName(functionName) {
+    return crypto
+      .createHash('md5')
+      .update(this.getAlbTargetGroupNameTagValue(functionName))
+      .digest('hex');
   },
   getAlbListenerRuleLogicalId(functionName, idx) {
     return `${this.getNormalizedFunctionName(functionName)}AlbListenerRule${idx}`;

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -703,4 +703,22 @@ describe('#naming()', () => {
       );
     });
   });
+
+  describe('#getAlbTargetGroupName()', () => {
+    it('should return a unique identifier based on the service name, function name and stage', () => {
+      serverless.service.service = 'myService';
+      expect(sdk.naming.getAlbTargetGroupName('functionName')).to.equal(
+        '1ea0b85512f1943fbae9f40a0451d718'
+      );
+    });
+  });
+
+  describe('#getAlbTargetGroupNameTagValue()', () => {
+    it('should return the composition of service name, function name and stage', () => {
+      serverless.service.service = 'myService';
+      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName')).to.equal(
+        `${serverless.service.service}-functionName-${sdk.naming.provider.getStage()}`
+      );
+    });
+  });
 });

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -23,7 +23,13 @@ module.exports = {
                 },
               },
             ],
-            Name: `${functionName}-${this.provider.getStage()}`,
+            Name: this.provider.naming.getAlbTargetGroupName(functionName),
+            Tags: [
+              {
+                Key: 'Name',
+                Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName),
+              },
+            ],
           },
           DependsOn: [lambdaPermissionLogicalId],
         },

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -54,7 +54,7 @@ describe('#compileTargetGroups()', () => {
     expect(resources.FirstAlbTargetGroup).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: 'first-dev',
+        Name: 'd370cffdc0b94175c8239183d0b344a4',
         TargetType: 'lambda',
         Targets: [
           {
@@ -63,19 +63,31 @@ describe('#compileTargetGroups()', () => {
             },
           },
         ],
+        Tags: [
+          {
+            Key: 'Name',
+            Value: 'some-service-first-dev',
+          },
+        ],
       },
       DependsOn: ['FirstLambdaPermissionAlb'],
     });
     expect(resources.SecondAlbTargetGroup).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: 'second-dev',
+        Name: '33af5fa54e565b8aca63f904de895aab',
         TargetType: 'lambda',
         Targets: [
           {
             Id: {
               'Fn::GetAtt': ['SecondLambdaFunction', 'Arn'],
             },
+          },
+        ],
+        Tags: [
+          {
+            Key: 'Name',
+            Value: 'some-service-second-dev',
           },
         ],
       },


### PR DESCRIPTION
## What did you implement:

Closes #6320 

This is a fix proposal, might have to wait until a better solution is found.

Instead of using `<normalizedFunctionName>-<stage>` as a Target Group name, use a md5 hash of the combination of service name, function name and stage. It would ensure uniqueness across services.

Also, to make Target Groups searchable in the EC2 console, add a `Name` tag to the Target Group with value `<service name>-<function name>-<stage>`.

Important: Target Group names are limited to 32 chars, that's why I had to use a hash instead of using a readable name. This is not satisfying but I could not come up with a better solution, so if someone has a better one, that would be great ! I hope AWS will increase this limitation in the futur.  

## How did you implement it:

Added some functions in `lib/plugins/aws/lib/naming.test.js` using the `crypto` module.

Use these functions in `targetGroups.js`.

## How can we verify it:

See the instructions to reproduce the bug in #6320 

## Todos:

- [x] Write tests and confirm existing functionality is not broken.  
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
- [x] Ensure introduced changes match Prettier formatting.  
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
