### PR TITLE
Retain existing Cognito User Pool config

### DIFF
--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
@@ -2,6 +2,29 @@
 
 const CognitoIdentityServiceProvider = require('aws-sdk/clients/cognitoidentityserviceprovider');
 
+function getUpdateConfigFromCurrentSetup(currentSetup) {
+  const updatedConfig = Object.assign({}, currentSetup);
+  delete updatedConfig.Id;
+  delete updatedConfig.Name;
+  delete updatedConfig.Status;
+  delete updatedConfig.LastModifiedDate;
+  delete updatedConfig.CreationDate;
+  delete updatedConfig.SchemaAttributes;
+  delete updatedConfig.AliasAttributes;
+  delete updatedConfig.UsernameAttributes;
+  delete updatedConfig.EstimatedNumberOfUsers;
+  delete updatedConfig.SmsConfigurationFailure;
+  delete updatedConfig.EmailConfigurationFailure;
+  delete updatedConfig.Domain;
+  delete updatedConfig.CustomDomain;
+  delete updatedConfig.Arn;
+  // necessary reassignments
+  updatedConfig.Policies.PasswordPolicy.TemporaryPasswordValidityDays =
+    updatedConfig.AdminCreateUserConfig.UnusedAccountValidityDays;
+  delete updatedConfig.AdminCreateUserConfig.UnusedAccountValidityDays;
+  return updatedConfig;
+}
+
 function findUserPoolByName(config) {
   const { userPoolName, region } = config;
   const cognito = new CognitoIdentityServiceProvider({ region });
@@ -58,7 +81,13 @@ function updateConfiguration(config) {
       LambdaConfig[poolConfig.Trigger] = lambdaArn;
     });
 
-    return cognito.updateUserPool({ UserPoolId, LambdaConfig }).promise();
+    const updatedConfig = getUpdateConfigFromCurrentSetup(res.UserPool);
+    Object.assign(updatedConfig, {
+      UserPoolId,
+      LambdaConfig,
+    });
+
+    return cognito.updateUserPool(updatedConfig).promise();
   });
 }
 
@@ -75,7 +104,13 @@ function removeConfiguration(config) {
       return accum;
     }, LambdaConfig);
 
-    return cognito.updateUserPool({ UserPoolId, LambdaConfig }).promise();
+    const updatedConfig = getUpdateConfigFromCurrentSetup(res.UserPool);
+    Object.assign(updatedConfig, {
+      UserPoolId,
+      LambdaConfig,
+    });
+
+    return cognito.updateUserPool(updatedConfig).promise();
   });
 }
 

--- a/tests/utils/cognito/index.js
+++ b/tests/utils/cognito/index.js
@@ -3,10 +3,11 @@
 const AWS = require('aws-sdk');
 const { region, persistentRequest } = require('../misc');
 
-function createUserPool(name) {
+function createUserPool(name, config = {}) {
   const cognito = new AWS.CognitoIdentityServiceProvider({ region });
 
-  return cognito.createUserPool({ PoolName: name }).promise();
+  const params = Object.assign({}, { PoolName: name }, config);
+  return cognito.createUserPool(params).promise();
 }
 
 function createUserPoolClient(name, userPoolId) {
@@ -53,6 +54,12 @@ function findUserPoolByName(name) {
   return recursiveFind();
 }
 
+function describeUserPool(userPoolId) {
+  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
+
+  return cognito.describeUserPool({ UserPoolId: userPoolId }).promise();
+}
+
 function createUser(userPoolId, username, password) {
   const cognito = new AWS.CognitoIdentityServiceProvider({ region });
 
@@ -94,6 +101,7 @@ module.exports = {
   createUserPool: persistentRequest.bind(this, createUserPool),
   deleteUserPool: persistentRequest.bind(this, deleteUserPool),
   findUserPoolByName: persistentRequest.bind(this, findUserPoolByName),
+  describeUserPool: persistentRequest.bind(this, describeUserPool),
   createUserPoolClient: persistentRequest.bind(this, createUserPoolClient),
   createUser: persistentRequest.bind(this, createUser),
   setUserPassword: persistentRequest.bind(this, setUserPassword),


### PR DESCRIPTION
## What did you implement:

Closes #6499 

Ensures that the existing Cognito User Pool Config is retained.

## How did you implement it:

Fetch the current config and re-apply it to the params when updating the Cognito User Pool with the desired Trigger config.

## How can we verify it:

1. Create a new User Pool
1. Add a tag
1. Deploy the following `serverless.yml` service

The Trigger config should be updated. The tag should not be removed.

Otherwise you can also run the integration tests.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO