### PR TITLE
Fix premature interactiveCli setup

### DIFF
--- a/lib/plugins/interactiveCli/index.js
+++ b/lib/plugins/interactiveCli/index.js
@@ -9,11 +9,12 @@ module.exports = class InteractiveCli {
   constructor(serverless) {
     if (!process.stdin.isTTY) return;
 
-    // Expose customized inquirer for other plugins
-    serverless.interactiveCli = { inquirer };
     const { processedInput } = serverless;
     if (processedInput.commands.length) return;
     if (!_.isEmpty(processedInput.options)) return;
+
+    // Expose customized inquirer for other plugins
+    serverless.interactiveCli = { inquirer };
 
     // Enforce interactive CLI
     processedInput.commands.push('interactiveCli');


### PR DESCRIPTION
Fix bug that prevents reasonable detection of interactive CLI by `sls.interactiveCli` (doesn't affect any users currently)