### PR TITLE
Revert "Pause for mfa input"

### DIFF
--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -51,9 +51,9 @@ class AwsPackage {
        * Outer lifecycle hooks
        */
       'package:cleanup': () =>
-        BbPromise.bind(this).then(() =>
-          this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')
-        ),
+        BbPromise.bind(this)
+          .then(() => this.serverless.pluginManager.spawn('aws:common:validate'))
+          .then(() => this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')),
 
       'package:initialize': () => BbPromise.bind(this).then(this.generateCoreTemplate),
 

--- a/lib/plugins/aws/package/index.test.js
+++ b/lib/plugins/aws/package/index.test.js
@@ -109,12 +109,16 @@ describe('AwsPackage', () => {
     });
 
     it('should run "package:cleanup" hook', () => {
+      const spawnAwsCommonValidateStub = spawnStub.withArgs('aws:common:validate').resolves();
       const spawnAwsCommonCleanupTempDirStub = spawnStub
         .withArgs('aws:common:cleanupTempDir')
         .resolves();
 
       return awsPackage.hooks['package:cleanup']().then(() => {
-        expect(spawnAwsCommonCleanupTempDirStub.calledOnce).to.equal(true);
+        expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
+        expect(spawnAwsCommonCleanupTempDirStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(
+          true
+        );
       });
     });
 


### PR DESCRIPTION
Reverts serverless/serverless#6780 and reopens: #6576

After merging #6780 our integration tests started to fail: https://travis-ci.org/serverless/serverless/jobs/597530715#L486

As I've investigated problem is that generated log grup has name `/aws/websocket/{serviceName}-undefined` while before that merge it was `/aws/websocket/{serviceName}-{stage}`.

What was overlooked, is that `validate()` method aside of resolving AWS credentials, also normalizes `options.stage` and `options.region`: https://github.com/serverless/serverless/blob/a4342239ea46e6c4b3951a23464a8f93e8daab16/lib/plugins/aws/lib/validate.js#L16-L17

And now it's not done before some logic which depends on it jumps in.

@drexler To come up with proper solution for https://github.com/serverless/serverless/issues/6576 can you help us reproduce the problem? I've successfully setup MFA with my AWS account, which is also triggered for me when I run some AWS CLI commands directly, but I don't have a success in triggering MFA prompt when running Framework commands (this area was never explored by me)

