### PR TITLE
Update Readme to replace SC5.io with nordcloud.com

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -493,7 +493,10 @@ class PluginManager {
    * Called by the CLI to start a public command.
    */
   run(commandsArray) {
-    return this.invoke(commandsArray);
+    // first initialize hooks
+    return this.getHooks(['initialize'])
+      .reduce((chain, { hook }) => chain.then(hook), BbPromise.resolve())
+      .then(() => this.invoke(commandsArray));
   }
 
   /**

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1372,9 +1372,7 @@ describe('PluginManager', () => {
 
       const commandsArray = ['foo'];
 
-      expect(() => {
-        pluginManager.run(commandsArray);
-      }).to.throw(Error);
+      return expect(pluginManager.run(commandsArray)).to.be.rejectedWith(Error);
     });
 
     it('should throw an error when the given command is an entrypoint', () => {
@@ -1382,9 +1380,7 @@ describe('PluginManager', () => {
 
       const commandsArray = ['myep'];
 
-      expect(() => {
-        pluginManager.run(commandsArray);
-      }).to.throw(Error);
+      expect(pluginManager.run(commandsArray)).to.be.rejectedWith(Error);
     });
 
     it('should throw an error when the given command is a container', () => {
@@ -1392,9 +1388,7 @@ describe('PluginManager', () => {
 
       const commandsArray = ['mycontainer'];
 
-      expect(() => {
-        pluginManager.run(commandsArray);
-      }).to.throw(Error);
+      expect(pluginManager.run(commandsArray)).to.be.rejectedWith(Error);
     });
 
     it('should NOT throw an error when the given command is a child of a container', () => {
@@ -1402,9 +1396,7 @@ describe('PluginManager', () => {
 
       const commandsArray = ['mycontainer', 'mysubcmd'];
 
-      expect(() => {
-        pluginManager.run(commandsArray);
-      }).to.not.throw(Error);
+      expect(pluginManager.run(commandsArray)).to.not.be.rejectedWith(Error);
     });
 
     it('should throw an error when the given command is a child of an entrypoint', () => {
@@ -1412,9 +1404,7 @@ describe('PluginManager', () => {
 
       const commandsArray = ['mysubcmd'];
 
-      expect(() => {
-        pluginManager.run(commandsArray);
-      }).to.throw(Error);
+      expect(pluginManager.run(commandsArray)).to.be.rejectedWith(Error);
     });
 
     it('should show warning if in debug mode and the given command has no hooks', () => {
@@ -1449,6 +1439,7 @@ describe('PluginManager', () => {
           };
 
           this.hooks = {
+            'initialize': this.initializeHookStatus.bind(this),
             'before:run:beforeHookStatus': this.beforeHookStatus.bind(this),
             'run:midHookStatus': this.midHookStatus.bind(this),
             'after:run:afterHookStatus': this.afterHookStatus.bind(this),
@@ -1456,6 +1447,10 @@ describe('PluginManager', () => {
 
           // used to test if the hooks were run in the correct order
           this.hookStatus = [];
+        }
+
+        initializeHookStatus() {
+          this.hookStatus.push('initialize');
         }
 
         beforeHookStatus() {
@@ -1474,9 +1469,10 @@ describe('PluginManager', () => {
       pluginManager.addPlugin(CorrectHookOrderPluginMock);
       const commandsArray = ['run'];
       return pluginManager.run(commandsArray).then(() => {
-        expect(pluginManager.plugins[0].hookStatus[0]).to.equal('before');
-        expect(pluginManager.plugins[0].hookStatus[1]).to.equal('mid');
-        expect(pluginManager.plugins[0].hookStatus[2]).to.equal('after');
+        expect(pluginManager.plugins[0].hookStatus[0]).to.equal('initialize');
+        expect(pluginManager.plugins[0].hookStatus[1]).to.equal('before');
+        expect(pluginManager.plugins[0].hookStatus[2]).to.equal('mid');
+        expect(pluginManager.plugins[0].hookStatus[3]).to.equal('after');
       });
     });
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Update to the Consultants section of the README. SC5 merged with Nordcloud, so time to make the replacement.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Only Markdown changes.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Be helpful to verify my spelling..
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [n/a ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ x] Write documentation
- [n'a ] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ n/a] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ n/a] Make sure code coverage hasn't dropped
- [ n/a] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
