### PR TITLE
Remove enterprise from upgrade notes

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -172,7 +172,7 @@ class PluginManager {
       const updates = updateNotifier({ pkg: sfePkgJson, interval: 1 });
       if (updates.update) {
         this.serverless.cli.log(
-          'An updated version of Serverless Enterprise is available. ' +
+          'An updated version of the Serverless Dashboard is available. ' +
             'Please upgrade by running `npm i -g serverless`'
         );
       }


### PR DESCRIPTION
## What did you implement:

I changed the wording of the upgrade message from Enterprise to Dashboard, and added `the`

## How did you implement it:

By deleting and adding text

## How can we verify it:

You can pull this branch with an outdated version of the enterprise-plugin and see this message

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
