### PR TITLE
Respect logRetentionInDays in log group for websocket

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -60,7 +60,7 @@ module.exports = {
       });
 
       Object.assign(cfTemplate.Resources, {
-        [logGroupLogicalId]: getLogGroupResource(service, stage),
+        [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider),
       });
 
       return ensureApiGatewayCloudWatchRole(this.provider);
@@ -68,11 +68,16 @@ module.exports = {
   },
 };
 
-function getLogGroupResource(service, stage) {
-  return {
+function getLogGroupResource(service, stage, provider) {
+  const resource = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
       LogGroupName: `/aws/websocket/${service}-${stage}`,
     },
   };
+  const logRetentionInDays = provider.getLogRetentionInDays();
+  if (logRetentionInDays) {
+    resource.Properties.RetentionInDays = logRetentionInDays;
+  }
+  return resource;
 }

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -134,6 +134,24 @@ describe('#compileStage()', () => {
         });
       }));
 
+    it('should set a RetentionInDays in a Log Group if provider has logRetentionInDays', () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logRetentionInDays = 42;
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[logGroupLogicalId]).to.deep.equal({
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: '/aws/websocket/my-service-dev',
+            RetentionInDays: 42,
+          },
+        });
+      });
+    });
+
     it('should ensure ClousWatch role custom resource', () => {
       return awsCompileWebsocketsEvents.compileStage().then(() => {
         const resources =


### PR DESCRIPTION
## What did you implement:

Closes #6657 


## How did you implement it:

Set `RetentionInDays` in `LogGroup` resource, in the same manner in #6548
https://github.com/serverless/serverless/blob/f187ba711330c518e0f47ef4a7bdf791739dd84a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js#L114-L117
## How can we verify it:

1. `npm install -g exoego/serverless#log-retention-for-websocket`
2. `sls deploy`
```yaml
service: logs
provider:
  name: aws
  runtime: nodejs10.x
  region: us-east-1
  logRetentionInDays: "3"
  logs:
    websocket: true

functions:
  helloWebSocket:
    handler: handler.hello
    events:
      - websocket: "$connect"
```

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] <del>Write documentation</del> N/A
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** YES
