### PR TITLE
Change strategy for deciding to deploy new function.

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -18,8 +18,15 @@ module.exports = {
 
     return BbPromise.bind(this)
       .then(this.getMostRecentObjects)
-      .then(this.getObjectMetadata)
-      .then(this.checkIfDeploymentIsNecessary)
+      .then(objs => {
+        return BbPromise.all([
+          this.getObjectMetadata(objs),
+          this.getFunctionsEarliestLastModifiedDate(),
+        ]);
+      })
+      .then(([objMetadata, lastModifiedDate]) =>
+        this.checkIfDeploymentIsNecessary(objMetadata, lastModifiedDate)
+      )
       .then(() => {
         if (this.serverless.service.provider.shouldNotDeploy) {
           return BbPromise.resolve();
@@ -78,6 +85,23 @@ module.exports = {
       });
   },
 
+  // Gives the least recent last modify date accross all the functions in the service.
+  getFunctionsEarliestLastModifiedDate() {
+    const getFunctionResults = this.serverless.service.getAllFunctions().map(funName => {
+      const functionObj = this.serverless.service.getFunction(funName);
+      return this.provider
+        .request('Lambda', 'getFunction', {
+          FunctionName: functionObj.name,
+        })
+        .then(res => new Date(res.Configuration.LastModified))
+        .catch(() => new Date(0)); // Function is missing, needs to be deployed
+    });
+
+    return BbPromise.all(getFunctionResults)
+      .then(_.min)
+      .then(x => x || null);
+  },
+
   getObjectMetadata(objects) {
     if (objects && objects.length) {
       const headObjectObjects = objects.map(obj =>
@@ -93,7 +117,7 @@ module.exports = {
     return BbPromise.resolve([]);
   },
 
-  checkIfDeploymentIsNecessary(objects) {
+  checkIfDeploymentIsNecessary(objects, funcLastModifiedDate) {
     if (objects && objects.length) {
       const remoteHashes = objects.map(object => object.Metadata.filesha256 || '');
 
@@ -125,7 +149,13 @@ module.exports = {
         const localHashes = zipFileHashes;
         localHashes.push(localCfHash);
 
-        if (_.isEqual(remoteHashes.sort(), localHashes.sort())) {
+        // If any objects were changed after the last time the function was updated
+        // there could have been a failed deploy.
+        const changedAfterDeploy = _.some(objects, object => {
+          return object.LastModified && object.LastModified > funcLastModifiedDate;
+        });
+
+        if (!changedAfterDeploy && _.isEqual(remoteHashes.sort(), localHashes.sort())) {
           this.serverless.service.provider.shouldNotDeploy = true;
 
           const message = ['Service files not changed. Skipping deployment...'].join('');

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -284,6 +284,36 @@ describe('checkForChanges', () => {
       });
     });
 
+    it('should resolve if objects are given, but no function last modified date', () => {
+      globbySyncStub.returns(['my-service.zip']);
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(0)
+        .returns('local-hash-cf-template');
+
+      const input = [{ Metadata: { filesha256: 'remote-hash-cf-template' } }];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input)).to.be.fulfilled.then(() => {
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+        expect(globbySyncStub).to.have.been.calledOnce;
+        expect(readFileStub).to.have.been.calledOnce;
+        expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+          awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+        );
+        expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
+          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          dot: true,
+          silent: true,
+        });
+        expect(readFileStub).to.have.been.calledWith(
+          path.join('my-service/.serverless/my-service.zip')
+        );
+        expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
+      });
+    });
+
     it('should not set a flag if there are more remote hashes', () => {
       globbySyncStub.returns(['my-service.zip']);
       cryptoStub
@@ -408,6 +438,48 @@ describe('checkForChanges', () => {
       });
     });
 
+    it('should not set a flag if the hashes are equal, but the objects were modified after their functions', () => {
+      globbySyncStub.returns(['my-service.zip']);
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(0)
+        .returns('hash-cf-template');
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(1)
+        .returns('hash-zip-file-1');
+
+      const now = new Date();
+      const inThePast = new Date(new Date().getTime() - 100000);
+      const inTheFuture = new Date(new Date().getTime() + 100000);
+
+      const input = [
+        { Metadata: { filesha256: 'hash-cf-template' }, LastModified: inThePast },
+        { Metadata: { filesha256: 'hash-zip-file-1' }, LastModified: inTheFuture },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input, now)).to.be.fulfilled.then(() => {
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+        expect(globbySyncStub).to.have.been.calledOnce;
+        expect(readFileStub).to.have.been.calledOnce;
+        expect(awsDeploy.serverless.cli.log).to.not.have.been.called;
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+          awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+        );
+        expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
+          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          dot: true,
+          silent: true,
+        });
+        expect(readFileStub).to.have.been.calledWith(
+          path.join('my-service/.serverless/my-service.zip')
+        );
+        expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
+      });
+    });
+
     it('should set a flag if the remote and local hashes are equal', () => {
       globbySyncStub.returns(['my-service.zip']);
       cryptoStub
@@ -444,6 +516,49 @@ describe('checkForChanges', () => {
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
       });
+    });
+
+    it('should set a flag if the remote and local hashes are equal, and the edit times are ordered', () => {
+      globbySyncStub.returns(['my-service.zip']);
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(0)
+        .returns('hash-cf-template');
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(1)
+        .returns('hash-zip-file-1');
+
+      const longAgo = new Date(new Date().getTime() - 100000);
+      const longerAgo = new Date(new Date().getTime() - 200000);
+
+      const input = [
+        { Metadata: { filesha256: 'hash-cf-template' }, LastModified: longerAgo },
+        { Metadata: { filesha256: 'hash-zip-file-1' }, LastModified: longerAgo },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input, longAgo)).to.be.fulfilled.then(
+        () => {
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+          expect(globbySyncStub).to.have.been.calledOnce;
+          expect(readFileStub).to.have.been.calledOnce;
+          expect(awsDeploy.serverless.cli.log).to.have.been.calledOnce;
+          expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+            awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+          );
+          expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
+            cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+            dot: true,
+            silent: true,
+          });
+          expect(readFileStub).to.have.been.calledWith(
+            path.join('my-service/.serverless/my-service.zip')
+          );
+          expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
+        }
+      );
     });
 
     it('should set a flag if the remote and local hashes are duplicated and equal', () => {
@@ -739,6 +854,101 @@ describe('checkForChanges', () => {
         return awsDeploy
           .checkForChanges()
           .then(() => expect(deleteSubscriptionFilterStub).to.have.been.called);
+      });
+    });
+
+    describe('#getFunctionsLatestLastModifiedDate', () => {
+      let getFunctionStub;
+
+      beforeEach(() => {
+        getFunctionStub = sandbox.stub(awsDeploy.provider, 'request').resolves();
+      });
+
+      afterEach(() => {
+        awsDeploy.provider.request.restore();
+      });
+
+      it('should return null when there are no functions', () => {
+        awsDeploy.serverless.service.functions = {};
+        awsDeploy.serverless.service.setFunctionNames();
+
+        return expect(awsDeploy.getFunctionsEarliestLastModifiedDate()).to.have.been.fulfilled.then(
+          ans => {
+            expect(getFunctionStub).to.have.not.been.called;
+            expect(ans).to.be.null;
+          }
+        );
+      });
+
+      it('should treat rejections as epoch', () => {
+        awsDeploy.provider.request.restore();
+
+        getFunctionStub = sandbox.stub(awsDeploy.provider, 'request');
+
+        const now = new Date();
+        getFunctionStub.onCall(0).returns(BbPromise.reject());
+        getFunctionStub
+          .onCall(1)
+          .returns(BbPromise.resolve({ Configuration: { LastModified: now } }));
+
+        awsDeploy.serverless.service.functions = {
+          first: {
+            events: [{ someevent: 'abc' }],
+          },
+          second: {
+            events: [{ anothaone: '1' }],
+          },
+        };
+
+        awsDeploy.serverless.service.setFunctionNames();
+
+        return expect(awsDeploy.getFunctionsEarliestLastModifiedDate()).to.have.been.fulfilled.then(
+          ans => {
+            expect(ans.valueOf()).to.equal(new Date(0).valueOf());
+            expect(getFunctionStub).to.have.been.calledTwice;
+          }
+        );
+      });
+
+      it('should return the earliest last modified date', () => {
+        awsDeploy.provider.request.restore();
+
+        getFunctionStub = sandbox.stub(awsDeploy.provider, 'request');
+
+        const now = new Date();
+        const longAgo = new Date(new Date().getTime() - 100000);
+        const longerAgo = new Date(new Date().getTime() - 100001);
+
+        getFunctionStub
+          .onCall(0)
+          .returns(BbPromise.resolve({ Configuration: { LastModified: longAgo } }));
+        getFunctionStub
+          .onCall(1)
+          .returns(BbPromise.resolve({ Configuration: { LastModified: longerAgo } }));
+        getFunctionStub
+          .onCall(2)
+          .returns(BbPromise.resolve({ Configuration: { LastModified: now } }));
+
+        awsDeploy.serverless.service.functions = {
+          first: {
+            events: [{ someevent: 'abc' }],
+          },
+          second: {
+            events: [{ anothaone: '1' }],
+          },
+          third: {
+            events: [{ thebest: 'around' }],
+          },
+        };
+
+        awsDeploy.serverless.service.setFunctionNames();
+
+        return expect(awsDeploy.getFunctionsEarliestLastModifiedDate()).to.have.been.fulfilled.then(
+          ans => {
+            expect(ans.valueOf()).to.equal(longerAgo.valueOf());
+            expect(getFunctionStub).to.have.been.calledThrice;
+          }
+        );
       });
     });
   });


### PR DESCRIPTION
Check that a function was modified after artifact when deciding to deploy.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #3983 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

The problems arose because serverless put the user's code inside the s3 bucket, but the stack update failed to update the lambda's code. On the next deploy attempt serverless would see that the artifacts in the s3 bucket are identical to the ones it is trying to push, and incorrectly assume that the deploy is a no-op. This fixes the issue by adding an additional check when deciding if the deploy would be a no-op or not: Was the function last edited **after** the s3 objects, or **before** the s3 objects? If it was edited after, you can presume that the cloudformation was succesful since you can only run the cloudformation after updating the objects in s3. If it was edited after, you can infer that something happened to stop the lambda from being updated. This strategy is not 100% foolproof, someone can confuse it by manually editing the lambda function, but they should be doing that using serverless anyways. As long as they use the library, this will work.

## How can we verify it:

Create a new service (I called mine `test` ... very creative, I know :P).
I used this serverless.yml to start:
```yml
service: test

provider:
  name: aws
  runtime: nodejs10.x

functions:
  hello:
    handler: handler.hello

resources:
  Resources:
    SomeQueue:
      Type: AWS::SQS::Queue
      Properties:
        QueueName: "MyQueue"
        VisibilityTimeout: 30
        RedrivePolicy:
          maxReceiveCount: 10
          deadLetterTargetArn:
            Fn::Sub: arn:aws:sqs:us-east-1:000000000000:Dead

```
The handler code can be anything, we won't be running it.


The demo steps, using the service yml above:
1. Replace `000000000000` with your account id.
1. Run `serverless deploy`. You'll see it creates the s3 bucket/objects fine, but the stack fails since `Dead` doesn't exist.
2. Make the queue: `aws sqs create-queue --queue-name Dead --region us-east-1`
3. Try and deploy again. This time, if running the current serverless (without this patch), it won't deploy since there were "no changes". With the patch, it does the deploy successfully.
4. Try and deploy again, you'll see that both say there are no changes.

Don't forget to delete `Dead` once you're finished ...
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [X] Write documentation
- [X] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
