### PR TITLE
Consolidate zipping utils

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -10,6 +10,7 @@ const fse = BbPromise.promisifyAll(require('fs-extra'));
 const _ = require('lodash');
 const fileExistsSync = require('../utils/fs/fileExistsSync');
 const writeFileSync = require('../utils/fs/writeFileSync');
+const writeFileDir = require('../utils/fs/writeFileDir');
 const copyDirContentsSync = require('../utils/fs/copyDirContentsSync');
 const readFileSync = require('../utils/fs/readFileSync');
 const walkDirSync = require('../utils/fs/walkDirSync');
@@ -48,7 +49,7 @@ class Utils {
   }
 
   writeFileDir(filePath) {
-    return fse.mkdirsSync(path.dirname(filePath));
+    return writeFileDir(filePath);
   }
 
   writeFileSync(filePath, contents, cycles) {

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const archiver = require('archiver');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
@@ -9,6 +8,7 @@ const fs = BbPromise.promisifyAll(require('fs'));
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const globby = require('globby');
 const _ = require('lodash');
+const createZipFile = require('../../../utils/fs/createZipFile');
 
 module.exports = {
   zipService(exclude, include, zipFileName) {
@@ -63,56 +63,10 @@ module.exports = {
    *                            used for golang support on windows.
    */
   zipFiles(files, zipFileName, prefix, filesToChmodPlusX) {
-    if (files.length === 0) {
-      const error = new this.serverless.classes.Error('No files to package');
-      return BbPromise.reject(error);
-    }
+    const srcDirPath = this.serverless.config.servicePath;
+    const zipFilePath = path.join(this.serverless.config.servicePath, '.serverless', zipFileName);
 
-    const zip = archiver.create('zip');
-    // Create artifact in temp path and move it to the package path (if any) later
-    const artifactFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      zipFileName
-    );
-    this.serverless.utils.writeFileDir(artifactFilePath);
-
-    const output = fs.createWriteStream(artifactFilePath);
-
-    return new BbPromise((resolve, reject) => {
-      output.on('close', () => resolve(artifactFilePath));
-      output.on('error', err => reject(err));
-      zip.on('error', err => reject(err));
-
-      output.on('open', () => {
-        zip.pipe(output);
-
-        const normalizedFiles = _.uniq(files.map(file => path.normalize(file)));
-
-        return BbPromise.all(normalizedFiles.map(this.getFileContentAndStat.bind(this)))
-          .then(contents => {
-            _.forEach(_.sortBy(contents, ['filePath']), file => {
-              const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
-              let mode = file.stat.mode;
-              if (
-                filesToChmodPlusX &&
-                _.includes(filesToChmodPlusX, name) &&
-                file.stat.mode % 2 === 0
-              ) {
-                mode += 1;
-              }
-              zip.append(file.data, {
-                name,
-                mode,
-                date: new Date(0), // necessary to get the same hash when zipping the same content
-              });
-            });
-
-            zip.finalize();
-          })
-          .catch(reject);
-      });
-    });
+    return createZipFile(srcDirPath, zipFilePath, files, { files, prefix, filesToChmodPlusX });
   },
 
   getFileContentAndStat(filePath) {

--- a/lib/utils/fs/createZipFile.js
+++ b/lib/utils/fs/createZipFile.js
@@ -1,38 +1,87 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
+const _ = require('lodash');
 const archiver = require('archiver');
 const BbPromise = require('bluebird');
-const walkDirSync = require('../fs/walkDirSync');
+const fs = BbPromise.promisifyAll(require('fs'));
+const walkDirSync = require('./walkDirSync');
+const writeFileDir = require('./writeFileDir');
+const getFileContent = require('./getFileContent');
 
-function createZipFile(srcDirPath, outputFilePath) {
-  const files = walkDirSync(srcDirPath).map(file => ({
-    input: file,
-    output: file.replace(path.join(srcDirPath, path.sep), ''),
+function getFileContentAndStat(filePath, fullPath) {
+  return BbPromise.all([
+    // Get file contents and stat in parallel
+    getFileContent(fullPath),
+    fs.statAsync(fullPath),
+  ]).then(result => ({
+    data: result[0],
+    stat: result[1],
+    filePath,
   }));
+}
+
+function createZipFile(srcDirPath, zipFilePath, opts) {
+  let files;
+  let prefix;
+  let filesToChmodPlusX;
+  if (opts) {
+    files = opts.prefix;
+    prefix = opts.prefix;
+    filesToChmodPlusX = opts.filesToChmodPlusX;
+
+    if (files && files.length === 0) {
+      return BbPromise.reject('No files to package');
+    }
+  }
+
+  if (!files) {
+    // NOTE: this can be really slow for large directories
+    files = walkDirSync(srcDirPath).map(file => file.replace(path.join(srcDirPath, path.sep), ''));
+  }
+
+  const zip = archiver.create('zip');
+  writeFileDir(zipFilePath);
+
+  const output = fs.createWriteStream(zipFilePath);
 
   return new BbPromise((resolve, reject) => {
-    const output = fs.createWriteStream(outputFilePath);
-    const archive = archiver('zip', {
-      zlib: { level: 9 },
-    });
+    output.on('close', () => resolve(zipFilePath));
+    output.on('error', err => reject(err));
+    zip.on('error', err => reject(err));
 
     output.on('open', () => {
-      archive.pipe(output);
+      zip.pipe(output);
 
-      files.forEach(file => {
-        // TODO: update since this is REALLY slow
-        if (fs.lstatSync(file.input).isFile()) {
-          archive.append(fs.createReadStream(file.input), { name: file.output });
-        }
-      });
+      const normalizedFiles = _.uniq(files.map(file => path.normalize(file)));
 
-      archive.finalize();
+      return BbPromise.all(
+        normalizedFiles.map(filePath =>
+          getFileContentAndStat(filePath, path.resolve(srcDirPath, filePath))
+        )
+      )
+        .then(contents => {
+          _.forEach(_.sortBy(contents, ['filePath']), file => {
+            const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
+            let mode = file.stat.mode;
+            if (
+              filesToChmodPlusX &&
+              _.includes(filesToChmodPlusX, name) &&
+              file.stat.mode % 2 === 0
+            ) {
+              mode += 1;
+            }
+            zip.append(file.data, {
+              name,
+              mode,
+              date: new Date(0), // necessary to get the same hash when zipping the same content
+            });
+          });
+
+          zip.finalize();
+        })
+        .catch(reject);
     });
-
-    archive.on('error', err => reject(err));
-    output.on('close', () => resolve(outputFilePath));
   });
 }
 

--- a/lib/utils/fs/getFileContent.js
+++ b/lib/utils/fs/getFileContent.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const fs = BbPromise.promisifyAll(require('fs'));
+
+function getFileContent(fullPath) {
+  return fs.readFileAsync(fullPath);
+}
+
+module.exports = getFileContent;

--- a/lib/utils/fs/writeFileDir.js
+++ b/lib/utils/fs/writeFileDir.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('path');
+const fse = require('fs-extra');
+
+function writeFileDir(filePath) {
+  return fse.mkdirsSync(path.dirname(filePath));
+}
+
+module.exports = writeFileDir;


### PR DESCRIPTION
## What did you implement:

Consolidate zipping utils.

## How did you implement it:

Unified our 2 different zipping functionalities into one util function which is used in both places:

1. When zipping the service
1. When zipping the custom resources

## How can we verify it:

Use the following service and run `serverless package`.

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0

functions:
  test:
    handler: handler.hello
    events:
      - eventBridge:
          schedule: rate(10 minutes)
```

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO