### PR TITLE
SQS integration tests

### DIFF
--- a/tests/integration-all/sqs/service/core.js
+++ b/tests/integration-all/sqs/service/core.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// NOTE: the `utils.js` file is bundled into the deployment package
+// eslint-disable-next-line
+const { log } = require('./utils');
+
+function sqsBasic(event, context, callback) {
+  const functionName = 'sqsBasic';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { sqsBasic };

--- a/tests/integration-all/sqs/service/serverless.yml
+++ b/tests/integration-all/sqs/service/serverless.yml
@@ -1,0 +1,21 @@
+service: CHANGE_TO_UNIQUE_PER_RUN
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+
+functions:
+  sqsBasic:
+    handler: core.sqsBasic
+    events:
+      - sqs:
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - sqs
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - CHANGE_TO_UNIQUE_PER_RUN

--- a/tests/integration-all/sqs/tests.js
+++ b/tests/integration-all/sqs/tests.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const path = require('path');
+const { expect } = require('chai');
+
+const { getTmpDirPath } = require('../../utils/fs');
+const { createSqsQueue, deleteSqsQueue, sendSqsMessage } = require('../../utils/sqs');
+const {
+  createTestService,
+  deployService,
+  removeService,
+  waitForFunctionLogs,
+} = require('../../utils/misc');
+const { getMarkers } = require('../shared/utils');
+
+describe('AWS - SQS Integration Test', function() {
+  this.timeout(1000 * 60 * 100); // Involves time-taking deploys
+  let serviceName;
+  let stackName;
+  let tmpDirPath;
+  let queueName;
+  const stage = 'dev';
+
+  before(() => {
+    tmpDirPath = getTmpDirPath();
+    console.info(`Temporary path: ${tmpDirPath}`);
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      filesToAdd: [path.join(__dirname, '..', 'shared')],
+      serverlessConfigHook:
+        // Ensure unique queues (to avoid collision among concurrent CI runs)
+        config => {
+          queueName = `${config.service}-basic`;
+          config.functions.sqsBasic.events[0].sqs.arn['Fn::Join'][1][5] = queueName;
+        },
+    });
+    serviceName = serverlessConfig.service;
+    stackName = `${serviceName}-${stage}`;
+    // create existing SQS queue
+    // NOTE: deployment can only be done once the SQS queue is created
+    console.info(`Creating SQS queue "${queueName}"...`);
+    return createSqsQueue(queueName).then(() => {
+      console.info(`Deploying "${stackName}" service...`);
+      deployService(tmpDirPath);
+    });
+  });
+
+  after(() => {
+    console.info('Removing service...');
+    removeService(tmpDirPath);
+    console.info('Deleting SQS queue');
+    return deleteSqsQueue(queueName);
+  });
+
+  describe('Basic Setup', () => {
+    it('should invoke on queue message(s)', () => {
+      const functionName = 'sqsBasic';
+      const markers = getMarkers(functionName);
+      const message = 'Hello from SQS!';
+
+      return sendSqsMessage(queueName, message)
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(logs).to.include(functionName);
+          expect(logs).to.include(message);
+        });
+    });
+  });
+});

--- a/tests/utils/sqs/index.js
+++ b/tests/utils/sqs/index.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const { region, persistentRequest } = require('../misc');
+
+function createSqsQueue(queueName) {
+  const SQS = new AWS.SQS({ region });
+
+  const params = {
+    QueueName: queueName,
+  };
+
+  return SQS.createQueue(params).promise();
+}
+
+function deleteSqsQueue(queueName) {
+  const SQS = new AWS.SQS({ region });
+
+  return SQS.getQueueUrl({ QueueName: queueName })
+    .promise()
+    .then(data => {
+      const params = {
+        QueueUrl: data.QueueUrl,
+      };
+      return SQS.deleteQueue(params).promise();
+    });
+}
+
+function sendSqsMessage(queueName, message) {
+  const SQS = new AWS.SQS({ region });
+
+  return SQS.getQueueUrl({ QueueName: queueName })
+    .promise()
+    .then(data => {
+      const params = {
+        QueueUrl: data.QueueUrl,
+        MessageBody: message,
+      };
+      return SQS.sendMessage(params).promise();
+    });
+}
+
+module.exports = {
+  createSqsQueue: persistentRequest.bind(this, createSqsQueue),
+  deleteSqsQueue: persistentRequest.bind(this, deleteSqsQueue),
+  sendSqsMessage: persistentRequest.bind(this, sendSqsMessage),
+};


### PR DESCRIPTION
## What did you implement

Integration tests for lambda invoked by SQS message on an existing topic (Serverless does not support queue creation).

This required writing an SQS test utility module, following the pattern of the existing SNS one.

Closes #6738 

## How can we verify it

I do not think that the integration tests run as part of the CI for PRs.

`npm run integration-test-run-all` will run all integration tests against a the locally configured AWS account (so make sure you set-up a test one!).

You can use `mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check tests/integration-all/sqs/tests.js"` to specifically run the SQS tests.

## Todos

- [x] Write and run all tests
- [ ] ~Write documentation~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
