### PR TITLE
Update SLS Deploy Documentation

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -22,7 +22,7 @@ serverless deploy
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.

--- a/docs/providers/azure/cli-reference/deploy-list.md
+++ b/docs/providers/azure/cli-reference/deploy-list.md
@@ -22,7 +22,7 @@ The displayed information is useful when rolling back a deployment or function v
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 
 ## Examples
 

--- a/docs/providers/azure/cli-reference/deploy.md
+++ b/docs/providers/azure/cli-reference/deploy.md
@@ -22,7 +22,7 @@ serverless deploy
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 

--- a/docs/providers/azure/cli-reference/invoke.md
+++ b/docs/providers/azure/cli-reference/invoke.md
@@ -22,7 +22,7 @@ serverless invoke --function functionName
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--function` or `-f` The name of the function in your service that you want to invoke. **Required**.
 - `--path` or `-p` The path to a json file with input data to be passed to the invoked function. This path is relative to the root directory of the service.
 - `--data` or `-d` Stringified JSON data to be used as input to the function

--- a/docs/providers/cloudflare/cli-reference/deploy.md
+++ b/docs/providers/cloudflare/cli-reference/deploy.md
@@ -45,7 +45,7 @@ This is the simplest deployment usage possible. With this command, Serverless wi
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--verbose` or `-v`: Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f`: Invokes `deploy function` (see above). Convenience shortcut
 

--- a/docs/providers/fn/cli-reference/deploy.md
+++ b/docs/providers/fn/cli-reference/deploy.md
@@ -26,7 +26,7 @@ This is the simplest deployment usage possible. With this command Serverless wil
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut
 

--- a/docs/providers/google/cli-reference/deploy.md
+++ b/docs/providers/google/cli-reference/deploy.md
@@ -22,7 +22,7 @@ serverless deploy
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 
 ## Artifacts
 

--- a/docs/providers/kubeless/cli-reference/deploy.md
+++ b/docs/providers/kubeless/cli-reference/deploy.md
@@ -26,7 +26,7 @@ This is the simplest deployment usage possible. With this command Serverless wil
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--package` or `-p` The path of a previously packaged deployment to get deployed (skips packaging step).

--- a/docs/providers/openwhisk/cli-reference/deploy.md
+++ b/docs/providers/openwhisk/cli-reference/deploy.md
@@ -22,7 +22,7 @@ serverless deploy
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.

--- a/docs/providers/spotinst/cli-reference/deploy.md
+++ b/docs/providers/spotinst/cli-reference/deploy.md
@@ -22,6 +22,6 @@ serverless deploy -v
 
 ## Options
 
-- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -555,9 +555,11 @@ class PluginManager {
   validateServerlessConfigDependency(command) {
     if ('configDependent' in command && command.configDependent) {
       if (!this.serverlessConfigFile) {
-        throw new this.serverless.classes.Error(
-          'This command can only be run in a Serverless service directory'
-        );
+        const msg = [
+          'This command can only be run in a Serverless service directory. ',
+          "Make sure to reference a valid config file in the current working directory if you're using a custom config file",
+        ].join('');
+        throw new this.serverless.classes.Error(msg);
       }
     }
   }


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
Update the documentation for the `--config or -c` argument. This option currently does not support path-based `serverless.yml` files like `my_dir/another_dir/serverless.yml`. Instead, it currently only supports non-standard naming conventions of the `serverless.yml` file (`serverless.yml|.yaml|.js|.json`).

<!-- Briefly describe the scope of your PR -->

Closes #XXXXX

## How can we verify it
With a directory structure like: `my_dir/another_dir/serverless.yml`, if you run:

```
sls deploy --config my_dir/another_dir/serverless.yml
```
It will fail with the error message:
```
This command can only be run in a Serverless service directory
```
<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
