### PR TITLE
Fix support for EventBridge partner event sources

### DIFF
--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/utils.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/utils.js
@@ -2,7 +2,7 @@
 
 function getEventBusName(eventBus) {
   if (eventBus && eventBus.startsWith('arn')) {
-    return eventBus.split('/').pop();
+    return eventBus.slice(eventBus.indexOf('/') + 1);
   }
   return eventBus;
 }

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -119,7 +119,7 @@ class AwsCompileEventBridgeEvents {
               if (EventBus) {
                 let eventBusName = EventBus;
                 if (EventBus.startsWith('arn')) {
-                  eventBusName = EventBus.split('/').pop();
+                  eventBusName = EventBus.slice(EventBus.indexOf('/') + 1);
                 }
                 eventBusResource = {
                   'Fn::Join': [

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -346,7 +346,7 @@ describe('AwsCompileEventBridgeEvents', () => {
       );
     });
 
-    it('should create the necessary resources when using an event bus arn', () => {
+    it('should create the necessary resources when using an own event bus arn', () => {
       awsCompileEventBridgeEvents.serverless.service.functions = {
         first: {
           name: 'first',
@@ -478,6 +478,134 @@ describe('AwsCompileEventBridgeEvents', () => {
                 },
                 RuleName: 'first-rule-1',
                 Schedule: 'rate(10 minutes)',
+              },
+            },
+          });
+        }
+      );
+    });
+
+    it('should create the necessary resources when using a partner event bus arn', () => {
+      awsCompileEventBridgeEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              eventBridge: {
+                eventBus: 'arn:aws:events:us-east-1:12345:event-bus/aws.partner/partner.com/12345',
+                pattern: {
+                  source: ['aws.partner/partner.com/12345'],
+                  detail: {
+                    event: ['My Event'],
+                    type: ['track'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(awsCompileEventBridgeEvents.compileEventBridgeEvents()).to.be.fulfilled.then(
+        () => {
+          const {
+            Resources,
+          } = awsCompileEventBridgeEvents.serverless.service.provider.compiledCloudFormationTemplate;
+
+          expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+          expect(addCustomResourceToServiceStub.args[0][1]).to.equal('eventBridge');
+          expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+            {
+              Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn:aws:events',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'event-bus/aws.partner/partner.com/12345',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: [
+                'events:PutRule',
+                'events:RemoveTargets',
+                'events:PutTargets',
+                'events:DeleteRule',
+              ],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn:aws:events',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'rule/aws.partner/partner.com/12345/first-rule-1',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn:aws:lambda',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'function',
+                    'first',
+                  ],
+                ],
+              },
+            },
+          ]);
+          expect(Resources.FirstCustomEventBridge1).to.deep.equal({
+            Type: 'Custom::EventBridge',
+            Version: 1,
+            DependsOn: [
+              'FirstLambdaFunction',
+              'CustomDashresourceDasheventDashbridgeLambdaFunction',
+            ],
+            Properties: {
+              ServiceToken: {
+                'Fn::GetAtt': ['CustomDashresourceDasheventDashbridgeLambdaFunction', 'Arn'],
+              },
+              FunctionName: 'first',
+              EventBridgeConfig: {
+                EventBus: 'arn:aws:events:us-east-1:12345:event-bus/aws.partner/partner.com/12345',
+                Input: undefined,
+                InputPath: undefined,
+                InputTransformer: undefined,
+                Pattern: {
+                  detail: {
+                    event: ['My Event'],
+                    type: ['track'],
+                  },
+
+                  source: ['aws.partner/partner.com/12345'],
+                },
+                Schedule: undefined,
+                RuleName: 'first-rule-1',
               },
             },
           });


### PR DESCRIPTION
## What did you implement:

Closes #6514 

Fixes support for EventBridge partner event sources.

## How did you implement it:

Fix the arn parser.

## How can we verify it:

See [service config](https://github.com/serverless/serverless/issues/6514#issue-478071889) posted in the issue.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO