### PR TITLE
Issue 4867 - Allowing InvokeBridge to find handleRequest method from super classes

### DIFF
--- a/lib/plugins/aws/invokeLocal/java/src/main/java/com/serverless/InvokeBridge.java
+++ b/lib/plugins/aws/invokeLocal/java/src/main/java/com/serverless/InvokeBridge.java
@@ -105,7 +105,7 @@ public class InvokeBridge {
 
   private Method findHandlerMethod(Class clazz, String handlerName) throws Exception {
     Method candidateMethod = null;
-    for(Method method: clazz.getDeclaredMethods()) {
+    for(Method method: clazz.getMethods()) {
       if (method.getName().equals(handlerName) && !method.isBridge()) {
         // Select the method with the largest number of parameters
         // If two or more methods have the same number of parameters, AWS Lambda selects the method that has

--- a/lib/plugins/aws/invokeLocal/java/src/test/java/com/serverless/AbstractRequestHandler.java
+++ b/lib/plugins/aws/invokeLocal/java/src/test/java/com/serverless/AbstractRequestHandler.java
@@ -1,0 +1,16 @@
+package com.serverless;
+
+import java.util.Map;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+public abstract class AbstractRequestHandler
+  implements com.amazonaws.services.lambda.runtime.RequestHandler<Map<String, Object>, Object> {
+
+  abstract Object handleMe();
+
+  @Override
+  public Object handleRequest(Map<String, Object> stringObjectMap, Context context) {
+    return "Parent Complete.|" + handleMe();
+  }
+}

--- a/lib/plugins/aws/invokeLocal/java/src/test/java/com/serverless/ConcreteRequestHandler.java
+++ b/lib/plugins/aws/invokeLocal/java/src/test/java/com/serverless/ConcreteRequestHandler.java
@@ -1,0 +1,10 @@
+package com.serverless;
+
+public class ConcreteRequestHandler extends AbstractRequestHandler {
+
+  @Override
+  Object handleMe() {
+    return "Child Complete.";
+  }
+
+}

--- a/lib/plugins/aws/invokeLocal/java/src/test/java/com/serverless/InvokeBridgeInheritanceTest.java
+++ b/lib/plugins/aws/invokeLocal/java/src/test/java/com/serverless/InvokeBridgeInheritanceTest.java
@@ -1,0 +1,22 @@
+package com.serverless;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class InvokeBridgeInheritanceTest {
+  @Before
+  public void before() {
+    System.setProperty("artifactPath", "target/test-classes/com/serverless/ConcreteRequestHandler.class");
+    System.setProperty("className", "com.serverless.ConcreteRequestHandler");
+    System.setProperty("handlerName", "handleRequest");
+  }
+
+  @Test
+  public void verifyInvoke() {
+    System.setIn(getClass().getResourceAsStream("/test.json"));
+    InvokeBridge.main(new String[] {});
+    // Nothing to verify, if this doesn't throw NoSuchMethodException, we are good.
+  }
+}


### PR DESCRIPTION
## What did you implement

Allowing InvokeBridge to find handleRequest method from super classes

Closes #4867

## How can we verify it

Provided the unit test

## Todos

<details>
<summary>Useful Scripts</summary>

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
