### PR TITLE
PLAT-1798 - set env vars for AWS creds from cached credentials…

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -128,6 +128,14 @@ class AwsInvokeLocal {
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
     };
 
+    const credentialEnvVars = this.provider.cachedCredentials
+      ? {
+          AWS_ACCESS_KEY_ID: this.provider.cachedCredentials.accessKeyId,
+          AWS_SECRET_ACCESS_KEY: this.provider.cachedCredentials.secretAccessKey,
+          AWS_SESSION_TOKEN: this.provider.cachedCredentials.sessionToken,
+        }
+      : {};
+
     // profile override from config
     const profileOverride = this.provider.getProfile();
     if (profileOverride) {
@@ -136,7 +144,7 @@ class AwsInvokeLocal {
 
     const configuredEnvVars = this.getConfiguredEnvVars();
 
-    _.merge(process.env, lambdaDefaultEnvVars, configuredEnvVars);
+    _.merge(process.env, lambdaDefaultEnvVars, credentialEnvVars, configuredEnvVars);
 
     return BbPromise.resolve();
   }

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -327,6 +327,18 @@ describe('AwsInvokeLocal', () => {
         expect(process.env.NODE_PATH).to.equal('/var/runtime:/var/task:/var/runtime/node_modules');
       }));
 
+    it('it should set credential env vars', () => {
+      provider.cachedCredentials.accessKeyId = 'ID';
+      provider.cachedCredentials.secretAccessKey = 'SECRET';
+      provider.cachedCredentials.sessionToken = 'TOKEN';
+
+      return awsInvokeLocal.loadEnvVars().then(() => {
+        expect(process.env.AWS_ACCESS_KEY_ID).to.equal('ID');
+        expect(process.env.AWS_SECRET_ACCESS_KEY).to.equal('SECRET');
+        expect(process.env.AWS_SESSION_TOKEN).to.equal('TOKEN');
+      });
+    });
+
     it('should fallback to service provider configuration when options are not available', () => {
       awsInvokeLocal.provider.options.region = null;
       awsInvokeLocal.serverless.service.provider.region = 'us-west-1';


### PR DESCRIPTION

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Allows for use of credentials provided by a deploy profile in the
serverless dashboard

<!-- Briefly describe the scope of your PR -->

Closes PLAT-1798
## How can we verify it

on a system with no credentials, set up a project using serverless dashbaord with an access role in your deploy profile. then create a project with `sls create -t aws-nodejs` then replace the `handler.js` with
```javascript
const AWS = require('aws-sdk');
const sts = new AWS.STS();
module.exports.hello = async () => {
  await sts.getCallerIdentity();
}
```

and configure your app/org in `serverless.yml` with the respective values from your dashboard config.

then install this branch and invoke
```
npm i -g serverless/serverless#sfe-creds-invoke-local
sls invoke local -f hello
```

it should work. on master it should fail due to lack of creds

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
