### PR TITLE
Fix broken lint outcome after 'no-confusing-arrow' change

### DIFF
--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -459,7 +459,9 @@ describe('Variables', () => {
       expectedPopulatedObject['some.nested.key'] = 'hello';
       const populateValueStub = sinon.stub(serverless.variables, 'populateValue').callsFake(
         // eslint-disable-next-line no-template-curly-in-string
-        val => (val === '${opt:stage}' ? BbPromise.resolve('prod') : BbPromise.resolve(val))
+        val => {
+          return val === '${opt:stage}' ? BbPromise.resolve('prod') : BbPromise.resolve(val);
+        }
       );
       return serverless.variables
         .populateObject(object)

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -223,7 +223,9 @@ class AwsInvokeLocal {
       docker.stdout.on('data', buf => {
         stdout += buf.toString();
       });
-      docker.on('exit', error => (error ? reject(error) : resolve(Boolean(stdout.trim()))));
+      docker.on('exit', error => {
+        return error ? reject(error) : resolve(Boolean(stdout.trim()));
+      });
     });
   }
 
@@ -234,7 +236,9 @@ class AwsInvokeLocal {
 
     return new BbPromise((resolve, reject) => {
       const docker = spawn('docker', ['pull', `lambci/lambda:${runtime}`]);
-      docker.on('exit', error => (error ? reject(error) : resolve()));
+      docker.on('exit', error => {
+        return error ? reject(error) : resolve();
+      });
     });
   }
 
@@ -299,7 +303,9 @@ class AwsInvokeLocal {
         '-f',
         dockerfilePath,
       ]);
-      docker.on('exit', error => (error ? reject(error) : resolve(imageName)));
+      docker.on('exit', error => {
+        return error ? reject(error) : resolve(imageName);
+      });
     });
   }
 
@@ -357,7 +363,9 @@ class AwsInvokeLocal {
     return this.serverless.pluginManager.spawn('package').then(() =>
       BbPromise.all([
         this.checkDockerDaemonStatus(),
-        this.checkDockerImage().then(exists => (exists ? {} : this.pullDockerImage())),
+        this.checkDockerImage().then(exists => {
+          return exists ? {} : this.pullDockerImage();
+        }),
         this.getLayerPaths().then(layerPaths => this.buildDockerImage(layerPaths)),
         this.extractArtifact(),
       ]).then(
@@ -382,7 +390,9 @@ class AwsInvokeLocal {
             const docker = spawn('docker', dockerArgs);
             docker.stdout.on('data', buf => this.serverless.cli.consoleLog(buf.toString()));
             docker.stderr.on('data', buf => this.serverless.cli.consoleLog(buf.toString()));
-            docker.on('exit', error => (error ? reject(error) : resolve(imageName)));
+            docker.on('exit', error => {
+              return error ? reject(error) : resolve(imageName);
+            });
           })
       )
     );

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -678,12 +678,9 @@ describe('AwsInvokeLocal', () => {
           .invokeLocalNodeJs('fixture/asyncHandlerWithSuccess', 'withMessageByDone')
           .then(() => {
             expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
-            const calls = serverless.cli.consoleLog
-              .getCalls()
-              .reduce(
-                (acc, call) => (_.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc),
-                []
-              );
+            const calls = serverless.cli.consoleLog.getCalls().reduce((acc, call) => {
+              return _.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc;
+            }, []);
             expect(calls.length).to.equal(1);
           });
       });
@@ -708,12 +705,9 @@ describe('AwsInvokeLocal', () => {
           .invokeLocalNodeJs('fixture/asyncHandlerWithSuccess', 'withMessageByCallback')
           .then(() => {
             expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
-            const calls = serverless.cli.consoleLog
-              .getCalls()
-              .reduce(
-                (acc, call) => (_.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc),
-                []
-              );
+            const calls = serverless.cli.consoleLog.getCalls().reduce((acc, call) => {
+              return _.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc;
+            }, []);
             expect(calls.length).to.equal(1);
           });
       });
@@ -727,12 +721,9 @@ describe('AwsInvokeLocal', () => {
           .invokeLocalNodeJs('fixture/asyncHandlerWithSuccess', 'withMessageAndDelayByCallback')
           .then(() => {
             expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
-            const calls = serverless.cli.consoleLog
-              .getCalls()
-              .reduce(
-                (acc, call) => (_.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc),
-                []
-              );
+            const calls = serverless.cli.consoleLog.getCalls().reduce((acc, call) => {
+              return _.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc;
+            }, []);
             expect(calls.length).to.equal(1);
           });
       });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -437,7 +437,9 @@ class AwsProvider {
     }));
   }
   firstValue(values) {
-    return values.reduce((result, current) => (result.value ? result : current), {});
+    return values.reduce((result, current) => {
+      return result.value ? result : current;
+    }, {});
   }
 
   getRegionSourceValue() {

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -253,7 +253,9 @@ module.exports = {
       const filePathStates = allFilePaths.reduce((p, c) => Object.assign(p, { [c]: true }), {});
       patterns
         // nanomatch only does / style path delimiters, so convert them if on windows
-        .map(p => (process.platform === 'win32' ? p.replace(/\\/g, '/') : p))
+        .map(p => {
+          return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
+        })
         .forEach(p => {
           const exclude = p.startsWith('!');
           const pattern = exclude ? p.slice(1) : p;

--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -9,7 +9,9 @@ const readFile = require('./fs/readFile');
 const getConfigFilePath = (servicePath, options = {}) => {
   if (options.config) {
     const customPath = path.join(servicePath, options.config);
-    return fileExists(customPath).then(exists => (exists ? customPath : null));
+    return fileExists(customPath).then(exists => {
+      return exists ? customPath : null;
+    });
   }
 
   const jsonPath = path.join(servicePath, 'serverless.json');


### PR DESCRIPTION
It appears that `@serverless/eslint-config` v1.1.0 unexpectedly broke lint status.

It's due to  this change: https://github.com/serverless/eslint-config/pull/9

Could be observed in CI master fail: https://travis-ci.org/serverless/serverless/jobs/561062590

**_Is it a breaking change?:_** NO
