### PR TITLE
Fixing typos in variable names

### DIFF
--- a/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
+++ b/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
@@ -110,5 +110,5 @@ function remove() {
 }
 
 module.exports = {
-  handler: handlerWrapper(handler, 'CustomResouceApiGatewayAccountCloudWatchRole'),
+  handler: handlerWrapper(handler, 'CustomResourceApiGatewayAccountCloudWatchRole'),
 };

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
@@ -73,5 +73,5 @@ function remove(event, context) {
 }
 
 module.exports = {
-  handler: handlerWrapper(handler, 'CustomResouceExistingCognitoUserPool'),
+  handler: handlerWrapper(handler, 'CustomResourceExistingCognitoUserPool'),
 };

--- a/lib/plugins/aws/customResources/resources/eventBridge/handler.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/handler.js
@@ -121,5 +121,5 @@ function remove(event, context) {
 }
 
 module.exports = {
-  handler: handlerWrapper(handler, 'CustomResouceEventBridge'),
+  handler: handlerWrapper(handler, 'CustomResourceEventBridge'),
 };

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -69,5 +69,5 @@ function remove(event, context) {
 }
 
 module.exports = {
-  handler: handlerWrapper(handler, 'CustomResouceExistingS3'),
+  handler: handlerWrapper(handler, 'CustomResourceExistingS3'),
 };

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -713,7 +713,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceS3HandlerFunctionName()', () => {
-    it('should return the nane of the S3 custom resouce handler function', () => {
+    it('should return the name of the S3 custom resource handler function', () => {
       expect(sdk.naming.getCustomResourceS3HandlerFunctionName()).to.equal(
         'custom-resource-existing-s3'
       );
@@ -721,7 +721,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceS3HandlerFunctionLogicalId()', () => {
-    it('should return the logical id of the S3 custom resouce handler function', () => {
+    it('should return the logical id of the S3 custom resource handler function', () => {
       expect(sdk.naming.getCustomResourceS3HandlerFunctionLogicalId()).to.equal(
         'CustomDashresourceDashexistingDashs3LambdaFunction'
       );
@@ -729,7 +729,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceS3ResourceLogicalId()', () => {
-    it('should return the logical id of the S3 custom resouce', () => {
+    it('should return the logical id of the S3 custom resource', () => {
       const functionName = 'my-function';
       expect(sdk.naming.getCustomResourceS3ResourceLogicalId(functionName)).to.equal(
         'MyDashfunctionCustomS31'
@@ -738,7 +738,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceCognitoUserPoolHandlerFunctionName()', () => {
-    it('should return the nane of the Cognito User Pool custom resouce handler function', () => {
+    it('should return the name of the Cognito User Pool custom resource handler function', () => {
       expect(sdk.naming.getCustomResourceCognitoUserPoolHandlerFunctionName()).to.equal(
         'custom-resource-existing-cup'
       );
@@ -746,7 +746,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceCognitoUserPoolHandlerFunctionLogicalId()', () => {
-    it('should return the logical id of the Cognito User Pool custom resouce handler function', () => {
+    it('should return the logical id of the Cognito User Pool custom resource handler function', () => {
       expect(sdk.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId()).to.equal(
         'CustomDashresourceDashexistingDashcupLambdaFunction'
       );
@@ -754,7 +754,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceCognitoUserPoolResourceLogicalId()', () => {
-    it('should return the logical id of the Cognito User Pool custom resouce', () => {
+    it('should return the logical id of the Cognito User Pool custom resource', () => {
       const functionName = 'my-function';
       expect(sdk.naming.getCustomResourceCognitoUserPoolResourceLogicalId(functionName)).to.equal(
         'MyDashfunctionCustomCognitoUserPool1'
@@ -763,7 +763,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceEventBridgeHandlerFunctionName()', () => {
-    it('should return the nane of the Event Bridge custom resouce handler function', () => {
+    it('should return the name of the Event Bridge custom resource handler function', () => {
       expect(sdk.naming.getCustomResourceEventBridgeHandlerFunctionName()).to.equal(
         'custom-resource-event-bridge'
       );
@@ -771,7 +771,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceEventBridgeHandlerFunctionLogicalId()', () => {
-    it('should return the logical id of the Event Bridge custom resouce handler function', () => {
+    it('should return the logical id of the Event Bridge custom resource handler function', () => {
       expect(sdk.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId()).to.equal(
         'CustomDashresourceDasheventDashbridgeLambdaFunction'
       );
@@ -779,7 +779,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceEventBridgeResourceLogicalId()', () => {
-    it('should return the logical id of the Event Bridge custom resouce', () => {
+    it('should return the logical id of the Event Bridge custom resource', () => {
       const functionName = 'my-function';
       const index = 1;
       expect(
@@ -789,7 +789,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()', () => {
-    it('should return the nane of the APIGW Account CloudWatch role custom resouce handler function', () => {
+    it('should return the name of the APIGW Account CloudWatch role custom resource handler function', () => {
       expect(
         sdk.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName()
       ).to.equal('custom-resource-apigw-cw-role');
@@ -797,7 +797,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId()', () => {
-    it('should return the logical id of the APIGW Account CloudWatch role custom resouce handler function', () => {
+    it('should return the logical id of the APIGW Account CloudWatch role custom resource handler function', () => {
       expect(
         sdk.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId()
       ).to.equal('CustomDashresourceDashapigwDashcwDashroleLambdaFunction');
@@ -805,7 +805,7 @@ describe('#naming()', () => {
   });
 
   describe('#getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId()', () => {
-    it('should return the logical id of the APIGW Account CloudWatch role custom resouce', () => {
+    it('should return the logical id of the APIGW Account CloudWatch role custom resource', () => {
       expect(
         sdk.naming.getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId()
       ).to.equal('CustomApiGatewayAccountCloudWatchRole');


### PR DESCRIPTION
nane -> name
resouce -> resource