### PR TITLE
Fixes bug with sns-cross-region definition using psuedo params

### DIFF
--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -62,6 +62,10 @@ class AwsCompileSNSEvents {
                   }
                 } else if (typeof topicArn === 'string') {
                   if (topicArn.indexOf('arn:') === 0) {
+                    // NOTE: we need to process the topic ARN that way due to lacking
+                    // support of regex lookbehind in Node.js 6.
+                    // Once Node.js 6 support is dropped we can change this to:
+                    // `const splitArn = topicArn.split(/(?<!:):(?!:)/);`
                     const splitArn = topicArn
                       .replace(/::/g, '@@')
                       .split(':')

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -62,7 +62,7 @@ class AwsCompileSNSEvents {
                   }
                 } else if (typeof topicArn === 'string') {
                   if (topicArn.indexOf('arn:') === 0) {
-                    const splitArn = topicArn.split(':');
+                    const splitArn = topicArn.split(/(?<!:):(?!:)/);
                     topicName = splitArn[splitArn.length - 1];
                     if (splitArn[3] !== this.options.region) {
                       region = splitArn[3];

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -62,7 +62,10 @@ class AwsCompileSNSEvents {
                   }
                 } else if (typeof topicArn === 'string') {
                   if (topicArn.indexOf('arn:') === 0) {
-                    const splitArn = topicArn.split(/(?<!:):(?!:)/);
+                    const splitArn = topicArn
+                      .replace(/::/g, '@@')
+                      .split(':')
+                      .map(s => s.replace(/@@/g, '::'));
                     topicName = splitArn[splitArn.length - 1];
                     if (splitArn[3] !== this.options.region) {
                       region = splitArn[3];

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -309,6 +309,39 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should create a cross region subscription when SNS topic arn in a different region is using pseudo params', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                arn: 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:foo',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+      expect(
+        Object.keys(
+          awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        )
+      ).to.have.length(2);
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionFoo.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionFoo.Properties.Region
+      ).to.equal('${AWS::Region}');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstLambdaPermissionFooSNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+    });
+
     it('should throw an error when the arn an object and the value is not a string', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

Fixes the split of of arn for sns topic, when using pseudo params.

<!-- Briefly describe the scope of your PR -->

Closes #6760 

## How can we verify it

Tests updated.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
