### PR TITLE
Resolving async test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,9 +104,6 @@ jobs:
           cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || :
         - rm -rf ./coverage
 
-    - name: 'Unit Tests - Linux - Node.js v6'
-      node_js: 6
-
     - stage: Integration Test
       name: 'Integration Tests - Linux - Node.js v12'
       node_js: 12

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,9 @@ jobs:
           cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || :
         - rm -rf ./coverage
 
+    - name: 'Unit Tests - Linux - Node.js v6'
+      node_js: 6
+
     - stage: Integration Test
       name: 'Integration Tests - Linux - Node.js v12'
       node_js: 12

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -240,7 +240,7 @@ describe('AwsProvider', () => {
 
   describe('#request()', () => {
     beforeEach(() => {
-      const originalSetTimeout = setTimeout;
+      const originalSetTimeout = global.setTimeout;
       sinon
         .stub(global, 'setTimeout')
         .callsFake((cb, timeout) => originalSetTimeout(cb, Math.min(timeout || 0, 10)));


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
working on resolving issue #5533
with the async aws tests failing.
went and reviewed the travis logs to see which specific test was failing.
Noticed that it was consistently:
```
should resolve to the same response with multiple parallel requests
``` 
Reviewed the test and noticed that this line 
```
 const originalSetTimeout = setTimeout;
```
was trying to call the node object timeout 
found the following through research
https://github.com/sinonjs/sinon/issues/269
reviewed documents from node.js  and confirmed this was true
https://nodejs.org/api/globals.html
Updated the line
## How can we verify it
The test should now no longer fail when travis is running.

## Todos

<details>
<summary>Useful Scripts</summary>
ran
 npm test
npm test-ci
npm run lint 
which all completed without error
</details>

- [x ] Write and run all tests
- [ x] Write documentation
- [x ] Enable "Allow edits from maintainers" for this PR
- [ x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
