### PR TITLE
Fix region error handling in Lambda@Edge implementation

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const url = require('url');
 const chalk = require('chalk');
-const ServerlessError = require('../../../../../../classes/Error');
+const { ServerlessError } = require('../../../../../../classes/Error');
 
 class AwsCompileCloudFrontEvents {
   constructor(serverless, options) {

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -13,12 +13,13 @@ const { expect } = chai;
 describe('AwsCompileCloudFrontEvents', () => {
   let serverless;
   let awsCompileCloudFrontEvents;
-  const options = {
-    stage: 'dev',
-    region: 'us-east-1',
-  };
+  let options;
 
   beforeEach(() => {
+    options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
     serverless = new Serverless();
     serverless.processedInput = {
       commands: [],
@@ -263,6 +264,83 @@ describe('AwsCompileCloudFrontEvents', () => {
       };
 
       expect(() => awsCompileCloudFrontEvents.compileCloudFrontEvents()).to.throw(Error);
+    });
+
+    it('should throw an error if the region is not us-east-1', () => {
+      options.region = 'eu-central-1';
+      awsCompileCloudFrontEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cloudFront: {
+                eventType: 'viewer-request',
+                origin: 's3://bucketname.s3.amazonaws.com/files',
+              },
+            },
+          ],
+        },
+      };
+      awsCompileCloudFrontEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
+        FirstLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            FunctionName: 'first',
+          },
+        },
+        FirstLambdaVersion: {
+          Type: 'AWS::Lambda::Version',
+          Properties: {
+            FunctionName: { Ref: 'FirstLambdaFunction' },
+          },
+        },
+        IamRoleLambdaExecution: {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            AssumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Principal: {
+                    Service: ['lambda.amazonaws.com'],
+                  },
+                  Action: ['sts:AssumeRole'],
+                },
+              ],
+            },
+            Policies: [
+              {
+                PolicyName: {
+                  'Fn::Join': ['-', ['dev', 'first', 'lambda']],
+                },
+                PolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [],
+                },
+              },
+            ],
+            Path: '/',
+            RoleName: {
+              'Fn::Join': [
+                '-',
+                [
+                  'first',
+                  'dev',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  'lambdaRole',
+                ],
+              ],
+            },
+          },
+        },
+      };
+
+      expect(() => awsCompileCloudFrontEvents.compileCloudFrontEvents()).to.throw(
+        /to the us-east-1 region/
+      );
     });
 
     it('should create corresponding resources when cloudFront events are given', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Fixes a problem where the `ServerlessError` class was not used correctly. Also added the unit tests which checks if the region is validated.

## How can we verify it

Run `serverless package` with the following `serverless.yml`. You shouldn't see an error due to a `ServerlessError` misuse (but you should see the error that the region is incorrect).

```yaml
service: test-${self:custom.idx}

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false
  region: eu-central-1
  stage: dev

custom:
  idx: 0

functions:
  hello:
    handler: functions/handler.handler
    events:
      - cloudFront:
          eventType: viewer-response
          origin: https://serverless.com/framework/docs
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO