### PR TITLE
Govcloud custom resource fix

### DIFF
--- a/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
+++ b/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
@@ -17,19 +17,19 @@ function handler(event, context) {
 
 async function create(event, context) {
   const { RoleArn } = event.ResourceProperties;
-  const { AccountId: accountId, Region: region } = getEnvironment(context);
+  const { Partition: partition, AccountId: accountId, Region: region } = getEnvironment(context);
 
   const apiGateway = new ApiGateway({ region });
   const assignedRoleArn = (await apiGateway.getAccount().promise()).cloudwatchRoleArn;
 
-  let roleArn = `arn:aws:iam::${accountId}:role/serverlessApiGatewayCloudWatchRole`;
+  let roleArn = `arn:${partition}:iam::${accountId}:role/serverlessApiGatewayCloudWatchRole`;
   if (RoleArn) {
     // if there's a roleArn in the Resource Properties, just re-use it here
     roleArn = RoleArn;
   } else {
     // Create an own API Gateway role if the roleArn was not set via Resource Properties
     const apiGatewayPushToCloudWatchLogsPolicyArn =
-      'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs';
+      `arn:${partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs`;
 
     const roleName = roleArn.slice(roleArn.lastIndexOf('/') + 1);
 

--- a/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
+++ b/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
@@ -28,8 +28,7 @@ async function create(event, context) {
     roleArn = RoleArn;
   } else {
     // Create an own API Gateway role if the roleArn was not set via Resource Properties
-    const apiGatewayPushToCloudWatchLogsPolicyArn =
-      `arn:${partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs`;
+    const apiGatewayPushToCloudWatchLogsPolicyArn = `arn:${partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs`;
 
     const roleName = roleArn.slice(roleArn.lastIndexOf('/') + 1);
 

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
@@ -17,9 +17,9 @@ function handler(event, context) {
 
 function create(event, context) {
   const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context);
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then(userPool =>
     addPermission({
@@ -40,10 +40,10 @@ function create(event, context) {
 }
 
 function update(event, context) {
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context);
   const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return updateConfiguration({
     lambdaArn,
@@ -54,10 +54,10 @@ function update(event, context) {
 }
 
 function remove(event, context) {
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context);
   const { FunctionName, UserPoolName } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return removePermission({
     functionName: FunctionName,

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
@@ -25,6 +25,7 @@ function create(event, context) {
     addPermission({
       functionName: FunctionName,
       userPoolName: UserPoolName,
+      partition: Partition,
       region: Region,
       accountId: AccountId,
       userPoolId: userPool.Id,

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Lambda = require('aws-sdk/clients/lambda');
+const { getPartition } = require('../../utils');
 
 function getStatementId(functionName, userPoolName) {
   const normalizedUserPoolName = userPoolName.toLowerCase().replace(/[.:*\s]/g, '');
@@ -14,7 +15,7 @@ function getStatementId(functionName, userPoolName) {
 function addPermission(config) {
   const { functionName, userPoolName, region, accountId, userPoolId } = config;
   const lambda = new Lambda({ region });
-  const partition = region && /^cn-/.test(region) ? 'aws-cn' : 'aws';
+  const partition = getPartition(region);
   const params = {
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Lambda = require('aws-sdk/clients/lambda');
-const { getPartition } = require('../../utils');
 
 function getStatementId(functionName, userPoolName) {
   const normalizedUserPoolName = userPoolName.toLowerCase().replace(/[.:*\s]/g, '');
@@ -13,9 +12,8 @@ function getStatementId(functionName, userPoolName) {
 }
 
 function addPermission(config) {
-  const { functionName, userPoolName, region, accountId, userPoolId } = config;
+  const { functionName, userPoolName, partition, region, accountId, userPoolId } = config;
   const lambda = new Lambda({ region });
-  const partition = getPartition(region);
   const params = {
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,

--- a/lib/plugins/aws/customResources/resources/eventBridge/handler.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/handler.js
@@ -30,6 +30,7 @@ function create(event, context) {
 
   return addPermission({
     functionName: FunctionName,
+    partition: Partition,
     region: Region,
     accountId: AccountId,
     eventBus: EventBridgeConfig.EventBus,

--- a/lib/plugins/aws/customResources/resources/eventBridge/handler.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/handler.js
@@ -24,9 +24,9 @@ function handler(event, context) {
 
 function create(event, context) {
   const { FunctionName, EventBridgeConfig } = event.ResourceProperties;
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context);
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return addPermission({
     functionName: FunctionName,
@@ -64,10 +64,10 @@ function create(event, context) {
 }
 
 function update(event, context) {
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context);
   const { FunctionName, EventBridgeConfig } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return updateRuleConfiguration({
     region: Region,

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
@@ -2,7 +2,6 @@
 
 const AWS = require('aws-sdk');
 const { getEventBusName } = require('./utils');
-const { getPartition } = require('../../utils');
 
 function getStatementId(functionName, ruleName) {
   const normalizedRuleName = ruleName.toLowerCase().replace(/[.:*]/g, '');
@@ -14,9 +13,8 @@ function getStatementId(functionName, ruleName) {
 }
 
 function addPermission(config) {
-  const { functionName, region, accountId, eventBus, ruleName } = config;
+  const { functionName, partition, region, accountId, eventBus, ruleName } = config;
   const lambda = new AWS.Lambda({ region });
-  const partition = getPartition(region);
   let SourceArn = `arn:${partition}:events:${region}:${accountId}:rule/${ruleName}`;
   if (eventBus) {
     const eventBusName = getEventBusName(eventBus);

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
@@ -2,6 +2,7 @@
 
 const AWS = require('aws-sdk');
 const { getEventBusName } = require('./utils');
+const { getPartition } = require('../../utils');
 
 function getStatementId(functionName, ruleName) {
   const normalizedRuleName = ruleName.toLowerCase().replace(/[.:*]/g, '');
@@ -15,7 +16,7 @@ function getStatementId(functionName, ruleName) {
 function addPermission(config) {
   const { functionName, region, accountId, eventBus, ruleName } = config;
   const lambda = new AWS.Lambda({ region });
-  const partition = region && /^cn-/.test(region) ? 'aws-cn' : 'aws';
+  const partition = getPartition(region);
   let SourceArn = `arn:${partition}:events:${region}:${accountId}:rule/${ruleName}`;
   if (eventBus) {
     const eventBusName = getEventBusName(eventBus);

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -16,7 +16,7 @@ function handler(event, context) {
 }
 
 function create(event, context) {
-  const { Partition, Region, AccountId } = getEnvironment(context); //here modify to extract Partition
+  const { Partition, Region, AccountId } = getEnvironment(context);
   const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
 
   const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -16,10 +16,10 @@ function handler(event, context) {
 }
 
 function create(event, context) {
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context); //here modify to extract Partition
   const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return addPermission({
     functionName: FunctionName,
@@ -37,10 +37,10 @@ function create(event, context) {
 }
 
 function update(event, context) {
-  const { Region, AccountId } = getEnvironment(context);
+  const { Partition, Region, AccountId } = getEnvironment(context);
   const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
   return updateConfiguration({
     lambdaArn,

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -24,6 +24,7 @@ function create(event, context) {
   return addPermission({
     functionName: FunctionName,
     bucketName: BucketName,
+    partition: Partition,
     region: Region,
   }).then(() =>
     updateConfiguration({

--- a/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const { getPartition } = require('../../utils');
 
 function getStatementId(functionName, bucketName) {
   const normalizedBucketName = bucketName.replace(/[.:*]/g, '');
@@ -13,9 +12,8 @@ function getStatementId(functionName, bucketName) {
 }
 
 function addPermission(config) {
-  const { functionName, bucketName, region } = config;
+  const { functionName, bucketName, partition, region } = config;
   const lambda = new AWS.Lambda({ region });
-  const partition = getPartition(region);
   const payload = {
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,

--- a/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+const { getPartition } = require('../../utils');
 
 function getStatementId(functionName, bucketName) {
   const normalizedBucketName = bucketName.replace(/[.:*]/g, '');
@@ -14,7 +15,7 @@ function getStatementId(functionName, bucketName) {
 function addPermission(config) {
   const { functionName, bucketName, region } = config;
   const lambda = new AWS.Lambda({ region });
-  const partition = region && /^cn-/.test(region) ? 'aws-cn' : 'aws';
+  const partition = getPartition(region);
   const payload = {
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -73,16 +73,6 @@ function getEnvironment(context) {
   };
 }
 
-function getPartition(region) {
-  let partition = 'aws';
-  if (region && /^cn-/.test(region)) {
-    partition = 'aws-cn';
-  } else if (region && /^us-gov-/.test(region)) {
-    partition = 'aws-us-gov';
-  }
-  return partition;
-}
-
 function handlerWrapper(handler, PhysicalResourceId) {
   return (event, context, callback) => {
     // extend the `event` object to include the PhysicalResourceId
@@ -105,7 +95,6 @@ module.exports = {
   response,
   getEnvironment,
   getLambdaArn,
-  getPartition,
   handlerWrapper,
   wait,
 };

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -57,7 +57,7 @@ function response(event, context, status, data = {}, err) {
 
 function getLambdaArn(region, accountId, functionName) {
   let awsNode = 'aws';
-  if(region === 'us-gov-west-1' || region === 'us-gov-east-1') {
+  if (region === 'us-gov-west-1' || region === 'us-gov-east-1') {
     awsNode = 'aws-us-gov';
   }
   return `arn:${awsNode}:lambda:${region}:${accountId}:function:${functionName}`;
@@ -70,9 +70,7 @@ function getEnvironment(context) {
       /^arn:aws-us-gov.*:lambda:(\w+-\w+-\w+-\d+):(\d+):function:(.*)$/
     );
   } else {
-    arn = context.invokedFunctionArn.match(
-      /^arn:aws.*:lambda:(\w+-\w+-\d+):(\d+):function:(.*)$/
-    );
+    arn = context.invokedFunctionArn.match(/^arn:aws.*:lambda:(\w+-\w+-\d+):(\d+):function:(.*)$/);
   }
   return {
     LambdaArn: arn[0],

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -56,13 +56,24 @@ function response(event, context, status, data = {}, err) {
 }
 
 function getLambdaArn(region, accountId, functionName) {
-  return `arn:aws:lambda:${region}:${accountId}:function:${functionName}`;
+  let awsNode = 'aws';
+  if(region === 'us-gov-west-1' || region === 'us-gov-east-2') {
+    awsNode = 'aws-us-gov';
+  }
+  return `arn:${awsNode}:lambda:${region}:${accountId}:function:${functionName}`;
 }
 
 function getEnvironment(context) {
-  const arn = context.invokedFunctionArn.match(
-    /^arn:aws.*:lambda:(\w+-\w+-\d+):(\d+):function:(.*)$/
-  );
+  let arn;
+  if (context.invokedFunctionArn.includes("arn:aws-us-gov")) {
+    arn = context.invokedFunctionArn.match(
+      /^arn:aws-us-gov.*:lambda:(\w+-\w+-\w+-\d+):(\d+):function:(.*)$/
+    );
+  } else {
+    arn = context.invokedFunctionArn.match(
+      /^arn:aws.*:lambda:(\w+-\w+-\d+):(\d+):function:(.*)$/
+    );
+  }
   return {
     LambdaArn: arn[0],
     Region: arn[1],

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -55,29 +55,32 @@ function response(event, context, status, data = {}, err) {
   });
 }
 
-function getLambdaArn(region, accountId, functionName) {
-  let awsNode = 'aws';
-  if (region === 'us-gov-west-1' || region === 'us-gov-east-1') {
-    awsNode = 'aws-us-gov';
-  }
-  return `arn:${awsNode}:lambda:${region}:${accountId}:function:${functionName}`;
+function getLambdaArn(partition, region, accountId, functionName) {
+  return `arn:${partition}:lambda:${region}:${accountId}:function:${functionName}`;
 }
 
 function getEnvironment(context) {
-  let arn;
-  if (context.invokedFunctionArn.includes('arn:aws-us-gov')) {
-    arn = context.invokedFunctionArn.match(
-      /^arn:aws-us-gov.*:lambda:(\w+-\w+-\w+-\d+):(\d+):function:(.*)$/
-    );
-  } else {
-    arn = context.invokedFunctionArn.match(/^arn:aws.*:lambda:(\w+-\w+-\d+):(\d+):function:(.*)$/);
-  }
+  const arn = context.invokedFunctionArn.match(
+    /^arn:(aws[\w-]*).*:lambda:([\w+-]{2,}\d+):(\d+):function:(.*)$/
+  );
+
   return {
     LambdaArn: arn[0],
-    Region: arn[1],
-    AccountId: arn[2],
-    LambdaName: arn[3],
+    Partition: arn[1],
+    Region: arn[2],
+    AccountId: arn[3],
+    LambdaName: arn[4],
   };
+}
+
+function getPartition(region) {
+  let partition = 'aws';
+  if (region && /^cn-/.test(region)) {
+    partition = 'aws-cn';
+  } else if (region && /^us-gov-/.test(region)) {
+    partition = 'aws-us-gov';
+  }
+  return partition;
 }
 
 function handlerWrapper(handler, PhysicalResourceId) {
@@ -102,6 +105,7 @@ module.exports = {
   response,
   getEnvironment,
   getLambdaArn,
+  getPartition,
   handlerWrapper,
   wait,
 };

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -57,7 +57,7 @@ function response(event, context, status, data = {}, err) {
 
 function getLambdaArn(region, accountId, functionName) {
   let awsNode = 'aws';
-  if(region === 'us-gov-west-1' || region === 'us-gov-east-2') {
+  if(region === 'us-gov-west-1' || region === 'us-gov-east-1') {
     awsNode = 'aws-us-gov';
   }
   return `arn:${awsNode}:lambda:${region}:${accountId}:function:${functionName}`;
@@ -65,7 +65,7 @@ function getLambdaArn(region, accountId, functionName) {
 
 function getEnvironment(context) {
   let arn;
-  if (context.invokedFunctionArn.includes("arn:aws-us-gov")) {
+  if (context.invokedFunctionArn.includes('arn:aws-us-gov')) {
     arn = context.invokedFunctionArn.match(
       /^arn:aws-us-gov.*:lambda:(\w+-\w+-\w+-\d+):(\d+):function:(.*)$/
     );

--- a/lib/plugins/aws/customResources/resources/utils.test.js
+++ b/lib/plugins/aws/customResources/resources/utils.test.js
@@ -15,6 +15,28 @@ describe('#getLambdaArn()', () => {
   });
 });
 
+describe('#getLambdaArn() govloud west', () => {
+  it('should return the govcloud Lambda arn', () => {
+    const region = 'us-gov-west-1';
+    const accountId = '123456';
+    const functionName = 'some-function';
+    const arn = getLambdaArn(region, accountId, functionName);
+
+    expect(arn).to.equal('arn:aws-us-gov:lambda:us-gov-west-1:123456:function:some-function');
+  });
+});
+
+describe('#getLambdaArn() govcloud east', () => {
+  it('should return the govcloud Lambda arn', () => {
+    const region = 'us-gov-east-1';
+    const accountId = '123456';
+    const functionName = 'some-function';
+    const arn = getLambdaArn(region, accountId, functionName);
+
+    expect(arn).to.equal('arn:aws-us-gov:lambda:us-gov-east-1:123456:function:some-function');
+  });
+});
+
 describe('#getEnvironment()', () => {
   it('should return an object with information about the execution environment', () => {
     const context = {
@@ -25,6 +47,38 @@ describe('#getEnvironment()', () => {
     expect(env).to.deep.equal({
       LambdaArn: 'arn:aws:lambda:us-east-1:123456:function:some-function',
       Region: 'us-east-1',
+      AccountId: '123456',
+      LambdaName: 'some-function',
+    });
+  });
+});
+
+describe('#getEnvironment() govcloud east', () => {
+  it('should return an object with information about the govcloud execution environment', () => {
+    const context = {
+      invokedFunctionArn: 'arn:aws-us-gov:lambda:us-gov-east-1:123456:function:some-function',
+    };
+    const env = getEnvironment(context);
+
+    expect(env).to.deep.equal({
+      LambdaArn: 'arn:aws-us-gov:lambda:us-gov-east-1:123456:function:some-function',
+      Region: 'us-gov-east-1',
+      AccountId: '123456',
+      LambdaName: 'some-function',
+    });
+  });
+});
+
+describe('#getEnvironment() govcloud west', () => {
+  it('should return an object with information about the govcloud execution environment', () => {
+    const context = {
+      invokedFunctionArn: 'arn:aws-us-gov:lambda:us-gov-west-1:123456:function:some-function',
+    };
+    const env = getEnvironment(context);
+
+    expect(env).to.deep.equal({
+      LambdaArn: 'arn:aws-us-gov:lambda:us-gov-west-1:123456:function:some-function',
+      Region: 'us-gov-west-1',
       AccountId: '123456',
       LambdaName: 'some-function',
     });

--- a/lib/plugins/aws/customResources/resources/utils.test.js
+++ b/lib/plugins/aws/customResources/resources/utils.test.js
@@ -2,14 +2,15 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { expect } = require('chai');
-const { getLambdaArn, getEnvironment } = require('./utils');
+const { getLambdaArn, getEnvironment, getPartition } = require('./utils');
 
 describe('#getLambdaArn()', () => {
   it('should return the Lambda arn', () => {
+    const partition = 'aws';
     const region = 'us-east-1';
     const accountId = '123456';
     const functionName = 'some-function';
-    const arn = getLambdaArn(region, accountId, functionName);
+    const arn = getLambdaArn(partition, region, accountId, functionName);
 
     expect(arn).to.equal('arn:aws:lambda:us-east-1:123456:function:some-function');
   });
@@ -17,10 +18,11 @@ describe('#getLambdaArn()', () => {
 
 describe('#getLambdaArn() govloud west', () => {
   it('should return the govcloud Lambda arn', () => {
+    const partition = 'aws-us-gov';
     const region = 'us-gov-west-1';
     const accountId = '123456';
     const functionName = 'some-function';
-    const arn = getLambdaArn(region, accountId, functionName);
+    const arn = getLambdaArn(partition, region, accountId, functionName);
 
     expect(arn).to.equal('arn:aws-us-gov:lambda:us-gov-west-1:123456:function:some-function');
   });
@@ -28,12 +30,25 @@ describe('#getLambdaArn() govloud west', () => {
 
 describe('#getLambdaArn() govcloud east', () => {
   it('should return the govcloud Lambda arn', () => {
+    const partition = 'aws-us-gov';
     const region = 'us-gov-east-1';
     const accountId = '123456';
     const functionName = 'some-function';
-    const arn = getLambdaArn(region, accountId, functionName);
+    const arn = getLambdaArn(partition, region, accountId, functionName);
 
     expect(arn).to.equal('arn:aws-us-gov:lambda:us-gov-east-1:123456:function:some-function');
+  });
+});
+
+describe('#getLambdaArn() china region', () => {
+  it('should return the china Lambda arn', () => {
+    const partition = 'aws-cn';
+    const region = 'cn-north-1';
+    const accountId = '123456';
+    const functionName = 'some-function';
+    const arn = getLambdaArn(partition, region, accountId, functionName);
+
+    expect(arn).to.equal('arn:aws-cn:lambda:cn-north-1:123456:function:some-function');
   });
 });
 
@@ -46,6 +61,7 @@ describe('#getEnvironment()', () => {
 
     expect(env).to.deep.equal({
       LambdaArn: 'arn:aws:lambda:us-east-1:123456:function:some-function',
+      Partition: 'aws',
       Region: 'us-east-1',
       AccountId: '123456',
       LambdaName: 'some-function',
@@ -62,6 +78,7 @@ describe('#getEnvironment() govcloud east', () => {
 
     expect(env).to.deep.equal({
       LambdaArn: 'arn:aws-us-gov:lambda:us-gov-east-1:123456:function:some-function',
+      Partition: 'aws-us-gov',
       Region: 'us-gov-east-1',
       AccountId: '123456',
       LambdaName: 'some-function',
@@ -78,9 +95,54 @@ describe('#getEnvironment() govcloud west', () => {
 
     expect(env).to.deep.equal({
       LambdaArn: 'arn:aws-us-gov:lambda:us-gov-west-1:123456:function:some-function',
+      Partition: 'aws-us-gov',
       Region: 'us-gov-west-1',
       AccountId: '123456',
       LambdaName: 'some-function',
     });
+  });
+});
+
+describe('#getEnvironment() china region', () => {
+  it('should return an object with information about the china region execution environment', () => {
+    const context = {
+      invokedFunctionArn: 'arn:aws-cn:lambda:cn-north-1:123456:function:some-function',
+    };
+    const env = getEnvironment(context);
+
+    expect(env).to.deep.equal({
+      LambdaArn: 'arn:aws-cn:lambda:cn-north-1:123456:function:some-function',
+      Partition: 'aws-cn',
+      Region: 'cn-north-1',
+      AccountId: '123456',
+      LambdaName: 'some-function',
+    });
+  });
+});
+
+describe('#getPartition() public', () => {
+  it('should return the partition for public region', () => {
+    const region = 'us-east-1';
+    const partition = getPartition(region);
+
+    expect(partition).to.equal('aws');
+  });
+});
+
+describe('#getPartition() china', () => {
+  it('should return the partition for china region', () => {
+    const region = 'cn-north-1';
+    const partition = getPartition(region);
+
+    expect(partition).to.equal('aws-cn');
+  });
+});
+
+describe('#getPartition() govcloud', () => {
+  it('should return the partition for govcloud region', () => {
+    const region = 'us-gov-west-1';
+    const partition = getPartition(region);
+
+    expect(partition).to.equal('aws-us-gov');
   });
 });

--- a/lib/plugins/aws/customResources/resources/utils.test.js
+++ b/lib/plugins/aws/customResources/resources/utils.test.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { expect } = require('chai');
-const { getLambdaArn, getEnvironment, getPartition } = require('./utils');
+const { getLambdaArn, getEnvironment } = require('./utils');
 
 describe('#getLambdaArn()', () => {
   it('should return the Lambda arn', () => {
@@ -117,32 +117,5 @@ describe('#getEnvironment() china region', () => {
       AccountId: '123456',
       LambdaName: 'some-function',
     });
-  });
-});
-
-describe('#getPartition() public', () => {
-  it('should return the partition for public region', () => {
-    const region = 'us-east-1';
-    const partition = getPartition(region);
-
-    expect(partition).to.equal('aws');
-  });
-});
-
-describe('#getPartition() china', () => {
-  it('should return the partition for china region', () => {
-    const region = 'cn-north-1';
-    const partition = getPartition(region);
-
-    expect(partition).to.equal('aws-cn');
-  });
-});
-
-describe('#getPartition() govcloud', () => {
-  it('should return the partition for govcloud region', () => {
-    const region = 'us-gov-west-1';
-    const partition = getPartition(region);
-
-    expect(partition).to.equal('aws-us-gov');
   });
 });


### PR DESCRIPTION

## What did you implement

Closes #6995 .  Fix GovCloud Region ARN and Environment parsing utilities in the AWS Plugin for Custom Resources.

## How can we verify it

Deploy a serverless function to `us-gov-west-1` or `us-gov-east-1`  that uses S3 Bucket events on an existing S3 bucket, for example:

```yml
service:
  name: myService
provider:
  name: aws
  runtime: nodejs10.x
  stage: dev
  region: us-gov-west-1
functions:
  users:
    handler: users.handler
    events:
      - s3:
          bucket: legacy-photos
          event: s3:ObjectCreated:*
          rules:
            - prefix: uploads/
            - suffix: .jpg
          existing: true

```
## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
