### PR TITLE
Streams integration tests

### DIFF
--- a/tests/integration-all/stream/service/core.js
+++ b/tests/integration-all/stream/service/core.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// NOTE: the `utils.js` file is bundled into the deployment package
+// eslint-disable-next-line
+const { log } = require('./utils');
+
+function streamKinesis(event, context, callback) {
+  const functionName = 'streamKinesis';
+  const { Records } = event;
+  const messages = Records.map(({ kinesis: { data } }) => Buffer.from(data, 'base64').toString());
+  log(functionName, JSON.stringify(messages));
+  return callback(null, event);
+}
+
+function streamDynamoDb(event, context, callback) {
+  const functionName = 'streamDynamoDb';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { streamKinesis, streamDynamoDb };

--- a/tests/integration-all/stream/service/serverless.yml
+++ b/tests/integration-all/stream/service/serverless.yml
@@ -1,0 +1,49 @@
+service: CHANGE_TO_UNIQUE_PER_RUN
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+
+functions:
+  streamDynamoDb:
+    handler: core.streamDynamoDb
+    events:
+      - stream:
+          type: dynamodb
+          arn:
+            Fn::GetAtt: [DynamoDbTable, StreamArn]
+          batchWindow: 10
+  streamKinesis:
+    handler: core.streamKinesis
+    events:
+      - stream:
+          type: kinesis
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - kinesis
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - stream/CHANGE_TO_UNIQUE_PER_RUN
+          batchSize: 100
+          startingPosition: TRIM_HORIZON
+          batchWindow: 1
+
+resources:
+  Resources:
+    DynamoDbTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        BillingMode: 'PAY_PER_REQUEST'
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        StreamSpecification:
+          StreamViewType: KEYS_ONLY
+        TableName: CHANGE_TO_UNIQUE_PER_RUN

--- a/tests/integration-all/stream/tests.js
+++ b/tests/integration-all/stream/tests.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const path = require('path');
+const { expect } = require('chai');
+
+const { getTmpDirPath } = require('../../utils/fs');
+const {
+  createKinesisStream,
+  deleteKinesisStream,
+  putKinesisRecord,
+} = require('../../utils/kinesis');
+const { putDynamoDbItem } = require('../../utils/dynamodb');
+const {
+  createTestService,
+  deployService,
+  removeService,
+  waitForFunctionLogs,
+} = require('../../utils/misc');
+const { getMarkers } = require('../shared/utils');
+
+describe('AWS - Stream Integration Test', function() {
+  this.timeout(1000 * 60 * 100); // Involves time-taking deploys
+  let serviceName;
+  let stackName;
+  let tmpDirPath;
+  let streamName;
+  let tableName;
+  const historicStreamMessage = 'Hello from the Kinesis horizon!';
+  const stage = 'dev';
+
+  before(() => {
+    tmpDirPath = getTmpDirPath();
+    console.info(`Temporary path: ${tmpDirPath}`);
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      filesToAdd: [path.join(__dirname, '..', 'shared')],
+      serverlessConfigHook:
+        // Ensure unique queues (to avoid collision among concurrent CI runs)
+        config => {
+          streamName = `${config.service}-kinesis`;
+          tableName = `${config.service}-table`;
+          config.functions.streamKinesis.events[0].stream.arn[
+            'Fn::Join'
+          ][1][5] = `stream/${streamName}`;
+          config.resources.Resources.DynamoDbTable.Properties.TableName = tableName;
+        },
+    });
+    serviceName = serverlessConfig.service;
+    stackName = `${serviceName}-${stage}`;
+    // create existing SQS queue
+    // NOTE: deployment can only be done once the SQS queue is created
+    console.info(`Creating Kinesis stream "${streamName}"...`);
+    return createKinesisStream(streamName)
+      .then(() => putKinesisRecord(streamName, historicStreamMessage))
+      .then(() => {
+        console.info(
+          `Deploying "${stackName}" service with DynamoDB table resource "${tableName}"...`
+        );
+        deployService(tmpDirPath);
+      });
+  });
+
+  after(() => {
+    console.info(`Removing service (and DynamoDB table resource "${tableName}")...`);
+    removeService(tmpDirPath);
+    console.info('Deleting Kinesis stream');
+    return deleteKinesisStream(streamName);
+  });
+
+  describe('Kinesis Streams', () => {
+    it('should invoke on kinesis messages from the trim horizon', () => {
+      const functionName = 'streamKinesis';
+      const markers = getMarkers(functionName);
+      const message = 'Hello from Kinesis!';
+
+      return putKinesisRecord(streamName, message)
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(logs).to.include(functionName);
+          expect(logs).to.include(message);
+          expect(logs).to.include(historicStreamMessage);
+        });
+    });
+  });
+
+  describe('DynamoDB Streams', () => {
+    it('should invoke on dynamodb messages from the latest position', () => {
+      const functionName = 'streamDynamoDb';
+      const markers = getMarkers(functionName);
+      const item = { id: 'message', hello: 'from dynamo!' };
+
+      return putDynamoDbItem(tableName, item)
+        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
+        .then(logs => {
+          expect(logs).to.include(functionName);
+          expect(logs).to.include('INSERT');
+          expect(logs).to.include(item.id);
+        });
+    });
+  });
+});

--- a/tests/utils/dynamodb/index.js
+++ b/tests/utils/dynamodb/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const { region, persistentRequest } = require('../misc');
+
+function putDynamoDbItem(tableName, item) {
+  const Ddb = new AWS.DynamoDB.DocumentClient({ region });
+
+  const params = {
+    TableName: tableName,
+    Item: item,
+  };
+
+  return Ddb.put(params).promise();
+}
+
+module.exports = {
+  putDynamoDbItem: persistentRequest.bind(this, putDynamoDbItem),
+};

--- a/tests/utils/kinesis/index.js
+++ b/tests/utils/kinesis/index.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const BbPromise = require('bluebird');
+const { region, persistentRequest } = require('../misc');
+
+function waitForKinesisStream(streamName) {
+  const Kinesis = new AWS.Kinesis({ region });
+  const params = {
+    StreamName: streamName,
+  };
+  return new BbPromise(resolve => {
+    const interval = setInterval(() => {
+      Kinesis.describeStream(params)
+        .promise()
+        .then(data => {
+          const status = data.StreamDescription.StreamStatus;
+          if (status === 'ACTIVE') {
+            clearInterval(interval);
+            return resolve(data);
+          }
+          return null;
+        });
+    }, 2000);
+  });
+}
+
+function createKinesisStream(streamName) {
+  const Kinesis = new AWS.Kinesis({ region });
+
+  const params = {
+    ShardCount: 1, // prevent complications from shards being processed in parallel
+    StreamName: streamName,
+  };
+
+  return Kinesis.createStream(params)
+    .promise()
+    .then(() => waitForKinesisStream(streamName));
+}
+
+function deleteKinesisStream(streamName) {
+  const Kinesis = new AWS.Kinesis({ region });
+
+  const params = {
+    StreamName: streamName,
+  };
+
+  return Kinesis.deleteStream(params).promise();
+}
+
+function putKinesisRecord(streamName, message) {
+  const Kinesis = new AWS.Kinesis({ region });
+
+  const params = {
+    StreamName: streamName,
+    Data: message,
+    PartitionKey: streamName, // test streams are single shards
+  };
+
+  return Kinesis.putRecord(params).promise();
+}
+
+module.exports = {
+  createKinesisStream: persistentRequest.bind(this, createKinesisStream),
+  deleteKinesisStream: persistentRequest.bind(this, deleteKinesisStream),
+  putKinesisRecord: persistentRequest.bind(this, putKinesisRecord),
+};

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -95,12 +95,17 @@ function createTestService(
 }
 
 function getFunctionLogs(cwd, functionName) {
-  const logs = execSync(`${serverlessExec} logs --function ${functionName} --noGreeting true`, {
-    cwd,
-  });
-  const logsString = Buffer.from(logs, 'base64').toString();
-  process.stdout.write(logsString);
-  return logsString;
+  try {
+    const logs = execSync(`${serverlessExec} logs --function ${functionName} --noGreeting true`, {
+      cwd,
+    });
+    const logsString = Buffer.from(logs, 'base64').toString();
+    process.stdout.write(logsString);
+    return logsString;
+  } catch (_) {
+    // Attempting to read logs before first invocation will will result in a "No existing streams for the function" error
+    return null;
+  }
 }
 
 function waitForFunctionLogs(cwd, functionName, startMarker, endMarker) {


### PR DESCRIPTION
## What did you implement

Integration tests for stream event sources:
 * Kinesis with `TRIM_HORIZON` to ensure messages prior to trigger attachment are processed
 * DynamoDB

This required writing a Kinesis test utility module, following the pattern of the existing SNS one. The setup and tear-down of the DynamoDB table and stream was done using the `resources` key in the serverless yaml file to simplify the process.

Closes #6739 

I had to modify the `tests/utils/misc/index.js > getFunctionLogs` to catch the case where the logs are waited for prior to the first invocation. This seems very common with Kinesis which can take around 30 seconds to first invoke. **Is there a better way of doing this?**.

## How can we verify it

I do not think that the integration tests run as part of the CI for PRs.

`npm run integration-test-run-all` will run all integration tests against a the locally configured AWS account (so make sure you set-up a test one!).

You can use `mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check tests/integration-all/stream/tests.js"` to specifically run the stream tests.

## Todos

- [x] Write and run all tests
- [ ] ~Write documentation~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
