### PR TITLE
Truncated aliyun events menuText

### DIFF
--- a/docs/providers/aliyun/events/README.md
+++ b/docs/providers/aliyun/events/README.md
@@ -1,6 +1,6 @@
 <!--
 title: Serverless - Alibaba Cloud Function Compute - Events
-menuText: Alibaba Cloud Functions Events
+menuText: Events
 layout: Doc
 -->
 


### PR DESCRIPTION
Currently the menuText for aliyun events is [Alibaba Cloud Functions Events]

Above breaks our sidebar styling, so similar to other providers I made it just [Events]

**_Is this ready for review?:_** YES 
**_Is it a breaking change?:_** NO
