### PR TITLE
Lint and style patches

### DIFF
--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -65,7 +65,7 @@ describe('PluginManager', () => {
     }
 
     functions() {
-      this.deployedFunctions = this.deployedFunctions + 1;
+      this.deployedFunctions += 1;
     }
   }
 
@@ -88,7 +88,7 @@ describe('PluginManager', () => {
     }
 
     functions() {
-      this.deployedFunctions = this.deployedFunctions + 1;
+      this.deployedFunctions += 1;
     }
   }
 
@@ -135,14 +135,14 @@ describe('PluginManager', () => {
 
     functions() {
       return new BbPromise(resolve => {
-        this.deployedFunctions = this.deployedFunctions + 1;
+        this.deployedFunctions += 1;
         return resolve();
       });
     }
 
     resources() {
       return new BbPromise(resolve => {
-        this.deployedResources = this.deployedResources + 1;
+        this.deployedResources += 1;
         return resolve();
       });
     }
@@ -190,11 +190,11 @@ describe('PluginManager', () => {
     }
 
     functions() {
-      this.deployedFunctions = this.deployedFunctions + 1;
+      this.deployedFunctions += 1;
     }
 
     resources() {
-      this.deployedResources = this.deployedResources + 1;
+      this.deployedResources += 1;
     }
   }
 
@@ -241,11 +241,11 @@ describe('PluginManager', () => {
     }
 
     functions() {
-      this.deployedFunctions = this.deployedFunctions + 1;
+      this.deployedFunctions += 1;
     }
 
     resources() {
-      this.deployedResources = this.deployedResources + 1;
+      this.deployedResources += 1;
     }
   }
 

--- a/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
+++ b/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
@@ -68,24 +68,25 @@ describe('#existsDeploymentBucket()', () => {
     });
   });
 
-  [{ region: 'eu-west-1', response: 'EU' }, { region: 'us-east-1', response: '' }].forEach(
-    value => {
-      it(`should handle inconsistent getBucketLocation responses for ${value.region} region`, () => {
-        const bucketName = 'com.serverless.deploys';
+  [
+    { region: 'eu-west-1', response: 'EU' },
+    { region: 'us-east-1', response: '' },
+  ].forEach(value => {
+    it(`should handle inconsistent getBucketLocation responses for ${value.region} region`, () => {
+      const bucketName = 'com.serverless.deploys';
 
-        awsPlugin.provider.options.region = value.region;
+      awsPlugin.provider.options.region = value.region;
 
-        sinon.stub(awsPlugin.provider, 'request').resolves({
-          LocationConstraint: value.response,
-        });
-
-        awsPlugin.serverless.service.provider.deploymentBucket = bucketName;
-        return expect(awsPlugin.existsDeploymentBucket(bucketName)).to.be.fulfilled.then(() => {
-          expect(awsPluginStub.args[0][0]).to.equal('S3');
-          expect(awsPluginStub.args[0][1]).to.equal('getBucketLocation');
-          expect(awsPluginStub.args[0][2].Bucket).to.equal(bucketName);
-        });
+      sinon.stub(awsPlugin.provider, 'request').resolves({
+        LocationConstraint: value.response,
       });
-    }
-  );
+
+      awsPlugin.serverless.service.provider.deploymentBucket = bucketName;
+      return expect(awsPlugin.existsDeploymentBucket(bucketName)).to.be.fulfilled.then(() => {
+        expect(awsPluginStub.args[0][0]).to.equal('S3');
+        expect(awsPluginStub.args[0][1]).to.equal('getBucketLocation');
+        expect(awsPluginStub.args[0][2].Bucket).to.equal(bucketName);
+      });
+    });
+  });
 });

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -153,7 +153,10 @@ describe('#generateCoreTemplate()', () => {
               },
             ],
           },
-          Tags: [{ Key: 'FOO', Value: 'bar' }, { Key: 'BAZ', Value: 'qux' }],
+          Tags: [
+            { Key: 'FOO', Value: 'bar' },
+            { Key: 'BAZ', Value: 'qux' },
+          ],
         },
       });
     }));

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -192,9 +192,11 @@ module.exports = {
       violationsFound = 'it is not an array';
     } else {
       const descriptions = statements.map((statement, i) => {
-        const missing = [['Effect'], ['Action', 'NotAction'], ['Resource', 'NotResource']].filter(
-          props => props.every(prop => statement[prop] === undefined)
-        );
+        const missing = [
+          ['Effect'],
+          ['Action', 'NotAction'],
+          ['Resource', 'NotResource'],
+        ].filter(props => props.every(prop => statement[prop] === undefined));
         return missing.length === 0
           ? null
           : `statement ${i} is missing the following properties: ${missing

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -627,9 +627,9 @@ describe('#packageService()', () => {
       };
       serverless.config.servicePath = servicePath;
 
-      return expect(packagePlugin.resolveFilePathsFromPatterns(params)).to.be.fulfilled.then(
-        actual => expect(actual).to.deep.equal([handlerFile])
-      );
+      return expect(
+        packagePlugin.resolveFilePathsFromPatterns(params)
+      ).to.be.fulfilled.then(actual => expect(actual).to.deep.equal([handlerFile]));
     });
 
     it('should include file specified with `!` in exclude params', () => {
@@ -639,9 +639,9 @@ describe('#packageService()', () => {
       };
       serverless.config.servicePath = servicePath;
 
-      return expect(packagePlugin.resolveFilePathsFromPatterns(params)).to.be.fulfilled.then(
-        actual => expect(actual).to.deep.equal([handlerFile, utilsFile])
-      );
+      return expect(
+        packagePlugin.resolveFilePathsFromPatterns(params)
+      ).to.be.fulfilled.then(actual => expect(actual).to.deep.equal([handlerFile, utilsFile]));
     });
 
     it('should exclude file specified with `!` in include params', () => {
@@ -652,9 +652,9 @@ describe('#packageService()', () => {
       const expected = [handlerFile];
       serverless.config.servicePath = servicePath;
 
-      return expect(packagePlugin.resolveFilePathsFromPatterns(params)).to.be.fulfilled.then(
-        actual => expect(actual).to.deep.equal(expected)
-      );
+      return expect(
+        packagePlugin.resolveFilePathsFromPatterns(params)
+      ).to.be.fulfilled.then(actual => expect(actual).to.deep.equal(expected));
     });
   });
 });


### PR DESCRIPTION
Purely style updates:

- ESlint with v6.7.0 got a [bug fix](https://github.com/eslint/eslint/pull/12495) to `operator-assignment`rule, on which we rely on, and that exposed few lint issues on our side -> https://travis-ci.org/serverless/serverless/jobs/616586600. Fixed here
- Prettier with v1.19 introduced minor changes to formatting, which affected few files. Updated those files to reflect new formatting. It's to help users avoid unrelated changes in their PR's (some prettify whole project)