### PR TITLE
[Docs] Added clarification on specifying SNS ARN

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -61,7 +61,7 @@ functions:
           arn: arn:xxx
 ```
 
-Or with intrinsic CloudFormation function like `Fn::Join` or `Fn::GetAtt`.
+Or with intrinsic CloudFormation function like `Fn::Join`, `Fn::GetAtt`, or `Fn::Ref` (or their shorthand counterparts).
 **Note:** The arn can be in a different region to enable cross region invocation
 
 ```yml
@@ -78,6 +78,25 @@ functions:
                 - Ref: 'AWS::AccountId'
                 - 'MyCustomTopic'
           topicName: MyCustomTopic
+```
+
+If your SNS topic doesn't yet exist but is defined in the serverless.yml file you're editing, you'll need to use `Fn::Ref` or `!Ref` to get the ARN. Do not build a string as in the above example!
+
+```yml
+functions:
+  dispatcher:
+    handler: dispatcher.dispatch
+    events:
+      - sns:
+          arn: !Ref SuperTopic
+          topicName: MyCustomTopic
+
+resources:
+  Resources:
+    SuperTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        TopicName: MyCustomTopic
 ```
 
 **Note:** If an `arn` string is specified but not a `topicName`, the last substring starting with `:` will be extracted as the `topicName`. If an `arn` object is specified, `topicName` must be specified as a string, used only to name the underlying Cloudformation mapping resources. You can take advantage of this behavior when subscribing to multiple topics with the same name in different regions/accounts to avoid collisions between Cloudformation resource names.


### PR DESCRIPTION
Provides a solution to referencing a topic ARN when it doesn't exist in AWS, but is in the serverless.yml file.