### PR TITLE
Enable Content Trust checking when pulling lambci/lambda images

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -243,7 +243,11 @@ class AwsInvokeLocal {
     this.serverless.cli.log('Downloading base Docker image...');
 
     return new BbPromise((resolve, reject) => {
-      const docker = spawn('docker', ['pull', `lambci/lambda:${runtime}`]);
+      const docker = spawn('docker', [
+        'pull',
+        '--disable-content-trust=false',
+        `lambci/lambda:${runtime}`,
+      ]);
       docker.on('exit', error => {
         return error ? reject(error) : resolve();
       });

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1219,7 +1219,7 @@ describe('AwsInvokeLocal', () => {
         ]);
         expect(spawnStub.getCall(2).args).to.deep.equal([
           'docker',
-          ['pull', 'lambci/lambda:nodejs12.x'],
+          ['pull', '--disable-content-trust=false', 'lambci/lambda:nodejs12.x'],
         ]);
         expect(spawnStub.getCall(3).args).to.deep.equal([
           'docker',


### PR DESCRIPTION
## What did you implement

Added the `--disable-content-trust=false` flag to the `docker pull` command to ensure that images are signed correctly (`lambci/lambda` images are now signed):

https://docs.docker.com/v17.09/engine/security/trust/content_trust/

## How can we verify it

Run invoke local with the docker option

## Todos

You could potentially add an option for this in case people don't want to check signed images...? Not sure why they'd want that.

The other way to implement it would be to set `DOCKER_CONTENT_TRUST=1` in the environment that you spawn the Docker command with. Not sure if you'd prefer that either

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
