### PR TITLE
fix #4711 when authroizers are deployed by current cloudformation

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.js
@@ -9,10 +9,13 @@ module.exports = {
     this.validated.events.forEach(event => {
       if (event.http.authorizer && event.http.authorizer.arn) {
         const authorizer = event.http.authorizer;
+        const functionRefFromArn  = _.get(authorizer.arn, ['Fn::GetAtt', '0']);
+        const authorizerName = functionRefFromArn ? {Ref : functionRefFromArn} : authorizer.name;
+
         const authorizerProperties = {
           AuthorizerResultTtlInSeconds: authorizer.resultTtlInSeconds,
           IdentitySource: authorizer.identitySource,
-          Name: authorizer.name,
+          Name: authorizerName,
           RestApiId: this.provider.getApiGatewayRestApiId(),
         };
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
@@ -57,7 +57,7 @@ describe('#compileAuthorizers()', () => {
       });
       expect(resource.Properties.IdentitySource).to.equal('method.request.header.Authorization');
       expect(resource.Properties.IdentityValidationExpression).to.equal(undefined);
-      expect(resource.Properties.Name).to.equal('authorizer');
+      expect(resource.Properties.Name).to.deep.equal({Ref : 'SomeLambdaFunction'});
       expect(resource.Properties.RestApiId.Ref).to.equal('ApiGatewayRestApi');
       expect(resource.Properties.Type).to.equal('TOKEN');
     });


### PR DESCRIPTION
## What did you implement

APIGateway authorizers will receive name of function but not a name of property.

Details:
Currently when sls deploys authorizers they will name defined by a property name. In following example APIG authorizer will have name `authorize` but with this patch it'll have `{prefix}-authorize` and will not conflict deploys with different prefixes:

Example serverless.yaml: 
```yaml
service: ${opt:prefix}-example
functions:
 authorize: # current authorizer name
   name: ${opt:prefix}-authorize # function name & patched authorizer name
   handler: api/auth.js
 getUsers:
   name : ${opt:prefix}-get-users
   handler: api/users.js
   events:
     - http:
       path: /${opt:prefix}/user
       method: get
       authorizer: authorize
```

#4711 is already closed by #4197 but only when configuration have custom authorizeId.
This pull request closes #4711 in case I don't use custom authorizerId.

## How can we verify it

Use custom function name for authorizer.

## Todos

- [ ] Write and run all tests
- [ ] Write documentation
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
