### PR TITLE
AWS - deployment bucket policy for HTTPS only

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -299,6 +299,9 @@ module.exports = {
   getDeploymentBucketOutputLogicalId() {
     return 'ServerlessDeploymentBucketName';
   },
+  getDeploymentBucketPolicyLogicalId() {
+    return 'ServerlessDeploymentBucketPolicy';
+  },
   normalizeBucketName(bucketName) {
     return this.normalizeNameToAlphaNumericOnly(bucketName);
   },

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -470,6 +470,12 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getDeploymentBucketPolicyLogicalId()', () => {
+    it('should return "ServerlessDeploymentBucketPolicy"', () => {
+      expect(sdk.naming.getDeploymentBucketPolicyLogicalId()).to.equal('ServerlessDeploymentBucketPolicy');
+    });
+  });
+
   describe('#normalizeBucketName()', () => {
     it('should remove all non-alpha-numeric characters and capitalize the first letter', () => {
       expect(sdk.naming.normalizeBucketName('b!u@c#k$e%t^N&a*m(e')).to.equal('BucketName');

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -472,7 +472,9 @@ describe('#naming()', () => {
 
   describe('#getDeploymentBucketPolicyLogicalId()', () => {
     it('should return "ServerlessDeploymentBucketPolicy"', () => {
-      expect(sdk.naming.getDeploymentBucketPolicyLogicalId()).to.equal('ServerlessDeploymentBucketPolicy');
+      expect(sdk.naming.getDeploymentBucketPolicyLogicalId()).to.equal(
+        'ServerlessDeploymentBucketPolicy'
+      );
     });
   });
 

--- a/lib/plugins/aws/package/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/package/lib/core-cloudformation-template.json
@@ -29,16 +29,11 @@
               "Effect": "Deny",
               "Principal": "*",
               "Resource": [
-                { "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    { "Ref": "ServerlessDeploymentBucket" },
-                    "/*"
-                  ]
-                ]}
+                {
+                  "Fn::Join": ["", ["arn:aws:s3:::", { "Ref": "ServerlessDeploymentBucket" }, "/*"]]
+                }
               ],
-              "Condition":{
+              "Condition": {
                 "Bool": { "aws:SecureTransport": false }
               }
             }

--- a/lib/plugins/aws/package/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/package/lib/core-cloudformation-template.json
@@ -15,6 +15,36 @@
           ]
         }
       }
+    },
+    "ServerlessDeploymentBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "ServerlessDeploymentBucket"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                { "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    { "Ref": "ServerlessDeploymentBucket" },
+                    "/*"
+                  ]
+                ]}
+              ],
+              "Condition":{
+                "Bool": { "aws:SecureTransport": false }
+              }
+            }
+          ]
+        }
+      }
     }
   },
   "Outputs": {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -47,8 +47,9 @@ describe('#generateCoreTemplate()', () => {
 
   it('should reject non-HTTPS requests to the deployment bucket', () => {
     return expect(awsPlugin.generateCoreTemplate()).to.be.fulfilled.then(() => {
-      const serverlessDeploymentBucketPolicy = awsPlugin.serverless.service.provider
-        .compiledCloudFormationTemplate.Resources.ServerlessDeploymentBucketPolicy;
+      const serverlessDeploymentBucketPolicy =
+        awsPlugin.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ServerlessDeploymentBucketPolicy;
 
       expect(serverlessDeploymentBucketPolicy).to.exist;
       expect(serverlessDeploymentBucketPolicy.Type).to.equal('AWS::S3::BucketPolicy');
@@ -65,14 +66,7 @@ describe('#generateCoreTemplate()', () => {
         Effect: 'Deny',
         Principal: '*',
         Resource: [
-          { 'Fn::Join': [
-            '',
-            [
-              'arn:aws:s3:::',
-              { Ref: 'ServerlessDeploymentBucket' },
-              '/*',
-            ],
-          ]},
+          { 'Fn::Join': ['', ['arn:aws:s3:::', { Ref: 'ServerlessDeploymentBucket' }, '/*']] },
         ],
         Condition: {
           Bool: { 'aws:SecureTransport': false },

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -45,6 +45,42 @@ describe('#generateCoreTemplate()', () => {
     };
   });
 
+  it('should reject non-HTTPS requests to the deployment bucket', () => {
+    return expect(awsPlugin.generateCoreTemplate()).to.be.fulfilled.then(() => {
+      const serverlessDeploymentBucketPolicy = awsPlugin.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources.ServerlessDeploymentBucketPolicy;
+
+      expect(serverlessDeploymentBucketPolicy).to.exist;
+      expect(serverlessDeploymentBucketPolicy.Type).to.equal('AWS::S3::BucketPolicy');
+      expect(serverlessDeploymentBucketPolicy.Properties).to.exist;
+      expect(serverlessDeploymentBucketPolicy.Properties.Bucket).to.deep.equal({
+        Ref: 'ServerlessDeploymentBucket',
+      });
+
+      expect(serverlessDeploymentBucketPolicy.Properties.PolicyDocument).to.exist;
+      expect(serverlessDeploymentBucketPolicy.Properties.PolicyDocument.Statement).to.exist;
+
+      expect(serverlessDeploymentBucketPolicy.Properties.PolicyDocument.Statement).to.deep.include({
+        Action: 's3:*',
+        Effect: 'Deny',
+        Principal: '*',
+        Resource: [
+          { 'Fn::Join': [
+            '',
+            [
+              'arn:aws:s3:::',
+              { Ref: 'ServerlessDeploymentBucket' },
+              '/*',
+            ],
+          ]},
+        ],
+        Condition: {
+          Bool: { 'aws:SecureTransport': false },
+        },
+      });
+    });
+  });
+
   it('should use a custom bucket if specified', () => {
     const bucketName = 'com.serverless.deploys';
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

This PR adds a policy to the deployment S3 bucket to reject all non-HTTPS requests.

I believe no documentation updates are necessary, but if wrong am happy to be pointed to the right places that require updates. 

<!-- Briefly describe the scope of your PR -->

Closes #5621

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

```yaml
service: simple-service
provider:
  name: aws
  runtime: nodejs10.x
functions:
  hello:
    handler: handler.hello
```

Once deployed:

* CloudFormation will include a `ServerlessDeploymentBucketPolicy` resource
* S3 bucket with logical ID `ServerlessDeploymentBucket` will have a policy attached that restricts non-HTTPS requests

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
