### PR TITLE
Non empty region will include region in the template URL

### DIFF
--- a/lib/plugins/aws/deploy/lib/validateTemplate.test.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.test.js
@@ -56,7 +56,7 @@ describe('validateTemplate', () => {
           'validateTemplate',
           {
             TemplateURL:
-              'https://s3.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
+              'https://s3.us-east-1.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
           }
         );
       });
@@ -73,7 +73,7 @@ describe('validateTemplate', () => {
           'validateTemplate',
           {
             TemplateURL:
-              'https://s3.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
+              'https://s3.us-east-1.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
           }
         );
         expect(error.message).to.match(/is invalid: Some error while validating/);

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -45,7 +45,7 @@ describe('updateStack', () => {
             OnFailure: 'ROLLBACK',
             Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
             Parameters: [],
-            TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
+            TemplateURL: `https://s3.us-east-1.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
             Tags: [{ Key: 'STAGE', Value: awsDeploy.provider.getStage() }],
           })
         ).to.be.equal(true);
@@ -137,7 +137,7 @@ describe('updateStack', () => {
             StackName: awsDeploy.provider.naming.getStackName(),
             Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
             Parameters: [],
-            TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
+            TemplateURL: `https://s3.us-east-1.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,
             Tags: [{ Key: 'STAGE', Value: awsDeploy.provider.getStage() }],
           })
         ).to.be.equal(true);

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -398,8 +398,13 @@ class AwsProvider {
   isS3TransferAccelerationSupported() {
     // Only enable s3 transfer acceleration for standard regions (non govcloud/china)
     // since those regions do not yet support it
-    const endpoint = getS3EndpointForRegion(this.getRegion());
-    return endpoint === 's3.amazonaws.com';
+    const region = this.getRegion();
+    const endpoint = getS3EndpointForRegion(region);
+    console.log(endpoint);
+    if (endpoint.match(/us-gov/ || endpoint.match(/cn-/))) {
+      return false;
+    }
+    return endpoint === `s3.${region}.amazonaws.com`;
   }
 
   isS3TransferAccelerationEnabled() {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -400,7 +400,6 @@ class AwsProvider {
     // since those regions do not yet support it
     const region = this.getRegion();
     const endpoint = getS3EndpointForRegion(region);
-    console.log(endpoint);
     if (endpoint.match(/us-gov/ || endpoint.match(/cn-/))) {
       return false;
     }

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -1406,9 +1406,27 @@ describe('AwsProvider', () => {
       awsProvider.options['aws-s3-accelerate'] = undefined;
       return expect(awsProvider.isS3TransferAccelerationEnabled()).to.equal(false);
     });
+
     it('should return true when CLI option is provided', () => {
       awsProvider.options['aws-s3-accelerate'] = true;
       return expect(awsProvider.isS3TransferAccelerationEnabled()).to.equal(true);
+    });
+  });
+
+  describe('#isS3TransferAccelerationSupported()', () => {
+    it('should return false for us-gov regions', () => {
+      awsProvider = new AwsProvider(serverless, { region: 'us-gov-west-1' });
+      return expect(awsProvider.isS3TransferAccelerationSupported()).to.equal(false);
+    });
+
+    it('should return false forcn regions regions', () => {
+      awsProvider = new AwsProvider(serverless, { region: 'cn-north-1' });
+      return expect(awsProvider.isS3TransferAccelerationSupported()).to.equal(false);
+    });
+
+    it('should return true for all other regions', () => {
+      awsProvider = new AwsProvider(serverless, { region: 'us-east-1' });
+      return expect(awsProvider.isS3TransferAccelerationSupported()).to.equal(true);
     });
   });
 
@@ -1419,24 +1437,29 @@ describe('AwsProvider', () => {
         awsProvider.canUseS3TransferAcceleration('lambda', 'updateFunctionCode')
       ).to.equal(false);
     });
+
     it('should return false by default with S3.upload too', () => {
       awsProvider.options['aws-s3-accelerate'] = undefined;
       return expect(awsProvider.canUseS3TransferAcceleration('S3', 'upload')).to.equal(false);
     });
+
     it('should return false by default with S3.putObject too', () => {
       awsProvider.options['aws-s3-accelerate'] = undefined;
       return expect(awsProvider.canUseS3TransferAcceleration('S3', 'putObject')).to.equal(false);
     });
+
     it('should return false when CLI option is provided but not an S3 upload', () => {
       awsProvider.options['aws-s3-accelerate'] = true;
       return expect(
         awsProvider.canUseS3TransferAcceleration('lambda', 'updateFunctionCode')
       ).to.equal(false);
     });
+
     it('should return true when CLI option is provided for S3.upload', () => {
       awsProvider.options['aws-s3-accelerate'] = true;
       return expect(awsProvider.canUseS3TransferAcceleration('S3', 'upload')).to.equal(true);
     });
+
     it('should return true when CLI option is provided for S3.putObject', () => {
       awsProvider.options['aws-s3-accelerate'] = true;
       return expect(awsProvider.canUseS3TransferAcceleration('S3', 'putObject')).to.equal(true);

--- a/lib/plugins/aws/utils/getS3EndpointForRegion.js
+++ b/lib/plugins/aws/utils/getS3EndpointForRegion.js
@@ -6,6 +6,8 @@ module.exports = function getS3EndpointForRegion(region) {
   if (strRegion.match(/us-gov/)) return `s3-${strRegion}.amazonaws.com`;
   // look for china - currently s3.cn-north-1.amazonaws.com.cn
   if (strRegion.match(/cn-/)) return `s3.${strRegion}.amazonaws.com.cn`;
+  // look for specific region - https://s3.ap-southeast-1.amazonaws.com/xxxx
+  if (strRegion) return `s3.${strRegion}.amazonaws.com`;
   // default s3 endpoint for other regions
   return 's3.amazonaws.com';
 };

--- a/lib/plugins/aws/utils/getS3EndpointForRegion.test.js
+++ b/lib/plugins/aws/utils/getS3EndpointForRegion.test.js
@@ -18,4 +18,9 @@ describe('getS3EndpointForRegion', () => {
     const actual = getS3EndpointForRegion('cn-north-1');
     expect(actual).to.equal(expected);
   });
+  it('should return southeast endpoint for ap-southeast-1', () => {
+    const expected = 's3.ap-southeast-1.amazonaws.com';
+    const actual = getS3EndpointForRegion('ap-southeast-1');
+    expect(actual).to.equal(expected);
+  });
 });

--- a/lib/plugins/aws/utils/getS3EndpointForRegion.test.js
+++ b/lib/plugins/aws/utils/getS3EndpointForRegion.test.js
@@ -3,8 +3,8 @@ const expect = require('chai').expect;
 const getS3EndpointForRegion = require('./getS3EndpointForRegion');
 
 describe('getS3EndpointForRegion', () => {
-  it('should return standard endpoint for us-east-1', () => {
-    const expected = 's3.amazonaws.com';
+  it('should return useast endpoint for us-east-1', () => {
+    const expected = 's3.us-east-1.amazonaws.com';
     const actual = getS3EndpointForRegion('us-east-1');
     expect(actual).to.equal(expected);
   });
@@ -21,6 +21,11 @@ describe('getS3EndpointForRegion', () => {
   it('should return southeast endpoint for ap-southeast-1', () => {
     const expected = 's3.ap-southeast-1.amazonaws.com';
     const actual = getS3EndpointForRegion('ap-southeast-1');
+    expect(actual).to.equal(expected);
+  });
+  it('should return standard endpoint for empty region', () => {
+    const expected = 's3.amazonaws.com';
+    const actual = getS3EndpointForRegion('');
     expect(actual).to.equal(expected);
   });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6539 

Now S3 bucket has specific regions, and can only be accessed by url like `https://s3.ap-southeast-1.amazonaws.com/xxxx` but in source code, serverless will return `https://s3.amazonaws.com/xxxx`.

This will cause error for cloud formation when validating the template.
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

With the fix, non-empty regions will return that region in the template URL. Only empty region will return the default standard template URL. 

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run unit tests - `npm test`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO