### PR TITLE
Fixes aws partition name in apigateway resourceArn to support GovCloud

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -279,7 +279,12 @@ function handleTags() {
   const restApiId = this.apiGatewayRestApiId;
   const stageName = this.options.stage;
   const region = this.options.region;
-  const resourceArn = `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+  let resourceArn;
+  if (region.includes('gov')) {
+      resourceArn = `arn:aws-us-gov:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+  } else {
+      resourceArn = `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+  }
 
   if (tagKeysToBeRemoved.length > 0) {
     this.apiGatewayUntagResourceParams.push({

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -233,10 +233,16 @@ function handleLogs() {
     const accessLogging = logs.accessLogging == null ? true : logs.accessLogging;
 
     if (accessLogging) {
+      let resourceArn;
+      if (region.includes('gov')) {
+        resourceArn = `arn:aws-us-gov:logs:${region}:${this.accountId}:log-group:${logGroupName}`;
+      } else {
+        resourceArn = `arn:aws:logs:${region}:${this.accountId}:log-group:${logGroupName}`;
+      }
       const destinationArn = {
         op: 'replace',
         path: '/accessLogSettings/destinationArn',
-        value: `arn:aws:logs:${region}:${this.accountId}:log-group:${logGroupName}`,
+        value: resourceArn,
       };
       const format = {
         op: 'replace',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -281,9 +281,9 @@ function handleTags() {
   const region = this.options.region;
   let resourceArn;
   if (region.includes('gov')) {
-      resourceArn = `arn:aws-us-gov:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+    resourceArn = `arn:aws-us-gov:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
   } else {
-      resourceArn = `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
+    resourceArn = `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
   }
 
   if (tagKeysToBeRemoved.length > 0) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -223,20 +223,20 @@ describe('#updateStage()', () => {
       expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[1][1]).to.equal('getStage');
       expect(providerRequestStub.args[1][2]).to.deep.equal({
-        restApiId: 'someRestApiId',
+        restApiId: 'devRestApiId',
         stageName: 'dev',
       });
       expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[2][1]).to.equal('updateStage');
       expect(providerRequestStub.args[2][2]).to.deep.equal({
-        restApiId: 'someRestApiId',
+        restApiId: 'devRestApiId',
         stageName: 'dev',
         patchOperations,
       });
       expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[3][1]).to.equal('tagResource');
       expect(providerRequestStub.args[3][2]).to.deep.equal({
-        resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/someRestApiId/stages/dev',
+        resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/devRestApiId/stages/dev',
         tags: {
           'Containing Space': 'bar',
           'bar': 'high-priority',
@@ -246,7 +246,7 @@ describe('#updateStage()', () => {
       expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[4][1]).to.equal('untagResource');
       expect(providerRequestStub.args[4][2]).to.deep.equal({
-        resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/someRestApiId/stages/dev',
+        resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/devRestApiId/stages/dev',
         tagKeys: ['old'],
       });
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -158,6 +158,82 @@ describe('#updateStage()', () => {
     });
   });
 
+  it('should support gov regions', () => {
+    options.region = 'us-gov-east-1';
+    context.state.service.provider.tags = {
+      'Containing Space': 'bar',
+      'bar': 'high-priority',
+    };
+    context.state.service.provider.stackTags = {
+      bar: 'low-priority',
+      num: 123,
+    };
+    context.state.service.provider.tracing = {
+      apiGateway: true,
+    };
+    context.state.service.provider.logs = {
+      restApi: true,
+    };
+
+    return updateStage.call(context).then(() => {
+      const patchOperations = [
+        { op: 'replace', path: '/tracingEnabled', value: 'true' },
+        {
+          op: 'replace',
+          path: '/accessLogSettings/destinationArn',
+          value:
+            'arn:aws-us-gov:logs:us-gov-east-1:123456:log-group:/aws/api-gateway/my-service-dev',
+        },
+        {
+          op: 'replace',
+          path: '/accessLogSettings/format',
+          value:
+            'requestId: $context.requestId, ip: $context.identity.sourceIp, caller: $context.identity.caller, user: $context.identity.user, requestTime: $context.requestTime, httpMethod: $context.httpMethod, resourcePath: $context.resourcePath, status: $context.status, protocol: $context.protocol, responseLength: $context.responseLength',
+        },
+        { op: 'replace', path: '/*/*/logging/dataTrace', value: 'true' },
+        { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' },
+      ];
+
+      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerRequestStub.args).to.have.length(5);
+      expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
+      expect(providerRequestStub.args[0][2]).to.deep.equal({
+        limit: 500,
+        position: undefined,
+      });
+      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[1][1]).to.equal('getStage');
+      expect(providerRequestStub.args[1][2]).to.deep.equal({
+        restApiId: 'someRestApiId',
+        stageName: 'dev',
+      });
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
+        restApiId: 'someRestApiId',
+        stageName: 'dev',
+        patchOperations,
+      });
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('tagResource');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
+        resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/someRestApiId/stages/dev',
+        tags: {
+          'Containing Space': 'bar',
+          'bar': 'high-priority',
+          'num': '123',
+        },
+      });
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('untagResource');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
+        resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/someRestApiId/stages/dev',
+        tagKeys: ['old'],
+      });
+    });
+  });
+
   it('should perform default actions if settings are not configure', () => {
     context.state.service.provider.tags = {
       old: 'tag',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Fixes aws partition name in apigateway resourceArn to allow for a govcloud partition name of aws-us-gov in the case where one is trying to deploy to AWS GovCloud -- without this adjustment, serverless template fails when trying to deploy apigateway to AWS GovCloud

Closes #XXXXX
Relates to: https://github.com/serverless/serverless/issues/4102
<!--
Briefly describe the feature if no issue exists for this PR
-->
When trying to deploy to apigateway in AWS GovCloud, the wrong partition is put into the resource arn (aws instead of aws-gov-us).  Here is an example error:
```
Expected ARN arn:aws-us-gov:apigateway:us-gov-east-1::/... for Stage <stage> on RestApi <api id>, not arn:aws:apigateway:us-gov-east-1::/...
```

## How did you implement it:
Added a conditional to change the resourceArn variable to have aws-us-gov instead of aws when the region has 'gov' in it.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Make an apigateway deployment to AWS GovCloud.  Without the change, one gets the error described above.  With the change, there is a successful deployment.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`** -- validated, but no tests
- [ ] Write documentation -- not really significant enough for documentation
- [ x ] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ x ] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ x ] Make sure code coverage hasn't dropped
- [ x ] Provide verification config / commands / resources
- [ x ] Enable "Allow edits from maintainers" for this PR
- [ x ] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
