### PR TITLE
Add support for contentHandling - Fixes gh-6949

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1494,6 +1494,22 @@ provider:
 
 In your Lambda function you need to ensure that the correct `content-type` header is set. Furthermore you might want to return the response body in base64 format.
 
+To convert the request or response payload, you can set the [contentHandling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html) property.
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          request:
+            contentHandling: CONVERT_TO_TEXT
+          response:
+            contentHandling: CONVERT_TO_TEXT
+```
+
 ## AWS X-Ray Tracing
 
 API Gateway supports a form of out of the box distributed tracing via [AWS X-Ray](https://aws.amazon.com/xray/) though enabling [active tracing](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html). To enable this feature for your serverless application's API Gateway add the following to your `serverless.yml`

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1110,6 +1110,35 @@ describe('#compileMethods()', () => {
       });
     });
 
+    it('should use defined content-handling behavior', () => {
+      awsCompileApigEvents.validated.events = [
+        {
+          functionName: 'First',
+          http: {
+            method: 'GET',
+            path: 'users/list',
+            integration: 'AWS',
+            request: {
+              contentHandling: 'CONVERT_TO_TEXT',
+            },
+            response: {
+              statusCodes: {
+                200: {
+                  pattern: '',
+                },
+              },
+            },
+          },
+        },
+      ];
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.ContentHandling
+        ).to.equal('CONVERT_TO_TEXT');
+      });
+    });
+
     it('should set custom request templates', () => {
       awsCompileApigEvents.validated.events = [
         {
@@ -1310,6 +1339,7 @@ describe('#compileMethods()', () => {
         SelectionPattern: 'foo',
         ResponseParameters: {},
         ResponseTemplates: {},
+        ContentHandling: undefined,
       });
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -1319,6 +1349,7 @@ describe('#compileMethods()', () => {
         SelectionPattern: '',
         ResponseParameters: {},
         ResponseTemplates: {},
+        ContentHandling: undefined,
       });
     });
   });
@@ -1481,6 +1512,34 @@ describe('#compileMethods()', () => {
           .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
           .ResponseParameters['method.response.header.Content-Type']
       ).to.equal('text/html');
+    });
+  });
+
+  it('should use defined content-handling behavior', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          method: 'get',
+          path: 'users/list',
+          integration: 'AWS',
+          response: {
+            contentHandling: 'CONVERT_TO_BINARY',
+            statusCodes: {
+              200: {
+                pattern: '',
+              },
+            },
+          },
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[0]
+          .ContentHandling
+      ).to.equal('CONVERT_TO_BINARY');
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -97,13 +97,15 @@ module.exports = {
     if (type === 'AWS' || type === 'HTTP' || type === 'MOCK') {
       _.assign(integration, {
         PassthroughBehavior: http.request && http.request.passThrough,
+        ContentHandling: http.request && http.request.contentHandling,
         RequestTemplates: this.getIntegrationRequestTemplates(http, type === 'AWS'),
         IntegrationResponses: this.getIntegrationResponses(http),
       });
     }
     if (
       ((type === 'AWS' || type === 'HTTP' || type === 'HTTP_PROXY') &&
-        (http.request && !_.isEmpty(http.request.parameters))) ||
+        http.request &&
+        !_.isEmpty(http.request.parameters)) ||
       http.async
     ) {
       _.assign(integration, {
@@ -151,6 +153,7 @@ module.exports = {
           SelectionPattern: config.pattern || '',
           ResponseParameters: responseParameters,
           ResponseTemplates: {},
+          ContentHandling: http.response.contentHandling,
         };
 
         if (config.headers) {


### PR DESCRIPTION
## What did you implement

<!-- Briefly describe the scope of your PR -->
Option to set `contentHandling` property of API gateway [method integration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration.html#cfn-apigateway-method-integration-contenthandling) and [integration response](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html#cfn-apigateway-method-integrationresponse-contenthandling).

Closes #6949 

## How can we verify it

```
service: content-handling

provider:
  name: aws
  logs:
    restApi:
      level: INFO
  runtime: nodejs8.10
  region: eu-central-1
  apiGateway:
    binaryMediaTypes:
      - 'image/jpeg'

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          method: POST
          path: hello
          integration: lambda
          request:
            contentHandling: CONVERT_TO_TEXT
            template:
              image/jpeg: '{"method": "$context.httpMethod","bodyLength": $input.body.length(),"body" : "$input.body"}'
          response:
            headers:
              Content-Type: "'image/jpg'"
            contentHandling: CONVERT_TO_BINARY
```

```
// handler.js
'use strict';

const fs = require('fs');

module.exports.hello = async (event) => {
  console.log(event)
  return fs.readFileSync('./image.jpg').toString('base64');
};
```
[image.jpg](https://user-images.githubusercontent.com/7386945/69278305-52ed0180-0be2-11ea-8bf1-3a36b5ade1de.jpg)

Steps:
- `sls deploy`
- `curl -XPOST -H "Content-Type: image/jpeg" -H "Accept: image/jpeg" https://<id>.execute-api.eu-central-1.amazonaws.com/dev/hello -d @image.jpg  --output response.jpg`
- `response.jpg` should be  the same as`image.jpg`


## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
