### PR TITLE
Ensure API Gateway CloudWatch role is setup via custom resource

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -17,41 +17,43 @@ function installDependencies(dirPath) {
   return childProcess.execAsync(`npm install --prefix ${dirPath}`);
 }
 
-function addCustomResourceToService(resourceName, iamRoleStatements) {
+function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
   let FunctionName;
   let Handler;
   let customResourceFunctionLogicalId;
 
-  const { Resources } = this.serverless.service.provider.compiledCloudFormationTemplate;
-  const customResourcesRoleLogicalId = this.provider.naming.getCustomResourcesRoleLogicalId();
+  const { serverless } = awsProvider;
+  const { cliOptions } = serverless.pluginManager;
+  const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+  const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
   const srcDirPath = path.join(__dirname, 'resources');
   const destDirPath = path.join(
-    this.serverless.config.servicePath,
+    serverless.config.servicePath,
     '.serverless',
-    this.provider.naming.getCustomResourcesArtifactDirectoryName()
+    awsProvider.naming.getCustomResourcesArtifactDirectoryName()
   );
   const tmpDirPath = path.join(getTmpDirPath(), 'resources');
-  const funcPrefix = `${this.serverless.service.service}-${this.options.stage}`;
+  const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
   const zipFilePath = `${destDirPath}.zip`;
-  this.serverless.utils.writeFileDir(zipFilePath);
+  serverless.utils.writeFileDir(zipFilePath);
 
   // check which custom resource should be used
   if (resourceName === 's3') {
-    FunctionName = `${funcPrefix}-${this.provider.naming.getCustomResourceS3HandlerFunctionName()}`;
+    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceS3HandlerFunctionName()}`;
     Handler = 's3/handler.handler';
-    customResourceFunctionLogicalId = this.provider.naming.getCustomResourceS3HandlerFunctionLogicalId();
+    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceS3HandlerFunctionLogicalId();
   } else if (resourceName === 'cognitoUserPool') {
-    FunctionName = `${funcPrefix}-${this.provider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName()}`;
+    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName()}`;
     Handler = 'cognitoUserPool/handler.handler';
-    customResourceFunctionLogicalId = this.provider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
+    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
   } else if (resourceName === 'eventBridge') {
-    FunctionName = `${funcPrefix}-${this.provider.naming.getCustomResourceEventBridgeHandlerFunctionName()}`;
+    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName()}`;
     Handler = 'eventBridge/handler.handler';
-    customResourceFunctionLogicalId = this.provider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();
+    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();
   } else if (resourceName === 'apiGatewayCloudWatchRole') {
-    FunctionName = `${funcPrefix}-${this.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()}`;
+    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()}`;
     Handler = 'apiGatewayCloudWatchRole/handler.handler';
-    customResourceFunctionLogicalId = this.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
+    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
   } else {
     return BbPromise.reject(`No implementation found for Custom Resource "${resourceName}"`);
   }
@@ -66,18 +68,18 @@ function addCustomResourceToService(resourceName, iamRoleStatements) {
   }
 
   // TODO: check every once in a while if external packages are still necessary
-  this.serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
+  serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
   return copyCustomResources(srcDirPath, tmpDirPath)
     .then(() => installDependencies(tmpDirPath))
     .then(() => createZipFile(tmpDirPath, zipFilePath))
     .then(outputFilePath => {
       let S3Bucket = {
-        Ref: this.provider.naming.getDeploymentBucketLogicalId(),
+        Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
       };
-      if (this.serverless.service.package.deploymentBucket) {
-        S3Bucket = this.serverless.service.package.deploymentBucket;
+      if (serverless.service.package.deploymentBucket) {
+        S3Bucket = serverless.service.package.deploymentBucket;
       }
-      const s3Folder = this.serverless.service.package.artifactDirectoryName;
+      const s3Folder = serverless.service.package.artifactDirectoryName;
       const s3FileName = outputFilePath.split(path.sep).pop();
       const S3Key = `${s3Folder}/${s3FileName}`;
 
@@ -104,8 +106,8 @@ function addCustomResourceToService(resourceName, iamRoleStatements) {
                   'Fn::Join': [
                     '-',
                     [
-                      this.provider.getStage(),
-                      this.provider.serverless.service.service,
+                      awsProvider.getStage(),
+                      awsProvider.serverless.service.service,
                       'custom-resources-lambda',
                     ],
                   ],

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -22,7 +22,6 @@ describe('#addCustomResourceToService()', () => {
   let tmpDirPath;
   let serverless;
   let provider;
-  let context;
   let execAsyncStub;
   const serviceName = 'some-service';
   const iamRoleStatements = [
@@ -42,6 +41,7 @@ describe('#addCustomResourceToService()', () => {
     execAsyncStub = sinon.stub(childProcess, 'execAsync').resolves();
     serverless = new Serverless();
     serverless.cli = new CLI();
+    serverless.pluginManager.cliOptions = options;
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = serviceName;
@@ -50,11 +50,6 @@ describe('#addCustomResourceToService()', () => {
     };
     serverless.config.servicePath = tmpDirPath;
     serverless.service.package.artifactDirectoryName = 'artifact-dir-name';
-    context = {
-      serverless,
-      provider,
-      options,
-    };
   });
 
   afterEach(() => {
@@ -65,7 +60,7 @@ describe('#addCustomResourceToService()', () => {
     return expect(
       BbPromise.all([
         // add the custom S3 resource
-        addCustomResourceToService.call(context, 's3', [
+        addCustomResourceToService(provider, 's3', [
           ...iamRoleStatements,
           {
             Effect: 'Allow',
@@ -74,7 +69,7 @@ describe('#addCustomResourceToService()', () => {
           },
         ]),
         // add the custom Cognito User Pool resource
-        addCustomResourceToService.call(context, 'cognitoUserPool', [
+        addCustomResourceToService(provider, 'cognitoUserPool', [
           ...iamRoleStatements,
           {
             Effect: 'Allow',
@@ -87,7 +82,7 @@ describe('#addCustomResourceToService()', () => {
           },
         ]),
         // add the custom Event Bridge resource
-        addCustomResourceToService.call(context, 'eventBridge', [
+        addCustomResourceToService(provider, 'eventBridge', [
           ...iamRoleStatements,
           {
             Effect: 'Allow',
@@ -227,7 +222,7 @@ describe('#addCustomResourceToService()', () => {
   });
 
   it('should throw when an unknown custom resource is used', () => {
-    return expect(addCustomResourceToService.call(context, 'unknown', [])).to.be.rejectedWith(
+    return expect(addCustomResourceToService(provider, 'unknown', [])).to.be.rejectedWith(
       'No implementation found'
     );
   });
@@ -237,7 +232,7 @@ describe('#addCustomResourceToService()', () => {
     return expect(
       BbPromise.all([
         // add the custom S3 resource
-        addCustomResourceToService.call(context, 's3', [
+        addCustomResourceToService(provider, 's3', [
           ...iamRoleStatements,
           {
             Effect: 'Allow',

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -214,12 +214,6 @@ module.exports = {
   getWebsocketsLogGroupLogicalId() {
     return 'WebsocketsLogGroup';
   },
-  getWebsocketsLogsRoleLogicalId() {
-    return 'IamRoleWebsocketsLogs';
-  },
-  getWebsocketsAccountLogicalId() {
-    return 'WebsocketsAccount';
-  },
 
   // API Gateway
   getApiGatewayName() {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -291,18 +291,6 @@ describe('#naming()', () => {
     });
   });
 
-  describe('#getWebsocketsLogsRoleLogicalId()', () => {
-    it('should return the Websockets logs IAM role logical id', () => {
-      expect(sdk.naming.getWebsocketsLogsRoleLogicalId()).to.equal('IamRoleWebsocketsLogs');
-    });
-  });
-
-  describe('#getWebsocketsAccountLogicalId()', () => {
-    it('should return the Websockets account logical id', () => {
-      expect(sdk.naming.getWebsocketsAccountLogicalId()).to.equal('WebsocketsAccount');
-    });
-  });
-
   describe('#getApiGatewayName()', () => {
     it('should return the composition of stage & service name if custom name not provided', () => {
       serverless.service.service = 'myService';

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -6,7 +6,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
-const { addCustomResourceToService } = require('../../../../../../customResources');
+const ensureApiGatewayCloudWatchRole = require('../../../lib/ensureApiGatewayCloudWatchRole');
 
 module.exports = {
   compileStage() {
@@ -84,41 +84,11 @@ module.exports = {
         // });
         // --------------------------------------------------------------------------------
 
-        const customResourceLogicalId = this.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId();
-        const customResourceFunctionLogicalId = this.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
-
         _.merge(cfTemplate.Resources, {
           [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider),
-          [customResourceLogicalId]: {
-            Type: 'Custom::ApiGatewayAccountRole',
-            Version: 1.0,
-            Properties: {
-              ServiceToken: {
-                'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
-              },
-            },
-          },
         });
 
-        return addCustomResourceToService(this.provider, 'apiGatewayCloudWatchRole', [
-          {
-            Effect: 'Allow',
-            Resource: {
-              'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWS::AccountId' }, 'role/*']],
-            },
-            Action: [
-              'iam:AttachRolePolicy',
-              'iam:CreateRole',
-              'iam:ListAttachedRolePolicies',
-              'iam:PassRole',
-            ],
-          },
-          {
-            Effect: 'Allow',
-            Resource: 'arn:aws:apigateway:*::/account',
-            Action: ['apigateway:GET', 'apigateway:PATCH'],
-          },
-        ]);
+        return ensureApiGatewayCloudWatchRole(this.provider);
       }
 
       // --- currently commented out since this is done via the SDK in updateStage.js ---

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -100,7 +100,7 @@ module.exports = {
           },
         });
 
-        return addCustomResourceToService.call(this, 'apiGatewayCloudWatchRole', [
+        return addCustomResourceToService(this.provider, 'apiGatewayCloudWatchRole', [
           {
             Effect: 'Allow',
             Resource: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -3,6 +3,7 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const AwsCompileApigEvents = require('../..');
 const Serverless = require('../../../../../../../../Serverless');
@@ -275,6 +276,21 @@ describe('#compileStage()', () => {
             RetentionInDays: serverless.service.provider.logRetentionInDays,
           },
         });
+      });
+    });
+
+    it('should ensure ClousWatch role custom resource', () => {
+      return awsCompileApigEvents.compileStage().then(() => {
+        const resources =
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+        expect(
+          _.isObject(
+            resources[
+              awsCompileApigEvents.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId()
+            ]
+          )
+        ).to.equal(true);
       });
     });
   });

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -224,7 +224,7 @@ class AwsCompileCognitoUserPoolEvents {
     }
 
     if (iamRoleStatements.length) {
-      return addCustomResourceToService.call(this, 'cognitoUserPool', iamRoleStatements);
+      return addCustomResourceToService(this.provider, 'cognitoUserPool', iamRoleStatements);
     }
 
     return null;

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.test.js
@@ -5,10 +5,9 @@
 const _ = require('lodash');
 const sinon = require('sinon');
 const chai = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
 const AwsProvider = require('../../../../provider/awsProvider');
-const AwsCompileCognitoUserPoolEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
-const customResources = require('../../../../customResources');
 
 const { expect } = chai;
 chai.use(require('sinon-chai'));
@@ -17,8 +16,15 @@ chai.use(require('chai-as-promised'));
 describe('AwsCompileCognitoUserPoolEvents', () => {
   let serverless;
   let awsCompileCognitoUserPoolEvents;
+  let addCustomResourceToServiceStub;
 
   beforeEach(() => {
+    addCustomResourceToServiceStub = sinon.stub().resolves();
+    const AwsCompileCognitoUserPoolEvents = proxyquire('./index', {
+      '../../../../customResources': {
+        addCustomResourceToService: addCustomResourceToServiceStub,
+      },
+    });
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
@@ -331,18 +337,6 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
   });
 
   describe('#existingCognitoUserPools()', () => {
-    let addCustomResourceToServiceStub;
-
-    beforeEach(() => {
-      addCustomResourceToServiceStub = sinon
-        .stub(customResources.addCustomResourceToService, 'call')
-        .resolves();
-    });
-
-    afterEach(() => {
-      customResources.addCustomResourceToService.call.restore();
-    });
-
     it('should create the necessary resources for the most minimal configuration', () => {
       awsCompileCognitoUserPoolEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -192,7 +192,7 @@ class AwsCompileEventBridgeEvents {
     });
 
     if (iamRoleStatements.length) {
-      return addCustomResourceToService.call(this, 'eventBridge', iamRoleStatements);
+      return addCustomResourceToService(this.provider, 'eventBridge', iamRoleStatements);
     }
 
     return null;

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -4,10 +4,9 @@
 
 const sinon = require('sinon');
 const chai = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
 const AwsProvider = require('../../../../provider/awsProvider');
-const AwsCompileEventBridgeEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
-const customResources = require('../../../../customResources');
 
 const { expect } = chai;
 chai.use(require('sinon-chai'));
@@ -16,12 +15,20 @@ chai.use(require('chai-as-promised'));
 describe('AwsCompileEventBridgeEvents', () => {
   let serverless;
   let awsCompileEventBridgeEvents;
+  let addCustomResourceToServiceStub;
 
   beforeEach(() => {
+    addCustomResourceToServiceStub = sinon.stub().resolves();
+    const AwsCompileEventBridgeEvents = proxyquire('./index', {
+      '../../../../customResources': {
+        addCustomResourceToService: addCustomResourceToServiceStub,
+      },
+    });
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileEventBridgeEvents = new AwsCompileEventBridgeEvents(serverless);
+
     awsCompileEventBridgeEvents.serverless.service.service = 'new-service';
   });
 
@@ -31,18 +38,6 @@ describe('AwsCompileEventBridgeEvents', () => {
   });
 
   describe('#compileEventBridgeEvents()', () => {
-    let addCustomResourceToServiceStub;
-
-    beforeEach(() => {
-      addCustomResourceToServiceStub = sinon
-        .stub(customResources.addCustomResourceToService, 'call')
-        .resolves();
-    });
-
-    afterEach(() => {
-      customResources.addCustomResourceToService.call.restore();
-    });
-
     it('should throw if the eventBridge config is a string', () => {
       awsCompileEventBridgeEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.js
+++ b/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { memoize } = require('lodash');
+const { addCustomResourceToService } = require('../../../../customResources');
+
+module.exports = memoize(provider => {
+  const cfTemplate = provider.serverless.service.provider.compiledCloudFormationTemplate;
+  const customResourceLogicalId = provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId();
+  const customResourceFunctionLogicalId = provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
+
+  cfTemplate.Resources[customResourceLogicalId] = {
+    Type: 'Custom::ApiGatewayAccountRole',
+    Version: 1.0,
+    Properties: {
+      ServiceToken: {
+        'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
+      },
+    },
+  };
+
+  return addCustomResourceToService(provider, 'apiGatewayCloudWatchRole', [
+    {
+      Effect: 'Allow',
+      Resource: {
+        'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWS::AccountId' }, 'role/*']],
+      },
+      Action: [
+        'iam:AttachRolePolicy',
+        'iam:CreateRole',
+        'iam:ListAttachedRolePolicies',
+        'iam:PassRole',
+      ],
+    },
+    {
+      Effect: 'Allow',
+      Resource: 'arn:aws:apigateway:*::/account',
+      Action: ['apigateway:GET', 'apigateway:PATCH'],
+    },
+  ]);
+});

--- a/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.test.js
+++ b/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+
+describe('ensureApiGatewayCloudWatchRole', () => {
+  let addCustomResourceToServiceStub;
+  let resources;
+  const customResourceLogicalId = 'CustomResourceId';
+
+  before(() => {
+    addCustomResourceToServiceStub = sinon.stub().resolves();
+    const ensureApiGatewayCloudWatchRole = proxyquire('./ensureApiGatewayCloudWatchRole', {
+      '../../../../customResources': {
+        addCustomResourceToService: addCustomResourceToServiceStub,
+      },
+    });
+    resources = {};
+    const provider = {
+      serverless: {
+        service: { provider: { compiledCloudFormationTemplate: { Resources: resources } } },
+      },
+      naming: {
+        getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId: () =>
+          customResourceLogicalId,
+        getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId: () => 'bar',
+      },
+    };
+    return BbPromise.all([
+      ensureApiGatewayCloudWatchRole(provider),
+      ensureApiGatewayCloudWatchRole(provider),
+    ]);
+  });
+
+  it('Should memoize custom resource generator', () => {
+    expect(addCustomResourceToServiceStub.calledOnce).to.equal(true);
+  });
+
+  it('Should ensure custom resource on template', () => {
+    expect(_.isObject(resources[customResourceLogicalId])).to.equal(true);
+  });
+});

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -339,7 +339,7 @@ class AwsCompileS3Events {
     }
 
     if (iamRoleStatements.length) {
-      return addCustomResourceToService.call(this, 's3', iamRoleStatements);
+      return addCustomResourceToService(this.provider, 's3', iamRoleStatements);
     }
 
     return null;

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -4,10 +4,9 @@
 
 const sinon = require('sinon');
 const chai = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
 const AwsProvider = require('../../../../provider/awsProvider');
-const AwsCompileS3Events = require('./index');
 const Serverless = require('../../../../../../Serverless');
-const customResources = require('../../../../customResources');
 
 const { expect } = chai;
 chai.use(require('sinon-chai'));
@@ -16,8 +15,15 @@ chai.use(require('chai-as-promised'));
 describe('AwsCompileS3Events', () => {
   let serverless;
   let awsCompileS3Events;
+  let addCustomResourceToServiceStub;
 
   beforeEach(() => {
+    addCustomResourceToServiceStub = sinon.stub().resolves();
+    const AwsCompileS3Events = proxyquire('./index', {
+      '../../../../customResources': {
+        addCustomResourceToService: addCustomResourceToServiceStub,
+      },
+    });
     serverless = new Serverless();
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
@@ -237,18 +243,6 @@ describe('AwsCompileS3Events', () => {
   });
 
   describe('#existingS3Buckets()', () => {
-    let addCustomResourceToServiceStub;
-
-    beforeEach(() => {
-      addCustomResourceToServiceStub = sinon
-        .stub(customResources.addCustomResourceToService, 'call')
-        .resolves();
-    });
-
-    afterEach(() => {
-      customResources.addCustomResourceToService.call.restore();
-    });
-
     it('should create the necessary resources for the most minimal configuration', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -4,70 +4,68 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileStage() {
-    const { service, provider } = this.serverless.service;
-    const stage = this.options.stage;
-    const cfTemplate = provider.compiledCloudFormationTemplate;
+    return BbPromise.try(() => {
+      const { service, provider } = this.serverless.service;
+      const stage = this.options.stage;
+      const cfTemplate = provider.compiledCloudFormationTemplate;
 
-    // immediately return if we're using an external websocket API id
-    // stage will be updated as part of the AWS::ApiGatewayV2::Deployment for the websocket
-    if (provider.apiGateway && provider.apiGateway.websocketApiId) {
-      return BbPromise.resolve();
-    }
+      // immediately return if we're using an external websocket API id
+      // stage will be updated as part of the AWS::ApiGatewayV2::Deployment for the websocket
+      if (provider.apiGateway && provider.apiGateway.websocketApiId) return;
 
-    // logs
-    const logsEnabled = provider.logs && provider.logs.websocket;
+      // logs
+      const logsEnabled = provider.logs && provider.logs.websocket;
 
-    const stageLogicalId = this.provider.naming.getWebsocketsStageLogicalId();
-    const logGroupLogicalId = this.provider.naming.getWebsocketsLogGroupLogicalId();
-    const logsRoleLogicalId = this.provider.naming.getWebsocketsLogsRoleLogicalId();
-    const accountLogicalid = this.provider.naming.getWebsocketsAccountLogicalId();
+      const stageLogicalId = this.provider.naming.getWebsocketsStageLogicalId();
+      const logGroupLogicalId = this.provider.naming.getWebsocketsLogGroupLogicalId();
+      const logsRoleLogicalId = this.provider.naming.getWebsocketsLogsRoleLogicalId();
+      const accountLogicalid = this.provider.naming.getWebsocketsAccountLogicalId();
 
-    const stageResource = {
-      Type: 'AWS::ApiGatewayV2::Stage',
-      Properties: {
-        ApiId: this.provider.getApiGatewayWebsocketApiId(),
-        DeploymentId: {
-          Ref: this.websocketsDeploymentLogicalId,
-        },
-        StageName: this.provider.getStage(),
-        Description:
-          this.serverless.service.provider.websocketsDescription || 'Serverless Websockets',
-      },
-    };
-
-    // create log-specific resources
-    if (logsEnabled) {
-      Object.assign(stageResource.Properties, {
-        AccessLogSettings: {
-          DestinationArn: {
-            'Fn::Sub': `arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:\${${logGroupLogicalId}}`,
+      const stageResource = {
+        Type: 'AWS::ApiGatewayV2::Stage',
+        Properties: {
+          ApiId: this.provider.getApiGatewayWebsocketApiId(),
+          DeploymentId: {
+            Ref: this.websocketsDeploymentLogicalId,
           },
-          Format: [
-            '$context.identity.sourceIp',
-            '$context.identity.caller',
-            '$context.identity.user',
-            '[$context.requestTime]',
-            '"$context.eventType $context.routeKey $context.connectionId"',
-            '$context.status',
-            '$context.requestId',
-          ].join(' '),
+          StageName: this.provider.getStage(),
+          Description:
+            this.serverless.service.provider.websocketsDescription || 'Serverless Websockets',
         },
-        DefaultRouteSettings: {
-          DataTraceEnabled: true,
-          LoggingLevel: 'INFO',
-        },
-      });
+      };
 
-      Object.assign(cfTemplate.Resources, {
-        [logGroupLogicalId]: getLogGroupResource(service, stage),
-        [logsRoleLogicalId]: getIamRoleResource(service, stage),
-        [accountLogicalid]: getAccountResource(logsRoleLogicalId),
-      });
-    }
+      // create log-specific resources
+      if (logsEnabled) {
+        Object.assign(stageResource.Properties, {
+          AccessLogSettings: {
+            DestinationArn: {
+              'Fn::Sub': `arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:\${${logGroupLogicalId}}`,
+            },
+            Format: [
+              '$context.identity.sourceIp',
+              '$context.identity.caller',
+              '$context.identity.user',
+              '[$context.requestTime]',
+              '"$context.eventType $context.routeKey $context.connectionId"',
+              '$context.status',
+              '$context.requestId',
+            ].join(' '),
+          },
+          DefaultRouteSettings: {
+            DataTraceEnabled: true,
+            LoggingLevel: 'INFO',
+          },
+        });
 
-    Object.assign(cfTemplate.Resources, { [stageLogicalId]: stageResource });
+        Object.assign(cfTemplate.Resources, {
+          [logGroupLogicalId]: getLogGroupResource(service, stage),
+          [logsRoleLogicalId]: getIamRoleResource(service, stage),
+          [accountLogicalid]: getAccountResource(logsRoleLogicalId),
+        });
+      }
 
-    return BbPromise.resolve();
+      Object.assign(cfTemplate.Resources, { [stageLogicalId]: stageResource });
+    });
   },
 };
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -34,37 +34,37 @@ module.exports = {
         },
       };
 
-      // create log-specific resources
-      if (logsEnabled) {
-        Object.assign(stageResource.Properties, {
-          AccessLogSettings: {
-            DestinationArn: {
-              'Fn::Sub': `arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:\${${logGroupLogicalId}}`,
-            },
-            Format: [
-              '$context.identity.sourceIp',
-              '$context.identity.caller',
-              '$context.identity.user',
-              '[$context.requestTime]',
-              '"$context.eventType $context.routeKey $context.connectionId"',
-              '$context.status',
-              '$context.requestId',
-            ].join(' '),
-          },
-          DefaultRouteSettings: {
-            DataTraceEnabled: true,
-            LoggingLevel: 'INFO',
-          },
-        });
-
-        Object.assign(cfTemplate.Resources, {
-          [logGroupLogicalId]: getLogGroupResource(service, stage),
-          [logsRoleLogicalId]: getIamRoleResource(service, stage),
-          [accountLogicalid]: getAccountResource(logsRoleLogicalId),
-        });
-      }
-
       Object.assign(cfTemplate.Resources, { [stageLogicalId]: stageResource });
+
+      if (!logsEnabled) return;
+
+      // create log-specific resources
+      Object.assign(stageResource.Properties, {
+        AccessLogSettings: {
+          DestinationArn: {
+            'Fn::Sub': `arn:aws:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:\${${logGroupLogicalId}}`,
+          },
+          Format: [
+            '$context.identity.sourceIp',
+            '$context.identity.caller',
+            '$context.identity.user',
+            '[$context.requestTime]',
+            '"$context.eventType $context.routeKey $context.connectionId"',
+            '$context.status',
+            '$context.requestId',
+          ].join(' '),
+        },
+        DefaultRouteSettings: {
+          DataTraceEnabled: true,
+          LoggingLevel: 'INFO',
+        },
+      });
+
+      Object.assign(cfTemplate.Resources, {
+        [logGroupLogicalId]: getLogGroupResource(service, stage),
+        [logsRoleLogicalId]: getIamRoleResource(service, stage),
+        [accountLogicalid]: getAccountResource(logsRoleLogicalId),
+      });
     });
   },
 };

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const ensureApiGatewayCloudWatchRole = require('../../lib/ensureApiGatewayCloudWatchRole');
 
 module.exports = {
   compileStage() {
@@ -11,15 +12,13 @@ module.exports = {
 
       // immediately return if we're using an external websocket API id
       // stage will be updated as part of the AWS::ApiGatewayV2::Deployment for the websocket
-      if (provider.apiGateway && provider.apiGateway.websocketApiId) return;
+      if (provider.apiGateway && provider.apiGateway.websocketApiId) return null;
 
       // logs
       const logsEnabled = provider.logs && provider.logs.websocket;
 
       const stageLogicalId = this.provider.naming.getWebsocketsStageLogicalId();
       const logGroupLogicalId = this.provider.naming.getWebsocketsLogGroupLogicalId();
-      const logsRoleLogicalId = this.provider.naming.getWebsocketsLogsRoleLogicalId();
-      const accountLogicalid = this.provider.naming.getWebsocketsAccountLogicalId();
 
       const stageResource = {
         Type: 'AWS::ApiGatewayV2::Stage',
@@ -36,7 +35,7 @@ module.exports = {
 
       Object.assign(cfTemplate.Resources, { [stageLogicalId]: stageResource });
 
-      if (!logsEnabled) return;
+      if (!logsEnabled) return null;
 
       // create log-specific resources
       Object.assign(stageResource.Properties, {
@@ -62,9 +61,9 @@ module.exports = {
 
       Object.assign(cfTemplate.Resources, {
         [logGroupLogicalId]: getLogGroupResource(service, stage),
-        [logsRoleLogicalId]: getIamRoleResource(service, stage),
-        [accountLogicalid]: getAccountResource(logsRoleLogicalId),
       });
+
+      return ensureApiGatewayCloudWatchRole(this.provider);
     });
   },
 };
@@ -74,54 +73,6 @@ function getLogGroupResource(service, stage) {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
       LogGroupName: `/aws/websocket/${service}-${stage}`,
-    },
-  };
-}
-
-function getIamRoleResource(service, stage) {
-  return {
-    Type: 'AWS::IAM::Role',
-    Properties: {
-      AssumeRolePolicyDocument: {
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Effect: 'Allow',
-            Principal: {
-              Service: ['apigateway.amazonaws.com'],
-            },
-            Action: ['sts:AssumeRole'],
-          },
-        ],
-      },
-      ManagedPolicyArns: [
-        'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs',
-      ],
-      Path: '/',
-      RoleName: {
-        'Fn::Join': [
-          '-',
-          [
-            service,
-            stage,
-            {
-              Ref: 'AWS::Region',
-            },
-            'apiGatewayLogsRole',
-          ],
-        ],
-      },
-    },
-  };
-}
-
-function getAccountResource(logsRoleLogicalId) {
-  return {
-    Type: 'AWS::ApiGateway::Account',
-    Properties: {
-      CloudWatchRoleArn: {
-        'Fn::GetAtt': [logsRoleLogicalId, 'Arn'],
-      },
     },
   };
 }

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+const childProcess = BbPromise.promisifyAll(require('child_process'));
 const AwsCompileWebsocketsEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
@@ -8,8 +12,6 @@ const AwsProvider = require('../../../../../provider/awsProvider');
 describe('#compileStage()', () => {
   let awsCompileWebsocketsEvents;
   let stageLogicalId;
-  let accountLogicalid;
-  let logsRoleLogicalId;
   let logGroupLogicalId;
 
   beforeEach(() => {
@@ -21,11 +23,11 @@ describe('#compileStage()', () => {
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    serverless.config.servicePath = 'my-service';
+    serverless.cli = { log: () => {} };
 
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
     stageLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsStageLogicalId();
-    accountLogicalid = awsCompileWebsocketsEvents.provider.naming.getWebsocketsAccountLogicalId();
-    logsRoleLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsLogsRoleLogicalId();
     logGroupLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsLogGroupLogicalId();
     awsCompileWebsocketsEvents.websocketsApiLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
     awsCompileWebsocketsEvents.websocketsDeploymentLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsDeploymentLogicalId(
@@ -69,6 +71,8 @@ describe('#compileStage()', () => {
   });
 
   describe('logs', () => {
+    before(() => sinon.stub(childProcess, 'execAsync'));
+    after(() => childProcess.execAsync.restore());
     beforeEach(() => {
       // setting up Websocket logs
       awsCompileWebsocketsEvents.serverless.service.provider.logs = {
@@ -130,62 +134,20 @@ describe('#compileStage()', () => {
         });
       }));
 
-    it('should create a IAM Role resource', () =>
-      awsCompileWebsocketsEvents.compileStage().then(() => {
+    it('should ensure ClousWatch role custom resource', () => {
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
         const resources =
           awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources;
 
-        expect(resources[logsRoleLogicalId]).to.deep.equal({
-          Type: 'AWS::IAM::Role',
-          Properties: {
-            AssumeRolePolicyDocument: {
-              Statement: [
-                {
-                  Action: ['sts:AssumeRole'],
-                  Effect: 'Allow',
-                  Principal: {
-                    Service: ['apigateway.amazonaws.com'],
-                  },
-                },
-              ],
-              Version: '2012-10-17',
-            },
-            ManagedPolicyArns: [
-              'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs',
-            ],
-            Path: '/',
-            RoleName: {
-              'Fn::Join': [
-                '-',
-                [
-                  'my-service',
-                  'dev',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  'apiGatewayLogsRole',
-                ],
-              ],
-            },
-          },
-        });
-      }));
-
-    it('should create an Account resource', () =>
-      awsCompileWebsocketsEvents.compileStage().then(() => {
-        const resources =
-          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources;
-
-        expect(resources[accountLogicalid]).to.deep.equal({
-          Type: 'AWS::ApiGateway::Account',
-          Properties: {
-            CloudWatchRoleArn: {
-              'Fn::GetAtt': [logsRoleLogicalId, 'Arn'],
-            },
-          },
-        });
-      }));
+        expect(
+          _.isObject(
+            resources[
+              awsCompileWebsocketsEvents.provider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId()
+            ]
+          )
+        ).to.equal(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
With #6531 we moved API Gateway CloudWatch role setup to custom resource (as it appeared it cannot be done reliably in context of CloudFormation stack)

Still we missed the fact that CloudWatch role is configured also with setup of WebSockets logs, and that part was left out.

This PR ensures CloudWatch role is setup same way in both cases, and that it's setup once if logs for both are configured.

--- 

I've run WebSocket integration tests to confirm nothing accidently got broken. Tests passed fine