### PR TITLE
Fail faster when no AWS creds exist

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -348,6 +348,13 @@ class AwsProvider {
     const stageUpper = this.getStage() ? this.getStage().toUpperCase() : null;
 
     // add specified credentials, overriding with more specific declarations
+    try {
+      impl.addProfileCredentials(result, 'default');
+    } catch (err) {
+      if (err.message !== 'Profile default does not exist') {
+        throw err;
+      }
+    }
     impl.addCredentials(result, this.serverless.service.provider.credentials); // config creds
     if (this.serverless.service.provider.profile && !this.options['aws-profile']) {
       // config profile
@@ -360,6 +367,18 @@ class AwsProvider {
     if (this.options['aws-profile']) {
       impl.addProfileCredentials(result, this.options['aws-profile']); // CLI option profile
     }
+
+    // Throw an error if credentials are invalid, don't wait for a request to be made to do so
+    if (Object.keys(result).length === 0) {
+      const message = [
+        'AWS provider credentials not found.',
+        ' Learn how to set up AWS provider credentials',
+        ` in our docs here: <${chalk.green('http://bit.ly/aws-creds-setup')}>.`,
+      ].join('');
+      userStats.track('user_awsCredentialsNotFound');
+      throw new this.serverless.classes.Error(message);
+    }
+
     result.region = this.getRegion();
 
     const deploymentBucketObject = this.serverless.service.provider.deploymentBucketObject;

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -908,14 +908,14 @@ describe('AwsProvider', () => {
     });
 
     it('should set region for credentials', () => {
+      serverless.service.provider.profile = 'notDefault';
       const credentials = newAwsProvider.getCredentials();
       expect(credentials.region).to.equal(newOptions.region);
     });
 
     it('should not set credentials if credentials is an empty object', () => {
       serverless.service.provider.credentials = {};
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => newAwsProvider.getCredentials()).to.throw('AWS provider credentials not found.');
     });
 
     it('should not set credentials if credentials has undefined values', () => {
@@ -924,8 +924,7 @@ describe('AwsProvider', () => {
         secretAccessKey: undefined,
         sessionToken: undefined,
       };
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => newAwsProvider.getCredentials()).to.throw('AWS provider credentials not found.');
     });
 
     it('should not set credentials if credentials has empty string values', () => {
@@ -934,8 +933,7 @@ describe('AwsProvider', () => {
         secretAccessKey: '',
         sessionToken: '',
       };
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => newAwsProvider.getCredentials()).to.throw('AWS provider credentials not found.');
     });
 
     it('should get credentials from provider declared credentials', () => {
@@ -972,20 +970,17 @@ describe('AwsProvider', () => {
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => newAwsProvider.getCredentials()).to.throw('AWS provider credentials not found.');
     });
 
     it('should not set credentials if profile is not set', () => {
       serverless.service.provider.profile = undefined;
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => newAwsProvider.getCredentials()).to.throw('AWS provider credentials not found.');
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(() => newAwsProvider.getCredentials()).to.throw('AWS provider credentials not found.');
     });
 
     it('should get credentials from provider declared temporary profile', () => {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -12,6 +12,7 @@ const os = require('os');
 const path = require('path');
 const overrideEnv = require('process-utils/override-env');
 
+const userStats = require('../../../utils/userStats');
 const AwsProvider = require('./awsProvider');
 const Serverless = require('../../../Serverless');
 const { replaceEnv } = require('../../../../tests/utils/misc');
@@ -846,6 +847,7 @@ describe('AwsProvider', () => {
     const AwsProviderProxyquired = proxyquire('./awsProvider.js', {
       'aws-sdk': awsStub,
     });
+    sinon.stub(userStats, 'track');
 
     // add environment variables here if you want them cleared prior to your test and restored
     // after it has completed.  Any environment variable that might alter credentials loading

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -847,7 +847,7 @@ describe('AwsProvider', () => {
     const AwsProviderProxyquired = proxyquire('./awsProvider.js', {
       'aws-sdk': awsStub,
     });
-    sinon.stub(userStats, 'track');
+    let trackStub
 
     // add environment variables here if you want them cleared prior to your test and restored
     // after it has completed.  Any environment variable that might alter credentials loading
@@ -882,6 +882,7 @@ describe('AwsProvider', () => {
     let originalEnvironmentVariables;
 
     beforeEach(() => {
+      trackStub = sinon.stub(userStats, 'track');
       originalProviderCredentials = serverless.service.provider.credentials;
       originalProviderProfile = serverless.service.provider.profile;
       originalEnvironmentVariables = replaceEnv(relevantEnvironment);
@@ -908,6 +909,7 @@ describe('AwsProvider', () => {
       replaceEnv(originalEnvironmentVariables);
       serverless.service.provider.profile = originalProviderProfile;
       serverless.service.provider.credentials = originalProviderCredentials;
+      trackStub.restore();
     });
 
     it('should set region for credentials', () => {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -847,7 +847,7 @@ describe('AwsProvider', () => {
     const AwsProviderProxyquired = proxyquire('./awsProvider.js', {
       'aws-sdk': awsStub,
     });
-    let trackStub
+    let trackStub;
 
     // add environment variables here if you want them cleared prior to your test and restored
     // after it has completed.  Any environment variable that might alter credentials loading

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -240,7 +240,7 @@ describe('AwsProvider', () => {
 
   describe('#request()', () => {
     beforeEach(() => {
-      serverless.service.provider.credentials = {}
+      serverless.service.provider.credentials = {};
       const originalSetTimeout = setTimeout;
       sinon
         .stub(global, 'setTimeout')

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -240,7 +240,7 @@ describe('AwsProvider', () => {
 
   describe('#request()', () => {
     beforeEach(() => {
-      serverless.service.provider.credentials = {};
+      serverless.service.provider.credentials = {accessKeyId: 'id'};
       const originalSetTimeout = setTimeout;
       sinon
         .stub(global, 'setTimeout')

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -240,7 +240,7 @@ describe('AwsProvider', () => {
 
   describe('#request()', () => {
     beforeEach(() => {
-      serverless.service.provider.credentials = {accessKeyId: 'id'};
+      serverless.service.provider.credentials = { accessKeyId: 'id', secretAccessKey: 'secret' };
       const originalSetTimeout = setTimeout;
       sinon
         .stub(global, 'setTimeout')

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -240,6 +240,7 @@ describe('AwsProvider', () => {
 
   describe('#request()', () => {
     beforeEach(() => {
+      serverless.service.provider.credentials = {}
       const originalSetTimeout = setTimeout;
       sinon
         .stub(global, 'setTimeout')


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes [PLAT-936](https://serverlessteam.atlassian.net/browse/PLAT-936)

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Adds default profile load attempt to list of credentials attempted (the fact it worked before was purely bc `aws-sdk` falls back to that), and then if no credentials are found at all, throws an error.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
```
npm i serverless/serverless#missing-aws-creds-fail-fast
mv ~/.aws ~/.awsbak
sls deploy
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
