### PR TITLE
New flag to bypass validation when deploying from ec2 machine

### DIFF
--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -35,27 +35,25 @@ module.exports = {
       !process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
     ) {
       // first check if the EC2 Metadata Service has creds before throwing error
-      const metadataService = new this.provider.sdk.MetadataService({
-        httpOptions: { timeout: 5000 }, // 5 seconds timeout
+      const ec2Credentials = new this.provider.sdk.EC2MetadataCredentials({
+        httpOptions: { timeout: 5000 }, // 5 second timeout
         maxRetries: 0, // retry 0 times
       });
       return new BbPromise((resolve, reject) =>
-        metadataService.loadCredentials((err, data) => {
-          return err ? reject(err) : resolve(data);
-        })
-      )
-        .catch(() => null)
-        .then(identity => {
-          if (!identity) {
+        ec2Credentials.load(err => {
+          if (err) {
             const message = [
               'AWS provider credentials not found.',
               ' Learn how to set up AWS provider credentials',
               ` in our docs here: <${chalk.green('http://slss.io/aws-creds-setup')}>.`,
             ].join('');
             userStats.track('user_awsCredentialsNotFound');
-            throw new this.serverless.classes.Error(message);
+            reject(new this.serverless.classes.Error(message));
+          } else {
+            resolve({});
           }
-        });
+        })
+      );
     }
     return BbPromise.resolve();
   },

--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -36,11 +36,11 @@ module.exports = {
     ) {
       // first check if the EC2 Metadata Service has creds before throwing error
       const metadataService = new this.provider.sdk.MetadataService({
-        httpOptions: { timeout: 100, connectTimeout: 100 }, // .1 second timeout
+        httpOptions: { timeout: 5000 }, // 5 seconds timeout
         maxRetries: 0, // retry 0 times
       });
       return new BbPromise((resolve, reject) =>
-        metadataService.request('/', (err, data) => {
+        metadataService.loadCredentials((err, data) => {
           return err ? reject(err) : resolve(data);
         })
       )

--- a/lib/plugins/aws/lib/validate.test.js
+++ b/lib/plugins/aws/lib/validate.test.js
@@ -9,9 +9,13 @@ chai.use(require('chai-as-promised'));
 
 const expect = chai.expect;
 
+var loadCredentialsMock = callback => {
+  callback('error');
+};
+
 class MetadataService {
-  request(error) {
-    error('error');
+  loadCredentials(callback) {
+    loadCredentialsMock(callback);
   }
 }
 
@@ -93,6 +97,31 @@ describe('#validate', () => {
       provider.cachedCredentials = {};
 
       return expect(awsPlugin.validate()).to.be.rejected.then(() => {
+        expect(awsPlugin.options.region).to.equal('some-region');
+      });
+    });
+
+    it('should check the metadata service and pass if return credentials', () => {
+      awsPlugin.options.region = false;
+      awsPlugin.serverless.service.provider = {
+        region: 'some-region',
+      };
+      provider.cachedCredentials = {};
+
+      provider.sdk.MetadataService.error = null;
+      loadCredentialsMock = callback => {
+        callback(null, {
+          Code: 'Success',
+          LastUpdated: '2019-12-04T22:43:25Z',
+          Type: 'AWS-HMAC',
+          AccessKeyId: 'AAAA',
+          SecretAccessKey: 'bbbb',
+          Token: 'dfadafsd',
+          Expiration: '2019-12-05T05:18:02Z',
+        });
+      };
+
+      return expect(awsPlugin.validate()).to.be.fulfilled.then(() => {
         expect(awsPlugin.options.region).to.equal('some-region');
       });
     });

--- a/lib/plugins/aws/lib/validate.test.js
+++ b/lib/plugins/aws/lib/validate.test.js
@@ -13,8 +13,8 @@ let loadCredentialsMock = callback => {
   callback('error');
 };
 
-class MetadataService {
-  loadCredentials(callback) {
+class EC2MetadataCredentials {
+  load(callback) {
     loadCredentialsMock(callback);
   }
 }
@@ -32,7 +32,7 @@ describe('#validate', () => {
     provider = new AwsProvider(serverless, awsPlugin.options);
     provider.cachedCredentials = { accessKeyId: 'foo', secretAccessKey: 'bar' };
     awsPlugin.provider = provider;
-    awsPlugin.provider.sdk = { MetadataService };
+    awsPlugin.provider.sdk = { EC2MetadataCredentials };
     awsPlugin.serverless = serverless;
     awsPlugin.serverless.setProvider('aws', provider);
 
@@ -108,18 +108,7 @@ describe('#validate', () => {
       };
       provider.cachedCredentials = {};
 
-      provider.sdk.MetadataService.error = null;
-      loadCredentialsMock = callback => {
-        callback(null, {
-          Code: 'Success',
-          LastUpdated: '2019-12-04T22:43:25Z',
-          Type: 'AWS-HMAC',
-          AccessKeyId: 'AAAA',
-          SecretAccessKey: 'bbbb',
-          Token: 'dfadafsd',
-          Expiration: '2019-12-05T05:18:02Z',
-        });
-      };
+      loadCredentialsMock = callback => callback(null);
 
       return expect(awsPlugin.validate()).to.be.fulfilled.then(() => {
         expect(awsPlugin.options.region).to.equal('some-region');

--- a/lib/plugins/aws/lib/validate.test.js
+++ b/lib/plugins/aws/lib/validate.test.js
@@ -9,7 +9,7 @@ chai.use(require('chai-as-promised'));
 
 const expect = chai.expect;
 
-var loadCredentialsMock = callback => {
+let loadCredentialsMock = callback => {
   callback('error');
 };
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Closes #6961

Stop using aws metadata service to validate if serveless is running inside of an ec2 machine or not. The check will never be relaible as it is not guaranteed that the latency of the api will be below .1 second.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
