### PR TITLE
added frontmatter to sdk docs

### DIFF
--- a/docs/dashboard/sdk/README.md
+++ b/docs/dashboard/sdk/README.md
@@ -4,6 +4,12 @@ menuText: sdk
 layout: Doc
 -->
 
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/sdk/)
+
+<!-- DOCS-SITE-LINK:END -->
+
 # `serverless_sdk`
 
 When using the Serverless Dashboard, the framework automatically injects the `serverless_sdk`

--- a/docs/dashboard/sdk/README.md
+++ b/docs/dashboard/sdk/README.md
@@ -1,3 +1,9 @@
+<!--
+title: Serverless SDK
+menuText: sdk
+layout: Doc
+-->
+
 # `serverless_sdk`
 
 When using the Serverless Dashboard, the framework automatically injects the `serverless_sdk`

--- a/docs/dashboard/sdk/nodejs.md
+++ b/docs/dashboard/sdk/nodejs.md
@@ -3,6 +3,13 @@ title: Serverless SDK - Node.js
 menuText: nodejs
 layout: Doc
 -->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/sdk/nodejs/)
+
+<!-- DOCS-SITE-LINK:END -->
+
 # `captureError`
 
 Your lambda function may throw an exception, but your function handles it in order to respond to

--- a/docs/dashboard/sdk/nodejs.md
+++ b/docs/dashboard/sdk/nodejs.md
@@ -1,5 +1,5 @@
 <!--
-title: Serverless SDK
+title: Serverless SDK - Node.js
 menuText: nodejs
 layout: Doc
 -->

--- a/docs/dashboard/sdk/nodejs.md
+++ b/docs/dashboard/sdk/nodejs.md
@@ -1,3 +1,8 @@
+<!--
+title: Serverless SDK
+menuText: nodejs
+layout: Doc
+-->
 # `captureError`
 
 Your lambda function may throw an exception, but your function handles it in order to respond to

--- a/docs/dashboard/sdk/python.md
+++ b/docs/dashboard/sdk/python.md
@@ -1,5 +1,5 @@
 <!--
-title: Serverless SDK
+title: Serverless SDK - Python
 menuText: python
 layout: Doc
 -->

--- a/docs/dashboard/sdk/python.md
+++ b/docs/dashboard/sdk/python.md
@@ -1,3 +1,8 @@
+<!--
+title: Serverless SDK
+menuText: python
+layout: Doc
+-->
 # `capture_exception`
 
 Your lambda function may throw an exception, but your function handles it in order to respond to

--- a/docs/dashboard/sdk/python.md
+++ b/docs/dashboard/sdk/python.md
@@ -3,6 +3,13 @@ title: Serverless SDK - Python
 menuText: python
 layout: Doc
 -->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/sdk/python/)
+
+<!-- DOCS-SITE-LINK:END -->
+
 # `capture_exception`
 
 Your lambda function may throw an exception, but your function handles it in order to respond to


### PR DESCRIPTION
There was frontmatter missing in the new sdk docs (docs/dashboard/sdk) and this broke serverless.com website build. 

I've fixed this by adding frontmatter to the docs mentioned above.

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
