### PR TITLE
Ensure inquirer's chalk override works through symlinks

### DIFF
--- a/lib/plugins/interactiveCli/inquirer.js
+++ b/lib/plugins/interactiveCli/inquirer.js
@@ -7,7 +7,7 @@ const requireUncached = require('ncjsm/require-uncached');
 const resolve = require('ncjsm/resolve/sync');
 const chalk = require('chalk');
 
-const inquirersChalkPath = resolve(dirname(require.resolve('inquirer')), 'chalk');
+const inquirersChalkPath = resolve(dirname(require.resolve('inquirer')), 'chalk').realPath;
 
 module.exports = requireUncached(inquirersChalkPath, () => {
   // Ensure distinct chalk instance for inquirer and hack it with altered styles

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.24.0",
     "nanomatch": "^1.2.13",
-    "ncjsm": "^2.3.0",
+    "ncjsm": "^3.0.0",
     "node-fetch": "^1.7.3",
     "object-hash": "^1.3.1",
     "promise-queue": "^2.2.5",


### PR DESCRIPTION
Fixes #6605 

Patch through which we ensure that inquirer works with hacked version of `chalk` was relying on resolution of module id (path), which did not took into account eventual symlinks redirection (hence when symlinks were involved, the resolved chalk path was not necessary correct).

This patch updates `ncjsm` to version that exposes module file real path (so one that's definitely used as module id).
