### PR TITLE
Strip trailing comment when renaming a service

### DIFF
--- a/lib/utils/renameService.js
+++ b/lib/utils/renameService.js
@@ -19,16 +19,11 @@ function renameService(name, servicePath) {
 
   const serverlessYml = fse
     .readFileSync(serviceFile, 'utf-8')
-    .replace(/service\s*:.+/gi, match => {
-      const fractions = match.split('#');
-      fractions[0] = `service: ${name}`;
-      return fractions.join(' #');
-    })
-    .replace(/service\s*:\n {2}name:.+/gi, match => {
-      const fractions = match.split('#');
-      fractions[0] = `service:\n  name: ${name}`;
-      return fractions.join(' #');
-    });
+    .replace(/service\s*:.+/gi, () => `service: ${name}`)
+    .replace(
+      /service\s*:\s*\n(\s+)name:.+/gi,
+      (match, indent) => `service:\n${indent}name: ${name}`
+    );
 
   fse.writeFileSync(serviceFile, serverlessYml);
 

--- a/lib/utils/renameService.test.js
+++ b/lib/utils/renameService.test.js
@@ -56,7 +56,7 @@ describe('renameService', () => {
     const defaultServiceYml =
       '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml =
-      '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+      '# comment\nservice: new-service-name\n\nprovider:\n  name: aws\n# comment';
 
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
@@ -78,7 +78,7 @@ describe('renameService', () => {
     const defaultServiceYml =
       '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml =
-      '# comment\nservice: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+      '# comment\nservice: new-service-name\n\nprovider:\n  name: aws\n# comment';
 
     const serviceFile = path.join(servicePath, 'serverless.yml');
 
@@ -114,7 +114,7 @@ describe('renameService', () => {
     const defaultServiceYml =
       '# comment\nservice:\n  name: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml =
-      '# comment\nservice:\n  name: new-service-name #comment\n\nprovider:\n  name: aws\n# comment';
+      '# comment\nservice:\n  name: new-service-name\n\nprovider:\n  name: aws\n# comment';
 
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';


### PR DESCRIPTION
Trailing comments in most template cases is a following instruction

```
# NOTE: update this with your service name
```

Leaving it after rename is misleading

**_Is it a breaking change?:_** NO
