### PR TITLE
Ignore Case when Checking 'darwin tty'

### DIFF
--- a/lib/plugins/aws/invokeLocal/invoke.py
+++ b/lib/plugins/aws/invokeLocal/invoke.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     input = json.load(sys.stdin)
     if sys.platform != 'win32':
         try:
-            if sys.platform != 'darwin':
+            if sys.platform.lower() != 'darwin':
                 subprocess.check_call('tty', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except (OSError, subprocess.CalledProcessError):
             pass


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
This change ignores case when checking the system platform on Mojave v.
10.14.5.  This version of macOS reports 'darwin' as 'Darwin', which in
turn fails to skip the tty check.

Related: PR 5760

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
skip call to tty when sys.platform == 'darwin', ignoring case on check
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
On a mac (no changes on other OS')

sls create -t aws-python3
echo -e 'def hello(event, context):\n    import pdb;pdb.set_trace()' > handler.py
sls invoke local -f hello
--Return--

> handler.py(2)hello()->None
-> import pdb;pdb.set_trace()
(Pdb)
on master it raises bdb.BdbQuit

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
-  [ ] NA Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
