### PR TITLE
awsprovider - adding support for SDK sub-classes.

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -284,7 +284,8 @@ class AwsProvider {
         if (options && !_.isUndefined(options.region)) {
           credentials.region = options.region;
         }
-        const awsService = new that.sdk[service](credentials);
+        const Service = _.get(that.sdk, service);
+        const awsService = new Service(credentials);
         const req = awsService[method](params);
 
         // TODO: Add listeners, put Debug statements here...

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -298,7 +298,7 @@ describe('AwsProvider', () => {
 
       awsProvider.sdk = {
         DynamoDB: {
-          DocumentClient
+          DocumentClient,
         },
       };
       awsProvider.serverless.service.environment = {

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -283,6 +283,41 @@ describe('AwsProvider', () => {
       });
     });
 
+    it('should handle subclasses', () => {
+      class DocumentClient {
+        constructor(credentials) {
+          this.credentials = credentials;
+        }
+
+        put() {
+          return {
+            send: cb => cb(null, { called: true }),
+          };
+        }
+      }
+
+      awsProvider.sdk = {
+        DynamoDB: {
+          DocumentClient
+        },
+      };
+      awsProvider.serverless.service.environment = {
+        vars: {},
+        stages: {
+          dev: {
+            vars: {
+              profile: 'default',
+            },
+            regions: {},
+          },
+        },
+      };
+
+      return awsProvider.request('DynamoDB.DocumentClient', 'put', {}).then(data => {
+        expect(data.called).to.equal(true);
+      });
+    });
+
     it('should call correct aws method with a promise', () => {
       // mocking API Gateway for testing
       class FakeAPIGateway {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Support for AWS SDK sub-classes

Closes #7030

## How can we verify it

`serverless.yml`:
```yaml
service: myService

provider:
  name: aws
  runtime: nodejs10.x

plugins:
  - serverless-test-plugin

functions:
  hello:
    handler: handler.hello
```

`.serverless_plugins/serverless-test-plugin.js`:
```js
'use strict';

class TestPlugin {
  constructor(serverless) {
    this.provider = serverless.getProvider('aws');
    this.serverless = serverless.service;
    this.hooks = {
      'after:package:finalize': () => this.test()
    };
  }

  async test() {
    await this.provider.request('DynamoDB.DocumentClient', 'put', {});
  }
}

module.exports = TestPlugin;
```

The code snippet errors both before and after the change, but still shows the `DynamoDB.DocumentClient` sub-class is being used.

Before:
```
  Type Error ---------------------------------------------
 
  TypeError: that.sdk[service] is not a constructor
      at /home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:287:28
      at doCall (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:238:11)
      at /home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:261:16
      at Promise._execute (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/debuggability.js:427:9)
      at Promise._resolveFromExecutor (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:518:18)
      at new Promise (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:103:10)
      at persistentRequest (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:236:7)
      at Object.promiseGenerator (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:283:7)
      at Queue._dequeue (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/promise-queue/lib/index.js:153:30)
      at /home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/promise-queue/lib/index.js:109:18
      at Promise._execute (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/debuggability.js:427:9)
      at Promise._resolveFromExecutor (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:518:18)
      at new Promise (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:103:10)
      at Queue.add (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/promise-queue/lib/index.js:94:16)
      at AwsProvider.request (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:282:39)
      at TestPlugin.test (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/.serverless_plugins/serverless-test-plugin.js:14:25)
      at Object.after:package:finalize [as hook] (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/.serverless_plugins/serverless-test-plugin.js:8:44)
      at /home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/serverless/lib/classes/PluginManager.js:505:55
      at tryCatcher (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/util.js:16:23)
      at Object.gotValue (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/reduce.js:168:18)
      at Object.gotAccum (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/reduce.js:155:25)
      at Object.tryCatcher (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:547:31)
      at Promise._settlePromise (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:604:18)
      at Promise._settlePromise0 (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:649:10)
      at Promise._settlePromises (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/promise.js:729:18)
      at _drainQueueStep (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/async.js:93:12)
      at _drainQueue (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/async.js:86:9)
      at Async._drainQueues (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (/home/neverendingqs/code/neverendingqs/barebones-serverless-framework-aws/node_modules/bluebird/js/release/async.js:15:14)
      at processImmediate (internal/timers.js:439:21)
      at process.topLevelDomainCallback (domain.js:130:23)
```

After:
```
  Serverless Error ---------------------------------------
 
  There were 2 validation errors:
  * MissingRequiredParameter: Missing required key 'TableName' in params
  * MissingRequiredParameter: Missing required key 'Item' in params
```


## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO

Please let me know if there is documentation to update.