### PR TITLE
Do not retry on AWS 403 errors

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -240,6 +240,7 @@ class AwsProvider {
             .then(resolve, e => {
               if (
                 numTry < MAX_TRIES &&
+                e.statusCode !== 403 && // Invalid credentials
                 ((e.providerError && e.providerError.retryable) || e.statusCode === 429)
               ) {
                 that.serverless.cli.log(

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -428,6 +428,38 @@ describe('AwsProvider', () => {
         .catch(done);
     });
 
+    it('should not retry if error code is 403 and retryable is set to true', done => {
+      const error = {
+        statusCode: 403,
+        retryable: true,
+        message: 'Testing retry',
+      };
+      const sendFake = {
+        send: sinon.stub(),
+      };
+      sendFake.send.onFirstCall().yields(error);
+      sendFake.send.yields(undefined, {});
+      class FakeS3 {
+        constructor(credentials) {
+          this.credentials = credentials;
+        }
+
+        error() {
+          return sendFake;
+        }
+      }
+      awsProvider.sdk = {
+        S3: FakeS3,
+      };
+      awsProvider
+        .request('S3', 'error', {})
+        .then(() => done('Should not succeed'))
+        .catch(() => {
+          expect(sendFake.send).to.have.been.calledOnce;
+          done();
+        });
+    });
+
     it('should reject errors', done => {
       const error = {
         statusCode: 500,


### PR DESCRIPTION
AWS reports `403` (bad credentials) errors as retryable.

Still we definitely do not want to retry requests if credentials are outdated or invalid.
