### PR TITLE
Schedule integration tests

### DIFF
--- a/tests/integration-all/schedule/service/core.js
+++ b/tests/integration-all/schedule/service/core.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// NOTE: the `utils.js` file is bundled into the deployment package
+// eslint-disable-next-line
+const { log } = require('./utils');
+
+function scheduleMinimal(event, context, callback) {
+  const functionName = 'scheduleMinimal';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+function scheduleExtended(event, context, callback) {
+  const functionName = 'scheduleExtended';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { scheduleMinimal, scheduleExtended };

--- a/tests/integration-all/schedule/service/serverless.yml
+++ b/tests/integration-all/schedule/service/serverless.yml
@@ -1,0 +1,21 @@
+service: CHANGE_TO_UNIQUE_PER_RUN
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  versionFunctions: false
+
+functions:
+  scheduleMinimal:
+    handler: core.scheduleMinimal
+    events:
+      - schedule: rate(1 minute)
+  scheduleExtended:
+    handler: core.scheduleExtended
+    events:
+      - schedule:
+          rate: cron(* * * * ? *)
+          inputTransformer:
+            inputPathsMap:
+              eventTime: '$.time'
+            inputTemplate: '{"time": <eventTime>, "name": "transformedInput"}'

--- a/tests/integration-all/schedule/tests.js
+++ b/tests/integration-all/schedule/tests.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const path = require('path');
+const { expect } = require('chai');
+
+const { getTmpDirPath } = require('../../utils/fs');
+const {
+  createTestService,
+  deployService,
+  removeService,
+  waitForFunctionLogs,
+} = require('../../utils/misc');
+const { getMarkers } = require('../shared/utils');
+
+describe('AWS - Schedule Integration Test', function() {
+  this.timeout(1000 * 60 * 100); // Involves time-taking deploys
+  let serviceName;
+  let stackName;
+  let tmpDirPath;
+  const stage = 'dev';
+
+  before(() => {
+    tmpDirPath = getTmpDirPath();
+    console.info(`Temporary path: ${tmpDirPath}`);
+    const serverlessConfig = createTestService(tmpDirPath, {
+      templateDir: path.join(__dirname, 'service'),
+      filesToAdd: [path.join(__dirname, '..', 'shared')],
+    });
+    serviceName = serverlessConfig.service;
+    stackName = `${serviceName}-${stage}`;
+    console.info(`Deploying "${stackName}" service...`);
+    deployService(tmpDirPath);
+  });
+
+  after(() => {
+    console.info('Removing service...');
+    removeService(tmpDirPath);
+  });
+
+  describe('Minimal Setup', () => {
+    it('should invoke every minute', () => {
+      const functionName = 'scheduleMinimal';
+      const markers = getMarkers(functionName);
+
+      return waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end).then(
+        logs => {
+          expect(logs).to.include(functionName);
+        }
+      );
+    });
+  });
+
+  describe('Extended Setup', () => {
+    it('should invoke every minute with transformed input', () => {
+      const functionName = 'scheduleExtended';
+      const markers = getMarkers(functionName);
+
+      return waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end).then(
+        logs => {
+          expect(logs).to.include(functionName);
+          expect(logs).to.include('transformedInput');
+        }
+      );
+    });
+  });
+});

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -95,12 +95,17 @@ function createTestService(
 }
 
 function getFunctionLogs(cwd, functionName) {
-  const logs = execSync(`${serverlessExec} logs --function ${functionName} --noGreeting true`, {
-    cwd,
-  });
-  const logsString = Buffer.from(logs, 'base64').toString();
-  process.stdout.write(logsString);
-  return logsString;
+  try {
+    const logs = execSync(`${serverlessExec} logs --function ${functionName} --noGreeting true`, {
+      cwd,
+    });
+    const logsString = Buffer.from(logs, 'base64').toString();
+    process.stdout.write(logsString);
+    return logsString;
+  } catch (_) {
+    // Attempting to read logs before first invocation will will result in a "No existing streams for the function" error
+    return null;
+  }
 }
 
 function waitForFunctionLogs(cwd, functionName, startMarker, endMarker) {


### PR DESCRIPTION
## What did you implement

Integration tests for schedule event sources:
 * Minimal setup using `rate` notaiton
 * Extended setup using `cron` notation and input transformations

Closes #6736 

I had to modify `tests/utils/misc/index.js > getFunctionLogs` to catch the case where the logs are waited for prior to the first invocation. Even though the lambdas scheduled is set to the minium (every minute), it can still take up to 60 seconds for the first invoke. During this time the previous `getFunctionLogs` would throw and cause the test to end. **Is there a better way of doing this?**.

## How can we verify it

I do not think that the integration tests run as part of the CI for PRs.

`npm run integration-test-run-all` will run all integration tests against a the locally configured AWS account (so make sure you set-up a test one!).

You can use `mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check tests/integration-all/schedule/tests.js"` to specifically run the stream tests.

## Todos

- [x] Write and run all tests
- [ ] ~Write documentation~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
