### PR TITLE
Fix deployment bucket policy handling with custom bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.56.1 (2019-10-31)
+
+- [Fix deployment bucket policy handling with custom bucket ](https://github.com/serverless/serverless/pull/6909)
+
+## Meta
+
+- [Comparison since last release](https://github.com/serverless/serverless/comparev1.56.0...v1.56.1)
+
 # 1.56.0 (2019-10-31)
 
 - [AWS - deployment bucket policy for HTTPS only](https://github.com/serverless/serverless/pull/6823)

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -90,6 +90,8 @@ module.exports = {
 
           delete this.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .ServerlessDeploymentBucket;
+          delete this.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ServerlessDeploymentBucketPolicy;
         });
     }
 

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -88,7 +88,6 @@ describe('#generateCoreTemplate()', () => {
     return expect(awsPlugin.generateCoreTemplate()).to.be.fulfilled.then(() => {
       const template = awsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
       expect(template.Outputs.ServerlessDeploymentBucketName.Value).to.equal(bucketName);
-      // eslint-disable-next-line no-unused-expressions
       expect(template.Resources.ServerlessDeploymentBucket).to.not.exist;
     });
   });

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -89,6 +89,7 @@ describe('#generateCoreTemplate()', () => {
       const template = awsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
       expect(template.Outputs.ServerlessDeploymentBucketName.Value).to.equal(bucketName);
       expect(template.Resources.ServerlessDeploymentBucket).to.not.exist;
+      expect(template.Resources.ServerlessDeploymentBucketPolicy).to.not.exist;
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
Fixes #6908

Regression introduced with #6823 where we've introduced a bucket policy for our default S3 bucket. Still it should not be introduced where custom deployment bucket is provided.