### PR TITLE
Update homepage in package.json to point to the docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "engineStrict": true,
   "preferGlobal": true,
-  "homepage": "https://github.com/serverless/serverless#readme",
+  "homepage": "https://serverless.com/framework/docs/",
   "description": "Serverless Framework - Build web, mobile and IoT applications with serverless architectures using AWS Lambda, Azure Functions, Google CloudFunctions & more",
   "author": "serverless.com",
   "license": "MIT",


### PR DESCRIPTION
A tiny thing that we probably should've done long time ago. Gives us that quick shortcut to the docs

```
npm home serverless
```