### PR TITLE
Changed AWS subscription filters to use function object name

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -149,8 +149,6 @@ module.exports = {
    */
   checkLogGroupSubscriptionFilterResourceLimitExceeded() {
     const region = this.provider.getRegion();
-    const serviceName = this.serverless.service.getServiceName();
-    const stage = this.provider.getStage();
     const cloudWatchLogsSdk = new this.provider.sdk.CloudWatchLogs({ region });
 
     return this.provider.getAccountId().then(accountId =>
@@ -187,10 +185,8 @@ module.exports = {
               cloudWatchLogsSdk,
               accountId,
               logGroupName,
-              functionName,
+              functionObj,
               region,
-              serviceName,
-              stage,
             });
           });
 
@@ -204,10 +200,8 @@ module.exports = {
     const cloudWatchLogsSdk = params.cloudWatchLogsSdk;
     const accountId = params.accountId;
     const logGroupName = params.logGroupName;
-    const functionName = params.functionName;
+    const functionObj = params.functionObj;
     const region = params.region;
-    const serviceName = params.serviceName;
-    const stage = params.stage;
 
     return (
       cloudWatchLogsSdk
@@ -223,7 +217,7 @@ module.exports = {
 
           const oldDestinationArn = subscriptionFilter.destinationArn;
           const filterName = subscriptionFilter.filterName;
-          const newDestinationArn = `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-${stage}-${functionName}`;
+          const newDestinationArn = `arn:aws:lambda:${region}:${accountId}:function:${functionObj.name}`;
 
           // everything is fine, just return
           if (oldDestinationArn === newDestinationArn) {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -577,6 +577,8 @@ describe('checkForChanges', () => {
           },
         };
 
+        awsDeploy.serverless.service.setFunctionNames();
+
         describeSubscriptionFiltersResponse = {
           subscriptionFilters: [],
         };
@@ -592,6 +594,8 @@ describe('checkForChanges', () => {
             events: [{ cloudwatchLog: '/aws/lambda/hello1' }],
           },
         };
+
+        awsDeploy.serverless.service.setFunctionNames();
 
         describeSubscriptionFiltersResponse = {
           subscriptionFilters: [
@@ -614,10 +618,60 @@ describe('checkForChanges', () => {
           },
         };
 
+        awsDeploy.serverless.service.setFunctionNames();
+
         describeSubscriptionFiltersResponse = {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-not-first`,
+              filterName: 'dummy-filter',
+            },
+          ],
+        };
+
+        return awsDeploy
+          .checkForChanges()
+          .then(() => expect(deleteSubscriptionFilterStub).to.have.been.called);
+      });
+
+      it('should not call delete if there is a subFilter and the ARNs are the same with custom function name', () => {
+        awsDeploy.serverless.service.functions = {
+          first: {
+            name: 'my-test-function',
+            events: [{ cloudwatchLog: '/aws/lambda/hello1' }],
+          },
+        };
+
+        awsDeploy.serverless.service.setFunctionNames();
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [
+            {
+              destinationArn: `arn:aws:lambda:${region}:${accountId}:function:my-test-function`,
+              filterName: 'dummy-filter',
+            },
+          ],
+        };
+
+        return awsDeploy
+          .checkForChanges()
+          .then(() => expect(deleteSubscriptionFilterStub).to.not.have.been.called);
+      });
+
+      it('should call delete if there is a subFilter but the ARNs are not the same with custom function name', () => {
+        awsDeploy.serverless.service.functions = {
+          first: {
+            name: 'my-test-function',
+            events: [{ cloudwatchLog: '/aws/lambda/hello1' }],
+          },
+        };
+
+        awsDeploy.serverless.service.setFunctionNames();
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [
+            {
+              destinationArn: `arn:aws:lambda:${region}:${accountId}:function:my-other-test-function`,
               filterName: 'dummy-filter',
             },
           ],


### PR DESCRIPTION
## What did you implement:

Closes #5700 

## How did you implement it:

Just changed the expecting log subscription ARN from being calculated using `functionName` (which is always the name of the function object in `serverless.yml`, to instead use `functionObj.name`, which will use the `name` field if provided, and the default name if not (as it is set in the `setFunctioNames` method in `Service.js`).

## How can we verify it:
`serverless deploy` a function with CloudWatch Logs triggers and with the `name` field set (an example is given in the original issue and re-listed below).

~~~~
functions:
  app:
    name: cloudwatch2loggly
    handler: src/index.handler
    events:
      - cloudwatchLog: '/aws/lambda/${self:provider.stage}-function1'
      - cloudwatchLog: '/aws/lambda/${self:provider.stage}-function2'
      - cloudwatchLog: '/aws/lambda/${self:provider.stage}-function3'
~~~~

Opening CloudWatch will show subscriptions for each of the log groups. Re-deploying (using `serverless deploy --force`) will cause all of the subscriptions to disappear in the upstream repo, but will not with these changes.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation **I don't think this is really applicable for such a minor bugfix**
- [X] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
