### PR TITLE
Showcase how to use AWS SDK in sls helpers

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -509,6 +509,28 @@ module.exports.promised = () => {
 };
 ```
 
+For example, in such helper you could call AWS SDK to get account details:
+```js
+// myCustomFile.js
+const { STS } = require('aws-sdk');
+const sts = new STS();
+
+module.exports.getAccountId = async () => {
+    // Checking AWS user details
+    const { Account } = await sts.getCallerIdentity().promise();
+    return Account;
+};
+```
+
+
+```yml
+# serverless.yml
+service: new-service
+provider: aws
+custom:
+  accountId: ${file(./myCustomFile.js):getAccountId}
+```
+
 ## Multiple Configuration Files
 
 Adding many custom resources to your `serverless.yml` file could bloat the whole file, so you can use the Serverless Variable syntax to split this up.

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -510,18 +510,18 @@ module.exports.promised = () => {
 ```
 
 For example, in such helper you could call AWS SDK to get account details:
+
 ```js
 // myCustomFile.js
 const { STS } = require('aws-sdk');
 const sts = new STS();
 
 module.exports.getAccountId = async () => {
-    // Checking AWS user details
-    const { Account } = await sts.getCallerIdentity().promise();
-    return Account;
+  // Checking AWS user details
+  const { Account } = await sts.getCallerIdentity().promise();
+  return Account;
 };
 ```
-
 
 ```yml
 # serverless.yml


### PR DESCRIPTION
## What did you implement

Added brief showcase how to use AWS SDK in serverless helpers.
I've stumbled across issue that I couldn't get account id at some times - depending on where I needed it -  that I think it's worth mentioning method that does not interfere with current serverless flow in documentation.

Mentioned also in #5001 

## How can we verify it

Snippet is available in docs, this is only docs update

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
