### PR TITLE
Allow AWS Subscription Filters to be reordered

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -160,6 +160,7 @@ module.exports = {
             return BbPromise.resolve();
           }
 
+          let logSubscriptionSerialNumber = 0;
           const promises = functionObj.events.map(event => {
             if (!event.cloudwatchLog) {
               return BbPromise.resolve();
@@ -180,6 +181,8 @@ module.exports = {
             const accountId = account.accountId;
             const partition = account.partition;
 
+            logSubscriptionSerialNumber++;
+
             /*
               return a new promise that will check the resource limit exceeded and will fix it if
               the option is enabled
@@ -188,9 +191,11 @@ module.exports = {
               cloudWatchLogsSdk,
               accountId,
               logGroupName,
+              functionName,
               functionObj,
               region,
               partition,
+              logSubscriptionSerialNumber,
             });
           });
 
@@ -204,9 +209,11 @@ module.exports = {
     const cloudWatchLogsSdk = params.cloudWatchLogsSdk;
     const accountId = params.accountId;
     const logGroupName = params.logGroupName;
+    const functionName = params.functionName;
     const functionObj = params.functionObj;
     const region = params.region;
     const partition = params.partition;
+    const logSubscriptionSerialNumber = params.logSubscriptionSerialNumber;
 
     return (
       cloudWatchLogsSdk
@@ -220,19 +227,26 @@ module.exports = {
             return false;
           }
 
-          const oldDestinationArn = subscriptionFilter.destinationArn;
           const filterName = subscriptionFilter.filterName;
+
+          const oldDestinationArn = subscriptionFilter.destinationArn;
           const newDestinationArn = `arn:${partition}:lambda:${region}:${accountId}:function:${functionObj.name}`;
 
+          const oldLogicalId = this.getLogicalIdFromFilterName(filterName);
+          const newLogicalId = this.provider.naming.getCloudWatchLogLogicalId(
+            functionName,
+            logSubscriptionSerialNumber
+          );
+
           // everything is fine, just return
-          if (oldDestinationArn === newDestinationArn) {
+          if (oldDestinationArn === newDestinationArn && oldLogicalId === newLogicalId) {
             return false;
           }
 
           /*
-          If the destinations functions' ARNs doesn't match, we need to delete the current
-          subscription filter to prevent the resource limit exceeded error to happen
-        */
+            If the destinations functions' ARNs doesn't match, we need to delete the current
+            subscription filter to prevent the resource limit exceeded error to happen
+          */
           return cloudWatchLogsSdk.deleteSubscriptionFilter({ logGroupName, filterName }).promise();
         })
         /*
@@ -241,5 +255,13 @@ module.exports = {
       */
         .catch(() => undefined)
     );
+  },
+
+  getLogicalIdFromFilterName(filterName) {
+    // Filter name format:
+    // {stack name}-{logical id}-{random alphanumeric characters}
+    // Note that the stack name can include hyphens
+    const split = filterName.split('-');
+    return split[split.length - 2];
   },
 };

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -593,7 +593,7 @@ describe('checkForChanges', () => {
           .then(() => expect(deleteSubscriptionFilterStub).to.not.have.been.called);
       });
 
-      it('should not call delete if there is a subFilter and the ARNs are the same', () => {
+      it('should not call delete if there is a subFilter and the ARNs/logical IDs are the same', () => {
         awsDeploy.serverless.service.functions = {
           first: {
             events: [{ cloudwatchLog: '/aws/lambda/hello1' }],
@@ -606,7 +606,7 @@ describe('checkForChanges', () => {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-first`,
-              filterName: 'dummy-filter',
+              filterName: 'stack-name-FirstLogsSubscriptionFilterCloudWatchLog1-1KAK9SAG7Y9YN',
             },
           ],
         };
@@ -629,7 +629,7 @@ describe('checkForChanges', () => {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-not-first`,
-              filterName: 'dummy-filter',
+              filterName: 'stack-name-FirstLogsSubscriptionFilterCloudWatchLog1-1KAK9SAG7Y9YN',
             },
           ],
         };
@@ -639,7 +639,30 @@ describe('checkForChanges', () => {
           .then(() => expect(deleteSubscriptionFilterStub).to.have.been.called);
       });
 
-      it('should not call delete if there is a subFilter and the ARNs are the same with custom function name', () => {
+      it('should call delete if there is a subFilter but the logical IDs are not the same', () => {
+        awsDeploy.serverless.service.functions = {
+          first: {
+            events: [{ cloudwatchLog: '/aws/lambda/hello1' }],
+          },
+        };
+
+        awsDeploy.serverless.service.setFunctionNames();
+
+        describeSubscriptionFiltersResponse = {
+          subscriptionFilters: [
+            {
+              destinationArn: `arn:aws:lambda:${region}:${accountId}:function:${serviceName}-dev-first`,
+              filterName: 'stack-name-FirstLogsSubscriptionFilterCloudWatchLog2-1KAK9SAG7Y9YN',
+            },
+          ],
+        };
+
+        return awsDeploy
+          .checkForChanges()
+          .then(() => expect(deleteSubscriptionFilterStub).to.have.been.called);
+      });
+
+      it('should not call delete if there is a subFilter and the ARNs/logical IDs are the same with custom function name', () => {
         awsDeploy.serverless.service.functions = {
           first: {
             name: 'my-test-function',
@@ -653,7 +676,7 @@ describe('checkForChanges', () => {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws:lambda:${region}:${accountId}:function:my-test-function`,
-              filterName: 'dummy-filter',
+              filterName: 'stack-name-FirstLogsSubscriptionFilterCloudWatchLog1-1KAK9SAG7Y9YN',
             },
           ],
         };
@@ -663,7 +686,7 @@ describe('checkForChanges', () => {
           .then(() => expect(deleteSubscriptionFilterStub).to.not.have.been.called);
       });
 
-      it('should not call delete when ARN is the same accounting for non-standard partitions', () => {
+      it('should not call delete when ARN/logical IDs are the same accounting for non-standard partitions', () => {
         provider.getAccountInfo.restore();
         sandbox.stub(provider, 'getAccountInfo').returns(
           BbPromise.resolve({
@@ -684,7 +707,7 @@ describe('checkForChanges', () => {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws-us-gov:lambda:${region}:${accountId}:function:my-test-function`,
-              filterName: 'dummy-filter',
+              filterName: 'stack-name-FirstLogsSubscriptionFilterCloudWatchLog1-1KAK9SAG7Y9YN',
             },
           ],
         };
@@ -708,7 +731,7 @@ describe('checkForChanges', () => {
           subscriptionFilters: [
             {
               destinationArn: `arn:aws:lambda:${region}:${accountId}:function:my-other-test-function`,
-              filterName: 'dummy-filter',
+              filterName: 'stack-name-FirstLogsSubscriptionFilterCloudWatchLog1-1KAK9SAG7Y9YN',
             },
           ],
         };


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5817 
Closes #6263 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

As suggested in #6263, changed cloudwatch log subscription filters to name their logical IDs using their log group name rather than using an incrementing serial number. This prevents CloudFormation from getting confused (due to new subscription filters having the same name but different log groups than older ones) when a subscription filter is added to or removed from anywhere except the end of a template.

However, this brings up another problem: this would break any projects that already existed using the serial number naming scheme (I tested and confirmed that this problem does exist). Therefore, I also added an extra condition to the code that removes subscription filters if the old and new destination ARNs don't match: they must also have the same logical ID. 

One last thing to note: while this second fix could be implemented on its own to solve the problem in #5817, there are some issues with taking that approach. First of all, continuing to implement subscription filters using serial numbers rather than filter names would end up causing many more deletions than are necessary. Additionally, this second fix is pretty much impossible (or at least very difficult) to implement without the first one, as there isn't really a way to calculate the "expected" logical ID from the `fixLogGroupSubscriptionFilters` method, since there's no good way to get which serial number will correspond to a log group.

## How can we verify it:
Create/deploy a project with CloudWatch logs subscriptions, and then re-deploy it with the order of some of the subscriptions swapped. This will throw a `Resource limit exceeded` on the upstream but should work fine on the PR. For the sake of brevity and time, I'm not going to rewrite it here, but there's a good example listed in the initial bug report (#5817). 

I've tested this locally, but you would also probably want to verify that a project deployed using the upstream version (with serial numbers) would redeploy fine on the newer version.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES 
**_Is it a breaking change?:_** NO
