### PR TITLE
Add Questions issue template that navigate users to forums

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: "🐛 Bug report"
+name: '🐛 Bug report'
 about: Create a bug report
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: "🐛 Bug report"
 about: Create a bug report
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: "🎉 Feature request"
 about: Suggest an idea
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: "🎉 Feature request"
+name: '🎉 Feature request'
 about: Suggest an idea
 ---
 

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -5,3 +5,6 @@ about: Please use https://forum.serverless.com, StackOverflow or other forums fo
 
 Please use https://forum.serverless.com, StackOverflow or other forums for questions.
 This issue tracker is dedicated for bug reports and feature requests.
+
+Useful links
+* [Ask on StackOverflow with `serverless-framework` tag](https://stackoverflow.com/questions/ask?tags=serverless-framework) (need login)

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -5,6 +5,8 @@ about: Please use https://forum.serverless.com, StackOverflow or other forums fo
 
 Please use https://forum.serverless.com, StackOverflow or other forums for questions.
 This issue tracker is dedicated for bug reports and feature requests.
+We'll close question issues immediately.
+
 
 Useful links
 * [Ask on StackOverflow with `serverless-framework` tag](https://stackoverflow.com/questions/ask?tags=serverless-framework) (need login)

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,0 +1,7 @@
+---
+name: "❓ Questions"
+about: Please use https://forum.serverless.com, StackOverflow or other forums for questions
+---
+
+Please use https://forum.serverless.com, StackOverflow or other forums for questions.
+This issue tracker is dedicated for bug reports and feature requests.

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,5 +1,5 @@
 ---
-name: "❓ Questions"
+name: '❓ Questions'
 about: Please use https://forum.serverless.com, StackOverflow or other forums for questions
 ---
 
@@ -7,6 +7,6 @@ Please use https://forum.serverless.com, StackOverflow or other forums for quest
 This issue tracker is dedicated for bug reports and feature requests.
 We'll close question issues immediately.
 
-
 Useful links
-* [Ask on StackOverflow with `serverless-framework` tag](https://stackoverflow.com/questions/ask?tags=serverless-framework) (need login)
+
+- [Ask on StackOverflow with `serverless-framework` tag](https://stackoverflow.com/questions/ask?tags=serverless-framework) (need login)

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -4,9 +4,10 @@ about: Please use https://forum.serverless.com, StackOverflow or other forums fo
 ---
 
 Please use https://forum.serverless.com, StackOverflow or other forums for questions.
-This issue tracker is dedicated for bug reports and feature requests.
-We'll close question issues immediately.
+This issue tracker is dedicated for bug reports and feature requests. Question issues might be closed immediately.
 
-Useful links
+**Useful links:**
 
-- [Ask on StackOverflow with `serverless-framework` tag](https://stackoverflow.com/questions/ask?tags=serverless-framework) (need login)
+- [Official Serverless Forum](https://forum.serverless.com)
+- [Official Serverless Slack Workspace](https://serverless.com/slack)
+- [StackOverflow `serverless-framework` tag](https://stackoverflow.com/questions/ask?tags=serverless-framework) (need login)


### PR DESCRIPTION
## What did you implement

Add a new **Questions** issue template that is intended to navigate users to forums.
Inspired from scala-js repository https://github.com/scala-js/scala-js/issues/new/choose


IIUC, the issue tracker for serverless is dedicated for **Bug report** and **Feature request**.
But not a small number of people open a question.
I think it is because they think the existing issue template are not for **Question**, then they find a `open a regular issue`. One such example is https://github.com/serverless/serverless/issues/6783#issuecomment-538282539

Also added fancy icons.

## How can we verify it

N/A


## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
