### PR TITLE
Automate keeping the sfe-next branch upto date

### DIFF
--- a/.github/workflows/update-sfe-next.yml
+++ b/.github/workflows/update-sfe-next.yml
@@ -1,25 +1,25 @@
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches:    
+    branches:
       - master
 name: Update the sfe-next branch on pushes to master
 jobs:
   updateSfeNextBranch:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Setup node
-      uses: actions/setup-node@v1
-    - name: update the dependency on @serverless/enterprise-plugin to the next tag
-      run: node scripts/update-sfe-dep.js
-    - name: git commit
-      uses: srt32/git-actions@v0.0.3
-      with:
-        args: git config --global user.email "engineering@serverless.com" && git config --global user.name "Github Action" && git commit -am 'update the dependency on @serverless/enterprise-plugin to the next tag'
-    - name: git push
-      uses: srt32/git-actions@v0.0.3
-      with:
-        args: git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} HEAD:sfe-next -f
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@master
+      - name: Setup node
+        uses: actions/setup-node@v1
+      - name: update the dependency on @serverless/enterprise-plugin to the next tag
+        run: node scripts/update-sfe-dep.js
+      - name: git commit
+        uses: srt32/git-actions@v0.0.3
+        with:
+          args: git config --global user.email "engineering@serverless.com" && git config --global user.name "Github Action" && git commit -am 'Update the dependency on @serverless/enterprise-plugin to the next tag'
+      - name: git push
+        uses: srt32/git-actions@v0.0.3
+        with:
+          args: git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} HEAD:sfe-next -f
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-sfe-next.yml
+++ b/.github/workflows/update-sfe-next.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:    
+      - master
+name: Update the sfe-next branch on pushes to master
+jobs:
+  updateSfeNextBranch:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup node
+      uses: actions/setup-node@v1
+    - name: update the dependency on @serverless/enterprise-plugin to the next tag
+      run: node scripts/update-sfe-dep.js
+    - name: git commit
+      uses: srt32/git-actions@v0.0.3
+      with:
+        args: git config --global user.email "engineering@serverless.com" && git config --global user.name "Github Action" && git commit -am 'update the dependency on @serverless/enterprise-plugin to the next tag'
+    - name: git push
+      uses: srt32/git-actions@v0.0.3
+      with:
+        args: git push https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} HEAD:sfe-next -f
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update-sfe-dep.js
+++ b/scripts/update-sfe-dep.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 
 const pkgJson = JSON.parse(fs.readFileSync('package.json'));

--- a/scripts/update-sfe-dep.js
+++ b/scripts/update-sfe-dep.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+const pkgJson = JSON.parse(fs.readFileSync('package.json'));
+
+pkgJson.dependencies['@serverless/enterprise-plugin'] = 'next';
+
+fs.writeFileSync('package.json', JSON.stringify(pkgJson, null, 2));

--- a/scripts/update-sfe-dep.js
+++ b/scripts/update-sfe-dep.js
@@ -1,9 +1,10 @@
 'use strict';
 
+const os = require('os');
 const fs = require('fs');
 
 const pkgJson = JSON.parse(fs.readFileSync('package.json'));
 
 pkgJson.dependencies['@serverless/enterprise-plugin'] = 'next';
 
-fs.writeFileSync('package.json', JSON.stringify(pkgJson, null, 2));
+fs.writeFileSync('package.json', JSON.stringify(pkgJson, null, 2) + os.EOL);


### PR DESCRIPTION
This uses github actions to automatically update the `sfe-next` branch. On pushes to master, it will update the package json, commit, & force push to the `sfe-next` branch.

example commit (from a version of this branch that had `branch: sfe-next-update-test` instead of `branch: master`) created by this: https://github.com/serverless/serverless/commit/e17690e05044e4ba8ab823451aa1b217bad11c53

and here's the build that created it: https://github.com/serverless/serverless/commit/9ea3244ccbc39f746232931918d7661328d884ca/checks