### PR TITLE
Fix handling of existing cognito pools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,9 @@ jobs:
     - name: 'Unit Tests - Node.js v12'
       if: type != pull_request
       node_js: 12
+      env:
+        # GITHUB_TOKEN
+        - secure: tKC+34Pvwvzs1ZNC1d7WfBoYlT9nYzMIhwhfG9/J6PBCpuDITQ5+VNDTVh3Lo1JxR6ZuERPauQCnHcrvEHJhEi/fp1qb550V5uYXhn/7X8h+rW8IZ7tJl333UBIACW0jh2JOBeB2ubpIwITv/l7sn6NFothIQE2r1ogLHyBdcipImDKx2RY7R20xCRq7nbg6LWZg11kMaHkdNWi6odXzrhO1FwIcVtWYWmeuJQDdjQuusehNh8/qcZFFXTEDzj+xSAecxSLSeZcDO7x/J5jNuG3khhdkHMAIFuKviFsgNUcGmNuXIB9TEPKhf4YBY00Cle/KNvHori8RplbWqxeyQbtpWMWF5v988qPvSeOqLH60PBeQRqSbYGumXooCClCRn73tYr14WZfUmf2fOTDHe7y5Rnk9jnGW/aPu+Py1hWBkTakn0/hoI3IRqFEGkC2YTtwroyLK8GSUC7W2yexoNfEykvMFlo9h8kiMSCd91mA6MFHruN+bhA4iwGpTWU2CQgq3gUq4aLwO/NXvmisn7Cf7NI3u3zj9e/e9i/qAFEP81mkTowjPgCR5vS8eI2TCvKFjNcANvMq+YHw9E5CGcKon42X6aUKnmdQSpzswKFSratmo7K+TWmbUCg5LL2sbvecm4wbsdJn9VcRZLQRZ6ZvRfjt4oymVvJdI0qrWmQ4=
       script:
         - |
           if [ $TRAVIS_BRANCH = master ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.59.2](https://github.com/serverless/serverless/compare/v1.59.1...v1.59.2) (2019-12-06)
+
+### Bug Fixes
+
+- Ensure to not create cognito pools marked as 'existing' ([fe546c5](https://github.com/serverless/serverless/commit/fe546c50d35b88b24556257182aacd9e24f07d1b))
+
 ### [1.59.1](https://github.com/serverless/serverless/compare/v1.59.0...v1.59.1) (2019-12-05)
 
 ### Bug Fixes

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -241,6 +241,7 @@ class AwsCompileCognitoUserPoolEvents {
       if (functionObj.events) {
         _.forEach(functionObj.events, event => {
           if (event.cognitoUserPool) {
+            if (event.cognitoUserPool.existing) return;
             // Check event definition for `cognitoUserPool` object
             if (typeof event.cognitoUserPool === 'object') {
               // Check `cognitoUserPool` object has required properties

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "engines": {
     "node": ">=6.0"
   },

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -4,6 +4,7 @@ const path = require('path');
 const AWS = require('aws-sdk');
 const _ = require('lodash');
 const { expect } = require('chai');
+const log = require('log').get('serverless:test');
 
 const { getTmpDirPath, readYamlFile, writeYamlFile } = require('../../utils/fs');
 const { region, confirmCloudWatchLogs } = require('../../utils/misc');
@@ -29,6 +30,13 @@ describe('AWS - API Gateway Integration Test', function() {
   let apiKey;
   const stage = 'dev';
 
+  const resolveEndpoint = async () => {
+    const result = await CF.describeStacks({ StackName: stackName }).promise();
+    const endpointOutput = _.find(result.Stacks[0].Outputs, { OutputKey: 'ServiceEndpoint' })
+      .OutputValue;
+    endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+  };
+
   before(async () => {
     tmpDirPath = getTmpDirPath();
     console.info(`Temporary path: ${tmpDirPath}`);
@@ -46,15 +54,7 @@ describe('AWS - API Gateway Integration Test', function() {
     stackName = `${serviceName}-${stage}`;
     console.info(`Deploying "${stackName}" service...`);
     await deployService(tmpDirPath);
-    CF.describeStacks({ StackName: stackName })
-      .promise()
-      .then(
-        result => _.find(result.Stacks[0].Outputs, { OutputKey: 'ServiceEndpoint' }).OutputValue
-      )
-      .then(endpointOutput => {
-        endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
-        endpoint = `${endpoint}`;
-      });
+    return resolveEndpoint();
   });
 
   after(async () => {
@@ -175,23 +175,30 @@ describe('AWS - API Gateway Integration Test', function() {
 
   describe('API Keys', () => {
     let testEndpoint;
+    let startTime;
 
     before(() => {
       testEndpoint = `${endpoint}/api-keys`;
+      startTime = Date.now();
+    });
+
+    it('should succeed if correct API key is given', async function self() {
+      const response = await fetch(testEndpoint, { headers: { 'X-API-Key': apiKey } });
+      const result = await response.json();
+      // API Key may take a moment to propagate, retry
+      if (response.status === 403 && startTime > Date.now() - 1000 * 60 * 3) {
+        log.notice('API Key rejected, retry');
+        return self();
+      }
+      expect(response.status).to.equal(200);
+      expect(result.message).to.equal('Hello from API Gateway! - (apiKeys)');
+      return null;
     });
 
     it('should reject a request with an invalid API Key', () => {
       return fetch(testEndpoint).then(response => {
         expect(response.status).to.equal(403);
       });
-    });
-
-    it('should succeed if correct API key is given', () => {
-      return fetch(testEndpoint, { headers: { 'X-API-Key': apiKey } })
-        .then(response => response.json())
-        .then(json => {
-          expect(json.message).to.equal('Hello from API Gateway! - (apiKeys)');
-        });
     });
   });
 
@@ -229,6 +236,13 @@ describe('AWS - API Gateway Integration Test', function() {
         // Confirm that CloudWatch logs for APIGW are written
       ).then(events => expect(events.length > 0).to.equal(true));
     });
+  });
+
+  describe('Integration Lambda Timeout', () => {
+    it('should result with 504 status code', () =>
+      fetch(`${endpoint}/integration-lambda-timeout`).then(response =>
+        expect(response.status).to.equal(504)
+      ));
   });
 
   // NOTE: this test should  be at the very end because we're using an external REST API here
@@ -270,6 +284,7 @@ describe('AWS - API Gateway Integration Test', function() {
       writeYamlFile(serverlessFilePath, serverless);
       console.info('Redeploying service (with external Rest API ID)...');
       await deployService(tmpDirPath);
+      return resolveEndpoint();
     });
 
     after(async () => {
@@ -293,12 +308,5 @@ describe('AWS - API Gateway Integration Test', function() {
         .then(response => response.json())
         .then(json => expect(json.message).to.equal('Hello from API Gateway! - (minimal)'));
     });
-  });
-
-  describe('Integration Lambda Timeout', () => {
-    it('should result with 504 status code', () =>
-      fetch(`${endpoint}/integration-lambda-timeout`).then(response =>
-        expect(response.status).to.equal(504)
-      ));
   });
 });

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -46,15 +46,7 @@ describe('AWS - API Gateway Integration Test', function() {
     stackName = `${serviceName}-${stage}`;
     console.info(`Deploying "${stackName}" service...`);
     await deployService(tmpDirPath);
-  });
-
-  after(async () => {
-    console.info('Removing service...');
-    await removeService(tmpDirPath);
-  });
-
-  beforeEach(() => {
-    return CF.describeStacks({ StackName: stackName })
+    CF.describeStacks({ StackName: stackName })
       .promise()
       .then(
         result => _.find(result.Stacks[0].Outputs, { OutputKey: 'ServiceEndpoint' }).OutputValue
@@ -63,6 +55,11 @@ describe('AWS - API Gateway Integration Test', function() {
         endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
         endpoint = `${endpoint}`;
       });
+  });
+
+  after(async () => {
+    console.info('Removing service...');
+    await removeService(tmpDirPath);
   });
 
   describe('Minimal Setup', () => {
@@ -147,7 +144,7 @@ describe('AWS - API Gateway Integration Test', function() {
   describe('Custom Authorizers', () => {
     let testEndpoint;
 
-    beforeEach(() => {
+    before(() => {
       testEndpoint = `${endpoint}/custom-auth`;
     });
 
@@ -179,7 +176,7 @@ describe('AWS - API Gateway Integration Test', function() {
   describe('API Keys', () => {
     let testEndpoint;
 
-    beforeEach(() => {
+    before(() => {
       testEndpoint = `${endpoint}/api-keys`;
     });
 

--- a/tests/utils/cognito/index.js
+++ b/tests/utils/cognito/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const log = require('log').get('aws');
+const awsLog = require('log').get('aws');
 const { region, persistentRequest } = require('../misc');
 
 function createUserPool(name, config = {}) {
@@ -31,7 +31,7 @@ function deleteUserPool(name) {
 }
 
 function findUserPoolByName(name) {
-  log.debug('find cognito user pool by name %s', name);
+  awsLog.debug('find cognito user pool by name %s', name);
   const cognito = new AWS.CognitoIdentityServiceProvider({ region });
 
   const params = {
@@ -44,7 +44,7 @@ function findUserPoolByName(name) {
       .listUserPools(params)
       .promise()
       .then(result => {
-        log.debug('cognito.listUserPools %j', result);
+        awsLog.debug('cognito.listUserPools %j', result);
         const matches = result.UserPools.filter(pool => pool.Name === name);
         if (matches.length) {
           return matches.shift();
@@ -64,7 +64,7 @@ function describeUserPool(userPoolId) {
     .describeUserPool({ UserPoolId: userPoolId })
     .promise()
     .then(result => {
-      log.debug('cognito.describeUserPool %s %j', userPoolId, result);
+      awsLog.debug('cognito.describeUserPool %s %j', userPoolId, result);
       return result;
     });
 }


### PR DESCRIPTION
It appears that when in a same service we refer to both, to be created and existing Cognito Pool, then one marked as existing is also created.

This issue was actually constantly exposed by repeatedly failing integration test as here: https://travis-ci.org/serverless/serverless/jobs/620574993

Updated test logic so this issue is exposed at all times meaningfully, and fixed the issue.

This PR initially was about fixing our tests (as integration tests after having #7058 will pre-validate all our releases). Therefore it comes also with fix to other integration test issue (e.g. exposed here: https://travis-ci.org/serverless/serverless/jobs/620679229 ), where defined API key sometimes demand a bit more time to be in effect.

Additionally fixed [issue](https://travis-ci.org/serverless/serverless/jobs/621582214) of missing `GITHUB_TOKEN` in one of the jobs of just introduced new CI configuration.

Prepared also a patch release (to also validate our new CI setup)
