### PR TITLE
fix(GITHUB-6525-5172): Rewrite copyDirContentsSyncAllow to call fs-extra::copySync() on the directories instead of calling it on the files to copy individually

### DIFF
--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -224,7 +224,7 @@ describe('Utils', () => {
   });
 
   describe('#copyDirContentsSync()', () => {
-    it('recursively copy directory files', () => {
+    it('should recursively copy directory files', () => {
       const tmpSrcDirPath = path.join(process.cwd(), 'testSrc');
       const tmpDestDirPath = path.join(process.cwd(), 'testDest');
 

--- a/lib/utils/fs/copyDirContentsSync.js
+++ b/lib/utils/fs/copyDirContentsSync.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const path = require('path');
+const fs = require('fs');
 const fse = require('./fse');
-const walkDirSync = require('./walkDirSync');
 
-function fileExists(srcDir, destDir, options) {
-  const fullFilesPaths = walkDirSync(srcDir, options);
+const isNotSymbolicLink = src => !fs.lstatSync(src).isSymbolicLink();
 
-  fullFilesPaths.forEach(fullFilePath => {
-    const relativeFilePath = fullFilePath.replace(srcDir, '');
-    fse.copySync(fullFilePath, path.join(destDir, relativeFilePath));
-  });
+function copyDirContentsSync(srcDir, destDir, { noLinks = false } = {}) {
+  const copySyncOptions = {
+    dereference: true,
+    filter: noLinks ? isNotSymbolicLink : null,
+  };
+  fse.copySync(srcDir, destDir, copySyncOptions);
 }
 
-module.exports = fileExists;
+module.exports = copyDirContentsSync;

--- a/lib/utils/fs/copyDirContentsSync.test.js
+++ b/lib/utils/fs/copyDirContentsSync.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const expect = require('chai').expect;
+const fs = require('fs');
+const path = require('path');
+const copyDirContentsSync = require('./copyDirContentsSync');
+const fileExistsSync = require('./fileExistsSync');
+const removeFileSync = require('./removeFileSync');
+const writeFileSync = require('./writeFileSync');
+const { skipOnWindowsDisabledSymlinks } = require('../../../tests/utils/misc');
+
+describe('#copyDirContentsSync()', () => {
+  afterEach(() => {
+    removeFileSync(path.join(process.cwd(), 'testSrc'));
+    removeFileSync(path.join(process.cwd(), 'testDest'));
+  });
+
+  it('should recursively copy directory files including symbolic links', function() {
+    const tmpSrcDirPath = path.join(process.cwd(), 'testSrc');
+    const tmpDestDirPath = path.join(process.cwd(), 'testDest');
+
+    const srcFile1 = path.join(tmpSrcDirPath, 'file1.txt');
+    const srcFile2 = path.join(tmpSrcDirPath, 'folder', 'file2.txt');
+    const srcFile3 = path.join(tmpSrcDirPath, 'folder', 'file3.txt');
+
+    const destFile1 = path.join(tmpDestDirPath, 'file1.txt');
+    const destFile2 = path.join(tmpDestDirPath, 'folder', 'file2.txt');
+    const destFile3 = path.join(tmpDestDirPath, 'folder', 'file3.txt');
+
+    writeFileSync(srcFile1, 'foo');
+    writeFileSync(srcFile2, 'bar');
+    try {
+      fs.symlinkSync(srcFile2, srcFile3);
+    } catch (error) {
+      skipOnWindowsDisabledSymlinks(error, this);
+      throw error;
+    }
+
+    copyDirContentsSync(tmpSrcDirPath, tmpDestDirPath);
+
+    expect(fileExistsSync(destFile1)).to.equal(true);
+    expect(fileExistsSync(destFile2)).to.equal(true);
+    expect(fileExistsSync(destFile3)).to.equal(true);
+  });
+
+  it('should recursively copy directory files excluding symbolic links', function() {
+    const tmpSrcDirPath = path.join(process.cwd(), 'testSrc');
+    const tmpDestDirPath = path.join(process.cwd(), 'testDest');
+
+    const srcFile1 = path.join(tmpSrcDirPath, 'file1.txt');
+    const srcFile2 = path.join(tmpSrcDirPath, 'folder', 'file2.txt');
+    const srcFile3 = path.join(tmpSrcDirPath, 'folder', 'file3.txt');
+
+    const destFile1 = path.join(tmpDestDirPath, 'file1.txt');
+    const destFile2 = path.join(tmpDestDirPath, 'folder', 'file2.txt');
+    const destFile3 = path.join(tmpDestDirPath, 'folder', 'file3.txt');
+
+    writeFileSync(srcFile1, 'foo');
+    writeFileSync(srcFile2, 'bar');
+    try {
+      fs.symlinkSync(srcFile2, srcFile3);
+    } catch (error) {
+      skipOnWindowsDisabledSymlinks(error, this);
+      throw error;
+    }
+
+    copyDirContentsSync(tmpSrcDirPath, tmpDestDirPath, {
+      noLinks: true,
+    });
+
+    expect(fileExistsSync(destFile1)).to.equal(true);
+    expect(fileExistsSync(destFile2)).to.equal(true);
+    expect(fileExistsSync(destFile3)).to.equal(false);
+  });
+});


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement

The main motivation behind these changes is to rely on https://github.com/jprichardson/node-fs-extra/blob/8.1.0/docs/copy-sync.md as much as possible in order to avoid having to do the `fullFilePath.replace(srcDir, '')` operation because this operation can be error-prone.

Doing so fixes the following issues because the user-submitted file paths are now correctly interpreted by fs-extra:

Fixes #6525
Fixes #5172

## How did you implement it

### About `noLinks`

`copyDirContentsSync()` is called only once with a third parameter.

This parameter is set to `{ noLinks: true }` at https://github.com/serverless/serverless/blob/v1.49.0/lib/plugins/create/create.js#L163.

Furthermore, `noLinks` is also the only option accepted by `walkDirSync`, as seen in https://github.com/serverless/serverless/blob/v1.49.0/lib/utils/fs/walkDirSync.js#L7.

Thus this `noLinks` option had to be kept in this new implementation, preventing the copy of symbolic links if it is set to `true`.

### About `dereference`

In the previous implementation, when copied, symbolic links were always dereferenced.

This means that, when the following folder was copied:

```
./my-artifacts/
├── cloudformation-template-create-stack.json
├── cloudformation-template-update-stack.json
├── my-symbolic-link-to-serverless-state.json -> serverless-state.json
├── sandbox-serverless.zip
└── serverless-state.json
```

This resulting file structure was created, with `my-symbolic-link-to-serverless-state.json` no longer being a symbolic link:

```
./.serverless/
├── cloudformation-template-create-stack.json
├── cloudformation-template-update-stack.json
├── my-symbolic-link-to-serverless-state.json
├── sandbox-serverless.zip
└── serverless-state.json
```

The reason why that is the case is not obvious when reading https://github.com/jprichardson/node-fs-extra/blob/0.30.0/lib/copy-sync/copy-sync.js.

Even though the `dereference` option was always left to its `false` default value, the symbolic links were always dereferenced in our case because:

1. The files to copy were passed one by one to `copySync()`
2. When called with a file and not a directory, the `dereference` option is ignored by `copySync()`, as shown in https://github.com/jprichardson/node-fs-extra/blob/0.30.0/lib/copy-sync/copy-sync.js#L21 

## How can we verify it

For #6525:

```
$ serverless create --template aws-nodejs
$ serverless package --package ./my-artifacts
$ serverless deploy --package ./my-artifacts
```

For #5172: Specifically in a Windows environment:

```
$ serverless create --template aws-nodejs
$ serverless package --package ./my-artifacts/my-subfolder
$ serverless deploy --package ./my-artifacts/my-subfolder
```

## Todos

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
