### PR TITLE
Ensure AWS SDK is mocked for tests that call it

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -613,6 +613,7 @@ describe('checkForChanges', () => {
     const serviceName = 'my-service';
     const region = 'us-east-1';
     let describeSubscriptionFiltersResponse = {};
+    let getFunctionStub;
 
     beforeEach(() => {
       CloudWatchLogsStub = class {
@@ -637,6 +638,7 @@ describe('checkForChanges', () => {
       );
 
       sandbox.stub(awsDeploy.serverless.service, 'getServiceName').returns(serviceName);
+      getFunctionStub = sandbox.stub(awsDeploy.provider, 'request').rejects(new Error('Error'));
 
       sandbox.stub(awsDeploy, 'getMostRecentObjects').resolves();
       sandbox.stub(awsDeploy, 'getObjectMetadata').resolves();
@@ -644,6 +646,7 @@ describe('checkForChanges', () => {
     });
 
     afterEach(() => {
+      awsDeploy.provider.request.restore();
       sandbox.restore();
     });
 
@@ -858,16 +861,6 @@ describe('checkForChanges', () => {
     });
 
     describe('#getFunctionsLatestLastModifiedDate', () => {
-      let getFunctionStub;
-
-      beforeEach(() => {
-        getFunctionStub = sandbox.stub(awsDeploy.provider, 'request').resolves();
-      });
-
-      afterEach(() => {
-        awsDeploy.provider.request.restore();
-      });
-
       it('should return null when there are no functions', () => {
         awsDeploy.serverless.service.functions = {};
         awsDeploy.serverless.service.setFunctionNames();


### PR DESCRIPTION
Regression introduced with https://github.com/serverless/serverless/pull/6520

Prepared mocks did not cover some tests which (after #6520 improvement) invoked `Lambda.getFunction` AWS SDK endpoints.

Those calls either crashed quickly (which didn't affect test result, as there's catch all), or timed out depending on AWS creds env setup.

This patch ensures no real SDK calls are made

**_Is it a breaking change?:_** NO
