### PR TITLE
Fix regular expression escaping in aws plugin.

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -83,7 +83,7 @@ class AwsCompileFunctions {
       _.get(functionObject, 'package.artifact') ||
       _.get(this, 'serverless.service.package.artifact');
 
-    const regex = new RegExp('.*s3.amazonaws.com/(.+)/(.+)');
+    const regex = new RegExp('s3\\.amazonaws\\.com/(.+)/(.+)');
     const match = artifactFilePath.match(regex);
 
     if (match) {

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -140,6 +140,20 @@ describe('AwsCompileFunctions', () => {
         expect(artifactFileName).to.equal(s3ArtifactName);
       });
     });
+
+    it('should not access AWS.S3 if URL is not an S3 URl', () => {
+      AWS.S3.restore();
+      const myRequestStub = sinon.stub(AWS, 'S3').returns({
+        getObject: () => {
+          throw new Error('should not be invoked');
+        },
+      });
+      awsCompileFunctions.serverless.service.functions[functionName].package.artifact =
+        'https://s33amazonaws.com/this/that';
+      return expect(awsCompileFunctions.downloadPackageArtifacts()).to.be.fulfilled.then(() => {
+        expect(myRequestStub.callCount).to.equal(1);
+      });
+    });
   });
 
   describe('#compileFunctions()', () => {


### PR DESCRIPTION
Also, remove leading `.*` in the regular expression. It will still match
if there are any characters preceding the matching text.

Fixes: https://github.com/serverless/serverless/issues/6688

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixed a small error in a regular expression. Added relevant test.

Closes #6688

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Modify the regular expression as appropriate, and add a test that fails on current master branch but passes with this change.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Code change is very small. Run test provided in this PR on master, then compare to result when running with the change here.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation (N/A)
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources (N/A)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
