### PR TITLE
Improve Travis CI conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,18 @@ before_script:
   # More info on below: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
   - set -e
 
+# Ensure to fail build if deploy fails, Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/921
+before_deploy:
+  # Remove eventual old npm logs
+  - rm -rf ~/.npm/_logs
+after_deploy:
+  - |
+    # npm creates log only on failure
+    if [ -d ~/.npm/_logs ]; then
+      # Undocumented way to force build to fail
+      travis_terminate 1
+    fi
+
 jobs:
   include:
     # In most cases it's best to configure one job per Platform & Node.js version combination

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ git:
   #   the last merge commit that is to be tested
   depth: 10
 
+cache:
+  # Not relying on 'npm' shortcut - per Travis docs it's the only 'node_modules' that it'll be cached
+  directories:
+    - $HOME/.npm
+    - node_modules
+
 branches:
   only:
     - master # Do not build PR branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ jobs:
       node_js: 8
       script: npm run coverage
       after_success: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+
     - name: 'Unit Tests - Linux - Node.js v6'
       node_js: 6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
   depth: 10
 
 cache:
-  # Not relying on 'npm' shortcut - per Travis docs it's the only 'node_modules' that it'll be cached
+  # Not relying on 'npm' shortcut, as per Travis docs it's the only 'node_modules' that it'll cache
   directories:
     - $HOME/.npm
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ cache:
     - $HOME/.npm
     - node_modules
 
+# Ensure to install dependencies at their latest versions
+install:
+  # Note: with `npm update` there seems no way to update all project dependency groups in one run
+  - npm update --no-save # Updates just dependencies
+  # Note: npm documents --dev option for dev dependencies update, but it's only --save-dev that works
+  - npm update --save-dev --no-save # Updates just devDependencies
+
 branches:
   only:
     - master # Do not build PR branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 git:
-  # Do not take whole history, but ensure to not break things:
+  # Minimize git history, but ensure to not break things:
   # - Merging multiple PR's around same time may introduce a case where it's not
   #   the last merge commit that is to be tested
   depth: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ branches:
 env:
   global:
     - SLS_IGNORE_WARNING=*
-    - FORCE_COLOR=1 # Ensure colored output for processes combined with '&&'
+    - FORCE_COLOR=1 # Ensure colored output (color support is not detected in some cases)
 
 stages:
   - name: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ stages:
   - name: Deploy
     if: tag =~ ^v\d+\.\d+\.\d+$
 
+before_script:
+  # Fail build right after first script fail, unfortunately Travis doesn't do that: https://github.com/travis-ci/travis-ci/issues/1066
+  # More info on below: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
+  - set -e
+
 jobs:
   include:
     # In most cases it's best to configure one job per Platform & Node.js version combination
@@ -45,20 +50,23 @@ jobs:
     - name: 'Prettier check updated, Lint updated, Unit Tests - Linux - Node.js v12'
       if: type = pull_request
       node_js: 12
-      # Combine with '&&' to not continue on fail
-      script: npm run prettier-check-updated && npm run lint-updated && npm test
+      script:
+        - npm run prettier-check-updated
+        - npm run lint-updated
+        - npm test
 
     # master branch and version tags
     - name: 'Lint, Unit Tests - Linux - Node.js v12'
       if: type != pull_request
       node_js: 12
-      # Combine with '&&' to not continue on fail
-      script: npm run lint && npm test
+      script:
+        - npm run lint
+        - npm test
 
     - name: 'Unit Tests - Windows - Node.js v12'
       os: windows
       node_js: 12
-      before_script:
+      before_install:
         # Ensure Python 2 in Windows enviroment (Ruby is already preinstalled)
         - |
           if [ $TRAVIS_OS_NAME = windows ]
@@ -69,13 +77,16 @@ jobs:
 
     - name: 'Isolated Unit Tests, Package Integration Tests - Linux - Node.js v10'
       node_js: 10
-      # Combine with '&&' to not continue on fail
-      script: npm run test-isolated && npm run integration-test-run-package
+      script:
+        - npm run test-isolated
+        - npm run integration-test-run-package
 
     - name: 'Unit Tests, Coverage - Linux - Node.js v8'
       node_js: 8
       script: npm run coverage
-      after_success: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+      after_success:
+        - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+        - rm -rf ./coverage
 
     - name: 'Unit Tests - Linux - Node.js v6'
       node_js: 6
@@ -89,7 +100,8 @@ jobs:
         # AWS_SECRET_ACCESS_KEY
         - secure: Dgaa5XIsA5Vbw/CYQLUAuVVsDX26C8+f1XYGwsbNmFQKbKvM8iy9lGrHlfrT3jftJkJH6re8tP1RjyZjjzLe25KPk4Tps7grNteCyiIIEDsC2aHhiXHD6zNHsItpxYusaFfyQinFWnK4CAYKWb9ZNIwHIDUIB4vq807QGAhYsnoj1Lg/ajWvtEKBwYjEzDz9OjB91lw7lpCnHtmKKw5A+TNIVGpDDZ/jRBqETsPaePtiXC9UTHZQyM3gFoeVXiJw9KSU/gjIx9REihCaWWPbnuQSeIONGGlVWY9V4DTZIsJr9/uwDcbioeXDD3G1ezGtNPPRSNTtq08QlUtE4mEtKea/+ObpllKZCeZGn6AJhMn+uqMIP95FFlqBB55YzRcLZY+Igi/qm/9LJ9RinAhxRVXiwzeQ+BdVA6jshAAzr+7wklux6lZAa0xGw9pgTv7MI4RP2LJ/LMP1ppFsnv9n/qt93Ax1VEwEu3xHZe3VTYL9tbXOPTZutf6fKjUrW7wSSuy637queESjYnnPKSb1vZcPxjSFlyh+GJvxu/3PurF9aqfiBdiorIBre+pQS4lakLtoft5nsbA+4iYUwrXR58qUPVUqQ7a0A0hedOWlp6g9ixLa6nugUP5aobJzR71T8l/IjqpnY2EEd/iINEb0XfUiZtB5zHaqFWejBtmWwCI=
       script:
-        - npm run integration-test-run-basic && npm run integration-test-run-all
+        - npm run integration-test-run-basic || { npm run integration-test-cleanup; exit 1; }
+        - npm run integration-test-run-all || { npm run integration-test-cleanup; exit 1; }
         - npm run integration-test-cleanup
 
     - stage: Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ branches:
     - master # Do not build PR branches
     - /^v\d+\.\d+\.\d+$/ # Ensure to build release tags
 
-env: SLS_IGNORE_WARNING=* # Default env
+env:
+  global:
+    - SLS_IGNORE_WARNING=*
+    - FORCE_COLOR=1 # Ensure colored output for processes combined with '&&'
 
 stages:
   - name: Test
@@ -29,9 +32,6 @@ jobs:
     - name: 'Prettier check updated, Lint updated, Unit Tests - Linux - Node.js v12'
       if: type = pull_request
       node_js: 12
-      env:
-        - SLS_IGNORE_WARNING=*
-        - FORCE_COLOR=1 # TTY is lost as processes are combined '&&'
       # Combine with '&&' to not continue on fail
       script: npm run prettier-check-updated && npm run lint-updated && npm test
 
@@ -39,18 +39,12 @@ jobs:
     - name: 'Lint, Unit Tests - Linux - Node.js v12'
       if: type != pull_request
       node_js: 12
-      env:
-        - SLS_IGNORE_WARNING=*
-        - FORCE_COLOR=1 # TTY is lost as processes are combined '&&'
       # Combine with '&&' to not continue on fail
       script: npm run lint && npm test
 
     - name: 'Unit Tests - Windows - Node.js v12'
       os: windows
       node_js: 12
-      env:
-        - SLS_IGNORE_WARNING=*
-        - FORCE_COLOR=1 # For some reason on Windows colors support is not detected
       before_script:
         # Ensure Python 2 in Windows enviroment (Ruby is already preinstalled)
         - |
@@ -62,9 +56,6 @@ jobs:
 
     - name: 'Isolated Unit Tests, Package Integration Tests - Linux - Node.js v10'
       node_js: 10
-      env:
-        - SLS_IGNORE_WARNING=*
-        - FORCE_COLOR=1 # TTY is lost as processes are combined '&&'
       # Combine with '&&' to not continue on fail
       script: npm run test-isolated && npm run integration-test-run-package
 
@@ -79,8 +70,6 @@ jobs:
       name: 'Integration Tests - Linux - Node.js v12'
       node_js: 12
       env:
-        - SLS_IGNORE_WARNING=*
-        - FORCE_COLOR=1 # TTY is lost as processes are combined '&&'
         # AWS_ACCESS_KEY_ID
         - secure: Ia2nYzOeYvTE6qOP7DBKX3BO7s/U7TXdsvB2nlc3kOPFi//IbTVD0/cLKCAE5XqTzrrliHINSVsFcJNSfjCwmDSRmgoIGrHj5CJkWpkI6FEPageo3mdqFQYEc8CZeAjsPBNaHe6Ewzg0Ev/sjTByLSJYVqokzDCF1QostSxx1Ss6SGt1zjxeP/Hp4yOJn52VAm9IHAKYn7Y62nMAFTaaTPUQHvW0mJj6m2Z8TWyPU+2Bx6mliO65gTPFGs+PdHGwHtmSF/4IcUO504x+HjDuwzW2itomLXZmIOFfGDcFYadKWzVMAfJzoRWOcVKF4jXdMoSCOviWpHGtK35E7K956MTXkroVoWCS7V0knQDovbRZj8c8td8mS4tdprUA+TzgZoHet2atWNtMuTh79rdmwoAO+IAWJegYj62Tdfy3ycESzY+KxSaV8kysG9sR3PRFoWjZerA7MhLZEzQMORXDGjJlgwLaZfYVqjlsGe5p5etFBUTd0WbFgSwOKLoA2U/fm7WzqItkjs3UWaHuvFVvwYixGxjEVmVczS6wa2cdGpHtVD9H7km4fPEzljHqQ26v0P5e8eylgqLF2IB6mL7UqGFrAtrMvAgN/M3gnq4dTs/wq1AJIOxEP7YW7kc0NAldk8vUz6t5GzCPNcuukxAku91Awnh0twxgUywatgJLZPY=
         # AWS_SECRET_ACCESS_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ stages:
     if: tag =~ ^v\d+\.\d+\.\d+$
 
 before_script:
-  # Fail build right after first script fail, unfortunately Travis doesn't do that: https://github.com/travis-ci/travis-ci/issues/1066
-  # More info on below: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
+  # Fail build right after first script fails. Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/1066
+  # More info on below line: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
   - set -e
 
 # Ensure to fail build if deploy fails, Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/921
@@ -49,7 +49,7 @@ after_deploy:
   - |
     # npm creates log only on failure
     if [ -d ~/.npm/_logs ]; then
-      # Undocumented way to force build to fail
+      # Undocumented way to force Travis build to fail
       travis_terminate 1
     fi
 


### PR DESCRIPTION
- Ensure that latest versions of dependencies are installed for each build
- Configure cache (reduces install time from ca 30s to 5s)
- Instead of joining scripts with `&&`, configure Travis bash with `set -e`. Improves configuration readability and makes Travis behave up to expectations (fail build on first script fail)
- Ensure to fail builds if deployment fails
- Reduplicate env vars configuration (by configuring common global group via `env.global`)
- Improve inline comments

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
