### PR TITLE
Improve error reporting

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -39,7 +39,7 @@ const writeMessage = (title, message) => {
   consoleLog(' ');
 
   if (message) {
-    consoleLog(`  ${message}`);
+    consoleLog(`  ${message.split('\n').join('\n  ')}`);
   }
 
   consoleLog(' ');

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -145,7 +145,7 @@ describe('Error', () => {
       const message = consoleLogSpy.args.join('\n');
 
       expect(consoleLogSpy.called).to.equal(true);
-      expect(message).to.have.string(error.stack);
+      expect(message).to.have.string(error.stack.split('\n').join('\n  '));
     });
 
     it('should not print stack trace without SLS_DEBUG', () => {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -64,7 +64,7 @@ module.exports = {
             "that there's a way to support your setup).",
           ].join('');
 
-          throw new Error(errorMessage);
+          throw new ServerlessError(errorMessage);
         }
         return resolveStage
           .call(this)


### PR DESCRIPTION
1. Ensure that Rest API resolution error is reported as _user_ error (via `ServerlessError`), so no stack trace is shown by default.

2. Improve formatting of multiline messages

Before:
```
  Serverless Error ---------------------------------------
 
  Rest API id could not be resolved.
This might be caused by a custom API Gateway configuration.

In given setup stage specific options such as `tracing`, `logs` and `tags` are not supported.

Please update your configuration (or open up an issue if you feel that there's a way to support your setup).
```

After:

```
  Serverless Error ---------------------------------------
 
  Rest API id could not be resolved.
  This might be caused by a custom API Gateway configuration.
  
  In given setup stage specific options such as `tracing`, `logs` and `tags` are not supported.
  
  Please update your configuration (or open up an issue if you feel that there's a way to support your setup).
 ```

 
