### PR TITLE
Fix cross-account/cross-regions SNS subscriptions to topics with the same name

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -80,7 +80,20 @@ functions:
           topicName: MyCustomTopic
 ```
 
-**Note:** If an `arn` string is specified but not a `topicName`, the last substring starting with `:` will be extracted as the `topicName`. If an `arn` object is specified, `topicName` must be specified as a string, used only to name the underlying Cloudformation mapping resources.
+**Note:** If an `arn` string is specified but not a `topicName`, the last substring starting with `:` will be extracted as the `topicName`. If an `arn` object is specified, `topicName` must be specified as a string, used only to name the underlying Cloudformation mapping resources. You can take advantage of this behavior when subscribing to multiple topics with the same name in different regions/accounts to avoid collisions between Cloudformation resource names.
+
+```yml
+functions:
+  hello:
+    handler: handler.run
+    events:
+      - sns:
+        arn: arn:aws:sns:us-east-1:00000000000:topicname
+        topicName: topicname-account-1-us-east-1
+      - sns:
+        arn: arn:aws:sns:us-east-1:11111111111:topicname
+        topicName: topicname-account-2-us-east-1
+```
 
 ## Setting a display name
 

--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -88,11 +88,11 @@ functions:
     handler: handler.run
     events:
       - sns:
-        arn: arn:aws:sns:us-east-1:00000000000:topicname
-        topicName: topicname-account-1-us-east-1
+          arn: arn:aws:sns:us-east-1:00000000000:topicname
+          topicName: topicname-account-1-us-east-1
       - sns:
-        arn: arn:aws:sns:us-east-1:11111111111:topicname
-        topicName: topicname-account-2-us-east-1
+          arn: arn:aws:sns:us-east-1:11111111111:topicname
+          topicName: topicname-account-2-us-east-1
 ```
 
 ## Setting a display name

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -77,7 +77,7 @@ class AwsCompileSNSEvents {
                     this.invalidPropertyErrorMessage(functionName, 'arn')
                   );
                 }
-                topicName = topicName || event.sns.topicName;
+                topicName = event.sns.topicName || topicName;
                 if (!topicName || typeof topicName !== 'string') {
                   throw new this.serverless.classes.Error(
                     this.invalidPropertyErrorMessage(functionName, 'topicName')

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -327,7 +327,7 @@ describe('AwsCompileSNSEvents', () => {
       }).to.throw(Error);
     });
 
-    it('should create SNS topic when arn and topicName are given as object properties', () => {
+    it('should create SNS topic when both arn and topicName are given as object properties', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {
           events: [
@@ -355,6 +355,74 @@ describe('AwsCompileSNSEvents', () => {
       expect(
         awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstLambdaPermissionBarSNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
+    it('should create two SNS topic subsriptions for ARNs with the same topic name in two regions when different topicName parameters are specified', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'first',
+                arn: 'arn:aws:sns:region-1:accountid:bar',
+              },
+            },
+            {
+              sns: {
+                topicName: 'second',
+                arn: 'arn:aws:sns:region-2:accountid:bar',
+              },
+            }
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(
+        Object.keys(
+          awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        )
+      ).to.have.length(4);
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionFirst.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionSecond.Type
+      ).to.equal('AWS::SNS::Subscription');
+    });
+
+    it('should override SNS topic subsription CF resource name when arn and topicName are given as object properties', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'foo',
+                arn: 'arn:aws:sns:region:accountid:bar',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(
+        Object.keys(
+          awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        )
+      ).to.have.length(2);
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionFoo.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstLambdaPermissionFooSNS.Type
       ).to.equal('AWS::Lambda::Permission');
     });
 

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -373,7 +373,7 @@ describe('AwsCompileSNSEvents', () => {
                 topicName: 'second',
                 arn: 'arn:aws:sns:region-2:accountid:bar',
               },
-            }
+            },
           ],
         },
       };


### PR DESCRIPTION
## What did you implement:

Closes #6444

## How did you implement it:

If Lambda function subscribes to multiple topics with the same name allow defined `topicName` to take precedence when creating CloudFormation resources and to prevent resource name collisions.

## How can we verify it:

Configure two topics with the same name in two different accounts (or in two different regions):
```
functions:
  hello:
    handler: handler.run
    events: 
      - sns: 
        arn: arn:aws:sns:us-east-1:00000000000:topicname
        topicName: topicname-account-1-us-east-1
      - sns: 
        arn: arn:aws:sns:us-east-1:11111111111:topicname
        topicName: topicname-account-2-us-east-1
```
Deployment should succeed without an error. Check if two CloudFormation resources of type AWS::SNS::Subscription exist and if they have "sanitized" name taken from `topicName`.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
