### PR TITLE
Remove spaces from Cognito Pool Name

### DIFF
--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
@@ -3,7 +3,7 @@
 const Lambda = require('aws-sdk/clients/lambda');
 
 function getStatementId(functionName, userPoolName) {
-  const normalizedUserPoolName = userPoolName.toLowerCase().replace(/[.:*]/g, '');
+  const normalizedUserPoolName = userPoolName.toLowerCase().replace(/[.:*\s]/g, '');
   const id = `${functionName}-${normalizedUserPoolName}`;
   if (id.length < 100) {
     return id;

--- a/tests/integration-all/cognito-user-pool/tests.js
+++ b/tests/integration-all/cognito-user-pool/tests.js
@@ -35,8 +35,8 @@ describe('AWS - Cognito User Pool Integration Test', () => {
       serverlessConfigHook:
         // Ensure unique user pool names for each test (to avoid collision among concurrent CI runs)
         config => {
-          poolBasicSetup = `${config.service}-cup-basic`;
-          poolExistingSetup = `${config.service}-cup-existing`;
+          poolBasicSetup = `${config.service} CUP Basic`;
+          poolExistingSetup = `${config.service} CUP Existing`;
           config.functions.basic.events[0].cognitoUserPool.pool = poolBasicSetup;
           config.functions.existing.events[0].cognitoUserPool.pool = poolExistingSetup;
         },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6418

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Updated regular expression to remove spaces.

## How can we verify it:

Simply create a Cognito User Pool with a name that has spaces in it.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
