### PR TITLE
Check if more than 1 existing bucket is configured

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -208,6 +208,7 @@ class AwsCompileS3Events {
 
     service.getAllFunctions().forEach(functionName => {
       let numEventsForFunc = 0;
+      let currentBucketName = null;
       let funcUsesExistingS3Bucket = false;
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
@@ -220,6 +221,17 @@ class AwsCompileS3Events {
             const bucket = event.s3.bucket;
             const notificationEvent = event.s3.event || 's3:ObjectCreated:*';
             funcUsesExistingS3Bucket = true;
+
+            if (!currentBucketName) {
+              currentBucketName = bucket;
+            }
+            if (bucket !== currentBucketName) {
+              const errorMessage = [
+                'Only one S3 Bucket can be configured per function.',
+                ` In "${FunctionName}" you're attempting to configure "${currentBucketName}" and "${bucket}" at the same time.`,
+              ].join('');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
 
             rules = _.map(event.s3.rules, rule => {
               const key = Object.keys(rule)[0];

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -741,5 +741,29 @@ describe('AwsCompileS3Events', () => {
         });
       });
     });
+
+    it('should throw if more than 1 S3 bucket is configured per function', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          name: 'second',
+          events: [
+            {
+              s3: {
+                bucket: 'existing-s3-bucket',
+                existing: true,
+              },
+            },
+            {
+              s3: {
+                bucket: 'existing-s3-bucket-2',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(() => awsCompileS3Events.existingS3Buckets()).to.throw('Only one S3 Bucket');
+    });
   });
 });


### PR DESCRIPTION
What did you implement:

Adds a check if more than 1 S3 bucket is being configured.

Related to changes made in #6491

## How did you implement it:

Track S3 bucket names while compiling CloudFormation resources.

## How can we verify it:

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0
  bucket: serverless-existing-s3-bucket

functions:
  created:
    handler: handler.hello
    events:
      - s3:
          bucket: ${self:custom.bucket}
          existing: true
      - s3:
          bucket: ${self:custom.bucket}-2
          existing: true
```

should throw, while the following doesn't:

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0
  bucket: serverless-existing-s3-bucket

functions:
  created:
    handler: handler.hello
    events:
      - s3:
          bucket: ${self:custom.bucket}
          existing: true
      - s3:
          bucket: ${self:custom.bucket}
          existing: true
```

You might also look into the added test case.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO