### PR TITLE
Fix deploy command if package.individually set on a function-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Serverless is an MIT open-source project, actively maintained by a full-time, ve
 
 <a href="https://www.youtube.com/watch?v=-Nf0ui3qP2E" target="_blank">Watch the video overview here.</a>
 
-[![serverless components notice](https://s3.amazonaws.com/assets.github.serverless/components/serverless_components_notice_dark.gif)](https://github.com/serverless/components) 
+[![serverless components notice](https://s3.amazonaws.com/assets.github.serverless/components/serverless_components_notice_dark.gif)](https://github.com/serverless/components)
 
 ## Contents
 

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -64,16 +64,20 @@ module.exports = {
         let artifactFilePath = path.join(this.packagePath, artifactFileName);
 
         const functionObject = this.serverless.service.getFunction(functionName);
-        const individually = _.has(functionObject, ['package', 'individually'])
-              && functionObject.package.individually
-              || this.serverless.service.package.individually;
+        const individually =
+          (_.has(functionObject, ['package', 'individually']) &&
+            functionObject.package.individually) ||
+          this.serverless.service.package.individually;
 
-        if (_.has(functionObject, ['package', 'artifact'])) { // Use function-level artifact
+        if (_.has(functionObject, ['package', 'artifact'])) {
+          // Use function-level artifact
           artifactFilePath = functionObject.package.artifact;
           artifactFileName = path.basename(artifactFilePath);
-        } else if (this.serverless.service.package.artifact) { // Use service-levle artifact
+        } else if (this.serverless.service.package.artifact) {
+          // Use service-levle artifact
           artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
-        } else if (individually) { // Use function-level generated artifact
+        } else if (individually) {
+          // Use function-level generated artifact
           artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
           artifactFilePath = path.join(this.packagePath, artifactFileName);
         }

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -74,7 +74,7 @@ module.exports = {
           artifactFilePath = functionObject.package.artifact;
           artifactFileName = path.basename(artifactFilePath);
         } else if (this.serverless.service.package.artifact) {
-          // Use service-levle artifact
+          // Use service-level artifact
           artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
         } else if (individually) {
           // Use function-level generated artifact

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -57,20 +57,25 @@ module.exports = {
       });
     }
 
-    if (
-      !_.isEmpty(this.serverless.service.functions) &&
-      this.serverless.service.package.individually
-    ) {
-      // artifact file validation (multiple function artifacts)
+    if (!_.isEmpty(this.serverless.service.functions)) {
       this.serverless.service.getAllFunctions().forEach(functionName => {
-        let artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
+        // By default assume service-level package
+        let artifactFileName = this.provider.naming.getServiceArtifactName();
         let artifactFilePath = path.join(this.packagePath, artifactFileName);
 
-        // check if an artifact is used in function package level
         const functionObject = this.serverless.service.getFunction(functionName);
-        if (_.has(functionObject, ['package', 'artifact'])) {
+        const individually = _.has(functionObject, ['package', 'individually'])
+              && functionObject.package.individually
+              || this.serverless.service.package.individually;
+
+        if (_.has(functionObject, ['package', 'artifact'])) { // Use function-level artifact
           artifactFilePath = functionObject.package.artifact;
           artifactFileName = path.basename(artifactFilePath);
+        } else if (this.serverless.service.package.artifact) { // Use service-levle artifact
+          artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
+        } else if (individually) { // Use function-level generated artifact
+          artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
+          artifactFilePath = path.join(this.packagePath, artifactFileName);
         }
 
         if (!this.serverless.utils.fileExistsSync(artifactFilePath)) {
@@ -79,21 +84,6 @@ module.exports = {
           );
         }
       });
-    } else if (!_.isEmpty(this.serverless.service.functions)) {
-      // artifact file validation (single service artifact)
-      let artifactFilePath;
-      let artifactFileName;
-      if (this.serverless.service.package.artifact) {
-        artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
-      } else {
-        artifactFileName = this.provider.naming.getServiceArtifactName();
-        artifactFilePath = path.join(this.packagePath, artifactFileName);
-      }
-      if (!this.serverless.utils.fileExistsSync(artifactFilePath)) {
-        throw new this.serverless.classes.Error(
-          `No ${artifactFileName} file found in the package path you provided.`
-        );
-      }
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -59,27 +59,29 @@ module.exports = {
 
     if (!_.isEmpty(this.serverless.service.functions)) {
       this.serverless.service.getAllFunctions().forEach(functionName => {
-        // By default assume service-level package
-        let artifactFileName = this.provider.naming.getServiceArtifactName();
-        let artifactFilePath = path.join(this.packagePath, artifactFileName);
-
         const functionObject = this.serverless.service.getFunction(functionName);
         const individually =
           (_.has(functionObject, ['package', 'individually']) &&
             functionObject.package.individually) ||
           this.serverless.service.package.individually;
 
-        if (_.has(functionObject, ['package', 'artifact'])) {
-          // Use function-level artifact
-          artifactFilePath = functionObject.package.artifact;
-          artifactFileName = path.basename(artifactFilePath);
-        } else if (this.serverless.service.package.artifact) {
-          // Use service-level artifact
-          artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
-        } else if (individually) {
+        // By default assume service-level package
+        let artifactFileName = this.provider.naming.getServiceArtifactName();
+        let artifactFilePath = path.join(this.packagePath, artifactFileName);
+
+        if (individually) {
           // Use function-level generated artifact
           artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
           artifactFilePath = path.join(this.packagePath, artifactFileName);
+
+          if (_.has(functionObject, ['package', 'artifact'])) {
+            // Use function-level artifact
+            artifactFilePath = functionObject.package.artifact;
+            artifactFileName = path.basename(artifactFilePath);
+          }
+        } else if (this.serverless.service.package.artifact) {
+          // Use service-level artifact
+          artifactFileName = artifactFilePath = this.serverless.service.package.artifact;
         }
 
         if (!this.serverless.utils.fileExistsSync(artifactFilePath)) {

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -113,6 +113,25 @@ describe('extendedValidate', () => {
       });
     });
 
+    it('should use function package level generated artifact if functions is packaged individiually', () => {
+      awsDeploy.serverless.service.package.individually = false;
+      stateFileMock.service.functions = {
+        first: {
+          package: {
+            individually: true,
+          },
+        },
+      };
+      fileExistsSyncStub.returns(true);
+      readFileSyncStub.returns(stateFileMock);
+
+      return awsDeploy.extendedValidate().then(() => {
+        expect(fileExistsSyncStub.calledTwice).to.equal(true);
+        expect(readFileSyncStub.calledOnce).to.equal(true);
+        expect(fileExistsSyncStub.lastCall.args[0]).to.have.string('.serverless/first.zip');
+      });
+    });
+
     it('should use function package level artifact when provided', () => {
       stateFileMock.service.functions = {
         first: {

--- a/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -113,7 +113,7 @@ describe('extendedValidate', () => {
       });
     });
 
-    it('should use function package level generated artifact if functions is packaged individiually', () => {
+    it('should not throw error if individual packaging defined on a function level', () => {
       awsDeploy.serverless.service.package.individually = false;
       stateFileMock.service.functions = {
         first: {
@@ -124,12 +124,7 @@ describe('extendedValidate', () => {
       };
       fileExistsSyncStub.returns(true);
       readFileSyncStub.returns(stateFileMock);
-
-      return awsDeploy.extendedValidate().then(() => {
-        expect(fileExistsSyncStub.calledTwice).to.equal(true);
-        expect(readFileSyncStub.calledOnce).to.equal(true);
-        expect(fileExistsSyncStub.lastCall.args[0]).to.have.string('.serverless/first.zip');
-      });
+      return awsDeploy.extendedValidate();
     });
 
     it('should use function package level artifact when provided', () => {


### PR DESCRIPTION
## What did you implement:

Closes #6120

The issue was that `sls deploy` didn't work if package.individually was set on a function-level. According to the docs, it should work but looks like it has never worked.

## How did you implement it:

I simplified & cleaned up the validation logic that runs before deployment.

## How can we verify it:

I gave two examples in the comment: https://github.com/serverless/serverless/issues/6120#issuecomment-520944321. Both works now.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
