### PR TITLE
Fix ServerlessError handling

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -48,12 +48,15 @@ const writeMessage = (title, message) => {
 class ServerlessError extends Error {
   constructor(message, statusCode) {
     super(message);
-    this.name = this.constructor.name;
-    this.message = message;
     this.statusCode = statusCode;
-    Error.captureStackTrace(this, this.constructor);
+    Error.captureStackTrace(this, this.constructor); // Not needed in Node.js v8+
   }
 }
+Object.defineProperty(ServerlessError.prototype, 'name', {
+  value: ServerlessError.name,
+  configurable: true,
+  writable: true,
+});
 
 module.exports.ServerlessError = ServerlessError;
 

--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -45,7 +45,7 @@ const writeMessage = (title, message) => {
   consoleLog(' ');
 };
 
-module.exports.ServerlessError = class ServerlessError extends Error {
+class ServerlessError extends Error {
   constructor(message, statusCode) {
     super(message);
     this.name = this.constructor.name;
@@ -53,10 +53,12 @@ module.exports.ServerlessError = class ServerlessError extends Error {
     this.statusCode = statusCode;
     Error.captureStackTrace(this, this.constructor);
   }
-};
+}
+
+module.exports.ServerlessError = ServerlessError;
 
 // Deprecated - use ServerlessError instead
-module.exports.SError = module.exports.ServerlessError;
+module.exports.SError = ServerlessError;
 
 const userErrorNames = new Set(['ServerlessError', 'YAMLException']);
 

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -25,6 +25,11 @@ describe('ServerlessError', () => {
       expect(error.statusCode).to.be.equal('a status code');
     });
 
+    it('message should always resolve as string', () => {
+      const error = new ServerlessError({});
+      expect(typeof error.message).to.be.equal('string');
+    });
+
     it('should have stack trace', () => {
       let expectedError;
       function testStackFrame() {

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -88,7 +88,7 @@ module.exports = {
           }
           return BbPromise.bind(this).then(this.create);
         }
-        throw new this.serverless.classes.Error(e);
+        throw e;
       });
   },
 };

--- a/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const AwsProvider = require('../../provider/awsProvider');
 const AwsDeploy = require('../index');
 const Serverless = require('../../../../Serverless');
+const { ServerlessError } = require('../../../../classes/Error');
 const { getTmpDirPath } = require('../../../../../tests/utils/fs');
 
 describe('createStack', () => {
@@ -129,9 +130,7 @@ describe('createStack', () => {
     });
 
     it('should throw error if describeStackResources fails for other reason than not found', () => {
-      const errorMock = {
-        message: 'Something went wrong.',
-      };
+      const errorMock = new ServerlessError('Something went wrong');
 
       sandbox.stub(awsDeploy.provider, 'request').rejects(errorMock);
 
@@ -140,7 +139,7 @@ describe('createStack', () => {
       return awsDeploy.createStack().catch(e => {
         expect(createStub.called).to.be.equal(false);
         expect(e.name).to.be.equal('ServerlessError');
-        expect(e.message).to.be.equal(errorMock);
+        expect(e.message).to.be.equal(errorMock.message);
       });
     });
 


### PR DESCRIPTION
I've just approached following error:

```
Type Error ---------------------------------------------
 
  TypeError: message.split is not a function
      at writeMessage (/Users/medikoo/npm-packages/serverless/lib/classes/Error.js:42:29)
      at module.exports.logError (/Users/medikoo/npm-packages/serverless/lib/classes/Error.js:71:3)
      at /Users/medikoo/npm-packages/serverless/bin/serverless.js:70:9
```

It's caused by error object passed directly to `ServerlessError`: 
https://github.com/serverless/serverless/blob/4d64b9d21b961cbb77e671256e8868e2a0bc8c74/lib/plugins/aws/deploy/lib/createStack.js#L91

And then being assigned to `error.message`:
https://github.com/serverless/serverless/blob/4d64b9d21b961cbb77e671256e8868e2a0bc8c74/lib/classes/Error.js#L52

I've fixed the error passing, so it's direclty the exception that occured that passed, and I've fixed `ServerlessError` definition, so in all cases `message` is resolved as string.
