### PR TITLE
Tests for interactive CLI 

### DIFF
--- a/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
+++ b/lib/plugins/aws/configCredentials/awsConfigCredentials.test.js
@@ -2,9 +2,10 @@
 
 const expect = require('chai').expect;
 const sandbox = require('sinon');
+const BbPromise = require('bluebird');
 const { constants } = require('fs');
 const fs = require('fs');
-const fse = require('fs-extra');
+const fse = BbPromise.promisifyAll(require('fs-extra'));
 const os = require('os');
 const path = require('path');
 const AwsConfigCredentials = require('./awsConfigCredentials');
@@ -22,8 +23,21 @@ describe('AwsConfigCredentials', () => {
     'aws_secret_access_key = my-old-profile-secret',
   ].join('\n');
 
+  before(() => {
+    // Abort if credentials are found in home directory
+    // (it should not be the case, as home directory is mocked to point temp dir)
+    return fse.lstatAsync(awsDirectoryPath).then(
+      () => {
+        throw new Error('Unexpected ~/.aws directory, related tests aborted');
+      },
+      error => {
+        if (error.code === 'ENOENT') return;
+        throw error;
+      }
+    );
+  });
+
   beforeEach(() => {
-    fse.removeSync(credentialsFilePath);
     serverless = new Serverless();
     return serverless.init().then(() => {
       const options = {
@@ -34,6 +48,8 @@ describe('AwsConfigCredentials', () => {
       awsConfigCredentials = new AwsConfigCredentials(serverless, options);
     });
   });
+
+  afterEach(() => fse.removeAsync(awsDirectoryPath));
 
   describe('#constructor()', () => {
     it('should have the command "config"', () => {

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -95,7 +95,7 @@ describe('AwsInvoke', () => {
 
     afterEach(() => {
       if (backupIsTTY) process.stdin.isTTY = backupIsTTY;
-      delete process.stdin.isTTY;
+      else delete process.stdin.isTTY;
     });
 
     it('it should throw error if function is not provided', () => {

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -118,7 +118,7 @@ describe('AwsInvokeLocal', () => {
 
     afterEach(() => {
       if (backupIsTTY) process.stdin.isTTY = backupIsTTY;
-      delete process.stdin.isTTY;
+      else delete process.stdin.isTTY;
     });
 
     it('should not throw error when there are no input data', () => {

--- a/lib/plugins/aws/utils/credentials.test.js
+++ b/lib/plugins/aws/utils/credentials.test.js
@@ -4,12 +4,31 @@ const expect = require('chai').expect;
 const BbPromise = require('bluebird');
 const os = require('os');
 const path = require('path');
-const { outputFile } = require('fs-extra');
+const { outputFile, lstatAsync: lstat, removeAsync: rmDir } = BbPromise.promisifyAll(
+  require('fs-extra')
+);
 const overrideEnv = require('process-utils/override-env');
 const credentials = require('./credentials');
 
 describe('#credentials', () => {
-  const credentialsFilePath = path.join(os.homedir(), '.aws', 'credentials');
+  const credentialsDirPath = path.join(os.homedir(), '.aws');
+  const credentialsFilePath = path.join(credentialsDirPath, 'credentials');
+
+  before(() => {
+    // Abort if credentials are found in home directory
+    // (it should not be the case, as home directory is mocked to point temp dir)
+    return lstat(credentialsDirPath).then(
+      () => {
+        throw new Error('Unexpected ~/.aws directory, related tests aborted');
+      },
+      error => {
+        if (error.code === 'ENOENT') return;
+        throw error;
+      }
+    );
+  });
+
+  afterEach(() => rmDir(credentialsDirPath));
 
   it('should resolve file profiles', () => {
     const profiles = new Map([

--- a/lib/plugins/interactiveCli/initializeService.js
+++ b/lib/plugins/interactiveCli/initializeService.js
@@ -55,7 +55,9 @@ module.exports = {
   },
   run(serverless) {
     const workingDir = process.cwd();
-    return confirm('No project detected. Do you want to create a new one?').then(isConfirmed => {
+    return confirm('No project detected. Do you want to create a new one?', {
+      name: 'shouldCreateNewProject',
+    }).then(isConfirmed => {
       if (!isConfirmed) return null;
       return projectTypeChoice().then(projectType => {
         if (projectType === 'other') {

--- a/lib/plugins/interactiveCli/initializeService.test.js
+++ b/lib/plugins/interactiveCli/initializeService.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { join } = require('path');
+const { expect } = require('chai');
+const BbPromise = require('bluebird');
+const { removeAsync: rmDir, lstatAsync: lstat } = BbPromise.promisifyAll(require('fs-extra'));
+const runServerless = require('../../../tests/utils/run-serverless');
+const inquirer = require('./inquirer');
+const configureInquirerStub = require('./test/configure-inquirer-stub');
+
+const interactiveCliPath = require.resolve('.');
+const fixturesPath = join(__dirname, 'test/fixtures');
+
+describe('interactiveCli: initializeService', () => {
+  const existingProjectName = 'some-other-service';
+  const newProjectName = 'foo-bar';
+  const newProjectPath = join(fixturesPath, newProjectName);
+
+  afterEach(() => {
+    if (inquirer.prompt.restore) inquirer.prompt.restore();
+  });
+
+  it('Should be ineffective, when at service path', () =>
+    runServerless({
+      cwd: join(fixturesPath, 'some-other-service'),
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:initializeService'],
+    }));
+
+  it("Should abort if user doesn't want setup", () => {
+    configureInquirerStub({
+      confirm: { shouldCreateNewProject: false },
+    });
+    return runServerless({
+      cwd: fixturesPath,
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:initializeService'],
+    });
+  });
+
+  it("Should abort if user choses 'other' template", () => {
+    configureInquirerStub({
+      confirm: { shouldCreateNewProject: true },
+      list: { projectType: 'other' },
+    });
+    return runServerless({
+      cwd: fixturesPath,
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:initializeService'],
+    });
+  });
+
+  describe('Create new project', () => {
+    after(() => rmDir(newProjectPath));
+
+    it('Should create project at not existing directory', () => {
+      configureInquirerStub({
+        confirm: { shouldCreateNewProject: true },
+        list: { projectType: 'aws-nodejs' },
+        input: { projectName: newProjectName },
+      });
+      return runServerless({
+        cwd: fixturesPath,
+        pluginPathsWhitelist: [interactiveCliPath],
+        hookNamesWhitelist: ['interactiveCli:initializeService'],
+      })
+        .then(() => lstat(join(newProjectPath, 'serverless.yml')))
+        .then(stats => expect(stats.isFile()).to.be.true);
+    });
+  });
+
+  it('Should not allow project creation in a directory in which already service is configured', () => {
+    configureInquirerStub({
+      confirm: { shouldCreateNewProject: true },
+      list: { projectType: 'aws-nodejs' },
+      input: { projectName: existingProjectName },
+    });
+    return runServerless({
+      cwd: fixturesPath,
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:initializeService'],
+    }).then(
+      () => {
+        throw new Error('Unexpected');
+      },
+      error => expect(error.code).to.equal('INVALID_ANSWER')
+    );
+  });
+
+  it('Should not allow project creation using an invalid project name', () => {
+    configureInquirerStub({
+      confirm: { shouldCreateNewProject: true },
+      list: { projectType: 'aws-nodejs' },
+      input: { projectName: 'elo grzegżółka' },
+    });
+    return runServerless({
+      cwd: fixturesPath,
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:initializeService'],
+    }).then(
+      () => {
+        throw new Error('Unexpected');
+      },
+      error => expect(error.code).to.equal('INVALID_ANSWER')
+    );
+  });
+});

--- a/lib/plugins/interactiveCli/initializeService.test.js
+++ b/lib/plugins/interactiveCli/initializeService.test.js
@@ -15,6 +15,15 @@ describe('interactiveCli: initializeService', () => {
   const existingProjectName = 'some-other-service';
   const newProjectName = 'foo-bar';
   const newProjectPath = join(fixturesPath, newProjectName);
+  let backupIsTTY;
+
+  before(() => {
+    backupIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+  });
+  after(() => {
+    process.stdin.isTTY = backupIsTTY;
+  });
 
   afterEach(() => {
     if (inquirer.prompt.restore) inquirer.prompt.restore();

--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -57,7 +57,7 @@ module.exports = {
       'No AWS credentials were found on your computer, ' +
         'you need these to host your application.\n\n'
     );
-    return confirm('Do you want to set them up now?')
+    return confirm('Do you want to set them up now?', { name: 'shouldSetupAwsCredentials' })
       .then(isConfirmed => {
         if (!isConfirmed) {
           process.stdout.write(`You can setup your AWS account later. More details available here:
@@ -68,7 +68,7 @@ http://slss.io/aws-creds-setup`);
       })
       .then(isConfirmed => {
         if (!isConfirmed) return null;
-        return confirm('Do you have an AWS account?')
+        return confirm('Do you have an AWS account?', { name: 'hasAwsAccount' })
           .then(hasAccount => {
             if (!hasAccount) {
               return openBrowser('https://portal.aws.amazon.com/billing/signup').then(() =>

--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -74,7 +74,7 @@ http://slss.io/aws-creds-setup`);
               return openBrowser('https://portal.aws.amazon.com/billing/signup').then(() =>
                 inquirer.prompt({
                   message: 'Press Enter to continue after creating an AWS account',
-                  name: 'junk',
+                  name: 'createAwsAccountPrompt',
                 })
               );
             }
@@ -89,7 +89,7 @@ http://slss.io/aws-creds-setup`);
           .then(() =>
             inquirer.prompt({
               message: 'Press Enter to continue after creating an AWS user with access keys',
-              name: 'junk',
+              name: 'generateAwsCredsPrompt',
             })
           )
           .then(() => {

--- a/lib/plugins/interactiveCli/setupAws.test.js
+++ b/lib/plugins/interactiveCli/setupAws.test.js
@@ -1,0 +1,198 @@
+'use strict';
+
+const { join } = require('path');
+const { homedir: getHomedir } = require('os');
+const { expect } = require('chai');
+const BbPromise = require('bluebird');
+const {
+  removeAsync: rmDir,
+  lstatAsync: lstat,
+  outputFileAsync: writeFile,
+} = BbPromise.promisifyAll(require('fs-extra'));
+const { resolveFileProfiles } = require('../aws/utils/credentials');
+const inquirer = require('./inquirer');
+const configureInquirerStub = require('./test/configure-inquirer-stub');
+const runServerless = require('../../../tests/utils/run-serverless');
+
+const interactiveCliPath = require.resolve('.');
+const fixturesPath = join(__dirname, 'test/fixtures');
+
+const openBrowserUrls = [];
+const modulesCacheStub = {
+  [require.resolve('../../utils/openBrowser')]: url =>
+    BbPromise.try(() => {
+      openBrowserUrls.push(url);
+    }),
+  // Ensure to rely on same inquirer module that we mock in tests
+  [require.resolve('./inquirer')]: inquirer,
+};
+
+describe('interactiveCli: setupAws', () => {
+  const awsProjectPath = join(fixturesPath, 'some-aws-service');
+  const accessKeyId = 'AKIAIOSFODNN7EXAMPLE';
+  const secretAccessKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+
+  afterEach(() => {
+    openBrowserUrls.length = 0;
+    if (inquirer.prompt.restore) inquirer.prompt.restore();
+  });
+
+  it('Should be ineffective, when not at service path', () =>
+    runServerless({
+      cwd: fixturesPath,
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:setupAws'],
+    }));
+
+  it('Should be ineffective, when not at AWS service', () =>
+    runServerless({
+      cwd: join(fixturesPath, 'some-other-service'),
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:setupAws'],
+    }));
+
+  it('Should be ineffective, when credentials are set in environment', () =>
+    runServerless({
+      cwd: awsProjectPath,
+      env: { AWS_ACCESS_KEY_ID: accessKeyId, AWS_SECRET_ACCESS_KEY: secretAccessKey },
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:setupAws'],
+    }));
+
+  it("Should not setup if user doesn't the setup", () => {
+    configureInquirerStub({ confirm: { shouldSetupAwsCredentials: false } });
+    return runServerless({
+      cwd: awsProjectPath,
+      pluginPathsWhitelist: [interactiveCliPath],
+      hookNamesWhitelist: ['interactiveCli:setupAws'],
+    });
+  });
+
+  describe('AWS config handling', () => {
+    const credentialsDirPath = join(getHomedir(), '.aws');
+    const credentialsFilePath = join(credentialsDirPath, 'credentials');
+    let shouldRemoveCredentialsDir = false;
+
+    before(() => {
+      // Abort if credentials are found in home directory
+      // (it should not be the case, as home directory is mocked to point temp dir)
+      return lstat(credentialsDirPath).then(
+        () => {
+          throw new Error('Unexpected ~/.aws directory, related tests aborted');
+        },
+        error => {
+          if (error.code === 'ENOENT') {
+            shouldRemoveCredentialsDir = true;
+            return;
+          }
+          throw error;
+        }
+      );
+    });
+
+    afterEach(() => {
+      if (shouldRemoveCredentialsDir) return rmDir(credentialsDirPath);
+      return null;
+    });
+
+    describe('Existing credentials case', () => {
+      before(() =>
+        writeFile(
+          credentialsFilePath,
+          [
+            '[some-profile]',
+            `aws_access_key_id = ${accessKeyId}`,
+            `aws_secret_access_key = ${secretAccessKey}`,
+          ].join('\n')
+        )
+      );
+
+      it('Should be ineffective, When credentials are set in AWS config', () =>
+        runServerless({
+          cwd: awsProjectPath,
+          pluginPathsWhitelist: [interactiveCliPath],
+          hookNamesWhitelist: ['interactiveCli:setupAws'],
+        }));
+    });
+
+    it('Should setup credentials for users not having an AWS account', () => {
+      configureInquirerStub({
+        confirm: { shouldSetupAwsCredentials: true, hasAwsAccount: false },
+        input: {
+          createAwsAccountPrompt: '',
+          generateAwsCredsPrompt: '',
+          accessKeyId,
+          secretAccessKey,
+        },
+      });
+      return runServerless({
+        cwd: awsProjectPath,
+        pluginPathsWhitelist: [interactiveCliPath],
+        hookNamesWhitelist: ['interactiveCli:setupAws'],
+        modulesCacheStub,
+      }).then(() => {
+        expect(openBrowserUrls.length).to.equal(2);
+        expect(openBrowserUrls[0].includes('signup')).to.be.true;
+        expect(openBrowserUrls[1].includes('console.aws.amazon.com')).to.be.true;
+        return resolveFileProfiles().then(profiles => {
+          expect(profiles).to.deep.equal(new Map([['default', { accessKeyId, secretAccessKey }]]));
+        });
+      });
+    });
+
+    it('Should setup credentials for users having an AWS account', () => {
+      configureInquirerStub({
+        confirm: { shouldSetupAwsCredentials: true, hasAwsAccount: true },
+        input: { generateAwsCredsPrompt: '', accessKeyId, secretAccessKey },
+      });
+      return runServerless({
+        cwd: awsProjectPath,
+        pluginPathsWhitelist: [interactiveCliPath],
+        hookNamesWhitelist: ['interactiveCli:setupAws'],
+        modulesCacheStub,
+      }).then(() => {
+        expect(openBrowserUrls.length).to.equal(1);
+        expect(openBrowserUrls[0].includes('console.aws.amazon.com')).to.be.true;
+        return resolveFileProfiles().then(profiles => {
+          expect(profiles).to.deep.equal(new Map([['default', { accessKeyId, secretAccessKey }]]));
+        });
+      });
+    });
+
+    it('Should not accept invalid access key id', () => {
+      configureInquirerStub({
+        confirm: { shouldSetupAwsCredentials: true, hasAwsAccount: true },
+        input: { generateAwsCredsPrompt: '', accessKeyId: 'foo', secretAccessKey },
+      });
+      return runServerless({
+        cwd: awsProjectPath,
+        pluginPathsWhitelist: [interactiveCliPath],
+        hookNamesWhitelist: ['interactiveCli:setupAws'],
+        modulesCacheStub,
+      }).then(
+        () => {
+          throw new Error('Unexpected');
+        },
+        error => expect(error.code).to.equal('INVALID_ANSWER')
+      );
+    });
+
+    it('Should not accept invalid secret access key', () => {
+      configureInquirerStub({
+        confirm: { shouldSetupAwsCredentials: true, hasAwsAccount: true },
+        input: { generateAwsCredsPrompt: '', accessKeyId, secretAccessKey: 'foo' },
+      });
+      return runServerless({
+        cwd: awsProjectPath,
+        pluginPathsWhitelist: [interactiveCliPath],
+        hookNamesWhitelist: ['interactiveCli:setupAws'],
+        modulesCacheStub,
+      }).then(
+        () => {
+          throw new Error('Unexpected');
+        },
+        error => expect(error.code).to.equal('INVALID_ANSWER')
+      );
+    });
+  });
+});

--- a/lib/plugins/interactiveCli/setupAws.test.js
+++ b/lib/plugins/interactiveCli/setupAws.test.js
@@ -71,7 +71,6 @@ describe('interactiveCli: setupAws', () => {
   describe('AWS config handling', () => {
     const credentialsDirPath = join(getHomedir(), '.aws');
     const credentialsFilePath = join(credentialsDirPath, 'credentials');
-    let shouldRemoveCredentialsDir = false;
 
     before(() => {
       // Abort if credentials are found in home directory
@@ -81,19 +80,13 @@ describe('interactiveCli: setupAws', () => {
           throw new Error('Unexpected ~/.aws directory, related tests aborted');
         },
         error => {
-          if (error.code === 'ENOENT') {
-            shouldRemoveCredentialsDir = true;
-            return;
-          }
+          if (error.code === 'ENOENT') return;
           throw error;
         }
       );
     });
 
-    afterEach(() => {
-      if (shouldRemoveCredentialsDir) return rmDir(credentialsDirPath);
-      return null;
-    });
+    afterEach(() => rmDir(credentialsDirPath));
 
     describe('Existing credentials case', () => {
       before(() =>

--- a/lib/plugins/interactiveCli/setupAws.test.js
+++ b/lib/plugins/interactiveCli/setupAws.test.js
@@ -31,6 +31,15 @@ describe('interactiveCli: setupAws', () => {
   const awsProjectPath = join(fixturesPath, 'some-aws-service');
   const accessKeyId = 'AKIAIOSFODNN7EXAMPLE';
   const secretAccessKey = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+  let backupIsTTY;
+
+  before(() => {
+    backupIsTTY = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+  });
+  after(() => {
+    process.stdin.isTTY = backupIsTTY;
+  });
 
   afterEach(() => {
     openBrowserUrls.length = 0;

--- a/lib/plugins/interactiveCli/test/configure-inquirer-stub.js
+++ b/lib/plugins/interactiveCli/test/configure-inquirer-stub.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const sinon = require('sinon');
+const BbPromise = require('bluebird');
+const inquirer = require('../inquirer');
+
+module.exports = config =>
+  sinon.stub(inquirer, 'prompt').callsFake(promptConfig => {
+    return BbPromise.try(() => {
+      const questions = config[promptConfig.type || 'input'];
+      if (!questions) throw new Error('Unexpected config type');
+      const answer = questions[promptConfig.name];
+      if (answer == null) throw new Error('Unexpected config name');
+      return BbPromise.try(() => {
+        if (promptConfig.type !== 'input') return true;
+        if (!promptConfig.validate) return true;
+        return promptConfig.validate(answer);
+      }).then(validationResult => {
+        if (validationResult !== true) {
+          throw Object.assign(new Error(validationResult), { code: 'INVALID_ANSWER' });
+        }
+        return { [promptConfig.name]: answer };
+      });
+    });
+  });

--- a/lib/plugins/interactiveCli/test/fixtures/some-aws-service/serverless.yml
+++ b/lib/plugins/interactiveCli/test/fixtures/some-aws-service/serverless.yml
@@ -1,0 +1,2 @@
+service: 'some-aws-service'
+provider: 'aws'

--- a/lib/plugins/interactiveCli/test/fixtures/some-other-service/serverless.yml
+++ b/lib/plugins/interactiveCli/test/fixtures/some-other-service/serverless.yml
@@ -1,0 +1,2 @@
+service: 'some-other-service'
+provider: 'other'

--- a/lib/plugins/interactiveCli/utils.js
+++ b/lib/plugins/interactiveCli/utils.js
@@ -3,12 +3,14 @@
 const inquirer = require('./inquirer');
 
 module.exports = {
-  confirm: message =>
-    inquirer
+  confirm: (message, options = {}) => {
+    const name = options.name || 'isConfirmed';
+    return inquirer
       .prompt({
         message,
         type: 'confirm',
-        name: 'isConfirmed',
+        name,
       })
-      .then(({ isConfirmed }) => isConfirmed),
+      .then(result => result[name]);
+  },
 };

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "timeout": 5000
   },
   "devDependencies": {
-    "@serverless/eslint-config": "^1.1.0",
+    "@serverless/eslint-config": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "child-process-ext": "^2.0.0",

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -45,7 +45,8 @@ module.exports = ({
   hookNamesWhitelist,
   modulesCacheStub,
 }) =>
-  overrideEnv(() => {
+  overrideEnv(originalEnv => {
+    process.env.APPDATA = originalEnv.APPDATA; // Needed on Windows
     if (env) Object.assign(process.env, env);
     return overrideCwd(cwd, () =>
       overrideArgv({ args: ['serverless', ...(cliArgs || [])] }, () =>

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -1,40 +1,74 @@
 // Runs complete serverless instance in preconfigured environment, limited
-// to predefined plugins and hook events
+// to predefined plugins and hook events.
+// Optionally serverless instance can be freshly required with specifc modules mocked
 
 'use strict';
 
 const { values } = require('lodash');
 const overrideCwd = require('process-utils/override-cwd');
 const overrideArgv = require('process-utils/override-argv');
-const Serverless = require('../../lib/Serverless');
 
-module.exports = ({ cwd, cliArgs, pluginConstructorsWhitelist, hookNamesWhitelist }) =>
+const resolveServerless = (modulesCacheStub, callback) => {
+  if (!modulesCacheStub) return callback(require('../../lib/Serverless'));
+  const originalCache = Object.assign({}, require.cache);
+  for (const key of Object.keys(require.cache)) delete require.cache[key];
+  Object.assign(require.cache, modulesCacheStub);
+  const restore = () => {
+    for (const key of Object.keys(require.cache)) delete require.cache[key];
+    Object.assign(require.cache, originalCache);
+  };
+  try {
+    return callback(require('../../lib/Serverless')).then(
+      result => {
+        restore();
+        return result;
+      },
+      error => {
+        restore();
+        throw error;
+      }
+    );
+  } catch (error) {
+    restore();
+    throw error;
+  }
+};
+
+module.exports = ({
+  cwd,
+  cliArgs,
+  pluginConstructorsWhitelist,
+  hookNamesWhitelist,
+  modulesCacheStub,
+}) =>
   overrideCwd(cwd, () =>
-    overrideArgv({ args: ['serverless', ...(cliArgs || [])] }, () => {
-      // Intialize serverless instances in preconfigured environement
-      const serverless = new Serverless();
-      const { pluginManager } = serverless;
-      return serverless.init().then(() => {
-        // Strip registered hooks, so only those intended are executed
-        const whitelistedPlugins = pluginManager.plugins.filter(plugin =>
-          pluginConstructorsWhitelist.some(Plugin => plugin instanceof Plugin)
-        );
-
-        const { hooks } = pluginManager;
-        for (const hookName of Object.keys(hooks)) {
-          if (!hookNamesWhitelist.includes(hookName)) {
-            delete hooks[hookName];
-            continue;
-          }
-          hooks[hookName] = hooks[hookName].filter(({ hook }) =>
-            whitelistedPlugins.some(whitelistedPlugin =>
-              values(whitelistedPlugin.hooks).includes(hook)
-            )
+    overrideArgv({ args: ['serverless', ...(cliArgs || [])] }, () =>
+      resolveServerless(modulesCacheStub, Serverless => {
+        // Intialize serverless instances in preconfigured environment
+        const serverless = new Serverless();
+        const { pluginManager } = serverless;
+        return serverless.init().then(() => {
+          // Strip registered hooks, so only those intended are executed
+          const whitelistedPlugins = pluginManager.plugins.filter(plugin =>
+            pluginConstructorsWhitelist.some(Plugin => plugin instanceof Plugin)
           );
-        }
 
-        // Run plugin manager hooks
-        return serverless.run();
-      });
-    })
+          const { hooks } = pluginManager;
+          for (const hookName of Object.keys(hooks)) {
+            if (!hookNamesWhitelist.includes(hookName)) {
+              delete hooks[hookName];
+              continue;
+            }
+            hooks[hookName] = hooks[hookName].filter(({ hook }) =>
+              whitelistedPlugins.some(whitelistedPlugin =>
+                values(whitelistedPlugin.hooks).includes(hook)
+              )
+            );
+          }
+
+          // Run plugin manager hooks
+          return serverless.run();
+        });
+      })
+    )
   );

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const { values } = require('lodash');
+const { entries, values } = require('lodash');
 const overrideEnv = require('process-utils/override-env');
 const overrideCwd = require('process-utils/override-cwd');
 const overrideArgv = require('process-utils/override-argv');
@@ -13,7 +13,8 @@ const resolveServerless = (modulesCacheStub, callback) => {
   if (!modulesCacheStub) return callback(require('../../lib/Serverless'));
   const originalCache = Object.assign({}, require.cache);
   for (const key of Object.keys(require.cache)) delete require.cache[key];
-  Object.assign(require.cache, modulesCacheStub);
+  for (const [key, value] of entries(modulesCacheStub)) require.cache[key] = { exports: value };
+
   const restore = () => {
     for (const key of Object.keys(require.cache)) delete require.cache[key];
     Object.assign(require.cache, originalCache);

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -1,4 +1,4 @@
-// Runs complete serverless instances in preconfigured environement, and limited
+// Runs complete serverless instance in preconfigured environment, limited
 // to predefined plugins and hook events
 
 'use strict';

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -13,6 +13,7 @@ const resolveServerless = (modulesCacheStub, callback) => {
   if (!modulesCacheStub) return callback(require('../../lib/Serverless'));
   const originalCache = Object.assign({}, require.cache);
   for (const key of Object.keys(require.cache)) delete require.cache[key];
+  require.cache[require.resolve('../../lib/utils/isTrackingDisabled')] = { exports: true };
   for (const [key, value] of entries(modulesCacheStub)) require.cache[key] = { exports: value };
 
   const restore = () => {

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -1,0 +1,40 @@
+// Runs complete serverless instances in preconfigured environement, and limited
+// to predefined plugins and hook events
+
+'use strict';
+
+const { values } = require('lodash');
+const overrideCwd = require('process-utils/override-cwd');
+const overrideArgv = require('process-utils/override-argv');
+const Serverless = require('../../lib/Serverless');
+
+module.exports = ({ cwd, cliArgs, pluginConstructorsWhitelist, hookNamesWhitelist }) =>
+  overrideCwd(cwd, () =>
+    overrideArgv({ args: ['serverless', ...(cliArgs || [])] }, () => {
+      // Intialize serverless instances in preconfigured environement
+      const serverless = new Serverless();
+      const { pluginManager } = serverless;
+      return serverless.init().then(() => {
+        // Strip registered hooks, so only those intended are executed
+        const whitelistedPlugins = pluginManager.plugins.filter(plugin =>
+          pluginConstructorsWhitelist.some(Plugin => plugin instanceof Plugin)
+        );
+
+        const { hooks } = pluginManager;
+        for (const hookName of Object.keys(hooks)) {
+          if (!hookNamesWhitelist.includes(hookName)) {
+            delete hooks[hookName];
+            continue;
+          }
+          hooks[hookName] = hooks[hookName].filter(({ hook }) =>
+            whitelistedPlugins.some(whitelistedPlugin =>
+              values(whitelistedPlugin.hooks).includes(hook)
+            )
+          );
+        }
+
+        // Run plugin manager hooks
+        return serverless.run();
+      });
+    })
+  );

--- a/tests/utils/run-serverless.js
+++ b/tests/utils/run-serverless.js
@@ -41,7 +41,7 @@ module.exports = ({
   cwd,
   cliArgs,
   env,
-  pluginConstructorsWhitelist,
+  pluginPathsWhitelist,
   hookNamesWhitelist,
   modulesCacheStub,
 }) =>
@@ -53,6 +53,7 @@ module.exports = ({
           // Intialize serverless instances in preconfigured environment
           const serverless = new Serverless();
           const { pluginManager } = serverless;
+          const pluginConstructorsWhitelist = pluginPathsWhitelist.map(path => require(path));
           return serverless.init().then(() => {
             // Strip registered hooks, so only those intended are executed
             const whitelistedPlugins = pluginManager.plugins.filter(plugin =>


### PR DESCRIPTION
We heavily missed tests for this important functionality.

To ensure tests do not depend too much on implementation internals (but more on an actual outcome with which user is faced). I've prepared an util that helps to create fully functional and isolated serverless instance mocks, which allow to test specific plugins and hooks (it's proposed in `tests/utils/run-serverless.js`)

I've also introduced a mock generator for `inquirer`, and having that configured tests for _intiailize project_ and _setup AWS credentials_ case.

--- 

Additionally cleanup problems were exposed in unrelated test files, fixed those.
