### PR TITLE
Add azure python to cli

### DIFF
--- a/docs/providers/azure/cli-reference/create.md
+++ b/docs/providers/azure/cli-reference/create.md
@@ -48,6 +48,7 @@ To see a list of available templates run `serverless create --help`
 Most commonly used templates:
 
 - [azure-nodejs](https://github.com/serverless/serverless/tree/master/lib/plugins/create/templates/azure-nodejs)
+- [azure-python](https://github.com/serverless/serverless/tree/master/lib/plugins/create/templates/azure-python)
 
 ## Examples
 

--- a/docs/providers/azure/guide/workflow.md
+++ b/docs/providers/azure/guide/workflow.md
@@ -35,10 +35,18 @@ A handy list of commands to use when developing with the Serverless Framework.
 
 ##### Create A Function App:
 
-Install the boilerplate application.
+Install the boilerplate application:
+
+- with node:
 
 ```bash
 sls create -t azure-nodejs -p my-app
+```
+
+- with python:
+
+```bash
+sls create -t azure-python -p my-app
 ```
 
 ##### Install A Service

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -43,6 +43,7 @@ const validTemplates = [
   'tencent-python',
   'tencent-php',
   'azure-nodejs',
+  'azure-python',
   'cloudflare-workers',
   'cloudflare-workers-enterprise',
   'cloudflare-workers-rust',

--- a/lib/plugins/create/create.test.js
+++ b/lib/plugins/create/create.test.js
@@ -588,6 +588,25 @@ describe('Create', () => {
       });
     });
 
+    it('should generate scaffolding for "azure-python" template', () => {
+      process.chdir(tmpDir);
+      create.options.template = 'azure-python';
+
+      return create.create().then(() => {
+        const dirContent = fs.readdirSync(tmpDir);
+        expect(dirContent).to.include('requirements.txt');
+        expect(dirContent).to.include('serverless.yml');
+        expect(dirContent).to.include('.gitignore');
+        expect(dirContent).to.include('host.json');
+        expect(dirContent).to.include('README.md');
+
+        const srcContent = fs.readdirSync('src/handlers');
+        expect(srcContent).to.include('__init__.py');
+        expect(srcContent).to.include('hello.py');
+        expect(srcContent).to.include('goodbye.py');
+      });
+    });
+
     it('should generate scaffolding for "cloudflare-workers" template', () => {
       process.chdir(tmpDir);
       create.options.template = 'cloudflare-workers';


### PR DESCRIPTION
## What did you implement

Add `azure-python` template to valid templates of the CLI.

Closes #6944 

## How can we verify it

`sls create -t azure-python`

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
