### PR TITLE
Allow to use Ref in stream arn property

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -48,6 +48,10 @@ functions:
           arn:
             Fn::ImportValue: MyExportedKinesisStreamArnId
       - stream:
+          type: dynamodb
+          arn:
+            Ref: MyDynamoDbTableStreamArn
+      - stream:
           type: kinesis
           arn:
             Fn::Join:

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -72,13 +72,15 @@ class AwsCompileStreamEvents {
                   !(
                     _.has(event.stream.arn, 'Fn::ImportValue') ||
                     _.has(event.stream.arn, 'Fn::GetAtt') ||
+                    (_.has(event.stream.arn, 'Ref') &&
+                      _.has(this.serverless.service.resources.Parameters, event.stream.arn.Ref)) ||
                     _.has(event.stream.arn, 'Fn::Join')
                   )
                 ) {
                   const errorMessage = [
                     `Bad dynamic ARN property on stream event in function "${functionName}"`,
-                    ' If you use a dynamic "arn" (such as with Fn::GetAtt, Fn::Join',
-                    ' or Fn::ImportValue) there must only be one key (either Fn::GetAtt, Fn::Join',
+                    ' If you use a dynamic "arn" (such as with Fn::GetAtt, Fn::Join, Ref',
+                    ' or Fn::ImportValue) there must only be one key (either Fn::GetAtt, Fn::Join, Ref',
                     ' or Fn::ImportValue) in the arn object. Please check the docs for more info.',
                   ].join('');
                   throw new this.serverless.classes.Error(errorMessage);
@@ -108,6 +110,8 @@ class AwsCompileStreamEvents {
                 return EventSourceArn['Fn::GetAtt'][0];
               } else if (EventSourceArn['Fn::ImportValue']) {
                 return EventSourceArn['Fn::ImportValue'];
+              } else if (EventSourceArn.Ref) {
+                return EventSourceArn.Ref;
               } else if (EventSourceArn['Fn::Join']) {
                 // [0] is the used delimiter, [1] is the array with values
                 const name = EventSourceArn['Fn::Join'][1].slice(-1).pop();
@@ -147,9 +151,9 @@ class AwsCompileStreamEvents {
               ) {
                 dependsOn = `"${funcRole['Fn::GetAtt'][0]}"`;
               } else if (
-                // otherwise, check if we have an import
+                // otherwise, check if we have an import or parameters ref
                 typeof funcRole === 'object' &&
-                'Fn::ImportValue' in funcRole
+                ('Fn::ImportValue' in funcRole || 'Ref' in funcRole)
               ) {
                 dependsOn = '[]';
               } else if (typeof funcRole === 'string') {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -237,7 +237,7 @@ describe('AwsCompileStreamEvents', () => {
     it('should not throw error if IAM role is referenced from cloudformation parameters', () => {
       awsCompileStreamEvents.serverless.service.functions = {
         first: {
-          role: { Ref: 'MyStreamArn' },
+          role: { Ref: 'MyStreamRoleArn' },
           events: [
             {
               // doesn't matter if DynamoDB or Kinesis stream

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -234,6 +234,35 @@ describe('AwsCompileStreamEvents', () => {
       ).to.equal(null);
     });
 
+    it('should not throw error if IAM role is referenced from cloudformation parameters', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          role: { Ref: 'MyStreamArn' },
+          events: [
+            {
+              // doesn't matter if DynamoDB or Kinesis stream
+              stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
+            },
+          ],
+        },
+      };
+
+      // pretend that the default IamRoleLambdaExecution is not in place
+      awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution = null;
+
+      expect(() => {
+        awsCompileStreamEvents.compileStreamEvents();
+      }).to.not.throw(Error);
+      expect(
+        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbFoo.DependsOn.length
+      ).to.equal(0);
+      expect(
+        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .IamRoleLambdaExecution
+      ).to.equal(null);
+    });
+
     it('should not throw error if IAM role is imported', () => {
       awsCompileStreamEvents.serverless.service.functions = {
         first: {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -473,6 +473,14 @@ describe('AwsCompileStreamEvents', () => {
       });
 
       it('should allow specifying DynamoDB and Kinesis streams as CFN reference types', () => {
+        awsCompileStreamEvents.serverless.service.resources.Parameters = {
+          SomeDdbTableStreamArn: {
+            Type: 'String',
+          },
+          ForeignKinesisStreamArn: {
+            Type: 'String',
+          },
+        };
         awsCompileStreamEvents.serverless.service.functions = {
           first: {
             events: [
@@ -510,6 +518,18 @@ describe('AwsCompileStreamEvents', () => {
                   type: 'kinesis',
                 },
               },
+              {
+                stream: {
+                  arn: { Ref: 'SomeDdbTableStreamArn' },
+                  type: 'dynamodb',
+                },
+              },
+              {
+                stream: {
+                  arn: { Ref: 'ForeignKinesisStreamArn' },
+                  type: 'kinesis',
+                },
+              },
             ],
           },
         };
@@ -535,6 +555,9 @@ describe('AwsCompileStreamEvents', () => {
           Resource: [
             {
               'Fn::GetAtt': ['SomeDdbTable', 'StreamArn'],
+            },
+            {
+              Ref: 'SomeDdbTableStreamArn',
             },
           ],
         });
@@ -566,6 +589,60 @@ describe('AwsCompileStreamEvents', () => {
             ],
           ],
         });
+
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement[1]
+        ).to.deep.equal({
+          Effect: 'Allow',
+          Action: [
+            'kinesis:GetRecords',
+            'kinesis:GetShardIterator',
+            'kinesis:DescribeStream',
+            'kinesis:ListStreams',
+          ],
+          Resource: [
+            {
+              'Fn::ImportValue': 'ForeignKinesis',
+            },
+            {
+              'Fn::Join': [
+                ':',
+                [
+                  'arn',
+                  'aws',
+                  'kinesis',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  'stream/MyStream',
+                ],
+              ],
+            },
+            {
+              Ref: 'ForeignKinesisStreamArn',
+            },
+          ],
+        });
+      });
+
+      it('fails if Ref/dynamic stream ARN is used without defining it to the CF parameters', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  arn: { Ref: 'SomeDdbTableStreamArn' },
+                },
+              },
+            ],
+          },
+        };
+
+        expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
       });
 
       it('fails if Fn::GetAtt/dynamic stream ARN is used without a type', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

This PR allows usage of `Ref` in stream arn properties. When using the `Reg` it has to be included in CloudFormation parameters.

Usage & use cases:
```yaml
# serverless.yml
resources:
  Parameters:
    DynamoDbStreamArn1:
      Description: 'ARN stored to SSM parameter store'
      Type: 'AWS::SSM::Parameter::Value<String>'
      Default: '/my/dynamodb/stream-arn'
    DynamoDbStreamArn2:
      Description: 'ARN from manually / other that cloudformation created Dynamo/Kinesis stream'
      Type: 'String'

functions:
  myStreamFunction:
    events:
      - stream:
          type: dynamodb
          arn: !Ref DynamoDbStreamArn1
      - stream:
          type: dynamodb
          arn: !Ref DynamoDbStreamArn2
```

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
