### PR TITLE
Add EventBridge event source

### DIFF
--- a/lib/plugins/aws/customResources/resources/eventBridge/handler.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/handler.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { addPermission, removePermission } = require('./lib/permissions');
+const { updateConfiguration, removeConfiguration } = require('./lib/eventBridge');
+const { getRuleName, getEventBusName } = require('./lib/utils');
+const { getEnvironment, getLambdaArn, handlerWrapper } = require('../utils');
+
+function handler(event, context) {
+  if (event.RequestType === 'Create') {
+    return create(event, context);
+  } else if (event.RequestType === 'Update') {
+    return update(event, context);
+  } else if (event.RequestType === 'Delete') {
+    return remove(event, context);
+  }
+  throw new Error(`Unhandled RequestType ${event.RequestType}`);
+}
+
+function create(event, context) {
+  const { FunctionName, EventBridgeName, EventBridgeConfig } = event.ResourceProperties;
+  const { Region, AccountId } = getEnvironment(context);
+
+  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const ruleName = getRuleName(EventBridgeName);
+  const eventBusName = getEventBusName(EventBridgeConfig);
+
+  return addPermission({
+    functionName: FunctionName,
+    region: Region,
+    accountId: AccountId,
+    ruleName,
+  }).then(() =>
+    updateConfiguration({
+      eventBusName,
+      ruleName,
+    })
+  );
+}
+
+// -- Everything below here is a WIP
+
+function update(event, context) {
+  const { Region, AccountId } = getEnvironment(context);
+  const { FunctionName, UserPoolName, UserPoolConfig } = event.ResourceProperties;
+
+  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+
+  return updateConfiguration({
+    lambdaArn,
+    userPoolName: UserPoolName,
+    userPoolConfig: UserPoolConfig,
+    region: Region,
+  });
+}
+
+function remove(event, context) {
+  const { Region, AccountId } = getEnvironment(context);
+  const { FunctionName, UserPoolName } = event.ResourceProperties;
+
+  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+
+  return removePermission({
+    functionName: FunctionName,
+    userPoolName: UserPoolName,
+    region: Region,
+  }).then(() =>
+    removeConfiguration({
+      lambdaArn,
+      userPoolName: UserPoolName,
+      region: Region,
+    })
+  );
+}
+
+module.exports = {
+  // handler: handlerWrapper(handler, 'CustomResouceExistingCognitoUserPool'),
+  handler,
+};

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/eventBridge.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/eventBridge.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+
+function findRuleByName(config) {
+  const { eventBusName, ruleName, region } = config;
+  const eventBridge = new AWS.EventBridge({ region });
+
+  const params = {
+    EventBusName: eventBusName,
+    Limit: 500,
+  };
+
+  function recursiveFind(nextToken) {
+    if (nextToken) params.NextToken = nextToken;
+    return eventBridge
+      .listRules(params)
+      .promise()
+      .then(result => {
+        const matches = result.Rules.filter(rule => rule.Name === ruleName);
+        if (matches.length) {
+          return matches.shift();
+        }
+        if (result.NextToken) return recursiveFind(false, result.NextToken);
+        return null;
+      });
+  }
+
+  return recursiveFind();
+}
+
+function getRuleConfiguration(config) {
+  const { eventBusName, region } = config;
+  const eventBridge = new AWS.EventBridge({ region });
+
+  return findRuleByName(config).then(rule =>
+    eventBridge
+      .describeRule({
+        Name: rule.Name,
+        EventBusName: eventBusName,
+      })
+      .promise()
+      .then(data => data)
+  );
+}
+
+// --- WIP
+
+function updateRuleConfiguration(config) {
+  const { lambdaArn, userPoolConfig, region } = config;
+  const eventBus = new AWS.EventBus({ region });
+
+  return getRuleConfiguration(config).then(res => {
+    const UserPoolId = res.UserPool.Id;
+    let { LambdaConfig } = res.UserPool;
+    // remove configurations for this specific function
+    LambdaConfig = Object.keys(LambdaConfig).reduce((accum, key) => {
+      if (LambdaConfig[key] === lambdaArn) delete accum[key];
+      return accum;
+    }, LambdaConfig);
+
+    LambdaConfig[userPoolConfig.Trigger] = lambdaArn;
+
+    return cognito.updateUserPool({ UserPoolId, LambdaConfig }).promise();
+  });
+}
+
+function removeConfiguration(config) {
+  const { lambdaArn, region } = config;
+  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
+
+  return getConfiguration(config).then(res => {
+    const UserPoolId = res.UserPool.Id;
+    let { LambdaConfig } = res.UserPool;
+    // remove configurations for this specific function
+    LambdaConfig = Object.keys(LambdaConfig).reduce((accum, key) => {
+      if (LambdaConfig[key] === lambdaArn) delete accum[key];
+      return accum;
+    }, LambdaConfig);
+
+    return cognito.updateUserPool({ UserPoolId, LambdaConfig }).promise();
+  });
+}
+
+module.exports = {
+  findUserPoolByName,
+  updateConfiguration,
+  removeConfiguration,
+};

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+
+function getStatementId(functionName, ruleName) {
+  const normalizedRuleName = ruleName.toLowerCase().replace(/[.:*]/g, '');
+  const id = `${functionName}-${normalizedRuleName}`;
+  if (id.length < 100) {
+    return id;
+  }
+  return id.substring(0, 100);
+}
+
+function addPermission(config) {
+  const { functionName, region, accountId, ruleName } = config;
+  const lambda = new AWS.Lambda({ region });
+  const partition = region && /^cn-/.test(region) ? 'aws-cn' : 'aws';
+  const params = {
+    Action: 'lambda:InvokeFunction',
+    FunctionName: functionName,
+    Principal: 'events.amazonaws.com',
+    StatementId: getStatementId(functionName),
+    SourceArn: `arn:${partition}:events:${region}:${accountId}:rule/${ruleName}`,
+  };
+  return lambda.addPermission(params).promise();
+}
+
+function removePermission(config) {
+  const { functionName, userPoolName, region } = config;
+  const lambda = new AWS.Lambda({ region });
+  const params = {
+    FunctionName: functionName,
+    StatementId: getStatementId(functionName, userPoolName),
+  };
+  return lambda.removePermission(params).promise();
+}
+
+module.exports = {
+  getStatementId,
+  addPermission,
+  removePermission,
+};

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/utils.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/utils.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function getRuleName(eventBridgeName) {
+  return `${eventBridgeName.toLowerCase()}-rule`;
+}
+
+function getEventBusName(eventBridgeConfig) {
+  if (!eventBridgeConfig.eventBus) {
+    return 'default';
+  }
+  // we're dealing with an ARN here, so we have to return its last part
+  return eventBridgeConfig.eventBus.split('/').pop();
+}
+
+module.exports = {
+  getRuleName,
+  getEventBusName,
+};

--- a/lib/plugins/aws/customResources/tinker-event-bridge.js
+++ b/lib/plugins/aws/customResources/tinker-event-bridge.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { handler } = require('./resources/eventBridge/handler');
+
+function main() {
+  const event = {
+    RequestType: 'Create',
+    ResourceProperties: {
+      FunctionName: 'philipp-test-dev-test',
+      EventBridgeName: 'MyEventBridge',
+      EventBridgeConfig: {
+        // --- schedule example ---
+        // EventBus: 'some-arn'
+        Schedule: 'rate(10 minutes)',
+        Input: {
+          key1: 'value1',
+          key2: 'value2',
+          stageParams: {
+            stage: 'dev',
+          },
+        },
+        // InputPath: '$.stageVariables'
+        // InputTransformer: {
+        //   inputPathsMap: {
+        //     eventTime: '$.time',
+        //   },
+        //   inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+        // },
+      },
+    },
+  };
+
+  const context = {
+    invokedFunctionArn: 'arn:aws:lambda:us-east-1:377024778620:function:philipp-test-dev-test',
+  };
+
+  return handler(event, context);
+}
+
+main();


### PR DESCRIPTION
## What did you implement:

Closes #6363

Adds support for the new AWS EventBridge service (see discussion in issue mentioned above for more 
details).

## How did you implement it:

Added the logic via raw SDK calls which are wrapped in a custom CloudFormation resource.

## How can we verify it:

See service definition in https://github.com/serverless/serverless/issues/6363#issuecomment-510853941

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO