### PR TITLE
Create distinct target groups for different ALBs

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -388,8 +388,10 @@ module.exports = {
       .update(this.getAlbTargetGroupNameTagValue(functionName, albId))
       .digest('hex');
   },
-  getAlbListenerRuleLogicalId(functionName, idx) {
-    return `${this.getNormalizedFunctionName(functionName)}AlbListenerRule${idx}`;
+  getAlbListenerRuleLogicalId(functionName, priority, albId, listenerId) {
+    return `${this.getNormalizedFunctionName(
+      functionName
+    )}AlbListenerRule${priority}${albId}${listenerId}`;
   },
 
   // Permissions

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -374,18 +374,18 @@ module.exports = {
   },
 
   // ALB
-  getAlbTargetGroupLogicalId(functionName, priority) {
-    return `${this.getNormalizedFunctionName(functionName)}AlbTargetGroup${priority}`;
+  getAlbTargetGroupLogicalId(functionName, albId) {
+    return `${this.getNormalizedFunctionName(functionName)}AlbTargetGroup${albId}`;
   },
-  getAlbTargetGroupNameTagValue(functionName, priority) {
+  getAlbTargetGroupNameTagValue(functionName, albId) {
     return `${
       this.provider.serverless.service.service
-    }-${functionName}-${priority}-${this.provider.getStage()}`;
+    }-${functionName}-${albId}-${this.provider.getStage()}`;
   },
-  getAlbTargetGroupName(functionName, priority) {
+  getAlbTargetGroupName(functionName, albId) {
     return crypto
       .createHash('md5')
-      .update(this.getAlbTargetGroupNameTagValue(functionName, priority))
+      .update(this.getAlbTargetGroupNameTagValue(functionName, albId))
       .digest('hex');
   },
   getAlbListenerRuleLogicalId(functionName, idx) {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -374,18 +374,18 @@ module.exports = {
   },
 
   // ALB
-  getAlbTargetGroupLogicalId(functionName) {
-    return `${this.getNormalizedFunctionName(functionName)}AlbTargetGroup`;
+  getAlbTargetGroupLogicalId(functionName, priority) {
+    return `${this.getNormalizedFunctionName(functionName)}AlbTargetGroup${priority}`;
   },
-  getAlbTargetGroupNameTagValue(functionName) {
+  getAlbTargetGroupNameTagValue(functionName, priority) {
     return `${
       this.provider.serverless.service.service
-    }-${functionName}-${this.provider.getStage()}`;
+    }-${functionName}-${priority}-${this.provider.getStage()}`;
   },
-  getAlbTargetGroupName(functionName) {
+  getAlbTargetGroupName(functionName, priority) {
     return crypto
       .createHash('md5')
-      .update(this.getAlbTargetGroupNameTagValue(functionName))
+      .update(this.getAlbTargetGroupNameTagValue(functionName, priority))
       .digest('hex');
   },
   getAlbListenerRuleLogicalId(functionName, idx) {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -388,10 +388,8 @@ module.exports = {
       .update(this.getAlbTargetGroupNameTagValue(functionName, albId))
       .digest('hex');
   },
-  getAlbListenerRuleLogicalId(functionName, priority, albId, listenerId) {
-    return `${this.getNormalizedFunctionName(
-      functionName
-    )}AlbListenerRule${priority}${albId}${listenerId}`;
+  getAlbListenerRuleLogicalId(functionName, idx) {
+    return `${this.getNormalizedFunctionName(functionName)}AlbListenerRule${idx}`;
   },
 
   // Permissions

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -682,9 +682,9 @@ describe('#naming()', () => {
 
   describe('#getAlbListenerRuleLogicalId()', () => {
     it('should normalize the function name and add an index', () => {
-      expect(
-        sdk.naming.getAlbListenerRuleLogicalId('functionName', 1, 'abc123', 'xyz789')
-      ).to.equal('FunctionNameAlbListenerRule1abc123xyz789');
+      expect(sdk.naming.getAlbListenerRuleLogicalId('functionName', 0)).to.equal(
+        'FunctionNameAlbListenerRule0'
+      );
     });
   });
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -674,8 +674,8 @@ describe('#naming()', () => {
 
   describe('#getAlbTargetGroupLogicalId()', () => {
     it('should normalize the function name', () => {
-      expect(sdk.naming.getAlbTargetGroupLogicalId('functionName')).to.equal(
-        'FunctionNameAlbTargetGroup'
+      expect(sdk.naming.getAlbTargetGroupLogicalId('functionName', 1)).to.equal(
+        'FunctionNameAlbTargetGroup1'
       );
     });
   });
@@ -691,8 +691,8 @@ describe('#naming()', () => {
   describe('#getAlbTargetGroupName()', () => {
     it('should return a unique identifier based on the service name, function name and stage', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupName('functionName')).to.equal(
-        '1ea0b85512f1943fbae9f40a0451d718'
+      expect(sdk.naming.getAlbTargetGroupName('functionName', 1)).to.equal(
+        '4e188e517d5406742f43905b64d911a9'
       );
     });
   });
@@ -700,8 +700,8 @@ describe('#naming()', () => {
   describe('#getAlbTargetGroupNameTagValue()', () => {
     it('should return the composition of service name, function name and stage', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName')).to.equal(
-        `${serverless.service.service}-functionName-${sdk.naming.provider.getStage()}`
+      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName', 1)).to.equal(
+        `${serverless.service.service}-functionName-1-${sdk.naming.provider.getStage()}`
       );
     });
   });

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -682,9 +682,9 @@ describe('#naming()', () => {
 
   describe('#getAlbListenerRuleLogicalId()', () => {
     it('should normalize the function name and add an index', () => {
-      expect(sdk.naming.getAlbListenerRuleLogicalId('functionName', 0)).to.equal(
-        'FunctionNameAlbListenerRule0'
-      );
+      expect(
+        sdk.naming.getAlbListenerRuleLogicalId('functionName', 1, 'abc123', 'xyz789')
+      ).to.equal('FunctionNameAlbListenerRule1abc123xyz789');
     });
   });
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -674,8 +674,8 @@ describe('#naming()', () => {
 
   describe('#getAlbTargetGroupLogicalId()', () => {
     it('should normalize the function name', () => {
-      expect(sdk.naming.getAlbTargetGroupLogicalId('functionName', 1)).to.equal(
-        'FunctionNameAlbTargetGroup1'
+      expect(sdk.naming.getAlbTargetGroupLogicalId('functionName', 'abc123')).to.equal(
+        'FunctionNameAlbTargetGroupabc123'
       );
     });
   });
@@ -691,8 +691,8 @@ describe('#naming()', () => {
   describe('#getAlbTargetGroupName()', () => {
     it('should return a unique identifier based on the service name, function name and stage', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupName('functionName', 1)).to.equal(
-        '4e188e517d5406742f43905b64d911a9'
+      expect(sdk.naming.getAlbTargetGroupName('functionName', 'abc123')).to.equal(
+        '61615b0fb1c56b80657106894392e27f'
       );
     });
   });
@@ -700,8 +700,8 @@ describe('#naming()', () => {
   describe('#getAlbTargetGroupNameTagValue()', () => {
     it('should return the composition of service name, function name and stage', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName', 1)).to.equal(
-        `${serverless.service.service}-functionName-1-${sdk.naming.provider.getStage()}`
+      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName', 'abc123')).to.equal(
+        `${serverless.service.service}-functionName-abc123-${sdk.naming.provider.getStage()}`
       );
     });
   });

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -9,7 +9,7 @@ module.exports = {
       );
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         event.functionName,
-        event.priority
+        event.albId
       );
 
       const Conditions = [

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -5,9 +5,7 @@ module.exports = {
     this.validated.events.forEach(event => {
       const listenerRuleLogicalId = this.provider.naming.getAlbListenerRuleLogicalId(
         event.functionName,
-        event.priority,
-        event.albId,
-        event.listenerId
+        event.priority
       );
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         event.functionName,

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -8,7 +8,8 @@ module.exports = {
         event.priority
       );
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
-        event.functionName
+        event.functionName,
+        event.priority
       );
 
       const Conditions = [

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -5,7 +5,9 @@ module.exports = {
     this.validated.events.forEach(event => {
       const listenerRuleLogicalId = this.provider.naming.getAlbListenerRuleLogicalId(
         event.functionName,
-        event.priority
+        event.priority,
+        event.albId,
+        event.listenerId
       );
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         event.functionName,

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -57,7 +57,7 @@ describe('#compileListenerRules()', () => {
         Actions: [
           {
             TargetGroupArn: {
-              Ref: 'FirstAlbTargetGroup',
+              Ref: 'FirstAlbTargetGroup1',
             },
             Type: 'forward',
           },
@@ -85,7 +85,7 @@ describe('#compileListenerRules()', () => {
         Actions: [
           {
             TargetGroupArn: {
-              Ref: 'SecondAlbTargetGroup',
+              Ref: 'SecondAlbTargetGroup2',
             },
             Type: 'forward',
           },

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -23,6 +23,7 @@ describe('#compileListenerRules()', () => {
         {
           functionName: 'first',
           albId: '50dc6c495c0c9188',
+          listenerId: 'f2f7dc8efc522ab2',
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -36,6 +37,7 @@ describe('#compileListenerRules()', () => {
         {
           functionName: 'second',
           albId: '50dc6c495c0c9188',
+          listenerId: 'f2f7dc8efc522ab2',
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -53,7 +55,7 @@ describe('#compileListenerRules()', () => {
     const resources =
       awsCompileAlbEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
-    expect(resources.FirstAlbListenerRule1).to.deep.equal({
+    expect(resources.FirstAlbListenerRule150dc6c495c0c9188f2f7dc8efc522ab2).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
       Properties: {
         Actions: [
@@ -81,7 +83,7 @@ describe('#compileListenerRules()', () => {
         Priority: 1,
       },
     });
-    expect(resources.SecondAlbListenerRule2).to.deep.equal({
+    expect(resources.SecondAlbListenerRule250dc6c495c0c9188f2f7dc8efc522ab2).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
       Properties: {
         Actions: [

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -22,6 +22,7 @@ describe('#compileListenerRules()', () => {
       events: [
         {
           functionName: 'first',
+          albId: '50dc6c495c0c9188',
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -34,6 +35,7 @@ describe('#compileListenerRules()', () => {
         },
         {
           functionName: 'second',
+          albId: '50dc6c495c0c9188',
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -57,7 +59,7 @@ describe('#compileListenerRules()', () => {
         Actions: [
           {
             TargetGroupArn: {
-              Ref: 'FirstAlbTargetGroup1',
+              Ref: 'FirstAlbTargetGroup50dc6c495c0c9188',
             },
             Type: 'forward',
           },
@@ -85,7 +87,7 @@ describe('#compileListenerRules()', () => {
         Actions: [
           {
             TargetGroupArn: {
-              Ref: 'SecondAlbTargetGroup2',
+              Ref: 'SecondAlbTargetGroup50dc6c495c0c9188',
             },
             Type: 'forward',
           },

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -55,7 +55,7 @@ describe('#compileListenerRules()', () => {
     const resources =
       awsCompileAlbEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
-    expect(resources.FirstAlbListenerRule150dc6c495c0c9188f2f7dc8efc522ab2).to.deep.equal({
+    expect(resources.FirstAlbListenerRule1).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
       Properties: {
         Actions: [
@@ -83,7 +83,7 @@ describe('#compileListenerRules()', () => {
         Priority: 1,
       },
     });
-    expect(resources.SecondAlbListenerRule250dc6c495c0c9188f2f7dc8efc522ab2).to.deep.equal({
+    expect(resources.SecondAlbListenerRule2).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::ListenerRule',
       Properties: {
         Actions: [

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -3,11 +3,11 @@
 module.exports = {
   compileTargetGroups() {
     this.validated.events.forEach(event => {
-      const { functionName, priority } = event;
+      const { functionName, albId } = event;
 
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         functionName,
-        priority
+        albId
       );
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
       const lambdaPermissionLogicalId = this.provider.naming.getLambdaAlbPermissionLogicalId(
@@ -26,11 +26,11 @@ module.exports = {
                 },
               },
             ],
-            Name: this.provider.naming.getAlbTargetGroupName(functionName, priority),
+            Name: this.provider.naming.getAlbTargetGroupName(functionName, albId),
             Tags: [
               {
                 Key: 'Name',
-                Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName, priority),
+                Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName, albId),
               },
             ],
           },

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -3,9 +3,12 @@
 module.exports = {
   compileTargetGroups() {
     this.validated.events.forEach(event => {
-      const { functionName } = event;
+      const { functionName, priority } = event;
 
-      const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(functionName);
+      const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
+        functionName,
+        priority
+      );
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
       const lambdaPermissionLogicalId = this.provider.naming.getLambdaAlbPermissionLogicalId(
         functionName
@@ -23,11 +26,11 @@ module.exports = {
                 },
               },
             ],
-            Name: this.provider.naming.getAlbTargetGroupName(functionName),
+            Name: this.provider.naming.getAlbTargetGroupName(functionName, priority),
             Tags: [
               {
                 Key: 'Name',
-                Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName),
+                Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName, priority),
               },
             ],
           },

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -51,10 +51,10 @@ describe('#compileTargetGroups()', () => {
     const resources =
       awsCompileAlbEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
-    expect(resources.FirstAlbTargetGroup).to.deep.equal({
+    expect(resources.FirstAlbTargetGroup1).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: 'd370cffdc0b94175c8239183d0b344a4',
+        Name: 'f84548ee49366c89ada86c9655ea00b5',
         TargetType: 'lambda',
         Targets: [
           {
@@ -66,16 +66,16 @@ describe('#compileTargetGroups()', () => {
         Tags: [
           {
             Key: 'Name',
-            Value: 'some-service-first-dev',
+            Value: 'some-service-first-1-dev',
           },
         ],
       },
       DependsOn: ['FirstLambdaPermissionAlb'],
     });
-    expect(resources.SecondAlbTargetGroup).to.deep.equal({
+    expect(resources.SecondAlbTargetGroup2).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: '33af5fa54e565b8aca63f904de895aab',
+        Name: '6dd7b94b30032ee093c50743d117b64d',
         TargetType: 'lambda',
         Targets: [
           {
@@ -87,7 +87,7 @@ describe('#compileTargetGroups()', () => {
         Tags: [
           {
             Key: 'Name',
-            Value: 'some-service-second-dev',
+            Value: 'some-service-second-2-dev',
           },
         ],
       },

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -22,6 +22,7 @@ describe('#compileTargetGroups()', () => {
       events: [
         {
           functionName: 'first',
+          albId: '50dc6c495c0c9188',
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -34,6 +35,7 @@ describe('#compileTargetGroups()', () => {
         },
         {
           functionName: 'second',
+          albId: '50dc6c495c0c9188',
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -51,10 +53,10 @@ describe('#compileTargetGroups()', () => {
     const resources =
       awsCompileAlbEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
-    expect(resources.FirstAlbTargetGroup1).to.deep.equal({
+    expect(resources.FirstAlbTargetGroup50dc6c495c0c9188).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: 'f84548ee49366c89ada86c9655ea00b5',
+        Name: '879129784b3012595bceeaa4a76fc7bc',
         TargetType: 'lambda',
         Targets: [
           {
@@ -66,16 +68,16 @@ describe('#compileTargetGroups()', () => {
         Tags: [
           {
             Key: 'Name',
-            Value: 'some-service-first-1-dev',
+            Value: 'some-service-first-50dc6c495c0c9188-dev',
           },
         ],
       },
       DependsOn: ['FirstLambdaPermissionAlb'],
     });
-    expect(resources.SecondAlbTargetGroup2).to.deep.equal({
+    expect(resources.SecondAlbTargetGroup50dc6c495c0c9188).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: '6dd7b94b30032ee093c50743d117b64d',
+        Name: '2107a18b6db85bd904d38cb2bdf5af5c',
         TargetType: 'lambda',
         Targets: [
           {
@@ -87,7 +89,7 @@ describe('#compileTargetGroups()', () => {
         Tags: [
           {
             Key: 'Name',
-            Value: 'some-service-second-2-dev',
+            Value: 'some-service-second-50dc6c495c0c9188-dev',
           },
         ],
       },

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -45,6 +45,19 @@ describe('#compileTargetGroups()', () => {
             path: '/world',
           },
         },
+        {
+          // Same function, same alb, different listener/priority
+          functionName: 'second',
+          albId: '50dc6c495c0c9188',
+          listenerArn:
+            'arn:aws:elasticloadbalancing:' +
+            'us-east-1:123456789012:listener/app/my-load-balancer/' +
+            '50dc6c495c0c9188/4e83ccee674eb02d',
+          priority: 3,
+          conditions: {
+            path: '/world',
+          },
+        },
       ],
     };
 
@@ -95,5 +108,7 @@ describe('#compileTargetGroups()', () => {
       },
       DependsOn: ['SecondLambdaPermissionAlb'],
     });
+    // Target groups are unique to functions/albs, so there should only be 2 target groups
+    expect(Object.keys(resources).length).to.be.equal(2);
   });
 });

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 // eslint-disable-next-line max-len
 const CIDR_IPV6_PATTERN = /^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))$/;
 const CIDR_IPV4_PATTERN = /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$/;
+// see https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-elb-application
+const ALB_LISTENER_PATTERN = /^arn:aws:elasticloadbalancing:.+:listener\/app\/[\w-]+\/([\w-]+)\/[\w-]+$/;
 
 module.exports = {
   validate() {
@@ -15,6 +17,7 @@ module.exports = {
         if (_.has(event, 'alb')) {
           if (_.isObject(event.alb)) {
             const albObj = {
+              albId: this.validateListenerArnAndExtractAlbId(event, functionName),
               listenerArn: event.alb.listenerArn,
               priority: event.alb.priority,
               conditions: {
@@ -48,6 +51,23 @@ module.exports = {
     return {
       events,
     };
+  },
+
+  validateListenerArnAndExtractAlbId(event, functionName) {
+    const listenerArn = event.alb.listenerArn;
+    if (!listenerArn) {
+      throw new this.serverless.classes.Error(
+        `listenerArn is missing in function "${functionName}".`
+      );
+    }
+    const matches = listenerArn.match(ALB_LISTENER_PATTERN);
+    if (!matches) {
+      throw new this.serverless.classes.Error(
+        `Invalid ALB listenerArn in function "${functionName}".`
+      );
+    }
+
+    return matches[1];
   },
 
   validateHeaderCondition(event, functionName) {

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -16,8 +16,8 @@ module.exports = {
       _.forEach(functionObject.events, event => {
         if (_.has(event, 'alb')) {
           if (_.isObject(event.alb)) {
-            const { albId, listenerId } = this.validateListenerArnAndExtractAlbId(
-              event,
+            const { albId, listenerId } = this.validateListenerArn(
+              event.alb.listenerArn,
               functionName
             );
             const albObj = {
@@ -61,16 +61,15 @@ module.exports = {
     };
   },
 
-  validateListenerArnAndExtractAlbId(event, functionName) {
-    const listenerArn = event.alb.listenerArn;
+  validateListenerArn(listenerArn, functionName) {
     if (!listenerArn) {
       throw new this.serverless.classes.Error(
         `listenerArn is missing in function "${functionName}".`
       );
     }
     // If the ARN is a ref, use the logical ID instead of the ALB ID
-    if (typeof listenerArn === 'object') {
-      if (Object.prototype.hasOwnProperty.call(listenerArn, 'Ref')) {
+    if (_.isObject(listenerArn)) {
+      if (_.has(listenerArn, 'Ref')) {
         return { albId: listenerArn.Ref, listenerId: listenerArn.Ref };
       }
       throw new this.serverless.classes.Error(
@@ -137,7 +136,7 @@ module.exports = {
     let duplicates;
     const samePriority = (e1, e2) => e1.priority === e2.priority;
     const samePriorityDifferentListener = (e1, e2) =>
-      e1.priority === e2.priority && e1.listenerId !== e2.listenerId;
+      samePriority(e1, e2) && e1.listenerId !== e2.listenerId;
 
     // For this special case, we need to let the user know
     // it is a Serverless limitation (but not an ALB limitation)

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 const CIDR_IPV6_PATTERN = /^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))$/;
 const CIDR_IPV4_PATTERN = /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$/;
 // see https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-elb-application
-const ALB_LISTENER_PATTERN = /^arn:aws:elasticloadbalancing:.+:listener\/app\/[\w-]+\/([\w-]+)\/[\w-]+$/;
+const ALB_LISTENER_PATTERN = /^arn:aws:elasticloadbalancing:.+:listener\/app\/[\w-]+\/([\w-]+)\/([\w-]+)$/;
 
 module.exports = {
   validate() {
@@ -16,8 +16,15 @@ module.exports = {
       _.forEach(functionObject.events, event => {
         if (_.has(event, 'alb')) {
           if (_.isObject(event.alb)) {
+            const { albId, listenerId } = this.validateListenerArnAndExtractAlbId(
+              event,
+              functionName
+            );
             const albObj = {
-              albId: this.validateListenerArnAndExtractAlbId(event, functionName),
+              // This is set to the ALB ID if the listener ARNs are provided as strings,
+              // or the listener logical ID if listenerARNs are given as refs
+              albId,
+              listenerId,
               listenerArn: event.alb.listenerArn,
               priority: event.alb.priority,
               conditions: {
@@ -60,14 +67,22 @@ module.exports = {
         `listenerArn is missing in function "${functionName}".`
       );
     }
+    // If the ARN is a ref, use the logical ID instead of the ALB ID
+    if (typeof listenerArn === 'object') {
+      if (Object.prototype.hasOwnProperty.call(listenerArn, 'Ref')) {
+        return { albId: listenerArn.Ref, listenerId: listenerArn.Ref };
+      }
+      throw new this.serverless.classes.Error(
+        `Invalid ALB listenerArn in function "${functionName}".`
+      );
+    }
     const matches = listenerArn.match(ALB_LISTENER_PATTERN);
     if (!matches) {
       throw new this.serverless.classes.Error(
         `Invalid ALB listenerArn in function "${functionName}".`
       );
     }
-
-    return matches[1];
+    return { albId: matches[1], listenerId: matches[2] };
   },
 
   validateHeaderCondition(event, functionName) {

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -136,7 +136,8 @@ module.exports = {
   validatePriorities(albEvents) {
     let duplicates;
     const samePriority = (e1, e2) => e1.priority === e2.priority;
-    const samePriorityDifferentListener = (e1, e2) => e1.priority === e2.priority && e1.listenerId !== e2.listenerId;
+    const samePriorityDifferentListener = (e1, e2) =>
+      e1.priority === e2.priority && e1.listenerId !== e2.listenerId;
 
     // For this special case, we need to let the user know
     // it is a Serverless limitation (but not an ALB limitation)

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -54,6 +54,7 @@ module.exports = {
         }
       });
     });
+    this.validatePriorities(events);
 
     return {
       events,
@@ -130,5 +131,33 @@ module.exports = {
       throw new this.serverless.classes.Error(errorMessage);
     }
     return cidrBlocks;
+  },
+
+  validatePriorities(albEvents) {
+    let duplicates;
+    const samePriority = (e1, e2) => e1.priority === e2.priority;
+    const samePriorityDifferentListener = (e1, e2) => e1.priority === e2.priority && e1.listenerId !== e2.listenerId;
+
+    // For this special case, we need to let the user know
+    // it is a Serverless limitation (but not an ALB limitation)
+    duplicates = _.difference(albEvents, _.uniqWith(albEvents, samePriorityDifferentListener));
+    if (duplicates.length > 0) {
+      const errorMessage = [
+        `ALB event in function "${duplicates[0].functionName}"`,
+        ` cannot use priority "${duplicates[0].priority}" because it is already in use.\n`,
+        '  Events cannot use the same priority even if they have a different listenerArn.\n',
+        '  This is a Serverless limitation that will be fixed in the next major release.',
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+
+    duplicates = _.difference(albEvents, _.uniqWith(albEvents, samePriority));
+    if (duplicates.length > 0) {
+      const errorMessage = [
+        `ALB event in function "${duplicates[0].functionName}"`,
+        ` cannot use priority "${duplicates[0].priority}" because it is already in use.`,
+      ].join('');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
   },
 };

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -133,25 +133,28 @@ module.exports = {
   },
 
   validatePriorities(albEvents) {
+    let comparator;
     let duplicates;
     const samePriority = (e1, e2) => e1.priority === e2.priority;
-    const samePriorityDifferentListener = (e1, e2) =>
-      samePriority(e1, e2) && e1.listenerId !== e2.listenerId;
+    const sameFunction = (e1, e2) => e1.functionName === e2.functionName;
+    const sameListener = (e1, e2) => e1.listenerId === e2.listenerId;
 
     // For this special case, we need to let the user know
     // it is a Serverless limitation (but not an ALB limitation)
-    duplicates = _.difference(albEvents, _.uniqWith(albEvents, samePriorityDifferentListener));
+    comparator = (e1, e2) => samePriority(e1, e2) && !sameListener(e1, e2) && sameFunction(e1, e2);
+    duplicates = _.difference(albEvents, _.uniqWith(albEvents, comparator));
     if (duplicates.length > 0) {
       const errorMessage = [
         `ALB event in function "${duplicates[0].functionName}"`,
         ` cannot use priority "${duplicates[0].priority}" because it is already in use.\n`,
-        '  Events cannot use the same priority even if they have a different listenerArn.\n',
+        '  Events in the same function cannot use the same priority even if they have a different listenerArn.\n',
         '  This is a Serverless limitation that will be fixed in the next major release.',
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }
 
-    duplicates = _.difference(albEvents, _.uniqWith(albEvents, samePriority));
+    comparator = (e1, e2) => samePriority(e1, e2) && sameListener(e1, e2) && !sameFunction(e1, e2);
+    duplicates = _.difference(albEvents, _.uniqWith(albEvents, comparator));
     if (duplicates.length > 0) {
       const errorMessage = [
         `ALB event in function "${duplicates[0].functionName}"`,

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -271,7 +271,7 @@ describe('#validate()', () => {
   });
 
   describe('#validatePriorities()', () => {
-    it('should throw if multiple events use the same priority', () => {
+    it('should throw if multiple events use the same priority and the same listener', () => {
       const albEvents = [
         { priority: 1, listenerId: 'aaa', functionName: 'foo' },
         { priority: 1, listenerId: 'aaa', functionName: 'bar' },
@@ -281,14 +281,22 @@ describe('#validate()', () => {
       );
     });
 
-    it('should throw a special error if multiple events with different listenerId use the same priority', () => {
+    it('should throw a special error if multiple events use the same priority and a different listener in the same function', () => {
       const albEvents = [
         { priority: 1, listenerId: 'aaa', functionName: 'foo' },
-        { priority: 1, listenerId: 'bbb', functionName: 'bar' },
+        { priority: 1, listenerId: 'bbb', functionName: 'foo' },
       ];
       expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(
         /Serverless limitation/
       );
+    });
+
+    it('should not throw if multiple events use the same priority and a different listener in different functions', () => {
+      const albEvents = [
+        { priority: 1, listenerId: 'aaa', functionName: 'foo' },
+        { priority: 1, listenerId: 'bbb', functionName: 'bar' },
+      ];
+      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.not.throw();
     });
 
     it('should not throw when all priorities are unique', () => {

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -67,6 +67,7 @@ describe('#validate()', () => {
       {
         functionName: 'first',
         albId: '50dc6c495c0c9188',
+        listenerId: 'f2f7dc8efc522ab2',
         listenerArn:
           'arn:aws:elasticloadbalancing:' +
           'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -82,6 +83,7 @@ describe('#validate()', () => {
       {
         functionName: 'second',
         albId: '50dc6c495c0c9188',
+        listenerId: 'f2f7dc8efc522ab2',
         listenerArn:
           'arn:aws:elasticloadbalancing:' +
           'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -180,7 +182,24 @@ describe('#validate()', () => {
       };
       expect(
         awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
-      ).to.be.equal('50dc6c495c0c9188');
+      ).to.deep.equal({
+        albId: '50dc6c495c0c9188',
+        listenerId: 'f2f7dc8efc522ab2',
+      });
+    });
+
+    it('returns the ref when given an object for the listener ARN', () => {
+      const event = {
+        alb: {
+          listenerArn: { Ref: 'HTTPListener1' },
+        },
+      };
+      expect(
+        awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
+      ).to.deep.equal({
+        albId: 'HTTPListener1',
+        listenerId: 'HTTPListener1',
+      });
     });
 
     it('throws an error if the listener ARN is missing', () => {
@@ -201,8 +220,8 @@ describe('#validate()', () => {
         'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/net/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2',
         // Non ec2 ARN
         'arn:aws:iam::123456789012:server-certificate/division_abc/subdivision_xyz/ProdServerCert',
-        // something completely different
-        'foo',
+        // Object without a ref
+        { foo: 'bar' },
       ];
       _.forEach(listenerArns, listenerArn => {
         const event = { alb: { listenerArn } };

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -285,17 +285,28 @@ describe('#validate()', () => {
 
   describe('#validatePriorities', () => {
     it('should throw if multiple events use the same priority', () => {
-      const albEvents = [{ priority: 1, listenerId: 'aaa', functionName: 'foo' },{ priority: 1, listenerId: 'aaa', functionName: 'bar' }];
+      const albEvents = [
+        { priority: 1, listenerId: 'aaa', functionName: 'foo' },
+        { priority: 1, listenerId: 'aaa', functionName: 'bar' },
+      ];
       expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(Error);
     });
 
     it('should throw a special error if multiple events with different listenerId use the same priority', () => {
-      const albEvents = [{ priority: 1, listenerId: 'aaa', functionName: 'foo' },{ priority: 1, listenerId: 'bbb', functionName: 'bar' }];
-      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(/Serverless limitation/);
+      const albEvents = [
+        { priority: 1, listenerId: 'aaa', functionName: 'foo' },
+        { priority: 1, listenerId: 'bbb', functionName: 'bar' },
+      ];
+      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(
+        /Serverless limitation/
+      );
     });
 
     it('should not throw when all priorities are unique', () => {
-      const albEvents = [{ priority: 1, listenerId: 'aaa', functionName: 'foo' },{ priority: 2, listenerId: 'bbb', functionName: 'bar' }];
+      const albEvents = [
+        { priority: 1, listenerId: 'aaa', functionName: 'foo' },
+        { priority: 2, listenerId: 'bbb', functionName: 'bar' },
+      ];
       expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.not.throw();
     });
   });

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const expect = require('chai').expect;
 const AwsCompileAlbEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
@@ -65,6 +66,7 @@ describe('#validate()', () => {
     expect(validated.events).to.deep.equal([
       {
         functionName: 'first',
+        albId: '50dc6c495c0c9188',
         listenerArn:
           'arn:aws:elasticloadbalancing:' +
           'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -79,6 +81,7 @@ describe('#validate()', () => {
       },
       {
         functionName: 'second',
+        albId: '50dc6c495c0c9188',
         listenerArn:
           'arn:aws:elasticloadbalancing:' +
           'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -165,6 +168,49 @@ describe('#validate()', () => {
     };
 
     expect(() => awsCompileAlbEvents.validate()).to.throw(Error);
+  });
+
+  describe('#validateListenerArnAndExtractAlbId()', () => {
+    it('returns the alb ID when given a valid listener ARN', () => {
+      const event = {
+        alb: {
+          listenerArn:
+            'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2',
+        },
+      };
+      expect(
+        awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
+      ).to.be.equal('50dc6c495c0c9188');
+    });
+
+    it('throws an error if the listener ARN is missing', () => {
+      const listenerArns = [undefined, null, false, ''];
+      _.forEach(listenerArns, listenerArn => {
+        const event = { alb: { listenerArn } };
+        expect(() =>
+          awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
+        ).to.throw('listenerArn is missing in function "functionname".');
+      });
+    });
+
+    it('throws an error if the listener ARN is invalid', () => {
+      const listenerArns = [
+        // ALB listener rule (not a listener)
+        'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener-rule/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2/9683b2d02a6cabee',
+        // ELB
+        'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/net/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2',
+        // Non ec2 ARN
+        'arn:aws:iam::123456789012:server-certificate/division_abc/subdivision_xyz/ProdServerCert',
+        // something completely different
+        'foo',
+      ];
+      _.forEach(listenerArns, listenerArn => {
+        const event = { alb: { listenerArn } };
+        expect(() =>
+          awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
+        ).to.throw('Invalid ALB listenerArn in function "functionname".');
+      });
+    });
   });
 
   describe('#validateIpCondition()', () => {

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -174,29 +174,17 @@ describe('#validate()', () => {
 
   describe('#validateListenerArnAndExtractAlbId()', () => {
     it('returns the alb ID when given a valid listener ARN', () => {
-      const event = {
-        alb: {
-          listenerArn:
-            'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2',
-        },
-      };
-      expect(
-        awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
-      ).to.deep.equal({
+      const listenerArn =
+        'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2';
+      expect(awsCompileAlbEvents.validateListenerArn(listenerArn, 'functionname')).to.deep.equal({
         albId: '50dc6c495c0c9188',
         listenerId: 'f2f7dc8efc522ab2',
       });
     });
 
     it('returns the ref when given an object for the listener ARN', () => {
-      const event = {
-        alb: {
-          listenerArn: { Ref: 'HTTPListener1' },
-        },
-      };
-      expect(
-        awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
-      ).to.deep.equal({
+      const listenerArn = { Ref: 'HTTPListener1' };
+      expect(awsCompileAlbEvents.validateListenerArn(listenerArn, 'functionname')).to.deep.equal({
         albId: 'HTTPListener1',
         listenerId: 'HTTPListener1',
       });
@@ -205,10 +193,9 @@ describe('#validate()', () => {
     it('throws an error if the listener ARN is missing', () => {
       const listenerArns = [undefined, null, false, ''];
       _.forEach(listenerArns, listenerArn => {
-        const event = { alb: { listenerArn } };
-        expect(() =>
-          awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
-        ).to.throw('listenerArn is missing in function "functionname".');
+        expect(() => awsCompileAlbEvents.validateListenerArn(listenerArn, 'functionname')).to.throw(
+          'listenerArn is missing in function "functionname".'
+        );
       });
     });
 
@@ -225,9 +212,9 @@ describe('#validate()', () => {
       ];
       _.forEach(listenerArns, listenerArn => {
         const event = { alb: { listenerArn } };
-        expect(() =>
-          awsCompileAlbEvents.validateListenerArnAndExtractAlbId(event, 'functionname')
-        ).to.throw('Invalid ALB listenerArn in function "functionname".');
+        expect(() => awsCompileAlbEvents.validateListenerArn(event, 'functionname')).to.throw(
+          'Invalid ALB listenerArn in function "functionname".'
+        );
       });
     });
   });
@@ -283,13 +270,15 @@ describe('#validate()', () => {
     });
   });
 
-  describe('#validatePriorities', () => {
+  describe('#validatePriorities()', () => {
     it('should throw if multiple events use the same priority', () => {
       const albEvents = [
         { priority: 1, listenerId: 'aaa', functionName: 'foo' },
         { priority: 1, listenerId: 'aaa', functionName: 'bar' },
       ];
-      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(Error);
+      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(
+        /^((?!Serverless limitation).)*$/
+      );
     });
 
     it('should throw a special error if multiple events with different listenerId use the same priority', () => {

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -282,4 +282,21 @@ describe('#validate()', () => {
       });
     });
   });
+
+  describe('#validatePriorities', () => {
+    it('should throw if multiple events use the same priority', () => {
+      const albEvents = [{ priority: 1, listenerId: 'aaa', functionName: 'foo' },{ priority: 1, listenerId: 'aaa', functionName: 'bar' }];
+      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(Error);
+    });
+
+    it('should throw a special error if multiple events with different listenerId use the same priority', () => {
+      const albEvents = [{ priority: 1, listenerId: 'aaa', functionName: 'foo' },{ priority: 1, listenerId: 'bbb', functionName: 'bar' }];
+      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.throw(/Serverless limitation/);
+    });
+
+    it('should not throw when all priorities are unique', () => {
+      const albEvents = [{ priority: 1, listenerId: 'aaa', functionName: 'foo' },{ priority: 2, listenerId: 'bbb', functionName: 'bar' }];
+      expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.not.throw();
+    });
+  });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6382 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

This creates unique target groups for each event of each function by adding the priority to the target group name/hash.

## How can we verify it:
Since serverless.yml requires a pre-existing ALB to add an ALB route, there's not a single serverless.yml that can be posted to test this. 

Below is an example of a single function with routes on different ALBs:

```yml
functions:
  ingest:
    handler: src/ingest/ingest-handler.ingest
    events:
      - alb:
          listenerArn: arn:aws:elasticloadbalancing:us-east-1:1234:listener/app/alb-one/88b747/8e6f9
          priority: 1
          conditions:
            path: /foo/bar/*
      - alb:
          listenerArn: arn:aws:elasticloadbalancing:us-east-1:1234:listener/app/alb-two/92eb3a/385da
          priority: 2
          conditions:
            path: /foo/bar/*
```

I also tried deploying these functions with master and then updating with this branch to ensure that the change doesn't require removing the stack.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
