### PR TITLE
Add promise completion report and improve promise reporting verbiage

### DIFF
--- a/lib/classes/PromiseTracker.js
+++ b/lib/classes/PromiseTracker.js
@@ -49,8 +49,7 @@ class PromiseTracker {
         `#   ${constants.rejected}: ${this.getRejected().length}`,
         `#   ${constants.pending}:  ${this.getPending().length}`,
         '##########################################################################################',
-      ]
-        .join('\n  ')
+      ].join('\n  ')
     );
     this.reset();
   }

--- a/lib/classes/PromiseTracker.js
+++ b/lib/classes/PromiseTracker.js
@@ -2,6 +2,12 @@
 
 const logInfo = require('./Error').logInfo;
 
+const constants = {
+  pending: 'pending',
+  rejected: 'rejected',
+  resolved: 'resolved',
+};
+
 class PromiseTracker {
   constructor() {
     this.reset();
@@ -20,9 +26,9 @@ class PromiseTracker {
     const pending = this.getPending();
     logInfo(
       [
-        '##########################################################################################',
+        '############################################################################################',
         `# ${delta}: ${this.getSettled().length} of ${this.getAll().length} promises have settled`,
-        `# ${delta}: ${pending.length} unsettled promises:`,
+        `# ${delta}: ${pending.length} are taking longer than expected:`,
       ]
         .concat(pending.map(promise => `# ${delta}:   ${promise.waitList}`))
         .concat([
@@ -34,19 +40,31 @@ class PromiseTracker {
   }
   stop() {
     clearInterval(this.interval);
+    logInfo(
+      [
+        '############################################################################################',
+        `# Completed after ${Date.now() - this.startTime}ms`,
+        `# ${this.getAll().length} promises are in the following states:`,
+        `#   ${constants.resolved}: ${this.getResolved().length}`,
+        `#   ${constants.rejected}: ${this.getRejected().length}`,
+        `#   ${constants.pending}:  ${this.getPending().length}`,
+        '##########################################################################################',
+      ]
+        .join('\n  ')
+    );
     this.reset();
   }
   add(variable, prms, specifier) {
     const promise = prms;
     promise.waitList = `${variable} waited on by: ${specifier}`;
-    promise.state = 'pending';
+    promise.state = constants.pending;
     promise.then(
       // creates a promise with the following effects but that we otherwise ignore
       () => {
-        promise.state = 'resolved';
+        promise.state = constants.resolved;
       },
       () => {
-        promise.state = 'rejected';
+        promise.state = constants.rejected;
       }
     );
     this.promiseList.push(promise);
@@ -62,10 +80,16 @@ class PromiseTracker {
     return promise;
   }
   getPending() {
-    return this.promiseList.filter(p => p.state === 'pending');
+    return this.promiseList.filter(p => p.state === constants.pending);
   }
   getSettled() {
-    return this.promiseList.filter(p => p.state !== 'pending');
+    return this.promiseList.filter(p => p.state !== constants.pending);
+  }
+  getResolved() {
+    return this.promiseList.filter(p => p.state === constants.resolved);
+  }
+  getRejected() {
+    return this.promiseList.filter(p => p.state === constants.rejected);
   }
   getAll() {
     return this.promiseList;

--- a/lib/classes/PromiseTracker.test.js
+++ b/lib/classes/PromiseTracker.test.js
@@ -28,45 +28,71 @@ describe('PromiseTracker', () => {
     promiseTracker.report(); // shouldn't throw
     return Promise.all(promiseTracker.getAll());
   });
-  it('reports no pending promises when none have been added', () => {
-    const promises = promiseTracker.getPending();
-    expect(promises).to.be.an.instanceof(Array);
-    expect(promises.length).to.equal(0);
+  it('reports no promises when none have been added', () => {
+    expect(promiseTracker.getAll()).to.be.an('array').that.is.empty;
+    expect(promiseTracker.getPending()).to.be.an('array').that.is.empty;
+    expect(promiseTracker.getSettled()).to.be.an('array').that.is.empty;
+    expect(promiseTracker.getResolved()).to.be.an('array').that.is.empty;
+    expect(promiseTracker.getRejected()).to.be.an('array').that.is.empty;
   });
-  it('reports one pending promise when one has been added', () => {
+  it('reports the correct number of added promise statuses', () => {
     let resolve;
-    const promise = new BbPromise(rslv => {
+    const pending = new BbPromise(rslv => {
       resolve = rslv;
     });
-    promiseTracker.add('foo', promise, '${foo:}');
+    const resolved = BbPromise.resolve();
+    const rejected = BbPromise.reject('reason');
+    promiseTracker.add('pending', pending, '${pending:}');
+    promiseTracker.add('resolved', resolved, '${resolved:}');
+    promiseTracker.add('rejected', rejected, '${rejected:}');
+    resolved.state = 'resolved';
+    rejected.state = 'rejected';
     return BbPromise.delay(1)
       .then(() => {
-        const promises = promiseTracker.getPending();
-        expect(promises).to.be.an.instanceof(Array);
-        expect(promises.length).to.equal(1);
-        expect(promises[0]).to.equal(promise);
+        const pendings = promiseTracker.getPending();
+        expect(pendings).to.be.an.instanceof(Array);
+        expect(pendings.length).to.equal(1);
+        expect(pendings[0]).to.equal(pending);
+        const settleds = promiseTracker.getSettled();
+        expect(settleds).to.be.an.instanceof(Array);
+        expect(settleds.length).to.equal(2);
+        expect(settleds).to.include(resolved);
+        expect(settleds).to.include(rejected);
+        const resolveds = promiseTracker.getResolved();
+        expect(resolveds).to.be.an.instanceof(Array);
+        expect(resolveds.length).to.equal(1);
+        expect(resolveds).to.include(resolved);
+        const rejecteds = promiseTracker.getRejected();
+        expect(rejecteds).to.be.an.instanceof(Array);
+        expect(rejecteds.length).to.equal(1);
+        expect(rejecteds).to.include(rejected);
       })
       .then(() => {
         resolve();
       });
   });
-  it('reports no settled promises when none have been added', () => {
-    const promises = promiseTracker.getSettled();
-    expect(promises).to.be.an.instanceof(Array);
-    expect(promises.length).to.equal(0);
-  });
-  it('reports one settled promise when one has been added', () => {
-    const promise = BbPromise.resolve();
-    promiseTracker.add('foo', promise, '${foo:}');
-    promise.state = 'resolved';
-    const promises = promiseTracker.getSettled();
-    expect(promises).to.be.an.instanceof(Array);
-    expect(promises.length).to.equal(1);
-    expect(promises[0]).to.equal(promise);
-    return Promise.all(promiseTracker.getAll());
-  });
-  it('reports no promises when none have been added', () => {
-    const promises = promiseTracker.getAll();
-    expect(promises).to.be.an('array').that.is.empty;
+  it('reports and then clears tracked promises when stopped.', () => {
+    let resolve;
+    const pending = new BbPromise(rslv => {
+      resolve = rslv;
+    });
+    const resolved = BbPromise.resolve();
+    const rejected = BbPromise.reject('reason');
+    promiseTracker.add('pending', pending, '${pending:}');
+    promiseTracker.add('resolved', resolved, '${resolved:}');
+    promiseTracker.add('rejected', rejected, '${rejected:}');
+    resolved.state = 'resolved';
+    rejected.state = 'rejected';
+    return BbPromise.delay(1)
+      .then(() => {
+        const all = promiseTracker.getAll();
+        expect(all).to.be.an.instanceof(Array);
+        expect(all.length).to.equal(3);
+        promiseTracker.stop();
+        const stopped = promiseTracker.getAll();
+        expect(stopped).to.be.an.instanceof(Array);
+        expect(stopped.length).to.equal(0);
+        resolve();
+      });
   });
 });

--- a/lib/classes/PromiseTracker.test.js
+++ b/lib/classes/PromiseTracker.test.js
@@ -83,16 +83,15 @@ describe('PromiseTracker', () => {
     promiseTracker.add('rejected', rejected, '${rejected:}');
     resolved.state = 'resolved';
     rejected.state = 'rejected';
-    return BbPromise.delay(1)
-      .then(() => {
-        const all = promiseTracker.getAll();
-        expect(all).to.be.an.instanceof(Array);
-        expect(all.length).to.equal(3);
-        promiseTracker.stop();
-        const stopped = promiseTracker.getAll();
-        expect(stopped).to.be.an.instanceof(Array);
-        expect(stopped.length).to.equal(0);
-        resolve();
-      });
+    return BbPromise.delay(1).then(() => {
+      const all = promiseTracker.getAll();
+      expect(all).to.be.an.instanceof(Array);
+      expect(all.length).to.equal(3);
+      promiseTracker.stop();
+      const stopped = promiseTracker.getAll();
+      expect(stopped).to.be.an.instanceof(Array);
+      expect(stopped.length).to.equal(0);
+      resolve();
+    });
   });
 });


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

The language used to report promise status is challenging to understand and doesn't state when completion has occurred.  This PR attempts to improve this.  For reference, see [comments on #4984](https://github.com/serverless/serverless/issues/4984#issuecomment-545388840).

Improves on #4984

Progress:

```
############################################################################################
    # 2: 3 of 5 promises have settled
    # 2: 2 are taking longer than expected:
    # 2:   foo waited on by: ${foo:}
    # 2:   bar waited on by: ${bar:}
    # This can result from latent connections but may represent a cyclic variable dependency
    ##########################################################################################
```

Completion:

```
############################################################################################
    # Completed after 6ms
    # 5 promises are in the following states:
    #   resolved: 3
    #   rejected: 1
    #   pending:  1
    ##########################################################################################
```

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

New tests added.

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
