### PR TITLE
Improve plugin loading error reporting

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -109,27 +109,20 @@ class PluginManager {
         if (this.cliCommands[0] === 'plugin') {
           return;
         }
-        let errorMessage;
         if (error && error.code === 'MODULE_NOT_FOUND' && error.message.endsWith(`'${plugin}'`)) {
           // Plugin not installed
-          errorMessage = [
+          const errorMessage = [
             `Serverless plugin "${plugin}" not found.`,
             ' Make sure it\'s installed and listed in the "plugins" section',
             ' of your serverless config file.',
           ].join('');
-        } else {
-          // Plugin initialization error
-          // Rethrow the original error in case we're in debug mode.
-          if (process.env.SLS_DEBUG) {
-            throw error;
-          }
-          errorMessage = `Serverless plugin "${plugin}" initialization errored: ${error.message}`;
-        }
-        if (!this.cliOptions.help) {
-          throw new this.serverless.classes.Error(errorMessage);
-        }
 
-        this.serverless.cli.log(`WARNING: ${errorMessage}\n`);
+          if (!this.cliOptions.help) throw new this.serverless.classes.Error(errorMessage);
+
+          this.serverless.cli.log(`WARNING: ${errorMessage}\n`);
+          return;
+        }
+        throw error;
       }
     });
   }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -106,25 +106,21 @@ class PluginManager {
       try {
         Plugin = require(pluginPath); // eslint-disable-line global-require
       } catch (error) {
-        if (isModuleNotFoundError(error, pluginPath)) {
-          if (this.cliCommands[0] === 'plugin') return;
-          // Plugin not installed
+        if (!isModuleNotFoundError(error, pluginPath)) throw error;
 
-          if (this.cliOptions.help) {
-            // User may intend to install plugins just listed in serverless config
-            // Therefore skip on MODULE_NOT_FOUND cases
-            return;
-          }
-
-          const errorMessage = [
-            `Serverless plugin "${plugin}" not found.`,
-            ' Make sure it\'s installed and listed in the "plugins" section',
-            ' of your serverless config file.',
-          ].join('');
-
-          throw new this.serverless.classes.Error(errorMessage);
+        // Plugin not installed
+        if (this.cliOptions.help || this.cliCommands[0] === 'plugin') {
+          // User may intend to install plugins just listed in serverless config
+          // Therefore skip on MODULE_NOT_FOUND case
+          return;
         }
-        throw error;
+
+        const errorMessage = [
+          `Serverless plugin "${plugin}" not found.`,
+          ' Make sure it\'s installed and listed in the "plugins" section',
+          ' of your serverless config file.',
+        ].join('');
+        throw new this.serverless.classes.Error(errorMessage);
       }
       this.addPlugin(Plugin);
     });

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -7,6 +7,7 @@ const BbPromise = require('bluebird');
 const _ = require('lodash');
 const crypto = require('crypto');
 const updateNotifier = require('update-notifier');
+const isModuleNotFoundError = require('ncjsm/is-module-not-found-error');
 const writeFile = require('../utils/fs/writeFile');
 const getCacheFilePath = require('../utils/getCacheFilePath');
 const serverlessConfigFileUtils = require('../utils/getServerlessConfigFile');
@@ -108,7 +109,7 @@ class PluginManager {
         if (this.cliCommands[0] === 'plugin') {
           return;
         }
-        if (error && error.code === 'MODULE_NOT_FOUND' && error.message.endsWith(`'${plugin}'`)) {
+        if (isModuleNotFoundError(error, pluginPath)) {
           // Plugin not installed
           const errorMessage = [
             `Serverless plugin "${plugin}" not found.`,

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -111,16 +111,20 @@ class PluginManager {
         }
         if (isModuleNotFoundError(error, pluginPath)) {
           // Plugin not installed
+
+          if (this.cliOptions.help) {
+            // User may intend to install plugins just listed in serverless config
+            // Therefore skip on MODULE_NOT_FOUND cases
+            return;
+          }
+
           const errorMessage = [
             `Serverless plugin "${plugin}" not found.`,
             ' Make sure it\'s installed and listed in the "plugins" section',
             ' of your serverless config file.',
           ].join('');
 
-          if (!this.cliOptions.help) throw new this.serverless.classes.Error(errorMessage);
-
-          this.serverless.cli.log(`WARNING: ${errorMessage}\n`);
-          return;
+          throw new this.serverless.classes.Error(errorMessage);
         }
         throw error;
       }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -99,12 +99,11 @@ class PluginManager {
 
   loadPlugins(plugins) {
     plugins.forEach(plugin => {
+      const servicePath = this.serverless.config.servicePath;
+      const pluginPath = plugin.startsWith('./') ? path.join(servicePath, plugin) : plugin;
+      let Plugin;
       try {
-        const servicePath = this.serverless.config.servicePath;
-        const pluginPath = plugin.startsWith('./') ? path.join(servicePath, plugin) : plugin;
-        const Plugin = require(pluginPath); // eslint-disable-line global-require
-
-        this.addPlugin(Plugin);
+        Plugin = require(pluginPath); // eslint-disable-line global-require
       } catch (error) {
         if (this.cliCommands[0] === 'plugin') {
           return;
@@ -124,6 +123,7 @@ class PluginManager {
         }
         throw error;
       }
+      this.addPlugin(Plugin);
     });
   }
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -106,10 +106,8 @@ class PluginManager {
       try {
         Plugin = require(pluginPath); // eslint-disable-line global-require
       } catch (error) {
-        if (this.cliCommands[0] === 'plugin') {
-          return;
-        }
         if (isModuleNotFoundError(error, pluginPath)) {
+          if (this.cliCommands[0] === 'plugin') return;
           // Plugin not installed
 
           if (this.cliOptions.help) {

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -38,9 +38,10 @@ describe('PluginManager', () => {
 
   class EnterprisePluginMock {}
 
+  const brokenPluginError = new Error('Broken plugin');
   class BrokenPluginMock {
     constructor() {
-      throw new Error('Broken plugin');
+      throw brokenPluginError;
     }
   }
 
@@ -644,19 +645,10 @@ describe('PluginManager', () => {
       expect(consoleLogStub.calledOnce).to.equal(true);
     });
 
-    it('should throw an error when trying to load a broken plugin (without SLS_DEBUG)', () => {
+    it('should pass through an error when trying to load a broken plugin', () => {
       const servicePlugins = ['BrokenPluginMock'];
 
-      expect(() => pluginManager.loadPlugins(servicePlugins)).to.throw(serverless.classes.Error);
-    });
-
-    it('should forward any errors when trying to load a broken plugin (with SLS_DEBUG)', () => {
-      const servicePlugins = ['BrokenPluginMock'];
-
-      return BbPromise.try(() => {
-        _.set(process.env, 'SLS_DEBUG', '*');
-        expect(() => pluginManager.loadPlugins(servicePlugins)).to.throw(/Broken plugin/);
-      });
+      expect(() => pluginManager.loadPlugins(servicePlugins)).to.throw(brokenPluginError);
     });
 
     it('should not throw error when running the plugin commands and given plugins does not exist', () => {

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -632,17 +632,15 @@ describe('PluginManager', () => {
       expect(() => pluginManager.loadPlugins(servicePlugins)).to.throw(serverless.classes.Error);
     });
 
-    it('should log a warning when trying to load unknown plugin with help flag', () => {
-      const consoleLogStub = sinon.stub(pluginManager.serverless.cli, 'log').returns();
+    it('should not throw error when trying to load unknown plugin with help flag', () => {
       const servicePlugins = ['ServicePluginMock3', 'ServicePluginMock1'];
 
       pluginManager.setCliOptions({ help: true });
       pluginManager.loadPlugins(servicePlugins);
 
-      expect(pluginManager.plugins.some(plugin => plugin instanceof ServicePluginMock1)).to.equal(
-        true
+      expect(() => pluginManager.loadPlugins(servicePlugins)).to.not.throw(
+        serverless.classes.Error
       );
-      expect(consoleLogStub.calledOnce).to.equal(true);
     });
 
     it('should pass through an error when trying to load a broken plugin', () => {


### PR DESCRIPTION
Currently any plugin initialization errors are reported as _user_ errors (unless `SLS_DEBUG=*` flag is on). That makes reasoning about eventual programming errors  that happen at that stage difficult (e.g. good case is this crash: https://travis-ci.org/serverless/serverless/jobs/581213485)

I've refactored error reporting, taking into account following use cases which lead to current state of errors handling
- [Do not crash on unknown modules when running `sls --help`](https://github.com/serverless/serverless/issues/3956)
- [Do not crash on unknown modules when running `sls plugin` commands](https://github.com/serverless/serverless/issues/3956)
- [Distinguish plugin not found from plugin initialization errors](https://github.com/serverless/serverless/pull/4322)

New solution:
- Do not crash on `MODULE_NOT_FOUND` in case of `sls --help` or `sls plugin`
- Report `MODULE_NOT_FOUND` errors meaningfully (also fixed its detection, as error message changed with Node.js v12)
- Pass through plugin initialization errors (it's in plugin logic where it should be decied whether we deal with _user_ error (so `ServerlessError` constructor should be used), or it's a programming error that's being thrown (which should be exposed with full stack trace)