### PR TITLE
Fixed apiKeys string issue due to no proper parsing from .yaml file

### DIFF
--- a/lib/plugins/aws/info/getApiKeyValues.js
+++ b/lib/plugins/aws/info/getApiKeyValues.js
@@ -16,7 +16,10 @@ module.exports = {
         // different API key types are nested in separate arrays
         if (_.isObject(definition)) {
           const keyTypeName = Object.keys(definition)[0];
-          _.forEach(definition[keyTypeName], keyName => apiKeyNames.push(keyName));
+          _.forEach(definition[keyTypeName], keyName => {
+            const eachKeyName = Object.keys(keyName)[0];
+            apiKeyNames.push(keyName[eachKeyName]);
+          });
         } else if (_.isString(definition)) {
           // plain strings are simple, non-nested API keys
           apiKeyNames.push(definition);

--- a/lib/plugins/aws/info/getApiKeyValues.test.js
+++ b/lib/plugins/aws/info/getApiKeyValues.test.js
@@ -83,6 +83,55 @@ describe('#getApiKeyValues()', () => {
     });
   });
 
+  it('should add multiple API Key values to this.gatheredData if API key names are available', () => {
+    // set the API Keys for the service
+    awsInfo.serverless.service.provider.apiKeys = ['foo'];
+
+    awsInfo.gatheredData = {
+      info: {},
+    };
+
+    requestStub.onCall(0).resolves({
+      StackResources: [
+        {
+          PhysicalResourceId: 'giwn5zgpqj',
+          ResourceType: 'AWS::ApiGateway::ApiKey',
+        },
+        {
+          PhysicalResourceId: 'e5wssvzmla',
+          ResourceType: 'AWS::ApiGateway::ApiKey',
+        },
+        {
+          PhysicalResourceId: 's3cwoo',
+          ResourceType: 'AWS::ApiGateway::Deployment',
+        },
+      ],
+    });
+
+    requestStub.onCall(1).resolves({ id: 'giwn5zgpqj', value: 'value1ForKeyFoo', name: 'foo' });
+    requestStub.onCall(2).resolves({ id: 'e5wssvzmla', value: 'value2ForKeyFoo', name: 'foo' });
+
+    const expectedGatheredDataObj = {
+      info: {
+        apiKeys: [
+          {
+            name: 'foo',
+            value: 'value1ForKeyFoo',
+          },
+          {
+            name: 'foo',
+            value: 'value2ForKeyFoo',
+          },
+        ],
+      },
+    };
+
+    return awsInfo.getApiKeyValues().then(() => {
+      expect(requestStub.calledThrice).to.equal(true);
+      expect(awsInfo.gatheredData).to.deep.equal(expectedGatheredDataObj);
+    });
+  });
+
   it('should resolve if AWS does not return API key values', () => {
     // set the API Keys for the service
     awsInfo.serverless.service.provider.apiKeys = ['foo', 'bar'];


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise, we probably have to close the PR due to missing information -->

## What did you implement
     I fixed an issue with the current apiKey parsing from the YAML file.

<!-- Briefly describe the scope of your PR -->
   The current apiKey parsing is having an issue while parsing it from the .yaml file if it is an apiKey is a map of multiple key lists. This PR has the fixed version of the apiKey parser.

Closes #6651 

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

See #6651 issue description.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
