### PR TITLE
Support resolution of CloudFormation ImportValue in RestAPI id resolution

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -86,11 +86,26 @@ function resolveAccountId() {
   return this.provider.getAccountId().then(id => (this.accountId = id));
 }
 
+function resolveExportedRestApiId(provider, name, sdkParams = {}) {
+  return provider.request('CloudFormation', 'listExports', sdkParams).then(result => {
+    const targetExportMeta = result.Exports.find(exportMeta => exportMeta.Name === name);
+    if (targetExportMeta) return targetExportMeta.Value;
+    if (result.NextToken) {
+      return resolveExportedRestApiId(provider, name, { NextToken: result.NextToken });
+    }
+    return null;
+  });
+}
+
 function resolveRestApiId() {
   return new BbPromise(resolve => {
     const provider = this.state.service.provider;
     const customRestApiId = provider.apiGateway && provider.apiGateway.restApiId;
     if (customRestApiId) {
+      if (customRestApiId['Fn::ImportValue']) {
+        resolve(resolveExportedRestApiId(this.provider, customRestApiId['Fn::ImportValue']));
+        return;
+      }
       resolve(isRestApiId(customRestApiId) ? customRestApiId : null);
       return;
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -99,8 +99,8 @@ function resolveExportedRestApiId(provider, name, sdkParams = {}) {
 
 function resolveRestApiId() {
   return new BbPromise(resolve => {
-    const provider = this.state.service.provider;
-    const customRestApiId = provider.apiGateway && provider.apiGateway.restApiId;
+    const providerSettings = this.state.service.provider;
+    const customRestApiId = providerSettings.apiGateway && providerSettings.apiGateway.restApiId;
     if (customRestApiId) {
       if (customRestApiId['Fn::ImportValue']) {
         resolve(resolveExportedRestApiId(this.provider, customRestApiId['Fn::ImportValue']));
@@ -109,7 +109,8 @@ function resolveRestApiId() {
       resolve(isRestApiId(customRestApiId) ? customRestApiId : null);
       return;
     }
-    const apiName = provider.apiName || `${this.options.stage}-${this.state.service.service}`;
+    const apiName =
+      providerSettings.apiName || `${this.options.stage}-${this.state.service.service}`;
     const resolvefromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(api => api.name === apiName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -328,6 +328,56 @@ describe('#updateStage()', () => {
     });
   });
 
+  it('should resolve expected restApiId out of CloudFormation ImportValue', () => {
+    providerRequestStub.withArgs('CloudFormation', 'listExports', {}).resolves({
+      ResponseMetadata: { RequestId: 'c7be00bc-c4ea-11e9-a1eb-35880340c794' },
+      Exports: [
+        {
+          ExportingStackId:
+            'arn:aws:cloudformation:us-east-1:992311060759:stack/test-api-gw-export-shared-dev/4305f900-c283-11e9-915c-0e1e9f06bbc4',
+          Name: 'CfExportedApiGw-restApiId',
+          Value: 'pkhriceyzl',
+        },
+        {
+          ExportingStackId:
+            'arn:aws:cloudformation:us-east-1:992311060759:stack/test-api-gw-export-shared-dev/4305f900-c283-11e9-915c-0e1e9f06bbc4',
+          Name: 'CfExportedApiGw-rootResourceId',
+          Value: '1xufji4tak',
+        },
+      ],
+      NextToken: 'foo',
+    });
+    providerRequestStub.withArgs('CloudFormation', 'listExports', { NextToken: 'foo' }).resolves({
+      ResponseMetadata: { RequestId: 'c7be00bc-c4ea-11e9-a1eb-35880340c794' },
+      Exports: [
+        {
+          ExportingStackId:
+            'arn:aws:cloudformation:us-east-1:992311060759:stack/test-api-gw-export-shared-dev/4305f900-c283-11e9-915c-0e1e9f06bbc4',
+          Name: 'RestApiId-bla',
+          Value: 'resolved-not',
+        },
+        {
+          ExportingStackId:
+            'arn:aws:cloudformation:us-east-1:992311060759:stack/test-api-gw-export-shared-dev/4305f900-c283-11e9-915c-0e1e9f06bbc4',
+          Name: 'RestApiId-foo',
+          Value: 'someRestApiId',
+        },
+        {
+          ExportingStackId:
+            'arn:aws:cloudformation:us-east-1:992311060759:stack/test-api-gw-export-shared-dev/4305f900-c283-11e9-915c-0e1e9f06bbc4',
+          Name: 'CfExportedApiGw-rootResourceId',
+          Value: '1xufji4tak',
+        },
+      ],
+    });
+    context.state.service.provider.apiGateway = {
+      restApiId: { 'Fn::ImportValue': 'RestApiId-foo' },
+    };
+    return updateStage.call(context).then(() => {
+      expect(context.apiGatewayRestApiId).to.equal('someRestApiId');
+    });
+  });
+
   it(
     'should not apply hack when restApiId could not be resolved and ' +
       'no custom settings are applied',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -333,7 +333,7 @@ describe('#updateStage()', () => {
       'no custom settings are applied',
     () => {
       context.state.service.provider.apiGateway = {
-        restApiId: { 'Fn::ImportValue': 'RestApiId-${self:custom.stage}' },
+        restApiId: {},
       };
       return updateStage.call(context).then(() => {
         expect(providerRequestStub.callCount).to.equal(0);


### PR DESCRIPTION
_Warning: This PR improves support for external API Gateway, when `logs`, `tracing` and `tags` options are concerning. Still as those settings are applied globally to given Rest API, it raises issues described at #6584_

For SDK handling of APIGateway settings (initially introduced with https://github.com/serverless/serverless/pull/6084 and published with v1.42.0) we need to resolve Rest API id programmatically. 

At that point we don't support resolution of it from `Fn::ImportValue` instruction (when external API Gateway is referenced), which means that many API Gateway options are not supported with such setup.

This PR ensures Rest API Id can be resolved from it.

**_Is it a breaking change?:_** NO
