### PR TITLE
Chore - stop using deprecated 'new Buffer()' method.

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -36,7 +36,7 @@ class CLI {
       inputArray = process.argv.slice(2);
     }
 
-    const base64Encode = valueStr => new Buffer(valueStr).toString('base64');
+    const base64Encode = valueStr => Buffer.from(valueStr).toString('base64');
 
     const toBase64Helper = value => {
       const valueStr = value.toString();
@@ -58,7 +58,7 @@ class CLI {
 
     const decodedArgsHelper = arg => {
       if (_.isString(arg)) {
-        return new Buffer(arg, 'base64').toString();
+        return Buffer.from(arg, 'base64').toString();
       } else if (_.isArray(arg)) {
         return _.map(arg, decodedArgsHelper);
       }

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -2065,7 +2065,7 @@ describe('PluginManager', () => {
         process.stdout.write(error.stderr);
         throw error;
       }
-      const stringifiedOutput = new Buffer(output, 'base64').toString();
+      const stringifiedOutput = Buffer.from(output, 'base64').toString();
       expect(stringifiedOutput).to.contain('SynchronousPluginMock');
       expect(stringifiedOutput).to.contain('PromisePluginMock');
     });

--- a/lib/plugins/aws/deployFunction/index.test.js
+++ b/lib/plugins/aws/deployFunction/index.test.js
@@ -539,7 +539,7 @@ describe('AwsDeployFunction', () => {
 
     it('should log artifact size', () => {
       // awnY7Oi280gp5kTCloXzsqJCO4J766x6hATWqQsN/uM= <-- hash of the local zip file
-      readFileSyncStub.returns(new Buffer('my-service.zip content'));
+      readFileSyncStub.returns(Buffer.from('my-service.zip content'));
 
       return awsDeployFunction.deployFunction().then(() => {
         const expected = 'Uploading function: first (1 KB)...';

--- a/lib/plugins/aws/invoke/index.js
+++ b/lib/plugins/aws/invoke/index.js
@@ -74,7 +74,7 @@ class AwsInvoke {
       FunctionName: this.options.functionObj.name,
       InvocationType: invocationType,
       LogType: this.options.log,
-      Payload: new Buffer(JSON.stringify(this.options.data || {})),
+      Payload: Buffer.from(JSON.stringify(this.options.data || {})),
     };
 
     if (this.options.qualifier) {
@@ -97,7 +97,7 @@ class AwsInvoke {
       this.consoleLog(
         chalk.gray('--------------------------------------------------------------------')
       );
-      const logResult = new Buffer(invocationReply.LogResult, 'base64').toString();
+      const logResult = Buffer.from(invocationReply.LogResult, 'base64').toString();
       logResult.split('\n').forEach(line => this.consoleLog(formatLambdaLogEvent(line)));
     }
 

--- a/lib/plugins/aws/invoke/index.test.js
+++ b/lib/plugins/aws/invoke/index.test.js
@@ -226,7 +226,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'RequestResponse',
             LogType: 'None',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
           })
         ).to.be.equal(true);
         awsInvoke.provider.request.restore();
@@ -242,7 +242,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'RequestResponse',
             LogType: 'Tail',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
           })
         ).to.be.equal(true);
         awsInvoke.provider.request.restore();
@@ -259,7 +259,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'OtherType',
             LogType: 'None',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
           })
         ).to.be.equal(true);
         awsInvoke.provider.request.restore();
@@ -277,7 +277,7 @@ describe('AwsInvoke', () => {
             FunctionName: 'customName',
             InvocationType: 'RequestResponse',
             LogType: 'None',
-            Payload: new Buffer(JSON.stringify({})),
+            Payload: Buffer.from(JSON.stringify({})),
             Qualifier: 'somelongqualifier',
           })
         ).to.be.equal(true);

--- a/lib/plugins/aws/invokeLocal/java/src/main/java/com/serverless/InvokeBridge.java
+++ b/lib/plugins/aws/invokeLocal/java/src/main/java/com/serverless/InvokeBridge.java
@@ -136,7 +136,7 @@ public class InvokeBridge {
   }
 
   private String getInput() throws IOException {
-    BufferedReader streamReader = Buffer.fromedReader(new InputStreamReader(System.in, "UTF-8"));
+    BufferedReader streamReader = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
     StringBuilder inputStringBuilder = new StringBuilder();
     String inputStr;
 

--- a/lib/plugins/aws/invokeLocal/java/src/main/java/com/serverless/InvokeBridge.java
+++ b/lib/plugins/aws/invokeLocal/java/src/main/java/com/serverless/InvokeBridge.java
@@ -136,7 +136,7 @@ public class InvokeBridge {
   }
 
   private String getInput() throws IOException {
-    BufferedReader streamReader = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
+    BufferedReader streamReader = Buffer.fromedReader(new InputStreamReader(System.in, "UTF-8"));
     StringBuilder inputStringBuilder = new StringBuilder();
     String inputStr;
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2357,7 +2357,7 @@ describe('AwsCompileFunctions', () => {
       });
 
       it('should throw for object type Buffer', () => {
-        const role = new Buffer('Foo');
+        const role = Buffer.from('Foo');
         const resource = { Properties: {} };
 
         expect(() => awsCompileFunctions.compileRole(resource, role)).to.throw(Error);

--- a/lib/plugins/aws/rollbackFunction/index.test.js
+++ b/lib/plugins/aws/rollbackFunction/index.test.js
@@ -207,7 +207,7 @@ describe('AwsRollbackFunction', () => {
 
     it('should restore the provided function', () => {
       awsRollbackFunction.options.function = 'hello';
-      const zipBuffer = new Buffer('');
+      const zipBuffer = Buffer.from('');
 
       return awsRollbackFunction.restoreFunction(zipBuffer).then(() => {
         expect(updateFunctionCodeStub.calledOnce).to.equal(true);

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -78,7 +78,7 @@ describe('zipService', () => {
     });
 
     it('should keep the file content as is', () => {
-      const buf = new Buffer([10, 20, 30, 40, 50]);
+      const buf = Buffer.from([10, 20, 30, 40, 50]);
       const filePath = path.join(servicePath, 'bin-file');
 
       fs.writeFileSync(filePath, buf);
@@ -98,7 +98,7 @@ describe('zipService', () => {
     });
 
     it('should keep the file content as is', () => {
-      const buf = new Buffer([10, 20, 30, 40, 50]);
+      const buf = Buffer.from([10, 20, 30, 40, 50]);
       const filePath = path.join(servicePath, 'bin-file');
 
       fs.writeFileSync(filePath, buf);


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Switch all uses of `new Buffer()` to `Buffer.from()`, as the former is deprecated. This change was done by running:

```sh
git ls-files -z | xargs -0 sed -i -e 's/new Buffer/Buffer.from/g'
```

Does not close any issues that are currently open.

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->
Automated tests

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
