### PR TITLE
Update Webpack version and usage of aws-nodejs-ecma-script template

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/package.json
@@ -11,8 +11,8 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",
-    "serverless-webpack": "^3.1.1",
-    "webpack": "^3.3.0"
+    "serverless-webpack": "^5.3.1",
+    "webpack": "^4.35.2"
   },
   "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
   "license": "MIT"

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/webpack.config.js
@@ -1,23 +1,29 @@
-const path = require('path');
+const path = require("path");
 // eslint-disable-next-line import/no-unresolved
-const slsw = require('serverless-webpack');
+const slsw = require("serverless-webpack");
 
 module.exports = {
   entry: slsw.lib.entries,
-  target: 'node',
+  output: {
+    libraryTarget: "commonjs",
+    filename: "[name].js",
+    path: path.join(__dirname, ".webpack"),
+  },
+  mode: "development",
+  target: "node",
   module: {
-    loaders: [
+    rules: [
       {
-        test: /\.js$/,
-        loaders: ['babel-loader'],
+        test: /\.js$/, // include .js files
+        enforce: "pre", // preload the jshint loader
+        exclude: /node_modules/, // exclude any and all files in the node_modules folder
         include: __dirname,
-        exclude: /node_modules/,
+        use: [
+          {
+            loader: "babel-loader",
+          },
+        ],
       },
     ],
-  },
-  output: {
-    libraryTarget: 'commonjs',
-    path: path.join(__dirname, '.webpack'),
-    filename: '[name].js',
   },
 };

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/webpack.config.js
@@ -1,26 +1,26 @@
-const path = require("path");
+const path = require('path');
 // eslint-disable-next-line import/no-unresolved
-const slsw = require("serverless-webpack");
+const slsw = require('serverless-webpack');
 
 module.exports = {
   entry: slsw.lib.entries,
   output: {
-    libraryTarget: "commonjs",
-    filename: "[name].js",
-    path: path.join(__dirname, ".webpack"),
+    libraryTarget: 'commonjs',
+    filename: '[name].js',
+    path: path.join(__dirname, '.webpack'),
   },
-  mode: "development",
-  target: "node",
+  mode: 'development',
+  target: 'node',
   module: {
     rules: [
       {
         test: /\.js$/, // include .js files
-        enforce: "pre", // preload the jshint loader
+        enforce: 'pre', // preload the jshint loader
         exclude: /node_modules/, // exclude any and all files in the node_modules folder
         include: __dirname,
         use: [
           {
-            loader: "babel-loader",
+            loader: 'babel-loader',
           },
         ],
       },


### PR DESCRIPTION
The current config will not work in the newest webpack version

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->

Using currently webpack.config.js will not work in the recent webpack version, you will get the following error when running `invoke`:

<img width="960" alt="Screen Shot 2019-06-29 at 2 19 12 PM" src="https://user-images.githubusercontent.com/19418590/60389581-16750980-9a79-11e9-93ef-e98bc3800f6f.png">

With the new config:
<img width="525" alt="Screen Shot 2019-06-29 at 2 19 32 PM" src="https://user-images.githubusercontent.com/19418590/60389583-1d038100-9a79-11e9-91ba-7938b7d85e3f.png">


## How did you implement it:
Just updating the webpack config file.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Install this template and run 
`sls invoke local -f first` with the current config will fail, with the webpack.config.js that I'm proposing will succeed. 



## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES 
**_Is it a breaking change?:_** NO sure

Not sure how to write tests for this template. 
