### PR TITLE
Allow empty arrays in overrides

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -523,7 +523,8 @@ class Variables {
     const validValue = value =>
       value !== null &&
       typeof value !== 'undefined' &&
-      !(typeof value === 'object' && _.isEmpty(value));
+      (Array.isArray(value) || !(typeof value === 'object' && _.isEmpty(value)));
+
     return BbPromise.all(variableValues)
       .then(values => values.filter(v => v !== FAIL_TOKEN))
       .then(values => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1366,8 +1366,8 @@ module.exports = {
 
     it('should overwrite values with an array even if it is empty', () => {
       const getValueFromSourceStub = sinon.stub(serverless.variables, 'getValueFromSource');
-        getValueFromSourceStub.onCall(0).resolves(undefined);
-        getValueFromSourceStub.onCall(1).resolves([]);
+      getValueFromSourceStub.onCall(0).resolves(undefined);
+      getValueFromSourceStub.onCall(1).resolves([]);
       return serverless.variables
         .overwrite(['opt:stage', 'env:stage'])
         .should.be.fulfilled.then(valueToPopulate => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1364,6 +1364,19 @@ module.exports = {
         .finally(() => getValueFromSourceStub.restore());
     });
 
+    it('should overwrite values with an array even if it is empty', () => {
+      const getValueFromSourceStub = sinon.stub(serverless.variables, 'getValueFromSource');
+        getValueFromSourceStub.onCall(0).resolves(undefined);
+        getValueFromSourceStub.onCall(1).resolves([]);
+      return serverless.variables
+        .overwrite(['opt:stage', 'env:stage'])
+        .should.be.fulfilled.then(valueToPopulate => {
+          expect(valueToPopulate).to.deep.equal([]);
+          expect(getValueFromSourceStub).to.have.been.calledTwice;
+        })
+        .finally(() => getValueFromSourceStub.restore());
+    });
+
     it('should not overwrite 0 values', () => {
       const getValueFromSourceStub = sinon.stub(serverless.variables, 'getValueFromSource');
       getValueFromSourceStub.onCall(0).resolves(0);


### PR DESCRIPTION
This is just a quick follow-up to https://github.com/serverless/serverless/pull/6554

Now that empty arrays are not warned, the variable override e.g. `foo: ${opt:xyz, self:custom.emptyArray}` doesn't default foo to an array, which can be surprising/annoying for plugin developers and users.

## How can we verify it

I added a test, and this is a simple example:

```
service: empty-array-test
provider:
  name: aws
  runtime: nodejs10.x
functions:
  hello:
    handler: handler.hello
custom:
  emptyArray: []
  foo: ${opt:foo, self:custom.emptyArray}
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
