### PR TITLE
Fixing an Azure docs broken link

### DIFF
--- a/docs/providers/azure/guide/quick-start.md
+++ b/docs/providers/azure/guide/quick-start.md
@@ -60,7 +60,7 @@ Deploy your new service to Azure! The first time you do this, you will be asked 
 $ sls deploy
 ```
 
-For more advanced deployment scenarios, see our [deployment docs](https://github.com/serverless/serverless-azure-functions/blob/dev/docs/DEPLOY.md)
+For more advanced deployment scenarios, see our [deployment docs](https://github.com/serverless/serverless-azure-functions/blob/master/docs/DEPLOY.md)
 
 ## Test Your Function App
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Clicking the original link in the [Serverless web site](https://serverless.com/framework/docs/providers/azure/guide/quick-start/) leads to a broken link.

## How can we verify it

Click on the link.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
