### PR TITLE
Allow unresolved Rest API id with  provider.tags setting

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -48,9 +48,8 @@ module.exports = {
           const provider = this.state.service.provider;
           const isTracingEnabled = provider.tracing && provider.tracing.apiGateway;
           const areLogsEnabled = provider.logs && provider.logs.restApi;
-          const hasTags = Boolean(provider.tags);
 
-          if (!isTracingEnabled && !areLogsEnabled && !hasTags) {
+          if (!isTracingEnabled && !areLogsEnabled) {
             // Do crash if there are no API Gateway customizations to apply
             return null;
           }


### PR DESCRIPTION
Closes #6140 

With #6048 (published with v1.42.0), we've introduced support for `logs`, `tags` (and improved `tracing`) options for APIGateway settings.  Still as modifications to those settings are not supported in CloudFormation, we decided to update them directly via SDK calls (after CloudFormation stack is successfully deployed)

To be able to pursue SDK calls we need to be able to resolve Rest API id programmatically.
If we're unable to resolve Rest API id, we crash. Still with one of the further patches (to revert from reported regression) we've improved the behavior, so we crash only if one of the new options is used 

Still that fix was not complete, as `tags` option is service wide, and was supported before v1.42.0 to tag on lambda resources.
Therefore if `tags` option is used together with external API Gateway setup of which we do not resolve programmatically, we still crash, and that's reported with #6140 

This patch ignores `provider.tags` setting, as it's not API Gateway only. This doesn't change anything to current behavior, aside of fact that we do not crash in explained corner case.

**_Is it a breaking change?:_** NO
