### PR TITLE
The provider.logs.restApi sub fields do not accept string values of "true" or "false".

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -212,7 +212,10 @@ function handleLogs() {
       logFormat = logs.format;
     }
 
-    const executionLogging = logs.executionLogging == null || logs.executionLogging == undefined ? true : /^true$/.test(String(logs.executionLogging));
+    const executionLogging =
+      logs.executionLogging === null || logs.executionLogging === undefined
+        ? true
+        : /^true$/.test(String(logs.executionLogging));
 
     let level = defaultApiGatewayLogLevel;
     if (!executionLogging) {
@@ -228,7 +231,10 @@ function handleLogs() {
       }
     }
 
-    const accessLogging = logs.accessLogging == null || logs.accessLogging == undefined ? true : /^true$/.test(String(logs.accessLogging));
+    const accessLogging =
+      logs.accessLogging === null || logs.accessLogging === undefined
+        ? true
+        : /^true$/.test(String(logs.accessLogging));
 
     if (accessLogging) {
       let resourceArn;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -212,7 +212,7 @@ function handleLogs() {
       logFormat = logs.format;
     }
 
-    const executionLogging = logs.executionLogging == null ? true : /^true$/.test(logs.executionLogging);
+    const executionLogging = logs.executionLogging == null || logs.executionLogging == undefined ? true : /^true$/.test(String(logs.executionLogging));
 
     let level = defaultApiGatewayLogLevel;
     if (!executionLogging) {
@@ -228,7 +228,7 @@ function handleLogs() {
       }
     }
 
-    const accessLogging = logs.accessLogging == null ? true : /^true$/.test(logs.accessLogging);
+    const accessLogging = logs.accessLogging == null || logs.accessLogging == undefined ? true : /^true$/.test(String(logs.accessLogging));
 
     if (accessLogging) {
       let resourceArn;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -235,6 +235,14 @@ function handleLogs() {
       logs.accessLogging === null || logs.accessLogging === undefined
         ? true
         : /^true$/.test(String(logs.accessLogging));
+    console.log('################');
+    console.log(
+      'accessLogging =',
+      accessLogging,
+      'logs.accessLogging =',
+      logs.accessLogging,
+      typeof logs.accessLogging
+    );
 
     if (accessLogging) {
       let resourceArn;
@@ -348,7 +356,10 @@ function removeAccessLoggingLogGroup() {
   let accessLogging = provider.logs && provider.logs.restApi;
 
   if (accessLogging) {
-    accessLogging = accessLogging.accessLogging == null ? true : accessLogging.accessLogging;
+    accessLogging =
+      accessLogging.accessLogging === null || accessLogging.accessLogging === undefined
+        ? true
+        : /^true$/.test(String(accessLogging.accessLogging));
   }
 
   // if there are no logs setup (or the user has disabled them) we need to

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -235,14 +235,6 @@ function handleLogs() {
       logs.accessLogging === null || logs.accessLogging === undefined
         ? true
         : /^true$/.test(String(logs.accessLogging));
-    console.log('################');
-    console.log(
-      'accessLogging =',
-      accessLogging,
-      'logs.accessLogging =',
-      logs.accessLogging,
-      typeof logs.accessLogging
-    );
 
     if (accessLogging) {
       let resourceArn;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -212,7 +212,7 @@ function handleLogs() {
       logFormat = logs.format;
     }
 
-    const executionLogging = logs.executionLogging == null ? true : logs.executionLogging;
+    const executionLogging = logs.executionLogging == null ? true : /^true$/.test(logs.executionLogging);
 
     let level = defaultApiGatewayLogLevel;
     if (!executionLogging) {
@@ -228,7 +228,7 @@ function handleLogs() {
       }
     }
 
-    const accessLogging = logs.accessLogging == null ? true : logs.accessLogging;
+    const accessLogging = logs.accessLogging == null ? true : /^true$/.test(logs.accessLogging);
 
     if (accessLogging) {
       let resourceArn;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -553,7 +553,19 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should disable execution logging when executionLogging is set to false', () => {
+  it('should disable execution logging when executionLogging is set to false (string)', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        executionLogging: 'false',
+      },
+    };
+    return updateStage.call(context).then(() => {
+      const patchOperation = { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' };
+      expectPatchOperation(patchOperation);
+    });
+  });
+
+  it('should disable execution logging when executionLogging is set to false (boolean)', () => {
     context.state.service.provider.logs = {
       restApi: {
         executionLogging: false,
@@ -575,7 +587,20 @@ describe('#updateStage()', () => {
     return expect(updateStage.call(context)).to.be.rejectedWith('invalid value');
   });
 
-  it('should disable existing access log settings when accessLogging is set to false', () => {
+  it('should disable existing access log settings when accessLogging is set to false (string)', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        accessLogging: 'false',
+      },
+    };
+
+    return updateStage.call(context).then(() => {
+      const removeOperation = { op: 'remove', path: '/accessLogSettings' };
+      expectPatchOperation(removeOperation);
+    });
+  });
+
+  it('should disable existing access log settings when accessLogging is set to false (boolean)', () => {
     context.state.service.provider.logs = {
       restApi: {
         accessLogging: false,
@@ -588,10 +613,26 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should delete any existing CloudWatch LogGroup when accessLogging is set to false', () => {
+  it('should delete any existing CloudWatch LogGroup when accessLogging is set to false (boolean)', () => {
     context.state.service.provider.logs = {
       restApi: {
         accessLogging: false,
+      },
+    };
+
+    return updateStage.call(context).then(() => {
+      expect(providerRequestStub.args[4][0]).to.equal('CloudWatchLogs');
+      expect(providerRequestStub.args[4][1]).to.equal('deleteLogGroup');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
+        logGroupName: '/aws/api-gateway/my-service-dev',
+      });
+    });
+  });
+
+  it('should delete any existing CloudWatch LogGroup when accessLogging is set to false (string)', () => {
+    context.state.service.provider.logs = {
+      restApi: {
+        accessLogging: 'false',
       },
     };
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Closes #6782 

## How can we verify it

Logs are disabled with this configuration:

```yaml
provider:
  logs:
    restApi:
      accessLogging:     "false"
      executionLogging:  "false"
      fullExecutionData: "false
```

Logs are enabled with this configuration:

```yaml
provider:
  logs:
    restApi:
      accessLogging:     "true"
      executionLogging:  "true"
      fullExecutionData: "true"
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** YES
