### PR TITLE
Remove Enterprise and Platform from log info

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -329,9 +329,7 @@ class CLI {
   }
 
   getVersionNumber() {
-    this.consoleLog(
-      `${version} (Plugin: ${enterpriseVersion}, SDK: ${sdkVersion})`
-    );
+    this.consoleLog(`${version} (Plugin: ${enterpriseVersion}, SDK: ${sdkVersion})`);
   }
 
   asciiGreeting() {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -330,7 +330,7 @@ class CLI {
 
   getVersionNumber() {
     this.consoleLog(
-      `${version} (Enterprise Plugin: ${enterpriseVersion}, Platform SDK: ${sdkVersion})`
+      `${version} (Plugin: ${enterpriseVersion}, SDK: ${sdkVersion})`
     );
   }
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -329,7 +329,9 @@ class CLI {
   }
 
   getVersionNumber() {
-    this.consoleLog(`${version} (Plugin: ${enterpriseVersion}, SDK: ${sdkVersion})`);
+    this.consoleLog(
+      `Framework Core: ${version}\nPlugin: ${enterpriseVersion}\nSDK: ${sdkVersion}\n`
+    );
   }
 
   asciiGreeting() {

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -449,8 +449,8 @@ describe('CLI', () => {
 
       expect(consoleLogSpy).to.have.been.calledOnce;
       expect(consoleLogSpy.args[0][0]).to.match(/[0-9]+\.[0-9]+\.[0-9]+ .+/);
-      expect(consoleLogSpy.args[0][0]).to.include('Enterprise Plugin');
-      expect(consoleLogSpy.args[0][0]).to.include('Platform SDK');
+      expect(consoleLogSpy.args[0][0]).to.include('Plugin');
+      expect(consoleLogSpy.args[0][0]).to.include('SDK');
     });
   });
 

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -448,7 +448,7 @@ describe('CLI', () => {
       cli.getVersionNumber();
 
       expect(consoleLogSpy).to.have.been.calledOnce;
-      expect(consoleLogSpy.args[0][0]).to.match(/[0-9]+\.[0-9]+\.[0-9]+ .+/);
+      expect(consoleLogSpy.args[0][0]).to.include('Framework Core');
       expect(consoleLogSpy.args[0][0]).to.include('Plugin');
       expect(consoleLogSpy.args[0][0]).to.include('SDK');
     });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Removed `Enterprise` and `Platform` from logline

## How did you implement it:
With the `delete` key.

## How can we verify it:
run `serverless -v` against this branch, or require this class in a node console and run `getVersionNumber()`
![image](https://user-images.githubusercontent.com/1598537/62467568-ae8d9f00-b759-11e9-94d4-d0ba0a3674f5.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
