### PR TITLE
AWS API Gateway customize log level

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1507,3 +1507,16 @@ provider:
     restApi:
       format: '{ "requestId":"$context.requestId",   "ip": "$context.identity.sourceIp" }'
 ```
+
+The default API Gateway log level will be INFO. You can change this to error with the following:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    restApi:
+      level: ERROR
+```
+
+Valid values are INFO, ERROR.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -130,7 +130,9 @@ provider:
     apiGateway: true
     lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
   logs:
-    restApi: true # Optional configuration which specifies if API Gateway logs are used
+    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to true to use defaults, or configured via subproperties.
+      format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use.
+      level: INFO # Optional configuration which specifies the log level to use. May be either INFO or ERROR.
     websocket: true # Optional configuration which specifies if Websockets logs are used
 
 package: # Optional deployment packaging configuration

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
+const ServerlessError = require('../../../../../../../../classes/Error').ServerlessError;
 
 const isRestApiId = RegExp.prototype.test.bind(/^[a-z0-9]{3,}$/);
 const defaultApiGatewayLogFormat = [
@@ -17,7 +18,7 @@ const defaultApiGatewayLogFormat = [
   'responseLength: $context.responseLength',
 ].join(', ');
 const defaultApiGatewayLogLevel = 'INFO';
-const apiGatewayValidLogLevels = ['INFO', 'ERROR'];
+const apiGatewayValidLogLevels = new Set(['INFO', 'ERROR']);
 
 // NOTE --> Keep this file in sync with ../stage.js
 
@@ -198,11 +199,11 @@ function handleLogs() {
     let level = defaultApiGatewayLogLevel;
     if (logs.level) {
       level = logs.level;
-      if (!apiGatewayValidLogLevels.includes(level)) {
-        throw new Error(
-          `provider.logs.restApi.level is set to an invalid value. Support values are ${apiGatewayValidLogLevels.join(
-            ', '
-          )}, got ${level}.`
+      if (!apiGatewayValidLogLevels.has(level)) {
+        throw new ServerlessError(
+          `provider.logs.restApi.level is set to an invalid value. Support values are ${Array.from(
+            apiGatewayValidLogLevels
+          ).join(', ')}, got ${level}.`
         );
       }
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -199,7 +199,11 @@ function handleLogs() {
     if (logs.level) {
       level = logs.level;
       if (!apiGatewayValidLogLevels.includes(level)) {
-        throw new Error(`provider.logs.restApi.level is set to an invalid value. Support values are ${apiGatewayValidLogLevels.join(', ')}, got ${level}.`)
+        throw new Error(
+          `provider.logs.restApi.level is set to an invalid value. Support values are ${apiGatewayValidLogLevels.join(
+            ', '
+          )}, got ${level}.`
+        );
       }
     }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -16,6 +16,8 @@ const defaultApiGatewayLogFormat = [
   'protocol: $context.protocol',
   'responseLength: $context.responseLength',
 ].join(', ');
+const defaultApiGatewayLogLevel = 'INFO';
+const apiGatewayValidLogLevels = ['INFO', 'ERROR'];
 
 // NOTE --> Keep this file in sync with ../stage.js
 
@@ -23,6 +25,8 @@ const defaultApiGatewayLogFormat = [
 // Stage resource (see https://github.com/serverless/serverless/pull/5692#issuecomment-467849311 for more information).
 
 module.exports = {
+  defaultApiGatewayLogLevel,
+  apiGatewayValidLogLevels,
   updateStage() {
     // this array is used to gather all the patch operations we need to
     // perform on the stage
@@ -191,6 +195,14 @@ function handleLogs() {
       logFormat = logs.format;
     }
 
+    let level = defaultApiGatewayLogLevel;
+    if (logs.level) {
+      level = logs.level;
+      if (!apiGatewayValidLogLevels.includes(level)) {
+        throw new Error(`provider.logs.restApi.level is set to an invalid value. Support values are ${apiGatewayValidLogLevels.join(', ')}, got ${level}.`)
+      }
+    }
+
     const destinationArn = {
       op: 'replace',
       path: '/accessLogSettings/destinationArn',
@@ -202,7 +214,7 @@ function handleLogs() {
       value: logFormat,
     };
     dataTrace = { op: 'replace', path: '/*/*/logging/dataTrace', value: 'true' };
-    logLevel = { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' };
+    logLevel = { op: 'replace', path: '/*/*/logging/loglevel', value: level };
     operations = [destinationArn, format, dataTrace, logLevel];
   }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -8,7 +8,11 @@ const sinon = require('sinon');
 const _ = require('lodash');
 const Serverless = require('../../../../../../../../Serverless');
 const AwsProvider = require('../../../../../../provider/awsProvider');
-const {updateStage, apiGatewayValidLogLevels, defaultApiGatewayLogLevel} = require('./updateStage');
+const {
+  updateStage,
+  apiGatewayValidLogLevels,
+  defaultApiGatewayLogLevel,
+} = require('./updateStage');
 
 chai.use(require('sinon-chai'));
 chai.use(require('chai-as-promised'));
@@ -398,15 +402,14 @@ describe('#updateStage()', () => {
           level: setLevel,
         },
       };
-    }
-    else {
+    } else {
       context.state.service.provider.logs = {
         restApi: true,
       };
     }
 
     return updateStage.call(context).then(() => {
-      const patchOperation = {op: 'replace', path: '/*/*/logging/loglevel', value: expectedLevel};
+      const patchOperation = { op: 'replace', path: '/*/*/logging/loglevel', value: expectedLevel };
 
       const patchOperations = providerRequestStub.args[2][2].patchOperations;
       expect(patchOperations).to.include.deep.members([patchOperation]);
@@ -417,7 +420,7 @@ describe('#updateStage()', () => {
     return checkLogLevel(null, defaultApiGatewayLogLevel);
   });
 
-  apiGatewayValidLogLevels.forEach((logLevel) => {
+  apiGatewayValidLogLevels.forEach(logLevel => {
     it(`should update the stage with a custom APIGW log level if given ${logLevel}`, () => {
       return checkLogLevel(logLevel, logLevel);
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -8,9 +8,10 @@ const sinon = require('sinon');
 const _ = require('lodash');
 const Serverless = require('../../../../../../../../Serverless');
 const AwsProvider = require('../../../../../../provider/awsProvider');
-const updateStage = require('./updateStage').updateStage;
+const {updateStage, apiGatewayValidLogLevels, defaultApiGatewayLogLevel} = require('./updateStage');
 
 chai.use(require('sinon-chai'));
+chai.use(require('chai-as-promised'));
 
 const { expect } = chai;
 
@@ -388,5 +389,47 @@ describe('#updateStage()', () => {
         tagKeys: ['old'],
       });
     });
+  });
+
+  function checkLogLevel(setLevel, expectedLevel) {
+    if (setLevel) {
+      context.state.service.provider.logs = {
+        restApi: {
+          level: setLevel,
+        },
+      };
+    }
+    else {
+      context.state.service.provider.logs = {
+        restApi: true,
+      };
+    }
+
+    return updateStage.call(context).then(() => {
+      const patchOperation = {op: 'replace', path: '/*/*/logging/loglevel', value: expectedLevel};
+
+      const patchOperations = providerRequestStub.args[2][2].patchOperations;
+      expect(patchOperations).to.include.deep.members([patchOperation]);
+    });
+  }
+
+  it('should use the default log level if no log level is given', () => {
+    return checkLogLevel(null, defaultApiGatewayLogLevel);
+  });
+
+  apiGatewayValidLogLevels.forEach((logLevel) => {
+    it(`should update the stage with a custom APIGW log level if given ${logLevel}`, () => {
+      return checkLogLevel(logLevel, logLevel);
+    });
+  });
+
+  it('should reject a custom APIGW log level if value is invalid', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        level: 'INVALID',
+      },
+    };
+
+    return expect(updateStage.call(context)).to.be.rejectedWith('invalid value');
   });
 });


### PR DESCRIPTION

## What did you implement:

Added support for specifying the AWS API Gateway log level to be used. I also updated the sample AWS serverless.yml.md file to include the log format option as that was missing when that feature was added.

This is an enhancement to API Gateway logs as part of #6094.

## How did you implement it:

Users can now customize the log level by setting the `provider.logs.restApi.level` optional setting in serverless.yml to either INFO (default value) or ERROR:

```yml
provider:
  name: aws
  logs:
    restApi: 
      level: ERROR
```

An error will be thrown if something other than INFO or ERROR is provided. I updated updateStage.js to use the user-provided log level if available, otherwise it falls back to the default INFO as before.

## How can we verify it:

Create a serverless project and set `provider.logs.restApi.level` to either INFO or ERROR and run a deploy. Set to something to cause an invalid value error.

## Todos:

- [x] Write tests and confirm existing functionality is not broken.  
- [x] Write documentation
- [x] Ensure there are no lint errors.  
- [x] Ensure introduced changes match Prettier formatting.  
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
