### PR TITLE
Revert "Resource policy" fix

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -3,23 +3,6 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
-const defaultPolicy = {
-  Version: '2012-10-17',
-  Statement: [
-    {
-      Effect: 'Allow',
-      Principal: '*',
-      Action: 'execute-api:Invoke',
-      Resource: ['execute-api:/*/*/*'],
-      Condition: {
-        IpAddress: {
-          'aws:SourceIp': ['0.0.0.0/32'],
-        },
-      },
-    },
-  ],
-};
-
 module.exports = {
   compileRestApi() {
     const apiGateway = this.serverless.service.provider.apiGateway || {};
@@ -78,17 +61,6 @@ module.exports = {
         ].Properties,
         {
           Policy: policy,
-        }
-      );
-    } else {
-      // setting up a policy with no restrictions in cases where no policy is specified
-      // this ensures that a policy is always present
-      _.merge(
-        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-          this.apiGatewayRestApiLogicalId
-        ].Properties,
-        {
-          Policy: defaultPolicy,
         }
       );
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -49,22 +49,6 @@ describe('#compileRestApi()', () => {
           EndpointConfiguration: {
             Types: ['EDGE'],
           },
-          Policy: {
-            Statement: [
-              {
-                Action: 'execute-api:Invoke',
-                Condition: {
-                  IpAddress: {
-                    'aws:SourceIp': ['0.0.0.0/32'],
-                  },
-                },
-                Effect: 'Allow',
-                Principal: '*',
-                Resource: ['execute-api:/*/*/*'],
-              },
-            ],
-            Version: '2012-10-17',
-          },
         },
       });
     }));
@@ -116,40 +100,6 @@ describe('#compileRestApi()', () => {
     });
   });
 
-  it('should provide open policy if no policy specified', () => {
-    const resources =
-      awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-
-    return awsCompileApigEvents.compileRestApi().then(() => {
-      expect(resources.ApiGatewayRestApi).to.deep.equal({
-        Type: 'AWS::ApiGateway::RestApi',
-        Properties: {
-          Name: 'dev-new-service',
-          BinaryMediaTypes: undefined,
-          EndpointConfiguration: {
-            Types: ['EDGE'],
-          },
-          Policy: {
-            Version: '2012-10-17',
-            Statement: [
-              {
-                Effect: 'Allow',
-                Principal: '*',
-                Action: 'execute-api:Invoke',
-                Resource: ['execute-api:/*/*/*'],
-                Condition: {
-                  IpAddress: {
-                    'aws:SourceIp': ['0.0.0.0/32'],
-                  },
-                },
-              },
-            ],
-          },
-        },
-      });
-    });
-  });
-
   it('should ignore REST API resource creation if there is predefined restApi config', () => {
     awsCompileApigEvents.serverless.service.provider.apiGateway = {
       restApiId: '6fyzt1pfpk',
@@ -178,22 +128,6 @@ describe('#compileRestApi()', () => {
             Types: ['EDGE'],
           },
           Name: 'dev-new-service',
-          Policy: {
-            Statement: [
-              {
-                Action: 'execute-api:Invoke',
-                Condition: {
-                  IpAddress: {
-                    'aws:SourceIp': ['0.0.0.0/32'],
-                  },
-                },
-                Effect: 'Allow',
-                Principal: '*',
-                Resource: ['execute-api:/*/*/*'],
-              },
-            ],
-            Version: '2012-10-17',
-          },
         },
       });
     });


### PR DESCRIPTION
Reverts serverless/serverless#7002

It appears that added policy doesn't reflect default behavior when no policy is added (our integration tests fail now: https://travis-ci.org/serverless/serverless/jobs/620628266 )

btw. We probably need to find a way to run integration tests on selected PR's prior merging them