### PR TITLE
Add support for MaximumBatchingWindowInSeconds property on stream events

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -78,3 +78,29 @@ functions:
           startingPosition: LATEST
           enabled: false
 ```
+
+## Setting the BatchWindow
+
+The configuration below sets up a Kinesis stream event for the `preprocess` function which has a batch window of `10`.
+
+The `batchWindow` property specifies a maximum amount of time to wait before triggering a Lambda invocation with a batch of records. Your Lambda function will be invoked when one of the following three things happens:
+
+1. The total payload size reaches 6MB;
+
+2. The `batchWindow` reaches its maximum value; or
+
+3. the `batchSize` reaches it maximum value.
+
+For more information, read the [AWS release announcement](https://aws.amazon.com/about-aws/whats-new/2019/09/aws-lambda-now-supports-custom-batch-window-for-kinesis-and-dynamodb-event-sources/) for this property.
+
+**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - stream:
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+          batchWindow: 10
+```

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -191,10 +191,10 @@ class AwsCompileStreamEvents {
               );
             }
 
-            const streamResource = JSON.parse(streamTemplate)
+            const streamResource = JSON.parse(streamTemplate);
 
             if (typeof event.stream.batchWindow !== 'undefined') {
-              streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow
+              streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 
             const newStreamObject = {

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -191,8 +191,14 @@ class AwsCompileStreamEvents {
               );
             }
 
+            const streamResource = JSON.parse(streamTemplate)
+
+            if (typeof event.stream.batchWindow !== 'undefined') {
+              streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow
+            }
+
             const newStreamObject = {
-              [streamLogicalId]: JSON.parse(streamTemplate),
+              [streamLogicalId]: streamResource,
             };
 
             _.merge(

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -193,7 +193,7 @@ class AwsCompileStreamEvents {
 
             const streamResource = JSON.parse(streamTemplate);
 
-            if (typeof event.stream.batchWindow !== 'undefined') {
+            if (event.stream.batchWindow) {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -343,6 +343,7 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: {
                   arn: 'arn:aws:dynamodb:region:account:table/bar/stream/2',
+                  batchWindow: 15,
                 },
               },
               {
@@ -410,6 +411,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.Enabled
         ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumBatchingWindowInSeconds
+        ).to.equal(15);
 
         // event 3
         expect(
@@ -625,6 +630,7 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/bar',
+                  batchWindow: 15,
                 },
               },
               {
@@ -692,6 +698,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.Enabled
         ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumBatchingWindowInSeconds
+        ).to.equal(15);
 
         // event 3
         expect(


### PR DESCRIPTION
##  What did you implement:

Closes: #6725

AWS [recently announced support for a `Batch Window` property on Kinesis & DynamoDB streams](https://aws.amazon.com/about-aws/whats-new/2019/09/aws-lambda-now-supports-custom-batch-window-for-kinesis-and-dynamodb-event-sources/). This allows users to specify that property in their `serverless.yml`.

Usage looks as follows:

```yml
functions:
  preprocess:
    handler: handler.preprocess
    events:
      - stream:
          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
          batchWindow: 10
```

## How did you implement it:

Added it to the `compile` stage for Kinesis & DynamoDB stream events.

Note that it's not a required property, and I don't know a good default value for it. Thus, I didn't set a default value at all. We only add this property if the user includes it on the `stream` event. Because of that, it's applied later in the compile process than other events.

## How can we verify it:

Deploy the following service:

```yml
service: batch-window
provider:
  name: aws
  runtime: nodejs10.x

functions:
  hello:
    handler: handler.hello
    events:
      - stream:
          type: kinesis
          arn: { Fn::GetAtt: [ KinesisStream, Arn ] }
          batchWindow: 10
          startingPosition: TRIM_HORIZON

resources:
  Resources:
    KinesisStream:
      Type: AWS::Kinesis::Stream
      Properties:
        ShardCount: 1
```

Check the Lambda console to make sure your Kinesis event source has the proper Batch Window property:

<img width="666" alt="Screen Shot 2019-09-24 at 7 18 48 AM" src="https://user-images.githubusercontent.com/6509926/65510984-bb965700-de9b-11e9-92ce-05fa60fedc47.png">


## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint-updated`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.  
       **Validate via `npm run prettier-check-updated`**  
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
