### PR TITLE
Lock graceful-fs at 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "fs-extra": "^0.30.0",
     "get-stdin": "^5.0.1",
     "globby": "^6.1.0",
-    "graceful-fs": "^4.2.2",
+    "graceful-fs": "4.2.1",
     "https-proxy-agent": "^2.2.2",
     "inquirer": "^6.5.2",
     "is-docker": "^1.1.0",


### PR DESCRIPTION
Tested that this patch fixes #6667

It appears that fix is to rely on 4.2.1 globally, I've also described it at https://github.com/isaacs/node-graceful-fs/issues/174

