### PR TITLE
Fix missing ALB trigger in console

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -446,6 +446,9 @@ module.exports = {
   getLambdaAlbPermissionLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlb`;
   },
+  getLambdaRegisterTargetPermissionLogicalId(functionName) {
+    return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionRegisterTarget`;
+  },
 
   // Custom Resources
   getCustomResourcesArtifactDirectoryName() {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -662,6 +662,14 @@ describe('#naming()', () => {
         );
       });
     });
+
+    describe('#getLambdaRegisterTargetPermissionLogicalId()', () => {
+      it('should normalize the function name and add the correct suffix', () => {
+        expect(sdk.naming.getLambdaRegisterTargetPermissionLogicalId('functionName')).to.equal(
+          'FunctionNameLambdaPermissionRegisterTarget'
+        );
+      });
+    });
   });
 
   describe('#getQueueLogicalId()', () => {

--- a/lib/plugins/aws/package/compile/events/alb/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/permissions.js
@@ -1,27 +1,44 @@
 'use strict';
 
+const _ = require('lodash');
+
 module.exports = {
   compilePermissions() {
     this.validated.events.forEach(event => {
-      const { functionName } = event;
+      const { functionName, albId } = event;
 
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
       const albPermissionLogicalId = this.provider.naming.getLambdaAlbPermissionLogicalId(
         functionName
       );
+      const registerTargetPermissionLogicalId = this.provider.naming.getLambdaRegisterTargetPermissionLogicalId(
+        functionName
+      );
+      const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
+        functionName,
+        albId
+      );
 
-      Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
-        [albPermissionLogicalId]: {
-          Type: 'AWS::Lambda::Permission',
-          Properties: {
-            FunctionName: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
-            Action: 'lambda:InvokeFunction',
-            Principal: 'elasticloadbalancing.amazonaws.com',
+      const albInvokePermission = {
+        Type: 'AWS::Lambda::Permission',
+        Properties: {
+          FunctionName: {
+            'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
           },
-          DependsOn: [lambdaLogicalId],
+          Action: 'lambda:InvokeFunction',
+          Principal: 'elasticloadbalancing.amazonaws.com',
         },
+      };
+
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+        [albPermissionLogicalId]: _.merge({}, albInvokePermission, {
+          Properties: {
+            SourceArn: {
+              Ref: targetGroupLogicalId,
+            },
+          },
+        }),
+        [registerTargetPermissionLogicalId]: albInvokePermission,
       });
     });
   },

--- a/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
@@ -31,6 +31,7 @@ describe('#compilePermissions()', () => {
             host: 'example.com',
             path: '/hello',
           },
+          albId: '50dc6c495c0c9188',
         },
         {
           functionName: 'second',
@@ -42,6 +43,7 @@ describe('#compilePermissions()', () => {
           conditions: {
             path: '/world',
           },
+          albId: '50dc6c495c0c9188',
         },
       ],
     };
@@ -59,8 +61,20 @@ describe('#compilePermissions()', () => {
           'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'],
         },
         Principal: 'elasticloadbalancing.amazonaws.com',
+        SourceArn: {
+          Ref: 'FirstAlbTargetGroup50dc6c495c0c9188',
+        },
       },
-      DependsOn: ['FirstLambdaFunction'],
+    });
+    expect(resources.FirstLambdaPermissionRegisterTarget).to.deep.equal({
+      Type: 'AWS::Lambda::Permission',
+      Properties: {
+        Action: 'lambda:InvokeFunction',
+        FunctionName: {
+          'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'],
+        },
+        Principal: 'elasticloadbalancing.amazonaws.com',
+      },
     });
     expect(resources.SecondLambdaPermissionAlb).to.deep.equal({
       Type: 'AWS::Lambda::Permission',
@@ -70,8 +84,21 @@ describe('#compilePermissions()', () => {
           'Fn::GetAtt': ['SecondLambdaFunction', 'Arn'],
         },
         Principal: 'elasticloadbalancing.amazonaws.com',
+        SourceArn: {
+          Ref: 'SecondAlbTargetGroup50dc6c495c0c9188',
+        },
       },
-      DependsOn: ['SecondLambdaFunction'],
+    });
+
+    expect(resources.SecondLambdaPermissionRegisterTarget).to.deep.equal({
+      Type: 'AWS::Lambda::Permission',
+      Properties: {
+        Action: 'lambda:InvokeFunction',
+        FunctionName: {
+          'Fn::GetAtt': ['SecondLambdaFunction', 'Arn'],
+        },
+        Principal: 'elasticloadbalancing.amazonaws.com',
+      },
     });
   });
 });

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -10,7 +10,7 @@ module.exports = {
         albId
       );
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-      const lambdaPermissionLogicalId = this.provider.naming.getLambdaAlbPermissionLogicalId(
+      const registerTargetPermissionLogicalId = this.provider.naming.getLambdaRegisterTargetPermissionLogicalId(
         functionName
       );
 
@@ -34,7 +34,7 @@ module.exports = {
               },
             ],
           },
-          DependsOn: [lambdaPermissionLogicalId],
+          DependsOn: [registerTargetPermissionLogicalId],
         },
       });
     });

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -85,7 +85,7 @@ describe('#compileTargetGroups()', () => {
           },
         ],
       },
-      DependsOn: ['FirstLambdaPermissionAlb'],
+      DependsOn: ['FirstLambdaPermissionRegisterTarget'],
     });
     expect(resources.SecondAlbTargetGroup50dc6c495c0c9188).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
@@ -106,7 +106,7 @@ describe('#compileTargetGroups()', () => {
           },
         ],
       },
-      DependsOn: ['SecondLambdaPermissionAlb'],
+      DependsOn: ['SecondLambdaPermissionRegisterTarget'],
     });
     // Target groups are unique to functions/albs, so there should only be 2 target groups
     expect(Object.keys(resources).length).to.be.equal(2);


### PR DESCRIPTION
## What did you implement

A fix for the missing Application Load Balancer trigger in the Lambda console.

Closes #6818 .

## How did I implemented it

The problem is caused by the incorrect Lambda [resource-based policy](https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html) created by Serverless.

Take this example of policy created by Serverless:
```json
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "test-dev-Hello1LambdaPermissionAlb-2WKZLN09SNOZ",
      "Effect": "Allow",
      "Principal": {
        "Service": "elasticloadbalancing.amazonaws.com"
      },
      "Action": "lambda:InvokeFunction",
      "Resource": "arn:aws:lambda:us-east-1:11111111111:function:test-dev-hello1"
    }
  ]
}
```
An then this example of policy created by the AWS console when you manually add the ALB trigger:
```json
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "lambda-ab7ae265-c2c9-4217-87e7-ebf9918db260",
      "Effect": "Allow",
      "Principal": {
        "Service": "elasticloadbalancing.amazonaws.com"
      },
      "Action": "lambda:InvokeFunction",
      "Resource": "arn:aws:lambda:us-east-1:11111111111:function:test-dev-hello1",
      "Condition": {
        "ArnLike": {
          "AWS:SourceArn": "arn:aws:elasticloadbalancing:us-east-1:11111111111:targetgroup/lambda-72ZAkhnEYNuLnTJpwfh0/2e637b34d268de44"
        }
      }
    }
  ]
}
```
So the difference is the missing `Condition.ArnLike.AWS:SourceArn` property. So I figured a fix would be simple.. but no.

The current version of Serverless creates Target Groups and Lambda Permissions as follows:
```json
{
  "Hello1AlbTargetGroupHTTPListener": {
    "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
    "Properties": {
      "TargetType": "lambda",
      "Targets": [
        {
          "Id": {
            "Fn::GetAtt": [
              "Hello1LambdaFunction",
              "Arn"
            ]
          }
        }
      ],
      "Name": "50b70c777a4a415cf59615c2892df119",
      "Tags": [
        {
          "Key": "Name",
          "Value": "test-hello1-HTTPListener-dev"
        }
      ]
    },
    "DependsOn": [
      "Hello1LambdaPermissionAlb"
    ]
  },
  "Hello1LambdaPermissionAlb": {
    "Type": "AWS::Lambda::Permission",
    "Properties": {
      "FunctionName": {
        "Fn::GetAtt": [
          "Hello1LambdaFunction",
          "Arn"
        ]
      },
      "Action": "lambda:InvokeFunction",
      "Principal": "elasticloadbalancing.amazonaws.com"
    }
  }
}
```
Note the `DependsOn` on the Target Group.
If you try to add to the Target Group a `SourceArn` property:
```json
"SourceArn": {
  "Ref": "Hello1AlbTargetGroupHTTPListener"
}
```
Then there is a circular reference error in CloudFormation.
And if you remove the `DependsOn` from the Target Group you have this error:
```
An error occurred: Hello1AlbTargetGroupHTTPListener - API: elasticloadbalancingv2:RegisterTargets elasticloadbalancing principal does not have permission to invoke arn:aws:lambda:us-east-1:11111111:function:test-dev-hello1 from target group arn:aws:elasticloadbalancing:us-east-1:111111111:targetgroup/50b70c777a4a415cf59615c2892df119/6b9774da36d20e72.
```
(cf. [documentation](https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html))

So the only way I found around that is to add an additional permission used specifically for the register target operation, and update the existing one with the `Condition.ArnLike.AWS:SourceArn`.

## How can we verify it

Deploy the service:

<details>
<summary>hello.js</summary>

```javascript
module.exports.hello = async () => ({
  isBase64Encoded: false,
  statusCode: 200,
  statusDescription: '200 OK',
  headers: {
    'Set-cookie': 'cookies',
    'Content-Type': 'application/json',
  },
  body: 'Hello from Lambda',
});
```

</details>

<details>
<summary>serverless.yml</summary>

(I use `package.artifact` property to speed up deployments so you need to `zip lambda-package hello.js` first).

```yaml
service: test

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

package:
  individually: true
  excludeDevDependencies: false

functions:
  hello1:
    handler: hello.hello
    package:
      artifact: lambda-package.zip
    events:
      - alb:
          listenerArn: { Ref: HTTPListener }
          priority: 1
          conditions:
            path: /hello1

custom:
  defaultRegion: us-east-1
  defaultStage: dev
  region: ${opt:region, self:custom.defaultRegion}
  stage: ${opt:stage, self:custom.defaultStage}
  objectPrefix: '${self:service}-${self:custom.stage}'

resources:
  Outputs:
    LoadBalancerDNSName:
      Value: { 'Fn::GetAtt': [ LoadBalancer, 'DNSName' ] }
      Export: { Name: '${self:custom.objectPrefix}-LoadBalancerDNSName' }
    ListenerArn:
      Value: { 'Ref': HTTPListener }
  Resources:
    VPC:
      Type: 'AWS::EC2::VPC'
      Properties:
        CidrBlock: 172.31.0.0/16
        EnableDnsHostnames: true
    InternetGateway:
      Type: 'AWS::EC2::InternetGateway'
    VPCGatewayAttachment:
      Type: 'AWS::EC2::VPCGatewayAttachment'
      Properties:
        VpcId: { Ref: VPC }
        InternetGatewayId: { Ref: InternetGateway }
    RouteTable:
      Type: 'AWS::EC2::RouteTable'
      Properties:
        VpcId: { Ref: VPC }
    InternetRoute:
      Type: 'AWS::EC2::Route'
      DependsOn: VPCGatewayAttachment
      Properties:
        DestinationCidrBlock: 0.0.0.0/0
        GatewayId: { Ref: InternetGateway }
        RouteTableId: { Ref: RouteTable }
    SubnetA:
      Type: 'AWS::EC2::Subnet'
      Properties:
        AvailabilityZone: '${self:custom.region}a'
        CidrBlock: 172.31.0.0/20
        MapPublicIpOnLaunch: false
        VpcId: { Ref: VPC }
    SubnetB:
      Type: 'AWS::EC2::Subnet'
      Properties:
        AvailabilityZone: '${self:custom.region}b'
        CidrBlock: 172.31.16.0/20
        MapPublicIpOnLaunch: false
        VpcId: { Ref: VPC }
    SubnetARouteTableAssociation:
      Type: 'AWS::EC2::SubnetRouteTableAssociation'
      Properties:
        SubnetId: { Ref: SubnetA }
        RouteTableId: { Ref: RouteTable }
    SubnetBRouteTableAssociation:
      Type: 'AWS::EC2::SubnetRouteTableAssociation'
      Properties:
        SubnetId: { Ref: SubnetB }
        RouteTableId: { Ref: RouteTable }
    SecurityGroup:
      Type: 'AWS::EC2::SecurityGroup'
      Properties:
        GroupName: 'http-https'
        GroupDescription: 'HTTPS / HTTPS inbound; Nothing outbound'
        VpcId: { Ref: VPC }
        SecurityGroupIngress:
          -
            IpProtocol: tcp
            FromPort: '80'
            ToPort: '80'
            CidrIp: 0.0.0.0/0
          -
            IpProtocol: tcp
            FromPort: '443'
            ToPort: '443'
            CidrIp: 0.0.0.0/0
        SecurityGroupEgress:
          -
            IpProtocol: -1
            FromPort: '1'
            ToPort: '1'
            CidrIp: 127.0.0.1/32
    LoadBalancer:
      Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
      Properties:
        Type: 'application'
        Name: '${self:custom.objectPrefix}'
        IpAddressType: 'ipv4'
        Scheme: 'internet-facing'
        LoadBalancerAttributes:
          - { Key: 'deletion_protection.enabled', Value: false }
          - { Key: 'routing.http2.enabled', Value: false }
          - { Key: 'access_logs.s3.enabled', Value: false }
        SecurityGroups:
          - { Ref: SecurityGroup }
        Subnets:
          - { Ref: SubnetA }
          - { Ref: SubnetB }
    HTTPListener:
      Type: 'AWS::ElasticLoadBalancingV2::Listener'
      Properties:
        LoadBalancerArn: { Ref: LoadBalancer }
        Port: 80
        Protocol: 'HTTP'
        DefaultActions:
          -
            Type: 'fixed-response'
            Order: 1
            FixedResponseConfig:
              StatusCode: 404
              ContentType: 'application/json'
              MessageBody: '{ "not": "found" }'
```
</details>

Check that the trigger appears in the Lambda console.
Retrieved the ALB DNS and check that you can reach the lambda:
```
curl -X GET \
  http://<your_dns_subdomain>.us-east-1.elb.amazonaws.com/hello1 \
  -H 'Postman-Token: f1780e10-58a7-4eca-9199-011d647ef61c' \
  -H 'cache-control: no-cache'
```


Then try to modify it in various ways (use multiple events with different listener, etc.) and repeat.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
