### PR TITLE
Improve post install message

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -13,12 +13,12 @@ const { CI, ADBLOCK, SILENT } = process.env;
 if (!truthyStr(CI) && !truthyStr(ADBLOCK) && !truthyStr(SILENT)) {
   console.log(
     chalk.yellow(`\
- +------------------------------------------------------------------+
- |                                                                  |
- |  Serverless Framework successfully installed!                    |
- |  To start your first project, run “serverless” in a new folder.  |
- |                                                                  |
- +------------------------------------------------------------------+
+ +--------------------------------------------------+
+ |                                                  |
+ |  Serverless Framework successfully installed!    |
+ |  To start your first project, run “serverless”.  |
+ |                                                  |
+ +--------------------------------------------------+
 `)
   );
 }


### PR DESCRIPTION
via @skierkowski:

> since `serverless` creates the new folder, we can truncate `in a new folder.` from the `npm i` message.

**_Is it a breaking change?:_** NO
