### PR TITLE
Improve error handling

### DIFF
--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -28,6 +28,8 @@ if (process.env.SLS_DEBUG) {
   });
 }
 
+process.on('uncaughtException', error => logError(error, { forceExit: true }));
+
 process.on('unhandledRejection', logError);
 
 require('../lib/utils/tracking').sendPending();

--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -59,14 +59,15 @@ initializeErrorReporter(invocationId).then(() => {
         }
       });
       if (!enterpriseErrorHandler) {
-        throw err;
+        logError(err);
+        return null;
       }
       return enterpriseErrorHandler(err, invocationId)
         .catch(error => {
           process.stdout.write(`${error.stack}\n`);
         })
         .then(() => {
-          throw err;
+          logError(err);
         });
     });
 });

--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -30,7 +30,13 @@ if (process.env.SLS_DEBUG) {
 
 process.on('uncaughtException', error => logError(error, { forceExit: true }));
 
-process.on('unhandledRejection', logError);
+process.on('unhandledRejection', error => {
+  if (process.listenerCount('unhandledRejection') > 1) {
+    // User attached its own unhandledRejection handler, abort
+    return;
+  }
+  throw error;
+});
 
 require('../lib/utils/tracking').sendPending();
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -58,9 +58,11 @@ module.exports.ServerlessError = class ServerlessError extends Error {
 // Deprecated - use ServerlessError instead
 module.exports.SError = module.exports.ServerlessError;
 
+const userErrorNames = new Set(['ServerlessError', 'YAMLException']);
+
 module.exports.logError = (exception, { forceExit = false } = {}) => {
   const exceptionMeta = resolveExceptionMeta(exception);
-  const isUserError = exceptionMeta.name === 'ServerlessError';
+  const isUserError = userErrorNames.has(exceptionMeta.name);
 
   const possiblyExit = () => {
     if (forceExit) process.exit();

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -2,6 +2,7 @@
 
 const chalk = require('chalk');
 const { inspect } = require('util');
+const { isError } = require('lodash');
 const version = require('./../../package.json').version;
 const sfeVersion = require('@serverless/enterprise-plugin/package.json').version;
 const { sdkVersion } = require('@serverless/enterprise-plugin');
@@ -10,6 +11,21 @@ const errorReporter = require('../utils/sentry').raven;
 
 const consoleLog = message => {
   console.log(message); // eslint-disable-line no-console
+};
+
+const resolveExceptionMeta = exception => {
+  if (isError(exception)) {
+    return {
+      name: exception.name,
+      title: exception.name.replace(/([A-Z])/g, ' $1'),
+      stack: exception.stack,
+      message: exception.message,
+    };
+  }
+  return {
+    title: 'Exception',
+    message: inspect(exception),
+  };
 };
 
 const writeMessage = (title, message) => {
@@ -43,56 +59,50 @@ module.exports.ServerlessError = class ServerlessError extends Error {
 module.exports.SError = module.exports.ServerlessError;
 
 module.exports.logError = exception => {
-  try {
-    const errorType = exception.name.replace(/([A-Z])/g, ' $1');
+  const exceptionMeta = resolveExceptionMeta(exception);
 
-    writeMessage(errorType, exception.message);
+  writeMessage(exceptionMeta.title, exceptionMeta.message);
 
-    if (exception.name !== 'ServerlessError') {
-      const debugInfo = [
-        '    ',
-        ' For debugging logs, run again after setting the',
-        ' "SLS_DEBUG=*" environment variable.',
-      ].join('');
-      consoleLog(chalk.red(debugInfo));
-      consoleLog(' ');
-    }
-
-    if (process.env.SLS_DEBUG) {
-      consoleLog(chalk.yellow('  Stack Trace --------------------------------------------'));
-      consoleLog(' ');
-      consoleLog(exception.stack);
-      consoleLog(' ');
-    }
-
-    const platform = process.platform;
-    const nodeVersion = process.version.replace(/^[v|V]/, '');
-    const slsVersion = version;
-
-    consoleLog(chalk.yellow('  Get Support --------------------------------------------'));
-    consoleLog(`${chalk.yellow('     Docs:          ')}${'docs.serverless.com'}`);
-    consoleLog(
-      `${chalk.yellow('     Bugs:          ')}${'github.com/serverless/serverless/issues'}`
-    );
-    consoleLog(`${chalk.yellow('     Issues:        ')}${'forum.serverless.com'}`);
-
+  if (exceptionMeta.name !== 'ServerlessError') {
+    const debugInfo = [
+      '    ',
+      ' For debugging logs, run again after setting the',
+      ' "SLS_DEBUG=*" environment variable.',
+    ].join('');
+    consoleLog(chalk.red(debugInfo));
     consoleLog(' ');
-    consoleLog(chalk.yellow('  Your Environment Information ---------------------------'));
-    consoleLog(chalk.yellow(`     Operating System:          ${platform}`));
-    consoleLog(chalk.yellow(`     Node Version:              ${nodeVersion}`));
-    consoleLog(chalk.yellow(`     Serverless Version:        ${slsVersion}`));
-    consoleLog(chalk.yellow(`     Enterprise Plugin Version: ${sfeVersion}`));
-    consoleLog(chalk.yellow(`     Platform SDK Version:      ${sdkVersion}`));
-    consoleLog(' ');
-
-    process.exitCode = 1;
-    // Exit early for users who have opted out of tracking
-    if (!errorReporter.installed) return;
-    // report error to sentry.
-    errorReporter.captureException(exception, () => {});
-  } catch (errorHandlingError) {
-    throw new Error(inspect(exception));
   }
+
+  if (process.env.SLS_DEBUG && exceptionMeta.stack) {
+    consoleLog(chalk.yellow('  Stack Trace --------------------------------------------'));
+    consoleLog(' ');
+    consoleLog(exceptionMeta.stack);
+    consoleLog(' ');
+  }
+
+  const platform = process.platform;
+  const nodeVersion = process.version.replace(/^[v|V]/, '');
+  const slsVersion = version;
+
+  consoleLog(chalk.yellow('  Get Support --------------------------------------------'));
+  consoleLog(`${chalk.yellow('     Docs:          ')}${'docs.serverless.com'}`);
+  consoleLog(`${chalk.yellow('     Bugs:          ')}${'github.com/serverless/serverless/issues'}`);
+  consoleLog(`${chalk.yellow('     Issues:        ')}${'forum.serverless.com'}`);
+
+  consoleLog(' ');
+  consoleLog(chalk.yellow('  Your Environment Information ---------------------------'));
+  consoleLog(chalk.yellow(`     Operating System:          ${platform}`));
+  consoleLog(chalk.yellow(`     Node Version:              ${nodeVersion}`));
+  consoleLog(chalk.yellow(`     Serverless Version:        ${slsVersion}`));
+  consoleLog(chalk.yellow(`     Enterprise Plugin Version: ${sfeVersion}`));
+  consoleLog(chalk.yellow(`     Platform SDK Version:      ${sdkVersion}`));
+  consoleLog(' ');
+
+  process.exitCode = 1;
+  // Exit early for users who have opted out of tracking
+  if (!errorReporter.installed) return;
+  // report error to sentry.
+  errorReporter.captureException(exception, () => {});
 };
 
 module.exports.logWarning = message => {

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -60,10 +60,11 @@ module.exports.SError = module.exports.ServerlessError;
 
 module.exports.logError = exception => {
   const exceptionMeta = resolveExceptionMeta(exception);
+  const isUserError = exceptionMeta.name === 'ServerlessError';
 
   writeMessage(exceptionMeta.title, exceptionMeta.message);
 
-  if (exceptionMeta.name !== 'ServerlessError' && !process.env.SLS_DEBUG) {
+  if (!isUserError && !process.env.SLS_DEBUG) {
     const debugInfo = [
       '    ',
       ' For debugging logs, run again after setting the',

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -58,9 +58,13 @@ module.exports.ServerlessError = class ServerlessError extends Error {
 // Deprecated - use ServerlessError instead
 module.exports.SError = module.exports.ServerlessError;
 
-module.exports.logError = exception => {
+module.exports.logError = (exception, { forceExit = false } = {}) => {
   const exceptionMeta = resolveExceptionMeta(exception);
   const isUserError = exceptionMeta.name === 'ServerlessError';
+
+  const possiblyExit = () => {
+    if (forceExit) process.exit();
+  };
 
   writeMessage(exceptionMeta.title, exceptionMeta.message);
 
@@ -101,9 +105,12 @@ module.exports.logError = exception => {
 
   process.exitCode = 1;
   // Exit early for users who have opted out of tracking
-  if (!errorReporter.installed) return;
+  if (!errorReporter.installed) {
+    possiblyExit();
+    return;
+  }
   // report error to sentry.
-  errorReporter.captureException(exception, () => {});
+  errorReporter.captureException(exception, possiblyExit);
 };
 
 module.exports.logWarning = message => {

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -63,7 +63,7 @@ module.exports.logError = exception => {
 
   writeMessage(exceptionMeta.title, exceptionMeta.message);
 
-  if (exceptionMeta.name !== 'ServerlessError') {
+  if (exceptionMeta.name !== 'ServerlessError' && !process.env.SLS_DEBUG) {
     const debugInfo = [
       '    ',
       ' For debugging logs, run again after setting the',

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -66,7 +66,12 @@ module.exports.logError = (exception, { forceExit = false } = {}) => {
     if (forceExit) process.exit();
   };
 
-  writeMessage(exceptionMeta.title, exceptionMeta.message);
+  writeMessage(
+    exceptionMeta.title,
+    exceptionMeta.stack && (!isUserError || process.env.SLS_DEBUG)
+      ? exceptionMeta.stack
+      : exceptionMeta.message
+  );
 
   if (!isUserError && !process.env.SLS_DEBUG) {
     const debugInfo = [
@@ -75,13 +80,6 @@ module.exports.logError = (exception, { forceExit = false } = {}) => {
       ' "SLS_DEBUG=*" environment variable.',
     ].join('');
     consoleLog(chalk.red(debugInfo));
-    consoleLog(' ');
-  }
-
-  if (exceptionMeta.stack && (!isUserError || process.env.SLS_DEBUG)) {
-    consoleLog(chalk.yellow('  Stack Trace --------------------------------------------'));
-    consoleLog(' ');
-    consoleLog(exceptionMeta.stack);
     consoleLog(' ');
   }
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -42,13 +42,13 @@ module.exports.ServerlessError = class ServerlessError extends Error {
 // Deprecated - use ServerlessError instead
 module.exports.SError = module.exports.ServerlessError;
 
-module.exports.logError = e => {
+module.exports.logError = exception => {
   try {
-    const errorType = e.name.replace(/([A-Z])/g, ' $1');
+    const errorType = exception.name.replace(/([A-Z])/g, ' $1');
 
-    writeMessage(errorType, e.message);
+    writeMessage(errorType, exception.message);
 
-    if (e.name !== 'ServerlessError') {
+    if (exception.name !== 'ServerlessError') {
       const errorMessage = [
         '    ',
         ' For debugging logs, run again after setting the',
@@ -61,7 +61,7 @@ module.exports.logError = e => {
     if (process.env.SLS_DEBUG) {
       consoleLog(chalk.yellow('  Stack Trace --------------------------------------------'));
       consoleLog(' ');
-      consoleLog(e.stack);
+      consoleLog(exception.stack);
       consoleLog(' ');
     }
 
@@ -89,9 +89,9 @@ module.exports.logError = e => {
     // Exit early for users who have opted out of tracking
     if (!errorReporter.installed) return;
     // report error to sentry.
-    errorReporter.captureException(e, () => {});
+    errorReporter.captureException(exception, () => {});
   } catch (errorHandlingError) {
-    throw new Error(inspect(e));
+    throw new Error(inspect(exception));
   }
 };
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -49,12 +49,12 @@ module.exports.logError = exception => {
     writeMessage(errorType, exception.message);
 
     if (exception.name !== 'ServerlessError') {
-      const errorMessage = [
+      const debugInfo = [
         '    ',
         ' For debugging logs, run again after setting the',
         ' "SLS_DEBUG=*" environment variable.',
       ].join('');
-      consoleLog(chalk.red(errorMessage));
+      consoleLog(chalk.red(debugInfo));
       consoleLog(' ');
     }
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -12,14 +12,14 @@ const consoleLog = message => {
   console.log(message); // eslint-disable-line no-console
 };
 
-const writeMessage = (messageType, message) => {
+const writeMessage = (title, message) => {
   let line = '';
-  while (line.length < 56 - messageType.length) {
+  while (line.length < 56 - title.length) {
     line = `${line}-`;
   }
 
   consoleLog(' ');
-  consoleLog(chalk.yellow(` ${messageType} ${line}`));
+  consoleLog(chalk.yellow(` ${title} ${line}`));
   consoleLog(' ');
 
   if (message) {

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -74,7 +74,7 @@ module.exports.logError = exception => {
     consoleLog(' ');
   }
 
-  if (process.env.SLS_DEBUG && exceptionMeta.stack) {
+  if (exceptionMeta.stack && (!isUserError || process.env.SLS_DEBUG)) {
     consoleLog(chalk.yellow('  Stack Trace --------------------------------------------'));
     consoleLog(' ');
     consoleLog(exceptionMeta.stack);

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -98,9 +98,9 @@ module.exports.logError = (exception, { forceExit = false } = {}) => {
   consoleLog(chalk.yellow('  Your Environment Information ---------------------------'));
   consoleLog(chalk.yellow(`     Operating System:          ${platform}`));
   consoleLog(chalk.yellow(`     Node Version:              ${nodeVersion}`));
-  consoleLog(chalk.yellow(`     Serverless Version:        ${slsVersion}`));
-  consoleLog(chalk.yellow(`     Enterprise Plugin Version: ${sfeVersion}`));
-  consoleLog(chalk.yellow(`     Platform SDK Version:      ${sdkVersion}`));
+  consoleLog(chalk.yellow(`     Framework Version:         ${slsVersion}`));
+  consoleLog(chalk.yellow(`     Plugin Version:            ${sfeVersion}`));
+  consoleLog(chalk.yellow(`     SDK Version:               ${sdkVersion}`));
   consoleLog(' ');
 
   process.exitCode = 1;

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -100,9 +100,9 @@ describe('Error', () => {
       expect(message).to.have.string('Your Environment Information');
       expect(message).to.have.string('Operating System:');
       expect(message).to.have.string('Node Version:');
-      expect(message).to.have.string('Serverless Version:');
-      expect(message).to.have.string('Enterprise Plugin Version:');
-      expect(message).to.have.string('Platform SDK Version:');
+      expect(message).to.have.string('Framework Version:');
+      expect(message).to.have.string('Plugin Version:');
+      expect(message).to.have.string('SDK Version:');
     });
 
     it('should capture the exception and exit the process with 1 if errorReporter is setup', () => {

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -145,7 +145,6 @@ describe('Error', () => {
       const message = consoleLogSpy.args.join('\n');
 
       expect(consoleLogSpy.called).to.equal(true);
-      expect(message).to.have.string('Stack Trace');
       expect(message).to.have.string(error.stack);
     });
 

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -160,15 +160,11 @@ describe('Error', () => {
       expect(message).to.not.have.string(error.stack);
     });
 
-    it('should re-throw error when handling raises an exception itself', () => {
-      let thrownError = null;
-      try {
-        logError('INVALID INPUT');
-      } catch (e) {
-        thrownError = e;
-      }
+    it('should handle non-error objects', () => {
+      logError('NON-ERROR INPUT');
+      const message = consoleLogSpy.args.join('\n');
 
-      expect(thrownError.message).to.equal("'INVALID INPUT'");
+      expect(message).to.have.string('NON-ERROR INPUT');
     });
   });
 


### PR DESCRIPTION
- Do not pass _handled_ errors via _unhandled rejections_ channel - it's a logic error, that's also  indirect cause of #6441 
- Use default error logging for _uncaught exceptions_, but ensure process exits immediately after report is made (improves UX)
- Propagate _unhandled rejections_ as _uncaught excpeptions_ but only if no other _unhandled rejection_ handlers were registered (it's to resemble eventual future Node.js behavior, and to allow users to opt out from this handling - related issue: https://github.com/dherault/serverless-offline/issues/255)
- Use default error logging for non error exceptions (improves UX)  
   _~~(Note: here to distinguish error instances I decided to rely on `type/error/is`, which makes it a new dependency. It's the best way known to me to detect a native error, and dependency on it's own is light (has no other deps), and has many other useful type validation utils which we may want to rely on. [It's also already used in `@serverless/enterprise-plugin`](https://github.com/serverless/enterprise-plugin/pull/191#discussion_r302853461))~~_
- Do not show `SLS_DEBUG=*` suggestion when it's already used
- Unconditionally expose stack trace for non user errors (so not `ServerlessError`'s, and others we recognize)  _(If they happen they're definitely a result of bug, and it'll be good to have stack trace provided in issue reports)_
- Improve variable naming

**_Is it a breaking change?:_** NO
