### PR TITLE
Fix: Remove Bluebird promise warning when NODE_ENV=development

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -352,6 +352,8 @@ class Utils {
       return resolve(data);
     }).then(data => {
       if (data) tracking.track('segment', data);
+      // prevent Bluebird `Warning: a promise was created in a handler but was not returned from it` by returning null
+      return null;
     });
   }
 

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -791,7 +791,8 @@ describe('Utils', () => {
         package: {},
       };
 
-      return expect(utils.logStat(serverless)).to.be.fulfilled.then(() => {
+      return expect(utils.logStat(serverless)).to.be.fulfilled.then(response => {
+        expect(response).to.be.null;
         expect(trackStub.calledOnce).to.equal(true);
         expect(getConfigStub.calledOnce).to.equal(true);
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6555

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Return `null` from `logStat` promise to remove Bluebird `Warning: a promise was created in a handler but was not returned from it` when NODE_ENV=development
http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Setting `NODE_ENV=development` triggers these warnings to be written to the console by Bluebird with `serverless@1.48.1` and above. I was also running locally with `serverless-offline` when I noticed this new warning.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation (N/A)
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
