### PR TITLE
AWS - adding naming function for S3 compiled template file name.

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -21,7 +21,7 @@ module.exports = {
   uploadCloudFormationFile() {
     this.serverless.cli.log('Uploading CloudFormation file to S3...');
 
-    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
+    const compiledTemplateFileName = this.provider.naming.getCompiledTemplateS3Suffix();
 
     const compiledCfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
     const normCfTemplate = normalizeFiles.normalizeCloudFormationTemplate(compiledCfTemplate);

--- a/lib/plugins/aws/deploy/lib/validateTemplate.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.js
@@ -1,11 +1,12 @@
 'use strict';
+const getCompiledTemplateS3Suffix = require('../../lib/naming').getCompiledTemplateS3Suffix;
 const getS3EndpointForRegion = require('../../utils/getS3EndpointForRegion');
 
 module.exports = {
   validateTemplate() {
     const bucketName = this.bucketName;
     const artifactDirectoryName = this.serverless.service.package.artifactDirectoryName;
-    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
+    const compiledTemplateFileName = getCompiledTemplateS3Suffix();
     const s3Endpoint = getS3EndpointForRegion(this.provider.getRegion());
     this.serverless.cli.log('Validating template...');
     const params = {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -75,6 +75,10 @@ module.exports = {
     return 'cloudformation-template-update-stack.json';
   },
 
+  getCompiledTemplateS3Suffix() {
+    return 'compiled-cloudformation-template.json';
+  },
+
   getCoreTemplateFileName() {
     return 'cloudformation-template-create-stack.json';
   },

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -13,7 +13,7 @@ module.exports = {
 
     const stackName = this.provider.naming.getStackName();
     let stackTags = { STAGE: this.provider.getStage() };
-    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
+    const compiledTemplateFileName = this.provider.naming.getCompiledTemplateS3Suffix();
     const s3Endpoint = getS3EndpointForRegion(this.provider.getRegion());
     const templateUrl = `https://${s3Endpoint}/${this.bucketName}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`;
 
@@ -52,7 +52,7 @@ module.exports = {
   },
 
   update() {
-    const compiledTemplateFileName = 'compiled-cloudformation-template.json';
+    const compiledTemplateFileName = this.provider.naming.getCompiledTemplateS3Suffix();
     const s3Endpoint = getS3EndpointForRegion(this.provider.getRegion());
     const templateUrl = `https://${s3Endpoint}/${this.bucketName}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`;
 

--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -70,7 +70,7 @@ class AwsRollback {
         const exists = _.some(deployments, deployment =>
           _.some(deployment, {
             directory: dateString,
-            file: 'compiled-cloudformation-template.json',
+            file: this.provider.naming.getCompiledTemplateS3Suffix(),
           })
         );
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

The name of the CloudFormation template file in S3 is `compiled-cloudformation-template.json`. Instead of hardcoding that string everywhere, this PR hardcodes it once in `naming.js`. 

Does not close any issues that are currently open.

## How can we verify it

Automated tests.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
