### PR TITLE
Switch integration tests runner from Jest to Mocha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
         # AWS_SECRET_ACCESS_KEY
         - secure: Dgaa5XIsA5Vbw/CYQLUAuVVsDX26C8+f1XYGwsbNmFQKbKvM8iy9lGrHlfrT3jftJkJH6re8tP1RjyZjjzLe25KPk4Tps7grNteCyiIIEDsC2aHhiXHD6zNHsItpxYusaFfyQinFWnK4CAYKWb9ZNIwHIDUIB4vq807QGAhYsnoj1Lg/ajWvtEKBwYjEzDz9OjB91lw7lpCnHtmKKw5A+TNIVGpDDZ/jRBqETsPaePtiXC9UTHZQyM3gFoeVXiJw9KSU/gjIx9REihCaWWPbnuQSeIONGGlVWY9V4DTZIsJr9/uwDcbioeXDD3G1ezGtNPPRSNTtq08QlUtE4mEtKea/+ObpllKZCeZGn6AJhMn+uqMIP95FFlqBB55YzRcLZY+Igi/qm/9LJ9RinAhxRVXiwzeQ+BdVA6jshAAzr+7wklux6lZAa0xGw9pgTv7MI4RP2LJ/LMP1ppFsnv9n/qt93Ax1VEwEu3xHZe3VTYL9tbXOPTZutf6fKjUrW7wSSuy637queESjYnnPKSb1vZcPxjSFlyh+GJvxu/3PurF9aqfiBdiorIBre+pQS4lakLtoft5nsbA+4iYUwrXR58qUPVUqQ7a0A0hedOWlp6g9ixLa6nugUP5aobJzR71T8l/IjqpnY2EEd/iINEb0XfUiZtB5zHaqFWejBtmWwCI=
       script:
-        #- npm run integration-test-run-basic || { npm run integration-test-cleanup; exit 1; }
+        - npm run integration-test-run-basic || { npm run integration-test-cleanup; exit 1; }
         - npm run integration-test-run-all || { npm run integration-test-cleanup; exit 1; }
         - npm run integration-test-cleanup
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lint:fix": "npm run lint -- --fix",
     "lint-updated": "pipe-git-updated --ext=js -- eslint --cache",
     "integration-test-run-package": "jest --maxWorkers=5 integration-package",
-    "integration-test-run-basic": "jest --maxWorkers=5 integration-basic",
+    "integration-test-run-basic": "mocha tests/integration-basic/tests.js",
     "integration-test-run-all": "jest --maxWorkers=5 integration-all",
     "integration-test-cleanup": "node tests/utils/aws-cleanup.js",
     "postinstall": "node ./scripts/postinstall.js",

--- a/package.json
+++ b/package.json
@@ -79,15 +79,6 @@
     "reporter": "tests/mocha-reporter",
     "timeout": 5000
   },
-  "jest": {
-    "setupFilesAfterEnv": [
-      "<rootDir>/tests/setup-tests.js"
-    ],
-    "testEnvironment": "node",
-    "testRegex": "(\\.|/)(tests)\\.js$",
-    "testRunner": "jest-circus/runner",
-    "useStderr": true
-  },
   "devDependencies": {
     "@serverless/eslint-config": "^1.1.0",
     "chai": "^4.2.0",
@@ -98,8 +89,6 @@
     "eslint": "^6.0.1",
     "eslint-plugin-import": "^2.18.1",
     "git-list-updated": "^1.2.1",
-    "jest-circus": "^24.8.0",
-    "jest-cli": "^24.8.0",
     "mocha": "^6.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "mock-require": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint-updated": "pipe-git-updated --ext=js -- eslint --cache",
     "integration-test-run-package": "node scripts/test-isolated --skip-fs-cleanup-check tests/integration-package/**/*.tests.js",
     "integration-test-run-basic": "mocha tests/integration-basic/tests.js",
-    "integration-test-run-all": "jest --maxWorkers=5 integration-all",
+    "integration-test-run-all": "node scripts/test-isolated --pass-through-aws-creds --skip-fs-cleanup-check tests/integration-all/**/tests.js",
     "integration-test-cleanup": "node tests/utils/aws-cleanup.js",
     "postinstall": "node ./scripts/postinstall.js",
     "prettier-check": "prettier -c --ignore-path .gitignore \"**/*.{css,html,js,json,md,yaml,yml}\"",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lint": "eslint . --cache",
     "lint:fix": "npm run lint -- --fix",
     "lint-updated": "pipe-git-updated --ext=js -- eslint --cache",
-    "integration-test-run-package": "jest --maxWorkers=5 integration-package",
+    "integration-test-run-package": "node scripts/test-isolated --skip-fs-cleanup-check tests/integration-package/**/*.tests.js",
     "integration-test-run-basic": "mocha tests/integration-basic/tests.js",
     "integration-test-run-all": "jest --maxWorkers=5 integration-all",
     "integration-test-cleanup": "node tests/utils/aws-cleanup.js",

--- a/scripts/test-isolated.js
+++ b/scripts/test-isolated.js
@@ -47,13 +47,14 @@ const initialSetupDeferred = !inputOptions.skipFsCleanupCheck
   ? initialGitStatusDeferred
   : Promise.resolve();
 
+const cwdPathLength = process.cwd().length + 1;
 const paths = mochaCollectFiles({
   ignore: [],
   extension: ['js'],
   file: [],
   recursive: process.argv.includes('--recursive'),
   spec: filePatterns,
-});
+}).map(filename => filename.slice(cwdPathLength));
 
 if (!paths.length) {
   process.stderr.write(chalk.red.bold('No test files matched\n\n'));

--- a/scripts/test-isolated.js
+++ b/scripts/test-isolated.js
@@ -17,7 +17,7 @@ const chalk = require('chalk');
 const pLimit = require('p-limit');
 
 const inputOptions = {};
-const patterns = process.argv.slice(2).filter(arg => {
+const filePatterns = process.argv.slice(2).filter(arg => {
   if (!arg.startsWith('-')) return true;
   switch (arg) {
     case '--skip-fs-cleanup-check':
@@ -29,8 +29,8 @@ const patterns = process.argv.slice(2).filter(arg => {
   }
   return false;
 });
-if (!patterns.length) patterns.push('**/*.test.js');
-patterns.push('!node_modules/**');
+if (!filePatterns.length) filePatterns.push('**/*.test.js');
+filePatterns.push('!node_modules/**');
 
 const resolveGitStatus = () =>
   spawn('git', ['status', '--porcelain']).then(
@@ -48,7 +48,7 @@ const initialSetupDeferred = !inputOptions.skipFsCleanupCheck
   ? initialGitStatusDeferred
   : Promise.resolve();
 
-globby(patterns).then(paths => {
+globby(filePatterns).then(paths => {
   if (!paths.length) {
     process.stderr.write(chalk.red.bold('No test files matched\n\n'));
     process.exit(1);

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -39,7 +39,7 @@ describe('AWS - API Gateway Integration Test', () => {
     serviceName = serverlessConfig.service;
     stackName = `${serviceName}-${stage}`;
     console.info(`Deploying "${stackName}" service...`);
-    deployService();
+    deployService(tmpDirPath);
     // create an external REST API
     const externalRestApiName = `${stage}-${serviceName}-ext-api`;
     return createRestApi(externalRestApiName)
@@ -64,9 +64,9 @@ describe('AWS - API Gateway Integration Test', () => {
     writeYamlFile(serverlessFilePath, serverless);
     // NOTE: deploying once again to get the stack into the original state
     console.info('Redeploying service...');
-    deployService();
+    deployService(tmpDirPath);
     console.info('Removing service...');
-    removeService();
+    removeService(tmpDirPath);
     console.info('Deleting external rest API...');
     return deleteRestApi(restApiId);
   });
@@ -233,7 +233,7 @@ describe('AWS - API Gateway Integration Test', () => {
         },
       });
       writeYamlFile(serverlessFilePath, serverless);
-      deployService();
+      deployService(tmpDirPath);
     });
 
     it('should update the stage without service interruptions', () => {
@@ -268,7 +268,7 @@ describe('AWS - API Gateway Integration Test', () => {
         },
       });
       writeYamlFile(serverlessFilePath, serverless);
-      deployService();
+      deployService(tmpDirPath);
     });
 
     it('should update the stage without service interruptions', () => {

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -12,7 +12,8 @@ const { createRestApi, deleteRestApi, getResources } = require('../../utils/api-
 
 const CF = new AWS.CloudFormation({ region });
 
-describe('AWS - API Gateway Integration Test', () => {
+describe('AWS - API Gateway Integration Test', function() {
+  this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let serviceName;
   let endpoint;
   let stackName;
@@ -23,7 +24,7 @@ describe('AWS - API Gateway Integration Test', () => {
   let apiKey;
   const stage = 'dev';
 
-  beforeAll(() => {
+  before(() => {
     tmpDirPath = getTmpDirPath();
     console.info(`Temporary path: ${tmpDirPath}`);
     serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
@@ -56,7 +57,7 @@ describe('AWS - API Gateway Integration Test', () => {
       });
   });
 
-  afterAll(() => {
+  after(() => {
     // NOTE: deleting the references to the old, external REST API
     const serverless = readYamlFile(serverlessFilePath);
     delete serverless.provider.apiGateway.restApiId;
@@ -217,7 +218,7 @@ describe('AWS - API Gateway Integration Test', () => {
   });
 
   describe('Using stage specific configuration', () => {
-    beforeAll(() => {
+    before(() => {
       const serverless = readYamlFile(serverlessFilePath);
       // enable Logs, Tags and Tracing
       _.merge(serverless.provider, {
@@ -248,7 +249,7 @@ describe('AWS - API Gateway Integration Test', () => {
 
   // NOTE: this test should  be at the very end because we're using an external REST API here
   describe('when using an existing REST API with stage specific configuration', () => {
-    beforeAll(() => {
+    before(() => {
       const serverless = readYamlFile(serverlessFilePath);
       // enable Logs, Tags and Tracing
       _.merge(serverless.provider, {

--- a/tests/integration-all/cognito-user-pool/tests.js
+++ b/tests/integration-all/cognito-user-pool/tests.js
@@ -22,7 +22,8 @@ const {
 } = require('../../utils/misc');
 const { getMarkers } = require('../shared/utils');
 
-describe('AWS - Cognito User Pool Integration Test', () => {
+describe('AWS - Cognito User Pool Integration Test', function() {
+  this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let serviceName;
   let stackName;
   let tmpDirPath;
@@ -31,7 +32,7 @@ describe('AWS - Cognito User Pool Integration Test', () => {
   let poolExistingMultiSetup;
   const stage = 'dev';
 
-  beforeAll(() => {
+  before(() => {
     tmpDirPath = getTmpDirPath();
     console.info(`Temporary path: ${tmpDirPath}`);
     const serverlessConfig = createTestService(tmpDirPath, {
@@ -63,7 +64,7 @@ describe('AWS - Cognito User Pool Integration Test', () => {
     });
   });
 
-  afterAll(() => {
+  after(() => {
     console.info('Removing service...');
     removeService(tmpDirPath);
     console.info('Deleting Cognito User Pools');

--- a/tests/integration-all/cognito-user-pool/tests.js
+++ b/tests/integration-all/cognito-user-pool/tests.js
@@ -59,13 +59,13 @@ describe('AWS - Cognito User Pool Integration Test', () => {
       createUserPool(poolExistingMultiSetup),
     ]).then(() => {
       console.info(`Deploying "${stackName}" service...`);
-      deployService();
+      deployService(tmpDirPath);
     });
   });
 
   afterAll(() => {
     console.info('Removing service...');
-    removeService();
+    removeService(tmpDirPath);
     console.info('Deleting Cognito User Pools');
     return BbPromise.all([
       deleteUserPool(poolExistingSimpleSetup),
@@ -84,7 +84,7 @@ describe('AWS - Cognito User Pool Integration Test', () => {
           userPoolId = pool.Id;
           return createUser(userPoolId, 'johndoe', '!!!wAsD123456wAsD!!!');
         })
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
         .then(logs => {
           expect(logs).to.include(`"userPoolId":"${userPoolId}"`);
           expect(logs).to.include('"userName":"johndoe"');
@@ -105,7 +105,7 @@ describe('AWS - Cognito User Pool Integration Test', () => {
             userPoolId = pool.Id;
             return createUser(userPoolId, 'janedoe', '!!!wAsD123456wAsD!!!');
           })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(logs).to.include(`"userPoolId":"${userPoolId}"`);
             expect(logs).to.include('"userName":"janedoe"');
@@ -133,7 +133,7 @@ describe('AWS - Cognito User Pool Integration Test', () => {
                 .then(() => initiateAuth(clientId, username, password));
             });
           })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(logs).to.include(`"userPoolId":"${userPoolId}"`);
             expect(logs).to.include(`"userName":"${username}"`);

--- a/tests/integration-all/event-bridge/tests.js
+++ b/tests/integration-all/event-bridge/tests.js
@@ -60,13 +60,13 @@ describe('AWS - Event Bridge Integration Test', () => {
       writeYamlFile(serverlessFilePath, config);
       // deploy the service
       console.info(`Deploying "${stackName}" service...`);
-      deployService();
+      deployService(tmpDirPath);
     });
   });
 
   afterAll(() => {
     console.info('Removing service...');
-    removeService();
+    removeService(tmpDirPath);
     console.info(`Deleting Event Bus "${arnEventBusName}"...`);
     return deleteEventBus(arnEventBusName);
   });
@@ -77,7 +77,7 @@ describe('AWS - Event Bridge Integration Test', () => {
       const markers = getMarkers(functionName);
 
       return putEvents('default', putEventEntries)
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
         .then(logs => {
           expect(logs).to.include(`"source":"${eventSource}"`);
           expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
@@ -92,7 +92,7 @@ describe('AWS - Event Bridge Integration Test', () => {
       const markers = getMarkers(functionName);
 
       return putEvents(namedEventBusName, putEventEntries)
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
         .then(logs => {
           expect(logs).to.include(`"source":"${eventSource}"`);
           expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
@@ -107,7 +107,7 @@ describe('AWS - Event Bridge Integration Test', () => {
       const markers = getMarkers(functionName);
 
       return putEvents(arnEventBusName, putEventEntries)
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
         .then(logs => {
           expect(logs).to.include(`"source":"${eventSource}"`);
           expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);

--- a/tests/integration-all/event-bridge/tests.js
+++ b/tests/integration-all/event-bridge/tests.js
@@ -13,7 +13,8 @@ const {
 } = require('../../utils/misc');
 const { getMarkers } = require('../shared/utils');
 
-describe('AWS - Event Bridge Integration Test', () => {
+describe('AWS - Event Bridge Integration Test', function() {
+  this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let serviceName;
   let stackName;
   let tmpDirPath;
@@ -30,7 +31,7 @@ describe('AWS - Event Bridge Integration Test', () => {
     },
   ];
 
-  beforeAll(() => {
+  before(() => {
     tmpDirPath = getTmpDirPath();
     console.info(`Temporary path: ${tmpDirPath}`);
     const serverlessConfig = createTestService(tmpDirPath, {
@@ -64,7 +65,7 @@ describe('AWS - Event Bridge Integration Test', () => {
     });
   });
 
-  afterAll(() => {
+  after(() => {
     console.info('Removing service...');
     removeService(tmpDirPath);
     console.info(`Deleting Event Bus "${arnEventBusName}"...`);

--- a/tests/integration-all/s3/tests.js
+++ b/tests/integration-all/s3/tests.js
@@ -56,13 +56,13 @@ describe('AWS - S3 Integration Test', () => {
       createBucket(bucketExistingComplexSetup),
     ]).then(() => {
       console.info(`Deploying "${stackName}" service...`);
-      deployService();
+      deployService(tmpDirPath);
     });
   });
 
   afterAll(() => {
     console.info('Removing service...');
-    removeService();
+    removeService(tmpDirPath);
     console.info('Deleting S3 buckets');
     return BbPromise.all([
       deleteBucket(bucketExistingSimpleSetup),
@@ -77,7 +77,7 @@ describe('AWS - S3 Integration Test', () => {
       const expectedMessage = `Hello from S3! - (${functionName})`;
 
       return createAndRemoveInBucket(bucketMinimalSetup)
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
         .then(logs => {
           expect(/aws:s3/g.test(logs)).to.equal(true);
           expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
@@ -93,7 +93,7 @@ describe('AWS - S3 Integration Test', () => {
       const expectedMessage = `Hello from S3! - (${functionName})`;
 
       return createAndRemoveInBucket(bucketExtendedSetup, { prefix: 'photos/', suffix: '.jpg' })
-        .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
         .then(logs => {
           expect(/aws:s3/g.test(logs)).to.equal(true);
           expect(/ObjectRemoved:Delete/g.test(logs)).to.equal(true);
@@ -113,7 +113,7 @@ describe('AWS - S3 Integration Test', () => {
           prefix: 'Files/',
           suffix: '.TXT',
         })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(/aws:s3/g.test(logs)).to.equal(true);
             expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
@@ -132,7 +132,7 @@ describe('AWS - S3 Integration Test', () => {
           prefix: 'photos',
           suffix: '.jpg',
         })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(/aws:s3/g.test(logs)).to.equal(true);
             expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
@@ -148,7 +148,7 @@ describe('AWS - S3 Integration Test', () => {
           prefix: 'photos',
           suffix: '.jpg',
         })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(/aws:s3/g.test(logs)).to.equal(true);
             expect(/ObjectRemoved:Delete/g.test(logs)).to.equal(true);
@@ -164,7 +164,7 @@ describe('AWS - S3 Integration Test', () => {
           prefix: 'photos',
           suffix: '.png',
         })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(/aws:s3/g.test(logs)).to.equal(true);
             expect(/ObjectCreated:Put/g.test(logs)).to.equal(true);
@@ -180,7 +180,7 @@ describe('AWS - S3 Integration Test', () => {
           prefix: 'photos',
           suffix: '.png',
         })
-          .then(() => waitForFunctionLogs(functionName, markers.start, markers.end))
+          .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
           .then(logs => {
             expect(/aws:s3/g.test(logs)).to.equal(true);
             expect(/ObjectRemoved:Delete/g.test(logs)).to.equal(true);

--- a/tests/integration-all/s3/tests.js
+++ b/tests/integration-all/s3/tests.js
@@ -14,7 +14,8 @@ const {
 } = require('../../utils/misc');
 const { getMarkers } = require('../shared/utils');
 
-describe('AWS - S3 Integration Test', () => {
+describe('AWS - S3 Integration Test', function() {
+  this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let serviceName;
   let stackName;
   let tmpDirPath;
@@ -24,7 +25,7 @@ describe('AWS - S3 Integration Test', () => {
   let bucketExistingComplexSetup;
   const stage = 'dev';
 
-  beforeAll(() => {
+  before(() => {
     tmpDirPath = getTmpDirPath();
     console.info(`Temporary path: ${tmpDirPath}`);
     const serverlessConfig = createTestService(tmpDirPath, {
@@ -60,7 +61,7 @@ describe('AWS - S3 Integration Test', () => {
     });
   });
 
-  afterAll(() => {
+  after(() => {
     console.info('Removing service...');
     removeService(tmpDirPath);
     console.info('Deleting S3 buckets');

--- a/tests/integration-basic/tests.js
+++ b/tests/integration-basic/tests.js
@@ -8,7 +8,7 @@ const AWS = require('aws-sdk');
 const stripAnsi = require('strip-ansi');
 const { expect } = require('chai');
 const { execSync } = require('../utils/child-process');
-const { getTmpDirPath, replaceTextInFile } = require('../utils/fs');
+const { getTmpDirPath } = require('../utils/fs');
 const { region, getServiceName } = require('../utils/misc');
 
 const serverlessExec = path.join(__dirname, '..', '..', 'bin', 'serverless');
@@ -29,8 +29,9 @@ describe('Service Lifecyle Integration Test', function() {
   });
 
   it('should create service in tmp directory', () => {
-    execSync(`${serverlessExec} create --template ${templateName}`, { cwd: tmpDir });
-    replaceTextInFile(path.join(tmpDir, 'serverless.yml'), templateName, serviceName);
+    execSync(`${serverlessExec} create --template ${templateName} --name ${serviceName}`, {
+      cwd: tmpDir,
+    });
     expect(fs.existsSync(path.join(tmpDir, 'serverless.yml'))).to.be.equal(true);
     expect(fs.existsSync(path.join(tmpDir, 'handler.js'))).to.be.equal(true);
   });

--- a/tests/integration-basic/tests.js
+++ b/tests/integration-basic/tests.js
@@ -15,14 +15,15 @@ const serverlessExec = path.join(__dirname, '..', '..', 'bin', 'serverless');
 
 const CF = new AWS.CloudFormation({ region });
 
-describe('Service Lifecyle Integration Test', () => {
+describe('Service Lifecyle Integration Test', function() {
+  this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   const templateName = 'aws-nodejs';
   const tmpDir = getTmpDirPath();
   let oldCwd;
   let serviceName;
   let StackName;
 
-  beforeAll(() => {
+  before(() => {
     oldCwd = process.cwd();
     serviceName = getServiceName();
     StackName = `${serviceName}-dev`;
@@ -30,7 +31,7 @@ describe('Service Lifecyle Integration Test', () => {
     process.chdir(tmpDir);
   });
 
-  afterAll(() => {
+  after(() => {
     process.chdir(oldCwd);
   });
 

--- a/tests/integration-package/cloudformation.tests.js
+++ b/tests/integration-package/cloudformation.tests.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { expect } = require('chai');
 const fse = require('fs-extra');
 const { execSync } = require('../utils/child-process');
 const { serverlessExec } = require('../utils/misc');
@@ -25,11 +26,11 @@ describe('Integration test - Packaging', () => {
     const cfnTemplate = JSON.parse(
       fs.readFileSync(path.join(cwd, '.serverless/cloudformation-template-update-stack.json'))
     );
-    expect(cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key).toMatch(
+    expect(cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key).to.match(
       /serverless\/aws-nodejs\/dev\/[^]*\/artifact.zip/
     );
     delete cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key;
-    expect(cfnTemplate.Resources.HelloLambdaFunction).toEqual({
+    expect(cfnTemplate.Resources.HelloLambdaFunction).to.deep.equal({
       Type: 'AWS::Lambda::Function',
       Properties: {
         Code: {
@@ -56,11 +57,11 @@ describe('Integration test - Packaging', () => {
     const cfnTemplate = JSON.parse(
       fs.readFileSync(path.join(cwd, '.serverless/cloudformation-template-update-stack.json'))
     );
-    expect(cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key).toMatch(
+    expect(cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key).to.match(
       /serverless\/aws-nodejs\/dev\/[^]*\/aws-nodejs.zip/
     );
     delete cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key;
-    expect(cfnTemplate.Resources.HelloLambdaFunction).toEqual({
+    expect(cfnTemplate.Resources.HelloLambdaFunction).to.deep.equal({
       Type: 'AWS::Lambda::Function',
       Properties: {
         Code: {
@@ -87,14 +88,14 @@ describe('Integration test - Packaging', () => {
     const cfnTemplate = JSON.parse(
       fs.readFileSync(path.join(cwd, '.serverless/cloudformation-template-update-stack.json'))
     );
-    expect(cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key).toMatch(
+    expect(cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key).to.match(
       /serverless\/aws-nodejs\/dev\/[^]*\/hello.zip/
     );
-    expect(cfnTemplate.Resources.Hello2LambdaFunction.Properties.Code.S3Key).toMatch(
+    expect(cfnTemplate.Resources.Hello2LambdaFunction.Properties.Code.S3Key).to.match(
       /serverless\/aws-nodejs\/dev\/[^]*\/hello2.zip/
     );
     delete cfnTemplate.Resources.HelloLambdaFunction.Properties.Code.S3Key;
-    expect(cfnTemplate.Resources.HelloLambdaFunction).toEqual({
+    expect(cfnTemplate.Resources.HelloLambdaFunction).to.deep.equal({
       Type: 'AWS::Lambda::Function',
       Properties: {
         Code: {
@@ -121,7 +122,7 @@ describe('Integration test - Packaging', () => {
     const cfnTemplate = JSON.parse(
       fs.readFileSync(path.join(cwd, '.serverless/cloudformation-template-update-stack.json'))
     );
-    expect(cfnTemplate.Resources.CustomDashnameLambdaFunction.Properties.FunctionName).toEqual(
+    expect(cfnTemplate.Resources.CustomDashnameLambdaFunction.Properties.FunctionName).to.equal(
       'aws-nodejs-us-east-1-custom-name'
     );
   });

--- a/tests/integration-package/lambda-files.tests.js
+++ b/tests/integration-package/lambda-files.tests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { expect } = require('chai');
 const fse = require('fs-extra');
 const { execSync } = require('../utils/child-process');
 const { serverlessExec } = require('../utils/misc');
@@ -11,7 +12,8 @@ const fixturePaths = {
   individually: path.join(__dirname, 'fixtures/individually'),
 };
 
-describe('Integration test - Packaging', () => {
+describe('Integration test - Packaging', function() {
+  this.timeout(10000);
   let cwd;
   beforeEach(() => {
     cwd = getTmpDirPath();
@@ -21,7 +23,7 @@ describe('Integration test - Packaging', () => {
     fse.copySync(fixturePaths.regular, cwd);
     execSync(`${serverlessExec} package`, { cwd });
     return listZipFiles(path.join(cwd, '.serverless/aws-nodejs.zip')).then(zipfiles => {
-      expect(zipfiles).toEqual(['handler.js']);
+      expect(zipfiles).to.deep.equal(['handler.js']);
     });
   });
 
@@ -35,8 +37,12 @@ describe('Integration test - Packaging', () => {
         zipfiles.filter(f => f.startsWith('node_modules')).map(f => f.split(path.sep)[1])
       );
       const nonNodeModulesFiles = zipfiles.filter(f => !f.startsWith('node_modules'));
-      expect(nodeModules).toEqual(new Set(['lodash']));
-      expect(nonNodeModulesFiles).toEqual(['handler.js', 'package-lock.json', 'package.json']);
+      expect(nodeModules).to.deep.equal(new Set(['lodash']));
+      expect(nonNodeModulesFiles).to.deep.equal([
+        'handler.js',
+        'package-lock.json',
+        'package.json',
+      ]);
     });
   });
 
@@ -50,8 +56,12 @@ describe('Integration test - Packaging', () => {
         zipfiles.filter(f => f.startsWith('node_modules')).map(f => f.split(path.sep)[1])
       );
       const nonNodeModulesFiles = zipfiles.filter(f => !f.startsWith('node_modules'));
-      expect(nodeModules).toEqual(new Set([]));
-      expect(nonNodeModulesFiles).toEqual(['handler.js', 'package-lock.json', 'package.json']);
+      expect(nodeModules).to.deep.equal(new Set([]));
+      expect(nonNodeModulesFiles).to.deep.equal([
+        'handler.js',
+        'package-lock.json',
+        'package.json',
+      ]);
     });
   });
 
@@ -66,8 +76,8 @@ describe('Integration test - Packaging', () => {
         zipfiles.filter(f => f.startsWith('node_modules')).map(f => f.split(path.sep)[1])
       );
       const nonNodeModulesFiles = zipfiles.filter(f => !f.startsWith('node_modules'));
-      expect(nodeModules).toEqual(new Set(['lodash']));
-      expect(nonNodeModulesFiles).toEqual(['handler.js']);
+      expect(nodeModules).to.deep.equal(new Set(['lodash']));
+      expect(nonNodeModulesFiles).to.deep.equal(['handler.js']);
     });
   });
 
@@ -75,8 +85,8 @@ describe('Integration test - Packaging', () => {
     fse.copySync(fixturePaths.individually, cwd);
     execSync(`${serverlessExec} package`, { cwd });
     return listZipFiles(path.join(cwd, '.serverless/hello.zip'))
-      .then(zipfiles => expect(zipfiles).toEqual(['handler.js']))
+      .then(zipfiles => expect(zipfiles).to.deep.equal(['handler.js']))
       .then(() => listZipFiles(path.join(cwd, '.serverless/hello2.zip')))
-      .then(zipfiles => expect(zipfiles).toEqual(['handler2.js']));
+      .then(zipfiles => expect(zipfiles).to.deep.equal(['handler2.js']));
   });
 });

--- a/tests/mocha-reporter.js
+++ b/tests/mocha-reporter.js
@@ -82,7 +82,7 @@ module.exports = class ServerlessSpec extends Spec {
       } catch (error) {
         if (error.code !== 'ENOENT') throw error;
       }
-      if (process.cwd() !== startCwd) {
+      if (process.cwd() !== startCwd && !runner.failures) {
         runner._abort = true; // eslint-disable-line no-underscore-dangle,no-param-reassign
         throw new Error(
           `Tests in ${suite.file.slice(startCwd.length + 1)} didn't revert ` +

--- a/tests/mocha-reporter.js
+++ b/tests/mocha-reporter.js
@@ -60,7 +60,7 @@ module.exports = class ServerlessSpec extends Spec {
 
         // Mocha ignores uncaught exceptions if they happen in conext of skipped test, expose them
         // https://github.com/mochajs/mocha/issues/3938
-        if (runner.currentRunnable.isPending()) throw err;
+        if (runner.currentRunnable.isPending() || runner._abort) throw err; // eslint-disable-line no-underscore-dangle
         return;
       }
       // If there's an uncaught exception after rest runner wraps up

--- a/tests/setup-tests.js
+++ b/tests/setup-tests.js
@@ -1,3 +1,0 @@
-'use strict';
-
-jest.setTimeout(500000);


### PR DESCRIPTION
There are various problems with Jest:

- It runs tests in copied/hacked Node.js environment which introduces some issues (not patchable)
  - `stdout` and `stderr` are output of out sync https://github.com/facebook/jest/issues/6718
  - Some public Node.js API's are replaced with non standard alternatives -> https://github.com/facebook/jest/issues/6725
  - Due to non standard and uneven modules cache handling it's prone to OOM errors: https://github.com/facebook/jest/issues/6399#issuecomment-415083479
- Tests progress is not output until tests finalize, which is inconvenient in long going tests (as integration ones) -> https://github.com/facebook/jest/issues/6616 (not easily patchable)
- Any stdout/stderr output is hidden until test finalizes -> https://github.com/facebook/jest/issues/5281 (patchable with `useStderr` option)
- Default runner exposes various bugs (patchable via using alternative [jest-circus](https://www.npmjs.com/package/jest-circus) runner)
  - Crashes in `beforeAll` do not prevent execution of tests -> https://github.com/facebook/jest/issues/6695
   - Crashes in `afterAll` are not exposed -> https://github.com/facebook/jest/issues/6692
   - `only` and `skip` are not fully respected -> https://github.com/facebook/jest/issues/4166
- Source code is result of transpilation which makes it more difficult to debug eventual issues in test runner.

Mocha is also not free from problems (still all known to me are patchable) and it doesn't provide test run parallelization out of a box, but we have achieved that through `script/test-isolated.js`

--- 

Additionally:
- Improved `script/test-isolated.js` to handle well case of integration tests
- Updated tests to not change cwd during run (it interfered with cwd change validation check we implied into Mocha runner)
- Fixed service name resolution in basic integration test. It got broken with https://github.com/serverless/serverless/pull/6386/commits/868c8a3794b874efe0f81f8d6a06c3e2b1060fac (until then it was simply `aws-nodejs`, after it reflected folder name). Uncommented also test run in Travis CI

**_Is it a breaking change?:_** NO
