### PR TITLE
Fix cached credentials mishandling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 branches:
   only:
     - master # Do not build PR branches
+    - release-fast-track # Do not build PR branches
     - /^v\d+\.\d+\.\d+$/ # Ensure to build release tags
 
 env:
@@ -70,7 +71,7 @@ jobs:
         - npm run lint-updated
         - npm test -- -b
 
-    # master branch and version tags
+    # release target branch and version tags
     - name: 'Lint, Unit Tests - Linux - Node.js v12'
       if: type != pull_request
       node_js: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.59.1](https://github.com/serverless/serverless/compare/v1.59.0...v1.59.1) (2019-12-05)
+
+### Bug Fixes
+
+- Fix mishandling of cachedCredentials in invokeLocal ([699e78d](https://github.com/serverless/serverless/commit/699e78d251b7cbb3e6553c6d8554c2bf568be1fb)), closes [#7050](https://github.com/serverless/serverless/issues/7050), regression introduced with [#7044](https://github.com/serverless/serverless/issues/7044)
+
 # 1.59.0 (2019-12-04)
 
 - [Fix spelling and typos in docs, code variables and code comments](https://github.com/serverless/serverless/pull/6986)

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -128,16 +128,18 @@ class AwsInvokeLocal {
       NODE_PATH: '/var/runtime:/var/task:/var/runtime/node_modules',
     };
 
-    const { cachedCredentials } = this.provider;
     const credentialEnvVars = {};
-    if (cachedCredentials.accessKeyId) {
-      credentialEnvVars.AWS_ACCESS_KEY_ID = cachedCredentials.accessKeyId;
-    }
-    if (cachedCredentials.secretAccessKey) {
-      credentialEnvVars.AWS_SECRET_ACCESS_KEY = cachedCredentials.secretAccessKey;
-    }
-    if (cachedCredentials.sessionToken) {
-      credentialEnvVars.AWS_SESSION_TOKEN = cachedCredentials.sessionToken;
+    const { cachedCredentials } = this.provider;
+    if (cachedCredentials) {
+      if (cachedCredentials.accessKeyId) {
+        credentialEnvVars.AWS_ACCESS_KEY_ID = cachedCredentials.accessKeyId;
+      }
+      if (cachedCredentials.secretAccessKey) {
+        credentialEnvVars.AWS_SECRET_ACCESS_KEY = cachedCredentials.secretAccessKey;
+      }
+      if (cachedCredentials.sessionToken) {
+        credentialEnvVars.AWS_SESSION_TOKEN = cachedCredentials.sessionToken;
+      }
     }
 
     // profile override from config

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -352,6 +352,18 @@ describe('AwsInvokeLocal', () => {
         });
     });
 
+    it('it should work without cached credentials set', () => {
+      provider.cachedCredentials = null;
+      return awsInvokeLocal
+        .loadEnvVars()
+
+        .then(() => {
+          expect('AWS_SESSION_TOKEN' in process.env).to.equal(false);
+          expect('AWS_ACCESS_KEY_ID' in process.env).to.equal(false);
+          expect('AWS_SECRET_ACCESS_KEY' in process.env).to.equal(false);
+        });
+    });
+
     it('should fallback to service provider configuration when options are not available', () => {
       awsInvokeLocal.provider.options.region = null;
       awsInvokeLocal.serverless.service.provider.region = 'us-west-1';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
Regression introduced with #7044

Fixes #7050

--- 

It's based against `release-fast-track` which points last release, so we can release it as v1.59.1 (without taking any other stuff that was eventually merged to master after v1.59.0)

Handling of `release-fast-track` branch will be mostly automated shortly (I will prepare PR with CI config update today), still to not hold this, patch, I will issue v1.59.1 mostly manually now.

After it's merged to `release-fast-track`, I'll tag it on that branch and in result CI will automatically publish new version to npm, then I'd also ensure that it's merged into master and that release notes are added.
