### PR TITLE
Resource policy

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -3,23 +3,24 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
-module.exports = {
-  resourcePolicy: {
-    Version: '2012-10-17',
-    Statement: [
-      {
-        Effect: 'Allow',
-        Principal: '*',
-        Action: 'execute-api:Invoke',
-        Resource: ['execute-api:/*/*/*'],
-        Condition: {
-          IpAddress: {
-            'aws:SourceIp': ['0.0.0.0/32'],
-          },
+const defaultPolicy = {
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Effect: 'Allow',
+      Principal: '*',
+      Action: 'execute-api:Invoke',
+      Resource: ['execute-api:/*/*/*'],
+      Condition: {
+        IpAddress: {
+          'aws:SourceIp': ['0.0.0.0/32'],
         },
       },
-    ],
-  },
+    },
+  ],
+};
+
+module.exports = {
   compileRestApi() {
     const apiGateway = this.serverless.service.provider.apiGateway || {};
 
@@ -80,12 +81,14 @@ module.exports = {
         }
       );
     } else {
+      // setting up a policy with no restrictions in cases where no policy is specified
+      // this ensures that a policy is always present
       _.merge(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
           this.apiGatewayRestApiLogicalId
         ].Properties,
         {
-          Policy: module.exports.resourcePolicy,
+          Policy: defaultPolicy,
         }
       );
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -4,6 +4,20 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 
 module.exports = {
+  resourcePolicy: {
+    Version: '2012-10-17',
+    Statement: [{
+      Effect: 'Allow',
+      Principal: '*',
+      Action: 'execute-api:Invoke',
+      Resource: ['execute-api:/*/*/*'],
+      Condition: {
+        IpAddress: {
+          'aws:SourceIp': ['0.0.0.0/32'],
+        },
+      },
+    }],
+  },
   compileRestApi() {
     const apiGateway = this.serverless.service.provider.apiGateway || {};
 
@@ -61,6 +75,16 @@ module.exports = {
         ].Properties,
         {
           Policy: policy,
+        }
+      );
+
+    } else {
+      _.merge(
+        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          this.apiGatewayRestApiLogicalId
+        ].Properties,
+        {
+          Policy: module.exports.resourcePolicy,
         }
       );
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -6,17 +6,19 @@ const BbPromise = require('bluebird');
 module.exports = {
   resourcePolicy: {
     Version: '2012-10-17',
-    Statement: [{
-      Effect: 'Allow',
-      Principal: '*',
-      Action: 'execute-api:Invoke',
-      Resource: ['execute-api:/*/*/*'],
-      Condition: {
-        IpAddress: {
-          'aws:SourceIp': ['0.0.0.0/32'],
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: '*',
+        Action: 'execute-api:Invoke',
+        Resource: ['execute-api:/*/*/*'],
+        Condition: {
+          IpAddress: {
+            'aws:SourceIp': ['0.0.0.0/32'],
+          },
         },
       },
-    }],
+    ],
   },
   compileRestApi() {
     const apiGateway = this.serverless.service.provider.apiGateway || {};
@@ -77,7 +79,6 @@ module.exports = {
           Policy: policy,
         }
       );
-
     } else {
       _.merge(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources[

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -104,7 +104,7 @@ describe('#compileRestApi()', () => {
 
   it('should provide open policy if no policy specified', () => {
     const resources =
-    awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
     return awsCompileApigEvents.compileRestApi().then(() => {
       expect(resources.ApiGatewayRestApi).to.deep.equal({

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
+const RestApi = require('./restApi');
 
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));
@@ -49,6 +50,7 @@ describe('#compileRestApi()', () => {
           EndpointConfiguration: {
             Types: ['EDGE'],
           },
+          Policy: RestApi.resourcePolicy,
         },
       });
     }));
@@ -100,6 +102,40 @@ describe('#compileRestApi()', () => {
     });
   });
 
+  it('should provide open policy if no policy specified', () => {
+    const resources =
+    awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+    return awsCompileApigEvents.compileRestApi().then(() => {
+      expect(resources.ApiGatewayRestApi).to.deep.equal({
+        Type: 'AWS::ApiGateway::RestApi',
+        Properties: {
+          Name: 'dev-new-service',
+          BinaryMediaTypes: undefined,
+          EndpointConfiguration: {
+            Types: ['EDGE'],
+          },
+          Policy: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: '*',
+                Action: 'execute-api:Invoke',
+                Resource: ['execute-api:/*/*/*'],
+                Condition: {
+                  IpAddress: {
+                    'aws:SourceIp': ['0.0.0.0/32'],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+
   it('should ignore REST API resource creation if there is predefined restApi config', () => {
     awsCompileApigEvents.serverless.service.provider.apiGateway = {
       restApiId: '6fyzt1pfpk',
@@ -128,6 +164,7 @@ describe('#compileRestApi()', () => {
             Types: ['EDGE'],
           },
           Name: 'dev-new-service',
+          Policy: RestApi.resourcePolicy,
         },
       });
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -4,7 +4,6 @@ const chai = require('chai');
 const AwsCompileApigEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
-const RestApi = require('./restApi');
 
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));
@@ -50,7 +49,22 @@ describe('#compileRestApi()', () => {
           EndpointConfiguration: {
             Types: ['EDGE'],
           },
-          Policy: RestApi.resourcePolicy,
+          Policy: {
+            Statement: [
+              {
+                Action: 'execute-api:Invoke',
+                Condition: {
+                  IpAddress: {
+                    'aws:SourceIp': ['0.0.0.0/32'],
+                  },
+                },
+                Effect: 'Allow',
+                Principal: '*',
+                Resource: ['execute-api:/*/*/*'],
+              },
+            ],
+            Version: '2012-10-17',
+          },
         },
       });
     }));
@@ -164,7 +178,22 @@ describe('#compileRestApi()', () => {
             Types: ['EDGE'],
           },
           Name: 'dev-new-service',
-          Policy: RestApi.resourcePolicy,
+          Policy: {
+            Statement: [
+              {
+                Action: 'execute-api:Invoke',
+                Condition: {
+                  IpAddress: {
+                    'aws:SourceIp': ['0.0.0.0/32'],
+                  },
+                },
+                Effect: 'Allow',
+                Principal: '*',
+                Resource: ['execute-api:/*/*/*'],
+              },
+            ],
+            Version: '2012-10-17',
+          },
         },
       });
     });


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Provides default apig resource policy.  This ensures any previously defined resource policy gets overwritten.  

<!-- Briefly describe the scope of your PR -->

Closes #6789 

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->
First create a resource policy that limits traffic to your source ip address.
```yaml
provider:
  name: aws
  runtime: nodejs12.x

  resourcePolicy:
    - Effect: Allow
      Principal: '*'
      Action: execute-api:Invoke
      Resource:
        - execute-api:/*/*/*
      Condition:
        IpAddress:
          aws:SourceIp:
            - '123.123.123.123'
```

Now remove said policy, and test accessing the endpoint using a different source address from original policy.

```yaml
provider:
  name: aws
  runtime: nodejs12.x

 # resourcePolicy:
 #  - Effect: Allow
 #     Principal: '*'
 #    Action: execute-api:Invoke
 #     Resource:
 #       - execute-api:/*/*/*
 #     Condition:
 #       IpAddress:
 #         aws:SourceIp:
 #           - '123.123.123.123' 
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
