### PR TITLE
SNS integration tests

### DIFF
--- a/tests/integration-all/sns/service/core.js
+++ b/tests/integration-all/sns/service/core.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// NOTE: the `utils.js` file is bundled into the deployment package
+// eslint-disable-next-line
+const { log } = require('./utils');
+
+function snsMinimal(event, context, callback) {
+  const functionName = 'snsMinimal';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+function snsMultipleFilteredLeft(event, context, callback) {
+  const functionName = 'snsMultipleFilteredLeft';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+function snsMultipleFilteredRight(event, context, callback) {
+  const functionName = 'snsMultipleFilteredRight';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+function snsExisting(event, context, callback) {
+  const functionName = 'snsExisting';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { snsMinimal, snsMultipleFilteredLeft, snsMultipleFilteredRight, snsExisting };

--- a/tests/integration-all/sns/service/serverless.yml
+++ b/tests/integration-all/sns/service/serverless.yml
@@ -1,0 +1,44 @@
+service: CHANGE_TO_UNIQUE_PER_RUN
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+
+functions:
+  snsMinimal:
+    handler: core.snsMinimal
+    events:
+      - sns: CHANGE_TO_UNIQUE_PER_RUN
+
+  snsMultipleFilteredLeft:
+    handler: core.snsMultipleFilteredLeft
+    events:
+      - sns:
+          topicName: CHANGE_TO_UNIQUE_PER_RUN
+          displayName: CHANGE_TO_UNIQUE_PER_RUN
+          filterPolicy:
+            side:
+              - left
+  snsMultipleFilteredRight:
+    handler: core.snsMultipleFilteredRight
+    events:
+      - sns:
+          topicName: CHANGE_TO_UNIQUE_PER_RUN
+          displayName: CHANGE_TO_UNIQUE_PER_RUN
+          filterPolicy:
+            side:
+              - right
+
+  snsExisting:
+    handler: core.snsExisting
+    events:
+      - sns:
+          arn:
+            Fn::Join:
+              - ':'
+              - - 'arn:aws:sns'
+                - Ref: 'AWS::Region'
+                - Ref: 'AWS::AccountId'
+                - CHANGE_TO_UNIQUE_PER_RUN
+          topicName: CHANGE_TO_UNIQUE_PER_RUN

--- a/tests/integration-all/sns/tests.js
+++ b/tests/integration-all/sns/tests.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const path = require('path');
+const BbPromise = require('bluebird');
+const { expect } = require('chai');
+
+const { getTmpDirPath } = require('../../utils/fs');
+const { createSnsTopic, removeSnsTopic, publishSnsMessage } = require('../../utils/sns');
+const {
+  createTestService,
+  deployService,
+  removeService,
+  waitForFunctionLogs,
+} = require('../../utils/misc');
+const { getMarkers } = require('../shared/utils');
+
+describe('AWS - SNS Integration Test', function() {
+  this.timeout(1000 * 60 * 100); // Involves time-taking deploys
+  let serviceName;
+  let stackName;
+  let tmpDirPath;
+  let minimalTopicName;
+  let filteredTopicName;
+  let existingTopicName;
+  const stage = 'dev';
+
+  before(() => {
+    tmpDirPath = getTmpDirPath();
+    console.info(`Temporary path: ${tmpDirPath}`);
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      filesToAdd: [path.join(__dirname, '..', 'shared')],
+      serverlessConfigHook:
+        // Ensure unique topics (to avoid collision among concurrent CI runs)
+        config => {
+          minimalTopicName = `${config.service}-minimal`;
+          filteredTopicName = `${config.service}-filtered`;
+          const filteredDisplayName = `Integration Test: ${config.service}-filtered`;
+          existingTopicName = `${config.service}-existing`;
+          config.functions.snsMinimal.events[0].sns = minimalTopicName;
+          config.functions.snsMultipleFilteredLeft.events[0].sns.topicName = filteredTopicName;
+          config.functions.snsMultipleFilteredRight.events[0].sns.topicName = filteredTopicName;
+          config.functions.snsMultipleFilteredLeft.events[0].sns.displayName = filteredDisplayName;
+          config.functions.snsMultipleFilteredRight.events[0].sns.displayName = filteredDisplayName;
+          config.functions.snsExisting.events[0].sns.arn['Fn::Join'][1][3] = existingTopicName;
+          config.functions.snsExisting.events[0].sns.topicName = existingTopicName;
+        },
+    });
+    serviceName = serverlessConfig.service;
+    stackName = `${serviceName}-${stage}`;
+    // create "existing" SNS topics
+    // NOTE: deployment can only be done once the SNS topics are created
+    console.info(`Creating SNS topic "${existingTopicName}"...`);
+    return createSnsTopic(existingTopicName).then(() => {
+      console.info(`Deploying "${stackName}" service...`);
+      deployService(tmpDirPath);
+    });
+  });
+
+  after(() => {
+    console.info('Removing service...');
+    removeService(tmpDirPath);
+    console.info('Deleting SNS topics');
+    return removeSnsTopic(existingTopicName);
+  });
+
+  describe('Minimal Setup', () => {
+    it('should invoke on a topic message', () => {
+      const functionName = 'snsMinimal';
+      const markers = getMarkers(functionName);
+      const message = 'Hello from SNS!';
+
+      return publishSnsMessage(minimalTopicName, message)
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(logs).to.include(functionName);
+          expect(logs).to.include(message);
+        });
+    });
+  });
+
+  describe('Multiple and Filtered Setup', () => {
+    it('should invoke on a topic message that matches filter', () => {
+      const leftFunctionName = 'snsMultipleFilteredLeft';
+      const leftMarkers = getMarkers(leftFunctionName);
+      const rightFunctionName = 'snsMultipleFilteredRight';
+      const rightMarkers = getMarkers(rightFunctionName);
+      const leftMessage = 'Hello to the left-side from SNS!';
+      const rightMessage = 'Hello to the right-side from SNS!';
+      const middleMessage = 'Hello to the middle-side from SNS!';
+      const leftAttributes = { side: { DataType: 'String', StringValue: 'left' } };
+      const middleAttributes = { side: { DataType: 'String', StringValue: 'middle' } };
+      const rightAttributes = { side: { DataType: 'String', StringValue: 'right' } };
+
+      return BbPromise.all([
+        publishSnsMessage(filteredTopicName, leftMessage, leftAttributes),
+        publishSnsMessage(filteredTopicName, middleMessage, middleAttributes),
+        publishSnsMessage(filteredTopicName, rightMessage, rightAttributes),
+      ])
+        .then(() =>
+          BbPromise.all([
+            waitForFunctionLogs(tmpDirPath, leftFunctionName, leftMarkers.start, leftMarkers.end),
+            waitForFunctionLogs(
+              tmpDirPath,
+              rightFunctionName,
+              rightMarkers.start,
+              rightMarkers.end
+            ),
+          ])
+        )
+        .then(logs => {
+          const leftLogs = logs[0];
+          const rightLogs = logs[1];
+          // left side is filtered to only get "left" messages from topic:
+          expect(leftLogs).to.include(leftFunctionName);
+          expect(leftLogs).to.include(leftMessage);
+          expect(leftLogs).not.to.include(middleMessage);
+          expect(leftLogs).not.to.include(rightMessage);
+          // right side is filtered to only get "right" messages from topic:
+          expect(rightLogs).to.include(rightFunctionName);
+          expect(rightLogs).not.to.include(leftMessage);
+          expect(rightLogs).not.to.include(middleMessage);
+          expect(rightLogs).to.include(rightMessage);
+          // "middle" messages will not cause an invocation.
+        });
+    });
+  });
+
+  describe('Existing Setup', () => {
+    it('should invoke on an existing topic message', () => {
+      const functionName = 'snsExisting';
+      const markers = getMarkers(functionName);
+      const message = 'Hello from an existing SNS!';
+
+      return publishSnsMessage(existingTopicName, message)
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(logs).to.include(functionName);
+          expect(logs).to.include(message);
+        });
+    });
+  });
+});

--- a/tests/utils/sns/index.js
+++ b/tests/utils/sns/index.js
@@ -30,7 +30,7 @@ function removeSnsTopic(topicName) {
     });
 }
 
-function publishSnsMessage(topicName, message) {
+function publishSnsMessage(topicName, message, messageAttributes = null) {
   const SNS = new AWS.SNS({ region });
 
   return SNS.listTopics()
@@ -43,6 +43,9 @@ function publishSnsMessage(topicName, message) {
         Message: message,
         TopicArn: topicArn,
       };
+      if (messageAttributes) {
+        params.MessageAttributes = messageAttributes;
+      }
 
       return SNS.publish(params).promise();
     });


### PR DESCRIPTION
## What did you implement

Integration tests for SNS:
 * Minimal setup with topic created by name
 * Complex setup with multiple lambdas triggering on the same topic (created with name and display name) filtered on message metadata
 * Existing setup where lambda is triggered by existing topic specified by ARN. 

Closes #6737 

## How can we verify it

I do not think that the integration tests run as part of the CI for PRs.

`npm run integration-test-run-all` will run all integration tests against a the locally configured AWS account (so make sure you set-up a test one!).

I developed against a modified version of this command which limited the suite to `mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check tests/integration-all/sns/tests.js"` as the whole suite takes circa 30 minutes to run.

## Todos

- [x] Write and run all tests
- [ ] ~Write documentation~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
