### PR TITLE
Fix overriding package settings after packaging function

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -163,7 +163,7 @@ module.exports = {
 
     return this.resolveFilePathsFunction(functionName).then(filePaths =>
       this.zipFiles(filePaths, zipFileName, undefined, filesToChmodPlusX).then(artifactPath => {
-        functionObject.package.artifact = artifactPath;
+        funcPackageConfig.artifact = artifactPath;
         return artifactPath;
       })
     );

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -163,9 +163,7 @@ module.exports = {
 
     return this.resolveFilePathsFunction(functionName).then(filePaths =>
       this.zipFiles(filePaths, zipFileName, undefined, filesToChmodPlusX).then(artifactPath => {
-        functionObject.package = {
-          artifact: artifactPath,
-        };
+        functionObject.package.artifact = artifactPath;
         return artifactPath;
       })
     );

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -529,6 +529,22 @@ describe('#packageService()', () => {
           ])
         );
     });
+
+    it('should not override package property', () => {
+      const funcName = 'test-func';
+      serverless.service.functions = {};
+      serverless.service.functions[funcName] = {
+        name: `test-proj-${funcName}`,
+        package: { individually: true }
+      };
+
+      return packagePlugin.packageFunction(funcName)
+        .then(() =>
+          BbPromise.all([
+            expect(serverless.service.functions[funcName].package.individually).to.equal(true),
+          ])
+        );
+    });
   });
 
   describe('#packageLayer()', () => {

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -535,10 +535,11 @@ describe('#packageService()', () => {
       serverless.service.functions = {};
       serverless.service.functions[funcName] = {
         name: `test-proj-${funcName}`,
-        package: { individually: true }
+        package: { individually: true },
       };
 
-      return packagePlugin.packageFunction(funcName)
+      return packagePlugin
+        .packageFunction(funcName)
         .then(() =>
           BbPromise.all([
             expect(serverless.service.functions[funcName].package.individually).to.equal(true),

--- a/tests/integration-package/fixtures/individually-function/handler.js
+++ b/tests/integration-package/fixtures/individually-function/handler.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports.hello = function(event) {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: 'Go Serverless v1.0! Your function executed successfully!',
+        input: event,
+      },
+      null,
+      2
+    ),
+  };
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // return { message: 'Go Serverless v1.0! Your function executed successfully!', event };
+};

--- a/tests/integration-package/fixtures/individually-function/handler2.js
+++ b/tests/integration-package/fixtures/individually-function/handler2.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports.hello = function(event) {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: 'Go Serverless v1.0! Your function executed successfully!',
+        input: event,
+      },
+      null,
+      2
+    ),
+  };
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // return { message: 'Go Serverless v1.0! Your function executed successfully!', event };
+};

--- a/tests/integration-package/fixtures/individually-function/serverless.yml
+++ b/tests/integration-package/fixtures/individually-function/serverless.yml
@@ -1,0 +1,23 @@
+service: aws-nodejs
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+functions:
+  hello:
+    handler: handler.hello
+    package:
+      individually: true
+      include:
+        - handler.js
+      exclude:
+        - handler2.js
+  hello2:
+    handler: handler2.hello
+    package:
+      individually: true
+      include:
+        - handler2.js
+      exclude:
+        - handler.js

--- a/tests/integration-package/lambda-files.tests.js
+++ b/tests/integration-package/lambda-files.tests.js
@@ -10,6 +10,7 @@ const { getTmpDirPath, listZipFiles } = require('../utils/fs');
 const fixturePaths = {
   regular: path.join(__dirname, 'fixtures/regular'),
   individually: path.join(__dirname, 'fixtures/individually'),
+  individuallyFunction: path.join(__dirname, 'fixtures/individually-function'),
 };
 
 describe('Integration test - Packaging', function() {
@@ -83,6 +84,15 @@ describe('Integration test - Packaging', function() {
 
   it('handles package individually with include/excludes correctly', () => {
     fse.copySync(fixturePaths.individually, cwd);
+    execSync(`${serverlessExec} package`, { cwd });
+    return listZipFiles(path.join(cwd, '.serverless/hello.zip'))
+      .then(zipfiles => expect(zipfiles).to.deep.equal(['handler.js']))
+      .then(() => listZipFiles(path.join(cwd, '.serverless/hello2.zip')))
+      .then(zipfiles => expect(zipfiles).to.deep.equal(['handler2.js']));
+  });
+
+  it('handles package individually on function level with include/excludes correctly', () => {
+    fse.copySync(fixturePaths.individuallyFunction, cwd);
     execSync(`${serverlessExec} package`, { cwd });
     return listZipFiles(path.join(cwd, '.serverless/hello.zip'))
       .then(zipfiles => expect(zipfiles).to.deep.equal(['handler.js']))


### PR DESCRIPTION
## What did you implement:

Closes #6120 

I'm not sure how did I miss that with my previous PR (https://github.com/serverless/serverless/pull/6537) but without this fix `sls deploy` (with `package.individually: true` on function level) still returns an error. I probably tested it with the wrong config.

## How did you implement it:

The issue is that during function zipping whole `package` object is overwritten instead of just setting `artifact` prop.

## How can we verify it:

I gave two examples in the comment: https://github.com/serverless/serverless/issues/6120#issuecomment-520944321. Both works now.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
