### PR TITLE
Support for NotAction and NotResource in IAM role statements

### DIFF
--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -192,12 +192,12 @@ module.exports = {
       violationsFound = 'it is not an array';
     } else {
       const descriptions = statements.map((statement, i) => {
-        const missing = ['Effect', 'Action', 'Resource'].filter(
-          prop => statement[prop] === undefined
+        const missing = [['Effect'], ['Action', 'NotAction'], ['Resource', 'NotResource']].filter(
+          props => props.every(prop => statement[prop] === undefined)
         );
         return missing.length === 0
           ? null
-          : `statement ${i} is missing the following properties: ${missing.join(', ')}`;
+          : `statement ${i} is missing the following properties: ${missing.map(m => m.join('/')).join(', ')}`;
       });
       const flawed = descriptions.filter(curr => curr);
       if (flawed.length) {
@@ -208,7 +208,7 @@ module.exports = {
     if (violationsFound) {
       const errorMessage = [
         'iamRoleStatements should be an array of objects,',
-        ' where each object has Effect, Action, Resource fields.',
+        ' where each object has Effect, Action/NotAction, Resource/NotResource fields.',
         ` Specifically, ${violationsFound}`,
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -197,7 +197,9 @@ module.exports = {
         );
         return missing.length === 0
           ? null
-          : `statement ${i} is missing the following properties: ${missing.map(m => m.join('/')).join(', ')}`;
+          : `statement ${i} is missing the following properties: ${missing
+              .map(m => m.join('/'))
+              .join(', ')}`;
       });
       const flawed = descriptions.filter(curr => curr);
       if (flawed.length) {

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -210,7 +210,7 @@ module.exports = {
     if (violationsFound) {
       const errorMessage = [
         'iamRoleStatements should be an array of objects,',
-        ' where each object has Effect, Action/NotAction, Resource/NotResource fields.',
+        ' where each object has Effect, Action / NotAction, Resource / NotResource fields.',
         ` Specifically, ${violationsFound}`,
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -198,7 +198,7 @@ module.exports = {
         return missing.length === 0
           ? null
           : `statement ${i} is missing the following properties: ${missing
-              .map(m => m.join('/'))
+              .map(m => m.join(' / '))
               .join(', ')}`;
       });
       const flawed = descriptions.filter(curr => curr);

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -513,8 +513,26 @@ describe('#mergeIamTemplates()', () => {
     ];
 
     expect(() => awsPackage.mergeIamTemplates()).to.throw(
-      'missing the following properties: Action'
+      'missing the following properties: Action/NotAction'
     );
+  });
+
+  it('should not throw error if a custom IAM policy statement has a NotAction field', () => {
+    awsPackage.serverless.service.provider.iamRoleStatements = [
+      {
+        Effect: 'Allow',
+        Resource: '*',
+        NotAction: 'iam:DeleteUser',
+      },
+    ];
+
+    return awsPackage.mergeIamTemplates().then(() => {
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          awsPackage.provider.naming.getRoleLogicalId()
+        ].Properties.Policies[0].PolicyDocument.Statement[2]
+      ).to.deep.equal(awsPackage.serverless.service.provider.iamRoleStatements[0]);
+    });
   });
 
   it('should throw error if a custom IAM policy statement does not have a Resource field', () => {
@@ -526,8 +544,26 @@ describe('#mergeIamTemplates()', () => {
     ];
 
     expect(() => awsPackage.mergeIamTemplates()).to.throw(
-      'missing the following properties: Resource'
+      'missing the following properties: Resource/NotResource'
     );
+  });
+
+  it('should not throw error if a custom IAM policy statement has a NotResource field', () => {
+    awsPackage.serverless.service.provider.iamRoleStatements = [
+      {
+        Action: ['something:SomethingElse'],
+        Effect: 'Allow',
+        NotResource: 'arn:aws:sns:*:*:*',
+      },
+    ];
+
+    return awsPackage.mergeIamTemplates().then(() => {
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          awsPackage.provider.naming.getRoleLogicalId()
+        ].Properties.Policies[0].PolicyDocument.Statement[2]
+      ).to.deep.equal(awsPackage.serverless.service.provider.iamRoleStatements[0]);
+    });
   });
 
   it('should throw an error describing all problematics custom IAM policy statements', () => {
@@ -547,7 +583,7 @@ describe('#mergeIamTemplates()', () => {
     ];
 
     expect(() => awsPackage.mergeIamTemplates()).to.throw(
-      /statement 0 is missing.*Resource; statement 2 is missing.*Effect, Action/
+      /statement 0 is missing.*Resource\/NotResource; statement 2 is missing.*Effect, Action\/NotAction/
     );
   });
 

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -513,7 +513,7 @@ describe('#mergeIamTemplates()', () => {
     ];
 
     expect(() => awsPackage.mergeIamTemplates()).to.throw(
-      'missing the following properties: Action/NotAction'
+      'missing the following properties: Action / NotAction'
     );
   });
 
@@ -544,7 +544,7 @@ describe('#mergeIamTemplates()', () => {
     ];
 
     expect(() => awsPackage.mergeIamTemplates()).to.throw(
-      'missing the following properties: Resource/NotResource'
+      'missing the following properties: Resource / NotResource'
     );
   });
 
@@ -583,7 +583,7 @@ describe('#mergeIamTemplates()', () => {
     ];
 
     expect(() => awsPackage.mergeIamTemplates()).to.throw(
-      /statement 0 is missing.*Resource\/NotResource; statement 2 is missing.*Effect, Action\/NotAction/
+      /statement 0 is missing.*Resource \/ NotResource; statement 2 is missing.*Effect, Action \/ NotAction/
     );
   });
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

Support for NotAction and NotResource in IAM role statements.

<!-- Briefly describe the scope of your PR -->

Closes #6841

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->
```yaml
service: simple-service
provider:
  name: aws
  runtime: nodejs10.x
  iamRoleStatements:
    - Effect: 'Allow'
      Action: 'sns:Publish'
      NotResource: 'arn:aws:sns:*:*:*'
functions:
  hello:
    handler: handler.hello
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
