### PR TITLE
Fix race conditions handling in stats requests

### DIFF
--- a/lib/utils/tracking.js
+++ b/lib/utils/tracking.js
@@ -167,6 +167,7 @@ function sendPending(options = {}) {
                   return request(data.type, data.event, { id: dirFilename, timeout: 3000 });
                 },
                 readJsonError => {
+                  if (readJsonError.code === 'ENOENT') return null; // Race condition
                   logError(`Cannot read cache file: ${dirFilename}`, readJsonError);
                   return fse.unlinkAsync(join(cacheDirPath, dirFilename));
                 }

--- a/lib/utils/tracking.js
+++ b/lib/utils/tracking.js
@@ -169,7 +169,9 @@ function sendPending(options = {}) {
                 readJsonError => {
                   if (readJsonError.code === 'ENOENT') return null; // Race condition
                   logError(`Cannot read cache file: ${dirFilename}`, readJsonError);
-                  return fse.unlinkAsync(join(cacheDirPath, dirFilename));
+                  return fse.unlinkAsync(join(cacheDirPath, dirFilename)).catch(error => {
+                    logError(`Could not remove cache file ${dirFilename}`, error);
+                  });
                 }
               );
             })


### PR DESCRIPTION
Fixes  #6917

When multiple invocation of `sls` command occur, there's a risk of race conditions.

One of the error scenarios was not handled gently. This PR fixes that