### PR TITLE
Fix AWS secret access key validation in interactive CLI

### DIFF
--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -8,7 +8,7 @@ const { confirm } = require('./utils');
 
 const isValidAwsProfileName = RegExp.prototype.test.bind(/^[a-zA-Z][a-zA-Z0-9-]{0,100}$/);
 const isValidAwsAccessKeyId = RegExp.prototype.test.bind(/^[A-Z0-9]{10,}$/);
-const isValidAwsSecretAccessKey = RegExp.prototype.test.bind(/^[a-zA-Z0-9/]{10,}$/);
+const isValidAwsSecretAccessKey = RegExp.prototype.test.bind(/^[a-zA-Z0-9/+]{10,}$/);
 
 const awsProfileNameInput = () =>
   inquirer


### PR DESCRIPTION
It didn't allow '+' chars, which may appear in secret keys (although are not present in all cases, hence didn't pick initially)

**_Is it a breaking change?:_** NO
