### PR TITLE
Serverless Components + custom CloudFormation Resources

### DIFF
--- a/cf-via-components/.gitignore
+++ b/cf-via-components/.gitignore
@@ -1,0 +1,1 @@
+.serverless

--- a/cf-via-components/README.md
+++ b/cf-via-components/README.md
@@ -1,0 +1,18 @@
+# Custom CloudFormation resources via Serverless Components
+
+An experiment on how to leverage existing [Serverless Components](https://github.com/serverless-components) via custom CloudFormation resources.
+
+## Local Testing
+
+1. `npm install`
+1. `node zlocal-test.js <EventType>` (EventType can be `Create`, `Update` or `Delete`)
+
+## Live Testing on AWS
+
+You might want to use the AWS console to see the current status of you stack and look for the Bucket and its properties the custon resource creates.
+
+1. `npm install`
+1. `serverless deploy`
+1. Change the S3 custom resource in `serverless.yml`
+1. `serverless deploy`
+1. `serverless remove`

--- a/cf-via-components/code/handler.js
+++ b/cf-via-components/code/handler.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Component = require('@serverless/aws-s3');
+const { Context, extractInputs, extractState, handlerWrapper } = require('./utils');
+
+function handler(event) {
+  const inputs = extractInputs(event);
+  // NOTE: apparently OldResourceProperties is only passed-in when dealing with Update requests
+  // see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
+  // therefore we re-use the inputs as `state` when dealing with `Delete` requests
+  let state = {};
+  if (event.RequestType === 'Update') {
+    state = extractState(event);
+  } else if (event.RequestType === 'Delete') {
+    state = inputs;
+  }
+
+  const context = new Context(state, {});
+  const component = new Component(undefined, context);
+  return component.init().then(() => {
+    if (event.RequestType === 'Create') {
+      return create(component, context, inputs);
+    } else if (event.RequestType === 'Update') {
+      return update(component, context, inputs);
+    } else if (event.RequestType === 'Delete') {
+      return remove(component, context);
+    }
+    throw new Error(`Unhandled RequestType ${event.RequestType}`);
+  });
+}
+
+function create(component, context, inputs) {
+  return component.default(inputs).then(() => context.readState());
+}
+
+function update(component, context, inputs) {
+  // TODO: check if the name changes in order to do a replacement
+  return component.default(inputs).then(() => context.readState());
+}
+
+function remove(component, context) {
+  return component.remove().then(() => context.readState());
+}
+
+module.exports = {
+  handler: handlerWrapper(handler, 'ComponentsViaCustomResourceS3'),
+  // TODO: remove this export since it's only used in local tests
+  handlerLocalTest: handler,
+};

--- a/cf-via-components/code/utils.js
+++ b/cf-via-components/code/utils.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const https = require('https');
+const url = require('url');
+
+// this is the Context class we pass into our component(s) upon creating
+// a new instance
+class Context {
+  constructor(state = {}, config = {}) {
+    const credentialsViaEnv = {
+      AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+      AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+      AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
+      AWS_SECURITY_TOKEN: process.env.AWS_SECURITY_TOKEN,
+    };
+
+    this.credentials = config.credentials || credentialsViaEnv || {};
+    this.debugMode = config.debug || false;
+    // set the state we get via our constructor
+    this.state = state;
+    this.state.id = this.state.id ? this.state.id : +new Date();
+    // set the id of our component
+    this.id = this.state.id;
+  }
+
+  init() {
+    this.id = this.state.id;
+  }
+
+  resourceId() {
+    return `${this.id}-${+new Date()}`;
+  }
+
+  readState() {
+    return this.state;
+  }
+
+  writeState() {
+    // we leverage AWS to manage the state via our custom CloudFormation resource.
+    // In our custom CloudFormation resource handler code we return an object
+    // with a nested `Data` object which holds the state
+    return this.state;
+  }
+
+  log() {
+    return;
+  }
+
+  // debug is useful and available even in programmatic mode
+  debug(msg) {
+    if (!this.debugMode || !msg || msg === '') {
+      return;
+    }
+
+    console.log(`  DEBUG: ${msg}`); // eslint-disable-line
+  }
+
+  status() {
+    return;
+  }
+}
+
+const logger = console;
+
+function extractor(object, keysToIgnore = []) {
+  return Object.keys(object).reduce((accum, key) => {
+    if (!keysToIgnore.includes(key)) {
+      const newKey = key.toLowerCase();
+      const newValue = object[key];
+      Object.assign(accum, { [newKey]: newValue });
+    }
+    return accum;
+  }, {});
+}
+
+function extractInputs(event) {
+  // TODO: see if `ResourceProperties` is already without `ServiceToken`
+  const props = event.ResourceProperties;
+  let inputs = {};
+  if (props) {
+    inputs = extractor(props, ['ServiceToken']);
+  }
+  return inputs;
+}
+
+function extractState(event) {
+  // TODO: see if `OldResourceProperties` is already without `ServiceToken`
+  const oldProps = event.OldResourceProperties;
+  let state = {};
+  if (oldProps) {
+    state = extractor(oldProps, ['ServiceToken']);
+  }
+  return state;
+}
+
+function response(event, context, status, data = {}, err) {
+  const reason = err ? err.message : '';
+  const { StackId, RequestId, LogicalResourceId, PhysicalResourceId, ResponseURL } = event;
+
+  const body = JSON.stringify({
+    StackId,
+    RequestId,
+    LogicalResourceId,
+    PhysicalResourceId,
+    Status: status,
+    Reason: reason && `${reason} See details in CloudWatch Log: ${context.logStreamName}`,
+    Data: data,
+  });
+
+  logger.log(body);
+
+  const parsedUrl = url.parse(ResponseURL);
+  const options = {
+    hostname: parsedUrl.hostname,
+    port: 443,
+    path: parsedUrl.path,
+    method: 'PUT',
+    headers: {
+      'Content-Type': '',
+      'Content-Length': body.length,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(options, resp => {
+      logger.log(`STATUS: ${resp.statusCode}`);
+      logger.log(`HEADERS: ${JSON.stringify(resp.headers)}`);
+      return resolve(data);
+    });
+
+    request.on('error', error => {
+      logger.log(`sendResponse Error:\n${error}`);
+      return reject(error);
+    });
+
+    request.on('end', () => {
+      logger.log('end');
+      return resolve();
+    });
+
+    request.write(body);
+    request.end();
+  });
+}
+
+// everything which is returned in the `handlerWrapper` call will be put inside the
+// `Data` object which in turn is persistent on AWS end in an S3 bucket AWS manages
+function handlerWrapper(handler, PhysicalResourceId) {
+  return (event, context, callback) => {
+    // extend the `event` object to include the PhysicalResourceId
+    event = Object.assign({}, event, { PhysicalResourceId });
+    return Promise.resolve(handler(event, context, callback))
+      .then(
+        result => response(event, context, 'SUCCESS', result),
+        error => response(event, context, 'FAILED', {}, error)
+      )
+      .then(result => callback(null, result), callback);
+  };
+}
+
+module.exports = {
+  Context,
+  logger,
+  extractInputs,
+  extractState,
+  response,
+  handlerWrapper,
+};

--- a/cf-via-components/package.json
+++ b/cf-via-components/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@serverless/cf-via-components",
+  "version": "0.1.0",
+  "dependencies": {
+    "@serverless/aws-s3": "^4.0.0"
+  }
+}

--- a/cf-via-components/serverless.yml
+++ b/cf-via-components/serverless.yml
@@ -1,0 +1,54 @@
+service: cf-via-components-${self:custom.idx}
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+  region: ${self:custom.region}
+  logs:
+    frameworkLambda: true
+  # we need this rule so that we can manage S3 buckets
+  iamRoleStatements:
+    - Effect: 'Allow'
+      Action:
+        - s3:CreateBucket
+        - s3:ListBucket
+        - s3:DeleteBucket
+        - s3:ListAllMyBuckets
+        - s3:GetAccelerateConfiguration
+        - s3:PutAccelerateConfiguration
+      Resource:
+        - arn:aws:s3:::*
+
+custom:
+  idx: 0
+  region: eu-central-1
+
+functions:
+  # this is the Lambda function in which we use our S3 Component to
+  # manage S3 buckets
+  cfHandler:
+    handler: code/handler.handler
+
+resources:
+  Resources:
+    ComponentsS3Bucket:
+      # we have to await the creation of our Lambda function which includes the logic
+      # to deal with this custom resource
+      DependsOn:
+        - CfHandlerLambdaFunction
+      # this is the actual interface / abstraction we later on use
+      # to manage S3 buckets via Components (although this is an implementation detail)
+      Type: Custom::ComponentsS3Bucket
+      Version: '0.1'
+      Properties:
+        # here we reference the Lambda function from above which
+        # carries out the different CRUD operations for our S3 bucket
+        ServiceToken:
+          Fn::GetAtt:
+            - CfHandlerLambdaFunction
+            - Arn
+        # the following are the actual parameters which are passed into the Lambda above
+        Name: components-via-cf-s3-bucket
+        Region: eu-central-1
+        Accelerated: false

--- a/cf-via-components/zlocal-test.js
+++ b/cf-via-components/zlocal-test.js
@@ -1,0 +1,52 @@
+'use strict'; // eslint-disable-line consistent-return
+
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-console */
+
+const handler = require('./code/handler').handlerLocalTest;
+
+const ServiceToken = 'the-custom-resource-lambda-function';
+const Name = 'components-via-cf-s3-bucket';
+const Region = 'eu-central-1';
+const Accelerated = false;
+
+// AWS mock events
+const eventMockCreate = {
+  RequestType: 'Create',
+  ResourceProperties: {
+    ServiceToken,
+    Name,
+    Region,
+    Accelerated,
+  },
+};
+
+const eventMockUpdate = {
+  RequestType: 'Update',
+  OldResourceProperties: eventMockCreate.ResourceProperties,
+  ResourceProperties: {
+    ServiceToken,
+    Name,
+    Region,
+    Accelerated: true,
+  },
+};
+
+const eventMockDelete = {
+  RequestType: 'Delete',
+  ResourceProperties: eventMockCreate.ResourceProperties,
+};
+
+const operation = process.argv[2];
+const validOperations = ['Create', 'Update', 'Delete'];
+
+if (!operation || !validOperations.includes(operation)) {
+  console.log('Please provide an operation like "Create", "Update", "Delete"');
+} else {
+  if (operation === 'Create') {
+    return handler(eventMockCreate).then(res => console.log(res));
+  } else if (operation === 'Update') {
+    return handler(eventMockUpdate).then(res => console.log(res));
+  }
+  return handler(eventMockDelete).then(res => console.log(res));
+}


### PR DESCRIPTION
## What did you implement

This is an experiment in which we use Serverless Components within custom CloudFormation resources. Using such a combination will unlock a lot of interesting features in the future + we can do code-sharing (write once, use "everywhere").

## How can we verify it

There's a `README.md` file in this PR which describes how it can be tested and used. The usage pattern might change so I refer to this `.md` file rather than constantly updating this PR description with the most recent version of such `.md` file.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
