### PR TITLE
Add support for multi-value headers in ALB events

### DIFF
--- a/docs/providers/aws/events/alb.md
+++ b/docs/providers/aws/events/alb.md
@@ -61,3 +61,45 @@ functions:
               - fe80:0000:0000:0000:0204:61ff:fe9d:f156/6
               - 192.168.0.1/0
 ```
+
+## Enabling multi-value headers
+
+By default when the request contains a duplicate header field name or query parameter key, the load balancer uses the last value sent by the client.
+
+Set the `multiValueHeaders` attribute to `true` if you want to receive headers and query parameters as an array of values.
+
+```yml
+functions:
+  albEventConsumer:
+    handler: handler.hello
+    events:
+      - alb:
+          listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
+          priority: 1
+          multiValueHeaders: true
+          conditions:
+            path: /hello
+```
+
+When this option is enabled, the event structure is changed:
+
+```javascript
+module.exports.hello = async (event, context, callback) => {
+  const headers = event.multiValueHeaders;
+  const queryString = event.multiValueQueryStringParameters;
+
+  ...
+
+  return {
+    statusCode: 200,
+    statusDescription: '200 OK',
+    isBase64Encoded: false,
+    multiValueHeaders: {
+      'Content-Type': ['application/json'],
+      'Set-Cookie': ['language=en-us', 'theme=rust']
+    }
+  };
+};
+```
+
+The handler response object must use `multiValueHeaders` to set HTTP response headers, `headers` would be ignored.

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -374,18 +374,20 @@ module.exports = {
   },
 
   // ALB
-  getAlbTargetGroupLogicalId(functionName, albId) {
-    return `${this.getNormalizedFunctionName(functionName)}AlbTargetGroup${albId}`;
+  getAlbTargetGroupLogicalId(functionName, albId, multiValueHeaders) {
+    return `${this.getNormalizedFunctionName(functionName)}Alb${
+      multiValueHeaders ? 'MultiValue' : ''
+    }TargetGroup${albId}`;
   },
-  getAlbTargetGroupNameTagValue(functionName, albId) {
-    return `${
-      this.provider.serverless.service.service
-    }-${functionName}-${albId}-${this.provider.getStage()}`;
+  getAlbTargetGroupNameTagValue(functionName, albId, multiValueHeaders) {
+    return `${this.provider.serverless.service.service}-${functionName}-${albId}-${
+      multiValueHeaders ? 'multi-value-' : ''
+    }${this.provider.getStage()}`;
   },
-  getAlbTargetGroupName(functionName, albId) {
+  getAlbTargetGroupName(functionName, albId, multiValueHeaders) {
     return crypto
       .createHash('md5')
-      .update(this.getAlbTargetGroupNameTagValue(functionName, albId))
+      .update(this.getAlbTargetGroupNameTagValue(functionName, albId, multiValueHeaders))
       .digest('hex');
   },
   getAlbListenerRuleLogicalId(functionName, idx) {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -686,6 +686,12 @@ describe('#naming()', () => {
         'FunctionNameAlbTargetGroupabc123'
       );
     });
+
+    it('should normalize the function name and add MultiValue prefix if multiValueHeader is true', () => {
+      expect(sdk.naming.getAlbTargetGroupLogicalId('functionName', 'abc123', true)).to.equal(
+        'FunctionNameAlbMultiValueTargetGroupabc123'
+      );
+    });
   });
 
   describe('#getAlbListenerRuleLogicalId()', () => {
@@ -697,19 +703,21 @@ describe('#naming()', () => {
   });
 
   describe('#getAlbTargetGroupName()', () => {
-    it('should return a unique identifier based on the service name, function name and stage', () => {
+    it('should return a unique identifier based on the service name, function name, alb id, multi-value attribute and stage', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupName('functionName', 'abc123')).to.equal(
-        '61615b0fb1c56b80657106894392e27f'
+      expect(sdk.naming.getAlbTargetGroupName('functionName', 'abc123', true)).to.equal(
+        '79039bd239ac0b3f6ff6d9296f23e27c'
       );
     });
   });
 
   describe('#getAlbTargetGroupNameTagValue()', () => {
-    it('should return the composition of service name, function name and stage', () => {
+    it('should return the composition of service name, function name, alb id, multi-value attribute and stage', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName', 'abc123')).to.equal(
-        `${serverless.service.service}-functionName-abc123-${sdk.naming.provider.getStage()}`
+      expect(sdk.naming.getAlbTargetGroupNameTagValue('functionName', 'abc123', true)).to.equal(
+        `${
+          serverless.service.service
+        }-functionName-abc123-multi-value-${sdk.naming.provider.getStage()}`
       );
     });
   });

--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -9,7 +9,8 @@ module.exports = {
       );
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         event.functionName,
-        event.albId
+        event.albId,
+        event.multiValueHeaders
       );
 
       const Conditions = [

--- a/lib/plugins/aws/package/compile/events/alb/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/permissions.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 module.exports = {
   compilePermissions() {
     this.validated.events.forEach(event => {
-      const { functionName, albId } = event;
+      const { functionName, albId, multiValueHeaders } = event;
 
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
       const albPermissionLogicalId = this.provider.naming.getLambdaAlbPermissionLogicalId(
@@ -16,7 +16,8 @@ module.exports = {
       );
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         functionName,
-        albId
+        albId,
+        multiValueHeaders
       );
 
       const albInvokePermission = {

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -3,39 +3,47 @@
 module.exports = {
   compileTargetGroups() {
     this.validated.events.forEach(event => {
-      const { functionName, albId } = event;
+      const { functionName, albId, multiValueHeaders = false } = event;
 
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         functionName,
-        albId
+        albId,
+        multiValueHeaders
       );
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
       const registerTargetPermissionLogicalId = this.provider.naming.getLambdaRegisterTargetPermissionLogicalId(
         functionName
       );
 
-      Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
-        [targetGroupLogicalId]: {
-          Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
-          Properties: {
-            TargetType: 'lambda',
-            Targets: [
-              {
-                Id: {
-                  'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                },
+      const TargetGroup = {
+        Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+        Properties: {
+          TargetType: 'lambda',
+          Targets: [
+            {
+              Id: {
+                'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
               },
-            ],
-            Name: this.provider.naming.getAlbTargetGroupName(functionName, albId),
-            Tags: [
-              {
-                Key: 'Name',
-                Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName, albId),
-              },
-            ],
-          },
-          DependsOn: [registerTargetPermissionLogicalId],
+            },
+          ],
+          Name: this.provider.naming.getAlbTargetGroupName(functionName, albId, multiValueHeaders),
+          Tags: [
+            {
+              Key: 'Name',
+              Value: this.provider.naming.getAlbTargetGroupNameTagValue(functionName, albId),
+            },
+          ],
+          TargetGroupAttributes: [
+            {
+              Key: 'lambda.multi_value_headers.enabled',
+              Value: multiValueHeaders,
+            },
+          ],
         },
+        DependsOn: [registerTargetPermissionLogicalId],
+      };
+      Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+        [targetGroupLogicalId]: TargetGroup,
       });
     });
   },

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -23,6 +23,7 @@ describe('#compileTargetGroups()', () => {
         {
           functionName: 'first',
           albId: '50dc6c495c0c9188',
+          multiValueHeaders: true,
           listenerArn:
             'arn:aws:elasticloadbalancing:' +
             'us-east-1:123456789012:listener/app/my-load-balancer/' +
@@ -76,6 +77,12 @@ describe('#compileTargetGroups()', () => {
             Id: {
               'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'],
             },
+          },
+        ],
+        TargetGroupAttributes: [
+          {
+            Key: 'lambda.multi_value_headers.enabled',
+            Value: true,
           },
         ],
         Tags: [

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -67,10 +67,10 @@ describe('#compileTargetGroups()', () => {
     const resources =
       awsCompileAlbEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
-    expect(resources.FirstAlbTargetGroup50dc6c495c0c9188).to.deep.equal({
+    expect(resources.FirstAlbMultiValueTargetGroup50dc6c495c0c9188).to.deep.equal({
       Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
       Properties: {
-        Name: '879129784b3012595bceeaa4a76fc7bc',
+        Name: 'cee340765bf4be569254b8969c1d07a0',
         TargetType: 'lambda',
         Targets: [
           {
@@ -104,6 +104,12 @@ describe('#compileTargetGroups()', () => {
             Id: {
               'Fn::GetAtt': ['SecondLambdaFunction', 'Arn'],
             },
+          },
+        ],
+        TargetGroupAttributes: [
+          {
+            Key: 'lambda.multi_value_headers.enabled',
+            Value: false,
           },
         ],
         Tags: [

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -174,7 +174,7 @@ module.exports = {
     if (event.alb.multiValueHeaders && !_.isBoolean(event.alb.multiValueHeaders)) {
       const errorMessage = [
         `Invalid ALB event "multiValueHeaders" attribute in function "${functionName}".`,
-        ` You must provide a boolean.`,
+        ' You must provide a boolean.',
       ].join('\n');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -49,6 +49,12 @@ module.exports = {
             if (event.alb.conditions.ip) {
               albObj.conditions.ip = this.validateIpCondition(event, functionName);
             }
+            if (event.alb.multiValueHeaders) {
+              albObj.multiValueHeaders = this.validateMultiValueHeadersAttribute(
+                event,
+                functionName
+              );
+            }
             events.push(albObj);
           }
         }
@@ -162,5 +168,16 @@ module.exports = {
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }
+  },
+
+  validateMultiValueHeadersAttribute(event, functionName) {
+    if (event.alb.multiValueHeaders && !_.isBoolean(event.alb.multiValueHeaders)) {
+      const errorMessage = [
+        `Invalid ALB event "multiValueHeaders" attribute in function "${functionName}".`,
+        ` You must provide a boolean.`,
+      ].join('\n');
+      throw new this.serverless.classes.Error(errorMessage);
+    }
+    return event.alb.multiValueHeaders;
   },
 };

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -307,4 +307,18 @@ describe('#validate()', () => {
       expect(() => awsCompileAlbEvents.validatePriorities(albEvents)).to.not.throw();
     });
   });
+
+  describe('#validateMultiValueHeadersAttribute()', () => {
+    it('should throw when multiValueHeaders value is not a boolean', () => {
+      const event = { alb: { multiValueHeaders: 'true' } };
+      expect(() => awsCompileAlbEvents.validateMultiValueHeadersAttribute(event, '')).to.throw(
+        /Invalid ALB event "multiValueHeaders" attribute/
+      );
+    });
+
+    it('should return multiValueHeaders attribute value when given a boolean', () => {
+      const event = { alb: { multiValueHeaders: true } };
+      expect(awsCompileAlbEvents.validateMultiValueHeadersAttribute(event, '')).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
## What did you implement

Closes #6504

Add multi-value header support.

Cf. [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers)

## How did I implemented it

I added the `TargetGroupAttributes` property to the Target Group definition.

There are a few things to consider tho while reading the code.

### Why do I add multiValueHeaders to Target Group name?

Because of this use case:
```yaml
functions:
  hello1:
    handler: handler.hello
    events:
      - alb:
          listenerArn: { Ref: HTTPListener }
          multiValueHeaders: true
          priority: 1
          conditions:
            path: /hello1
      - alb:
          listenerArn: { Ref: HTTPListener }
          multiValueHeaders: false
          priority: 2
          conditions:
            path: /hello2
```
Normally a single Target Group would be created for the function and used for both events. But this is not possible anymore since multiValueHeaders is set on the Target Group. Hence adding the multiValueHeaders attribute value to the Target Group name which would produces 2 TGs instead of 1 for this example.

What about adding multiValueHeaders option at the function level? I didn't really think about it but it is worth considering. 

### Why do I always add TargetGroupAttributes (even when multiValueHeaders is not set)?

I faced another annoying behavior of CloudFormation during my tests.

Take this Target Group definition:
```json
"Hello2AlbMultiValueTargetGroupHTTPListener": {
      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
      "Properties": {
        "TargetType": "lambda",
        "Targets": [
          {
            "Id": {
              "Fn::GetAtt": [
                "Hello2LambdaFunction",
                "Arn"
              ]
            }
          }
        ],
        "Name": "3e71dae291111391cbe00f3546ca61a2",
        "Tags": [
          {
            "Key": "Name",
            "Value": "test-hello2-HTTPListener-dev"
          }
        ],
        "TargetGroupAttributes": [
          {
            "Key": "lambda.multi_value_headers.enabled",
            "Value": true
          }
        ]
      },
      "DependsOn": [
        "Hello2LambdaPermissionRegisterTarget"
      ]
    },
```

If you remove the `TargetGroupAttributes` property:
```json
"Hello2AlbMultiValueTargetGroupHTTPListener": {
      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
      "Properties": {
        "TargetType": "lambda",
        "Targets": [
          {
            "Id": {
              "Fn::GetAtt": [
                "Hello2LambdaFunction",
                "Arn"
              ]
            }
          }
        ],
        "Name": "3e71dae291111391cbe00f3546ca61a2",
        "Tags": [
          {
            "Key": "Name",
            "Value": "test-hello2-HTTPListener-dev"
          }
        ]
      },
      "DependsOn": [
        "Hello2LambdaPermissionRegisterTarget"
      ]
    },
```

And then update the stack, no change will be applied (the `lambda.multi_value_headers.enabled` will stay true). You have to set explicitly `lambda.multi_value_headers.enabled` to false for CloudFormation to perform the update.

## How can we verify it

Deploy the service:
<details>
<summary>handler.js</summary>

```javascript
module.exports.hello = async event => {
  const response = {
    isBase64Encoded: false,
    statusCode: 200,
    statusDescription: '200 OK',
    body: JSON.stringify({
      message: 'Hello from Lambda with multi-value headers',
      event
    }),
  };

  let message;
  if (event.multiValueHeaders) {
    message = 'Hello from Lambda with multi-value headers';
    response.multiValueHeaders = {
      'Content-Type': ['application/json'],
    };
  } else {
    message = 'Hello from Lambda';
    response.headers = {
      'Content-Type': 'application/json',
    };
  }

  response.body = JSON.stringify({ message, event });
  return response;
};
```
</details>

<details>
<summary>serverless.yml</summary>

```yml
service: test

provider:
  name: aws
  runtime: nodejs10.x
  versionFunctions: false

package:
  individually: true
  excludeDevDependencies: false
  exclude:
    - "**"
  include:
    - "handler.js"

functions:
  hello1:
    handler: handler.hello
    events:
      - alb:
          listenerArn: { Ref: HTTPListener }
          priority: 1
          conditions:
            path: /hello1
  hello2:
    handler: handler.hello
    events:
      - alb:
          listenerArn: { Ref: HTTPListener }
          multiValueHeaders: true
          priority: 2
          conditions:
            path: /hello2
      - alb:
          listenerArn: { Ref: HTTPListener }
          priority: 3
          conditions:
            path: /hello3

custom:
  defaultRegion: us-east-1
  defaultStage: dev
  region: ${opt:region, self:custom.defaultRegion}
  stage: ${opt:stage, self:custom.defaultStage}
  objectPrefix: '${self:service}-${self:custom.stage}'

resources:
  Outputs:
    LoadBalancerDNSName:
      Value: { 'Fn::GetAtt': [LoadBalancer, 'DNSName'] }
      Export: { Name: '${self:custom.objectPrefix}-LoadBalancerDNSName' }
    ListenerArn:
      Value: { 'Ref': HTTPListener }
  Resources:
    VPC:
      Type: 'AWS::EC2::VPC'
      Properties:
        CidrBlock: 172.31.0.0/16
        EnableDnsHostnames: true
    InternetGateway:
      Type: 'AWS::EC2::InternetGateway'
    VPCGatewayAttachment:
      Type: 'AWS::EC2::VPCGatewayAttachment'
      Properties:
        VpcId: { Ref: VPC }
        InternetGatewayId: { Ref: InternetGateway }
    RouteTable:
      Type: 'AWS::EC2::RouteTable'
      Properties:
        VpcId: { Ref: VPC }
    InternetRoute:
      Type: 'AWS::EC2::Route'
      DependsOn: VPCGatewayAttachment
      Properties:
        DestinationCidrBlock: 0.0.0.0/0
        GatewayId: { Ref: InternetGateway }
        RouteTableId: { Ref: RouteTable }
    SubnetA:
      Type: 'AWS::EC2::Subnet'
      Properties:
        AvailabilityZone: '${self:custom.region}a'
        CidrBlock: 172.31.0.0/20
        MapPublicIpOnLaunch: false
        VpcId: { Ref: VPC }
    SubnetB:
      Type: 'AWS::EC2::Subnet'
      Properties:
        AvailabilityZone: '${self:custom.region}b'
        CidrBlock: 172.31.16.0/20
        MapPublicIpOnLaunch: false
        VpcId: { Ref: VPC }
    SubnetARouteTableAssociation:
      Type: 'AWS::EC2::SubnetRouteTableAssociation'
      Properties:
        SubnetId: { Ref: SubnetA }
        RouteTableId: { Ref: RouteTable }
    SubnetBRouteTableAssociation:
      Type: 'AWS::EC2::SubnetRouteTableAssociation'
      Properties:
        SubnetId: { Ref: SubnetB }
        RouteTableId: { Ref: RouteTable }
    SecurityGroup:
      Type: 'AWS::EC2::SecurityGroup'
      Properties:
        GroupName: 'http-https'
        GroupDescription: 'HTTPS / HTTPS inbound; Nothing outbound'
        VpcId: { Ref: VPC }
        SecurityGroupIngress:
        - IpProtocol: tcp
          FromPort: '80'
          ToPort: '80'
          CidrIp: 0.0.0.0/0
        - IpProtocol: tcp
          FromPort: '443'
          ToPort: '443'
          CidrIp: 0.0.0.0/0
        SecurityGroupEgress:
        - IpProtocol: -1
          FromPort: '1'
          ToPort: '1'
          CidrIp: 127.0.0.1/32
    LoadBalancer:
      Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
      Properties:
        Type: 'application'
        Name: '${self:custom.objectPrefix}'
        IpAddressType: 'ipv4'
        Scheme: 'internet-facing'
        LoadBalancerAttributes:
        - { Key: 'deletion_protection.enabled', Value: false }
        - { Key: 'routing.http2.enabled', Value: false }
        - { Key: 'access_logs.s3.enabled', Value: false }
        SecurityGroups:
        - { Ref: SecurityGroup }
        Subnets:
        - { Ref: SubnetA }
        - { Ref: SubnetB }
    HTTPListener:
      Type: 'AWS::ElasticLoadBalancingV2::Listener'
      Properties:
        LoadBalancerArn: { Ref: LoadBalancer }
        Port: 80
        Protocol: 'HTTP'
        DefaultActions:
        - Type: 'fixed-response'
          Order: 1
          FixedResponseConfig:
            StatusCode: 404
            ContentType: 'application/json'
            MessageBody: '{ "not": "found" }'
```

</details>

Call /hello1 endpoint with multi-value headers:
```bash
curl -X GET \
  http://<your_alb_dns>/hello1 \
  -H 'Token: aaa' \
  -H 'Token: bbb'
````
The ALB event is included in the response, so you can see that only the last header is available in the request headers.

Call /hello2 endpoint with multi-value headers:
```bash
curl -X GET \
  http://<your_alb_dns>/hello2 \
  -H 'Token: aaa' \
  -H 'Token: bbb'
```
Note that all headers values are included.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
