### PR TITLE
Do not override defined resources for s3 events

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -153,9 +153,14 @@ class AwsCompileS3Events {
       const bucketCFResource = {
         [bucketLogicalId]: bucketTemplate,
       };
-      _.merge(
+      _.mergeWith(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        bucketCFResource
+        bucketCFResource,
+        function(objValue, srcValue, key) {
+          if (key === 'BucketName') {
+            return objValue;
+          }
+        }
       );
     });
 
@@ -189,9 +194,14 @@ class AwsCompileS3Events {
       const permissionCFResource = {
         [lambdaPermissionLogicalId]: permissionTemplate,
       };
-      _.merge(
+      _.mergeWith(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        permissionCFResource
+        permissionCFResource,
+        function(objValue, srcValue, key) {
+          if (key === 'SourceArn') {
+            return objValue;
+          }
+        }
       );
     });
   }

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -142,6 +142,46 @@ describe('AwsCompileS3Events', () => {
       });
     });
 
+    it('should not modify SourceArn if custom resources are defined', () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: 'first-function-bucket-one',
+            },
+          ],
+        },
+      };
+
+      serverless.service.provider.compiledCloudFormationTemplate.Resources = {
+        S3BucketFirstfunctionbucketone: {
+          Properties: {
+            BucketName: 'stage-first-function-bucket-one',
+          },
+        },
+        FirstLambdaPermissionFirstfunctionbucketoneS3: {
+          Properties: {
+            SourceArn: {
+              'Fn::GetAtt': ['S3BucketDatalake', 'Arn'],
+            },
+          },
+        },
+      };
+
+      awsCompileS3Events.newS3Buckets();
+
+      expect(
+        awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .S3BucketFirstfunctionbucketone.Properties.BucketName
+      ).to.equal('stage-first-function-bucket-one');
+      expect(
+        awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstLambdaPermissionFirstfunctionbucketoneS3.Properties.SourceArn
+      ).to.deep.equal({
+        'Fn::GetAtt': ['S3BucketDatalake', 'Arn'],
+      });
+    });
+
     it('should create single bucket resource when the same bucket referenced repeatedly', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6569

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
If the User had defined the matching resources like specified at https://serverless.com/framework/docs/providers/aws/events/s3#custom-bucket-configuration avoid merging objects like _.merge() would do and through the use of _.mergeWith() override the BucketName and SourceArn from the ones defined by the SLS.


## How can we verify it:
This Sample repo https://github.com/ebisbe/s3test should work. I have tried to install my fork in local but I was unable to do it. I don't see any where how to install that package.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
