### PR TITLE
Allow plugins not in registry to be installed

### DIFF
--- a/lib/plugins/plugin/install/install.js
+++ b/lib/plugins/plugin/install/install.js
@@ -7,8 +7,8 @@ const path = require('path');
 const _ = require('lodash');
 const userStats = require('../../../utils/userStats');
 const yamlAstParser = require('../../../utils/yamlAstParser');
-const pluginUtils = require('../lib/utils');
 const fileExists = require('../../../utils/fs/fileExists');
+const pluginUtils = require('../lib/utils');
 
 class PluginInstall {
   constructor(serverless, options) {
@@ -43,13 +43,7 @@ class PluginInstall {
   }
 
   install() {
-    let pluginInfo;
-    if (this.options.name.startsWith('@')) {
-      pluginInfo = _.split(this.options.name.slice(1), '@', 2);
-      pluginInfo[0] = `@${pluginInfo[0]}`;
-    } else {
-      pluginInfo = _.split(this.options.name, '@', 2);
-    }
+    const pluginInfo = pluginUtils.getPluginInfo(this.options.name);
     this.options.pluginName = pluginInfo[0];
     this.options.pluginVersion = pluginInfo[1] || 'latest';
 

--- a/lib/plugins/plugin/install/install.js
+++ b/lib/plugins/plugin/install/install.js
@@ -58,21 +58,20 @@ class PluginInstall {
       .then(this.getPlugins)
       .then(plugins => {
         const plugin = plugins.find(item => item.name === this.options.pluginName);
-        if (plugin) {
-          return BbPromise.bind(this)
-            .then(this.pluginInstall)
-            .then(this.addPluginToServerlessFile)
-            .then(this.installPeerDependencies)
-            .then(() => {
-              const message = [
-                'Successfully installed',
-                ` "${this.options.pluginName}@${this.options.pluginVersion}"`,
-              ].join('');
-              this.serverless.cli.log(message);
-            });
+        if (!plugin) {
+          this.serverless.cli.log('Plugin not found in serverless registry, continuing to install');
         }
-        const message = `Plugin "${this.options.pluginName}" not found. Did you spell it correct?`;
-        throw new this.serverless.classes.Error(message);
+        return BbPromise.bind(this)
+          .then(this.pluginInstall)
+          .then(this.addPluginToServerlessFile)
+          .then(this.installPeerDependencies)
+          .then(() => {
+            const message = [
+              'Successfully installed',
+              ` "${this.options.pluginName}@${this.options.pluginVersion}"`,
+            ].join('');
+            this.serverless.cli.log(message);
+          });
       });
   }
 

--- a/lib/plugins/plugin/install/install.test.js
+++ b/lib/plugins/plugin/install/install.test.js
@@ -178,7 +178,7 @@ describe('PluginInstall', () => {
       });
     });
 
-    it('should not install the plugin if it can not be found in the registry', () => {
+    it('should install the plugin even if it can not be found in the registry', () => {
       // serverless.yml
       const serverlessYml = {
         service: 'plugin-service',
@@ -186,15 +186,15 @@ describe('PluginInstall', () => {
       };
       serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
 
-      pluginInstall.options.name = 'serverless-not-available-plugin';
-      return expect(pluginInstall.install()).to.be.rejected.then(() => {
+      pluginInstall.options.name = 'serverless-not-in-registry-plugin';
+      return expect(pluginInstall.install()).to.be.fulfilled.then(() => {
         expect(validateStub.calledOnce).to.equal(true);
         expect(getPluginsStub.calledOnce).to.equal(true);
-        expect(pluginInstallStub.calledOnce).to.equal(false);
-        expect(consoleLogStub.called).to.equal(false);
-        expect(serverlessErrorStub.calledOnce).to.equal(true);
-        expect(addPluginToServerlessFileStub.calledOnce).to.equal(false);
-        expect(installPeerDependenciesStub.calledOnce).to.equal(false);
+        expect(pluginInstallStub.calledOnce).to.equal(true);
+        expect(consoleLogStub.called).to.equal(true);
+        expect(serverlessErrorStub.calledOnce).to.equal(false);
+        expect(addPluginToServerlessFileStub.calledOnce).to.equal(true);
+        expect(installPeerDependenciesStub.calledOnce).to.equal(true);
       });
     });
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -69,6 +69,17 @@ module.exports = {
       .then(json => json);
   },
 
+  getPluginInfo(name) {
+    let pluginInfo;
+    if (name.startsWith('@')) {
+      pluginInfo = _.split(name.slice(1), '@', 2);
+      pluginInfo[0] = `@${pluginInfo[0]}`;
+    } else {
+      pluginInfo = _.split(name, '@', 2);
+    }
+    return pluginInfo;
+  },
+
   display(plugins) {
     let message = '';
     if (plugins && plugins.length) {

--- a/lib/plugins/plugin/lib/utils.test.js
+++ b/lib/plugins/plugin/lib/utils.test.js
@@ -149,6 +149,23 @@ describe('PluginUtils', () => {
     });
   });
 
+  describe('#getPluginInfo()', () => {
+    it('should return the plugins name', () => {
+      expect(pluginUtils.getPluginInfo('some-plugin')).to.deep.equal(['some-plugin']);
+    });
+
+    it('should return the plugins name and version', () => {
+      expect(pluginUtils.getPluginInfo('some-plugin@0.1.0')).to.deep.equal([
+        'some-plugin',
+        '0.1.0',
+      ]);
+    });
+
+    it('should support scoped names', () => {
+      expect(pluginUtils.getPluginInfo('@acme/some-plugin')).to.deep.equal(['@acme/some-plugin']);
+    });
+  });
+
   describe('#display()', () => {
     it('should display the plugins if present', () => {
       let expectedMessage = '';

--- a/lib/plugins/plugin/uninstall/uninstall.js
+++ b/lib/plugins/plugin/uninstall/uninstall.js
@@ -5,9 +5,9 @@ const childProcess = BbPromise.promisifyAll(require('child_process'));
 const fse = require('../../../utils/fs/fse');
 const path = require('path');
 const _ = require('lodash');
-const pluginUtils = require('../lib/utils');
 const userStats = require('../../../utils/userStats');
 const yamlAstParser = require('../../../utils/yamlAstParser');
+const pluginUtils = require('../lib/utils');
 
 class PluginUninstall {
   constructor(serverless, options) {
@@ -43,7 +43,7 @@ class PluginUninstall {
   }
 
   uninstall() {
-    const pluginInfo = _.split(this.options.name, '@', 2);
+    const pluginInfo = pluginUtils.getPluginInfo(this.options.name);
     this.options.pluginName = pluginInfo[0];
 
     return BbPromise.bind(this)
@@ -51,18 +51,19 @@ class PluginUninstall {
       .then(this.getPlugins)
       .then(plugins => {
         const plugin = plugins.find(item => item.name === this.options.pluginName);
-        if (plugin) {
-          return BbPromise.bind(this)
-            .then(this.uninstallPeerDependencies)
-            .then(this.pluginUninstall)
-            .then(this.removePluginFromServerlessFile)
-            .then(() => {
-              this.serverless.cli.log(`Successfully uninstalled "${this.options.pluginName}"`);
-              return BbPromise.resolve();
-            });
+        if (!plugin) {
+          this.serverless.cli.log(
+            'Plugin not found in serverless registry, continuing to uninstall'
+          );
         }
-        const message = `Plugin "${this.options.pluginName}" not found. Did you spell it correct?`;
-        throw new this.serverless.classes.Error(message);
+        return BbPromise.bind(this)
+          .then(this.uninstallPeerDependencies)
+          .then(this.pluginUninstall)
+          .then(this.removePluginFromServerlessFile)
+          .then(() => {
+            this.serverless.cli.log(`Successfully uninstalled "${this.options.pluginName}"`);
+            return BbPromise.resolve();
+          });
       });
   }
 

--- a/lib/plugins/plugin/uninstall/uninstall.test.js
+++ b/lib/plugins/plugin/uninstall/uninstall.test.js
@@ -155,6 +155,27 @@ describe('PluginUninstall', () => {
       });
     });
 
+    it('should uninstall the plugin even if it can not be found in the registry', () => {
+      // serverless.yml
+      const serverlessYml = {
+        service: 'plugin-service',
+        provider: 'aws',
+      };
+      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+
+      pluginUninstall.options.name = 'serverless-not-in-registry-plugin';
+
+      return expect(pluginUninstall.uninstall()).to.be.fulfilled.then(() => {
+        expect(validateStub.calledOnce).to.equal(true);
+        expect(getPluginsStub.calledOnce).to.equal(true);
+        expect(pluginUninstallStub.calledOnce).to.equal(true);
+        expect(consoleLogStub.called).to.equal(true);
+        expect(serverlessErrorStub.calledOnce).to.equal(false);
+        expect(removePluginFromServerlessFileStub.calledOnce).to.equal(true);
+        expect(uninstallPeerDependenciesStub.calledOnce).to.equal(true);
+      });
+    });
+
     it('should not uninstall the plugin if it can not be found in the registry', () => {
       // serverless.yml
       const serverlessYml = {

--- a/lib/plugins/plugin/uninstall/uninstall.test.js
+++ b/lib/plugins/plugin/uninstall/uninstall.test.js
@@ -176,26 +176,6 @@ describe('PluginUninstall', () => {
       });
     });
 
-    it('should not uninstall the plugin if it can not be found in the registry', () => {
-      // serverless.yml
-      const serverlessYml = {
-        service: 'plugin-service',
-        provider: 'aws',
-      };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
-
-      pluginUninstall.options.name = 'serverless-not-available-plugin';
-      return expect(pluginUninstall.uninstall()).to.be.rejected.then(() => {
-        expect(validateStub.calledOnce).to.equal(true);
-        expect(getPluginsStub.calledOnce).to.equal(true);
-        expect(pluginUninstallStub.calledOnce).to.equal(false);
-        expect(consoleLogStub.called).to.equal(false);
-        expect(serverlessErrorStub.calledOnce).to.equal(true);
-        expect(removePluginFromServerlessFileStub.calledOnce).to.equal(false);
-        expect(uninstallPeerDependenciesStub.calledOnce).to.equal(false);
-      });
-    });
-
     it('should drop the version if specify', () => {
       const serverlessYml = {
         service: 'plugin-service',


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #6710

There are enterprise use cases where we need to install plugins and add them to the serverless.yml using the `plugin install`. For example, we have a CICD pipeline that executes `serverless deploy`. Individual developers do not have that access from their local machines. When the pipeline deploys, we want to `plugin install` certain plugins automatically that are only implementation details of the pipeline. For example, we do this for `serverless-aws-alias`. But we have a monitoring plugin that gathers deployment metadata so we can track usage and compliance. This plugin does not exist in the serverless registry as it is published to our internal npm registry. This PR relaxes the restriction on only installing things in the serverless registry.

`npm install` is not an adequate alternative since we need the plugin added to the serverless.yml config.

## How did you implement it:

With ❤️ 
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

The code changes are minimal. `plugin install` now only logs a message if the plugin is not in the registry.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
