### PR TITLE
Fix minor typo

### DIFF
--- a/docs/providers/kubeless/guide/intro.md
+++ b/docs/providers/kubeless/guide/intro.md
@@ -37,7 +37,7 @@ You can perform multiple jobs in your code, but we don't recommend doing that wi
 
 ### Events
 
-Anything that triggers an Kubeless Event to execute is regarded by the Framework as an **Event**. Events are platform events on Kubeless such as:
+Anything that triggers a Kubeless Event to execute is regarded by the Framework as an **Event**. Events are platform events on Kubeless such as:
 
 - _An API Gateway HTTP endpoint (e.g., for a REST API)_
 - _A Kafka queue message (e.g., a message)_


### PR DESCRIPTION
## What did you implement

Fix minor typo in `docs/providers/kubeless/guide/intro.md`

## How can we verify it

Nothing to verify, no changes to functionality

## Todos

- [* ] Write documentation

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
