### PR TITLE
PLAT-1385 Ensure expected service name in interactively created project

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -247,15 +247,8 @@ class Create {
 
     this.serverless.config.update({ servicePath: process.cwd() });
 
-    return createFromTemplate(this.options.template, process.cwd()).then(
+    return createFromTemplate(this.options.template, process.cwd(), { name: serviceName }).then(
       () => {
-        // rename the service if the user has provided a path via options and is creating a service
-        if ((boilerplatePath || serviceName) && notPlugin) {
-          const newServiceName = serviceName || boilerplatePath.split(path.sep).pop();
-
-          renameService(newServiceName, this.serverless.config.servicePath);
-        }
-
         userStats.track('service_created', {
           template: this.options.template,
           serviceName,

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -71,6 +71,16 @@ const humanReadableTemplateList = `${validTemplates
   .map(template => `"${template}"`)
   .join(', ')} and "${validTemplates.slice(-1)}"`;
 
+const handleServiceCreationError = error => {
+  if (error.code !== 'EACCESS') throw error;
+  const errorMessage = [
+    'Error unable to create a service in this directory. ',
+    'Please check that you have the required permissions to write to the directory',
+  ].join('');
+
+  throw new this.serverless.classes.Error(errorMessage);
+};
+
 class Create {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -222,9 +232,20 @@ class Create {
       });
     }
 
-    if (notPlugin) {
-      this.serverless.config.update({ servicePath: process.cwd() });
+    if (!notPlugin) {
+      return BbPromise.try(() => {
+        try {
+          fse.copySync(
+            path.join(__dirname, '../../../lib/plugins/create/templates', this.options.template),
+            process.cwd()
+          );
+        } catch (error) {
+          handleServiceCreationError(error);
+        }
+      });
     }
+
+    this.serverless.config.update({ servicePath: process.cwd() });
 
     return createFromTemplate(this.options.template, process.cwd()).then(
       () => {
@@ -251,15 +272,7 @@ class Create {
           );
         }
       },
-      error => {
-        if (error.code !== 'EACCESS') throw error;
-        const errorMessage = [
-          'Error unable to create a service in this directory. ',
-          'Please check that you have the required permissions to write to the directory',
-        ].join('');
-
-        throw new this.serverless.classes.Error(errorMessage);
-      }
+      handleServiceCreationError
     );
   }
 }

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -251,7 +251,8 @@ class Create {
           );
         }
       },
-      () => {
+      error => {
+        if (error.code !== 'EACCESS') throw error;
         const errorMessage = [
           'Error unable to create a service in this directory. ',
           'Please check that you have the required permissions to write to the directory',

--- a/lib/utils/createFromTemplate.js
+++ b/lib/utils/createFromTemplate.js
@@ -1,30 +1,66 @@
 'use strict';
 
-const { join } = require('path');
+const { basename, join } = require('path');
 const BbPromise = require('bluebird');
-const { copy, exists, rename } = require('fs-extra');
+const { copy, exists, readFile, rename } = require('fs-extra');
+const { renameService } = require('./renameService');
 
 const serverlessPath = join(__dirname, '../../');
 
-module.exports = (templateName, destPath) =>
+const resolveServiceName = path => {
+  let serviceName = basename(path)
+    .toLowerCase()
+    .replace(/[^0-9a-z.]+/g, '-');
+  if (!serviceName.match(/^[a-z]/)) serviceName = `service-${serviceName}`;
+  return serviceName;
+};
+
+module.exports = (templateName, destPath, options = {}) =>
   new BbPromise((resolve, reject) => {
+    if (!options) options = {};
     const templateSrcDir = join(serverlessPath, 'lib/plugins/create/templates', templateName);
 
-    copy(templateSrcDir, destPath, copyError => {
-      if (copyError) {
-        reject(copyError);
-        return;
-      }
-      const gitignorePath = join(destPath, 'gitignore');
-      exists(gitignorePath, hasGitignore => {
-        if (!hasGitignore) {
-          resolve();
+    readFile(join(destPath, 'package.json'), 'utf8', (readFileError, content) => {
+      if (readFileError) {
+        if (readFileError.code !== 'ENOENT') {
+          reject(readFileError);
           return;
         }
-        rename(gitignorePath, join(destPath, '.gitignore'), renameError => {
-          if (renameError) reject(renameError);
-          else resolve();
-        });
+      } else if (!options.name) {
+        const packageName = (() => {
+          try {
+            return JSON.parse(content).name;
+          } catch (error) {
+            return null;
+          }
+        })();
+        if (packageName) options.name = packageName;
+      }
+      copy(templateSrcDir, destPath, copyError => {
+        if (copyError) {
+          reject(copyError);
+          return;
+        }
+        resolve(
+          BbPromise.all([
+            new BbPromise((gitignoreRenameResolve, gitIgnoreRenameReject) => {
+              const gitignorePath = join(destPath, 'gitignore');
+              exists(gitignorePath, hasGitignore => {
+                if (!hasGitignore) {
+                  gitignoreRenameResolve();
+                  return;
+                }
+                rename(gitignorePath, join(destPath, '.gitignore'), renameError => {
+                  if (renameError) gitIgnoreRenameReject(renameError);
+                  else gitignoreRenameResolve();
+                });
+              });
+            }),
+            BbPromise.try(() =>
+              renameService(options.name || resolveServiceName(destPath), destPath)
+            ),
+          ])
+        );
       });
     });
   });

--- a/lib/utils/createFromTemplate.test.js
+++ b/lib/utils/createFromTemplate.test.js
@@ -2,7 +2,8 @@
 
 const path = require('path');
 const chai = require('chai');
-const { existsSync } = require('fs-extra');
+const { existsSync, outputJsonSync, readFileSync } = require('fs-extra');
+const { safeLoad: yamlParse } = require('js-yaml');
 const installTemplate = require('./createFromTemplate');
 const { getTmpDirPath } = require('../../tests/utils/fs');
 
@@ -13,14 +14,52 @@ const expect = chai.expect;
 describe('#createFromTemplate()', () => {
   let tmpDirPath;
 
-  beforeEach(() => {
-    tmpDirPath = getTmpDirPath();
-    return installTemplate('aws-nodejs', tmpDirPath);
+  describe('Empty folder', () => {
+    before(() => {
+      tmpDirPath = path.join(getTmpDirPath(), 'some-service');
+      return installTemplate('aws-nodejs', tmpDirPath);
+    });
+
+    it('should create from template', () =>
+      expect(existsSync(path.join(tmpDirPath, 'serverless.yml'))).to.be.true);
+
+    it('should handle .gitignore', () =>
+      expect(existsSync(path.join(tmpDirPath, '.gitignore'))).to.be.true);
+
+    it('should set service name in serverless.yml', () =>
+      expect(yamlParse(readFileSync(path.join(tmpDirPath, 'serverless.yml'))).service).to.equal(
+        'some-service'
+      ));
   });
 
-  it('should create from template', () =>
-    expect(existsSync(path.join(tmpDirPath, 'serverless.yml'))).to.be.true);
+  describe('Existing project', () => {
+    before(() => {
+      tmpDirPath = path.join(getTmpDirPath(), 'some-service');
+      outputJsonSync(path.join(tmpDirPath, 'package.json'), { name: 'foo-bar' });
+      return installTemplate('aws-nodejs', tmpDirPath);
+    });
 
-  it('should handle .gitignore', () =>
-    expect(existsSync(path.join(tmpDirPath, '.gitignore'))).to.be.true);
+    it('should respect package.json name', () =>
+      expect(yamlParse(readFileSync(path.join(tmpDirPath, 'serverless.yml'))).service).to.equal(
+        'foo-bar'
+      ));
+  });
+
+  describe('Should override name if specified', () => {
+    before(() => {
+      tmpDirPath = path.join(getTmpDirPath(), 'some-service');
+      outputJsonSync(path.join(tmpDirPath, 'package.json'), { name: 'foo-bar' });
+      return installTemplate('aws-nodejs', tmpDirPath, { name: 'miszka' });
+    });
+
+    it('should set service name in serverless.yml', () =>
+      expect(yamlParse(readFileSync(path.join(tmpDirPath, 'serverless.yml'))).service).to.equal(
+        'miszka'
+      ));
+
+    it('should set name in package.json', () =>
+      expect(JSON.parse(readFileSync(path.join(tmpDirPath, 'package.json'))).name).to.equal(
+        'miszka'
+      ));
+  });
 });


### PR DESCRIPTION
Service name in `serverless.yml` of interactively created project was not updated to chosen project name.

This patch ensures that `createFromTemplate` util that covers that part

Additionally improved error handling of eventual file system access issue.

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO
