### PR TITLE
Remove incorrect AWS Access Role test instruction

### DIFF
--- a/docs/dashboard/access-roles.md
+++ b/docs/dashboard/access-roles.md
@@ -30,16 +30,6 @@ If you do not use the Serverless Framework Dashboard to set up an AWS Access Rol
 5. Follow the directions which will take you through creating an IAM Role for the Serverless Framework.
 6. Click "**save changes**" in the deployment profile to save the IAM Role ARN to the profile.
 
-## Test your configuration
-
-Before you run `serverless deploy` ensure that the Serverless Framework open-source CLI is resolving the new AWS Access Keys from the Serverless Framework Dashboard.
-
-```
-serverless info
-```
-
-This command requires authentication therefore requires that the AWS Access Keys from the Serverless Framework Dashboard to be resolved. You should expect this command to succeed.
-
 ## Use the generated AWS Access Keys in your service
 
 You don't have to do anything in your `serverless.yml` file. When you run `sls deploy` the Serverless Framework will identify the deployment profile associated with the application or stage and it will generate the AWS Access Keys using the associated AWS Access Role automatically.


### PR DESCRIPTION
## What did you implement:

Update docs to remove incorrect instruction.

Explanation: after setting up a new serverless project with an AWS Access Role through the serverless dashboard, I attempted to run `serverless info`, and it failed for the following reason:

`Stack with id my-app-dev does not exist`

The docs instruct you to run `sls info` before `sls deploy,` to verify your access roles are working. But, you cannot run `sls info` without running `sls deploy` first, and having a stack generated for you.

I didn't feel this was worth a whole Github issue, so I just went ahead and offered a PR. If there is a better way to verify access roles are working, I think that should be added here, rather than just deleting the current failing option.

## How did you implement it:

Removed text

## How can we verify it:

## Todos:

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
