### PR TITLE
Remove trailing & leading quotes from env refs

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -133,6 +133,10 @@ functions:
 
 To reference environment variables, use the `${env:SOME_VAR}` syntax in your `serverless.yml` configuration file. It is valid to use the empty string in place of `SOME_VAR`. This looks like "`${env:}`" and the result of declaring this in your `serverless.yml` is to embed the complete `process.env` object (i.e. all the variables defined in your environment).
 
+Using trailing & leading quotes in your environment variables will be removed once inserted into the generated CloudFormation template i.e:
+
+`export SOME_VAR="some value"` would be inserted as `some value`
+
 **Note:**
 
 Keep in mind that sensitive information which is provided through environment variables can be written into less protected or publicly accessible build logs, CloudFormation templates, et cetera.

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -576,7 +576,9 @@ class Variables {
     } else {
       valueToPopulate = process.env;
     }
-    return typeof valueToPopulate === 'string' ? this.getValueFromString(valueToPopulate) : BbPromise.resolve(valueToPopulate)
+    return typeof valueToPopulate === 'string'
+      ? this.getValueFromString(valueToPopulate)
+      : BbPromise.resolve(valueToPopulate);
   }
 
   getValueFromString(variableString) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -576,7 +576,7 @@ class Variables {
     } else {
       valueToPopulate = process.env;
     }
-    return BbPromise.resolve(valueToPopulate);
+    return typeof valueToPopulate === 'string' ? this.getValueFromString(valueToPopulate) : BbPromise.resolve(valueToPopulate)
   }
 
   getValueFromString(variableString) {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1583,6 +1583,11 @@ module.exports = {
       return serverless.variables.getValueFromEnv('env:TEST_VAR').should.become('someValue');
     });
 
+    it('should remove first and last quote of environment variable', () => {
+      process.env.TEST_VAR = '"someValue"';
+      return serverless.variables.getValueFromEnv('env:TEST_VAR').should.become('someValue');
+    });
+
     it('should allow top-level references to the environment variables hive', () => {
       process.env.TEST_VAR = 'someValue';
       return serverless.variables.getValueFromEnv('env:').then(valueToPopulate => {


### PR DESCRIPTION
## What did you implement:
This PR removes straling and leading `"` or `'` from env variables. This was not a problem for function cloud formation template definition but was so for resources.

If you had en env like so `export TEST_ENV="abcdefg?a"` the quotes would be escaped in the resource CF template json as `Value: "\"abcdefg?a\""`.

## How did you implement it:

`getValueFromEnv` now calls `getValueFromString` if the value is a string

## How can we verify it:

Try use an env value surrounded by quotes and use that somewhere in your resources, ie:
```yaml
resources:
  Resources:
    DBCluster:
      Type: "AWS::DocDB::DBCluster"
      DeletionPolicy: Delete
      Properties:
        DBClusterIdentifier: ${self:custom.dbClusterName}
        MasterUsername: rvadmin
        MasterUserPassword: ${env:DB_PASSWORD}
```
## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [X] Write documentation
- [X] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
