### PR TITLE
Improve Rest API id resolution for SDK updates

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -85,6 +85,16 @@ function resolveAccountId() {
   return this.provider.getAccountId().then(id => (this.accountId = id));
 }
 
+function resolveApiGatewayResource(resources) {
+  if (resources.ApiGatewayRestApi) return resources.ApiGatewayRestApi;
+  const apiGatewayResources = _.values(resources).filter(
+    resource => resource.Type === 'AWS::ApiGateway::Resource'
+  );
+  if (apiGatewayResources.length === 1) return apiGatewayResources[0];
+  // None, or more than one API Gateway found (currently there's no support for multiple APIGW's)
+  return null;
+}
+
 function resolveRestApiId() {
   return new BbPromise(resolve => {
     const provider = this.state.service.provider;
@@ -93,7 +103,14 @@ function resolveRestApiId() {
       resolve(isRestApiId(externalRestApiId) ? externalRestApiId : null);
       return;
     }
-    const apiName = provider.apiName || `${this.options.stage}-${this.state.service.service}`;
+    const apiGatewayResource = resolveApiGatewayResource(
+      this.serverless.service.provider.compiledCloudFormationTemplate.Resources
+    );
+    if (!apiGatewayResource) {
+      resolve(null);
+      return;
+    }
+    const apiName = apiGatewayResource.Properties.Name;
     const resolvefromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(api => api.name === apiName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -88,9 +88,9 @@ function resolveAccountId() {
 function resolveRestApiId() {
   return new BbPromise(resolve => {
     const provider = this.state.service.provider;
-    const customRestApiId = provider.apiGateway && provider.apiGateway.restApiId;
-    if (customRestApiId) {
-      resolve(isRestApiId(customRestApiId) ? customRestApiId : null);
+    const externalRestApiId = provider.apiGateway && provider.apiGateway.restApiId;
+    if (externalRestApiId) {
+      resolve(isRestApiId(externalRestApiId) ? externalRestApiId : null);
       return;
     }
     const apiName = provider.apiName || `${this.options.stage}-${this.state.service.service}`;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -35,6 +35,16 @@ describe('#updateStage()', () => {
     serverless.setProvider('aws', awsProvider);
     providerGetAccountIdStub = sinon.stub(awsProvider, 'getAccountId').resolves(123456);
     providerRequestStub = sinon.stub(awsProvider, 'request');
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {
+        ApiGatewayRestApi: {
+          Type: 'AWS::ApiGateway::Resource',
+          Properties: {
+            Name: 'dev-my-service',
+          },
+        },
+      },
+    };
 
     context = {
       serverless,
@@ -298,9 +308,20 @@ describe('#updateStage()', () => {
           old: 'tag',
         },
       });
+    context.serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayRestApi.Properties.Name =
+      'custom-api-gateway-name';
     context.state.service.provider.apiName = 'custom-api-gateway-name';
     return updateStage.call(context).then(() => {
       expect(context.apiGatewayRestApiId).to.equal('restapicus');
+    });
+  });
+
+  it('should resolve custom APIGateway resource', () => {
+    const resources = context.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+    resources.CustomApiGatewayRestApi = resources.ApiGatewayRestApi;
+    delete resources.ApiGatewayRestApi;
+    return updateStage.call(context).then(() => {
+      expect(context.apiGatewayRestApiId).to.equal('someRestApiId');
     });
   });
 


### PR DESCRIPTION
Fixes #6251

Our REST API id resolution is quite high level and not fully reliable, as it's based on checking of some configuration settings as setup by user (searching for custom `provider.apiName` and if not found assuming the name will be default as setup by Framework).

It didn't work for cases where API Gateway resource was configured at lower level, e.g. fully in `resources.Resources` or extended there with custom name.

This patch ensures we read the API name directly from generated CloudFormation template.

At same time, it fixes the regression introduced with v1.42.0 after which relying on `tracing.apiGateway` option (with shared API Gateway setup) started to crash as Rest API was not resolved programmatically (reported at #6251)