### PR TITLE
do not log warnings on empty arrays

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -889,7 +889,9 @@ class Variables {
     if (
       valueToPopulate === null ||
       typeof valueToPopulate === 'undefined' ||
-      (typeof valueToPopulate === 'object' && _.isEmpty(valueToPopulate))
+      (typeof valueToPopulate === 'object' &&
+        !Array.isArray(valueToPopulate) &&
+        _.isEmpty(valueToPopulate))
     ) {
       let varType;
       if (variableString.match(this.envRefSyntax)) {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2436,6 +2436,10 @@ module.exports = {
       varProxy.warnIfNotFound('self:service', {});
       expect(logWarningSpy).to.have.been.calledOnce;
     });
+    it('should not log if variable has empty array value.', () => {
+      varProxy.warnIfNotFound('self:service', []);
+      expect(logWarningSpy).to.not.have.been.called;
+    });
     it('should detect the "environment variable" variable type', () => {
       varProxy.warnIfNotFound('env:service', null);
       expect(logWarningSpy).to.have.been.calledOnce;

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -613,6 +613,7 @@ describe('checkForChanges', () => {
     const serviceName = 'my-service';
     const region = 'us-east-1';
     let describeSubscriptionFiltersResponse = {};
+    let getFunctionStub;
 
     beforeEach(() => {
       CloudWatchLogsStub = class {
@@ -637,6 +638,7 @@ describe('checkForChanges', () => {
       );
 
       sandbox.stub(awsDeploy.serverless.service, 'getServiceName').returns(serviceName);
+      getFunctionStub = sandbox.stub(awsDeploy.provider, 'request').rejects(new Error('Error'));
 
       sandbox.stub(awsDeploy, 'getMostRecentObjects').resolves();
       sandbox.stub(awsDeploy, 'getObjectMetadata').resolves();
@@ -644,6 +646,7 @@ describe('checkForChanges', () => {
     });
 
     afterEach(() => {
+      awsDeploy.provider.request.restore();
       sandbox.restore();
     });
 
@@ -858,16 +861,6 @@ describe('checkForChanges', () => {
     });
 
     describe('#getFunctionsLatestLastModifiedDate', () => {
-      let getFunctionStub;
-
-      beforeEach(() => {
-        getFunctionStub = sandbox.stub(awsDeploy.provider, 'request').resolves();
-      });
-
-      afterEach(() => {
-        awsDeploy.provider.request.restore();
-      });
-
       it('should return null when there are no functions', () => {
         awsDeploy.serverless.service.functions = {};
         awsDeploy.serverless.service.setFunctionNames();


### PR DESCRIPTION
## What did you implement:

Closes #3655

## How did you implement it:

I used ~`!_.isArray`~ `!Array.isArray` instead of `_.isPlainObject()` because I wasn't sure if some plugins might write configuration that isn't technically a "plain" object?

## How can we verify it:

I added a test, and this is just around logged warning messages, so no other behaviour is modified.

## Todos:

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation (N/A)
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO (IMO - could be debated depending on who's parsing stdout looking for warnings)
