### PR TITLE
PLAT-1390 - check for cached creds in interactive setupAws

### DIFF
--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -45,7 +45,10 @@ module.exports = {
       return BbPromise.all([
         awsCredentials.resolveFileProfiles(),
         awsCredentials.resolveEnvCredentials(),
-      ]).then(([fileProfiles, envCredentials]) => !fileProfiles.size && !envCredentials);
+      ]).then(
+        ([fileProfiles, envCredentials]) =>
+          !fileProfiles.size && !envCredentials && !serverless.getProvider('aws').cachedCredentials
+      );
     });
   },
   run() {


### PR DESCRIPTION
because this is how the sfe plugin sets creds

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

partially implements PLAT-1390

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
also check the AWS provider class's `cachedCredentials` property that the plugin uses to pass credentials into serverless