### PR TITLE
Do not apply APIGW wide settings on externally referenced APIGW

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -4,7 +4,6 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const ServerlessError = require('../../../../../../../../classes/Error').ServerlessError;
 
-const isRestApiId = RegExp.prototype.test.bind(/^[a-z0-9]{3,}$/);
 const defaultApiGatewayLogFormat = [
   'requestId: $context.requestId',
   'ip: $context.identity.sourceIp',
@@ -42,6 +41,8 @@ module.exports = {
       .call(this)
       .then(resolveRestApiId.bind(this))
       .then(() => {
+        // Do not update APIGW-wide settings, in case external APIGW is referenced
+        if (this.isExternalRestApi) return null;
         if (!this.apiGatewayRestApiId) {
           // Could not resolve REST API id automatically
 
@@ -103,7 +104,8 @@ function resolveRestApiId() {
     const provider = this.state.service.provider;
     const externalRestApiId = provider.apiGateway && provider.apiGateway.restApiId;
     if (externalRestApiId) {
-      resolve(isRestApiId(externalRestApiId) ? externalRestApiId : null);
+      this.isExternalRestApi = true;
+      resolve(null);
       return;
     }
     const apiGatewayResource = resolveApiGatewayResource(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -454,20 +454,11 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should resolve custom restApiId', () => {
-    providerRequestStub
-      .withArgs('APIGateway', 'getStage', {
-        restApiId: 'foobarfoo1',
-        stageName: 'dev',
-      })
-      .resolves({
-        variables: {
-          old: 'tag',
-        },
-      });
+  it('should ignore external api gateway', () => {
     context.state.service.provider.apiGateway = { restApiId: 'foobarfoo1' };
     return updateStage.call(context).then(() => {
-      expect(context.apiGatewayRestApiId).to.equal('foobarfoo1');
+      expect(context.isExternalRestApi).to.equal(true);
+      expect(context.apiGatewayRestApiId).to.equal(null);
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -440,6 +440,7 @@ describe('#updateStage()', () => {
 
   it('should ignore external api gateway', () => {
     context.state.service.provider.apiGateway = { restApiId: 'foobarfoo1' };
+    context.state.service.provider.tracing = { apiGateway: false };
     return updateStage.call(context).then(() => {
       expect(context.isExternalRestApi).to.equal(true);
       expect(context.apiGatewayRestApiId).to.equal(null);


### PR DESCRIPTION
Fixes https://github.com/serverless/enterprise-plugin/issues/266

And partially addresses https://github.com/serverless/serverless/issues/6584