### PR TITLE
Multiple event definitions for existing S3 bucket

### DIFF
--- a/docs/providers/aws/events/s3.md
+++ b/docs/providers/aws/events/s3.md
@@ -119,6 +119,8 @@ resources:
 
 Sometimes you might want to attach Lambda functions to existing S3 buckets. In that case you just need to set the `existing` event configuration property to `true`. All the other config parameters can also be used on existing buckets:
 
+**IMPORTANT:** You can only attach 1 existing S3 bucket per function.
+
 **NOTE:** Using the `existing` config will add an additional Lambda function and IAM Role to your stack. The Lambda function backs-up the Custom S3 Resource which is used to support existing S3 buckets.
 
 **NOTE:** This property was added in version 1.47.0. Older versions don't support this feature.

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -17,7 +17,7 @@ function handler(event, context) {
 
 function create(event, context) {
   const { Region, AccountId } = getEnvironment(context);
-  const { FunctionName, BucketName, BucketConfig } = event.ResourceProperties;
+  const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
 
   const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
 
@@ -31,14 +31,14 @@ function create(event, context) {
       region: Region,
       functionName: FunctionName,
       bucketName: BucketName,
-      bucketConfig: BucketConfig,
+      bucketConfigs: BucketConfigs,
     })
   );
 }
 
 function update(event, context) {
   const { Region, AccountId } = getEnvironment(context);
-  const { FunctionName, BucketName, BucketConfig } = event.ResourceProperties;
+  const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
 
   const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
 
@@ -47,7 +47,7 @@ function update(event, context) {
     region: Region,
     functionName: FunctionName,
     bucketName: BucketName,
-    bucketConfig: BucketConfig,
+    bucketConfigs: BucketConfigs,
   });
 }
 

--- a/lib/plugins/aws/customResources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/bucket.js
@@ -46,7 +46,7 @@ function getConfiguration(config) {
 }
 
 function updateConfiguration(config) {
-  const { lambdaArn, functionName, bucketName, bucketConfig, region } = config;
+  const { lambdaArn, functionName, bucketName, bucketConfigs, region } = config;
   const s3 = new AWS.S3({ region });
   const Bucket = bucketName;
 
@@ -56,16 +56,18 @@ function updateConfiguration(config) {
       conf => !conf.Id.startsWith(functionName)
     );
 
-    // add the event to the existing NotificationConfiguration
-    const Events = [bucketConfig.Event];
-    const LambdaFunctionArn = lambdaArn;
-    const Id = generateId(functionName, bucketConfig);
-    const Filter = createFilter(bucketConfig);
-    NotificationConfiguration.LambdaFunctionConfigurations.push({
-      Events,
-      LambdaFunctionArn,
-      Filter,
-      Id,
+    // add the events to the existing NotificationConfiguration
+    bucketConfigs.forEach(bucketConfig => {
+      const Events = [bucketConfig.Event];
+      const LambdaFunctionArn = lambdaArn;
+      const Id = generateId(functionName, bucketConfig);
+      const Filter = createFilter(bucketConfig);
+      NotificationConfiguration.LambdaFunctionConfigurations.push({
+        Events,
+        LambdaFunctionArn,
+        Filter,
+        Id,
+      });
     });
 
     const payload = {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -468,8 +468,11 @@ module.exports = {
       `${this.getNormalizedFunctionName(this.getCustomResourceS3HandlerFunctionName())}`
     );
   },
-  getCustomResourceS3ResourceLogicalId(functionName, idx) {
-    return `${this.getNormalizedFunctionName(functionName)}CustomS3${idx}`;
+  getCustomResourceS3ResourceLogicalId(functionName) {
+    // NOTE: we have to keep the 1 at the end to ensure backwards compatibility
+    // previously we've used an index to allow the creation of multiple custom S3 resources
+    // we're now using one resource to handle multiple S3 event definitions
+    return `${this.getNormalizedFunctionName(functionName)}CustomS31`;
   },
   // Cognito User Pool
   getCustomResourceCognitoUserPoolHandlerFunctionName() {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -755,8 +755,7 @@ describe('#naming()', () => {
   describe('#getCustomResourceS3ResourceLogicalId()', () => {
     it('should return the logical id of the S3 custom resouce', () => {
       const functionName = 'my-function';
-      const index = 1;
-      expect(sdk.naming.getCustomResourceS3ResourceLogicalId(functionName, index)).to.equal(
+      expect(sdk.naming.getCustomResourceS3ResourceLogicalId(functionName)).to.equal(
         'MyDashfunctionCustomS31'
       );
     });

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -200,18 +200,23 @@ class AwsCompileS3Events {
     const { service } = this.serverless;
     const { provider } = service;
     const { compiledCloudFormationTemplate } = provider;
+    const { Resources } = compiledCloudFormationTemplate;
     const iamRoleStatements = [];
 
+    // used to keep track of the custom resources created for each bucket
+    const bucketResources = {};
+
     service.getAllFunctions().forEach(functionName => {
+      let numEventsForFunc = 0;
       let funcUsesExistingS3Bucket = false;
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
 
       if (functionObj.events) {
-        functionObj.events.forEach((event, idx) => {
+        functionObj.events.forEach(event => {
           if (event.s3 && _.isObject(event.s3) && event.s3.existing) {
+            numEventsForFunc++;
             let rules = null;
-            idx = idx += 1;
             const bucket = event.s3.bucket;
             const notificationEvent = event.s3.event || 's3:ObjectCreated:*';
             funcUsesExistingS3Bucket = true;
@@ -227,38 +232,58 @@ class AwsCompileS3Events {
             const eventFunctionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const customResourceFunctionLogicalId = this.provider.naming.getCustomResourceS3HandlerFunctionLogicalId();
             const customS3ResourceLogicalId = this.provider.naming.getCustomResourceS3ResourceLogicalId(
-              functionName,
-              idx
+              functionName
             );
 
-            const customS3Resource = {
-              [customS3ResourceLogicalId]: {
-                Type: 'Custom::S3',
-                Version: 1.0,
-                DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
-                Properties: {
-                  ServiceToken: {
-                    'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
-                  },
-                  FunctionName,
-                  BucketName: bucket,
-                  BucketConfig: {
-                    Event: notificationEvent,
-                    Rules: rules,
+            // store how often the custom S3 resource is used
+            if (bucketResources[bucket]) {
+              bucketResources[bucket] = _.union(bucketResources[bucket], [
+                customS3ResourceLogicalId,
+              ]);
+            } else {
+              Object.assign(bucketResources, {
+                [bucket]: [customS3ResourceLogicalId],
+              });
+            }
+
+            let customS3Resource;
+            if (numEventsForFunc === 1) {
+              customS3Resource = {
+                [customS3ResourceLogicalId]: {
+                  Type: 'Custom::S3',
+                  Version: 1.0,
+                  DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                  Properties: {
+                    ServiceToken: {
+                      'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
+                    },
+                    FunctionName,
+                    BucketName: bucket,
+                    BucketConfigs: [
+                      {
+                        Event: notificationEvent,
+                        Rules: rules,
+                      },
+                    ],
                   },
                 },
-              },
-            };
+              };
 
-            _.merge(compiledCloudFormationTemplate.Resources, customS3Resource);
+              iamRoleStatements.push({
+                Effect: 'Allow',
+                Resource: {
+                  'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, `:s3:::${bucket}`]],
+                },
+                Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+              });
+            } else {
+              Resources[customS3ResourceLogicalId].Properties.BucketConfigs.push({
+                Event: notificationEvent,
+                Rules: rules,
+              });
+            }
 
-            iamRoleStatements.push({
-              Effect: 'Allow',
-              Resource: {
-                'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, `:s3:::${bucket}`]],
-              },
-              Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
-            });
+            _.merge(Resources, customS3Resource);
           }
         });
       }
@@ -284,6 +309,22 @@ class AwsCompileS3Events {
         });
       }
     });
+
+    // check if we need to add DependsOn clauses in case more than 1
+    // custom resources are created for one bucket (to avoid race conditions)
+    if (Object.keys(bucketResources).length > 0) {
+      Object.keys(bucketResources).forEach(bucket => {
+        const resources = bucketResources[bucket];
+        if (resources.length > 1) {
+          resources.forEach((currResourceLogicalId, idx) => {
+            if (idx > 0) {
+              const prevResourceLogicalId = resources[idx - 1];
+              Resources[currResourceLogicalId].DependsOn.push(prevResourceLogicalId);
+            }
+          });
+        }
+      });
+    }
 
     if (iamRoleStatements.length) {
       return addCustomResourceToService.call(this, 's3', iamRoleStatements);

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -323,7 +323,7 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'first',
             BucketName: 'existing-s3-bucket',
-            BucketConfig: { Event: 's3:ObjectCreated:*', Rules: [] },
+            BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
           },
         });
       });
@@ -405,10 +405,338 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
-            BucketConfig: {
-              Event: 's3:ObjectCreated:Put',
-              Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpg' }],
+            BucketConfigs: [
+              {
+                Event: 's3:ObjectCreated:Put',
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpg' }],
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    it('should create the necessary resources for a service using multiple event definitions', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          name: 'second',
+          events: [
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectCreated:Put',
+                rules: [{ prefix: 'uploads' }, { suffix: '.jpg' }],
+                existing: true,
+              },
             },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectRemoved:Delete',
+                rules: [{ prefix: 'downloads' }, { suffix: '.txt' }],
+                existing: true,
+              },
+            },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectRestore:Post',
+                rules: [{ prefix: 'avatars' }, { suffix: '.png' }],
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(awsCompileS3Events.existingS3Buckets()).to.be.fulfilled.then(() => {
+        const {
+          Resources,
+        } = awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate;
+
+        expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+        expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':s3:::existing-s3-bucket',
+                ],
+              ],
+            },
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                ':',
+                [
+                  'arn',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  'lambda',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  'function',
+                  'second',
+                ],
+              ],
+            },
+          },
+        ]);
+        expect(Resources.FirstCustomS31).to.deep.equal({
+          Type: 'Custom::S3',
+          Version: 1,
+          DependsOn: ['FirstLambdaFunction', 'CustomDashresourceDashexistingDashs3LambdaFunction'],
+          Properties: {
+            ServiceToken: {
+              'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
+            },
+            FunctionName: 'second',
+            BucketName: 'existing-s3-bucket',
+            BucketConfigs: [
+              {
+                Event: 's3:ObjectCreated:Put',
+
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpg' }],
+              },
+              {
+                Event: 's3:ObjectRemoved:Delete',
+                Rules: [{ Prefix: 'downloads' }, { Suffix: '.txt' }],
+              },
+              {
+                Event: 's3:ObjectRestore:Post',
+
+                Rules: [{ Prefix: 'avatars' }, { Suffix: '.png' }],
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    it('should create DependsOn clauses when one bucket is used in more than 1 custom resources', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectCreated:*',
+                rules: [{ prefix: 'uploads' }, { suffix: '.jpg' }],
+                existing: true,
+              },
+            },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectCreated:*',
+                rules: [{ prefix: 'uploads' }, { suffix: '.jpeg' }],
+                existing: true,
+              },
+            },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectCreated:*',
+                rules: [{ prefix: 'uploads' }, { suffix: '.png' }],
+                existing: true,
+              },
+            },
+          ],
+        },
+        second: {
+          name: 'second',
+          events: [
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectRemoved:*',
+                rules: [{ prefix: 'uploads' }, { suffix: '.jpg' }],
+                existing: true,
+              },
+            },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectRemoved:*',
+                rules: [{ prefix: 'uploads' }, { suffix: '.jpeg' }],
+                existing: true,
+              },
+            },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                event: 's3:ObjectRemoved:*',
+                rules: [{ prefix: 'uploads' }, { suffix: '.png' }],
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(awsCompileS3Events.existingS3Buckets()).to.be.fulfilled.then(() => {
+        const {
+          Resources,
+        } = awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate;
+
+        expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+        expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':s3:::existing-s3-bucket',
+                ],
+              ],
+            },
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                ':',
+                [
+                  'arn',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  'lambda',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  'function',
+                  'first',
+                ],
+              ],
+            },
+          },
+          {
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':s3:::existing-s3-bucket',
+                ],
+              ],
+            },
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                ':',
+                [
+                  'arn',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  'lambda',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  'function',
+                  'second',
+                ],
+              ],
+            },
+          },
+        ]);
+        expect(Object.keys(Resources)).to.have.length(2);
+        expect(Resources.FirstCustomS31).to.deep.equal({
+          Type: 'Custom::S3',
+          Version: 1,
+          DependsOn: ['FirstLambdaFunction', 'CustomDashresourceDashexistingDashs3LambdaFunction'],
+          Properties: {
+            ServiceToken: {
+              'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
+            },
+            FunctionName: 'first',
+            BucketName: 'existing-s3-bucket',
+            BucketConfigs: [
+              {
+                Event: 's3:ObjectCreated:*',
+
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpg' }],
+              },
+              {
+                Event: 's3:ObjectCreated:*',
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpeg' }],
+              },
+              {
+                Event: 's3:ObjectCreated:*',
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.png' }],
+              },
+            ],
+          },
+        });
+        expect(Resources.SecondCustomS31).to.deep.equal({
+          Type: 'Custom::S3',
+          Version: 1,
+          DependsOn: [
+            'SecondLambdaFunction',
+            'CustomDashresourceDashexistingDashs3LambdaFunction',
+            'FirstCustomS31',
+          ],
+          Properties: {
+            ServiceToken: {
+              'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
+            },
+            FunctionName: 'second',
+            BucketName: 'existing-s3-bucket',
+            BucketConfigs: [
+              {
+                Event: 's3:ObjectRemoved:*',
+
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpg' }],
+              },
+              {
+                Event: 's3:ObjectRemoved:*',
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.jpeg' }],
+              },
+              {
+                Event: 's3:ObjectRemoved:*',
+                Rules: [{ Prefix: 'uploads' }, { Suffix: '.png' }],
+              },
+            ],
           },
         });
       });

--- a/tests/integration-all/s3/service/core.js
+++ b/tests/integration-all/s3/service/core.js
@@ -43,4 +43,30 @@ function existing(event, context, callback) {
   return callback(null, response);
 }
 
-module.exports = { minimal, extended, existing };
+function existingCreated(event, context, callback) {
+  const functionName = 'existingCreated';
+  const response = { message: `Hello from S3! - (${functionName})`, event };
+  const message = [
+    event.Records[0].eventSource,
+    event.Records[0].eventName,
+    ' ',
+    response.message,
+  ].join('');
+  log(functionName, message);
+  return callback(null, response);
+}
+
+function existingRemoved(event, context, callback) {
+  const functionName = 'existingRemoved';
+  const response = { message: `Hello from S3! - (${functionName})`, event };
+  const message = [
+    event.Records[0].eventSource,
+    event.Records[0].eventName,
+    ' ',
+    response.message,
+  ].join('');
+  log(functionName, message);
+  return callback(null, response);
+}
+
+module.exports = { minimal, extended, existing, existingCreated, existingRemoved };

--- a/tests/integration-all/s3/service/serverless.yml
+++ b/tests/integration-all/s3/service/serverless.yml
@@ -29,3 +29,38 @@ functions:
             - prefix: Files/
             - suffix: .TXT
           existing: true
+  # testing if two functions share one bucket with multiple bucket configs
+  existingCreated:
+    handler: core.existingCreated
+    events:
+      - s3:
+          bucket: CHANGE_TO_UNIQUE_PER_RUN
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: photos
+            - suffix: .jpg
+          existing: true
+      - s3:
+          bucket: CHANGE_TO_UNIQUE_PER_RUN
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: photos
+            - suffix: .png
+          existing: true
+  existingRemoved:
+    handler: core.existingRemoved
+    events:
+      - s3:
+          bucket: CHANGE_TO_UNIQUE_PER_RUN
+          event: s3:ObjectRemoved:*
+          rules:
+            - prefix: photos
+            - suffix: .jpg
+          existing: true
+      - s3:
+          bucket: CHANGE_TO_UNIQUE_PER_RUN
+          event: s3:ObjectRemoved:*
+          rules:
+            - prefix: photos
+            - suffix: .png
+          existing: true

--- a/tests/integration-all/s3/tests.js
+++ b/tests/integration-all/s3/tests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const BbPromise = require('bluebird');
 const { expect } = require('chai');
 
 const { getTmpDirPath } = require('../../utils/fs');
@@ -19,7 +20,8 @@ describe('AWS - S3 Integration Test', () => {
   let tmpDirPath;
   let bucketMinimalSetup;
   let bucketExtendedSetup;
-  let bucketExistingSetup;
+  let bucketExistingSimpleSetup;
+  let bucketExistingComplexSetup;
   const stage = 'dev';
 
   beforeAll(() => {
@@ -33,18 +35,26 @@ describe('AWS - S3 Integration Test', () => {
         config => {
           bucketMinimalSetup = `${config.service}-s3-minimal`;
           bucketExtendedSetup = `${config.service}-s3-extended`;
-          bucketExistingSetup = `${config.service}-s3-existing`;
+          bucketExistingSimpleSetup = `${config.service}-s3-existing-simple`;
+          bucketExistingComplexSetup = `${config.service}-s3-existing-complex`;
           config.functions.minimal.events[0].s3 = bucketMinimalSetup;
           config.functions.extended.events[0].s3.bucket = bucketExtendedSetup;
-          config.functions.existing.events[0].s3.bucket = bucketExistingSetup;
+          config.functions.existing.events[0].s3.bucket = bucketExistingSimpleSetup;
+          config.functions.existingCreated.events[0].s3.bucket = bucketExistingComplexSetup;
+          config.functions.existingCreated.events[1].s3.bucket = bucketExistingComplexSetup;
+          config.functions.existingRemoved.events[0].s3.bucket = bucketExistingComplexSetup;
+          config.functions.existingRemoved.events[1].s3.bucket = bucketExistingComplexSetup;
         },
     });
     serviceName = serverlessConfig.service;
     stackName = `${serviceName}-${stage}`;
-    // create an external S3 bucket
-    // NOTE: deployment can only be done once the S3 bucket is created
-    console.info(`Creating S3 bucket "${bucketExistingSetup}"...`);
-    return createBucket(bucketExistingSetup).then(() => {
+    // create external S3 buckets
+    // NOTE: deployment can only be done once the S3 buckets are created
+    console.info('Creating S3 buckets...');
+    return BbPromise.all([
+      createBucket(bucketExistingSimpleSetup),
+      createBucket(bucketExistingComplexSetup),
+    ]).then(() => {
       console.info(`Deploying "${stackName}" service...`);
       deployService();
     });
@@ -53,8 +63,11 @@ describe('AWS - S3 Integration Test', () => {
   afterAll(() => {
     console.info('Removing service...');
     removeService();
-    console.info(`Deleting S3 bucket "${bucketExistingSetup}"...`);
-    return deleteBucket(bucketExistingSetup);
+    console.info('Deleting S3 buckets');
+    return BbPromise.all([
+      deleteBucket(bucketExistingSimpleSetup),
+      deleteBucket(bucketExistingComplexSetup),
+    ]);
   });
 
   describe('Minimal Setup', () => {
@@ -90,18 +103,90 @@ describe('AWS - S3 Integration Test', () => {
   });
 
   describe('Existing Setup', () => {
-    it('should invoke function when an object is created', () => {
-      const functionName = 'existing';
-      const markers = getMarkers(functionName);
-      const expectedMessage = `Hello from S3! - (${functionName})`;
+    describe('Single fuction / single bucket setup', () => {
+      it('should invoke function when an object is created', () => {
+        const functionName = 'existing';
+        const markers = getMarkers(functionName);
+        const expectedMessage = `Hello from S3! - (${functionName})`;
 
-      return createAndRemoveInBucket(bucketExistingSetup, { prefix: 'Files/', suffix: '.TXT' })
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
-        .then(logs => {
-          expect(/aws:s3/g.test(logs)).to.equal(true);
-          expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
-          expect(logs.includes(expectedMessage)).to.equal(true);
-        });
+        return createAndRemoveInBucket(bucketExistingSimpleSetup, {
+          prefix: 'Files/',
+          suffix: '.TXT',
+        })
+          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(logs => {
+            expect(/aws:s3/g.test(logs)).to.equal(true);
+            expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
+            expect(logs.includes(expectedMessage)).to.equal(true);
+          });
+      });
+    });
+
+    describe('Multi function / multi bucket setup', () => {
+      it('should invoke function when a .jpg object is created', () => {
+        const functionName = 'existingCreated';
+        const markers = getMarkers(functionName);
+        const expectedMessage = `Hello from S3! - (${functionName})`;
+
+        return createAndRemoveInBucket(bucketExistingComplexSetup, {
+          prefix: 'photos',
+          suffix: '.jpg',
+        })
+          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(logs => {
+            expect(/aws:s3/g.test(logs)).to.equal(true);
+            expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
+            expect(logs.includes(expectedMessage)).to.equal(true);
+          });
+      });
+      it('should invoke function when a .jpg object is removed', () => {
+        const functionName = 'existingRemoved';
+        const markers = getMarkers(functionName);
+        const expectedMessage = `Hello from S3! - (${functionName})`;
+
+        return createAndRemoveInBucket(bucketExistingComplexSetup, {
+          prefix: 'photos',
+          suffix: '.jpg',
+        })
+          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(logs => {
+            expect(/aws:s3/g.test(logs)).to.equal(true);
+            expect(/ObjectRemoved:Delete/g.test(logs)).to.equal(true);
+            expect(logs.includes(expectedMessage)).to.equal(true);
+          });
+      });
+      it('should invoke function when a .png object is created', () => {
+        const functionName = 'existingCreated';
+        const markers = getMarkers(functionName);
+        const expectedMessage = `Hello from S3! - (${functionName})`;
+
+        return createAndRemoveInBucket(bucketExistingComplexSetup, {
+          prefix: 'photos',
+          suffix: '.png',
+        })
+          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(logs => {
+            expect(/aws:s3/g.test(logs)).to.equal(true);
+            expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
+            expect(logs.includes(expectedMessage)).to.equal(true);
+          });
+      });
+      it('should invoke function when a .png object is removed', () => {
+        const functionName = 'existingRemoved';
+        const markers = getMarkers(functionName);
+        const expectedMessage = `Hello from S3! - (${functionName})`;
+
+        return createAndRemoveInBucket(bucketExistingComplexSetup, {
+          prefix: 'photos',
+          suffix: '.png',
+        })
+          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(logs => {
+            expect(/aws:s3/g.test(logs)).to.equal(true);
+            expect(/ObjectRemoved:Delete/g.test(logs)).to.equal(true);
+            expect(logs.includes(expectedMessage)).to.equal(true);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #6461

Adds support to define multiple S3 events in one function.

## How did you implement it:

Fix it and write regression tests.

## How can we verify it:

Use the following `serverless.yml` file or run the S3 integration tests (which were updated as well).

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0
  bucket: serverless-existing-s3-bucket # replace this with your bucket name

functions:
  created:
    handler: handler.hello
    events:
      - s3:
          bucket: ${self:custom.bucket}
          events: s3:ObjectCreated:*
          rules:
            - suffix: .txt
            - prefix: files
          existing: true
      - s3:
          bucket: ${self:custom.bucket}
          events: s3:ObjectCreated:*
          rules:
            - suffix: .pdf
            - prefix: files
          existing: true
  removed:
    handler: handler.hello
    events:
      - s3:
          bucket: ${self:custom.bucket}
          event: s3:ObjectRemoved:*
          rules:
            - suffix: .txt
            - prefix: files
          existing: true
      - s3:
          bucket: ${self:custom.bucket}
          event: s3:ObjectRemoved:*
          rules:
            - suffix: .pdf
            - prefix: files
          existing: true
```

The easiest way is to run the integration tests for S3 buckets.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO