### PR TITLE
Fix invalid path char in GoLang packaging on Windows

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -113,7 +113,7 @@ module.exports = {
               )
             )
             .filter(f => f.runtime && f.runtime.startsWith('go'))
-            .map(f => f.handler);
+            .map(f => path.normalize(f.handler));
 
     return this.resolveFilePathsAll().then(filePaths =>
       this.zipFiles(filePaths, zipFileName, undefined, filesToChmodPlusX).then(filePath => {

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -113,7 +113,7 @@ module.exports = {
               )
             )
             .filter(f => f.runtime && f.runtime.startsWith('go'))
-            .map(f => path.normalize(f.handler));
+            .map(f => f.handler);
 
     return this.resolveFilePathsAll().then(filePaths =>
       this.zipFiles(filePaths, zipFileName, undefined, filesToChmodPlusX).then(filePath => {

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -25,7 +25,7 @@ describe('#packageService()', () => {
     packagePlugin.serverless.cli = new serverless.classes.CLI();
     packagePlugin.serverless.service.functions = {
       first: {
-        handler: 'foo/bar//foo\\bar\\\\foo',
+        handler: 'foo',
       },
     };
     packagePlugin.serverless.service.provider = { runtime: 'nodejs:8.10' };
@@ -346,7 +346,7 @@ describe('#packageService()', () => {
             expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
             expect(zipFilesStub).to.be.calledOnce,
             expect(zipFilesStub).to.have.been.calledWithExactly(files, zipFileName, undefined, [
-              path.normalize(serverless.service.functions[0].handler),
+              'foo',
             ]),
           ])
         );
@@ -367,8 +367,32 @@ describe('#packageService()', () => {
             expect(getIncludesStub).to.be.calledOnce,
             expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
             expect(zipFilesStub).to.be.calledOnce,
+            expect(zipFilesStub).to.have.been.calledWithExactly(files, zipFileName, undefined, []),
+          ])
+        );
+      }
+    );
+
+    (process.platfrom === 'win32' ? it : it.skip)(
+      'should normalize the handler path for go runtimes on win32',
+      () => {
+        serverless.service.functions.first.handler = 'foo/bar//foo\\bar\\\\foo';
+        serverless.service.provider.runtime = 'go1.x';
+
+        const servicePath = 'test';
+        const zipFileName = `${serverless.service.service}.zip`;
+
+        serverless.config.servicePath = servicePath;
+
+        return expect(packagePlugin.packageService()).to.be.fulfilled.then(() =>
+          BbPromise.all([
+            expect(getExcludesStub).to.be.calledOnce,
+            expect(getIncludesStub).to.be.calledOnce,
+            expect(serverless.service.functions.first),
+            expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
+            expect(zipFilesStub).to.be.calledOnce,
             expect(zipFilesStub).to.have.been.calledWithExactly(files, zipFileName, undefined, [
-              path.normalize(serverless.service.functions[0].handler),
+              path.normalize(serverless.service.functions.first.handler),
             ]),
           ])
         );

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -25,7 +25,7 @@ describe('#packageService()', () => {
     packagePlugin.serverless.cli = new serverless.classes.CLI();
     packagePlugin.serverless.service.functions = {
       first: {
-        handler: 'foo',
+        handler: 'foo/bar//foo\\bar\\\\foo',
       },
     };
     packagePlugin.serverless.service.provider = { runtime: 'nodejs:8.10' };
@@ -346,7 +346,7 @@ describe('#packageService()', () => {
             expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
             expect(zipFilesStub).to.be.calledOnce,
             expect(zipFilesStub).to.have.been.calledWithExactly(files, zipFileName, undefined, [
-              'foo',
+              path.normalize(serverless.service.functions[0].handler),
             ]),
           ])
         );
@@ -368,7 +368,7 @@ describe('#packageService()', () => {
             expect(resolveFilePathsFromPatternsStub).to.be.calledOnce,
             expect(zipFilesStub).to.be.calledOnce,
             expect(zipFilesStub).to.have.been.calledWithExactly(files, zipFileName, undefined, [
-              'foo',
+              path.normalize(serverless.service.functions[0].handler),
             ]),
           ])
         );


### PR DESCRIPTION
fix for https://github.com/serverless/serverless/issues/6482

## What did you implement:
Normalize paths before matching

Closes #6482

## How did you implement it:

I wrapped the paths in `path.normalize` 

## How can we verify it:

Deploy a Golang binary (built & packaged on Windows with linux as target) to AWS lambda and try to execute it.

## Todos:

None

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO

(This is my first contribution on Github ever, feedback is much appreciated)
