### PR TITLE
Use slss.io for links

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -209,7 +209,7 @@ class CLI {
     this.consoleLog('');
 
     this.consoleLog(chalk.yellow.underline('Framework'));
-    this.consoleLog(chalk.dim('* Documentation: https://serverless.com/framework/docs/'));
+    this.consoleLog(chalk.dim('* Documentation: http://slss.io/docs'));
 
     this.consoleLog('');
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -300,7 +300,7 @@ class AwsProvider {
             const errorMessage = [
               'AWS provider credentials not found.',
               ' Learn how to set up AWS provider credentials',
-              ` in our docs here: <${chalk.green('http://bit.ly/aws-creds-setup')}>.`,
+              ` in our docs here: <${chalk.green('http://slss.io/aws-creds-setup')}>.`,
             ].join('');
             message = errorMessage;
             userStats.track('user_awsCredentialsNotFound');
@@ -373,7 +373,7 @@ class AwsProvider {
       const message = [
         'AWS provider credentials not found.',
         ' Learn how to set up AWS provider credentials',
-        ` in our docs here: <${chalk.green('http://bit.ly/aws-creds-setup')}>.`,
+        ` in our docs here: <${chalk.green('http://slss.io/aws-creds-setup')}>.`,
       ].join('');
       userStats.track('user_awsCredentialsNotFound');
       throw new this.serverless.classes.Error(message);

--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -57,12 +57,12 @@ module.exports = {
       if (!isConfirmed) {
         process.stdout.write(`You can setup your AWS account later. More details available here:
 
-https://serverless.com/framework/docs/providers/aws/guide/credentials#creating-aws-access-keys`);
+http://slss.io/aws-creds-setup`);
         return null;
       }
       process.stdout.write(
         `\nGo here to learn how to create your AWS credentials:\n${chalk.bold(
-          'https://serverless.com/framework/docs/providers/aws/guide/credentials#creating-aws-access-keys'
+          'http://slss.io/aws-creds-setup'
         )}\nThen enter them here:\n\n`
       );
       return awsAccessKeyIdInput().then(accessKeyId =>


### PR DESCRIPTION
## What did you implement:

Updated the copy in the CLI to use the shorter slss.io links

## How did you implement it:

Replacing a number of strings in the CLI, AWS Provider, and Interactive sign up.

## How can we verify it:

- run `sls --help` and the "Framework" section should show the new link
- run `sls` without a '~/.aws/credentials` file and the wizard should prompt for AWS credentials. In the subsequent step the link should be updated.
- Run `sls deploy` without a `~/.aws/credentials` or an AWS Access Role in SFE. It should fail and display the new link
