### PR TITLE
Honor cfnRole in custom resources

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -86,79 +86,83 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
       const s3FileName = outputFilePath.split(path.sep).pop();
       const S3Key = `${s3Folder}/${s3FileName}`;
 
-      let customResourceRole = Resources[customResourcesRoleLogicalId];
-      if (!customResourceRole) {
-        customResourceRole = {
-          Type: 'AWS::IAM::Role',
-          Properties: {
-            AssumeRolePolicyDocument: {
-              Version: '2012-10-17',
-              Statement: [
-                {
-                  Effect: 'Allow',
-                  Principal: {
-                    Service: ['lambda.amazonaws.com'],
-                  },
-                  Action: ['sts:AssumeRole'],
-                },
-              ],
-            },
-            Policies: [
-              {
-                PolicyName: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      awsProvider.getStage(),
-                      awsProvider.serverless.service.service,
-                      'custom-resources-lambda',
-                    ],
-                  ],
-                },
-                PolicyDocument: {
-                  Version: '2012-10-17',
-                  Statement: [],
-                },
-              },
-            ],
-          },
-        };
-        Resources[customResourcesRoleLogicalId] = customResourceRole;
+      const cfnRoleArn = serverless.service.provider.cfnRole;
 
-        if (shouldWriteLogs) {
-          const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
-          customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
-            {
-              Effect: 'Allow',
-              Action: ['logs:CreateLogStream'],
-              Resource: [
+      if (!cfnRoleArn) {
+        let customResourceRole = Resources[customResourcesRoleLogicalId];
+        if (!customResourceRole) {
+          customResourceRole = {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+              AssumeRolePolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Principal: {
+                      Service: ['lambda.amazonaws.com'],
+                    },
+                    Action: ['sts:AssumeRole'],
+                  },
+                ],
+              },
+              Policies: [
                 {
-                  'Fn::Sub':
-                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                    `:log-group:${logGroupsPrefix}*:*`,
+                  PolicyName: {
+                    'Fn::Join': [
+                      '-',
+                      [
+                        awsProvider.getStage(),
+                        awsProvider.serverless.service.service,
+                        'custom-resources-lambda',
+                      ],
+                    ],
+                  },
+                  PolicyDocument: {
+                    Version: '2012-10-17',
+                    Statement: [],
+                  },
                 },
               ],
             },
-            {
-              Effect: 'Allow',
-              Action: ['logs:PutLogEvents'],
-              Resource: [
-                {
-                  'Fn::Sub':
-                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                    `:log-group:${logGroupsPrefix}*:*:*`,
-                },
-              ],
-            }
-          );
+          };
+          Resources[customResourcesRoleLogicalId] = customResourceRole;
+
+          if (shouldWriteLogs) {
+            const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
+            customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+              {
+                Effect: 'Allow',
+                Action: ['logs:CreateLogStream'],
+                Resource: [
+                  {
+                    'Fn::Sub':
+                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                      `:log-group:${logGroupsPrefix}*:*`,
+                  },
+                ],
+              },
+              {
+                Effect: 'Allow',
+                Action: ['logs:PutLogEvents'],
+                Resource: [
+                  {
+                    'Fn::Sub':
+                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                      `:log-group:${logGroupsPrefix}*:*:*`,
+                  },
+                ],
+              }
+            );
+          }
         }
+        const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
+        iamRoleStatements.forEach(newStmt => {
+          if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
+            Statement.push(newStmt);
+          }
+        });
       }
-      const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
-      iamRoleStatements.forEach(newStmt => {
-        if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
-          Statement.push(newStmt);
-        }
-      });
 
       const customResourceFunction = {
         Type: 'AWS::Lambda::Function',
@@ -170,15 +174,20 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
           FunctionName: absoluteFunctionName,
           Handler,
           MemorySize: 1024,
-          Role: {
-            'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
-          },
           Runtime: 'nodejs10.x',
           Timeout: 180,
         },
-        DependsOn: [customResourcesRoleLogicalId],
       };
       Resources[customResourceFunctionLogicalId] = customResourceFunction;
+
+      if (cfnRoleArn) {
+        customResourceFunction.Properties.Role = cfnRoleArn;
+      } else {
+        customResourceFunction.Properties.Role = {
+          'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+        };
+        customResourceFunction.DependsOn = [customResourcesRoleLogicalId];
+      }
 
       if (shouldWriteLogs) {
         const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -123,6 +123,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
             ],
           },
         };
+        Resources[customResourcesRoleLogicalId] = customResourceRole;
 
         if (shouldWriteLogs) {
           const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
@@ -177,11 +178,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
         },
         DependsOn: [customResourcesRoleLogicalId],
       };
-
-      Object.assign(Resources, {
-        [customResourceFunctionLogicalId]: customResourceFunction,
-        [customResourcesRoleLogicalId]: customResourceRole,
-      });
+      Resources[customResourceFunctionLogicalId] = customResourceFunction;
 
       if (shouldWriteLogs) {
         const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -177,6 +177,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
           Runtime: 'nodejs10.x',
           Timeout: 180,
         },
+        DependsOn: [],
       };
       Resources[customResourceFunctionLogicalId] = customResourceFunction;
 
@@ -186,7 +187,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
         customResourceFunction.Properties.Role = {
           'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
         };
-        customResourceFunction.DependsOn = [customResourcesRoleLogicalId];
+        customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
       }
 
       if (shouldWriteLogs) {

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -293,6 +293,7 @@ describe('#addCustomResourceToService()', () => {
           Runtime: 'nodejs10.x',
           Timeout: 180,
         },
+        DependsOn: [],
       });
       // Cognito User Pool Lambda Function
       expect(Resources.CustomDashresourceDashexistingDashcupLambdaFunction).to.deep.equal({
@@ -309,6 +310,7 @@ describe('#addCustomResourceToService()', () => {
           Runtime: 'nodejs10.x',
           Timeout: 180,
         },
+        DependsOn: [],
       });
       // Event Bridge Lambda Function
       expect(Resources.CustomDashresourceDasheventDashbridgeLambdaFunction).to.deep.equal({
@@ -325,6 +327,7 @@ describe('#addCustomResourceToService()', () => {
           Runtime: 'nodejs10.x',
           Timeout: 180,
         },
+        DependsOn: [],
       });
       // Iam Role
       expect(Resources.IamRoleCustomResourcesLambdaExecution).to.be.undefined;

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -221,6 +221,116 @@ describe('#addCustomResourceToService()', () => {
     });
   });
 
+  it('Should not setup new IAM role, when cfnRole is provided', () => {
+    const cfnRoleArn = (serverless.service.provider.cfnRole =
+      'arn:aws:iam::999999999999:role/some-role');
+    return expect(
+      BbPromise.all([
+        // add the custom S3 resource
+        addCustomResourceToService(provider, 's3', [
+          ...iamRoleStatements,
+          {
+            Effect: 'Allow',
+            Resource: 'arn:aws:s3:::some-bucket',
+            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+          },
+        ]),
+        // add the custom Cognito User Pool resource
+        addCustomResourceToService(provider, 'cognitoUserPool', [
+          ...iamRoleStatements,
+          {
+            Effect: 'Allow',
+            Resource: '*',
+            Action: [
+              'cognito-idp:ListUserPools',
+              'cognito-idp:DescribeUserPool',
+              'cognito-idp:UpdateUserPool',
+            ],
+          },
+        ]),
+        // add the custom Event Bridge resource
+        addCustomResourceToService(provider, 'eventBridge', [
+          ...iamRoleStatements,
+          {
+            Effect: 'Allow',
+            Resource: 'arn:aws:events:*:*:rule/some-rule',
+            Action: [
+              'events:PutRule',
+              'events:RemoveTargets',
+              'events:PutTargets',
+              'events:DeleteRule',
+            ],
+          },
+          {
+            Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+            Effect: 'Allow',
+            Resource: 'arn:aws:events:*:*:event-bus/some-event-bus',
+          },
+        ]),
+      ])
+    ).to.be.fulfilled.then(() => {
+      const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+      const customResourcesZipFilePath = path.join(
+        tmpDirPath,
+        '.serverless',
+        'custom-resources.zip'
+      );
+
+      expect(execAsyncStub).to.have.callCount(3);
+      expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
+      // S3 Lambda Function
+      expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction).to.deep.equal({
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact-dir-name/custom-resources.zip',
+          },
+          FunctionName: `${serviceName}-dev-custom-resource-existing-s3`,
+          Handler: 's3/handler.handler',
+          MemorySize: 1024,
+          Role: cfnRoleArn,
+          Runtime: 'nodejs10.x',
+          Timeout: 180,
+        },
+      });
+      // Cognito User Pool Lambda Function
+      expect(Resources.CustomDashresourceDashexistingDashcupLambdaFunction).to.deep.equal({
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact-dir-name/custom-resources.zip',
+          },
+          FunctionName: `${serviceName}-dev-custom-resource-existing-cup`,
+          Handler: 'cognitoUserPool/handler.handler',
+          MemorySize: 1024,
+          Role: cfnRoleArn,
+          Runtime: 'nodejs10.x',
+          Timeout: 180,
+        },
+      });
+      // Event Bridge Lambda Function
+      expect(Resources.CustomDashresourceDasheventDashbridgeLambdaFunction).to.deep.equal({
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+            S3Key: 'artifact-dir-name/custom-resources.zip',
+          },
+          FunctionName: `${serviceName}-dev-custom-resource-event-bridge`,
+          Handler: 'eventBridge/handler.handler',
+          MemorySize: 1024,
+          Role: cfnRoleArn,
+          Runtime: 'nodejs10.x',
+          Timeout: 180,
+        },
+      });
+      // Iam Role
+      expect(Resources.IamRoleCustomResourcesLambdaExecution).to.be.undefined;
+    });
+  });
+
   it('should setup CloudWatch Logs when logs.frameworkLambda is true', () => {
     serverless.service.provider.logs = { frameworkLambda: true };
     return BbPromise.all([


### PR DESCRIPTION
Fixes #6595

Some projects rely on setup where access rights is handled externally (not in a scope of Serveless service), and those cannot be reliably now run with custom resources involved, as any IAM roles creation crashes the deployment.

This improvements, ensures that `cfnRole` setting is honored as a role under which custom resources lambda invocation should be made.

When it's provided no custom IAM role is created when custom resources are setup.