### PR TITLE
Use hooks to log Lambda@Edge removal reminder

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -14,27 +14,27 @@ class AwsCompileCloudFrontEvents {
       'package:initialize': this.validate.bind(this),
       'before:package:compileFunctions': this.prepareFunctions.bind(this),
       'package:compileEvents': this.compileCloudFrontEvents.bind(this),
+      'before:remove:remove': this.logRemoveReminder.bind(this),
     };
-    if (this.serverless.processedInput.commands[0] === 'remove') {
-      this.logRemoveReminder.call(this);
-    }
   }
 
   logRemoveReminder() {
-    let isEventUsed = false;
-    const funcKeys = this.serverless.service.getAllFunctions();
-    if (funcKeys.length) {
-      isEventUsed = funcKeys.some(funcKey => {
-        const func = this.serverless.service.getFunction(funcKey);
-        return func.events && func.events.find(e => Object.keys(e)[0] === 'cloudFront');
-      });
-    }
-    if (isEventUsed) {
-      const message = [
-        "Don't forget to manually remove your Lambda@Edge functions ",
-        'once the CloudFront distribution removal is successfully propagated!',
-      ].join('');
-      this.serverless.cli.log(message, 'Serverless', { color: 'orange' });
+    if (this.serverless.processedInput.commands[0] === 'remove') {
+      let isEventUsed = false;
+      const funcKeys = this.serverless.service.getAllFunctions();
+      if (funcKeys.length) {
+        isEventUsed = funcKeys.some(funcKey => {
+          const func = this.serverless.service.getFunction(funcKey);
+          return func.events && func.events.find(e => Object.keys(e)[0] === 'cloudFront');
+        });
+      }
+      if (isEventUsed) {
+        const message = [
+          "Don't forget to manually remove your Lambda@Edge functions ",
+          'once the CloudFront distribution removal is successfully propagated!',
+        ].join('');
+        this.serverless.cli.log(message, 'Serverless', { color: 'orange' });
+      }
     }
   }
 

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -82,15 +82,15 @@ describe('AwsCompileCloudFrontEvents', () => {
     it('should set the provider variable to an instance of AwsProvider', () =>
       expect(awsCompileCloudFrontEvents.provider).to.be.instanceof(AwsProvider));
 
-    it('should log an info message if the users wants to remove the stack with a cloudFront event', () => {
+    it('should use "before:remove:remove" hook to log a message before removing the service', () => {
       serverless.processedInput.commands = ['remove'];
       serverless.service.functions = {
         first: {
           events: [
             {
               cloudFront: {
-                eventType: 'viewer-response',
-                origin: 's3://some-bucket.s3.amazonaws.com/files',
+                eventType: 'viewer-request',
+                origin: 's3://bucketname.s3.amazonaws.com/files',
               },
             },
           ],
@@ -98,6 +98,7 @@ describe('AwsCompileCloudFrontEvents', () => {
       };
       const awsCompileCloudFrontEventsRemoval = new AwsCompileCloudFrontEvents(serverless, options);
 
+      awsCompileCloudFrontEventsRemoval.hooks['before:remove:remove']();
       expect(awsCompileCloudFrontEventsRemoval.serverless.cli.log).to.have.been.calledOnce;
       expect(awsCompileCloudFrontEventsRemoval.serverless.cli.log.args[0][0]).to.include(
         'remove your Lambda@Edge functions'


### PR DESCRIPTION
## What did you implement:

Fixes a bug caused by using the plugin constructor to log a removal reminder for `cloudFront` events. This was mainly an issue where events were pulled-in via variable definitions (e.g. [smth. like this](https://github.com/serverless/enterprise-plugin/blob/fe071921b90b3a0b34ebe36a0b86223d841115c5/integration-testing/service/serverless.yml#L80))

## How did you implement it:

Moved the code from the constructor to the hooks section. This way we can be sure that all the variables are populated and the check for function events will be successful.

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO