### PR TITLE
Merge patch 1.46.1 release artifacts back into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,5 +83,7 @@ jobs:
       deploy:
         provider: npm
         email: services@serverless.com
+        on:
+          tags: true
         api_key:
           secure: EgoetjrRlGfvGnmVp8A0btr1CzB0hl7owVIpbfk4zXJzhGEbHoVu0CG0IdmyLN+JlaZa7EDJTjkDCd6g3fVAh9TT7ZCeaq8YwbZDrql7mAJj7xYQAyM4eSkc95BRzcFJBx7Mxr6H90IDLxKr6ZtB+HEdiHN+59XbepKYYJeb1jHfnKn5xzOqk4BdnZo6pKfudfeO+7/BwJJ0FwlFA40bY2HS/Lp+NG/2IedNR7k3m/5W83/XH5qlWP8jhBKlxrAzks27aNo+42xHkRCVyPViJKq0mfz1hl2bfswChWHgaCuajp+0amNL39pgIX9eXxFc3bNX9Iftox5t31elEhsw06vvuAaVkKEd+VEMaDySbQ9M+irKZeREg+NFYZLnc2WiEE3Sexo6hm9eM2q2KEZ7bleN9B0CQAut1XXLRQEts80rzss4Z2Q7AZb9cOYBQlj9Wf1X0Y74UqvnDn83a4Y38a+lhx7J2q691ZeM1UFSCdO0QfeJRkB55bSyHqUqrLAqUN7eNsKGdBH0kvYIGFREgGgReEpBRAuNqWuJ/5qexp63Kbf+09raG5IvfxSIM5fJ5KE5VxSduBdRnSH0GNKfjuq296/Rg4fmm/bygZ3Yk5L6Wd41SUU8uHzlZFBwtcvxAKDTQe6s+5JU24ilqxOx6J4Ut34X3dIbLLAmoB1ogdM=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.46.1 (2019-06-28)
 
 - [Fix service.provider.region resolution](https://github.com/serverless/serverless/pull/6317)
+- [Ensure deploy is triggered in CI](https://github.com/serverless/serverless/pull/6306)
 
 ## Meta
 - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.46.0...v1.46.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.46.1 (2019-06-28)
+
+- [Fix service.provider.region resolution](https://github.com/serverless/serverless/pull/6317)
+
+## Meta
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.46.0...v1.46.1)
+
 # 1.46.0 (2019-06-26)
 
 - [Fix formatting issue with Markdown link](https://github.com/serverless/serverless/pull/6228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Ensure deploy is triggered in CI](https://github.com/serverless/serverless/pull/6306)
 
 ## Meta
+
 - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.46.0...v1.46.1)
 
 # 1.46.0 (2019-06-26)
@@ -31,6 +32,7 @@
 - [Feature/support external websocket api](https://github.com/serverless/serverless/pull/6272)
 
 ## Meta
+
 - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.45.1...v1.46.0)
 
 # 1.45.1 (2019-06-12)
@@ -39,8 +41,8 @@
 - [Fix Travis CI deploy config](https://github.com/serverless/serverless/pull/6234)
 
 ## Meta
-- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.45.0...v1.45.1)
 
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.45.0...v1.45.1)
 
 # 1.45.0 (2019-06-12)
 
@@ -64,16 +66,16 @@
 - [Update Scala version to 2.13.0 for aws-scala-sbt template](https://github.com/serverless/serverless/pull/6222)
 
 ## Meta
-- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.44.1...v1.45.0)
 
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.44.1...v1.45.0)
 
 # 1.44.1 (2019-05-28)
 
 - [Fix enterprise plugin lookup in global yarn installs](https://github.com/serverless/serverless/pull/6183)
 
 ## Meta
-- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.44.0...v1.44.1)
 
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.44.0...v1.44.1)
 
 # 1.44.0 (2019-05-28)
 
@@ -88,8 +90,8 @@
 - [Upgrade mocha, switch from istanbul to nyc, improve tests configuration](https://github.com/serverless/serverless/pull/6169)
 
 ## Meta
-- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.43.0...v1.44.0)
 
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.43.0...v1.44.0)
 
 # 1.43.0 (2019-05-20)
 
@@ -100,6 +102,7 @@
 - [Fix tests setup issues](https://github.com/serverless/serverless/pull/6147)
 
 ## Meta
+
 - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.42.3...v1.43.0)
 
 # 1.42.3 (2019-05-14)
@@ -115,7 +118,8 @@
 - [Improve handling of custom API Gateway options](https://github.com/serverless/serverless/pull/6129)
 
 ## Meta
- - [Comparison since last release](https://github.com/serverless/serverless/compare/v1.42.2...v1.42.3)
+
+- [Comparison since last release](https://github.com/serverless/serverless/compare/v1.42.2...v1.42.3)
 
 # 1.42.2 (2019-05-10)
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -124,6 +124,9 @@ class AwsProvider {
     this.serverless = serverless;
     this.sdk = AWS;
     this.serverless.setProvider(constants.providerName, this);
+    if (this.serverless.service.provider.name === 'aws') {
+      this.serverless.service.provider.region = this.getRegion();
+    }
     this.requestCache = {};
     this.requestQueue = new PromiseQueue(2, Infinity);
     // Store credentials in this variable to avoid creating them several times (messes up MFA).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
Merging the Patch release artifacts (e.g. updates to `CHANGELOG.md`) back into `master` to keep the history.

**IMPORTANT:** Don't delete the branch after merging as we might have other patch releases we want to do and need to merge back into `master` once released.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
