### PR TITLE
Update Google provider documentation for functions

### DIFF
--- a/docs/providers/google/guide/functions.md
+++ b/docs/providers/google/guide/functions.md
@@ -96,6 +96,30 @@ functions:
     timeout: 120s
 ```
 
+## Environment variables
+
+Google Cloud Functions support environment variables. Those can be useful in a lot of ways, especially when deploying across multiple environments. Environment variables are defined as key-value pairs.
+
+The `environment` property can be specified at the provider or at the function level. The provider wide definition causes all functions to share those environment variables, whereas the function wide definition means that this configuration is only valid for the function.
+
+By default, no environment variable is passed to the functions. All environment variable values must be strings.
+
+```yml
+# serverless.yml
+
+provider:
+  environment:
+    max_delay: "5000"
+
+functions:
+  first:
+    handler: first
+  second:
+    handler: second
+    environment:
+      auth_provider: oauth2
+```
+
 ## Handler signatures
 
 Google Cloud Functions have different handler signatures dependent on the event type which will trigger them.
@@ -104,7 +128,7 @@ Google Cloud Functions have different handler signatures dependent on the event 
 
 ```javascript
 exports.http = (request, response) => {
-  response.status(200).send('Hello World!');
+  response.status(200).send("Hello World!");
 };
 ```
 
@@ -112,7 +136,7 @@ exports.http = (request, response) => {
 
 ```javascript
 exports.event = (event, callback) => {
-  console.log('Hello World!');
+  console.log("Hello World!");
   callback();
 };
 ```
@@ -125,13 +149,15 @@ Labels are defined as key-value pairs.
 
 Labels can be applied globally, to all functions in your configuration file, and to specific functions.
 
+There are limitations to labels. Make sure to consult the link above to learn about the requirements.
+
 ```yml
 # serverless.yml
 
 provider:
   name: google
   labels:
-    application: Serverless Example
+    application: serverless-example
 
 functions:
   first:
@@ -139,19 +165,19 @@ functions:
     events:
       - http: path
     labels:
-      team: GCF Team
+      team: gcf-team
   second:
     handler: httpSecond
     events:
       - http: path
     labels:
-      application: Serverless Example - Documentation
+      application: serverless-example_documentation
 ```
 
 With the above configuration the `httpFirst` function would have two labels applied, `application` and `team`.
-The value of the `application` label would be `Serverless Example`, the value of the `team` label would be `GCF Team`.
+The value of the `application` label would be `serverless-example`, the value of the `team` label would be `gcf-team`.
 
-The `httpSecond` function would have only one label applied, `application`, and it would have a value of `Serverless Example - Documentation`.
+The `httpSecond` function would have only one label applied, `application`, and it would have a value of `serverless-example_documentation`.
 
 Labels defined under the `provider` object are applied to all functions in the file.
 Labels defined under specific functions only apply to that function.

--- a/docs/providers/google/guide/functions.md
+++ b/docs/providers/google/guide/functions.md
@@ -109,7 +109,7 @@ By default, no environment variable is passed to the functions. All environment 
 
 provider:
   environment:
-    max_delay: "5000"
+    max_delay: '5000'
 
 functions:
   first:
@@ -128,7 +128,7 @@ Google Cloud Functions have different handler signatures dependent on the event 
 
 ```javascript
 exports.http = (request, response) => {
-  response.status(200).send("Hello World!");
+  response.status(200).send('Hello World!');
 };
 ```
 
@@ -136,7 +136,7 @@ exports.http = (request, response) => {
 
 ```javascript
 exports.event = (event, callback) => {
-  console.log("Hello World!");
+  console.log('Hello World!');
   callback();
 };
 ```


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
- Added a section in the Google Provider documentation to explain how to define environment variables. To feature was added with [PR 117](https://github.com/serverless/serverless-google-cloudfunctions/pull/117), but was never documented. Was also added some clarifications on the expected format of those environment variables, especially when the type could be confused, as illustrated in [issue 128](https://github.com/serverless/serverless-google-cloudfunctions/issues/128).

- Corrected mistaken documentation about labels. Example provided was not working and could confuse new users, as illustrated in [issue 185](https://github.com/serverless/serverless-google-cloudfunctions/issues/185). Fixed example and added a note about labels requirements and pointed to official Google Cloud documentation.


<!-- Briefly describe the scope of your PR -->
Documentation update

## How can we verify it
Changed examples in the documentation should now execute without errors.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
