### PR TITLE
Only add merged IAM policies for Lambda when they will be used (#6262)

### DIFF
--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -90,23 +90,13 @@ module.exports = {
       .Resources[this.provider.naming.getRoleLogicalId()].Properties.Policies[0].PolicyDocument
       .Statement;
 
-    // Ensure general polices for functions with default name resolution
-    policyDocumentStatements[0].Resource.push({
-      'Fn::Sub':
-        'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-        `:log-group:${logGroupsPrefix}*:*`,
-    });
-
-    policyDocumentStatements[1].Resource.push({
-      'Fn::Sub':
-        'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-        `:log-group:${logGroupsPrefix}*:*:*`,
-    });
+    let hasOneOrMoreCanonicallyNamedFunctions = false;
 
     // Ensure policies for functions with custom name resolution
     this.serverless.service.getAllFunctions().forEach(functionName => {
       const { name: resolvedFunctionName } = this.serverless.service.getFunction(functionName);
       if (!resolvedFunctionName || resolvedFunctionName.startsWith(canonicalFunctionNamePrefix)) {
+        hasOneOrMoreCanonicallyNamedFunctions = true;
         return;
       }
 
@@ -126,6 +116,21 @@ module.exports = {
           `:log-group:${customFunctionNamelogGroupsPrefix}:*:*`,
       });
     });
+
+    if (hasOneOrMoreCanonicallyNamedFunctions) {
+      // Ensure general policies for functions with default name resolution
+      policyDocumentStatements[0].Resource.push({
+        'Fn::Sub':
+          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+          `:log-group:${logGroupsPrefix}*:*`,
+      });
+
+      policyDocumentStatements[1].Resource.push({
+        'Fn::Sub':
+          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+          `:log-group:${logGroupsPrefix}*:*:*`,
+      });
+    }
 
     if (this.serverless.service.provider.iamRoleStatements) {
       // add custom iam role statements

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -127,11 +127,96 @@ describe('#mergeIamTemplates()', () => {
       });
     }));
 
-  it('should ensure IAM policies for custom named functions', () => {
+  it('should ensure IAM policies when service contains only custom named functions', () => {
     const customFunctionName = 'foo-bar';
     awsPackage.serverless.service.functions = {
       [functionName]: {
         name: customFunctionName,
+        artifact: 'test.zip',
+        handler: 'handler.hello',
+      },
+    };
+    serverless.service.setFunctionNames(); // Ensure to resolve function names
+
+    return awsPackage.mergeIamTemplates().then(() => {
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          awsPackage.provider.naming.getRoleLogicalId()
+        ]
+      ).to.deep.equal({
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: {
+                  Service: ['lambda.amazonaws.com'],
+                },
+                Action: ['sts:AssumeRole'],
+              },
+            ],
+          },
+          Path: '/',
+          Policies: [
+            {
+              PolicyName: {
+                'Fn::Join': [
+                  '-',
+                  [awsPackage.provider.getStage(), awsPackage.serverless.service.service, 'lambda'],
+                ],
+              },
+              PolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Action: ['logs:CreateLogStream'],
+                    Resource: [
+                      {
+                        'Fn::Sub':
+                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+                          `log-group:/aws/lambda/${customFunctionName}:*`,
+                      },
+                    ],
+                  },
+                  {
+                    Effect: 'Allow',
+                    Action: ['logs:PutLogEvents'],
+                    Resource: [
+                      {
+                        'Fn::Sub':
+                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+                          `log-group:/aws/lambda/${customFunctionName}:*:*`,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          RoleName: {
+            'Fn::Join': [
+              '-',
+              [
+                awsPackage.serverless.service.service,
+                awsPackage.provider.getStage(),
+                {
+                  Ref: 'AWS::Region',
+                },
+                'lambdaRole',
+              ],
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  it('should ensure IAM policies when service contains only canonically named functions', () => {
+    awsPackage.serverless.service.functions = {
+      [functionName]: {
         artifact: 'test.zip',
         handler: 'handler.hello',
       },
@@ -183,11 +268,6 @@ describe('#mergeIamTemplates()', () => {
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*`,
                       },
-                      {
-                        'Fn::Sub':
-                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
-                          `log-group:/aws/lambda/${customFunctionName}:*`,
-                      },
                     ],
                   },
                   {
@@ -199,10 +279,110 @@ describe('#mergeIamTemplates()', () => {
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*:*`,
                       },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          RoleName: {
+            'Fn::Join': [
+              '-',
+              [
+                awsPackage.serverless.service.service,
+                awsPackage.provider.getStage(),
+                {
+                  Ref: 'AWS::Region',
+                },
+                'lambdaRole',
+              ],
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  it('should ensure IAM policies for custom and canonically named functions', () => {
+    const customFunctionName = 'foo-bar';
+    awsPackage.serverless.service.functions = {
+      [functionName]: {
+        name: customFunctionName,
+        artifact: 'test.zip',
+        handler: 'handler.hello',
+      },
+      test2: {
+        artifact: 'test.zip',
+        handler: 'handler.hello',
+      },
+    };
+    serverless.service.setFunctionNames(); // Ensure to resolve function names
+
+    return awsPackage.mergeIamTemplates().then(() => {
+      const canonicalFunctionsPrefix = `${
+        awsPackage.serverless.service.service
+      }-${awsPackage.provider.getStage()}`;
+
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          awsPackage.provider.naming.getRoleLogicalId()
+        ]
+      ).to.deep.equal({
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: {
+                  Service: ['lambda.amazonaws.com'],
+                },
+                Action: ['sts:AssumeRole'],
+              },
+            ],
+          },
+          Path: '/',
+          Policies: [
+            {
+              PolicyName: {
+                'Fn::Join': [
+                  '-',
+                  [awsPackage.provider.getStage(), awsPackage.serverless.service.service, 'lambda'],
+                ],
+              },
+              PolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Action: ['logs:CreateLogStream'],
+                    Resource: [
+                      {
+                        'Fn::Sub':
+                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+                          `log-group:/aws/lambda/${customFunctionName}:*`,
+                      },
+                      {
+                        'Fn::Sub':
+                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+                          `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*`,
+                      },
+                    ],
+                  },
+                  {
+                    Effect: 'Allow',
+                    Action: ['logs:PutLogEvents'],
+                    Resource: [
                       {
                         'Fn::Sub':
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${customFunctionName}:*:*`,
+                      },
+                      {
+                        'Fn::Sub':
+                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+                          `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*:*`,
                       },
                     ],
                   },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6262 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Made serverless only add the wildcard IAM policy for canonically named functions if there are actually canonically named functions in the service.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

Full source: [log-group-policy.zip](https://github.com/serverless/serverless/files/3496926/log-group-policy.zip)


```yml
service: log-group-policy

provider:
   name: aws
   runtime: nodejs8.10

functions:
   testFunction:
      name: ${self:service}-custom-named-fn
      handler: index.handler
```

```
mkdir /tmp/test-packaging-for-6262
cd /tmp/test-packaging-for-6262
unzip log-group-policy.zip
cd log-group-policy
echo '{}' > package.json
npm i serverless@1.44.1
./node_modules/.bin/sls package
cp .serverless/cloudformation-template-update-stack.json cf-update-stack-v1.44.1.json
${PATH_TO_SERVERLESS_CLONE}/bin/serverless package
cp .serverless/cloudformation-template-update-stack.json cf-update-stack-using-PR.json
diff cf-update-stack-v1.44.1.json cf-update-stack-using-PR.json
```
_The above is based on tests from #6262._

**Expected:** There should be no change to the IAM policies for the example stack.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
   - Does this need to be documented? If so, where does it belong?
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
