### PR TITLE
Update API Gateway tagging to use partition for deployed region

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -38,7 +38,7 @@ module.exports = {
     this.apiGatewayDeploymentId = null;
     this.apiGatewayRestApiId = null;
 
-    return resolveAccountId
+    return resolveAccountInfo
       .call(this)
       .then(resolveRestApiId.bind(this))
       .then(() => {
@@ -83,6 +83,14 @@ module.exports = {
 function resolveAccountId() {
   // eslint-disable-next-line no-return-assign
   return this.provider.getAccountId().then(id => (this.accountId = id));
+}
+
+function resolveAccountInfo() {
+  // eslint-disable-next-line no-return-assign
+  return this.provider.getAccountInfo().then(account => {
+    this.accountId = account.accountId;
+    this.partition = account.partition;
+  });
 }
 
 function resolveApiGatewayResource(resources) {
@@ -203,6 +211,7 @@ function handleLogs() {
     const service = this.state.service.service;
     const stage = this.options.stage;
     const region = this.options.region;
+    const partition = this.partition;
     const logGroupName = `/aws/api-gateway/${service}-${stage}`;
 
     operations = [];
@@ -231,12 +240,7 @@ function handleLogs() {
     const accessLogging = logs.accessLogging == null ? true : logs.accessLogging;
 
     if (accessLogging) {
-      let resourceArn;
-      if (region.includes('gov')) {
-        resourceArn = `arn:aws-us-gov:logs:${region}:${this.accountId}:log-group:${logGroupName}`;
-      } else {
-        resourceArn = `arn:aws:logs:${region}:${this.accountId}:log-group:${logGroupName}`;
-      }
+      const resourceArn = `arn:${partition}:logs:${region}:${this.accountId}:log-group:${logGroupName}`;
       const destinationArn = {
         op: 'replace',
         path: '/accessLogSettings/destinationArn',
@@ -283,12 +287,8 @@ function handleTags() {
   const restApiId = this.apiGatewayRestApiId;
   const stageName = this.options.stage;
   const region = this.options.region;
-  let resourceArn;
-  if (region.includes('gov')) {
-    resourceArn = `arn:aws-us-gov:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
-  } else {
-    resourceArn = `arn:aws:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
-  }
+  const partition = this.partition;
+  const resourceArn = `arn:${partition}:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
 
   if (tagKeysToBeRemoved.length > 0) {
     this.apiGatewayUntagResourceParams.push({

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -80,11 +80,6 @@ module.exports = {
   },
 };
 
-function resolveAccountId() {
-  // eslint-disable-next-line no-return-assign
-  return this.provider.getAccountId().then(id => (this.accountId = id));
-}
-
 function resolveAccountInfo() {
   // eslint-disable-next-line no-return-assign
   return this.provider.getAccountInfo().then(account => {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -35,7 +35,7 @@ describe('#updateStage()', () => {
     serverless.setProvider('aws', awsProvider);
     providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
       accountId: '123456',
-      partition: 'aws'
+      partition: 'aws',
     });
     providerRequestStub = sinon.stub(awsProvider, 'request');
     serverless.service.provider.compiledCloudFormationTemplate = {
@@ -184,7 +184,7 @@ describe('#updateStage()', () => {
     awsProvider.getAccountInfo.restore();
     providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
       accountId: '123456',
-      partition: 'aws-us-gov'
+      partition: 'aws-us-gov',
     });
     context.state.service.provider.tags = {
       'Containing Space': 'bar',
@@ -265,7 +265,7 @@ describe('#updateStage()', () => {
     awsProvider.getAccountInfo.restore();
     providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
       accountId: '123456',
-      partition: 'aws-cn'
+      partition: 'aws-cn',
     });
     context.state.service.provider.tags = {
       'Containing Space': 'bar',
@@ -288,8 +288,7 @@ describe('#updateStage()', () => {
         {
           op: 'replace',
           path: '/accessLogSettings/destinationArn',
-          value:
-            'arn:aws-cn:logs:cn-northwest-1:123456:log-group:/aws/api-gateway/my-service-dev',
+          value: 'arn:aws-cn:logs:cn-northwest-1:123456:log-group:/aws/api-gateway/my-service-dev',
         },
         {
           op: 'replace',
@@ -340,7 +339,6 @@ describe('#updateStage()', () => {
       });
     });
   });
-
 
   it('should perform default actions if settings are not configure', () => {
     context.state.service.provider.tags = {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -23,7 +23,7 @@ describe('#updateStage()', () => {
   let serverless;
   let options;
   let awsProvider;
-  let providerGetAccountIdStub;
+  let providerGetAccountInfoStub;
   let providerRequestStub;
   let context;
 
@@ -33,7 +33,10 @@ describe('#updateStage()', () => {
     options = { stage: 'dev', region: 'us-east-1' };
     awsProvider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', awsProvider);
-    providerGetAccountIdStub = sinon.stub(awsProvider, 'getAccountId').resolves(123456);
+    providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
+      accountId: '123456',
+      partition: 'aws'
+    });
     providerRequestStub = sinon.stub(awsProvider, 'request');
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {
@@ -98,7 +101,7 @@ describe('#updateStage()', () => {
   });
 
   afterEach(() => {
-    awsProvider.getAccountId.restore();
+    awsProvider.getAccountInfo.restore();
     awsProvider.request.restore();
   });
 
@@ -136,7 +139,7 @@ describe('#updateStage()', () => {
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' },
       ];
 
-      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerGetAccountInfoStub).to.be.calledOnce;
       expect(providerRequestStub.args).to.have.length(5);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
@@ -178,6 +181,11 @@ describe('#updateStage()', () => {
 
   it('should support gov regions', () => {
     options.region = 'us-gov-east-1';
+    awsProvider.getAccountInfo.restore();
+    providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
+      accountId: '123456',
+      partition: 'aws-us-gov'
+    });
     context.state.service.provider.tags = {
       'Containing Space': 'bar',
       'bar': 'high-priority',
@@ -212,7 +220,7 @@ describe('#updateStage()', () => {
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' },
       ];
 
-      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerGetAccountInfoStub).to.be.calledOnce;
       expect(providerRequestStub.args).to.have.length(5);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
@@ -252,6 +260,88 @@ describe('#updateStage()', () => {
     });
   });
 
+  it('should support all partitions', () => {
+    options.region = 'cn-northwest-1';
+    awsProvider.getAccountInfo.restore();
+    providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
+      accountId: '123456',
+      partition: 'aws-cn'
+    });
+    context.state.service.provider.tags = {
+      'Containing Space': 'bar',
+      'bar': 'high-priority',
+    };
+    context.state.service.provider.stackTags = {
+      bar: 'low-priority',
+      num: 123,
+    };
+    context.state.service.provider.tracing = {
+      apiGateway: true,
+    };
+    context.state.service.provider.logs = {
+      restApi: true,
+    };
+
+    return updateStage.call(context).then(() => {
+      const patchOperations = [
+        { op: 'replace', path: '/tracingEnabled', value: 'true' },
+        {
+          op: 'replace',
+          path: '/accessLogSettings/destinationArn',
+          value:
+            'arn:aws-cn:logs:cn-northwest-1:123456:log-group:/aws/api-gateway/my-service-dev',
+        },
+        {
+          op: 'replace',
+          path: '/accessLogSettings/format',
+          value:
+            'requestId: $context.requestId, ip: $context.identity.sourceIp, caller: $context.identity.caller, user: $context.identity.user, requestTime: $context.requestTime, httpMethod: $context.httpMethod, resourcePath: $context.resourcePath, status: $context.status, protocol: $context.protocol, responseLength: $context.responseLength',
+        },
+        { op: 'replace', path: '/*/*/logging/dataTrace', value: 'true' },
+        { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' },
+      ];
+
+      expect(providerGetAccountInfoStub).to.be.calledOnce;
+      expect(providerRequestStub.args).to.have.length(5);
+      expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
+      expect(providerRequestStub.args[0][2]).to.deep.equal({
+        limit: 500,
+        position: undefined,
+      });
+      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[1][1]).to.equal('getStage');
+      expect(providerRequestStub.args[1][2]).to.deep.equal({
+        restApiId: 'devRestApiId',
+        stageName: 'dev',
+      });
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
+        restApiId: 'devRestApiId',
+        stageName: 'dev',
+        patchOperations,
+      });
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('tagResource');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
+        resourceArn: 'arn:aws-cn:apigateway:cn-northwest-1::/restapis/devRestApiId/stages/dev',
+        tags: {
+          'Containing Space': 'bar',
+          'bar': 'high-priority',
+          'num': '123',
+        },
+      });
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('untagResource');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
+        resourceArn: 'arn:aws-cn:apigateway:cn-northwest-1::/restapis/devRestApiId/stages/dev',
+        tagKeys: ['old'],
+      });
+    });
+  });
+
+
   it('should perform default actions if settings are not configure', () => {
     context.state.service.provider.tags = {
       old: 'tag',
@@ -263,7 +353,7 @@ describe('#updateStage()', () => {
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' },
       ];
 
-      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerGetAccountInfoStub).to.be.calledOnce;
       expect(providerRequestStub.args).to.have.length(4);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
@@ -324,7 +414,7 @@ describe('#updateStage()', () => {
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'OFF' },
       ];
 
-      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerGetAccountInfoStub).to.be.calledOnce;
       expect(providerRequestStub.args).to.have.length(6);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
@@ -489,7 +579,7 @@ describe('#updateStage()', () => {
         { op: 'replace', path: '/*/*/logging/loglevel', value: 'INFO' },
       ];
 
-      expect(providerGetAccountIdStub).to.be.calledOnce;
+      expect(providerGetAccountInfoStub).to.be.calledOnce;
       expect(providerRequestStub.args).to.have.length(4);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');


### PR DESCRIPTION
## What did you implement

Updated the section for adding tags to API gateway resources to use whatever partition the user is deploying from, rather than only checking whether commercial or govcloud

Closes #6925 

## How can we verify it

```yaml
provider:
  name: aws
  stage: ${opt:stage, 'dev'}
  region: cn-northwest-1
  memorySize: 128
  timeout: 15
  # ...
  tags:
    foo: 'bar'

functions:
  hello-world:
    handler: functions/hello-world.handler
    runtime: nodejs10.x
    endpointType: regional
    events:
      - http:
          path: /
          method: GET
          cors: true
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
