### PR TITLE
[AWS] Allow string true/false as tracing option

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -133,7 +133,7 @@ provider:
     baz: qux
   tracing:
     apiGateway: true
-    lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
+    lambda: true # Optional, can be true (true equals 'Active'), false (equals 'PassThrough), 'Active' or 'PassThrough'
   logs:
     restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to true to use defaults, or configured via subproperties.
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use.

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -46,7 +46,10 @@ module.exports = {
           // Could not resolve REST API id automatically
 
           const provider = this.state.service.provider;
-          const isTracingEnabled = provider.tracing && provider.tracing.apiGateway;
+          const isTracingEnabled =
+            provider.tracing &&
+            provider.tracing.apiGateway &&
+            provider.tracing.apiGateway !== 'false';
           const areLogsEnabled = provider.logs && provider.logs.restApi;
           const hasTags = Boolean(provider.tags);
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -148,6 +148,30 @@ describe('#updateStage()', () => {
     });
   });
 
+  it('should alsi turn off the log if string false given to tracing', () => {
+    context.state.service.provider.tracing = {
+      apiGateway: 'false', // passed as command line argument
+    };
+
+    return updateStage.call(context).then(() => {
+      const patchOperations = [
+        { op: 'replace', path: '/tracingEnabled', value: 'true' },
+        { op: 'replace', path: '/*/*/logging/dataTrace', value: 'false' },
+        { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' },
+      ];
+
+      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerRequestStub.args).to.have.length(5);
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
+        restApiId: 'someRestApiId',
+        stageName: 'dev',
+        patchOperations,
+      });
+    });
+  });
+
   it('should perform default actions if settings are not configure', () => {
     context.state.service.provider.tags = {
       old: 'tag',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -20,7 +20,8 @@ module.exports = {
 
     // TracingEnabled
     const tracing = provider.tracing;
-    const TracingEnabled = !_.isEmpty(tracing) && tracing.apiGateway;
+    const TracingEnabled =
+      !_.isEmpty(tracing) && tracing.apiGateway && tracing.apiGateway !== 'false';
 
     // Tags
     const tagsMerged = Object.assign({}, provider.stackTags, provider.tags);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -99,6 +99,26 @@ describe('#compileStage()', () => {
         });
       });
     });
+
+    it('should NOT create a dedicated stage resource if string false given to tracing', () => {
+      awsCompileApigEvents.serverless.service.provider.tracing = {
+        apiGateway: 'false',
+      };
+
+      return awsCompileApigEvents.compileStage().then(() => {
+        const resources =
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+        // eslint-disable-next-line
+        expect(resources[stageLogicalId]).not.to.exist;
+
+        expect(resources[awsCompileApigEvents.apiGatewayDeploymentLogicalId]).to.deep.equal({
+          Properties: {
+            StageName: stage,
+          },
+        });
+      });
+    });
   });
 
   describe('tags', () => {

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -290,10 +290,12 @@ class AwsCompileFunctions {
       (this.serverless.service.provider.tracing && this.serverless.service.provider.tracing.lambda);
 
     if (tracing) {
-      if (typeof tracing === 'boolean' || typeof tracing === 'string') {
+      if (tracing === 'false') {
+        // no tracing
+      } else if (typeof tracing === 'boolean' || typeof tracing === 'string') {
         let mode = tracing;
 
-        if (typeof tracing === 'boolean') {
+        if (tracing === true || tracing === 'true') {
           mode = 'Active';
         }
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1368,6 +1368,66 @@ describe('AwsCompileFunctions', () => {
         });
       });
 
+      describe('tracing value', () => {
+        function shouldHaveMode(tracingValue) {
+          Object.assign(awsCompileFunctions.serverless.service.provider, {
+            tracing: {
+              lambda: tracingValue,
+            },
+          });
+
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+            },
+          };
+
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
+            const compiledCfTemplate =
+              awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate;
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+            expect(functionResource.Properties.TracingConfig.Mode).to.equal('Active');
+          });
+        }
+
+        function shouldNotHaveTracingConfig(tracingValue) {
+          Object.assign(awsCompileFunctions.serverless.service.provider, {
+            tracing: {
+              lambda: tracingValue,
+            },
+          });
+
+          awsCompileFunctions.serverless.service.functions = {
+            func: {
+              handler: 'func.function.handler',
+              name: 'new-service-dev-func',
+            },
+          };
+
+          return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
+            const compiledCfTemplate =
+              awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate;
+            const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+            expect(functionResource.Properties.TracingConfig).to.equal(undefined);
+          });
+        }
+
+        it('should accept boolean true as "Active"', () => {
+          return shouldHaveMode(true);
+        });
+        it('should accept string "true" as "Active"', () => {
+          return shouldHaveMode('true');
+        });
+
+        it('should accept boolean false to remove tracing config', () => {
+          return shouldNotHaveTracingConfig(false);
+        });
+        it('should accept string "false" to remove tracing config', () => {
+          return shouldNotHaveTracingConfig('false');
+        });
+      });
+
       it('should prefer a function tracing config over a provider config', () => {
         Object.assign(awsCompileFunctions.serverless.service.provider, {
           tracing: {


### PR DESCRIPTION
## What did you implement:

This allow users to pass `tracing` from command line argument. 

## How did you implement it:

Treat string `'true'`/`'false'` as boolean in `tracing.lambda` and `tracing.apiGateway`

## How can we verify it:

1.  Install from PR branch.
1. Add 
```yaml
provider:
   tracing:
      lambda: '${opt:tracing, "false"}'
      apiGateway:  '${opt:tracing, "false"}'
```
1. `sls deploy` should disable tracing
1. `sls deploy --tracing true` enable tracing
1. `sls deploy --tracing false` disable tracing

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
