### PR TITLE
Find origin by domain name and path

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -166,7 +166,12 @@ class AwsCompileCloudFrontEvents {
 
             let origin = createOrigin(functionName, event.cloudFront.origin, this.provider.naming);
 
-            const existingOrigin = _.find(origins, o => o.OriginPath === origin.OriginPath);
+            const existingOrigin = _.find(
+              origins,
+              o =>
+                o.DomainName === origin.DomainName &&
+                o.OriginPath === origin.OriginPath
+            );
 
             if (!existingOrigin) {
               origins.push(origin);

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -168,9 +168,7 @@ class AwsCompileCloudFrontEvents {
 
             const existingOrigin = _.find(
               origins,
-              o =>
-                o.DomainName === origin.DomainName &&
-                o.OriginPath === origin.OriginPath
+              o => o.DomainName === origin.DomainName && o.OriginPath === origin.OriginPath
             );
 
             if (!existingOrigin) {

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -412,7 +412,6 @@ describe('AwsCompileCloudFrontEvents', () => {
     });
 
     it('should create different origins if for different domains with the same path', () => {
-
       awsCompileCloudFrontEvents.serverless.service.functions = {
         first: {
           name: 'first',

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -410,5 +410,70 @@ describe('AwsCompileCloudFrontEvents', () => {
         S3OriginConfig: {},
       });
     });
+
+    it('should create different origins if for different domains with the same path', () => {
+
+      awsCompileCloudFrontEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cloudFront: {
+                eventType: 'viewer-request',
+                origin: 's3://bucketname.s3.amazonaws.com/files',
+              },
+            },
+          ],
+        },
+        second: {
+          name: 'second',
+          events: [
+            {
+              cloudFront: {
+                eventType: 'viewer-request',
+                origin: 's3://anotherbucket.s3.amazonaws.com/files',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileCloudFrontEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
+        FirstLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            FunctionName: 'first',
+          },
+        },
+        SecondLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            FunctionName: 'second',
+          },
+        },
+      };
+
+      awsCompileCloudFrontEvents.compileCloudFrontEvents();
+
+      expect(
+        awsCompileCloudFrontEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.CloudFrontDistribution.Properties.DistributionConfig.Origins[0]
+      ).to.eql({
+        Id: 'First/files',
+        DomainName: 'bucketname.s3.amazonaws.com',
+        OriginPath: '/files',
+        S3OriginConfig: {},
+      });
+
+      expect(
+        awsCompileCloudFrontEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.CloudFrontDistribution.Properties.DistributionConfig.Origins[1]
+      ).to.eql({
+        Id: 'Second/files',
+        DomainName: 'anotherbucket.s3.amazonaws.com',
+        OriginPath: '/files',
+        S3OriginConfig: {},
+      });
+    });
   });
 });

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -411,7 +411,7 @@ describe('AwsCompileCloudFrontEvents', () => {
       });
     });
 
-    it('should create different origins if for different domains with the same path', () => {
+    it('should create different origins for different domains with the same path', () => {
       awsCompileCloudFrontEvents.serverless.service.functions = {
         first: {
           name: 'first',


### PR DESCRIPTION
## What did you implement

Use both the domain name and the origin path to determine if two origins are equal

Closes #6864

## How can we verify it
Unit test has been added.

The following serverless.yaml should create two origins, previously only one was created

```
service:
  name: cloudfront-test

provider:
  name: aws
  runtime: nodejs10.x

functions:
  first:
    handler: first.handler
    events:
      - cloudFront:
          eventType: viewer-request
          origin: s3://bucketname.s3.amazonaws.com/files
  second:
    handler: second.handler
    events:
      - cloudFront:
          eventType: viewer-request
          pathPattern: /second
          origin: s3://bucketname.s3.amazonaws.com/files
```

## Todos

- [x] Write and run all tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
