### PR TITLE
Removed travis configuration for deprecated node v 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,9 +104,6 @@ jobs:
           cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || :
         - rm -rf ./coverage
 
-    - name: 'Unit Tests - Linux - Node.js v6'
-      node_js: 6
-
     - stage: Integration Test
       name: 'Integration Tests - Linux - Node.js v12'
       node_js: 12


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
Reviewed into why async tests are failing as mentioned on #5533
Noticed that the travis.yml log was still running tests for node v6 which has been retired since April of this year:
https://github.com/nodejs/Release

Async / await was introduced in Node version 8
## How can we verify it
For example, the popular async/await pattern to interact with promises was first introduced in the Node.js 8 (“Carbon”)
https://aws.amazon.com/blogs/developer/node-js-6-is-approaching-end-of-life-upgrade-your-aws-lambda-functions-to-the-node-js-10-lts/


when you take a look at the examples included in the original issue the tests that failed were all Node v 6 and older.

https://travis-ci.org/serverless/serverless/jobs/433968798#L6846
https://travis-ci.org/serverless/serverless/jobs/460342754#L6803
https://travis-ci.org/serverless/serverless/jobs/461000739#L6803
https://travis-ci.org/serverless/serverless/jobs/461008020#L6173

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->
ran npm test
npm lint 
which completed without error.
Please let me know if anything else needs to be done for this!
</details>

- [x ] Write and run all tests
- [ x] Write documentation
- [x ] Enable "Allow edits from maintainers" for this PR
- [ x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
