### PR TITLE
Existing S3 bucket fixes

### DIFF
--- a/lib/plugins/aws/customResources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/bucket.js
@@ -17,7 +17,7 @@ function createFilter(config) {
     const FilterRules = rules.map(rule => {
       const key = Object.keys(rule)[0];
       const Name = key.toLowerCase();
-      const Value = rule[key].toLowerCase();
+      const Value = rule[key];
       return {
         Name,
         Value,

--- a/lib/plugins/aws/customResources/resources/utils.test.js
+++ b/lib/plugins/aws/customResources/resources/utils.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 const { expect } = require('chai');
 const { getLambdaArn, getEnvironment } = require('./utils');
 

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -254,7 +254,9 @@ class AwsCompileS3Events {
 
             iamRoleStatements.push({
               Effect: 'Allow',
-              Resource: `arn:aws:s3:::${bucket}`,
+              Resource: {
+                'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, `:s3:::${bucket}`]],
+              },
               Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
             });
           }
@@ -264,7 +266,20 @@ class AwsCompileS3Events {
       if (funcUsesExistingS3Bucket) {
         iamRoleStatements.push({
           Effect: 'Allow',
-          Resource: `arn:aws:lambda:*:*:function:${FunctionName}`,
+          Resource: {
+            'Fn::Join': [
+              ':',
+              [
+                'arn',
+                { Ref: 'AWS::Partition' },
+                'lambda',
+                { Ref: 'AWS::Region' },
+                { Ref: 'AWS::AccountId' },
+                'function',
+                FunctionName,
+              ],
+            ],
+          },
           Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
         });
       }

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -271,6 +271,48 @@ describe('AwsCompileS3Events', () => {
 
         expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
         expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':s3:::existing-s3-bucket',
+                ],
+              ],
+            },
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                ':',
+                [
+                  'arn',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  'lambda',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  'function',
+                  'first',
+                ],
+              ],
+            },
+          },
+        ]);
         expect(Resources.FirstCustomS31).to.deep.equal({
           Type: 'Custom::S3',
           Version: 1,
@@ -311,6 +353,48 @@ describe('AwsCompileS3Events', () => {
 
         expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
         expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':s3:::existing-s3-bucket',
+                ],
+              ],
+            },
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                ':',
+                [
+                  'arn',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  'lambda',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  'function',
+                  'second',
+                ],
+              ],
+            },
+          },
+        ]);
         expect(Resources.FirstCustomS31).to.deep.equal({
           Type: 'Custom::S3',
           Version: 1,

--- a/tests/integration-all/s3/service/serverless.yml
+++ b/tests/integration-all/s3/service/serverless.yml
@@ -26,6 +26,6 @@ functions:
           bucket: CHANGE_TO_UNIQUE_PER_RUN
           event: s3:ObjectCreated:*
           rules:
-            - prefix: files/
-            - suffix: .txt
+            - prefix: Files/
+            - suffix: .TXT
           existing: true

--- a/tests/integration-all/s3/tests.js
+++ b/tests/integration-all/s3/tests.js
@@ -95,7 +95,7 @@ describe('AWS - S3 Integration Test', () => {
       const markers = getMarkers(functionName);
       const expectedMessage = `Hello from S3! - (${functionName})`;
 
-      return createAndRemoveInBucket(bucketExistingSetup, { prefix: 'files/', suffix: '.txt' })
+      return createAndRemoveInBucket(bucketExistingSetup, { prefix: 'Files/', suffix: '.TXT' })
         .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
         .then(logs => {
           expect(/aws:s3/g.test(logs)).to.equal(true);


### PR DESCRIPTION
## What did you implement:

Closes #6409

Fixes some issues with existing S3 buckets. E.g. the prefix / suffix values were always lowercased. Also uses Refs and AWS Variables to construct IAM policies.

## How did you implement it:

Fix it and write regression tests.

## How can we verify it:

The easiest way is to run the integration tests for S3 buckets.

Otherwise you can also deploy the following service:

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0
  bucket: serverless-existing-s3-bucket # change this with your bucket name

functions:
  test:
    handler: handler.hello
    events:
      - s3:
          bucket: ${self:custom.bucket}
          events: s3:ObjectCreated:*
          rules:
            - suffix: .txt
            - prefix: CamelCase/
          existing: true
```

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO