### PR TITLE
Resolve empty config object for an empty config file

### DIFF
--- a/lib/utils/getServerlessConfigFile.js
+++ b/lib/utils/getServerlessConfigFile.js
@@ -70,7 +70,7 @@ const getServerlessConfigFile = _.memoize(
           return handleJsConfigFile(configFilePath);
         }
 
-        return readFile(configFilePath);
+        return readFile(configFilePath).then(result => result || {});
       }
 
       return '';

--- a/lib/utils/getServerlessConfigFile.test.js
+++ b/lib/utils/getServerlessConfigFile.test.js
@@ -33,6 +33,20 @@ describe('#getServerlessConfigFile()', () => {
     });
   });
 
+  it('should return an empty object for empty configuration', () => {
+    const serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
+
+    writeFileSync(serverlessFilePath, '');
+    return expect(
+      getServerlessConfigFile({
+        processedInput: { options: {} },
+        config: { servicePath: tmpDirPath },
+      })
+    ).to.be.fulfilled.then(result => {
+      expect(result).to.deep.equal({});
+    });
+  });
+
   it('should return the file content if a serverless.yml file is found', () => {
     const serverlessFilePath = path.join(tmpDirPath, 'serverless.yml');
 


### PR DESCRIPTION
Currently an empty config files resolves to `undefined`, which produces obscure errors as:

```
TypeError: Cannot read property 'frameworkVersion' of undefined
```

I take if config exists, it always should resolve to object, eventually empty