### PR TITLE
Support for Github Entreprise in sls create

### DIFF
--- a/docs/providers/aws/cli-reference/install.md
+++ b/docs/providers/aws/cli-reference/install.md
@@ -29,6 +29,13 @@ serverless install --url https://github.com/some/service
 
 - `install:install`
 
+## Supported Code Hosting Platforms
+
+- GitHub
+- GitHub Enterprise
+- GitLab
+- BitBucket
+
 ## Examples
 
 ### Installing a service from a GitHub URL

--- a/docs/providers/azure/cli-reference/install.md
+++ b/docs/providers/azure/cli-reference/install.md
@@ -29,6 +29,13 @@ serverless install --url https://github.com/some/service
 
 - `install:install`
 
+## Supported Code Hosting Platforms
+
+- GitHub
+- GitHub Enterprise
+- GitLab
+- BitBucket
+
 ## Examples
 
 ### Installing a service from a GitHub URL

--- a/docs/providers/google/cli-reference/install.md
+++ b/docs/providers/google/cli-reference/install.md
@@ -25,6 +25,13 @@ serverless install --url https://github.com/some/service
 - `--url` or `-u` The services GitHub URL. **Required**.
 - `--name` or `-n` Name for the service.
 
+## Supported Code Hosting Platforms
+
+- GitHub
+- GitHub Enterprise
+- GitLab
+- BitBucket
+
 ## Examples
 
 ### Installing a service from a GitHub URL

--- a/docs/providers/openwhisk/cli-reference/install.md
+++ b/docs/providers/openwhisk/cli-reference/install.md
@@ -29,6 +29,13 @@ serverless install --url https://github.com/some/service
 
 - `install:install`
 
+## Supported Code Hosting Platforms
+
+- GitHub
+- GitHub Enterprise
+- GitLab
+- BitBucket
+
 ## Examples
 
 ### Installing a service from a GitHub URL

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -46,18 +46,17 @@ function validateUrl(url, hostname, service, owner, repo) {
 }
 
 /**
- * isGhe = is github entreprise url?
  * @param {Object} url
- * @param {Boolean} isGhe
  * @returns {Object}
  */
-function parseGitHubURL(url, isGhe) {
+function parseGitHubURL(url) {
   const pathLength = 4;
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > pathLength;
   const owner = parts[1];
   const repo = parts[2];
   const branch = isSubdirectory ? parts[pathLength] : 'master';
+  const isGhe = url.hostname !== 'github.com';
 
   if (!isGhe) {
     // validate if given url is a valid GitHub url
@@ -157,27 +156,17 @@ function parseRepoURL(inputUrl) {
     throw new ServerlessError('The URL you passed is not a valid URL');
   }
 
-  switch (url.hostname) {
-    case 'github.com': {
-      return parseGitHubURL(url, false);
-    }
-    case 'bitbucket.org': {
-      return parseBitbucketURL(url);
-    }
-    case 'gitlab.com': {
-      return parseGitlabURL(url);
-    }
-    default: {
-      // test for github entreprise  url
-      // check if the hostname contains 'github'
-      if (url.hostname.indexOf('github') !== -1) {
-        return parseGitHubURL(url, true);
-      }
-      const msg =
-        'The URL you passed is not one of the valid providers: "GitHub", "GitHub Entreprise", "Bitbucket", or "GitLab".';
-      throw new ServerlessError(msg);
-    }
+  if (url.hostname === 'github.com' || url.hostname.indexOf('github.') !== -1) {
+    return parseGitHubURL(url);
+  } else if (url.hostname === 'bitbucket.org') {
+    return parseBitbucketURL(url);
+  } else if (url.hostname === 'gitlab.com') {
+    return parseGitlabURL(url);
   }
+
+  const msg =
+    'The URL you passed is not one of the valid providers: "GitHub", "GitHub Entreprise", "Bitbucket", or "GitLab".';
+  throw new ServerlessError(msg);
 }
 
 /**

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -65,8 +65,8 @@ function parseGitHubURL(url, isGhe) {
   }
 
   const downloadUrl = `https://${
-    url.auth ? `${url.auth}@` : ''
-  }${isGhe ? url.hostname : 'github.com'}/${owner}/${repo}/archive/${branch}.zip`;
+    isGhe ? url.hostname : 'github.com'
+  }/${owner}/${repo}/archive/${branch}.zip`;
 
   return {
     owner,
@@ -75,6 +75,7 @@ function parseGitHubURL(url, isGhe) {
     downloadUrl,
     isSubdirectory,
     pathToDirectory: getPathDirectory(pathLength + 1, parts),
+    auth: url.auth ? url.auth : '',
   };
 }
 
@@ -104,6 +105,7 @@ function parseBitbucketURL(url) {
     downloadUrl,
     isSubdirectory,
     pathToDirectory: getPathDirectory(pathLength + 1, parts),
+    auth: '',
   };
 }
 
@@ -132,6 +134,7 @@ function parseGitlabURL(url) {
     downloadUrl,
     isSubdirectory,
     pathToDirectory: getPathDirectory(pathLength + 1, parts),
+    auth: '',
   };
 }
 
@@ -211,13 +214,15 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
 
   log(`Downloading and installing "${serviceName}"...`);
 
-  // download service
-  return download(repoInformation.downloadUrl, downloadServicePath, {
+  const downloadOptions = {
     timeout: 30000,
     extract: true,
     strip: 1,
     mode: '755',
-  })
+    auth: repoInformation.auth || '',
+  };
+  // download service
+  return download(repoInformation.downloadUrl, downloadServicePath, downloadOptions)
     .then(() => {
       // if it's a directory inside of git
       if (repoInformation.isSubdirectory) {

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -56,15 +56,15 @@ function parseGitHubURL(url) {
   const owner = parts[1];
   const repo = parts[2];
   const branch = isSubdirectory ? parts[pathLength] : 'master';
-  const isGhe = url.hostname !== 'github.com';
+  const isGitHubEnterprise = url.hostname !== 'github.com';
 
-  if (!isGhe) {
+  if (!isGitHubEnterprise) {
     // validate if given url is a valid GitHub url
     validateUrl(url, 'github.com', 'GitHub', owner, repo);
   }
 
   const downloadUrl = `https://${
-    isGhe ? url.hostname : 'github.com'
+    isGitHubEnterprise ? url.hostname : 'github.com'
   }/${owner}/${repo}/archive/${branch}.zip`;
 
   return {
@@ -74,7 +74,7 @@ function parseGitHubURL(url) {
     downloadUrl,
     isSubdirectory,
     pathToDirectory: getPathDirectory(pathLength + 1, parts),
-    auth: url.auth ? url.auth : '',
+    auth: url.auth || '',
   };
 }
 
@@ -181,6 +181,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
   let serviceName;
   let dirName;
   let downloadServicePath;
+  const { auth } = repoInformation;
 
   if (repoInformation.isSubdirectory) {
     const folderName = repoInformation.pathToDirectory.split('/').splice(-1)[0];
@@ -208,7 +209,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
     extract: true,
     strip: 1,
     mode: '755',
-    auth: repoInformation.auth || '',
+    auth,
   };
   // download service
   return download(repoInformation.downloadUrl, downloadServicePath, downloadOptions)

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -7,7 +7,6 @@ const download = require('download');
 const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const qs = require('querystring');
-const fetch = require('node-fetch');
 const renameService = require('./renameService').renameService;
 const ServerlessError = require('../classes/Error').ServerlessError;
 const copyDirContentsSync = require('./fs/copyDirContentsSync');

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -7,6 +7,7 @@ const download = require('download');
 const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const qs = require('querystring');
+const fetch = require('node-fetch');
 const renameService = require('./renameService').renameService;
 const ServerlessError = require('../classes/Error').ServerlessError;
 const copyDirContentsSync = require('./fs/copyDirContentsSync');
@@ -46,10 +47,12 @@ function validateUrl(url, hostname, service, owner, repo) {
 }
 
 /**
+ * isGhe = is github entreprise url?
  * @param {Object} url
+ * @param {Boolean} isGhe
  * @returns {Object}
  */
-function parseGitHubURL(url) {
+function parseGitHubURL(url, isGhe) {
   const pathLength = 4;
   const parts = url.pathname.split('/');
   const isSubdirectory = parts.length > pathLength;
@@ -57,12 +60,14 @@ function parseGitHubURL(url) {
   const repo = parts[2];
   const branch = isSubdirectory ? parts[pathLength] : 'master';
 
-  // validate if given url is a valid GitHub url
-  validateUrl(url, 'github.com', 'GitHub', owner, repo);
+  if (!isGhe) {
+    // validate if given url is a valid GitHub url
+    validateUrl(url, 'github.com', 'GitHub', owner, repo);
+  }
 
   const downloadUrl = `https://${
     url.auth ? `${url.auth}@` : ''
-  }github.com/${owner}/${repo}/archive/${branch}.zip`;
+  }${isGhe ? url.hostname : 'github.com'}/${owner}/${repo}/archive/${branch}.zip`;
 
   return {
     owner,
@@ -152,7 +157,7 @@ function parseRepoURL(inputUrl) {
 
   switch (url.hostname) {
     case 'github.com': {
-      return parseGitHubURL(url);
+      return parseGitHubURL(url, false);
     }
     case 'bitbucket.org': {
       return parseBitbucketURL(url);
@@ -161,8 +166,13 @@ function parseRepoURL(inputUrl) {
       return parseGitlabURL(url);
     }
     default: {
+      // test for github entreprise  url
+      // check if the hostname contains 'github'
+      if (url.hostname.indexOf('github') !== -1) {
+        return parseGitHubURL(url, true);
+      }
       const msg =
-        'The URL you passed is not one of the valid providers: "GitHub", "Bitbucket", or "GitLab".';
+        'The URL you passed is not one of the valid providers: "GitHub", "GitHub Entreprise", "Bitbucket", or "GitLab".';
       throw new ServerlessError(msg);
     }
   }

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -154,6 +154,7 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://github.com/serverless/serverless/archive/master.zip',
         isSubdirectory: false,
         pathToDirectory: '',
+        auth: '',
       });
     });
 
@@ -167,6 +168,7 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://github.com/serverless/serverless/archive/master.zip',
         isSubdirectory: true,
         pathToDirectory: 'assets',
+        auth: '',
       });
     });
 
@@ -180,10 +182,11 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://github.mydomain.com/serverless/serverless/archive/master.zip',
         isSubdirectory: false,
         pathToDirectory: '',
+        auth: '',
       });
     });
 
-    it('should parse a valid GitHub URL with subdirectory', () => {
+    it('should parse a valid GitHub Entreprise with subdirectory', () => {
       const output = parseRepoURL('https://github.mydomain.com/serverless/serverless/tree/master/assets');
 
       expect(output).to.deep.eq({
@@ -193,6 +196,21 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://github.mydomain.com/serverless/serverless/archive/master.zip',
         isSubdirectory: true,
         pathToDirectory: 'assets',
+        auth: '',
+      });
+    });
+
+    it('should parse a valid GitHub Entreprise URL with authentication', () => {
+      const output = parseRepoURL('https://username:password@github.com/serverless/serverless/');
+
+      expect(output).to.deep.eq({
+        owner: 'serverless',
+        repo: 'serverless',
+        branch: 'master',
+        downloadUrl: 'https://github.com/serverless/serverless/archive/master.zip',
+        isSubdirectory: false,
+        pathToDirectory: '',
+        auth: 'username:password',
       });
     });
 
@@ -206,6 +224,7 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://bitbucket.org/atlassian/localstack/get/master.zip',
         isSubdirectory: false,
         pathToDirectory: '',
+        auth: '',
       });
     });
 
@@ -221,6 +240,7 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://bitbucket.org/atlassian/localstack/get/mvn.zip',
         isSubdirectory: true,
         pathToDirectory: `localstack${path.sep}dashboard`,
+        auth: '',
       });
     });
 
@@ -235,6 +255,7 @@ describe('downloadTemplateFromRepo', () => {
           'https://gitlab.com/serverless/serverless/-/archive/master/serverless-master.zip',
         isSubdirectory: false,
         pathToDirectory: '',
+        auth: '',
       });
     });
 
@@ -248,6 +269,7 @@ describe('downloadTemplateFromRepo', () => {
         downloadUrl: 'https://gitlab.com/serverless/serverless/-/archive/dev/serverless-dev.zip',
         isSubdirectory: true,
         pathToDirectory: 'subdir',
+        auth: '',
       });
     });
   });

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -51,7 +51,7 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should throw an error if the passed URL is not a valid GitHub URL', () => {
-      expect(() => downloadTemplateFromRepo('http://no-github-url.com/foo/bar')).to.throw(Error);
+      expect(() => downloadTemplateFromRepo('http://no-git-url.com/foo/bar')).to.throw(Error);
     });
 
     it('should throw an error if a directory with the same service name is already present', () => {
@@ -165,6 +165,32 @@ describe('downloadTemplateFromRepo', () => {
         repo: 'serverless',
         branch: 'master',
         downloadUrl: 'https://github.com/serverless/serverless/archive/master.zip',
+        isSubdirectory: true,
+        pathToDirectory: 'assets',
+      });
+    });
+
+    it('should parse a valid GitHub Entreprise URL', () => {
+      const output = parseRepoURL('https://github.mydomain.com/serverless/serverless');
+
+      expect(output).to.deep.eq({
+        owner: 'serverless',
+        repo: 'serverless',
+        branch: 'master',
+        downloadUrl: 'https://github.mydomain.com/serverless/serverless/archive/master.zip',
+        isSubdirectory: false,
+        pathToDirectory: '',
+      });
+    });
+
+    it('should parse a valid GitHub URL with subdirectory', () => {
+      const output = parseRepoURL('https://github.mydomain.com/serverless/serverless/tree/master/assets');
+
+      expect(output).to.deep.eq({
+        owner: 'serverless',
+        repo: 'serverless',
+        branch: 'master',
+        downloadUrl: 'https://github.mydomain.com/serverless/serverless/archive/master.zip',
         isSubdirectory: true,
         pathToDirectory: 'assets',
       });

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -187,7 +187,9 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should parse a valid GitHub Entreprise with subdirectory', () => {
-      const output = parseRepoURL('https://github.mydomain.com/serverless/serverless/tree/master/assets');
+      const output = parseRepoURL(
+        'https://github.mydomain.com/serverless/serverless/tree/master/assets'
+      );
 
       expect(output).to.deep.eq({
         owner: 'serverless',
@@ -209,8 +211,8 @@ describe('downloadTemplateFromRepo', () => {
         branch: 'master',
         downloadUrl: 'https://github.com/serverless/serverless/archive/master.zip',
         isSubdirectory: false,
-        pathToDirectory: '',
         auth: 'username:password',
+        pathToDirectory: '',
       });
     });
 

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -51,7 +51,7 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should throw an error if the passed URL is not a valid GitHub URL', () => {
-      expect(() => downloadTemplateFromRepo('http://no-git-url.com/foo/bar')).to.throw(Error);
+      expect(() => downloadTemplateFromRepo('http://no-git-hub-url.com/foo/bar')).to.throw(Error);
     });
 
     it('should throw an error if a directory with the same service name is already present', () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5332 

## How did you implement it:

Check wether the provided repository url contains 'github' keyword. I originally intended to also check if the url was a valid github entreprise url (using the /api/v3 endpoint as a verification endpoint), but i had trouble having the test running fine after, so i stopped at "if url is not github.com, but contains github, then it's a github entreprise url".

## How can we verify it:

Provided you have a github entreprise setup:

`./bin/serverless create --template-url https://github.mydomain.com/serverless-template/tree/master/non-prod/aws-nodejs --path test`

`./bin/serverless create --template-url https://username:password@github.mydomain.com/serverless-template/tree/master/non-prod/aws-nodejs --path test`

I tested with my own setup (I'm working in a company that has its own dedicated github entreprise running on premise), and it worked fine.

or run the `npm run test` command.

Note: There was an issue with the auth management in lib/utils/downloadTemplateFromRepo.js - parseGitHubURL function. When using the 'download' library (that relies on 'got' module), it refuses to handle basic authentication in the url directly and asked for an auth option (see line 205 of node_modules/got/index.js). I change the mechanism in lib/utils/downloadTemplateFromRepo.js and updated the test accordingly.

## Todos:

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
