### PR TITLE
Implement an AWSLambdaBasicExecutionRole with the least privilege principle

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -126,30 +126,17 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
         if (shouldWriteLogs) {
           const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
-          customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
-            {
-              Effect: 'Allow',
-              Action: ['logs:CreateLogStream'],
-              Resource: [
-                {
-                  'Fn::Sub':
-                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                    `:log-group:${logGroupsPrefix}*:*`,
-                },
-              ],
-            },
-            {
-              Effect: 'Allow',
-              Action: ['logs:PutLogEvents'],
-              Resource: [
-                {
-                  'Fn::Sub':
-                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                    `:log-group:${logGroupsPrefix}*:*:*`,
-                },
-              ],
-            }
-          );
+          customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push({
+            Effect: 'Allow',
+            Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+            Resource: [
+              {
+                'Fn::Sub':
+                  'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                  `:log-group:${logGroupsPrefix}*:*`,
+              },
+            ],
+          });
         }
       }
       const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -286,23 +286,12 @@ describe('#addCustomResourceToService()', () => {
       expect(RoleProps.Policies[0].PolicyDocument.Statement).to.include.deep.members([
         {
           Effect: 'Allow',
-          Action: ['logs:CreateLogStream'],
+          Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
           Resource: [
             {
               'Fn::Sub':
                 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
                 ':log-group:/aws/lambda/some-service-dev*:*',
-            },
-          ],
-        },
-        {
-          Effect: 'Allow',
-          Action: ['logs:PutLogEvents'],
-          Resource: [
-            {
-              'Fn::Sub':
-                'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                ':log-group:/aws/lambda/some-service-dev*:*:*',
             },
           ],
         },

--- a/lib/plugins/aws/package/lib/iam-role-lambda-execution-template.json
+++ b/lib/plugins/aws/package/lib/iam-role-lambda-execution-template.json
@@ -21,12 +21,7 @@
           "Statement": [
             {
               "Effect": "Allow",
-              "Action": ["logs:CreateLogStream"],
-              "Resource": []
-            },
-            {
-              "Effect": "Allow",
-              "Action": ["logs:PutLogEvents"],
+              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
               "Resource": []
             }
           ]

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -103,12 +103,6 @@ module.exports = {
           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
           `:log-group:${customFunctionNamelogGroupsPrefix}:*`,
       });
-
-      policyDocumentStatements[1].Resource.push({
-        'Fn::Sub':
-          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${customFunctionNamelogGroupsPrefix}:*:*`,
-      });
     });
 
     if (hasOneOrMoreCanonicallyNamedFunctions) {
@@ -117,12 +111,6 @@ module.exports = {
         'Fn::Sub':
           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
           `:log-group:${logGroupsPrefix}*:*`,
-      });
-
-      policyDocumentStatements[1].Resource.push({
-        'Fn::Sub':
-          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${logGroupsPrefix}*:*:*`,
       });
     }
 

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -86,23 +86,12 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
                     Resource: [
                       {
                         'Fn::Sub':
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*`,
-                      },
-                    ],
-                  },
-                  {
-                    Effect: 'Allow',
-                    Action: ['logs:PutLogEvents'],
-                    Resource: [
-                      {
-                        'Fn::Sub':
-                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
-                          `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*:*`,
                       },
                     ],
                   },
@@ -172,23 +161,12 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
                     Resource: [
                       {
                         'Fn::Sub':
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${customFunctionName}:*`,
-                      },
-                    ],
-                  },
-                  {
-                    Effect: 'Allow',
-                    Action: ['logs:PutLogEvents'],
-                    Resource: [
-                      {
-                        'Fn::Sub':
-                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
-                          `log-group:/aws/lambda/${customFunctionName}:*:*`,
                       },
                     ],
                   },
@@ -261,23 +239,12 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
                     Resource: [
                       {
                         'Fn::Sub':
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*`,
-                      },
-                    ],
-                  },
-                  {
-                    Effect: 'Allow',
-                    Action: ['logs:PutLogEvents'],
-                    Resource: [
-                      {
-                        'Fn::Sub':
-                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
-                          `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*:*`,
                       },
                     ],
                   },
@@ -356,7 +323,7 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
                     Resource: [
                       {
                         'Fn::Sub':
@@ -367,22 +334,6 @@ describe('#mergeIamTemplates()', () => {
                         'Fn::Sub':
                           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
                           `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*`,
-                      },
-                    ],
-                  },
-                  {
-                    Effect: 'Allow',
-                    Action: ['logs:PutLogEvents'],
-                    Resource: [
-                      {
-                        'Fn::Sub':
-                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
-                          `log-group:/aws/lambda/${customFunctionName}:*:*`,
-                      },
-                      {
-                        'Fn::Sub':
-                          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
-                          `log-group:/aws/lambda/${canonicalFunctionsPrefix}*:*:*`,
                       },
                     ],
                   },
@@ -421,7 +372,7 @@ describe('#mergeIamTemplates()', () => {
       expect(
         awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources[
           awsPackage.provider.naming.getRoleLogicalId()
-        ].Properties.Policies[0].PolicyDocument.Statement[2]
+        ].Properties.Policies[0].PolicyDocument.Statement[1]
       ).to.deep.equal(awsPackage.serverless.service.provider.iamRoleStatements[0]);
     });
   });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
<!--
Briefly describe the feature if no issue exists for this PR
-->
Closes #6241 Implement an `AWSLambdaBasicExecutionRole` with the least privilege principle

## How did you implement it:
- Take the default [AWSLambdaBasicExecutionRole](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) and reduce permission scope the function resources.
- Reduce duplications in resources list by combining multiple actions into a single policy statement.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Previously the inline policy would have looked something like this:
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "logs:CreateLogStream"
      ],
      "Resource": [
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-a}:*",
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-b}:*",
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-c}:*",
      ],
      "Effect": "Allow"
    },
    {
      "Action": [
        "logs:PutLogEvents"
      ],
      "Resource": [
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-a}:*:*",
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-b}:*:*",
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-c}:*:*",
      ],
      "Effect": "Allow"
    }
  ]
}
```
Now
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "logs:CreateLogGroup",
        "logs:CreateLogStream",
        "logs:PutLogEvents"
      ],
      "Resource": [
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-a}:*",
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-b}:*",
        "arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT}:log-group:/aws/lambda/{stage}-{function-c}:*",
      ],
      "Effect": "Allow"
    }
  ]
}
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
