### PR TITLE
Support optional CloudWatch logs writing for custom resource lambdas

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -142,6 +142,7 @@ provider:
       level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR.
       fullExecutionData: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
     websocket: true # Optional configuration which specifies if Websockets logs are used
+    frameworkLambda: true # Optional, whether to write CloudWatch logs for custom resource lambdas as added by the framework
 
 package: # Optional deployment packaging configuration
   include: # Specify the directories and files which should be included in the deployment package

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -18,7 +18,7 @@ function installDependencies(dirPath) {
 }
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
-  let FunctionName;
+  let absoluteFunctionName;
   let Handler;
   let customResourceFunctionLogicalId;
 
@@ -39,31 +39,31 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
   // check which custom resource should be used
   if (resourceName === 's3') {
-    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceS3HandlerFunctionName()}`;
+    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceS3HandlerFunctionName()}`;
     Handler = 's3/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceS3HandlerFunctionLogicalId();
   } else if (resourceName === 'cognitoUserPool') {
-    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName()}`;
+    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName()}`;
     Handler = 'cognitoUserPool/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
   } else if (resourceName === 'eventBridge') {
-    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName()}`;
+    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName()}`;
     Handler = 'eventBridge/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();
   } else if (resourceName === 'apiGatewayCloudWatchRole') {
-    FunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()}`;
+    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()}`;
     Handler = 'apiGatewayCloudWatchRole/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
   } else {
     return BbPromise.reject(`No implementation found for Custom Resource "${resourceName}"`);
   }
-  if (FunctionName.length > 64) {
+  if (absoluteFunctionName.length > 64) {
     // Function names cannot be longer than 64.
     // Temporary solution until we have https://github.com/serverless/serverless/issues/6598
     // (which doesn't change names of already deployed functions)
-    FunctionName = `${FunctionName.slice(0, 32)}${crypto
+    absoluteFunctionName = `${absoluteFunctionName.slice(0, 32)}${crypto
       .createHash('md5')
-      .update(FunctionName)
+      .update(absoluteFunctionName)
       .digest('hex')}`;
   }
 
@@ -136,7 +136,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
             S3Bucket,
             S3Key,
           },
-          FunctionName,
+          FunctionName: absoluteFunctionName,
           Handler,
           MemorySize: 1024,
           Role: {

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const crypto = require('crypto');
 const BbPromise = require('bluebird');
-const _ = require('lodash');
 const fse = BbPromise.promisifyAll(require('fs-extra'));
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const getTmpDirPath = require('../../../utils/fs/getTmpDirPath');
@@ -149,7 +148,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
         DependsOn: [customResourcesRoleLogicalId],
       };
 
-      _.merge(Resources, {
+      Object.assign(Resources, {
         [customResourceFunctionLogicalId]: customResourceFunction,
         [customResourcesRoleLogicalId]: customResourceRole,
       });

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -24,7 +24,9 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
   const { serverless } = awsProvider;
   const { cliOptions } = serverless.pluginManager;
-  const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+  const providerConfig = serverless.service.provider;
+  const shouldWriteLogs = providerConfig.logs && providerConfig.logs.frameworkLambda;
+  const { Resources } = providerConfig.compiledCloudFormationTemplate;
   const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
   const srcDirPath = path.join(__dirname, 'resources');
   const destDirPath = path.join(
@@ -121,6 +123,34 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
             ],
           },
         };
+
+        if (shouldWriteLogs) {
+          const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
+          customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+            {
+              Effect: 'Allow',
+              Action: ['logs:CreateLogStream'],
+              Resource: [
+                {
+                  'Fn::Sub':
+                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                    `:log-group:${logGroupsPrefix}*:*`,
+                },
+              ],
+            },
+            {
+              Effect: 'Allow',
+              Action: ['logs:PutLogEvents'],
+              Resource: [
+                {
+                  'Fn::Sub':
+                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                    `:log-group:${logGroupsPrefix}*:*:*`,
+                },
+              ],
+            }
+          );
+        }
       }
       const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
       iamRoleStatements.forEach(newStmt => {
@@ -152,6 +182,21 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
         [customResourceFunctionLogicalId]: customResourceFunction,
         [customResourcesRoleLogicalId]: customResourceRole,
       });
+
+      if (shouldWriteLogs) {
+        const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
+          functionName
+        );
+        customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
+        Object.assign(Resources, {
+          [customResourceLogGroupLogicalId]: {
+            Type: 'AWS::Logs::LogGroup',
+            Properties: {
+              LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+            },
+          },
+        });
+      }
     });
 }
 

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -18,6 +18,7 @@ function installDependencies(dirPath) {
 }
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
+  let functionName;
   let absoluteFunctionName;
   let Handler;
   let customResourceFunctionLogicalId;
@@ -39,24 +40,25 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
   // check which custom resource should be used
   if (resourceName === 's3') {
-    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceS3HandlerFunctionName()}`;
+    functionName = awsProvider.naming.getCustomResourceS3HandlerFunctionName();
     Handler = 's3/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceS3HandlerFunctionLogicalId();
   } else if (resourceName === 'cognitoUserPool') {
-    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName()}`;
+    functionName = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName();
     Handler = 'cognitoUserPool/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
   } else if (resourceName === 'eventBridge') {
-    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName()}`;
+    functionName = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName();
     Handler = 'eventBridge/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();
   } else if (resourceName === 'apiGatewayCloudWatchRole') {
-    absoluteFunctionName = `${funcPrefix}-${awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()}`;
+    functionName = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName();
     Handler = 'apiGatewayCloudWatchRole/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
   } else {
     return BbPromise.reject(`No implementation found for Custom Resource "${resourceName}"`);
   }
+  absoluteFunctionName = `${funcPrefix}-${functionName}`;
   if (absoluteFunctionName.length > 64) {
     // Function names cannot be longer than 64.
     // Temporary solution until we have https://github.com/serverless/serverless/issues/6598

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -116,20 +116,19 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
                 },
                 PolicyDocument: {
                   Version: '2012-10-17',
-                  Statement: iamRoleStatements,
+                  Statement: [],
                 },
               },
             ],
           },
         };
-      } else {
-        const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
-        iamRoleStatements.forEach(newStmt => {
-          if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
-            Statement.push(newStmt);
-          }
-        });
       }
+      const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
+      iamRoleStatements.forEach(newStmt => {
+        if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
+          Statement.push(newStmt);
+        }
+      });
 
       const customResourceFunction = {
         Type: 'AWS::Lambda::Function',

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -221,6 +221,95 @@ describe('#addCustomResourceToService()', () => {
     });
   });
 
+  it('should setup CloudWatch Logs when logs.frameworkLambda is true', () => {
+    serverless.service.provider.logs = { frameworkLambda: true };
+    return BbPromise.all([
+      // add the custom S3 resource
+      addCustomResourceToService(provider, 's3', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::some-bucket',
+          Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+        },
+      ]),
+      // add the custom Cognito User Pool resource
+      addCustomResourceToService(provider, 'cognitoUserPool', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: '*',
+          Action: [
+            'cognito-idp:ListUserPools',
+            'cognito-idp:DescribeUserPool',
+            'cognito-idp:UpdateUserPool',
+          ],
+        },
+      ]),
+      // add the custom Event Bridge resource
+      addCustomResourceToService(provider, 'eventBridge', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:events:*:*:rule/some-rule',
+          Action: [
+            'events:PutRule',
+            'events:RemoveTargets',
+            'events:PutTargets',
+            'events:DeleteRule',
+          ],
+        },
+        {
+          Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:events:*:*:event-bus/some-event-bus',
+        },
+      ]),
+    ]).then(() => {
+      const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+
+      // S3 Lambda Function
+      expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction.DependsOn).to.include(
+        'CustomDashresourceDashexistingDashs3LogGroup'
+      );
+      // Cognito User Pool Lambda Function
+      expect(Resources.CustomDashresourceDashexistingDashcupLambdaFunction.DependsOn).to.include(
+        'CustomDashresourceDashexistingDashcupLogGroup'
+      );
+      // Event Bridge Lambda Function
+      expect(Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.DependsOn).to.include(
+        'CustomDashresourceDasheventDashbridgeLogGroup'
+      );
+      // Iam Role
+      const RoleProps = Resources.IamRoleCustomResourcesLambdaExecution.Properties;
+
+      expect(RoleProps.Policies[0].PolicyDocument.Statement).to.include.deep.members([
+        {
+          Effect: 'Allow',
+          Action: ['logs:CreateLogStream'],
+          Resource: [
+            {
+              'Fn::Sub':
+                'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                ':log-group:/aws/lambda/some-service-dev*:*',
+            },
+          ],
+        },
+        {
+          Effect: 'Allow',
+          Action: ['logs:PutLogEvents'],
+          Resource: [
+            {
+              'Fn::Sub':
+                'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                ':log-group:/aws/lambda/some-service-dev*:*:*',
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
   it('should throw when an unknown custom resource is used', () => {
     return expect(addCustomResourceToService(provider, 'unknown', [])).to.be.rejectedWith(
       'No implementation found'


### PR DESCRIPTION
It's helpful when debugging custom resources to be able to inspect their logs.

Still at this point those logs are not written to CloudWatch (I take it's intentional, as we want to generate as least resources as possible).

I've added an option to have those logs written if needed.
