### PR TITLE
Adding exit code on exception

### DIFF
--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -59,6 +59,7 @@ initializeErrorReporter(invocationId).then(() => {
         }
       });
       if (!enterpriseErrorHandler) {
+        process.exitCode = 1;
         throw err;
       }
       return enterpriseErrorHandler(err, invocationId)


### PR DESCRIPTION
## What did you implement:

Closes #6441 

## How did you implement it:

set the process.exit in the catch for serverless. This will only trigger if serverless enterprise is not configured

## How can we verify it:

Run a serverless deploy using a role which does not have permission to deploy Lambda functions

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** Yes  
**_Is it a breaking change?:_** No
