### PR TITLE
Fix custom resources install

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -13,7 +13,7 @@ function copyCustomResources(srcDirPath, destDirPath) {
 }
 
 function installDependencies(dirPath) {
-  return childProcess.execAsync(`npm install --prefix ${dirPath}`);
+  return childProcess.execAsync('npm install', { cwd: dirPath });
 }
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {


### PR DESCRIPTION
Fixes #6557 

As I investigated, the problem is in `npm install --prefix ${dirPath}` command.

The `--prefix` option is not documented on [npm](https://docs.npmjs.com/cli/install), so it's not clear exactly what it's intended to do (maybe it was supported in some older versions)

I found a few stackoverflow answers that were suggesting it, so I guess hint was taken from there.

Still when testing locally, I found it behaves differently on Linux than on Windows (where indeed it hangs and does processing against current working directory)

Fixed the issue, by switching to (imo) more natural approach where bare `npm install` is run in context of specified directory.

Tested, and now custom resources setup works now same on Windows as it was on macOs or Linux.
