### PR TITLE
#6162: Support multiple schemas, don't overwrite RequestModels for each

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -85,7 +85,8 @@ module.exports = {
           );
 
           template.Properties.RequestValidatorId = { Ref: validatorLogicalId };
-          template.Properties.RequestModels = { [contentType]: { Ref: modelLogicalId } };
+          template.Properties.RequestModels = template.Properties.RequestModels || {};
+          template.Properties.RequestModels[contentType] = { Ref: modelLogicalId };
 
           _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
             [modelLogicalId]: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -105,6 +105,55 @@ describe('#compileMethods()', () => {
     });
   });
 
+  it('should support multiple request schemas', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          integration: 'AWS',
+          request: { schema: { 'application/json': { foo: 'bar' }, 'text/plain': 'foo' } },
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePostValidator
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::RequestValidator',
+        Properties: {
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          ValidateRequestBody: true,
+          ValidateRequestParameters: true,
+        },
+      });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePostApplicationJsonModel
+      ).to.deep.equal({
+        Type: 'AWS::ApiGateway::Model',
+        Properties: {
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          ContentType: 'application/json',
+          Schema: { foo: 'bar' },
+        },
+      });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.RequestModels
+      ).to.deep.equal({
+        'application/json': { Ref: 'ApiGatewayMethodUsersCreatePostApplicationJsonModel' },
+        'text/plain': { Ref: 'ApiGatewayMethodUsersCreatePostTextPlainModel' },
+      });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.RequestValidatorId
+      ).to.deep.equal({ Ref: 'ApiGatewayMethodUsersCreatePostValidator' });
+    });
+  });
+
   it('should have request parameters defined when they are set', () => {
     awsCompileApigEvents.validated.events = [
       {


### PR DESCRIPTION
Bugfix to support multiple schemas per function.

Closes #6162

## Verification
- See the ticket for `serverless.yml` and template file.  
- run `serverless package`
- Confirm both mime-types are in `ApiGatewayMethodUsersCreatePost.Properties.RequestModels`

