### PR TITLE
Allow optionally splitting SSM parameter value for StringList type

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -294,6 +294,19 @@ custom:
 
 In this example, the serverless variable will contain the decrypted value of the SecureString.
 
+For StringList type parameters, you can optionally split the resolved variable into an array using the extended syntax, `ssm:/path/to/stringlistparam~split`.
+
+```yml
+service: new-service
+provider: aws
+functions:
+  hello:
+    name: hello
+    handler: handler.hello
+custom:
+  myArrayVar: ${ssm:/path/to/stringlistparam~split}
+```
+
 ## Reference Variables using AWS Secrets Manager
 
 Variables in [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) can be referenced [using SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html). Use the `ssm:/aws/reference/secretsmanager/secret_ID_in_Secrets_Manager~true` syntax(note `~true` as secrets are always encrypted). For example:

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -54,7 +54,7 @@ class Variables {
     this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(\.[a-zA-Z0-9-]+)?:/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
-    this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false)?/);
+    this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/);
   }
 
   loadVariableSyntax() {
@@ -762,6 +762,7 @@ class Variables {
     const groups = variableString.match(this.ssmRefSyntax);
     const param = groups[1];
     const decrypt = groups[2] === 'true';
+    const split = groups[2] === 'split';
     return this.serverless
       .getProvider('aws')
       .request(
@@ -775,14 +776,19 @@ class Variables {
       ) // Use request cache
       .then(response => {
         const plainText = response.Parameter.Value;
+        const type = response.Parameter.Type;
         // Only if Secrets Manager. Parameter Store does not support JSON.
-        if (param.startsWith('/aws/reference/secretsmanager')) {
+        // We cannot parse StringList types, so don't try
+        if (type !== 'StringList' && param.startsWith('/aws/reference/secretsmanager')) {
           try {
             const json = JSON.parse(plainText);
             return BbPromise.resolve(json);
           } catch (err) {
             // return as plain text if value is not JSON
           }
+        }
+        if (type === 'StringList' && split) {
+          return BbPromise.resolve(plainText.split(','));
         }
         return BbPromise.resolve(plainText);
       })

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -787,8 +787,13 @@ class Variables {
             // return as plain text if value is not JSON
           }
         }
-        if (type === 'StringList' && split) {
-          return BbPromise.resolve(plainText.split(','));
+        if (split) {
+          if (type === 'StringList') {
+            return BbPromise.resolve(plainText.split(','));
+          }
+          logWarning(
+            `Cannot split SSM parameter '${param}' of type '${type}'. Must be 'StringList'.`
+          );
         }
         return BbPromise.resolve(plainText);
       })

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2154,6 +2154,63 @@ module.exports = {
         })
         .finally(() => ssmStub.restore());
     });
+    it('should get split StringList variable from Ssm using extended syntax', () => {
+      const stringListValue = 'MockValue1,MockValue2';
+      const parsedValue = [ 'MockValue1', 'MockValue2' ];
+      const stringListResponseMock = {
+        Parameter: {
+          Value: stringListValue,
+          Type: 'StringList',
+        },
+      };
+      const ssmStub = sinon
+        .stub(awsProvider, 'request')
+        .callsFake(() => BbPromise.resolve(stringListResponseMock));
+      return serverless.variables
+        .getValueFromSsm(`ssm:${param}~split`)
+        .should.become(parsedValue)
+        .then(() => {
+          expect(ssmStub).to.have.been.calledOnce;
+          expect(ssmStub).to.have.been.calledWithExactly(
+            'SSM',
+            'getParameter',
+            {
+              Name: param,
+              WithDecryption: false,
+            },
+            { useCache: true }
+          );
+        })
+        .finally(() => ssmStub.restore());
+    });
+    it('should get unsplit StringList variable from Ssm by default', () => {
+      const stringListValue = 'MockValue1,MockValue2';
+      const stringListResponseMock = {
+        Parameter: {
+          Value: stringListValue,
+          Type: 'StringList',
+        },
+      };
+      const ssmStub = sinon
+        .stub(awsProvider, 'request')
+        .callsFake(() => BbPromise.resolve(stringListResponseMock));
+      return serverless.variables
+        .getValueFromSsm(`ssm:${param}`)
+        .should.become(stringListValue)
+        .then(() => {
+          expect(ssmStub).to.have.been.calledOnce;
+          expect(ssmStub).to.have.been.calledWithExactly(
+            'SSM',
+            'getParameter',
+            {
+              Name: param,
+              WithDecryption: false,
+            },
+            { useCache: true }
+          );
+        })
+        .finally(() => ssmStub.restore());
+    });
     describe('Referencing to AWS SecretsManager', () => {
       it('should NOT parse value as json if not referencing to AWS SecretsManager', () => {
         const secretParam = '/path/to/foo-bar';

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2211,6 +2211,44 @@ module.exports = {
         })
         .finally(() => ssmStub.restore());
     });
+    it('should warn when attempting to split a non-StringList Ssm variable', () => {
+      const logWarningSpy = sinon.spy(slsError, 'logWarning');
+      const consoleLogStub = sinon.stub(console, 'log').returns();
+      const ProxyQuiredVariables = proxyquire('./Variables.js', { './Error': logWarningSpy });
+      const varProxy = new ProxyQuiredVariables(serverless);
+      const stringListResponseMock = {
+        Parameter: {
+          Value: value,
+          Type: 'String',
+        },
+      };
+      const ssmStub = sinon
+        .stub(awsProvider, 'request')
+        .callsFake(() => BbPromise.resolve(stringListResponseMock));
+      return varProxy
+        .getValueFromSsm(`ssm:${param}~split`)
+        .should.become(value)
+        .then(() => {
+          expect(ssmStub).to.have.been.calledOnce;
+          expect(ssmStub).to.have.been.calledWithExactly(
+            'SSM',
+            'getParameter',
+            {
+              Name: param,
+              WithDecryption: false,
+            },
+            { useCache: true }
+          );
+          expect(logWarningSpy).to.have.been.calledWithExactly(
+            `Cannot split SSM parameter '${param}' of type 'String'. Must be 'StringList'.`
+          );
+        })
+        .finally(() => {
+          ssmStub.restore();
+          logWarningSpy.restore();
+          consoleLogStub.restore();
+        });
+    });
     describe('Referencing to AWS SecretsManager', () => {
       it('should NOT parse value as json if not referencing to AWS SecretsManager', () => {
         const secretParam = '/path/to/foo-bar';

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2156,7 +2156,7 @@ module.exports = {
     });
     it('should get split StringList variable from Ssm using extended syntax', () => {
       const stringListValue = 'MockValue1,MockValue2';
-      const parsedValue = [ 'MockValue1', 'MockValue2' ];
+      const parsedValue = ['MockValue1', 'MockValue2'];
       const stringListResponseMock = {
         Parameter: {
           Value: stringListValue,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #4608

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Per @lorengordon's suggestion in the issue, I looked at the `Type` field in the `getParameter` response and, based on the presence of the `~split` extended option, I split the resulting string by comma.

## How can we verify it:

1. Create an AWS SSM StringList parameter:

```sh
aws ssm put-parameter --name /Testing/MyStringListParam --type StringList --value "Val1,Val2"
```

2. Reference that parameter in `serverless.yml`:

```yml
custom:
  array: ${ssm:/Testing/MyStringListParam~split}
```

3. Print the CloudFormation template using `sls print` and verify that the `array` variable value is an array:

```sh-session
$ sls print
#...
custom:
  array:
    - Val1
    - Val2
#...
```

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
