### PR TITLE
Fix perms with several CloudWatch log subscriptions

### DIFF
--- a/docs/providers/aws/events/cloudwatch-log.md
+++ b/docs/providers/aws/events/cloudwatch-log.md
@@ -26,6 +26,8 @@ functions:
       - cloudwatchLog: '/aws/lambda/hello'
 ```
 
+**WARNING**: If you specify several CloudWatch Log events for one AWS Lambda function you'll only see the first subscription in the AWS Lambda Web console. This is a known AWS problem but it's only graphical, you should be able to view your CloudWatch Log Group subscriptions in the CloudWatch Web console.
+
 ## Specifying a filter
 
 Here's an example how you can specify a filter rule.

--- a/lib/plugins/aws/package/compile/events/cloudWatchLog/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchLog/index.js
@@ -151,7 +151,7 @@ class AwsCompileCloudWatchLogEvents {
 
   longestCommonSuffix(logGroupNames) {
     const first = logGroupNames[0];
-    const longestCommon = logGroupNames.reduce((last, current) => {
+    let longestCommon = logGroupNames.reduce((last, current) => {
       for (let i = 0; i < last.length; i++) {
         if (last[i] !== current[i]) {
           return last.substring(0, i);
@@ -159,7 +159,12 @@ class AwsCompileCloudWatchLogEvents {
       }
       return last;
     }, first);
-    return longestCommon + (longestCommon === first ? '' : '*');
+
+    if (logGroupNames.length > 1 && !longestCommon.endsWith('*')) {
+      longestCommon += '*';
+    }
+
+    return longestCommon;
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/cloudWatchLog/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchLog/index.test.js
@@ -311,6 +311,15 @@ describe('AwsCompileCloudWatchLogEvents', () => {
       expect(
         awsCompileCloudWatchLogEvents.longestCommonSuffix(['/aws/lambda/*', '/aws/lambda/hello'])
       ).to.equal('/aws/lambda/*');
+      expect(
+        awsCompileCloudWatchLogEvents.longestCommonSuffix(['/aws/lambda', '/aws/lambda/hello'])
+      ).to.equal('/aws/lambda*');
+      expect(
+        awsCompileCloudWatchLogEvents.longestCommonSuffix([
+          '/aws/lambda/yada-dev-dummy',
+          '/aws/lambda/yada-dev-dummy2',
+        ])
+      ).to.equal('/aws/lambda/yada-dev-dummy*');
     });
 
     it('should throw an error if "logGroup" is duplicated in one CloudFormation stack', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Closes #6266 and possibly #5833

This PR completes the work associated to https://github.com/serverless/serverless/pull/5531. But in some specific cases it did not work when several events were provided for the samel AWS Lambda function.

See the test cases to see 2 cases were the CloudWatch Log Group ARN prefix with `*` was not correctly created.

Withou this fix the following error could be encountered (because the expression was not "complete enough" to target all the CloudWatch Log Groups specified).

```
Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function. (Service: AWSLogs; Status Code: 400; Error Code: InvalidParameterException; Request ID: 0b096e01-87d2-11e9-b52a-59a1410a5e04
```

I tested the fix and successfully deployed my Lambda function with 3 subscriptions.

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
