### PR TITLE
Multiple event definitions for existing Cognito User Pools

### DIFF
--- a/docs/providers/aws/events/cognito-user-pool.md
+++ b/docs/providers/aws/events/cognito-user-pool.md
@@ -78,6 +78,8 @@ functions:
 
 Sometimes you might want to attach Lambda functions to existing Cognito User Pools. In that case you just need to set the `existing` event configuration property to `true`. All the other config parameters can also be used on existing user pools:
 
+**IMPORTANT:** You can only attach 1 existing Cognito User Pool per function.
+
 **NOTE:** Using the `existing` config will add an additional Lambda function and IAM Role to your stack. The Lambda function backs-up the Custom Cognito User Pool Resource which is used to support existing user pools.
 
 ```yaml

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
@@ -16,7 +16,7 @@ function handler(event, context) {
 }
 
 function create(event, context) {
-  const { FunctionName, UserPoolName, UserPoolConfig } = event.ResourceProperties;
+  const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
   const { Region, AccountId } = getEnvironment(context);
 
   const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
@@ -32,7 +32,7 @@ function create(event, context) {
       updateConfiguration({
         lambdaArn,
         userPoolName: UserPoolName,
-        userPoolConfig: UserPoolConfig,
+        userPoolConfigs: UserPoolConfigs,
         region: Region,
       })
     )
@@ -41,14 +41,14 @@ function create(event, context) {
 
 function update(event, context) {
   const { Region, AccountId } = getEnvironment(context);
-  const { FunctionName, UserPoolName, UserPoolConfig } = event.ResourceProperties;
+  const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
 
   const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
 
   return updateConfiguration({
     lambdaArn,
     userPoolName: UserPoolName,
-    userPoolConfig: UserPoolConfig,
+    userPoolConfigs: UserPoolConfigs,
     region: Region,
   });
 }

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
@@ -42,7 +42,7 @@ function getConfiguration(config) {
 }
 
 function updateConfiguration(config) {
-  const { lambdaArn, userPoolConfig, region } = config;
+  const { lambdaArn, userPoolConfigs, region } = config;
   const cognito = new CognitoIdentityServiceProvider({ region });
 
   return getConfiguration(config).then(res => {
@@ -54,7 +54,9 @@ function updateConfiguration(config) {
       return accum;
     }, LambdaConfig);
 
-    LambdaConfig[userPoolConfig.Trigger] = lambdaArn;
+    userPoolConfigs.forEach(poolConfig => {
+      LambdaConfig[poolConfig.Trigger] = lambdaArn;
+    });
 
     return cognito.updateUserPool({ UserPoolId, LambdaConfig }).promise();
   });

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -485,8 +485,12 @@ module.exports = {
       )}`
     );
   },
-  getCustomResourceCognitoUserPoolResourceLogicalId(functionName, idx) {
-    return `${this.getNormalizedFunctionName(functionName)}CustomCognitoUserPool${idx}`;
+  getCustomResourceCognitoUserPoolResourceLogicalId(functionName) {
+    // NOTE: we have to keep the 1 at the end to ensure backwards compatibility
+    // previously we've used an index to allow the creation of multiple custom
+    // Cognito User Pool resources
+    // we're now using one resource to handle multiple Cognito User Pool event definitions
+    return `${this.getNormalizedFunctionName(functionName)}CustomCognitoUserPool1`;
   },
   // Event Bridge
   getCustomResourceEventBridgeHandlerFunctionName() {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -780,10 +780,9 @@ describe('#naming()', () => {
   describe('#getCustomResourceCognitoUserPoolResourceLogicalId()', () => {
     it('should return the logical id of the Cognito User Pool custom resouce', () => {
       const functionName = 'my-function';
-      const index = 1;
-      expect(
-        sdk.naming.getCustomResourceCognitoUserPoolResourceLogicalId(functionName, index)
-      ).to.equal('MyDashfunctionCustomCognitoUserPool1');
+      expect(sdk.naming.getCustomResourceCognitoUserPoolResourceLogicalId(functionName)).to.equal(
+        'MyDashfunctionCustomCognitoUserPool1'
+      );
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -108,56 +108,90 @@ class AwsCompileCognitoUserPoolEvents {
     const { service } = this.serverless;
     const { provider } = service;
     const { compiledCloudFormationTemplate } = provider;
+    const { Resources } = compiledCloudFormationTemplate;
     const iamRoleStatements = [];
 
+    // used to keep track of the custom resources created for each Cognito User Pool
+    const poolResources = {};
+
     service.getAllFunctions().forEach(functionName => {
+      let numEventsForFunc = 0;
+      let currentPoolName = null;
       let funcUsesExistingCognitoUserPool = false;
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
 
       if (functionObj.events) {
-        functionObj.events.forEach((event, idx) => {
+        functionObj.events.forEach(event => {
           if (event.cognitoUserPool && event.cognitoUserPool.existing) {
-            idx++;
+            numEventsForFunc++;
             const { pool, trigger } = event.cognitoUserPool;
             funcUsesExistingCognitoUserPool = true;
 
+            if (!currentPoolName) {
+              currentPoolName = pool;
+            }
+            if (pool !== currentPoolName) {
+              const errorMessage = [
+                'Only one Cognito User Pool can be configured per function.',
+                ` In "${FunctionName}" you're attempting to configure "${currentPoolName}" and "${pool}" at the same time.`,
+              ].join('');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
+
             const eventFunctionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const customResourceFunctionLogicalId = this.provider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
-            const customCognitoUserPoolResourceLogicalId = this.provider.naming.getCustomResourceCognitoUserPoolResourceLogicalId(
-              functionName,
-              idx
+            const customPoolResourceLogicalId = this.provider.naming.getCustomResourceCognitoUserPoolResourceLogicalId(
+              functionName
             );
 
-            const customCognitoUserPool = {
-              [customCognitoUserPoolResourceLogicalId]: {
-                Type: 'Custom::CognitoUserPool',
-                Version: 1.0,
-                DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
-                Properties: {
-                  ServiceToken: {
-                    'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
-                  },
-                  FunctionName,
-                  UserPoolName: pool,
-                  UserPoolConfig: {
-                    Trigger: trigger,
+            // store how often the custom Cognito User Pool resource is used
+            if (poolResources[pool]) {
+              poolResources[pool] = _.union(poolResources[pool], [customPoolResourceLogicalId]);
+            } else {
+              Object.assign(poolResources, {
+                [pool]: [customPoolResourceLogicalId],
+              });
+            }
+
+            let customCognitoUserPoolResource;
+            if (numEventsForFunc === 1) {
+              customCognitoUserPoolResource = {
+                [customPoolResourceLogicalId]: {
+                  Type: 'Custom::CognitoUserPool',
+                  Version: 1.0,
+                  DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                  Properties: {
+                    ServiceToken: {
+                      'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
+                    },
+                    FunctionName,
+                    UserPoolName: pool,
+                    UserPoolConfigs: [
+                      {
+                        Trigger: trigger,
+                      },
+                    ],
                   },
                 },
-              },
-            };
+              };
 
-            _.merge(compiledCloudFormationTemplate.Resources, customCognitoUserPool);
+              iamRoleStatements.push({
+                Effect: 'Allow',
+                Resource: '*',
+                Action: [
+                  'cognito-idp:ListUserPools',
+                  'cognito-idp:DescribeUserPool',
+                  'cognito-idp:UpdateUserPool',
+                ],
+              });
+            } else {
+              Resources[customPoolResourceLogicalId].Properties.UserPoolConfigs.push({
+                Trigger: trigger,
+              });
+            }
 
-            iamRoleStatements.push({
-              Effect: 'Allow',
-              Resource: '*',
-              Action: [
-                'cognito-idp:ListUserPools',
-                'cognito-idp:DescribeUserPool',
-                'cognito-idp:UpdateUserPool',
-              ],
-            });
+            _.merge(Resources, customCognitoUserPoolResource);
           }
         });
       }
@@ -170,6 +204,22 @@ class AwsCompileCognitoUserPoolEvents {
         });
       }
     });
+
+    // check if we need to add DependsOn clauses in case more than 1
+    // custom resources are created for one Cognito User Pool (to avoid race conditions)
+    if (Object.keys(poolResources).length > 0) {
+      Object.keys(poolResources).forEach(pool => {
+        const resources = poolResources[pool];
+        if (resources.length > 1) {
+          resources.forEach((currResourceLogicalId, idx) => {
+            if (idx > 0) {
+              const prevResourceLogicalId = resources[idx - 1];
+              Resources[currResourceLogicalId].DependsOn.push(prevResourceLogicalId);
+            }
+          });
+        }
+      });
+    }
 
     if (iamRoleStatements.length) {
       return addCustomResourceToService.call(this, 'cognitoUserPool', iamRoleStatements);

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
@@ -368,6 +368,22 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
 
         expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
         expect(addCustomResourceToServiceStub.args[0][1]).to.equal('cognitoUserPool');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: [
+              'cognito-idp:ListUserPools',
+              'cognito-idp:DescribeUserPool',
+              'cognito-idp:UpdateUserPool',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: 'arn:aws:lambda:*:*:function:first',
+          },
+        ]);
         expect(Resources.FirstCustomCognitoUserPool1).to.deep.equal({
           Type: 'Custom::CognitoUserPool',
           Version: 1,
@@ -378,12 +394,272 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             },
             FunctionName: 'first',
             UserPoolName: 'existing-cognito-user-pool',
-            UserPoolConfig: {
-              Trigger: 'CustomMessage',
-            },
+            UserPoolConfigs: [
+              {
+                Trigger: 'CustomMessage',
+              },
+            ],
           },
         });
       });
+    });
+
+    it('should create the necessary resources for a service using multiple event definitions', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'CustomMessage',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'PreSignUp',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'DefineAuthChallenge',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(
+        awsCompileCognitoUserPoolEvents.existingCognitoUserPools()
+      ).to.be.fulfilled.then(() => {
+        const {
+          Resources,
+        } = awsCompileCognitoUserPoolEvents.serverless.service.provider.compiledCloudFormationTemplate;
+
+        expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+        expect(addCustomResourceToServiceStub.args[0][1]).to.equal('cognitoUserPool');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: [
+              'cognito-idp:ListUserPools',
+              'cognito-idp:DescribeUserPool',
+              'cognito-idp:UpdateUserPool',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: 'arn:aws:lambda:*:*:function:first',
+          },
+        ]);
+        expect(Resources.FirstCustomCognitoUserPool1).to.deep.equal({
+          Type: 'Custom::CognitoUserPool',
+          Version: 1,
+          DependsOn: ['FirstLambdaFunction', 'CustomDashresourceDashexistingDashcupLambdaFunction'],
+          Properties: {
+            ServiceToken: {
+              'Fn::GetAtt': ['CustomDashresourceDashexistingDashcupLambdaFunction', 'Arn'],
+            },
+            FunctionName: 'first',
+            UserPoolName: 'existing-cognito-user-pool',
+            UserPoolConfigs: [
+              {
+                Trigger: 'CustomMessage',
+              },
+              {
+                Trigger: 'PreSignUp',
+              },
+              {
+                Trigger: 'DefineAuthChallenge',
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    it('should create DependsOn clauses when one cognito user pool is used in more than 1 custom resources', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'CustomMessage',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'PreSignUp',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'DefineAuthChallenge',
+                existing: true,
+              },
+            },
+          ],
+        },
+        second: {
+          name: 'second',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'PostConfirmation',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'PreAuthentication',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'PostAuthentication',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(
+        awsCompileCognitoUserPoolEvents.existingCognitoUserPools()
+      ).to.be.fulfilled.then(() => {
+        const {
+          Resources,
+        } = awsCompileCognitoUserPoolEvents.serverless.service.provider.compiledCloudFormationTemplate;
+
+        expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+        expect(addCustomResourceToServiceStub.args[0][1]).to.equal('cognitoUserPool');
+        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+          {
+            Action: [
+              'cognito-idp:ListUserPools',
+              'cognito-idp:DescribeUserPool',
+              'cognito-idp:UpdateUserPool',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: 'arn:aws:lambda:*:*:function:first',
+          },
+          {
+            Action: [
+              'cognito-idp:ListUserPools',
+              'cognito-idp:DescribeUserPool',
+              'cognito-idp:UpdateUserPool',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: 'arn:aws:lambda:*:*:function:second',
+          },
+        ]);
+        expect(Object.keys(Resources)).to.have.length(2);
+        expect(Resources.FirstCustomCognitoUserPool1).to.deep.equal({
+          Type: 'Custom::CognitoUserPool',
+          Version: 1,
+          DependsOn: ['FirstLambdaFunction', 'CustomDashresourceDashexistingDashcupLambdaFunction'],
+          Properties: {
+            ServiceToken: {
+              'Fn::GetAtt': ['CustomDashresourceDashexistingDashcupLambdaFunction', 'Arn'],
+            },
+            FunctionName: 'first',
+            UserPoolName: 'existing-cognito-user-pool',
+            UserPoolConfigs: [
+              {
+                Trigger: 'CustomMessage',
+              },
+              {
+                Trigger: 'PreSignUp',
+              },
+              {
+                Trigger: 'DefineAuthChallenge',
+              },
+            ],
+          },
+        });
+        expect(Resources.SecondCustomCognitoUserPool1).to.deep.equal({
+          Type: 'Custom::CognitoUserPool',
+          Version: 1,
+          DependsOn: [
+            'SecondLambdaFunction',
+            'CustomDashresourceDashexistingDashcupLambdaFunction',
+            'FirstCustomCognitoUserPool1',
+          ],
+          Properties: {
+            ServiceToken: {
+              'Fn::GetAtt': ['CustomDashresourceDashexistingDashcupLambdaFunction', 'Arn'],
+            },
+            FunctionName: 'second',
+            UserPoolName: 'existing-cognito-user-pool',
+            UserPoolConfigs: [
+              {
+                Trigger: 'PostConfirmation',
+              },
+              {
+                Trigger: 'PreAuthentication',
+              },
+              {
+                Trigger: 'PostAuthentication',
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    it('should throw if more than 1 Cognito User Pool is configured per function', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool',
+                trigger: 'CustomMessage',
+                existing: true,
+              },
+            },
+            {
+              cognitoUserPool: {
+                pool: 'existing-cognito-user-pool-2',
+                trigger: 'PreSignUp',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(() => awsCompileCognitoUserPoolEvents.existingCognitoUserPools()).to.throw(
+        'Only one Cognito User Pool'
+      );
     });
   });
 

--- a/tests/integration-all/cognito-user-pool/service/core.js
+++ b/tests/integration-all/cognito-user-pool/service/core.js
@@ -13,8 +13,8 @@ function basic(event, context, callback) {
   return callback(null, nextEvent);
 }
 
-function existing(event, context, callback) {
-  const functionName = 'existing';
+function existingSimple(event, context, callback) {
+  const functionName = 'existingSimple';
   const nextEvent = Object.assign({}, event);
   nextEvent.response.autoConfirmUser = true;
 
@@ -22,4 +22,11 @@ function existing(event, context, callback) {
   return callback(null, nextEvent);
 }
 
-module.exports = { basic, existing };
+function existingMulti(event, context, callback) {
+  const functionName = 'existingMulti';
+
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { basic, existingSimple, existingMulti };

--- a/tests/integration-all/cognito-user-pool/service/serverless.yml
+++ b/tests/integration-all/cognito-user-pool/service/serverless.yml
@@ -12,10 +12,22 @@ functions:
       - cognitoUserPool:
           pool: CHANGE_TO_UNIQUE_PER_RUN
           trigger: PreSignUp
-  existing:
-    handler: core.existing
+  existingSimple:
+    handler: core.existingSimple
     events:
       - cognitoUserPool:
           pool: CHANGE_TO_UNIQUE_PER_RUN
           trigger: PreSignUp
+          existing: true
+  # testing if two functions share one cognito user pool with multiple configs
+  existingMulti:
+    handler: core.existingMulti
+    events:
+      - cognitoUserPool:
+          pool: CHANGE_TO_UNIQUE_PER_RUN
+          trigger: PreSignUp
+          existing: true
+      - cognitoUserPool:
+          pool: CHANGE_TO_UNIQUE_PER_RUN
+          trigger: PreAuthentication
           existing: true

--- a/tests/utils/cognito/index.js
+++ b/tests/utils/cognito/index.js
@@ -9,6 +9,17 @@ function createUserPool(name) {
   return cognito.createUserPool({ PoolName: name }).promise();
 }
 
+function createUserPoolClient(name, userPoolId) {
+  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
+
+  const params = {
+    ClientName: name,
+    UserPoolId: userPoolId,
+    ExplicitAuthFlows: ['USER_PASSWORD_AUTH'],
+  };
+  return cognito.createUserPoolClient(params).promise();
+}
+
 function deleteUserPool(name) {
   const cognito = new AWS.CognitoIdentityServiceProvider({ region });
 
@@ -53,9 +64,38 @@ function createUser(userPoolId, username, password) {
   return cognito.adminCreateUser(params).promise();
 }
 
+function setUserPassword(userPoolId, username, password) {
+  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
+
+  const params = {
+    UserPoolId: userPoolId,
+    Username: username,
+    Password: password,
+    Permanent: true,
+  };
+  return cognito.adminSetUserPassword(params).promise();
+}
+
+function initiateAuth(clientId, username, password) {
+  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
+
+  const params = {
+    ClientId: clientId,
+    AuthFlow: 'USER_PASSWORD_AUTH',
+    AuthParameters: {
+      USERNAME: username,
+      PASSWORD: password,
+    },
+  };
+  return cognito.initiateAuth(params).promise();
+}
+
 module.exports = {
   createUserPool: persistentRequest.bind(this, createUserPool),
   deleteUserPool: persistentRequest.bind(this, deleteUserPool),
   findUserPoolByName: persistentRequest.bind(this, findUserPoolByName),
+  createUserPoolClient: persistentRequest.bind(this, createUserPoolClient),
   createUser: persistentRequest.bind(this, createUser),
+  setUserPassword: persistentRequest.bind(this, setUserPassword),
+  initiateAuth: persistentRequest.bind(this, initiateAuth),
 };


### PR DESCRIPTION
## What did you implement:

Closes #6420 

Adds support to define multiple Cognito User Pool events in one function.

## How did you implement it:

Fix it and write regression tests.

## How can we verify it:

Use the following serverless.yml file or run the Cognito User Pool integration tests (which were updated as well).

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0
  pool: ExistingUserPool

functions:
  pre:
    handler: handler.hello
    events:
      - cognitoUserPool:
          pool: ${self:custom.pool}
          trigger: PreSignUp
          existing: true
      - cognitoUserPool:
          pool: ${self:custom.pool}
          trigger: DefineAuthChallenge
          existing: true
  post:
    handler: handler.hello
    events:
      - cognitoUserPool:
          pool: ${self:custom.pool}
          trigger: CreateAuthChallenge
          existing: true
      - cognitoUserPool:
          pool: ${self:custom.pool}
          trigger: VerifyAuthChallengeResponse
          existing: true
```

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO
