### PR TITLE
Added Cloud Build option for serverless deploy guide

### DIFF
--- a/docs/providers/google/guide/deploying.md
+++ b/docs/providers/google/guide/deploying.md
@@ -41,3 +41,59 @@ The Serverless Framework translates all syntax in `serverless.yml` to a Google D
 - Use this in your CI/CD systems, as it is the safest method of deployment.
 
 Check out the [deploy command docs](../cli-reference/deploy.md) for all details and options.
+
+## Cloud Build
+
+This method incorporates the above serverless deploy command into a Google Cloud Build process.  This allows the serverless deploy to be automatically triggered from the code repository and executed within a container; avoiding the need to manually run the serverless deploy command locally.
+
+### cloudbuild.yaml
+
+The Cloud Build process relies on a cloudbuild.yaml file to define the build steps.  Each build step is run in a Docker container.  The following `cloudbuild.yaml` file provides a sample of how to run a serverless deploy in a container.
+
+```yaml
+steps:
+  - name: 'gcr.io/cloud-builders/npm'
+    id: 'Install node_modules based on package.json'
+    args: ['install']
+  # NOTE: npx is used as workaround to allow serverless command to be found
+  # https://github.com/serverless/serverless/issues/4889
+  - name: 'gcr.io/cloud-builders/npm'
+    id: 'Install npx'
+    args: ['install','-g','npx']
+  - name: 'gcr.io/cloud-builders/npm'
+    id: 'Install Serverless framework using npm'
+    args: ['install','-g','serverless']
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+    - kms
+    - decrypt
+    - --ciphertext-file=mykeyfile.json.enc
+    - --plaintext-file=mykeyfile.json
+    - --location=global
+    - --keyring=${_KEYRING}
+    - --key=${_KEY}
+  - name: 'gcr.io/cloud-builders/npm'
+    id: 'Deploy serverless framework'
+    entrypoint: bash
+    args: ['-c','npx serverless deploy -v']
+substitutions:
+  _KEYRING: my_GCP_Keyring
+  _KEY: my_GCP_Key
+
+```
+
+### Handling Credentials
+
+The serverless framework requires credentials for executing the build (specified in the `serverless.yml` file).  For the above code to work, the `serverless.yml` file was updated to include the following credentials path; since an absolute path is required.
+
+```yaml
+    credentials: /workspace/mykeyfile.json
+```
+
+To secure the keyfile, the keyfile is encrypted using Google's Key Management System (KMS) in the console.  You define a Keyring and Key that can be used for encryption and decryption.  The Cloud Build service requires decrypt permissions for the KMS service.  In the above example, the encrypted keyfile was included in the root project folder and named `mykeyfile.json.enc`.  The Cloud Build process includes a step to decrypt this file (within the Docker instance) and save as `mykeyfile.json`.  This is what is used by the serverless deploy process.
+
+NOTE: The non-encrypted version can be excluded from your code repository by adding to the `.gitignore` file.  The file should only be used locally to generate the encrypted version.
+
+### Cloud Build Costs
+
+Google offers a daily free tier, which means many Cloud Build processes can run for free if the required build minutes are within the allotted minutes.  Running beyond the allotted minutes may incur costs.  For complete pricing check out the [pricing documentation](https://cloud.google.com/cloud-build/pricing). 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #XXXXX

<!--
I updated the guide documentation for Google platform related to deployment.  I provide an example of how to deploy the Serverless framework using the Cloud Build service in Google Cloud Platform.
-->

## How did you implement it:

<!--
I updated the deploying.md document with an additional section at the bottom for Cloud Build.
-->

## How can we verify it:

<!--
The documentation does include a sample `cloudbuild.yaml` and the remaining steps to incorporate a keyfile could be used.
-->

## Todos:

NONE

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
