### PR TITLE
Fix policy definition

### DIFF
--- a/lib/plugins/aws/package/lib/core-cloudformation-template.json
+++ b/lib/plugins/aws/package/lib/core-cloudformation-template.json
@@ -32,7 +32,13 @@
                 {
                   "Fn::Join": [
                     "",
-                    ["arn:${AWS::Partition}:s3:::", { "Ref": "ServerlessDeploymentBucket" }, "/*"]
+                    [
+                      "arn:",
+                      { "Ref": "AWS::Partition" },
+                      ":s3:::",
+                      { "Ref": "ServerlessDeploymentBucket" },
+                      "/*"
+                    ]
                   ]
                 }
               ],

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -48,7 +48,13 @@ describe('#generateCoreTemplate()', () => {
           {
             'Fn::Join': [
               '',
-              ['arn:${AWS::Partition}:s3:::', { Ref: 'ServerlessDeploymentBucket' }, '/*'],
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':s3:::',
+                { Ref: 'ServerlessDeploymentBucket' },
+                '/*',
+              ],
             ],
           },
         ],


### PR DESCRIPTION
Regression just introduced with https://github.com/serverless/serverless/pull/6934

It appears AWS doesn't accept pseudoparams in strings sneaked into Fn::Join