### PR TITLE
Fix lambda provisioned concurrency setup

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -414,21 +414,13 @@ class AwsCompileFunctions {
         ? functionObject.versionFunction
         : this.serverless.service.provider.versionFunctions;
 
-    if (functionObject.provisionedConcurrency) {
-      const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
-
-      if (_.isInteger(provisionedConcurrency)) {
-        newFunction.Properties.ProvisionedConcurrencyConfig = {
-          ProvisionedConcurrentExecutions: provisionedConcurrency,
-        };
-      } else {
-        return BbPromise.reject(
-          new this.serverless.classes.Error(
-            'You should use integer as provisionedConcurrency value on function: ' +
-              `${newFunction.Properties.FunctionName}`
-          )
-        );
-      }
+    if (functionObject.provisionedConcurrency && !versionFunction) {
+      return BbPromise.reject(
+        new this.serverless.classes.Error(
+          'Cannot setup provisioned conncurrency with lambda versioning disabled on function: ' +
+            `${newFunction.Properties.FunctionName}`
+        )
+      );
     }
 
     newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)].concat(
@@ -501,6 +493,21 @@ class AwsCompileFunctions {
       newVersion.Properties.FunctionName = { Ref: functionLogicalId };
       if (functionObject.description) {
         newVersion.Properties.Description = functionObject.description;
+      }
+
+      if (functionObject.provisionedConcurrency) {
+        const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
+
+        if (_.isInteger(provisionedConcurrency)) {
+          newVersion.Properties.ProvisionedConcurrencyConfig = {
+            ProvisionedConcurrentExecutions: provisionedConcurrency,
+          };
+        } else {
+          throw new this.serverless.classes.Error(
+            'You should use integer as provisionedConcurrency value on function: ' +
+              `${newFunction.Properties.FunctionName}`
+          );
+        }
       }
 
       // use the version SHA in the logical resource ID of the version because

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -409,6 +409,11 @@ class AwsCompileFunctions {
       }
     }
 
+    const versionFunction =
+      functionObject.versionFunction != null
+        ? functionObject.versionFunction
+        : this.serverless.service.provider.versionFunctions;
+
     if (functionObject.provisionedConcurrency) {
       const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
 
@@ -449,8 +454,6 @@ class AwsCompileFunctions {
       newFunctionObject
     );
 
-    const newVersion = this.cfLambdaVersionTemplate();
-
     // Create hashes for the artifact and the logical id of the version resource
     // The one for the version resource must include the function configuration
     // to make sure that a new version is created on configuration changes and
@@ -490,6 +493,10 @@ class AwsCompileFunctions {
       const fileDigest = fileHash.read();
       const versionDigest = versionHash.read();
 
+      if (!versionFunction) return;
+
+      const newVersion = this.cfLambdaVersionTemplate();
+
       newVersion.Properties.CodeSha256 = fileDigest;
       newVersion.Properties.FunctionName = { Ref: functionLogicalId };
       if (functionObject.description) {
@@ -506,17 +513,10 @@ class AwsCompileFunctions {
         [versionLogicalId]: newVersion,
       };
 
-      const versionFunction =
-        functionObject.versionFunction != null
-          ? functionObject.versionFunction
-          : this.serverless.service.provider.versionFunctions;
-
-      if (versionFunction) {
-        _.merge(
-          this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-          newVersionObject
-        );
-      }
+      _.merge(
+        this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+        newVersionObject
+      );
 
       // Add function versions to Outputs section
       const functionVersionOutputLogicalId = this.provider.naming.getLambdaVersionOutputLogicalId(
@@ -526,13 +526,9 @@ class AwsCompileFunctions {
 
       newVersionOutput.Value = { Ref: versionLogicalId };
 
-      if (versionFunction) {
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-          [functionVersionOutputLogicalId]: newVersionOutput,
-        });
-      }
-
-      return BbPromise.resolve();
+      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+        [functionVersionOutputLogicalId]: newVersionOutput,
+      });
     });
   }
 

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2201,10 +2201,6 @@ describe('AwsCompileFunctions', () => {
     });
 
     it('should set function declared provisioned concurrency limit', () => {
-      const s3Folder = awsCompileFunctions.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop();
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -2212,29 +2208,16 @@ describe('AwsCompileFunctions', () => {
           provisionedConcurrency: 5,
         },
       };
-      const compiledFunction = {
-        Type: 'AWS::Lambda::Function',
-        DependsOn: ['FuncLogGroup', 'IamRoleLambdaExecution'],
-        Properties: {
-          Code: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          FunctionName: 'new-service-dev-func',
-          Handler: 'func.function.handler',
-          MemorySize: 1024,
-          ProvisionedConcurrencyConfig: { ProvisionedConcurrentExecutions: 5 },
-          Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs12.x',
-          Timeout: 6,
-        },
-      };
 
       return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
+        const resourceId =
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Outputs
+            .FuncLambdaFunctionQualifiedArn.Value.Ref;
         expect(
-          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .FuncLambdaFunction
-        ).to.deep.equal(compiledFunction);
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+            resourceId
+          ].Properties.ProvisionedConcurrencyConfig
+        ).to.deep.equal({ ProvisionedConcurrentExecutions: 5 });
       });
     });
 


### PR DESCRIPTION
When testing locally it now, when it's available, I've realized it was not setup properly, and that it should be setup on `AWS::Lambda::Version` resource.

Having that patch in, I've successfully deployed new lambdas with provisioned concurrency setup. 
However I observed `Internal error` CF stack udpate crashes when trying to update already deployed lambdas with that config (This looks as AWS issue, which I discuss with them over email)