### PR TITLE
PLAT-1629 - Fix custom resource lambda naming

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const crypto = require('crypto');
 const BbPromise = require('bluebird');
 const _ = require('lodash');
 const fse = BbPromise.promisifyAll(require('fs-extra'));
@@ -55,9 +56,13 @@ function addCustomResourceToService(resourceName, iamRoleStatements) {
     return BbPromise.reject(`No implementation found for Custom Resource "${resourceName}"`);
   }
   if (FunctionName.length > 64) {
-    return BbPromise.reject(
-      new Error(`Resolved custom resource function name '${FunctionName}' is too long`)
-    );
+    // Function names cannot be longer than 64.
+    // Temporary solution until we have https://github.com/serverless/serverless/issues/6598
+    // (which doesn't change names of already deployed functions)
+    FunctionName = `${FunctionName.slice(0, 32)}${crypto
+      .createHash('md5')
+      .update(FunctionName)
+      .digest('hex')}`;
   }
 
   // TODO: check every once in a while if external packages are still necessary

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -231,4 +231,27 @@ describe('#addCustomResourceToService()', () => {
       'No implementation found'
     );
   });
+
+  it("should ensure function name doesn't extend maximum length", () => {
+    serverless.service.service = 'some-unexpectedly-long-service-name';
+    return expect(
+      BbPromise.all([
+        // add the custom S3 resource
+        addCustomResourceToService.call(context, 's3', [
+          ...iamRoleStatements,
+          {
+            Effect: 'Allow',
+            Resource: 'arn:aws:s3:::some-bucket',
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+          },
+        ]),
+      ])
+    ).to.be.fulfilled.then(() => {
+      const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+      // S3 Lambda Function
+      expect(
+        Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties.FunctionName.length
+      ).to.be.below(65);
+    });
+  });
 });

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -24,6 +24,7 @@ describe('#addCustomResourceToService()', () => {
   let provider;
   let context;
   let execAsyncStub;
+  const serviceName = 'some-service';
   const iamRoleStatements = [
     {
       Effect: 'Allow',
@@ -43,7 +44,7 @@ describe('#addCustomResourceToService()', () => {
     serverless.cli = new CLI();
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
-    serverless.service.service = 'some-service';
+    serverless.service.service = serviceName;
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
     };
@@ -123,7 +124,7 @@ describe('#addCustomResourceToService()', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
             S3Key: 'artifact-dir-name/custom-resources.zip',
           },
-          FunctionName: 'some-service-dev-custom-resource-existing-s3',
+          FunctionName: `${serviceName}-dev-custom-resource-existing-s3`,
           Handler: 's3/handler.handler',
           MemorySize: 1024,
           Role: {
@@ -142,7 +143,7 @@ describe('#addCustomResourceToService()', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
             S3Key: 'artifact-dir-name/custom-resources.zip',
           },
-          FunctionName: 'some-service-dev-custom-resource-existing-cup',
+          FunctionName: `${serviceName}-dev-custom-resource-existing-cup`,
           Handler: 'cognitoUserPool/handler.handler',
           MemorySize: 1024,
           Role: {
@@ -161,7 +162,7 @@ describe('#addCustomResourceToService()', () => {
             S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
             S3Key: 'artifact-dir-name/custom-resources.zip',
           },
-          FunctionName: 'some-service-dev-custom-resource-event-bridge',
+          FunctionName: `${serviceName}-dev-custom-resource-event-bridge`,
           Handler: 'eventBridge/handler.handler',
           MemorySize: 1024,
           Role: {


### PR DESCRIPTION
Currently with long service names, there's a chance that generated lambda function names for custom resources will extend 64 lenght limit.

With this patch we ensure such names are truncacted (without a risk of collision, and without changing the names of already deployed functions)