### PR TITLE
Improve message for Windows users in AWS credentials setup

### DIFF
--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -83,7 +83,9 @@ const steps = {
             process.stdout.write(
               `\n${chalk.green(
                 `AWS credentials saved on your machine at ${chalk.bold(
-                  '~/.aws/credentials'
+                  process.platform === 'win32'
+                    ? '%userprofile%\\.aws\\credentials'
+                    : '~/.aws/credentials'
                 )}. Go there to change them at any time.`
               )}\n`
             )


### PR DESCRIPTION
Currently we unconditionally output *nix path. This update ensures Windows users get their variant