### PR TITLE
fix: remove `$context.status` from websocket access log format

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -49,7 +49,6 @@ module.exports = {
             '$context.identity.user',
             '[$context.requestTime]',
             '"$context.eventType $context.routeKey $context.connectionId"',
-            '$context.status',
             '$context.requestId',
           ].join(' '),
         },

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -108,7 +108,6 @@ describe('#compileStage()', () => {
                 '$context.identity.user',
                 '[$context.requestTime]',
                 '"$context.eventType $context.routeKey $context.connectionId"',
-                '$context.status',
                 '$context.requestId',
               ].join(' '),
             },


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

It looks like AWS may have recently introduced a change where `$context.status` is invalid on API Gateway WebSocket APIs (or at least now they're enforcing invalid tokens).

> The following context variables are not supported: [$context.status] (Service: AmazonApiGatewayV2; Status Code: 400; Error Code: BadRequestException; Request ID: a37f886a-d719-485d-9593-fe2b14182df7)

This change simply removes the offending token from the WebSocket log format so WebSocket APIs will deploy properly.

## How can we verify it

Create a WebSocket-based service.

```yaml
service: websocket-test
provider:
  logs:
    websocket: true
functions:
  websocket:
    handler: src/websocket
    events:
      - websocket: $default
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
