### PR TITLE
Allow casting to boolean in Serverless variables

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -679,6 +679,7 @@ Note: These are examples of how the conversion works.
 ${strToBool(true)} => true
 ${strToBool(false)} => false
 ${strToBool(0)} => false
-${strToBool(null)} => true
-${strToBool(anything)} => true
+${strToBool(1)} => true
+${strToBool(null)} => Error
+${strToBool(anything)} => Error
 ```

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -46,7 +46,7 @@ You can define your own variable syntax (regex) if it conflicts with CloudFormat
 - [CloudFormation stack outputs](#reference-cloudformation-outputs)
 - [Properties exported from Javascript files (sync or async)](#reference-variables-in-javascript-files)
 - [Pseudo Parameters Reference](#pseudo-parameters-reference)
-- [Read String Variables Values as Boolean Values](#read-string-variables-values-as-boolean-values)
+- [Read String Variable Values as Boolean Values](#read-string-variable-values-as-boolean-values)
 
 ## Casting string variables to boolean values
 
@@ -661,7 +661,7 @@ Resources:
         - 'log-group:/aws/lambda/*:*:*'
 ```
 
-## Read String Variables Values as Boolean Values
+## Read String Variable Values as Boolean Values
 
 In some cases, a parameter expect a `true` or `false` boolean value. If you are using a variable to define the value, it may return as a string (e.g. when using SSM variables) and thus return a `"true"` or `"false"` string value.
 

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -679,7 +679,5 @@ Note: These are examples of how the conversion works.
 ${strToBool(true)} => true
 ${strToBool(false)} => false
 ${strToBool(null)} => true
-${strToBool( )} => true
 ${strToBool(anything)} => true
-${strToBool()} => ServerlessError
 ```

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -657,3 +657,15 @@ Resources:
         - Ref: 'AWS::AccountId'
         - 'log-group:/aws/lambda/*:*:*'
 ```
+
+## Casting string variables to boolean values
+
+In some cases, a parameter expect a `true` or `false` value. If you are using a variable to define the value, it may return as a string (e.g. when using SSM variables) and thus return a `"true"` or `"false"` value.
+
+To ensure a boolean value is returned, cast the variable value. For example:
+
+```yml
+provider:
+  tracing:
+    apiGateway: ${toBool:${ssm:API_GW_DEBUG_ENABLED}}
+```

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -673,13 +673,14 @@ provider:
     apiGateway: ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}
 ```
 
-Note: These are examples of how the conversion works.
+These are examples that explain how the conversion works:
 
 ```plaintext
 ${strToBool(true)} => true
 ${strToBool(false)} => false
 ${strToBool(0)} => false
 ${strToBool(1)} => true
+${strToBool(2)} => Error
 ${strToBool(null)} => Error
 ${strToBool(anything)} => Error
 ```

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -678,6 +678,7 @@ Note: These are examples of how the conversion works.
 ```plaintext
 ${strToBool(true)} => true
 ${strToBool(false)} => false
+${strToBool(0)} => false
 ${strToBool(null)} => true
 ${strToBool(anything)} => true
 ```

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -672,3 +672,14 @@ provider:
   tracing:
     apiGateway: ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}
 ```
+
+Note: These are examples of how the conversion works.
+
+```plaintext
+${strToBool(true)} => true
+${strToBool(false)} => false
+${strToBool(null)} => true
+${strToBool( )} => true
+${strToBool(anything)} => true
+${strToBool()} => ServerlessError
+```

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -46,6 +46,9 @@ You can define your own variable syntax (regex) if it conflicts with CloudFormat
 - [CloudFormation stack outputs](#reference-cloudformation-outputs)
 - [Properties exported from Javascript files (sync or async)](#reference-variables-in-javascript-files)
 - [Pseudo Parameters Reference](#pseudo-parameters-reference)
+- [Casting String Variable Values to Boolean](#casting-string-variables-values-to-boolean)
+
+## Casting string variables to boolean values
 
 ## Recursively reference properties
 
@@ -658,7 +661,7 @@ Resources:
         - 'log-group:/aws/lambda/*:*:*'
 ```
 
-## Casting string variables to boolean values
+## Casting string variables values to boolean
 
 In some cases, a parameter expect a `true` or `false` value. If you are using a variable to define the value, it may return as a string (e.g. when using SSM variables) and thus return a `"true"` or `"false"` value.
 

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -46,7 +46,7 @@ You can define your own variable syntax (regex) if it conflicts with CloudFormat
 - [CloudFormation stack outputs](#reference-cloudformation-outputs)
 - [Properties exported from Javascript files (sync or async)](#reference-variables-in-javascript-files)
 - [Pseudo Parameters Reference](#pseudo-parameters-reference)
-- [Casting String Variable Values to Boolean](#casting-string-variables-values-to-boolean)
+- [Read String Variables Values as Boolean Values](#read-string-variables-values-as-boolean-values)
 
 ## Casting string variables to boolean values
 
@@ -661,14 +661,14 @@ Resources:
         - 'log-group:/aws/lambda/*:*:*'
 ```
 
-## Casting string variables values to boolean
+## Read String Variables Values as Boolean Values
 
-In some cases, a parameter expect a `true` or `false` value. If you are using a variable to define the value, it may return as a string (e.g. when using SSM variables) and thus return a `"true"` or `"false"` value.
+In some cases, a parameter expect a `true` or `false` boolean value. If you are using a variable to define the value, it may return as a string (e.g. when using SSM variables) and thus return a `"true"` or `"false"` string value.
 
-To ensure a boolean value is returned, cast the variable value. For example:
+To ensure a boolean value is returned, read the string variable value as a boolean value. For example:
 
 ```yml
 provider:
   tracing:
-    apiGateway: ${toBool:${ssm:API_GW_DEBUG_ENABLED}}
+    apiGateway: ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}
 ```

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -838,11 +838,10 @@ class Variables {
           }
           // truthy or non-empty strings
           return true;
-        } else {
-          throw new this.serverless.classes.Error(
-            'Unexpected strToBool input; expected either "true", "false", "0", or "1".'
-          );
         }
+        throw new this.serverless.classes.Error(
+          'Unexpected strToBool input; expected either "true", "false", "0", or "1".'
+        );
       }
       // Cast non-string inputs
       return Boolean(variableString);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -55,6 +55,7 @@ class Variables {
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(\.[a-zA-Z0-9-]+)?:/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/);
+    this.toBoolRefSyntax = RegExp(/^(?:\${)?toBool:([a-zA-Z0-9_.\-/]+)/);
 
     this.variableResolvers = [
       { regex: this.slsRefSyntax, resolver: this.getValueFromSls.bind(this) },
@@ -80,6 +81,10 @@ class Variables {
         resolver: this.getValueFromSsm.bind(this),
         isDisabledAtPrepopulation: true,
         serviceName: 'SSM',
+      },
+      {
+        regex: this.toBoolRefSyntax,
+        resolver: this.getValueToBool.bind(this),
       },
       { regex: this.deepRefSyntax, resolver: this.getValueFromDeep.bind(this) },
     ];
@@ -820,6 +825,16 @@ class Variables {
 
         return BbPromise.resolve(undefined);
       });
+  }
+
+  getValueToBool(variableString) {
+    if (/^true$/.test(variableString)) {
+      return BbPromise.resolve(true);
+    }
+    else if (/^false$/.test(variableString)) {
+      return BbPromise.resolve(false);
+    }
+    return BbPromise.resolve(true);
   }
 
   getDeepIndex(variableString) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -834,7 +834,7 @@ class Variables {
         const param = groups[1].trim();
           if (param === 'false') {
             return false;
-          } else if (!param || param === '') {
+          } else if (!param) {
             throw new this.serverless.classes.Error(`${variableString} resolved to null`);
           }
           // truthy or non-empty strings

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -828,14 +828,19 @@ class Variables {
   }
 
   getValueStrToBool(variableString) {
-    const groups = variableString.match(this.strToBoolRefSyntax);
-    const param = groups[1];
-    if (param === 'true') {
-      return BbPromise.resolve(true);
-    } else if (param === 'false') {
-      return BbPromise.resolve(false);
-    }
-    return BbPromise.resolve(true);
+    return BbPromise.try(() => {
+      const groups = variableString.match(this.strToBoolRefSyntax);
+      if (groups.length < 2) {
+        throw new this.serverless.classes.Error(`${variableString} cannot have an empty string`);
+      }
+      const param = groups[1].trim();
+      if (param === 'false') {
+        return false;
+      } else if (!param || param === '' || param === 'null') {
+        throw new this.serverless.classes.Error(`${variableString} resolved to null`);
+      }
+      return true;
+    });
   }
 
   getDeepIndex(variableString) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -839,7 +839,9 @@ class Variables {
           // truthy or non-empty strings
           return true;
         } else {
-          throw new this.serverless.classes.Error('Unexpected strToBool input; expected either "true", "false", "0", or "1".');
+          throw new this.serverless.classes.Error(
+            'Unexpected strToBool input; expected either "true", "false", "0", or "1".'
+          );
         }
       }
       // Cast non-string inputs

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -829,17 +829,20 @@ class Variables {
 
   getValueStrToBool(variableString) {
     return BbPromise.try(() => {
-      const groups = variableString.match(this.strToBoolRefSyntax);
-      if (groups.length < 2) {
-        throw new this.serverless.classes.Error(`${variableString} cannot have an empty string`);
+      if (_.isString(variableString)) {
+        // valid variableString
+        const groups = variableString.match(this.strToBoolRefSyntax);
+        const param = groups[1].trim();
+          if (param === 'false') {
+            return false;
+          } else if (!param || param === '') {
+            throw new this.serverless.classes.Error(`${variableString} resolved to null`);
+          }
+          // truthy or non-empty strings
+          return true;
       }
-      const param = groups[1].trim();
-      if (param === 'false') {
-        return false;
-      } else if (!param || param === '' || param === 'null') {
-        throw new this.serverless.classes.Error(`${variableString} resolved to null`);
-      }
-      return true;
+      // Cast non-string inputs
+      return Boolean(variableString);
     });
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -830,7 +830,6 @@ class Variables {
   getValueStrToBool(variableString) {
     return BbPromise.try(() => {
       if (_.isString(variableString)) {
-        // valid variableString
         const groups = variableString.match(this.strToBoolRefSyntax);
         const param = groups[1].trim();
           if (param === 'false') {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -828,10 +828,10 @@ class Variables {
   }
 
   getValueToBool(variableString) {
-    if (/^true$/.test(variableString)) {
+    if (/^toBool:true$/.test(variableString)) {
       return BbPromise.resolve(true);
     }
-    else if (/^false$/.test(variableString)) {
+    else if (/^toBool:false$/.test(variableString)) {
       return BbPromise.resolve(false);
     }
     return BbPromise.resolve(true);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -55,7 +55,7 @@ class Variables {
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(\.[a-zA-Z0-9-]+)?:/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/);
-    this.toBoolRefSyntax = RegExp(/^(?:\${)?toBool:([a-zA-Z0-9_.\-/]+)/);
+    this.strToBoolRefSyntax = RegExp(/^(?:\${)?strToBool\(([a-zA-Z0-9_.\-/]+)\)/);
 
     this.variableResolvers = [
       { regex: this.slsRefSyntax, resolver: this.getValueFromSls.bind(this) },
@@ -83,8 +83,8 @@ class Variables {
         serviceName: 'SSM',
       },
       {
-        regex: this.toBoolRefSyntax,
-        resolver: this.getValueToBool.bind(this),
+        regex: this.strToBoolRefSyntax,
+        resolver: this.getValueStrToBool.bind(this),
       },
       { regex: this.deepRefSyntax, resolver: this.getValueFromDeep.bind(this) },
     ];
@@ -827,10 +827,16 @@ class Variables {
       });
   }
 
-  getValueToBool(variableString) {
-    if (/^toBool:true$/.test(variableString)) {
+  getValueStrToBool(variableString) {
+    const groups = variableString.match(this.strToBoolRefSyntax);
+    const param = groups[1];
+    console.log('***********')
+    console.log('***********')
+    console.log('***********')
+    console.log('variableString', param);
+    if (param === 'true') {
       return BbPromise.resolve(true);
-    } else if (/^toBool:false$/.test(variableString)) {
+    } else if (param === 'false') {
       return BbPromise.resolve(false);
     }
     return BbPromise.resolve(true);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -830,8 +830,7 @@ class Variables {
   getValueToBool(variableString) {
     if (/^toBool:true$/.test(variableString)) {
       return BbPromise.resolve(true);
-    }
-    else if (/^toBool:false$/.test(variableString)) {
+    } else if (/^toBool:false$/.test(variableString)) {
       return BbPromise.resolve(false);
     }
     return BbPromise.resolve(true);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -832,11 +832,15 @@ class Variables {
       if (_.isString(variableString)) {
         const groups = variableString.match(this.strToBoolRefSyntax);
         const param = groups[1].trim();
-        if (param === 'false' || param === '0') {
-          return false;
+        if (/^(true|false|0|1)$/.test(param)) {
+          if (param === 'false' || param === '0') {
+            return false;
+          }
+          // truthy or non-empty strings
+          return true;
+        } else {
+          throw new this.serverless.classes.Error('Unexpected strToBool input; expected either "true", "false", "0", or "1".');
         }
-        // truthy or non-empty strings
-        return true;
       }
       // Cast non-string inputs
       return Boolean(variableString);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -832,7 +832,7 @@ class Variables {
       if (_.isString(variableString)) {
         const groups = variableString.match(this.strToBoolRefSyntax);
         const param = groups[1].trim();
-        if (param === 'false') {
+        if (param === 'false' || param === '0') {
           return false;
         }
         // truthy or non-empty strings

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -830,10 +830,6 @@ class Variables {
   getValueStrToBool(variableString) {
     const groups = variableString.match(this.strToBoolRefSyntax);
     const param = groups[1];
-    console.log('***********')
-    console.log('***********')
-    console.log('***********')
-    console.log('variableString', param);
     if (param === 'true') {
       return BbPromise.resolve(true);
     } else if (param === 'false') {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -832,13 +832,13 @@ class Variables {
       if (_.isString(variableString)) {
         const groups = variableString.match(this.strToBoolRefSyntax);
         const param = groups[1].trim();
-          if (param === 'false') {
-            return false;
-          } else if (!param) {
-            throw new this.serverless.classes.Error(`${variableString} resolved to null`);
-          }
-          // truthy or non-empty strings
-          return true;
+        if (param === 'false') {
+          return false;
+        } else if (!param) {
+          throw new this.serverless.classes.Error(`${variableString} resolved to null`);
+        }
+        // truthy or non-empty strings
+        return true;
       }
       // Cast non-string inputs
       return Boolean(variableString);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -834,8 +834,6 @@ class Variables {
         const param = groups[1].trim();
         if (param === 'false') {
           return false;
-        } else if (!param) {
-          throw new this.serverless.classes.Error(`${variableString} resolved to null`);
         }
         // truthy or non-empty strings
         return true;

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2379,6 +2379,7 @@ module.exports = {
   });
 
   describe('#getValueStrToBool()', () => {
+    const errMessage = 'Unexpected strToBool input; expected either "true", "false", "0", or "1".';
     beforeEach(() => {
       serverless.variables.service = {
         service: 'testService',
@@ -2419,11 +2420,17 @@ module.exports = {
     it('0 (string) should return false (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(0)').should.become(false);
     });
-    it('truthy string should return true (boolean)', () => {
-      return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);
+    it('truthy string should throw an error', () => {
+      return serverless.variables
+        .getValueStrToBool('strToBool(anything)')
+        .catch(err => err.message)
+        .should.become(errMessage);
     });
-    it('null (string) should return true (boolean)', () => {
-      return serverless.variables.getValueStrToBool('strToBool(null)').should.become(true);
+    it('null (string) should throw an error', () => {
+      return serverless.variables
+        .getValueStrToBool('strToBool(null)')
+        .catch(err => err.message)
+        .should.become(errMessage);
     });
     it('strToBool(true) as an input to strToBool', () => {
       const input = serverless.variables.getValueStrToBool('strToBool(true)');

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2378,6 +2378,24 @@ module.exports = {
     });
   });
 
+  describe('#getValueToBool()', () => {
+    it('should return true (boolean) for a true (string)', () => {
+      return serverless.variables
+        .getValueToBool(`toBool:true`)
+        .should.become(true);
+    });
+    it('should return false (boolean) for a false (string)', () => {
+      return serverless.variables
+        .getValueToBool(`toBool:false`)
+        .should.become(true);
+    });
+    it('should return true (boolean) for a truthy string', () => {
+      return serverless.variables
+        .getValueToBool(`toBool:anything`)
+        .should.become(true);
+    });
+  });
+
   describe('#getDeeperValue()', () => {
     it('should get deep values', () => {
       const valueToPopulateMock = {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2378,15 +2378,15 @@ module.exports = {
     });
   });
 
-  describe('#getValueToBool()', () => {
+  describe('#getValueStrToBool()', () => {
     it('should return true (boolean) for a true (string)', () => {
-      return serverless.variables.getValueToBool('toBool:true').should.become(true);
+      return serverless.variables.getValueStrToBool('strToBool(true)').should.become(true);
     });
     it('should return false (boolean) for a false (string)', () => {
-      return serverless.variables.getValueToBool('toBool:false').should.become(false);
+      return serverless.variables.getValueStrToBool('strToBool(false)').should.become(false);
     });
     it('should return true (boolean) for a truthy string', () => {
-      return serverless.variables.getValueToBool('toBool:anything').should.become(true);
+      return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);
     });
   });
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2410,7 +2410,7 @@ module.exports = {
     it('truthy string should return true (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);
     });
-    it('null-like string should throw error', () => {
+    it('null (string) should return true (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(null)').should.become(true);
     });
     it('strToBool(true) as an input to strToBool', () => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2380,19 +2380,13 @@ module.exports = {
 
   describe('#getValueToBool()', () => {
     it('should return true (boolean) for a true (string)', () => {
-      return serverless.variables
-        .getValueToBool('toBool:true')
-        .should.become(true);
+      return serverless.variables.getValueToBool('toBool:true').should.become(true);
     });
     it('should return false (boolean) for a false (string)', () => {
-      return serverless.variables
-        .getValueToBool('toBool:false')
-        .should.become(false);
+      return serverless.variables.getValueToBool('toBool:false').should.become(false);
     });
     it('should return true (boolean) for a truthy string', () => {
-      return serverless.variables
-        .getValueToBool('toBool:anything')
-        .should.become(true);
+      return serverless.variables.getValueToBool('toBool:anything').should.become(true);
     });
   });
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2388,6 +2388,24 @@ module.exports = {
     it('should return true (boolean) for a truthy string', () => {
       return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);
     });
+    it('should throw error for a null-like string', () => {
+      return serverless.variables
+        .getValueStrToBool('strToBool(null)')
+        .catch(() => null)
+        .should.become(null);
+    });
+    it('should throw error for an empty string', () => {
+      return serverless.variables
+        .getValueStrToBool('strToBool()')
+        .catch(() => null)
+        .should.become(null);
+    });
+    it('should throw error for string with spaces only', () => {
+      return serverless.variables
+        .getValueStrToBool('strToBool( )')
+        .catch(() => null)
+        .should.become(null);
+    });
   });
 
   describe('#getDeeperValue()', () => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2386,23 +2386,32 @@ module.exports = {
       };
       serverless.variables.loadVariableSyntax();
     });
-    it('should return true (boolean) for a true (string)', () => {
+    it('regex for "true" input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(true)}')).to.equal(true);
+    });
+    it('regex for "false" input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(false)}')).to.equal(true);
+    });
+    it('regex for "null" input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(null)}')).to.equal(true);
+    });
+    it('regex for truthy input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(anything)}')).to.equal(true);
+    });
+    it('regex for empty input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool()}')).to.equal(false);
+    });
+    it('true (string) should return true (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(true)').should.become(true);
     });
-    it('should return false (boolean) for a false (string)', () => {
+    it('false (string) should return false (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(false)').should.become(false);
     });
-    it('should return true (boolean) for a truthy string', () => {
+    it('truthy string should return true (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);
     });
-    it('should throw error for a null-like string', () => {
+    it('null-like string should throw error', () => {
       return serverless.variables.getValueStrToBool('strToBool(null)').should.become(true);
-    });
-    it('should throw error for string with spaces only', () => {
-      return serverless.variables
-        .getValueStrToBool('strToBool( )')
-        .catch(() => null)
-        .should.become(null);
     });
     it('strToBool(true) as an input to strToBool', () => {
       const input = serverless.variables.getValueStrToBool('strToBool(true)');

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2379,6 +2379,13 @@ module.exports = {
   });
 
   describe('#getValueStrToBool()', () => {
+    beforeEach(() => {
+      serverless.variables.service = {
+        service: 'testService',
+        provider: serverless.service.provider,
+      };
+      serverless.variables.loadVariableSyntax();
+    });
     it('should return true (boolean) for a true (string)', () => {
       return serverless.variables.getValueStrToBool('strToBool(true)').should.become(true);
     });
@@ -2389,22 +2396,21 @@ module.exports = {
       return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);
     });
     it('should throw error for a null-like string', () => {
-      return serverless.variables
-        .getValueStrToBool('strToBool(null)')
-        .catch(() => null)
-        .should.become(null);
-    });
-    it('should throw error for an empty string', () => {
-      return serverless.variables
-        .getValueStrToBool('strToBool()')
-        .catch(() => null)
-        .should.become(null);
+      return serverless.variables.getValueStrToBool('strToBool(null)').should.become(true);
     });
     it('should throw error for string with spaces only', () => {
       return serverless.variables
         .getValueStrToBool('strToBool( )')
         .catch(() => null)
         .should.become(null);
+    });
+    it('strToBool(true) as an input to strToBool', () => {
+      const input = serverless.variables.getValueStrToBool('strToBool(true)');
+      return serverless.variables.getValueStrToBool(input).should.become(true);
+    });
+    it('strToBool(false) as an input to strToBool', () => {
+      const input = serverless.variables.getValueStrToBool('strToBool(false)');
+      return serverless.variables.getValueStrToBool(input).should.become(true);
     });
   });
 

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2392,6 +2392,12 @@ module.exports = {
     it('regex for "false" input', () => {
       expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(false)}')).to.equal(true);
     });
+    it('regex for "0" input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(0)}')).to.equal(true);
+    });
+    it('regex for "1" input', () => {
+      expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(1)}')).to.equal(true);
+    });
     it('regex for "null" input', () => {
       expect(serverless.variables.strToBoolRefSyntax.test('${strToBool(null)}')).to.equal(true);
     });
@@ -2406,6 +2412,12 @@ module.exports = {
     });
     it('false (string) should return false (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(false)').should.become(false);
+    });
+    it('1 (string) should return true (boolean)', () => {
+      return serverless.variables.getValueStrToBool('strToBool(1)').should.become(true);
+    });
+    it('0 (string) should return false (boolean)', () => {
+      return serverless.variables.getValueStrToBool('strToBool(0)').should.become(false);
     });
     it('truthy string should return true (boolean)', () => {
       return serverless.variables.getValueStrToBool('strToBool(anything)').should.become(true);

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2381,17 +2381,17 @@ module.exports = {
   describe('#getValueToBool()', () => {
     it('should return true (boolean) for a true (string)', () => {
       return serverless.variables
-        .getValueToBool(`toBool:true`)
+        .getValueToBool('toBool:true')
         .should.become(true);
     });
     it('should return false (boolean) for a false (string)', () => {
       return serverless.variables
-        .getValueToBool(`toBool:false`)
-        .should.become(true);
+        .getValueToBool('toBool:false')
+        .should.become(false);
     });
     it('should return true (boolean) for a truthy string', () => {
       return serverless.variables
-        .getValueToBool(`toBool:anything`)
+        .getValueToBool('toBool:anything')
         .should.become(true);
     });
   });


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise, we probably have to close the PR due to missing information -->

## What did you implement

Variables can now cast values to booleans. For example, if a parameter expects a boolean, but a string is passed, it will convert a `"true"` to `true`, a `"false"` to `false`, and `"anything"` to `true`.

Closes #6782

## How can we verify it

Reference an SSM value and cast it in the API Gateway logging and X-ray tracing provider sections.

```yaml
  tracing:
    apiGateway: ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}

  logs:
    restApi:
      accessLogging:     ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}
      executionLogging:  ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}
      fullExecutionData: ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}

```

Set `API_GW_DEBUG_ENABLED` to `true` in SSM, deploy and see the API Gateway settings turn on. Update `API_GW_DEBUG_ENABLED` to `false` in SSM, deploy and see the API Gateway settings turn off.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [x] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
