### PR TITLE
Improve config error handling

### DIFF
--- a/lib/utils/config/index.js
+++ b/lib/utils/config/index.js
@@ -5,6 +5,7 @@ const p = require('path');
 const os = require('os');
 const _ = require('lodash');
 const rc = require('rc');
+const chalk = require('chalk');
 const writeFileAtomic = require('write-file-atomic');
 const fileExistsSync = require('../fs/fileExistsSync');
 const readFileSync = require('../fs/readFileSync');
@@ -16,6 +17,24 @@ let serverlessrcPath = p.join(os.homedir(), `.${rcFileBase}rc`);
 if (process.env.SERVERLESS_PLATFORM_STAGE && process.env.SERVERLESS_PLATFORM_STAGE !== 'prod') {
   rcFileBase = 'serverlessdev';
   serverlessrcPath = p.join(os.homedir(), `.${rcFileBase}rc`);
+}
+
+function storeConfig(config) {
+  try {
+    writeFileAtomic.sync(serverlessrcPath, JSON.stringify(config, null, 2));
+  } catch (error) {
+    if (process.env.SLS_DEBUG) process.stdout.write(`${chalk.red(error.stack)}\n`);
+    process.stdout.write(
+      `Serverless: ${chalk.red(`Unable to store serverless config due to ${error.code} error`)}\n`
+    );
+    try {
+      return JSON.parse(readFileSync(serverlessrcPath));
+    } catch (readError) {
+      // Ignore
+    }
+    return {};
+  }
+  return config;
 }
 
 function createConfig() {
@@ -35,8 +54,7 @@ function createConfig() {
   initialSetup.removeLegacyFrameworkIdFiles();
 
   // save new config
-  writeFileAtomic.sync(serverlessrcPath, JSON.stringify(config, null, 2));
-  return JSON.parse(readFileSync(serverlessrcPath));
+  return storeConfig(config);
 }
 
 // check for global .serverlessrc file
@@ -78,8 +96,7 @@ function set(key, value) {
   config.meta = config.meta || {};
   config.meta.updated_at = Math.round(+new Date() / 1000);
   // write to .serverlessrc file
-  writeFileAtomic.sync(serverlessrcPath, JSON.stringify(config, null, 2));
-  return config;
+  return storeConfig(config);
 }
 
 function deleteValue(key) {
@@ -90,8 +107,7 @@ function deleteValue(key) {
     config = _.omit(config, key);
   }
   // write to .serverlessrc file
-  writeFileAtomic.sync(serverlessrcPath, JSON.stringify(config, null, 2));
-  return config;
+  return storeConfig(config);
 }
 
 /* Get config value with object path */


### PR DESCRIPTION
When processing config crashes could be observed when:
- For some reason `os.homedir()` resolves to not existing directory (e.g. it seems to be the case in this report: https://stackoverflow.com/questions/58842120/aws-serverless-unknown-error-shows-up-when-trying-to-reach-my-lambda )
- Process has no write access to `~/.serverless` folder (observed in case of some global installations)

This patch ensures that such errors are handled gently