### PR TITLE
Support functions without events in CloudFront remove logging

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -24,11 +24,10 @@ class AwsCompileCloudFrontEvents {
     let isEventUsed = false;
     const funcKeys = this.serverless.service.getAllFunctions();
     if (funcKeys.length) {
-      isEventUsed = !!funcKeys.find(funcKey =>
-        this.serverless.service
-          .getFunction(funcKey)
-          .events.find(e => Object.keys(e)[0] === 'cloudFront')
-      );
+      isEventUsed = funcKeys.some(funcKey => {
+        const func = this.serverless.service.getFunction(funcKey);
+        return func.events && func.events.find(e => Object.keys(e)[0] === 'cloudFront');
+      });
     }
     if (isEventUsed) {
       const message = [

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -103,12 +103,23 @@ describe('AwsCompileCloudFrontEvents', () => {
         'remove your Lambda@Edge functions'
       );
     });
+  });
 
+  describe('#logRemoveReminder()', () => {
     it('should not log an info message if the users wants to remove the stack without a cloudFront event', () => {
       serverless.processedInput.commands = ['remove'];
       const awsCompileCloudFrontEventsRemoval = new AwsCompileCloudFrontEvents(serverless, options);
 
       expect(awsCompileCloudFrontEventsRemoval.serverless.cli.log).not.to.have.been.calledOnce;
+    });
+
+    it('should not throw if function has no events', () => {
+      serverless.processedInput.commands = ['remove'];
+      serverless.service.functions = {
+        first: {},
+      };
+
+      expect(() => new AwsCompileCloudFrontEvents(serverless, options)).not.throw(Error);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "nyc": "^14.1.1",
     "p-limit": "^2.2.1",
     "prettier": "^1.18.2",
-    "process-utils": "^2.3.1",
+    "process-utils": "^2.5.0",
     "proxyquire": "^2.1.3",
     "sinon": "^7.4.1",
     "sinon-chai": "^3.3.0",


### PR DESCRIPTION
What did you implement:

Fixes a bug where a function with 0 events caused the removal to fail.

## How did you implement it:

Add a check if the function has events defined in the CloudFront removal logger. Also added a regression test.

## How can we verify it:

Deploy and remove the following service (the removal fails without this fix):

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

custom:
  idx: 0

functions:
  hello:
    handler: handler.greeter
```

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
