### PR TITLE
API Gateway enable/disable access/execution logs

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -140,7 +140,7 @@ provider:
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
       executionLogging: true # Optional configuration which enables or disables execution logging. Defaults to true.
       level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR.
-      fullData: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
+      fullExecutionData: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
     websocket: true # Optional configuration which specifies if Websockets logs are used
 
 package: # Optional deployment packaging configuration

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -136,10 +136,10 @@ provider:
     lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
   logs:
     restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to true to use defaults, or configured via subproperties.
-      enableAccessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
+      accessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
       level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR, or set to OFF to disable.
-      dateTrace: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
+      fullData: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
     websocket: true # Optional configuration which specifies if Websockets logs are used
 
 package: # Optional deployment packaging configuration

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -136,8 +136,10 @@ provider:
     lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
   logs:
     restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to true to use defaults, or configured via subproperties.
-      format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use.
-      level: INFO # Optional configuration which specifies the log level to use. May be either INFO or ERROR.
+      enableAccessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
+      format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
+      level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR, or set to OFF to disable.
+      dateTrace: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
     websocket: true # Optional configuration which specifies if Websockets logs are used
 
 package: # Optional deployment packaging configuration

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -138,7 +138,8 @@ provider:
     restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to true to use defaults, or configured via subproperties.
       accessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
-      level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR, or set to OFF to disable.
+      executionLogging: true # Optional configuration which enables or disables execution logging. Defaults to true.
+      level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR.
       fullData: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
     websocket: true # Optional configuration which specifies if Websockets logs are used
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -76,7 +76,7 @@ module.exports = {
           .then(applyUpdates.bind(this))
           .then(addTags.bind(this))
           .then(removeTags.bind(this))
-          .then(removeLogGroup.bind(this));
+          .then(removeAccessLoggingLogGroup.bind(this));
       });
   },
 };
@@ -308,22 +308,22 @@ function applyUpdates() {
   return BbPromise.resolve();
 }
 
-function removeLogGroup() {
+function removeAccessLoggingLogGroup() {
   const service = this.state.service.service;
   const provider = this.state.service.provider;
   const stage = this.options.stage;
   const logGroupName = `/aws/api-gateway/${service}-${stage}`;
 
-  let logs = provider.logs && provider.logs.restApi;
+  let accessLogging = provider.logs && provider.logs.restApi;
 
-  if (logs) {
-    logs = logs.accessLogging == null ? true : logs.accessLogging;
+  if (accessLogging) {
+    accessLogging = accessLogging.accessLogging == null ? true : accessLogging.accessLogging;
   }
 
   // if there are no logs setup (or the user has disabled them) we need to
   // ensure that the log group is removed. Otherwise we'll run into duplicate
   // log group name issues when logs are enabled again
-  if (!logs) {
+  if (!accessLogging) {
     return this.provider
       .request('CloudWatchLogs', 'deleteLogGroup', {
         logGroupName,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -180,10 +180,10 @@ function handleLogs() {
   const logs = provider.logs && provider.logs.restApi;
   const ops = this.apiGatewayStagePatchOperations;
 
-  const dataTrace = { op: 'replace', path: '/*/*/logging/dataTrace', value: 'false' };
-  const logLevel = { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' };
-
-  let operations = [dataTrace, logLevel];
+  let operations = [
+    { op: 'replace', path: '/*/*/logging/dataTrace', value: 'false' },
+    { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' },
+  ];
 
   if (logs) {
     const service = this.state.service.service;
@@ -210,12 +210,9 @@ function handleLogs() {
       }
     }
 
-    let enableAccessLogs = logs.enableAccessLogging;
-    if (enableAccessLogs === undefined) {
-      enableAccessLogs = true;
-    }
+    const accessLogging = logs.accessLogging == null ? true : logs.accessLogging;
 
-    if (enableAccessLogs) {
+    if (accessLogging) {
       const destinationArn = {
         op: 'replace',
         path: '/accessLogSettings/destinationArn',
@@ -236,14 +233,11 @@ function handleLogs() {
       });
     }
 
-    let enableDataTracing = logs.dataTrace;
-    if (enableDataTracing === undefined) {
-      enableDataTracing = true;
-    }
+    const fullData = logs.fullData == null ? true : logs.fullData;
     operations.push({
       op: 'replace',
       path: '/*/*/logging/dataTrace',
-      value: (!!enableDataTracing).toString(),
+      value: String(Boolean(fullData)),
     });
 
     operations.push({ op: 'replace', path: '/*/*/logging/loglevel', value: level });
@@ -319,10 +313,7 @@ function removeLogGroup() {
   let logs = provider.logs && provider.logs.restApi;
 
   if (logs) {
-    const enableAccessLogs = logs.enableAccessLogging;
-    if (enableAccessLogs !== undefined) {
-      logs = enableAccessLogs;
-    }
+    logs = logs.accessLogging == null ? true : logs.accessLogging;
   }
 
   // if there are no logs setup (or the user has disabled them) we need to

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -18,7 +18,7 @@ const defaultApiGatewayLogFormat = [
   'responseLength: $context.responseLength',
 ].join(', ');
 const defaultApiGatewayLogLevel = 'INFO';
-const apiGatewayValidLogLevels = new Set(['INFO', 'ERROR']);
+const apiGatewayValidLogLevels = new Set(['INFO', 'ERROR', 'OFF']);
 
 // NOTE --> Keep this file in sync with ../stage.js
 
@@ -180,8 +180,8 @@ function handleLogs() {
   const logs = provider.logs && provider.logs.restApi;
   const ops = this.apiGatewayStagePatchOperations;
 
-  let dataTrace = { op: 'replace', path: '/*/*/logging/dataTrace', value: 'false' };
-  let logLevel = { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' };
+  const dataTrace = { op: 'replace', path: '/*/*/logging/dataTrace', value: 'false' };
+  const logLevel = { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' };
 
   let operations = [dataTrace, logLevel];
 
@@ -190,6 +190,8 @@ function handleLogs() {
     const stage = this.options.stage;
     const region = this.options.region;
     const logGroupName = `/aws/api-gateway/${service}-${stage}`;
+
+    operations = [];
 
     let logFormat = defaultApiGatewayLogFormat;
     if (logs.format) {
@@ -208,19 +210,43 @@ function handleLogs() {
       }
     }
 
-    const destinationArn = {
+    let enableAccessLogs = logs.enableAccessLogging;
+    if (enableAccessLogs === undefined) {
+      enableAccessLogs = true;
+    }
+
+    if (enableAccessLogs) {
+      const destinationArn = {
+        op: 'replace',
+        path: '/accessLogSettings/destinationArn',
+        value: `arn:aws:logs:${region}:${this.accountId}:log-group:${logGroupName}`,
+      };
+      const format = {
+        op: 'replace',
+        path: '/accessLogSettings/format',
+        value: logFormat,
+      };
+
+      operations.push(destinationArn, format);
+    } else {
+      // this is required to remove any existing log setting
+      operations.push({
+        op: 'remove',
+        path: '/accessLogSettings',
+      });
+    }
+
+    let enableDataTracing = logs.dataTrace;
+    if (enableDataTracing === undefined) {
+      enableDataTracing = true;
+    }
+    operations.push({
       op: 'replace',
-      path: '/accessLogSettings/destinationArn',
-      value: `arn:aws:logs:${region}:${this.accountId}:log-group:${logGroupName}`,
-    };
-    const format = {
-      op: 'replace',
-      path: '/accessLogSettings/format',
-      value: logFormat,
-    };
-    dataTrace = { op: 'replace', path: '/*/*/logging/dataTrace', value: 'true' };
-    logLevel = { op: 'replace', path: '/*/*/logging/loglevel', value: level };
-    operations = [destinationArn, format, dataTrace, logLevel];
+      path: '/*/*/logging/dataTrace',
+      value: (!!enableDataTracing).toString(),
+    });
+
+    operations.push({ op: 'replace', path: '/*/*/logging/loglevel', value: level });
   }
 
   ops.push.apply(ops, operations); // eslint-disable-line prefer-spread
@@ -290,7 +316,14 @@ function removeLogGroup() {
   const stage = this.options.stage;
   const logGroupName = `/aws/api-gateway/${service}-${stage}`;
 
-  const logs = provider.logs && provider.logs.restApi;
+  let logs = provider.logs && provider.logs.restApi;
+
+  if (logs) {
+    const enableAccessLogs = logs.enableAccessLogging;
+    if (enableAccessLogs !== undefined) {
+      logs = enableAccessLogs;
+    }
+  }
 
   // if there are no logs setup (or the user has disabled them) we need to
   // ensure that the log group is removed. Otherwise we'll run into duplicate

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -237,11 +237,11 @@ function handleLogs() {
       });
     }
 
-    const fullData = logs.fullData == null ? true : logs.fullData;
+    const fullExecutionData = logs.fullExecutionData == null ? true : logs.fullExecutionData;
     operations.push({
       op: 'replace',
       path: '/*/*/logging/dataTrace',
-      value: String(Boolean(fullData)),
+      value: String(Boolean(fullExecutionData)),
     });
 
     operations.push({ op: 'replace', path: '/*/*/logging/loglevel', value: level });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -18,7 +18,7 @@ const defaultApiGatewayLogFormat = [
   'responseLength: $context.responseLength',
 ].join(', ');
 const defaultApiGatewayLogLevel = 'INFO';
-const apiGatewayValidLogLevels = new Set(['INFO', 'ERROR', 'OFF']);
+const apiGatewayValidLogLevels = new Set(['INFO', 'ERROR']);
 
 // NOTE --> Keep this file in sync with ../stage.js
 
@@ -198,8 +198,12 @@ function handleLogs() {
       logFormat = logs.format;
     }
 
+    const executionLogging = logs.executionLogging == null ? true : logs.executionLogging;
+
     let level = defaultApiGatewayLogLevel;
-    if (logs.level) {
+    if (!executionLogging) {
+      level = 'OFF';
+    } else if (logs.level) {
       level = logs.level;
       if (!apiGatewayValidLogLevels.has(level)) {
         throw new ServerlessError(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -395,6 +395,14 @@ describe('#updateStage()', () => {
     });
   });
 
+  function expectPatchOperation(patchOperation, callOffset) {
+    if (callOffset === undefined) {
+      callOffset = 2;
+    }
+    const patchOperations = providerRequestStub.args[callOffset][2].patchOperations;
+    expect(patchOperations).to.include.deep.members([patchOperation]);
+  }
+
   function checkLogLevel(setLevel, expectedLevel) {
     if (setLevel) {
       context.state.service.provider.logs = {
@@ -410,9 +418,7 @@ describe('#updateStage()', () => {
 
     return updateStage.call(context).then(() => {
       const patchOperation = { op: 'replace', path: '/*/*/logging/loglevel', value: expectedLevel };
-
-      const patchOperations = providerRequestStub.args[2][2].patchOperations;
-      expect(patchOperations).to.include.deep.members([patchOperation]);
+      expectPatchOperation(patchOperation);
     });
   }
 
@@ -434,5 +440,59 @@ describe('#updateStage()', () => {
     };
 
     return expect(updateStage.call(context)).to.be.rejectedWith('invalid value');
+  });
+
+  it('should disable existing access log settings when enableAccessLogging is set to false', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        enableAccessLogging: false,
+      },
+    };
+
+    return updateStage.call(context).then(() => {
+      const removeOperation = { op: 'remove', path: '/accessLogSettings' };
+      expectPatchOperation(removeOperation);
+    });
+  });
+
+  it('should delete any existing CloudWatch LogGroup when enableAccessLogging is set to false', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        enableAccessLogging: false,
+      },
+    };
+
+    return updateStage.call(context).then(() => {
+      expect(providerRequestStub.args[4][0]).to.equal('CloudWatchLogs');
+      expect(providerRequestStub.args[4][1]).to.equal('deleteLogGroup');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
+        logGroupName: '/aws/api-gateway/my-service-dev',
+      });
+    });
+  });
+
+  function checkDataTrace(value) {
+    context.state.service.provider.logs = {
+      restApi: {
+        dataTrace: value,
+      },
+    };
+
+    return updateStage.call(context).then(() => {
+      const patchOperation = {
+        op: 'replace',
+        path: '/*/*/logging/dataTrace',
+        value: value.toString(),
+      };
+      expectPatchOperation(patchOperation);
+    });
+  }
+
+  it('should disable tracing if dataTrace is set to false', () => {
+    return checkDataTrace(false);
+  });
+
+  it('should enable tracing if dataTrace is set to true', () => {
+    return checkDataTrace(true);
   });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -395,11 +395,8 @@ describe('#updateStage()', () => {
     });
   });
 
-  function expectPatchOperation(patchOperation, callOffset) {
-    if (callOffset === undefined) {
-      callOffset = 2;
-    }
-    const patchOperations = providerRequestStub.args[callOffset][2].patchOperations;
+  function expectPatchOperation(patchOperation) {
+    const patchOperations = providerRequestStub.args[2][2].patchOperations;
     expect(patchOperations).to.include.deep.members([patchOperation]);
   }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -486,7 +486,7 @@ describe('#updateStage()', () => {
   function checkDataTrace(value) {
     context.state.service.provider.logs = {
       restApi: {
-        fullData: value,
+        fullExecutionData: value,
       },
     };
 
@@ -500,11 +500,11 @@ describe('#updateStage()', () => {
     });
   }
 
-  it('should disable tracing if fullData is set to false', () => {
+  it('should disable tracing if fullExecutionData is set to false', () => {
     return checkDataTrace(false);
   });
 
-  it('should enable tracing if fullData is set to true', () => {
+  it('should enable tracing if fullExecutionData is set to true', () => {
     return checkDataTrace(true);
   });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -432,6 +432,18 @@ describe('#updateStage()', () => {
     });
   });
 
+  it('should disable execution logging when executionLogging is set to false', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        executionLogging: false,
+      },
+    };
+    return updateStage.call(context).then(() => {
+      const patchOperation = { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' };
+      expectPatchOperation(patchOperation);
+    });
+  });
+
   it('should reject a custom APIGW log level if value is invalid', () => {
     context.state.service.provider.logs = {
       restApi: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -442,10 +442,10 @@ describe('#updateStage()', () => {
     return expect(updateStage.call(context)).to.be.rejectedWith('invalid value');
   });
 
-  it('should disable existing access log settings when enableAccessLogging is set to false', () => {
+  it('should disable existing access log settings when accessLogging is set to false', () => {
     context.state.service.provider.logs = {
       restApi: {
-        enableAccessLogging: false,
+        accessLogging: false,
       },
     };
 
@@ -455,10 +455,10 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should delete any existing CloudWatch LogGroup when enableAccessLogging is set to false', () => {
+  it('should delete any existing CloudWatch LogGroup when accessLogging is set to false', () => {
     context.state.service.provider.logs = {
       restApi: {
-        enableAccessLogging: false,
+        accessLogging: false,
       },
     };
 
@@ -474,7 +474,7 @@ describe('#updateStage()', () => {
   function checkDataTrace(value) {
     context.state.service.provider.logs = {
       restApi: {
-        dataTrace: value,
+        fullData: value,
       },
     };
 
@@ -488,11 +488,11 @@ describe('#updateStage()', () => {
     });
   }
 
-  it('should disable tracing if dataTrace is set to false', () => {
+  it('should disable tracing if fullData is set to false', () => {
     return checkDataTrace(false);
   });
 
-  it('should enable tracing if dataTrace is set to true', () => {
+  it('should enable tracing if fullData is set to true', () => {
     return checkDataTrace(true);
   });
 });


### PR DESCRIPTION
## What did you implement:

Implemented to ability to control enabling and disabling both access and execution logs for API Gateway, as well as the ability to configure the dataTrace parameter ("Log full requests/responses data" in the AWS Console). This allows for finer-grained control over which aspects of logging are enabled for the API Gateway.

This is an enhancement to API Gateway logs as part of #6094.

## How did you implement it:

You can now configure whether or not access logging is enabled by setting enableAccessLogging to true/false (defaults to true if not set), dataTrace to true/false (defaults to true) and level to OFF to disable execution logging.

```yml
provider:
  aws: aws

  logs:
    restApi:
      enableAccessLogging: false

      level: OFF
      dataTrace: true
```

## How can we verify it:

Create a serverless project and set any of the provider.logs attributes mentioned above and check the AWS Console to see them reflected.

## Todos:

- [x] Write tests and confirm existing functionality is not broken.
- [x] Write documentation
- [x] Ensure there are no lint errors.
- [x] Ensure introduced changes match Prettier formatting.
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO