### PR TITLE
Make question mark available as variables fallback

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -21,7 +21,7 @@ class Service {
     this.serviceObject = null;
     this.provider = {
       stage: 'dev',
-      variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}',
+      variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -31,7 +31,7 @@ describe('Service', () => {
       expect(serviceInstance.serviceObject).to.be.equal(null);
       expect(serviceInstance.provider).to.deep.equal({
         stage: 'dev',
-        variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}',
+        variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}',
       });
       expect(serviceInstance.custom).to.deep.equal({});
       expect(serviceInstance.plugins).to.deep.equal([]);
@@ -132,7 +132,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -164,7 +164,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}'
+          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -187,7 +187,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -218,7 +218,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}'
+          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -241,7 +241,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -275,7 +275,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}'
+          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -298,7 +298,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -332,7 +332,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}'
+          '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -355,7 +355,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -389,7 +389,7 @@ describe('Service', () => {
         expect(serviceInstance.service).to.be.equal('new-service');
         expect(serviceInstance.provider.name).to.deep.equal('aws');
         expect(serviceInstance.provider.variableSyntax).to.equal(
-          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}}'
+          '\\${{([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)*?]+?)}}'
         );
         expect(serviceInstance.plugins).to.deep.equal(['testPlugin']);
         expect(serviceInstance.resources.aws).to.deep.equal({ resourcesProp: 'value' });
@@ -429,7 +429,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {
@@ -997,7 +997,7 @@ describe('Service', () => {
           name: 'aws',
           stage: 'dev',
           region: 'us-east-1',
-          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}',
+          variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}',
         },
         plugins: ['testPlugin'],
         functions: {

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -276,7 +276,7 @@ class Utils {
       }
 
       let hasCustomVariableSyntaxDefined = false;
-      const defaultVariableSyntax = '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)]+?)}';
+      const defaultVariableSyntax = '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}';
 
       // check if the variableSyntax in the provider section is defined
       if (

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -56,7 +56,7 @@ describe('Variables', () => {
   describe('#loadVariableSyntax()', () => {
     it('should set variableSyntax', () => {
       // eslint-disable-next-line no-template-curly-in-string
-      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}';
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}';
       serverless.variables.loadVariableSyntax();
       expect(serverless.variables.variableSyntax).to.be.a('RegExp');
     });
@@ -480,7 +480,7 @@ describe('Variables', () => {
       beforeEach(() => {
         service = makeDefault();
         // eslint-disable-next-line no-template-curly-in-string
-        service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}'; // default
+        service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}'; // default
         serverless.variables.service = service;
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
@@ -889,6 +889,24 @@ describe('Variables', () => {
         };
         return serverless.variables.populateObject(service.custom).should.become(expected);
       });
+      it('should preserve question mark in single-quote literal fallback', () => {
+        service.custom = {
+          val0: "${self:custom.val, '?'}",
+        };
+        const expected = {
+          val0: '?',
+        };
+        return serverless.variables.populateObject(service.custom).should.become(expected);
+      });
+      it('should preserve question mark in single-quote literal fallback', () => {
+        service.custom = {
+          val0: "${self:custom.val, 'cron(0 0 * * ? *)'}",
+        };
+        const expected = {
+          val0: 'cron(0 0 * * ? *)',
+        };
+        return serverless.variables.populateObject(service.custom).should.become(expected);
+      });
       it('should accept whitespace in variables', () => {
         service.custom = {
           val0: '${self: custom.val}',
@@ -901,7 +919,7 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom).should.become(expected);
       });
       it('should handle deep variables regardless of custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -917,7 +935,7 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom).should.become(expected);
       });
       it('should handle deep variable continuations regardless of custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -933,7 +951,7 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom).should.become(expected);
       });
       it('should handle deep variables regardless of recursion into custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -953,7 +971,7 @@ describe('Variables', () => {
         return serverless.variables.populateObject(service.custom).should.become(expected);
       });
       it('should handle deep variables in complex recursions of custom variableSyntax', () => {
-        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*]+?)}}';
+        service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}';
         serverless.variables.loadVariableSyntax();
         delete service.provider.variableSyntax;
         service.custom = {
@@ -1333,7 +1351,7 @@ module.exports = {
 
   describe('#overwrite()', () => {
     beforeEach(() => {
-      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}';
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}';
       serverless.variables.loadVariableSyntax();
       delete serverless.service.provider.variableSyntax;
     });
@@ -1622,7 +1640,7 @@ module.exports = {
 
   describe('#getValueFromSelf()', () => {
     beforeEach(() => {
-      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}}';
+      serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}}';
       serverless.variables.loadVariableSyntax();
       delete serverless.service.provider.variableSyntax;
     });

--- a/lib/plugins/print/print.js
+++ b/lib/plugins/print/print.js
@@ -54,7 +54,7 @@ class Print {
       {
         stage: 'dev',
         region: 'us-east-1',
-        variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}',
+        variableSyntax: '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}',
       },
       service.provider
     );

--- a/lib/plugins/print/print.test.js
+++ b/lib/plugins/print/print.test.js
@@ -38,7 +38,7 @@ describe('Print', () => {
   });
 
   afterEach(() => {
-    serverless.service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*]+?)}';
+    serverless.service.provider.variableSyntax = '\\${([ ~:a-zA-Z0-9._@\'",\\-\\/\\(\\)*?]+?)}';
   });
 
   it('should print standard config', () => {
@@ -262,10 +262,10 @@ describe('Print', () => {
       provider: {
         name: 'aws',
         stage: '${{opt:stage}}',
-        variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*]+?)}}',
+        variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}',
       },
     };
-    serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*]+?)}}';
+    serverless.service.provider.variableSyntax = '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}';
     getServerlessConfigFileStub.resolves(conf);
 
     serverless.processedInput = {
@@ -278,7 +278,7 @@ describe('Print', () => {
       provider: {
         name: 'aws',
         stage: 'dev',
-        variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*]+?)}}',
+        variableSyntax: '\\${{([ ~:a-zA-Z0-9._@\\\'",\\-\\/\\(\\)*?]+?)}}',
       },
     };
 


### PR DESCRIPTION

## What did you implement

<!-- Briefly describe the scope of your PR -->

Closes #4624

With this serverless.yml, 
```
service: sls1
provider:
  name: aws
  runtime: nodejs10.x
  environment:
    LAMBDA_SCHEDULE: ${env:LAMBDA_SCHEDULE, 'cron(0 0 * * ? *)'}

functions:
  hello:
    handler: handler.hello
    events:
      - schedule:
        rate: ${self:provider.environment.LAMBDA_SCHEDULE}
        enabled: true
```

`serverless print` will get the following result :
```
service: sls1
provider:
  name: aws
  runtime: nodejs10.x
  environment:
    LAMBDA_SCHEDULE: cron(0 0 * * ? *)
functions:
  hello:
    handler: handler.hello
    events:
      - schedule: null
        rate: cron(0 0 * * ? *)
        enabled: true
    name: sls1-dev-hello
```

## How can we verify it

Example  `serverless.yml` file is provided in the issue #4624 and I tested like above.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
