### PR TITLE
IoT integration tests

### DIFF
--- a/tests/integration-all/iot/service/core.js
+++ b/tests/integration-all/iot/service/core.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// NOTE: the `utils.js` file is bundled into the deployment package
+// eslint-disable-next-line
+const { log } = require('./utils');
+
+function iotBasic(event, context, callback) {
+  const functionName = 'iotBasic';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { iotBasic };

--- a/tests/integration-all/iot/service/serverless.yml
+++ b/tests/integration-all/iot/service/serverless.yml
@@ -1,0 +1,13 @@
+service: CHANGE_TO_UNIQUE_PER_RUN
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+
+functions:
+  iotBasic:
+    handler: core.iotBasic
+    events:
+      - iot:
+          sql: "SELECT * FROM 'CHANGE_TO_UNIQUE_PER_RUN'"

--- a/tests/integration-all/iot/tests.js
+++ b/tests/integration-all/iot/tests.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const path = require('path');
+const { expect } = require('chai');
+
+const { getTmpDirPath } = require('../../utils/fs');
+const { publishIotData } = require('../../utils/iot');
+const {
+  createTestService,
+  deployService,
+  removeService,
+  waitForFunctionLogs,
+} = require('../../utils/misc');
+const { getMarkers } = require('../shared/utils');
+
+describe('AWS - IoT Integration Test', function() {
+  this.timeout(1000 * 60 * 100); // Involves time-taking deploys
+  let serviceName;
+  let stackName;
+  let iotTopic;
+  let tmpDirPath;
+  const stage = 'dev';
+
+  before(() => {
+    tmpDirPath = getTmpDirPath();
+    console.info(`Temporary path: ${tmpDirPath}`);
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      filesToAdd: [path.join(__dirname, '..', 'shared')],
+      serverlessConfigHook:
+        // Ensure unique topics (to avoid collision among concurrent CI runs)
+        config => {
+          iotTopic = `${config.service}/test`;
+          config.functions.iotBasic.events[0].iot.sql = `SELECT * FROM '${iotTopic}'`;
+        },
+    });
+    serviceName = serverlessConfig.service;
+    stackName = `${serviceName}-${stage}`;
+    console.info(`Deploying "${stackName}" service...`);
+    return deployService(tmpDirPath);
+  });
+
+  after(() => {
+    // Topics are ephemeral and IoT endpoint is part of the account
+    console.info('Removing service...');
+    removeService(tmpDirPath);
+  });
+
+  describe('Basic Setup', () => {
+    it('should invoke on a topic message matching the rule', () => {
+      const functionName = 'iotBasic';
+      const markers = getMarkers(functionName);
+      const message = JSON.stringify({ message: 'Hello from IoT!' });
+
+      // NOTE: This test may fail on fresh accounts where the IoT endpoint has not completed provisioning
+      return publishIotData(iotTopic, message)
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(logs).to.include(message);
+        });
+    });
+  });
+});

--- a/tests/integration-all/s3/tests.js
+++ b/tests/integration-all/s3/tests.js
@@ -104,7 +104,7 @@ describe('AWS - S3 Integration Test', function() {
   });
 
   describe('Existing Setup', () => {
-    describe('Single fuction / single bucket setup', () => {
+    describe('Single function / single bucket setup', () => {
       it('should invoke function when an object is created', () => {
         const functionName = 'existing';
         const markers = getMarkers(functionName);


### PR DESCRIPTION
## What did you implement

Integration tests for AWS IoT rule invoked lambdas.

Closes #6735 

## How can we verify it

~The test `AWS - IoT Integration Test > Basic Setup` should run as part of the CI for this PR.~

I do not think that the integration tests _did_ run as part of the CI.

`npm run integration-test-run-all` will run all integration tests against a the locally configured AWS account (so make sure you set-up a test one!). I developed against a modified version of this command which limited the suite to `mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check tests/integration-all/iot/tests.js"` as the whole suite takes circa 30 minutes to run.

## Todos

*The owner of the AWS account doing the integration test may need to visit https://console.aws.amazon.com/iot/home?region=us-east-1#/settings to provision the IoT Core endpoint.*

This is because we use `iotData::publish` to send data through the endpoint. As far as I can see AWS do not allow you to programatically determine if the endpoint has been provisioned. In testing `iot:describeEndpoint` always returned even if the endpoint has not yet finished provisioning.

- [x] Write and run all tests
- [ ] ~Write documentation~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
