### PR TITLE
Add PreTokenGeneration & UserMigration Cognito triggers

### DIFF
--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -9,10 +9,12 @@ const validTriggerSources = [
   'PostConfirmation',
   'PreAuthentication',
   'PostAuthentication',
+  'PreTokenGeneration',
   'CustomMessage',
   'DefineAuthChallenge',
   'CreateAuthChallenge',
   'VerifyAuthChallengeResponse',
+  'UserMigration',
 ];
 
 class AwsCompileCognitoUserPoolEvents {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #5513 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added PreTokenGeneration & UserMigration triggers to the validTriggerSources since CloudFormation already supports [it](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html):

```js
const validTriggerSources = [
  'PreSignUp',
  'PostConfirmation',
  'PreAuthentication',
  'PostAuthentication',
  'PreTokenGeneration',
  'CustomMessage',
  'DefineAuthChallenge',
  'CreateAuthChallenge',
  'VerifyAuthChallengeResponse',
  'UserMigration',
];
```

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

1. Bootstrap Serverless framework project.
2. Add the following code to `serverless.yml`:

```yaml
service:
  name: testservicename
custom:
  stage: ${opt:stage, 'dev'}
  region: ${opt:region, 'eu-central-1'}
provider:
  name: aws
  runtime: nodejs10.x
  stage: ${self:custom.stage}
  region: ${self:custom.region}
functions:
  user-migration:
    handler: user-migration.handler
    events:
      - cognitoUserPool:
          pool: ${self:service.name}-${self:custom.stage}-user-pool
          trigger: UserMigration
          existing: true
  pre-token-generation:
    handler: pre-token-generation.handler
    events:
      - cognitoUserPool:
          pool: ${self:service.name}-${self:custom.stage}-user-pool
          trigger: PreTokenGeneration
          existing: true
resources:
  Resources:
    CognitoUserPool:
      Type: AWS::Cognito::UserPool
      Properties:
        UserPoolName: ${self:service.name}-${self:custom.stage}-user-pool
        UsernameAttributes:
          - email
        AutoVerifiedAttributes:
          - email

    CognitoUserPoolClient:
      Type: AWS::Cognito::UserPoolClient
      Properties:
        ClientName: ${self:service.name}-${self:custom.stage}-user-pool-client
        UserPoolId:
          Ref: CognitoUserPool
        ExplicitAuthFlows: [ADMIN_NO_SRP_AUTH, USER_PASSWORD_AUTH]
        GenerateSecret: false
```
3. Deploy the app.
4. Check if triggers are referenced properly in AWS Cognito User Pool settings. 

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO
