### PR TITLE
Allow for tail on GetAtt parsing

### DIFF
--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -34,7 +34,6 @@ const yamlType = (name, kind) => {
           const [first, ...tail] = data.split('.');
           data = [first, tail.join('.')];
         }
-        return { [functionName]: data };
       }
       return { [functionName]: data };
     },

--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -30,7 +30,12 @@ const yamlType = (name, kind) => {
     construct: data => {
       if (name === 'GetAtt') {
         // special GetAtt dot syntax
-        return { [functionName]: _.isString(data) ? _.split(data, '.', 2) : data };
+        if (_.isString(data)) {
+          let [first, ...tail] = _.split(data, '.') // eslint-disable-line prefer-const
+          tail = tail.join('.')
+          data = [first, tail]
+        }
+        return { [functionName]: data }
       }
       return { [functionName]: data };
     },

--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -31,11 +31,11 @@ const yamlType = (name, kind) => {
       if (name === 'GetAtt') {
         // special GetAtt dot syntax
         if (_.isString(data)) {
-          let [first, ...tail] = _.split(data, '.') // eslint-disable-line prefer-const
-          tail = tail.join('.')
-          data = [first, tail]
+          let [first, ...tail] = _.split(data, '.'); // eslint-disable-line prefer-const
+          tail = tail.join('.');
+          data = [first, tail];
         }
-        return { [functionName]: data }
+        return { [functionName]: data };
       }
       return { [functionName]: data };
     },

--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -30,10 +30,9 @@ const yamlType = (name, kind) => {
     construct: data => {
       if (name === 'GetAtt') {
         // special GetAtt dot syntax
-        if (_.isString(data)) {
-          let [first, ...tail] = _.split(data, '.'); // eslint-disable-line prefer-const
-          tail = tail.join('.');
-          data = [first, tail];
+        if (typeof data === 'string') {
+          const [first, ...tail] = data.split('.');
+          data = [first, tail.join('.')];
         }
         return { [functionName]: data };
       }

--- a/lib/utils/fs/parse.test.js
+++ b/lib/utils/fs/parse.test.js
@@ -20,6 +20,11 @@ const shortHandOptions = [
     json: { Item: { 'Fn::GetAtt': ['MyResource', 'Arn'] } },
   },
   {
+    name: 'GetAtt, dot syntax with tail',
+    yaml: 'Item: !GetAtt MyResource.Outputs.Arn',
+    json: { Item: { 'Fn::GetAtt': ['MyResource', 'Outputs.Arn'] } },
+  },
+  {
     name: 'GetAtt, array syntax',
     yaml: 'Item: !GetAtt\n- MyResource\n- Arn',
     json: { Item: { 'Fn::GetAtt': ['MyResource', 'Arn'] } },


### PR DESCRIPTION
## What did you implement:

Fixed `!GetAtt` parsing to allow for nested properties on the value -- e.g. `Resource.Outputs.MyValue`

This was triggered by [this tweet](https://twitter.com/aaron_osborne_/status/1167238870800510977) asking why he couldn't use an SAR Output in his serverless.yml. After reviewing, I noticed that `!GetAtt RequirementsLayerApp.Outputs.LayerVersion` was getting converted to:

```
Fn::GetAtt:
  - RequirementsLayerApp
  - Outputs
```

Notice that `LayerVersion` has been stripped off of Outputs.

## How did you implement it:

The original parsing of `!GetAtt` splits on a period and allows for two return values, as most usage of GetAtt don't have nested attributes. I updated the logic to split on all the periods, then rejoin all elements after the first period.

## How can we verify it:

Use [Aaron's sample serverless.yml](https://github.com/aaronosb/serverless-sar-lambda-layer-test/blob/master/serverless.yml). Run `sls package` and confirm that the Fn:GetAtt includes Outputs.LayerVersion.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** YES
