### PR TITLE
Fix/cors omit access control allow credentials on false

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -284,6 +284,8 @@ Please note that since you can't send multiple values for [Access-Control-Allow-
 
 Configuring the `cors` property sets [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers), [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods),[Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) headers in the CORS preflight response.
 
+Please note that the [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)-Header is omitted when not explicitly set to `true`.
+
 To enable the `Access-Control-Max-Age` preflight response header, set the `maxAge` property in the `cors` object:
 
 ```yml

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -33,7 +33,7 @@ module.exports = {
       };
 
       // Only set Access-Control-Allow-Credentials when explicitly allowed (omit if false)
-      if(config.allowCredentials) {
+      if (config.allowCredentials) {
         preflightHeaders['Access-Control-Allow-Credentials'] = `'${config.allowCredentials}'`;
       }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -33,7 +33,7 @@ module.exports = {
       };
 
       // Only set Access-Control-Allow-Credentials when explicitly allowed (omit if false)
-      if(config.allowCredentials === true) {
+      if(config.allowCredentials) {
         preflightHeaders['Access-Control-Allow-Credentials'] = `'${config.allowCredentials}'`;
       }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -30,8 +30,12 @@ module.exports = {
         'Access-Control-Allow-Origin': `'${origin}'`,
         'Access-Control-Allow-Headers': `'${config.headers.join(',')}'`,
         'Access-Control-Allow-Methods': `'${config.methods.join(',')}'`,
-        'Access-Control-Allow-Credentials': `'${config.allowCredentials}'`,
       };
+
+      // Only set Access-Control-Allow-Credentials when explicitly allowed (omit if false)
+      if(config.allowCredentials === true) {
+        preflightHeaders['Access-Control-Allow-Credentials'] = `'${config.allowCredentials}'`;
+      }
 
       // Enable CORS Max Age usage if set
       if (_.has(config, 'maxAge')) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -157,7 +157,7 @@ describe('#compileCors()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersUpdateOptions.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
-      ).to.equal(undefined);
+      ).to.be.undefined;
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -194,7 +194,7 @@ describe('#compileCors()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersDeleteOptions.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
-      ).to.equal(undefined);
+      ).to.be.undefined;
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -233,7 +233,7 @@ describe('#compileCors()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersAnyOptions.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
-      ).to.equal(undefined);
+      ).to.be.undefined;
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -157,7 +157,7 @@ describe('#compileCors()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersUpdateOptions.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
-      ).to.equal("'false'");
+      ).to.equal(undefined);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -194,7 +194,7 @@ describe('#compileCors()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersDeleteOptions.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
-      ).to.equal("'false'");
+      ).to.equal(undefined);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -233,7 +233,7 @@ describe('#compileCors()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersAnyOptions.Properties.Integration.IntegrationResponses[0]
           .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
-      ).to.equal("'false'");
+      ).to.equal(undefined);
     });
   });
 

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -117,7 +117,7 @@ describe('AWS - API Gateway Integration Test', function() {
         ].join(',');
         expect(headers.get('access-control-allow-headers')).to.equal(allowHeaders);
         expect(headers.get('access-control-allow-methods')).to.equal('OPTIONS,GET');
-        expect(headers.get('access-control-allow-credentials')).to.equal('false');
+        expect(headers.get('access-control-allow-credentials')).to.equal(null);
         // TODO: for some reason this test fails for now...
         // expect(headers.get('access-control-allow-origin')).to.equal('*');
       });


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Only return `Access-Control-Allow-Credentials`-Header when `allowCredentials` is explicitly set to true. Otherwise the header is omitted as described in the specifications. 

Closes #6994 

## How can we verify it

(taken from the examples)

```yaml
service: aws-java-simple-http-endpoint

frameworkVersion: ">=1.2.0 <2.0.0"

provider:
  name: aws
  runtime: java8
  
package:
  artifact: build/distributions/aws-java-simple-http-endpoint.zip

functions:
  currentTime:
    handler: com.serverless.Handler
    events:
      - http:
          path: ping
          method: get
          cors: true
```

```yaml
service: aws-java-simple-http-endpoint

frameworkVersion: ">=1.2.0 <2.0.0"

provider:
  name: aws
  runtime: java8
  
package:
  artifact: build/distributions/aws-java-simple-http-endpoint.zip

functions:
  currentTime:
    handler: com.serverless.Handler
    events:
      - http:
          path: ping
          method: get
          cors:
            origin: '*' # <-- Specify allowed origin
            headers: # <-- Specify allowed headers
              - Content-Type
              - X-Amz-Date
              - Authorization
              - X-Api-Key
              - X-Amz-Security-Token
              - X-Amz-User-Agent
            allowCredentials: false
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
