### PR TITLE
Add option to change log level for websocket logs

### DIFF
--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -212,3 +212,16 @@ provider:
 ```
 
 The log streams will be generated in a dedicated log group which follows the naming schema `/aws/websocket/{service}-{stage}`.
+
+The default log level will be INFO. You can change this to error with the following:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    websocket:
+      level: ERROR
+```
+
+Valid values are INFO, ERROR.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -136,14 +136,15 @@ provider:
     apiGateway: true
     lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
   logs:
-    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to true to use defaults, or configured via subproperties.
+    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to `true` to use defaults, or configured via subproperties.
       accessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
       executionLogging: true # Optional configuration which enables or disables execution logging. Defaults to true.
       level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR.
       fullExecutionData: true # Optional configuration which specifies whether or not to log full requests/responses for execution logging. Defaults to true.
       role: arn:aws:iam::123456:role # Optional IAM role for ApiGateway to use when managing CloudWatch Logs
-    websocket: true # Optional configuration which specifies if Websockets logs are used
+    websocket: # Optional configuration which specifies if Websocket logs are used. This can either be set to `true` to use defaults, or configured via subproperties.
+      level: INFO # Optional configuration which specifies the log level to use for execution logging. May be set to either INFO or ERROR.
     frameworkLambda: true # Optional, whether to write CloudWatch logs for custom resource lambdas as added by the framework
 
 package: # Optional deployment packaging configuration

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -2,6 +2,10 @@
 
 const BbPromise = require('bluebird');
 const ensureApiGatewayCloudWatchRole = require('../../lib/ensureApiGatewayCloudWatchRole');
+const ServerlessError = require('../../../../../../../classes/Error').ServerlessError;
+
+const defaultLogLevel = 'INFO';
+const validLogLevels = new Set(['INFO', 'ERROR']);
 
 module.exports = {
   compileStage() {
@@ -15,7 +19,7 @@ module.exports = {
       if (provider.apiGateway && provider.apiGateway.websocketApiId) return null;
 
       // logs
-      const logsEnabled = provider.logs && provider.logs.websocket;
+      const logs = provider.logs && provider.logs.websocket;
 
       const stageLogicalId = this.provider.naming.getWebsocketsStageLogicalId();
       const logGroupLogicalId = this.provider.naming.getWebsocketsLogGroupLogicalId();
@@ -35,7 +39,19 @@ module.exports = {
 
       Object.assign(cfTemplate.Resources, { [stageLogicalId]: stageResource });
 
-      if (!logsEnabled) return null;
+      if (!logs) return null;
+
+      let level = defaultLogLevel;
+      if (logs.level) {
+        level = logs.level;
+        if (!validLogLevels.has(level)) {
+          throw new ServerlessError(
+            `provider.logs.websocket.level is set to an invalid value. Support values are ${Array.from(
+              validLogLevels
+            ).join(', ')}, got ${level}.`
+          );
+        }
+      }
 
       // create log-specific resources
       Object.assign(stageResource.Properties, {
@@ -54,7 +70,7 @@ module.exports = {
         },
         DefaultRouteSettings: {
           DataTraceEnabled: true,
-          LoggingLevel: 'INFO',
+          LoggingLevel: level,
         },
       });
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
+
+const expect = chai.expect;
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
 const _ = require('lodash');
@@ -8,6 +10,8 @@ const childProcess = BbPromise.promisifyAll(require('child_process'));
 const AwsCompileWebsocketsEvents = require('../index');
 const Serverless = require('../../../../../../../Serverless');
 const AwsProvider = require('../../../../../provider/awsProvider');
+
+chai.use(require('chai-as-promised'));
 
 describe('#compileStage()', () => {
   let awsCompileWebsocketsEvents;
@@ -149,6 +153,34 @@ describe('#compileStage()', () => {
           },
         });
       });
+    });
+
+    it('should use valid logging level', () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logs = {
+        websocket: {
+          level: 'ERROR',
+        },
+      };
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[stageLogicalId].Properties.DefaultRouteSettings.LoggingLevel).equal(
+          'ERROR'
+        );
+      });
+    });
+
+    it('should reject invalid logging level', () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logs = {
+        websocket: {
+          level: 'FOOBAR',
+        },
+      };
+
+      expect(awsCompileWebsocketsEvents.compileStage()).to.be.rejectedWith('invalid value');
     });
 
     it('should ensure ClousWatch role custom resource', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Add option to change the log level of websocket logs to ERROR. Note that I did not add an option to disable logs on purpose in order to keep the change small. 

## How can we verify it

```
service: serverless-ws-test

provider:
  name: aws
  logs:
    websocket:
      level: ERROR
  runtime: nodejs12.x
  websocketsApiName: custom-websockets-api-name

functions:
  connectionHandler:
    handler: handler.connectionHandler
    events:
      - websocket:
          route: $connect
  defaultHandler:
    handler: handler.defaultHandler
    events:
      - websocket: $default
```

1. Run `sls deploy`
1. Open the _Logs/Tracing_ settings of the API gateway. 
1. Should look like this: <img width="883" alt="Screen Shot 2019-12-02 at 23 28 21" src="https://user-images.githubusercontent.com/7386945/70000544-883b0d00-155b-11ea-9ce2-3bd4b7d6dce4.png">
1. Change `level: ERROR` to `level: INFO` in the `serverless.yml`
1. Check that the Log Level in the _Logs/Tracing_ settings was changed to INFO


## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test-ci` --> Run all validation checks on proposed changes
- `npm run lint-updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
