### PR TITLE
Remove hard coded partition when validating subscription filters

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -151,7 +151,7 @@ module.exports = {
     const region = this.provider.getRegion();
     const cloudWatchLogsSdk = new this.provider.sdk.CloudWatchLogs({ region });
 
-    return this.provider.getAccountId().then(accountId =>
+    return this.provider.getAccountInfo().then(account =>
       Promise.all(
         this.serverless.service.getAllFunctions().map(functionName => {
           const functionObj = this.serverless.service.getFunction(functionName);
@@ -177,6 +177,9 @@ module.exports = {
               logGroupName = event.cloudwatchLog.replace(/\r?\n/g, '');
             }
 
+            const accountId = account.accountId;
+            const partition = account.partition;
+
             /*
               return a new promise that will check the resource limit exceeded and will fix it if
               the option is enabled
@@ -187,6 +190,7 @@ module.exports = {
               logGroupName,
               functionObj,
               region,
+              partition,
             });
           });
 
@@ -202,6 +206,7 @@ module.exports = {
     const logGroupName = params.logGroupName;
     const functionObj = params.functionObj;
     const region = params.region;
+    const partition = params.partition;
 
     return (
       cloudWatchLogsSdk
@@ -217,7 +222,7 @@ module.exports = {
 
           const oldDestinationArn = subscriptionFilter.destinationArn;
           const filterName = subscriptionFilter.filterName;
-          const newDestinationArn = `arn:aws:lambda:${region}:${accountId}:function:${functionObj.name}`;
+          const newDestinationArn = `arn:${partition}:lambda:${region}:${accountId}:function:${functionObj.name}`;
 
           // everything is fine, just return
           if (oldDestinationArn === newDestinationArn) {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -514,10 +514,12 @@ describe('checkForChanges', () => {
 
       provider.sdk.CloudWatchLogs = CloudWatchLogsStub;
 
-      sandbox.stub(provider, 'getAccountInfo').returns(BbPromise.resolve({
-        accountId,
-        partition: 'aws',
-      }));
+      sandbox.stub(provider, 'getAccountInfo').returns(
+        BbPromise.resolve({
+          accountId,
+          partition: 'aws',
+        })
+      );
 
       sandbox.stub(awsDeploy.serverless.service, 'getServiceName').returns(serviceName);
 
@@ -662,11 +664,13 @@ describe('checkForChanges', () => {
       });
 
       it('should not call delete when ARN is the same accounting for non-standard partitions', () => {
-        provider.getAccountInfo.restore()
-        sandbox.stub(provider, 'getAccountInfo').returns(BbPromise.resolve({
-          accountId,
-          partition: 'aws-us-gov',
-        }));
+        provider.getAccountInfo.restore();
+        sandbox.stub(provider, 'getAccountInfo').returns(
+          BbPromise.resolve({
+            accountId,
+            partition: 'aws-us-gov',
+          })
+        );
         awsDeploy.serverless.service.functions = {
           first: {
             name: 'my-test-function',

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -661,7 +661,7 @@ describe('checkForChanges', () => {
           .then(() => expect(deleteSubscriptionFilterStub).to.not.have.been.called);
       });
 
-      it('should not call delete if there is a subFilter and the ARNs are the same with custom function name accounting for non-standard partitions', () => {
+      it('should not call delete when ARN is the same accounting for non-standard partitions', () => {
         provider.getAccountInfo.restore()
         sandbox.stub(provider, 'getAccountInfo').returns(BbPromise.resolve({
           accountId,

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -514,7 +514,10 @@ describe('checkForChanges', () => {
 
       provider.sdk.CloudWatchLogs = CloudWatchLogsStub;
 
-      sandbox.stub(provider, 'getAccountId').returns(BbPromise.resolve(accountId));
+      sandbox.stub(provider, 'getAccountInfo').returns(BbPromise.resolve({
+        accountId,
+        partition: 'aws',
+      }));
 
       sandbox.stub(awsDeploy.serverless.service, 'getServiceName').returns(serviceName);
 
@@ -648,6 +651,35 @@ describe('checkForChanges', () => {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws:lambda:${region}:${accountId}:function:my-test-function`,
+              filterName: 'dummy-filter',
+            },
+          ],
+        };
+
+        return awsDeploy
+          .checkForChanges()
+          .then(() => expect(deleteSubscriptionFilterStub).to.not.have.been.called);
+      });
+
+      it('should not call delete if there is a subFilter and the ARNs are the same with custom function name accounting for non-standard partitions', () => {
+        provider.getAccountInfo.restore()
+        sandbox.stub(provider, 'getAccountInfo').returns(BbPromise.resolve({
+          accountId,
+          partition: 'aws-us-gov',
+        }));
+        awsDeploy.serverless.service.functions = {
+          first: {
+            name: 'my-test-function',
+            events: [{ cloudwatchLog: '/aws/lambda/hello1' }],
+          },
+        };
+
+        awsDeploy.serverless.service.setFunctionNames();
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [
+            {
+              destinationArn: `arn:aws-us-gov:lambda:${region}:${accountId}:function:my-test-function`,
               filterName: 'dummy-filter',
             },
           ],


### PR DESCRIPTION


<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6443

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Rather than calling `getAccountId`, call `getAccountInfo` which will include the partition, and include the partition as a variable when setting [`newDestinationArn `](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/deploy/lib/checkForChanges.js#L220)

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it. Previously the event source would get deleted

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

```
service: my-service

provider:
  name: aws
  runtime: python3.6
  region: us-gov-west-1

functions:
  hello:
    handler: handler.hello
    events:
      - cloudwatchLog:
          logGroup: '/var/log/cloud-init-output.log'
          filter: 'some filter'
```

Deploy a function with a cloudwatch log group with a [filter](https://serverless.com/framework/docs/providers/aws/events/cloudwatch-log/) as the event source on a gov-cloud account.

Make some kind of update to the event source, or to the function and `sls deploy` again. The event source should remain

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
