### PR TITLE
Revert "Add promise completion report and improve promise reporting verbiage"

### DIFF
--- a/lib/classes/PromiseTracker.js
+++ b/lib/classes/PromiseTracker.js
@@ -2,12 +2,6 @@
 
 const logInfo = require('./Error').logInfo;
 
-const constants = {
-  pending: 'pending',
-  rejected: 'rejected',
-  resolved: 'resolved',
-};
-
 class PromiseTracker {
   constructor() {
     this.reset();
@@ -26,9 +20,9 @@ class PromiseTracker {
     const pending = this.getPending();
     logInfo(
       [
-        '############################################################################################',
+        '##########################################################################################',
         `# ${delta}: ${this.getSettled().length} of ${this.getAll().length} promises have settled`,
-        `# ${delta}: ${pending.length} are taking longer than expected:`,
+        `# ${delta}: ${pending.length} unsettled promises:`,
       ]
         .concat(pending.map(promise => `# ${delta}:   ${promise.waitList}`))
         .concat([
@@ -40,30 +34,19 @@ class PromiseTracker {
   }
   stop() {
     clearInterval(this.interval);
-    logInfo(
-      [
-        '############################################################################################',
-        `# Completed after ${Date.now() - this.startTime}ms`,
-        `# ${this.getAll().length} promises are in the following states:`,
-        `#   ${constants.resolved}: ${this.getResolved().length}`,
-        `#   ${constants.rejected}: ${this.getRejected().length}`,
-        `#   ${constants.pending}:  ${this.getPending().length}`,
-        '##########################################################################################',
-      ].join('\n  ')
-    );
     this.reset();
   }
   add(variable, prms, specifier) {
     const promise = prms;
     promise.waitList = `${variable} waited on by: ${specifier}`;
-    promise.state = constants.pending;
+    promise.state = 'pending';
     promise.then(
       // creates a promise with the following effects but that we otherwise ignore
       () => {
-        promise.state = constants.resolved;
+        promise.state = 'resolved';
       },
       () => {
-        promise.state = constants.rejected;
+        promise.state = 'rejected';
       }
     );
     this.promiseList.push(promise);
@@ -79,16 +62,10 @@ class PromiseTracker {
     return promise;
   }
   getPending() {
-    return this.promiseList.filter(p => p.state === constants.pending);
+    return this.promiseList.filter(p => p.state === 'pending');
   }
   getSettled() {
-    return this.promiseList.filter(p => p.state !== constants.pending);
-  }
-  getResolved() {
-    return this.promiseList.filter(p => p.state === constants.resolved);
-  }
-  getRejected() {
-    return this.promiseList.filter(p => p.state === constants.rejected);
+    return this.promiseList.filter(p => p.state !== 'pending');
   }
   getAll() {
     return this.promiseList;

--- a/lib/classes/PromiseTracker.test.js
+++ b/lib/classes/PromiseTracker.test.js
@@ -28,70 +28,45 @@ describe('PromiseTracker', () => {
     promiseTracker.report(); // shouldn't throw
     return Promise.all(promiseTracker.getAll());
   });
-  it('reports no promises when none have been added', () => {
-    expect(promiseTracker.getAll()).to.be.an('array').that.is.empty;
-    expect(promiseTracker.getPending()).to.be.an('array').that.is.empty;
-    expect(promiseTracker.getSettled()).to.be.an('array').that.is.empty;
-    expect(promiseTracker.getResolved()).to.be.an('array').that.is.empty;
-    expect(promiseTracker.getRejected()).to.be.an('array').that.is.empty;
+  it('reports no pending promises when none have been added', () => {
+    const promises = promiseTracker.getPending();
+    expect(promises).to.be.an.instanceof(Array);
+    expect(promises.length).to.equal(0);
   });
-  it('reports the correct number of added promise statuses', () => {
+  it('reports one pending promise when one has been added', () => {
     let resolve;
-    const pending = new BbPromise(rslv => {
+    const promise = new BbPromise(rslv => {
       resolve = rslv;
     });
-    const resolved = BbPromise.resolve();
-    const rejected = BbPromise.reject('reason');
-    promiseTracker.add('pending', pending, '${pending:}');
-    promiseTracker.add('resolved', resolved, '${resolved:}');
-    promiseTracker.add('rejected', rejected, '${rejected:}');
-    resolved.state = 'resolved';
-    rejected.state = 'rejected';
+    promiseTracker.add('foo', promise, '${foo:}');
     return BbPromise.delay(1)
       .then(() => {
-        const pendings = promiseTracker.getPending();
-        expect(pendings).to.be.an.instanceof(Array);
-        expect(pendings.length).to.equal(1);
-        expect(pendings[0]).to.equal(pending);
-        const settleds = promiseTracker.getSettled();
-        expect(settleds).to.be.an.instanceof(Array);
-        expect(settleds.length).to.equal(2);
-        expect(settleds).to.include(resolved);
-        expect(settleds).to.include(rejected);
-        const resolveds = promiseTracker.getResolved();
-        expect(resolveds).to.be.an.instanceof(Array);
-        expect(resolveds.length).to.equal(1);
-        expect(resolveds).to.include(resolved);
-        const rejecteds = promiseTracker.getRejected();
-        expect(rejecteds).to.be.an.instanceof(Array);
-        expect(rejecteds.length).to.equal(1);
-        expect(rejecteds).to.include(rejected);
+        const promises = promiseTracker.getPending();
+        expect(promises).to.be.an.instanceof(Array);
+        expect(promises.length).to.equal(1);
+        expect(promises[0]).to.equal(promise);
       })
       .then(() => {
         resolve();
       });
   });
-  it('reports and then clears tracked promises when stopped.', () => {
-    let resolve;
-    const pending = new BbPromise(rslv => {
-      resolve = rslv;
-    });
-    const resolved = BbPromise.resolve();
-    const rejected = BbPromise.reject('reason');
-    promiseTracker.add('pending', pending, '${pending:}');
-    promiseTracker.add('resolved', resolved, '${resolved:}');
-    promiseTracker.add('rejected', rejected, '${rejected:}');
-    resolved.state = 'resolved';
-    rejected.state = 'rejected';
-    return BbPromise.delay(1).then(() => {
-      const all = promiseTracker.getAll();
-      expect(all).to.be.an.instanceof(Array);
-      expect(all.length).to.equal(3);
-      promiseTracker.stop();
-      const stopped = promiseTracker.getAll();
-      expect(stopped).to.be.an.instanceof(Array);
-      expect(stopped.length).to.equal(0);
-      resolve();
-    });
+  it('reports no settled promises when none have been added', () => {
+    const promises = promiseTracker.getSettled();
+    expect(promises).to.be.an.instanceof(Array);
+    expect(promises.length).to.equal(0);
+  });
+  it('reports one settled promise when one has been added', () => {
+    const promise = BbPromise.resolve();
+    promiseTracker.add('foo', promise, '${foo:}');
+    promise.state = 'resolved';
+    const promises = promiseTracker.getSettled();
+    expect(promises).to.be.an.instanceof(Array);
+    expect(promises.length).to.equal(1);
+    expect(promises[0]).to.equal(promise);
+    return Promise.all(promiseTracker.getAll());
+  });
+  it('reports no promises when none have been added', () => {
+    const promises = promiseTracker.getAll();
+    expect(promises).to.be.an('array').that.is.empty;
   });
 });


### PR DESCRIPTION
@erikerikson sorry, I didn't look carefully enough. We actually need to revert that improvement, as it logs promises report unconditionally on every command, we definitely do not want that (I thought it's triggered only on SLS_DEBUG or some other special env var).

Can you reopen the PR with that, and clarify what use case it serves for you (?)

At least what it currently does, it's adding output on every command that involves variable resolution, which seems not that useful

```
Serverless Information ----------------------------------
 
  ############################################################################################
    # Completed after 27ms
    # 0 promises are in the following states:
    #   resolved: 0
    #   rejected: 0
    #   pending:  0
    ##########################################################################################
```