### PR TITLE
Support empty deploymentPrefix

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -472,7 +472,7 @@ class AwsProvider {
   getDeploymentPrefix() {
     const provider = this.serverless.service.provider;
     if (provider.deploymentPrefix === null || provider.deploymentPrefix === undefined) {
-      return 'serverless;
+      return 'serverless';
     }
     return provider.deploymentPrefix + '';
   }

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -470,8 +470,13 @@ class AwsProvider {
   }
 
   getDeploymentPrefix() {
-    const prefix = this.serverless.service.provider.deploymentPrefix;
-    return !prefix && prefix !== '' ? 'serverless' : prefix;
+    const provider = this.serverless.service.provider;
+    if (!('deploymentPrefix' in provider)) {
+      return 'serverless;
+    }
+
+    const prefix = provider.deploymentPrefix;
+    return (prefix || '') + '';
   }
 
   getLogRetentionInDays() {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -474,9 +474,7 @@ class AwsProvider {
     if (!('deploymentPrefix' in provider)) {
       return 'serverless;
     }
-
-    const prefix = provider.deploymentPrefix;
-    return (prefix || '') + '';
+    return provider.deploymentPrefix + '';
   }
 
   getLogRetentionInDays() {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -474,7 +474,7 @@ class AwsProvider {
     if (provider.deploymentPrefix === null || provider.deploymentPrefix === undefined) {
       return 'serverless';
     }
-    return provider.deploymentPrefix + '';
+    return `${provider.deploymentPrefix}`;
   }
 
   getLogRetentionInDays() {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -471,7 +471,7 @@ class AwsProvider {
 
   getDeploymentPrefix() {
     const provider = this.serverless.service.provider;
-    if (!('deploymentPrefix' in provider)) {
+    if (provider.deploymentPrefix === null || provider.deploymentPrefix === undefined) {
       return 'serverless;
     }
     return provider.deploymentPrefix + '';

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -470,7 +470,8 @@ class AwsProvider {
   }
 
   getDeploymentPrefix() {
-    return this.serverless.service.provider.deploymentPrefix || 'serverless';
+    const prefix = this.serverless.service.provider.deploymentPrefix;
+    return !prefix && prefix !== '' ? 'serverless' : prefix;
   }
 
   getLogRetentionInDays() {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -1312,6 +1312,12 @@ describe('AwsProvider', () => {
 
       expect(awsProvider.getDeploymentPrefix()).to.equal('serverless');
     });
+
+    it('should support no prefix', () => {
+      serverless.service.provider.deploymentPrefix = '';
+
+      expect(awsProvider.getDeploymentPrefix()).to.equal('');
+    });
   });
 
   describe('#getStage()', () => {


### PR DESCRIPTION
# What did you implement

This allows setting `deploymentPrefix: ''` in `serverless.yml` to use an empty `deploymentPrefix` instead of the default "serverless" prefix. Without this change, `deploymentPrefix: ''`, `deploymentPrefix: 0`, `deploymentPrefix: off`, `deploymentPrefix: false`, etc. all are equivalent to `deploymentPrefix: serverless`.

Note that this will only clear out the `deploymentPrefix` if one is explicitly included in the config file, or if the deploymentPrefix is falsey (e.g. `false`). If the key is not included, it will still return "serverless".

This could be interpreted as a breaking change, although I can imagine that the number of folks impacted is very small.

# Verification

* `provider.deploymentPrefix` can be set to the following too indicate an empty prefix:
    * `false`
    * `off`
    * `0`
    * `''`
* `provider.DeploymentPrefix` is still serverless if missing
* `provider.deploymentPrefix` is set to the verbatim strings:
    * `'false'`
    * `'off'`
    * `'0'`