### PR TITLE
Update insights.md

### DIFF
--- a/docs/dashboard/insights.md
+++ b/docs/dashboard/insights.md
@@ -39,16 +39,6 @@ custom:
 
 Serverless Insights include pre-configured alerts designed to help you develop and optimize the performance and security of your serverless applications. These events are presented in the "alerts" tab within the Serverless Framework [dashboard](https://dashboard.serverless.com/). Preconfigured alerts include the following:
 
-### Memory: Unused Memory
-
-Configured memory for a function defines memory, cpu, and I/O capacity. It is also what defines a function's price. While there are sometimes good reasons to overprovision memory (e.g. because your workload is cpu bound), unused memory can often represent an opportunity to save money by better optimizing your function's configured memory.
-
-The unused memory insight runs once per week at midnight UTC on Sunday. It looks at all invocations of a function over the prior seven days and identifies the function invocation during that period that used the most amount of its configured memory. If that amount is less than 80% of the function's configured memory it will generate an alert.
-
-### Memory: Approaching Out of Memory
-
-The approaching out of memory alert runs every 5 minutes. It looks at the memory usage of all invocations of that function over the past 60 minutes. If any of the invocations exceed 90% of the allocated memory, then it will generate an alert. If an alert was already triggered in the past 60 minutes, a new alert will not be triggered.
-
 ### Memory: Out of Memory
 
 The out of memory alert is checked on every invocation of the function. If any invocation uses more memory than is configured for that function, Lambda will abruptly shut down the invocation and trigger an out of memory error. The alert will be triggered immediately and only once in a given 48 hour period.


### PR DESCRIPTION
Removed descriptions for 'approaching out of memory' and 'unused memory' alerts until these are implemented. The following copy can be re-inserted, once the relevant alerts are live:

### Memory: Unused Memory

Configured memory for a function defines memory, cpu, and I/O capacity. It is also what defines a function's price. While there are sometimes good reasons to overprovision memory (e.g. because your workload is cpu bound), unused memory can often represent an opportunity to save money by better optimizing your function's configured memory.

The unused memory insight runs once per week at midnight UTC on Sunday. It looks at all invocations of a function over the prior seven days and identifies the function invocation during that period that used the most amount of its configured memory. If that amount is less than 80% of the function's configured memory it will generate an alert.

### Memory: Approaching Out of Memory

The approaching out of memory alert runs every 5 minutes. It looks at the memory usage of all invocations of that function over the past 60 minutes. If any of the invocations exceed 90% of the allocated memory, then it will generate an alert. If an alert was already triggered in the past 60 minutes, a new alert will not be triggered.


**_Is this ready for review?:_** YES 
**_Is it a breaking change?:_** NO
