### PR TITLE
documented url+zip deploy strategy for serverless-kubeless

### DIFF
--- a/docs/providers/kubeless/guide/deploying.md
+++ b/docs/providers/kubeless/guide/deploying.md
@@ -77,6 +77,27 @@ rs/hello-699783077   1         1         1         2m
 
 Kubeless will create a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) for your function and a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) for each event.
 
+Deployment will spin up a [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)) based on runtime you have defined in your `serverless.yml`. Runtime is a public docker image, providing only binaries for your code. Function code itself is injected into Pod by `kubeless-controller-manager` and stored in Kubernetes Function object definition.
+
+Kubernetes Function definition has a size limit, since it is stored as yaml in cluster's etcd. So, you can't deploy function any larger than approximately 1.5MB.
+
+In order to overcome this limitation, function code can be fetched from [external url](https://kubeless.io/docs/advanced-function-deployment/); in this case only link (and checksum) is stored in Kubernetes function definition. Starting from v0.8.0 of `serverless-kubeless`, you can change default deployment method to `S3ZipContent` and configure `serverless-kubeless` with S3 bucket, where the function code will be stored:
+
+```yaml
+provider:
+  name: kubeless
+  runtime: python2.7
+  deploy:
+    strategy: S3ZipContent
+    options:
+      accessKeyId: minio
+      secretAccessKey: minio123
+      endpoint: http://minio.local
+      bucket: workbench
+      region: eu-central-1
+      s3ForcePathStyle: True
+```
+
 ## Deploy Function
 
 This deployment method updates or deploys a single function. It performs the platform API call to deploy your package without the other resources. It is much faster than redeploying your whole service each time.


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

Documentation update for `serverless-kubeless` provider, describing `url+zip` function deployment option.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
