### PR TITLE
Pause for mfa input

### DIFF
--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -51,9 +51,9 @@ class AwsPackage {
        * Outer lifecycle hooks
        */
       'package:cleanup': () =>
-        BbPromise.bind(this)
-          .then(() => this.serverless.pluginManager.spawn('aws:common:validate'))
-          .then(() => this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')),
+        BbPromise.bind(this).then(() =>
+          this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')
+        ),
 
       'package:initialize': () => BbPromise.bind(this).then(this.generateCoreTemplate),
 

--- a/lib/plugins/aws/package/index.test.js
+++ b/lib/plugins/aws/package/index.test.js
@@ -109,16 +109,12 @@ describe('AwsPackage', () => {
     });
 
     it('should run "package:cleanup" hook', () => {
-      const spawnAwsCommonValidateStub = spawnStub.withArgs('aws:common:validate').resolves();
       const spawnAwsCommonCleanupTempDirStub = spawnStub
         .withArgs('aws:common:cleanupTempDir')
         .resolves();
 
       return awsPackage.hooks['package:cleanup']().then(() => {
-        expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
-        expect(spawnAwsCommonCleanupTempDirStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(
-          true
-        );
+        expect(spawnAwsCommonCleanupTempDirStub.calledOnce).to.equal(true);
       });
     });
 


### PR DESCRIPTION




<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
This allows credential validation checks to be applied when running the `package` hook only if the initial command is to create an artifact for deployment, that is explicitly `sls package`. Since the package hook is invoked by other commands like `deploy`, the validation step is deferred to that command's hook.
<!-- Briefly describe the scope of your PR -->

Closes #6576

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

Setup an MFA requirement with the AWS CLI and attempt to deploy: `sls deploy`. It should await input on the MFA prompt.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
