### PR TITLE
Feat: add qualifier option to invoke command

### DIFF
--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -27,6 +27,7 @@ serverless invoke [local] --function functionName
 - `--function` or `-f` The name of the function in your service that you want to invoke. **Required**.
 - `--stage` or `-s` The stage in your service you want to invoke your function in.
 - `--region` or `-r` The region in your stage that you want to invoke your function in.
+- `--qualifier` or `-q` The version number or alias to invoke your function in. Default is `$LATEST`.
 - `--data` or `-d` String data to be passed as an event to your function. By default data is read from standard input.
 - `--raw` Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.
 - `--path` or `-p` The path to a json file with input data to be passed to the invoked function. This path is relative to the root directory of the service.

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -77,6 +77,10 @@ class AwsInvoke {
       Payload: new Buffer(JSON.stringify(this.options.data || {})),
     };
 
+    if (this.options.qualifier) {
+      params.Qualifier = this.options.qualifier;
+    }
+
     return this.provider.request('Lambda', 'invoke', params);
   }
 

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -265,6 +265,26 @@ describe('AwsInvoke', () => {
         awsInvoke.provider.request.restore();
       });
     });
+
+    it('should be able to invoke with a qualifier', () => {
+      awsInvoke.options.qualifier = 'somelongqualifier';
+
+      return awsInvoke.invoke().then(() => {
+        expect(invokeStub.calledOnce).to.be.equal(true);
+
+        expect(
+          invokeStub.calledWithExactly('Lambda', 'invoke', {
+            FunctionName: 'customName',
+            InvocationType: 'RequestResponse',
+            LogType: 'None',
+            Payload: new Buffer(JSON.stringify({})),
+            Qualifier: 'somelongqualifier',
+          })
+        ).to.be.equal(true);
+
+        awsInvoke.provider.request.restore();
+      });
+    });
   });
 
   describe('#log()', () => {

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -28,6 +28,10 @@ class Invoke {
             usage: 'Region of the service',
             shortcut: 'r',
           },
+          qualifier: {
+            usage: 'Version number or alias to invoke',
+            shortcut: 'q',
+          },
           path: {
             usage: 'Path to JSON or YAML file holding input data',
             shortcut: 'p',


### PR DESCRIPTION
## What did you implement:

Closes #6289 

This adds a `--qualifier (-q)` option to the invoke CLI that enables calling specific version numbers or aliases.

## How can we verify it:

Try invoking any function that has more than one version and confirm that the versioned (or aliased) is being called instead of $LATEST, in case the option is passed.

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
