### PR TITLE
Adding configurable MaximumRetryAttempts for stream(Dynamo& Kinesis) event sourcing

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -80,6 +80,7 @@ functions:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           batchSize: 100
           startingPosition: LATEST
+          maximumRetryAttempts: 10
           enabled: false
 ```
 
@@ -107,6 +108,27 @@ functions:
       - stream:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           batchWindow: 10
+```
+
+## Setting the MaximumRetryAttempts
+
+This configuration sets up the maximum number of times to retry when the function returns an error.
+
+[Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumretryattempts)
+
+**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - stream:
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+          batchSize: 100
+          maximumRetryAttempts: 10
+          startingPosition: LATEST
+          enabled: false
 ```
 
 ## Setting the ParallelizationFactor

--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -114,6 +114,8 @@ functions:
 
 This configuration sets up the maximum number of times to retry when the function returns an error.
 
+**Note:** Serverless only sets this property if you explicitly add it to the stream configuration(like below example), if not AWS will default this value.
+
 [Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumretryattempts)
 
 **Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.

--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -114,7 +114,7 @@ functions:
 
 This configuration sets up the maximum number of times to retry when the function returns an error.
 
-**Note:** Serverless only sets this property if you explicitly add it to the stream configuration(like below example), if not AWS will default this value.
+**Note:** Serverless only sets this property if you explicitly add it to the stream configuration (see example below).
 
 [Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumretryattempts)
 

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -45,6 +45,7 @@ class AwsCompileStreamEvents {
             let ParallelizationFactor = 1;
             let StartingPosition = 'TRIM_HORIZON';
             let Enabled = 'True';
+            let MaximumRetryAttempts = 10000;
 
             // TODO validate arn syntax
             if (typeof event.stream === 'object') {
@@ -89,6 +90,7 @@ class AwsCompileStreamEvents {
               }
               EventSourceArn = event.stream.arn;
               BatchSize = event.stream.batchSize || BatchSize;
+              MaximumRetryAttempts = event.stream.maximumRetryAttempts || MaximumRetryAttempts;
               ParallelizationFactor = event.stream.parallelizationFactor || ParallelizationFactor;
               StartingPosition = event.stream.startingPosition || StartingPosition;
               if (typeof event.stream.enabled !== 'undefined') {
@@ -177,6 +179,7 @@ class AwsCompileStreamEvents {
                     ]
                   },
                   "StartingPosition": "${StartingPosition}",
+                  "MaximumRetryAttempts": ${MaximumRetryAttempts},
                   "Enabled": "${Enabled}"
                 }
               }

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -45,7 +45,6 @@ class AwsCompileStreamEvents {
             let ParallelizationFactor = 1;
             let StartingPosition = 'TRIM_HORIZON';
             let Enabled = 'True';
-            let MaximumRetryAttempts = 10000;
 
             // TODO validate arn syntax
             if (typeof event.stream === 'object') {
@@ -90,7 +89,6 @@ class AwsCompileStreamEvents {
               }
               EventSourceArn = event.stream.arn;
               BatchSize = event.stream.batchSize || BatchSize;
-              MaximumRetryAttempts = event.stream.maximumRetryAttempts || MaximumRetryAttempts;
               ParallelizationFactor = event.stream.parallelizationFactor || ParallelizationFactor;
               StartingPosition = event.stream.startingPosition || StartingPosition;
               if (typeof event.stream.enabled !== 'undefined') {
@@ -179,7 +177,6 @@ class AwsCompileStreamEvents {
                     ]
                   },
                   "StartingPosition": "${StartingPosition}",
-                  "MaximumRetryAttempts": ${MaximumRetryAttempts},
                   "Enabled": "${Enabled}"
                 }
               }
@@ -205,6 +202,10 @@ class AwsCompileStreamEvents {
 
             if (event.stream.batchWindow) {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
+            }
+
+            if (event.stream.maximumRetryAttempts) {
+              streamResource.Properties.MaximumRetryAttempts = event.stream.maximumRetryAttempts;
             }
 
             const newStreamObject = {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -366,6 +366,7 @@ describe('AwsCompileStreamEvents', () => {
                   arn: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
                   batchSize: 1,
                   startingPosition: 'STARTING_POSITION_ONE',
+                  maximumRetryAttempts: 3,
                   enabled: false,
                 },
               },
@@ -405,6 +406,12 @@ describe('AwsCompileStreamEvents', () => {
         );
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbFoo.Properties.MaximumRetryAttempts
+        ).to.equal(
+          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.maximumRetryAttempts
+        );
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.StartingPosition
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
@@ -432,6 +439,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.BatchSize
         ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumRetryAttempts
+        ).to.equal(10000);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.StartingPosition
@@ -462,6 +473,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.BatchSize
         ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumRetryAttempts
+        ).to.equal(10000);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.StartingPosition
@@ -729,6 +744,7 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/foo',
                   batchSize: 1,
+                  maximumRetryAttempts: 3,
                   startingPosition: 'STARTING_POSITION_ONE',
                   enabled: false,
                   parallelizationFactor: 10,
@@ -770,6 +786,12 @@ describe('AwsCompileStreamEvents', () => {
         );
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.Properties.MaximumRetryAttempts
+        ).to.equal(
+          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.maximumRetryAttempts
+        );
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.StartingPosition
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
@@ -806,6 +828,10 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal(10);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumRetryAttempts
+        ).to.equal(10000);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.ParallelizationFactor
         ).to.equal(1);
         expect(
@@ -838,6 +864,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.BatchSize
         ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumRetryAttempts
+        ).to.equal(10000);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.StartingPosition

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -366,7 +366,6 @@ describe('AwsCompileStreamEvents', () => {
                   arn: 'arn:aws:dynamodb:region:account:table/foo/stream/1',
                   batchSize: 1,
                   startingPosition: 'STARTING_POSITION_ONE',
-                  maximumRetryAttempts: 3,
                   enabled: false,
                 },
               },
@@ -374,6 +373,7 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:dynamodb:region:account:table/bar/stream/2',
                   batchWindow: 15,
+                  maximumRetryAttempts: 4,
                 },
               },
               {
@@ -406,13 +406,6 @@ describe('AwsCompileStreamEvents', () => {
         );
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbFoo.Properties.MaximumRetryAttempts
-        ).to.equal(
-          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
-            .maximumRetryAttempts
-        );
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.StartingPosition
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
@@ -422,6 +415,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.Enabled
         ).to.equal('False');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbFoo.Properties.MaximumRetryAttempts
+        ).to.be.undefined;
 
         // event 2
         expect(
@@ -442,10 +439,6 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal(10);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumRetryAttempts
-        ).to.equal(10000);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.StartingPosition
         ).to.equal('TRIM_HORIZON');
         expect(
@@ -456,6 +449,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumBatchingWindowInSeconds
         ).to.equal(15);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumRetryAttempts
+        ).to.equal(4);
 
         // event 3
         expect(
@@ -476,16 +473,16 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal(10);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumRetryAttempts
-        ).to.equal(10000);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.StartingPosition
         ).to.equal('TRIM_HORIZON');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.Enabled
         ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBaz.Properties.MaximumRetryAttempts
+        ).to.be.undefined;
       });
 
       it('should allow specifying DynamoDB and Kinesis streams as CFN reference types', () => {
@@ -745,7 +742,6 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/foo',
                   batchSize: 1,
-                  maximumRetryAttempts: 3,
                   startingPosition: 'STARTING_POSITION_ONE',
                   enabled: false,
                   parallelizationFactor: 10,
@@ -755,6 +751,7 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/bar',
                   batchWindow: 15,
+                  maximumRetryAttempts: 5,
                 },
               },
               {
@@ -787,13 +784,6 @@ describe('AwsCompileStreamEvents', () => {
         );
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.Properties.MaximumRetryAttempts
-        ).to.equal(
-          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
-            .maximumRetryAttempts
-        );
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.StartingPosition
         ).to.equal(
           awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
@@ -810,6 +800,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.Enabled
         ).to.equal('False');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.Properties.MaximumRetryAttempts
+        ).to.be.undefined;
 
         // event 2
         expect(
@@ -830,10 +824,6 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal(10);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumRetryAttempts
-        ).to.equal(10000);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.ParallelizationFactor
         ).to.equal(1);
         expect(
@@ -848,6 +838,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumBatchingWindowInSeconds
         ).to.equal(15);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumRetryAttempts
+        ).to.equal(5);
 
         // event 3
         expect(
@@ -868,16 +862,16 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal(10);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumRetryAttempts
-        ).to.equal(10000);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.StartingPosition
         ).to.equal('TRIM_HORIZON');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.Enabled
         ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBaz.Properties.MaximumRetryAttempts
+        ).to.be.undefined;
       });
 
       it('should add the necessary IAM role statements', () => {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -415,10 +415,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.Enabled
         ).to.equal('False');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbFoo.Properties.MaximumRetryAttempts
-        ).to.be.undefined;
 
         // event 2
         expect(
@@ -479,10 +475,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.Enabled
         ).to.equal('True');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbBaz.Properties.MaximumRetryAttempts
-        ).to.be.undefined;
       });
 
       it('should allow specifying DynamoDB and Kinesis streams as CFN reference types', () => {
@@ -800,10 +792,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.Enabled
         ).to.equal('False');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.Properties.MaximumRetryAttempts
-        ).to.be.undefined;
 
         // event 2
         expect(
@@ -868,10 +856,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.Enabled
         ).to.equal('True');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisBaz.Properties.MaximumRetryAttempts
-        ).to.be.undefined;
       });
 
       it('should add the necessary IAM role statements', () => {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -408,7 +408,8 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.MaximumRetryAttempts
         ).to.equal(
-          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.maximumRetryAttempts
+          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
+            .maximumRetryAttempts
         );
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -788,7 +789,8 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.MaximumRetryAttempts
         ).to.equal(
-          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.maximumRetryAttempts
+          awsCompileStreamEvents.serverless.service.functions.first.events[0].stream
+            .maximumRetryAttempts
         );
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate


### PR DESCRIPTION
Adding MaximumRetryAttempts for stream event sourcing to avoid retry attempts to be default 10000 and potential poison pill scenarios and related documentation

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

`Details`
Adding configurability of MaximumRetryAttempts for stream event sourcing(Dynamo& Kinesis) to avoid maximum retry attempts(default 10000) and potential poison pill scenarios and related documentation

Closes #7012

## How can we verify it

`Example serverless.yml:`

```yml
functions:
  preprocess:
    handler: handler.preprocess
    events:
      - stream:
          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
          batchSize: 100
          maximumRetryAttempts: 10
          startingPosition: LATEST
          enabled: false
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- [x] `npm run test-ci` --> Run all validation checks on proposed changes
- [x] `npm run lint-updated` --> Lint all the updated files
- [x] `npm run lint:fix` --> Automatically fix lint problems (if possible)
- [x] `npm run prettier-check-updated` --> Check if updated files adhere to Prettier config
- [x] `npm run prettify-updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
