### PR TITLE
Optimize custom resources generation

### DIFF
--- a/lib/plugins/aws/customResources/generateZip.js
+++ b/lib/plugins/aws/customResources/generateZip.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { memoize } = require('lodash');
+const BbPromise = require('bluebird');
+const childProcess = BbPromise.promisifyAll(require('child_process'));
+const fse = BbPromise.promisifyAll(require('fs-extra'));
+const { version } = require('../../../../package');
+const getTmpDirPath = require('../../../utils/fs/getTmpDirPath');
+const createZipFile = require('../../../utils/fs/createZipFile');
+
+const srcDirPath = path.join(__dirname, 'resources');
+const cachedZipFilePath = path.join(
+  os.homedir(),
+  '.serverless/cache/custom-resources',
+  version,
+  'custom-resources.zip'
+);
+
+module.exports = memoize(() =>
+  fse
+    .lstatAsync(cachedZipFilePath)
+    .then(
+      stats => {
+        if (stats.isFile()) return true;
+        return false;
+      },
+      error => {
+        if (error.code === 'ENOENT') return false;
+        throw error;
+      }
+    )
+    .then(isCached => {
+      if (isCached) return cachedZipFilePath;
+      const ensureCachedDirDeferred = fse.ensureDirAsync(path.dirname(cachedZipFilePath));
+      const tmpDirPath = getTmpDirPath();
+      return fse
+        .copyAsync(srcDirPath, tmpDirPath)
+        .then(() => childProcess.execAsync('npm install', { cwd: tmpDirPath }))
+        .then(() => ensureCachedDirDeferred)
+        .then(() => createZipFile(tmpDirPath, cachedZipFilePath))
+        .then(() => cachedZipFilePath);
+    })
+);
+
+module.exports.cachedZipFilePath = cachedZipFilePath;

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -3,18 +3,7 @@
 const path = require('path');
 const crypto = require('crypto');
 const BbPromise = require('bluebird');
-const fse = BbPromise.promisifyAll(require('fs-extra'));
-const childProcess = BbPromise.promisifyAll(require('child_process'));
-const getTmpDirPath = require('../../../utils/fs/getTmpDirPath');
-const createZipFile = require('../../../utils/fs/createZipFile');
-
-function copyCustomResources(srcDirPath, destDirPath) {
-  return fse.ensureDirAsync(destDirPath).then(() => fse.copyAsync(srcDirPath, destDirPath));
-}
-
-function installDependencies(dirPath) {
-  return childProcess.execAsync('npm install', { cwd: dirPath });
-}
+const generateZip = require('./generateZip');
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
   let functionName;
@@ -28,13 +17,11 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
   const shouldWriteLogs = providerConfig.logs && providerConfig.logs.frameworkLambda;
   const { Resources } = providerConfig.compiledCloudFormationTemplate;
   const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
-  const srcDirPath = path.join(__dirname, 'resources');
   const destDirPath = path.join(
     serverless.config.servicePath,
     '.serverless',
     awsProvider.naming.getCustomResourcesArtifactDirectoryName()
   );
-  const tmpDirPath = path.join(getTmpDirPath(), 'resources');
   const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
   const zipFilePath = `${destDirPath}.zip`;
   serverless.utils.writeFileDir(zipFilePath);
@@ -72,139 +59,134 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
   // TODO: check every once in a while if external packages are still necessary
   serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
-  return copyCustomResources(srcDirPath, tmpDirPath)
-    .then(() => installDependencies(tmpDirPath))
-    .then(() => createZipFile(tmpDirPath, zipFilePath))
-    .then(outputFilePath => {
-      let S3Bucket = {
-        Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
-      };
-      if (serverless.service.package.deploymentBucket) {
-        S3Bucket = serverless.service.package.deploymentBucket;
-      }
-      const s3Folder = serverless.service.package.artifactDirectoryName;
-      const s3FileName = outputFilePath.split(path.sep).pop();
-      const S3Key = `${s3Folder}/${s3FileName}`;
+  return generateZip().then(outputFilePath => {
+    let S3Bucket = {
+      Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
+    };
+    if (serverless.service.package.deploymentBucket) {
+      S3Bucket = serverless.service.package.deploymentBucket;
+    }
+    const s3Folder = serverless.service.package.artifactDirectoryName;
+    const s3FileName = outputFilePath.split(path.sep).pop();
+    const S3Key = `${s3Folder}/${s3FileName}`;
 
-      const cfnRoleArn = serverless.service.provider.cfnRole;
+    const cfnRoleArn = serverless.service.provider.cfnRole;
 
-      if (!cfnRoleArn) {
-        let customResourceRole = Resources[customResourcesRoleLogicalId];
-        if (!customResourceRole) {
-          customResourceRole = {
-            Type: 'AWS::IAM::Role',
-            Properties: {
-              AssumeRolePolicyDocument: {
-                Version: '2012-10-17',
-                Statement: [
-                  {
-                    Effect: 'Allow',
-                    Principal: {
-                      Service: ['lambda.amazonaws.com'],
-                    },
-                    Action: ['sts:AssumeRole'],
-                  },
-                ],
-              },
-              Policies: [
+    if (!cfnRoleArn) {
+      let customResourceRole = Resources[customResourcesRoleLogicalId];
+      if (!customResourceRole) {
+        customResourceRole = {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            AssumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
                 {
-                  PolicyName: {
-                    'Fn::Join': [
-                      '-',
-                      [
-                        awsProvider.getStage(),
-                        awsProvider.serverless.service.service,
-                        'custom-resources-lambda',
-                      ],
-                    ],
+                  Effect: 'Allow',
+                  Principal: {
+                    Service: ['lambda.amazonaws.com'],
                   },
-                  PolicyDocument: {
-                    Version: '2012-10-17',
-                    Statement: [],
-                  },
+                  Action: ['sts:AssumeRole'],
                 },
               ],
             },
-          };
-          Resources[customResourcesRoleLogicalId] = customResourceRole;
-
-          if (shouldWriteLogs) {
-            const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
-            customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+            Policies: [
               {
-                Effect: 'Allow',
-                Action: ['logs:CreateLogStream'],
-                Resource: [
-                  {
-                    'Fn::Sub':
-                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                      `:log-group:${logGroupsPrefix}*:*`,
-                  },
-                ],
+                PolicyName: {
+                  'Fn::Join': [
+                    '-',
+                    [
+                      awsProvider.getStage(),
+                      awsProvider.serverless.service.service,
+                      'custom-resources-lambda',
+                    ],
+                  ],
+                },
+                PolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [],
+                },
               },
-              {
-                Effect: 'Allow',
-                Action: ['logs:PutLogEvents'],
-                Resource: [
-                  {
-                    'Fn::Sub':
-                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                      `:log-group:${logGroupsPrefix}*:*:*`,
-                  },
-                ],
-              }
-            );
-          }
-        }
-        const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
-        iamRoleStatements.forEach(newStmt => {
-          if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
-            Statement.push(newStmt);
-          }
-        });
-      }
-
-      const customResourceFunction = {
-        Type: 'AWS::Lambda::Function',
-        Properties: {
-          Code: {
-            S3Bucket,
-            S3Key,
+            ],
           },
-          FunctionName: absoluteFunctionName,
-          Handler,
-          MemorySize: 1024,
-          Runtime: 'nodejs12.x',
-          Timeout: 180,
-        },
-        DependsOn: [],
-      };
-      Resources[customResourceFunctionLogicalId] = customResourceFunction;
-
-      if (cfnRoleArn) {
-        customResourceFunction.Properties.Role = cfnRoleArn;
-      } else {
-        customResourceFunction.Properties.Role = {
-          'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
         };
-        customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
-      }
+        Resources[customResourcesRoleLogicalId] = customResourceRole;
 
-      if (shouldWriteLogs) {
-        const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
-          functionName
-        );
-        customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
-        Object.assign(Resources, {
-          [customResourceLogGroupLogicalId]: {
-            Type: 'AWS::Logs::LogGroup',
-            Properties: {
-              LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+        if (shouldWriteLogs) {
+          const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
+          customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+            {
+              Effect: 'Allow',
+              Action: ['logs:CreateLogStream'],
+              Resource: [
+                {
+                  'Fn::Sub':
+                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                    `:log-group:${logGroupsPrefix}*:*`,
+                },
+              ],
             },
-          },
-        });
+            {
+              Effect: 'Allow',
+              Action: ['logs:PutLogEvents'],
+              Resource: [
+                {
+                  'Fn::Sub':
+                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                    `:log-group:${logGroupsPrefix}*:*:*`,
+                },
+              ],
+            }
+          );
+        }
       }
-    });
+      const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
+      iamRoleStatements.forEach(newStmt => {
+        if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
+          Statement.push(newStmt);
+        }
+      });
+    }
+
+    const customResourceFunction = {
+      Type: 'AWS::Lambda::Function',
+      Properties: {
+        Code: {
+          S3Bucket,
+          S3Key,
+        },
+        FunctionName: absoluteFunctionName,
+        Handler,
+        MemorySize: 1024,
+        Runtime: 'nodejs12.x',
+        Timeout: 180,
+      },
+      DependsOn: [],
+    };
+    Resources[customResourceFunctionLogicalId] = customResourceFunction;
+
+    if (cfnRoleArn) {
+      customResourceFunction.Properties.Role = cfnRoleArn;
+    } else {
+      customResourceFunction.Properties.Role = {
+        'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+      };
+      customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
+    }
+
+    if (shouldWriteLogs) {
+      const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(functionName);
+      customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
+      Object.assign(Resources, {
+        [customResourceLogGroupLogicalId]: {
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+          },
+        },
+      });
+    }
+  });
 }
 
 module.exports = {

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const crypto = require('crypto');
 const BbPromise = require('bluebird');
+const fse = BbPromise.promisifyAll(require('fs-extra'));
 const generateZip = require('./generateZip');
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
@@ -17,13 +18,12 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
   const shouldWriteLogs = providerConfig.logs && providerConfig.logs.frameworkLambda;
   const { Resources } = providerConfig.compiledCloudFormationTemplate;
   const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
-  const destDirPath = path.join(
+  const zipFilePath = path.join(
     serverless.config.servicePath,
     '.serverless',
-    awsProvider.naming.getCustomResourcesArtifactDirectoryName()
+    awsProvider.naming.getCustomResourcesArtifactName()
   );
   const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
-  const zipFilePath = `${destDirPath}.zip`;
   serverless.utils.writeFileDir(zipFilePath);
 
   // check which custom resource should be used
@@ -59,133 +59,138 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
   // TODO: check every once in a while if external packages are still necessary
   serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
-  return generateZip().then(outputFilePath => {
-    let S3Bucket = {
-      Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
-    };
-    if (serverless.service.package.deploymentBucket) {
-      S3Bucket = serverless.service.package.deploymentBucket;
-    }
-    const s3Folder = serverless.service.package.artifactDirectoryName;
-    const s3FileName = outputFilePath.split(path.sep).pop();
-    const S3Key = `${s3Folder}/${s3FileName}`;
-
-    const cfnRoleArn = serverless.service.provider.cfnRole;
-
-    if (!cfnRoleArn) {
-      let customResourceRole = Resources[customResourcesRoleLogicalId];
-      if (!customResourceRole) {
-        customResourceRole = {
-          Type: 'AWS::IAM::Role',
-          Properties: {
-            AssumeRolePolicyDocument: {
-              Version: '2012-10-17',
-              Statement: [
-                {
-                  Effect: 'Allow',
-                  Principal: {
-                    Service: ['lambda.amazonaws.com'],
-                  },
-                  Action: ['sts:AssumeRole'],
-                },
-              ],
-            },
-            Policies: [
-              {
-                PolicyName: {
-                  'Fn::Join': [
-                    '-',
-                    [
-                      awsProvider.getStage(),
-                      awsProvider.serverless.service.service,
-                      'custom-resources-lambda',
-                    ],
-                  ],
-                },
-                PolicyDocument: {
-                  Version: '2012-10-17',
-                  Statement: [],
-                },
-              },
-            ],
-          },
-        };
-        Resources[customResourcesRoleLogicalId] = customResourceRole;
-
-        if (shouldWriteLogs) {
-          const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
-          customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
-            {
-              Effect: 'Allow',
-              Action: ['logs:CreateLogStream'],
-              Resource: [
-                {
-                  'Fn::Sub':
-                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                    `:log-group:${logGroupsPrefix}*:*`,
-                },
-              ],
-            },
-            {
-              Effect: 'Allow',
-              Action: ['logs:PutLogEvents'],
-              Resource: [
-                {
-                  'Fn::Sub':
-                    'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                    `:log-group:${logGroupsPrefix}*:*:*`,
-                },
-              ],
-            }
-          );
-        }
-      }
-      const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
-      iamRoleStatements.forEach(newStmt => {
-        if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
-          Statement.push(newStmt);
-        }
-      });
-    }
-
-    const customResourceFunction = {
-      Type: 'AWS::Lambda::Function',
-      Properties: {
-        Code: {
-          S3Bucket,
-          S3Key,
-        },
-        FunctionName: absoluteFunctionName,
-        Handler,
-        MemorySize: 1024,
-        Runtime: 'nodejs12.x',
-        Timeout: 180,
-      },
-      DependsOn: [],
-    };
-    Resources[customResourceFunctionLogicalId] = customResourceFunction;
-
-    if (cfnRoleArn) {
-      customResourceFunction.Properties.Role = cfnRoleArn;
-    } else {
-      customResourceFunction.Properties.Role = {
-        'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+  return generateZip().then(cachedZipFilePath => {
+    const zipFileBasename = path.basename(zipFilePath);
+    return fse.copyAsync(cachedZipFilePath, zipFilePath).then(() => {
+      let S3Bucket = {
+        Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
       };
-      customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
-    }
+      if (serverless.service.package.deploymentBucket) {
+        S3Bucket = serverless.service.package.deploymentBucket;
+      }
+      const s3Folder = serverless.service.package.artifactDirectoryName;
+      const s3FileName = zipFileBasename;
+      const S3Key = `${s3Folder}/${s3FileName}`;
 
-    if (shouldWriteLogs) {
-      const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(functionName);
-      customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
-      Object.assign(Resources, {
-        [customResourceLogGroupLogicalId]: {
-          Type: 'AWS::Logs::LogGroup',
-          Properties: {
-            LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+      const cfnRoleArn = serverless.service.provider.cfnRole;
+
+      if (!cfnRoleArn) {
+        let customResourceRole = Resources[customResourcesRoleLogicalId];
+        if (!customResourceRole) {
+          customResourceRole = {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+              AssumeRolePolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Principal: {
+                      Service: ['lambda.amazonaws.com'],
+                    },
+                    Action: ['sts:AssumeRole'],
+                  },
+                ],
+              },
+              Policies: [
+                {
+                  PolicyName: {
+                    'Fn::Join': [
+                      '-',
+                      [
+                        awsProvider.getStage(),
+                        awsProvider.serverless.service.service,
+                        'custom-resources-lambda',
+                      ],
+                    ],
+                  },
+                  PolicyDocument: {
+                    Version: '2012-10-17',
+                    Statement: [],
+                  },
+                },
+              ],
+            },
+          };
+          Resources[customResourcesRoleLogicalId] = customResourceRole;
+
+          if (shouldWriteLogs) {
+            const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
+            customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+              {
+                Effect: 'Allow',
+                Action: ['logs:CreateLogStream'],
+                Resource: [
+                  {
+                    'Fn::Sub':
+                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                      `:log-group:${logGroupsPrefix}*:*`,
+                  },
+                ],
+              },
+              {
+                Effect: 'Allow',
+                Action: ['logs:PutLogEvents'],
+                Resource: [
+                  {
+                    'Fn::Sub':
+                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                      `:log-group:${logGroupsPrefix}*:*:*`,
+                  },
+                ],
+              }
+            );
+          }
+        }
+        const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
+        iamRoleStatements.forEach(newStmt => {
+          if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
+            Statement.push(newStmt);
+          }
+        });
+      }
+
+      const customResourceFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket,
+            S3Key,
           },
+          FunctionName: absoluteFunctionName,
+          Handler,
+          MemorySize: 1024,
+          Runtime: 'nodejs12.x',
+          Timeout: 180,
         },
-      });
-    }
+        DependsOn: [],
+      };
+      Resources[customResourceFunctionLogicalId] = customResourceFunction;
+
+      if (cfnRoleArn) {
+        customResourceFunction.Properties.Role = cfnRoleArn;
+      } else {
+        customResourceFunction.Properties.Role = {
+          'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+        };
+        customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
+      }
+
+      if (shouldWriteLogs) {
+        const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
+          functionName
+        );
+        customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
+        Object.assign(Resources, {
+          [customResourceLogGroupLogicalId]: {
+            Type: 'AWS::Logs::LogGroup',
+            Properties: {
+              LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+            },
+          },
+        });
+      }
+    });
   });
 }
 

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -13,6 +13,7 @@ const CLI = require('../../../classes/CLI');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const { createTmpDir } = require('../../../../tests/utils/fs');
 const { addCustomResourceToService } = require('./index.js');
+const customResourcesZipFilePath = require('./generateZip').cachedZipFilePath;
 
 const expect = chai.expect;
 chai.use(require('sinon-chai'));
@@ -103,13 +104,8 @@ describe('#addCustomResourceToService()', () => {
       ])
     ).to.be.fulfilled.then(() => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
-      const customResourcesZipFilePath = path.join(
-        tmpDirPath,
-        '.serverless',
-        'custom-resources.zip'
-      );
 
-      expect(execAsyncStub).to.have.callCount(3);
+      expect(execAsyncStub).to.have.callCount(1);
       expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
       // S3 Lambda Function
       expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction).to.deep.equal({
@@ -270,13 +266,6 @@ describe('#addCustomResourceToService()', () => {
       ])
     ).to.be.fulfilled.then(() => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
-      const customResourcesZipFilePath = path.join(
-        tmpDirPath,
-        '.serverless',
-        'custom-resources.zip'
-      );
-
-      expect(execAsyncStub).to.have.callCount(3);
       expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
       // S3 Lambda Function
       expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction).to.deep.equal({

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -2,7 +2,6 @@
 
 /* eslint-disable no-unused-expressions */
 
-const path = require('path');
 const fs = require('fs');
 const chai = require('chai');
 const sinon = require('sinon');

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -134,7 +134,7 @@ module.exports = {
     const artifactFilePath = path.join(
       this.serverless.config.servicePath,
       '.serverless',
-      `${this.provider.naming.getCustomResourcesArtifactDirectoryName()}.zip`
+      this.provider.naming.getCustomResourcesArtifactName()
     );
 
     if (this.serverless.utils.fileExistsSync(artifactFilePath)) {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -453,8 +453,8 @@ module.exports = {
   },
 
   // Custom Resources
-  getCustomResourcesArtifactDirectoryName() {
-    return 'custom-resources';
+  getCustomResourcesArtifactName() {
+    return 'custom-resources.zip';
   },
   getCustomResourcesRoleLogicalId() {
     return 'IamRoleCustomResourcesLambdaExecution';

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -724,7 +724,7 @@ describe('#naming()', () => {
 
   describe('#getCustomResourcesArtifactDirectoryName()', () => {
     it('should return the custom resources artifact directory name', () => {
-      expect(sdk.naming.getCustomResourcesArtifactDirectoryName()).to.equal('custom-resources');
+      expect(sdk.naming.getCustomResourcesArtifactName()).to.equal('custom-resources.zip');
     });
   });
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -722,7 +722,7 @@ describe('#naming()', () => {
     });
   });
 
-  describe('#getCustomResourcesArtifactDirectoryName()', () => {
+  describe('#getCustomResourcesArtifactName()', () => {
     it('should return the custom resources artifact directory name', () => {
       expect(sdk.naming.getCustomResourcesArtifactName()).to.equal('custom-resources.zip');
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -19,8 +19,8 @@ describe('#compileStage()', () => {
   let logGroupLogicalId;
 
   // Ensure to clear stored custom resource zip path
-  // As with other test file run it's not existent
-  // (temporary home directories are removed)
+  // As if it was created with previous test file run, it'll be not existent
+  // due to temporary home directory being removed in a meantime
   before(() => generateCustomResourceZip.cache.clear());
 
   beforeEach(() => {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -8,6 +8,7 @@ const childProcess = BbPromise.promisifyAll(require('child_process'));
 const AwsCompileApigEvents = require('../..');
 const Serverless = require('../../../../../../../../Serverless');
 const AwsProvider = require('../../../../../../provider/awsProvider');
+const generateCustomResourceZip = require('../../../../../../customResources/generateZip');
 
 describe('#compileStage()', () => {
   let serverless;
@@ -16,6 +17,11 @@ describe('#compileStage()', () => {
   let stage;
   let stageLogicalId;
   let logGroupLogicalId;
+
+  // Ensure to clear stored custom resource zip path
+  // As with other test file run it's not existent
+  // (temporary home directories are removed)
+  before(() => generateCustomResourceZip.cache.clear());
 
   beforeEach(() => {
     const options = {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -16,8 +16,8 @@ describe('#compileStage()', () => {
   let logGroupLogicalId;
 
   // Ensure to clear stored custom resource zip path
-  // As with other test file run it's not existent
-  // (temporary home directories are removed)
+  // As if it was created with previous test file run, it'll be not existent
+  // due to temporary home directory being removed in a meantime
   before(() => generateCustomResourceZip.cache.clear());
 
   beforeEach(() => {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -8,11 +8,17 @@ const childProcess = BbPromise.promisifyAll(require('child_process'));
 const AwsCompileWebsocketsEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
+const generateCustomResourceZip = require('../../../../../customResources/generateZip');
 
 describe('#compileStage()', () => {
   let awsCompileWebsocketsEvents;
   let stageLogicalId;
   let logGroupLogicalId;
+
+  // Ensure to clear stored custom resource zip path
+  // As with other test file run it's not existent
+  // (temporary home directories are removed)
+  before(() => generateCustomResourceZip.cache.clear());
 
   beforeEach(() => {
     const options = {


### PR DESCRIPTION
This should partially address custom resource installation efficiency issues, as discussed recently on slack.

It ensures that custom resource package is prepared once for installed Serverless versions, and in further runs existing package is re-used.
