### PR TITLE
Add SLS_NO_WARNINGS env var

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -210,6 +210,12 @@ class CLI {
     this.consoleLog(chalk.dim('* Documentation: https://serverless.com/framework/docs/'));
 
     this.consoleLog('');
+
+    this.consoleLog(chalk.yellow.underline('Environment Variables'));
+    this.consoleLog(chalk.dim('* Set SLS_DEBUG=* to see debugging logs'));
+    this.consoleLog(chalk.dim('* Set SLS_WARNING_DISABLE=* to hide warnings from the output'));
+
+    this.consoleLog('');
     if (!_.isEmpty(this.loadedCommands)) {
       _.forEach(this.loadedCommands, (details, command) => {
         this.displayCommandUsage(details, command);

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -97,7 +97,7 @@ module.exports.logError = e => {
 };
 
 module.exports.logWarning = message => {
-  if (process.env.SLS_NO_WARNINGS) {
+  if (process.env.SLS_WARNING_DISABLE) {
     return;
   }
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -97,6 +97,10 @@ module.exports.logError = e => {
 };
 
 module.exports.logWarning = message => {
+  if (process.env.SLS_NO_WARNINGS) {
+    return;
+  }
+
   writeMessage('Serverless Warning', message);
 };
 

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -110,6 +110,20 @@ describe('Error', () => {
       expect(message).to.have.string('SLS_DEBUG=*');
     });
 
+    it('should hide warnings if SLS_NO_WARNINGS is defined', () => {
+      process.env.SLS_NO_WARNINGS = '1';
+
+      logWarning('This is a warning');
+      logWarning('This is another warning');
+      logError(new Error('an error'));
+
+      const message = consoleLogSpy.args.join('\n');
+
+      expect(consoleLogSpy.called).to.equal(true);
+      expect(message).to.have.string('an error');
+      expect(message).not.to.have.string('This is a warning');
+    });
+
     it('should print stack trace with SLS_DEBUG', () => {
       process.env.SLS_DEBUG = '1';
       const error = new ServerlessError('a message');

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -110,8 +110,8 @@ describe('Error', () => {
       expect(message).to.have.string('SLS_DEBUG=*');
     });
 
-    it('should hide warnings if SLS_NO_WARNINGS is defined', () => {
-      process.env.SLS_NO_WARNINGS = '1';
+    it('should hide warnings if SLS_WARNING_DISABLE is defined', () => {
+      process.env.SLS_WARNING_DISABLE = '*';
 
       logWarning('This is a warning');
       logWarning('This is another warning');


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

In `logWarning` function, added a check for an environment variable named `SLS_NO_WARNINGS`.

When this env var is set (much like `SLS_DEBUG`) all the warnings are hidden from the output.

<!--
Briefly describe the feature if no issue exists for this PR
-->

Closes #6346 

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Well, I added a guard clause at the beginning of the `logWarning` function.

If the env var is set, the function exits without printing.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

* In your `serverless.yml`, try to define some SSM parameters that are not defined
* Run `sls deploy` and see the warnings about undefined SSM params
* Run `SLS_NO_WARNINGS=* sls deploy` and enjoy no warnings

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
