### PR TITLE
AWS API Gateway set value of provider.logRetentionInDays for log group expiration

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -141,8 +141,9 @@ function getLogGroupResource(service, stage, provider) {
     },
   };
 
-  if (provider.hasLogRetentionInDays()) {
-    resource.Properties.RetentionInDays = provider.getLogRetentionInDays();
+  const logRetentionInDays = provider.getLogRetentionInDays();
+  if (logRetentionInDays !== null) {
+    resource.Properties.RetentionInDays = logRetentionInDays;
   }
 
   return resource;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -88,7 +88,7 @@ module.exports = {
         const customResourceFunctionLogicalId = this.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
 
         _.merge(cfTemplate.Resources, {
-          [logGroupLogicalId]: getLogGroupResource(service, stage),
+          [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider),
           [customResourceLogicalId]: {
             Type: 'Custom::ApiGatewayAccountRole',
             Version: 1.0,
@@ -133,11 +133,17 @@ module.exports = {
   },
 };
 
-function getLogGroupResource(service, stage) {
-  return {
+function getLogGroupResource(service, stage, provider) {
+  const resource = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
       LogGroupName: `/aws/api-gateway/${service}-${stage}`,
     },
   };
+
+  if (provider.hasLogRetentionInDays()) {
+    resource.Properties.RetentionInDays = provider.getLogRetentionInDays();
+  }
+
+  return resource;
 }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -142,7 +142,7 @@ function getLogGroupResource(service, stage, provider) {
   };
 
   const logRetentionInDays = provider.getLogRetentionInDays();
-  if (logRetentionInDays !== null) {
+  if (logRetentionInDays) {
     resource.Properties.RetentionInDays = logRetentionInDays;
   }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -260,5 +260,22 @@ describe('#compileStage()', () => {
         });
       });
     });
+
+    it('should set log retention if provider.logRetentionInDays is set', () => {
+      serverless.service.provider.logRetentionInDays = 30;
+
+      return awsCompileApigEvents.compileStage().then(() => {
+        const resources =
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+        expect(resources[logGroupLogicalId]).to.deep.equal({
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: '/aws/api-gateway/my-service-dev',
+            RetentionInDays: serverless.service.provider.logRetentionInDays,
+          },
+        });
+      });
+    });
   });
 });

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -30,15 +30,10 @@ module.exports = {
         },
       };
 
-      if (_.has(this.serverless.service.provider, 'logRetentionInDays')) {
-        const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;
-        const retentionInDays = parseInt(rawRetentionInDays, 10);
-        if (_.isInteger(retentionInDays) && retentionInDays > 0) {
-          newLogGroup[logGroupLogicalId].Properties.RetentionInDays = retentionInDays;
-        } else {
-          const errorMessage = `logRetentionInDays should be an integer over 0 but ${rawRetentionInDays}`;
-          throw new this.serverless.classes.Error(errorMessage);
-        }
+      if (this.provider.hasLogRetentionInDays()) {
+        newLogGroup[
+          logGroupLogicalId
+        ].Properties.RetentionInDays = this.provider.getLogRetentionInDays();
       }
 
       _.merge(

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -30,10 +30,9 @@ module.exports = {
         },
       };
 
-      if (this.provider.hasLogRetentionInDays()) {
-        newLogGroup[
-          logGroupLogicalId
-        ].Properties.RetentionInDays = this.provider.getLogRetentionInDays();
+      const logRetentionInDays = this.provider.getLogRetentionInDays();
+      if (logRetentionInDays !== null) {
+        newLogGroup[logGroupLogicalId].Properties.RetentionInDays = logRetentionInDays;
       }
 
       _.merge(

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -31,7 +31,7 @@ module.exports = {
       };
 
       const logRetentionInDays = this.provider.getLogRetentionInDays();
-      if (logRetentionInDays !== null) {
+      if (logRetentionInDays) {
         newLogGroup[logGroupLogicalId].Properties.RetentionInDays = logRetentionInDays;
       }
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -472,6 +472,21 @@ class AwsProvider {
     return this.serverless.service.provider.deploymentPrefix || 'serverless';
   }
 
+  getLogRetentionInDays() {
+    const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;
+    const retentionInDays = parseInt(rawRetentionInDays, 10);
+    if (_.isInteger(retentionInDays) && retentionInDays > 0) {
+      return retentionInDays;
+    }
+
+    const errorMessage = `logRetentionInDays should be an integer over 0 but ${rawRetentionInDays}`;
+    throw new this.serverless.classes.Error(errorMessage);
+  }
+
+  hasLogRetentionInDays() {
+    return _.has(this.serverless.service.provider, 'logRetentionInDays');
+  }
+
   getStageSourceValue() {
     const values = this.getValues(this, [
       ['options', 'stage'],

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -473,6 +473,9 @@ class AwsProvider {
   }
 
   getLogRetentionInDays() {
+    if (!_.has(this.serverless.service.provider, 'logRetentionInDays')) {
+      return null;
+    }
     const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;
     const retentionInDays = parseInt(rawRetentionInDays, 10);
     if (_.isInteger(retentionInDays) && retentionInDays > 0) {
@@ -481,10 +484,6 @@ class AwsProvider {
 
     const errorMessage = `logRetentionInDays should be an integer over 0 but ${rawRetentionInDays}`;
     throw new this.serverless.classes.Error(errorMessage);
-  }
-
-  hasLogRetentionInDays() {
-    return _.has(this.serverless.service.provider, 'logRetentionInDays');
   }
 
   getStageSourceValue() {


### PR DESCRIPTION
What did you implement:

Implemented setting the value of RetentionInDays to provider.logRetentionInDays on the API Gateway LogGroup created when logging is enabled.

This is an enhancement to API Gateway logs as part of #6094.

## How did you implement it:

The created API Gateway log group will now respect the value set on logRetentionInDays:

```yml
provider:
  aws: aws

  logRetentionInDays: 30

  logs:
    restApi: true
```

If this value is unset then the expiration is set to never expire, which is the current default.

## How can we verify it:

Create a serverless project and set provider.logs.restApi=true and provider.logRetentionInDays to an integer greater than 0 and run a deploy. Remove the value to unset the log retention value.

## Todos:

- [x] Write tests and confirm existing functionality is not broken.  
- [x] Write documentation
- [x] Ensure there are no lint errors.  
- [x] Ensure introduced changes match Prettier formatting.  
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
