### PR TITLE
Fix provisioned concurrency & ParallelizationFactor handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_script:
   # Fail build right after first script fails. Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/1066
   # More info on below line: https://www.davidpashley.com/articles/writing-robust-shell-scripts/#idm5413512
   - set -e
+  - git config --global user.email "platform@serverless.com"
+  - git config --global user.name "Serverless CI"
 
 script:
   - npm test -- -b # Bail after first fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,9 +167,10 @@ jobs:
               git fetch --unshallow
               git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
               git fetch origin master
+              git checkout -b rebase-target
               git rebase origin/master
               git checkout master
-              git merge release-fast-track
+              git merge rebase-target
               git push https://$GITHUB_TOKEN@github.com/serverless/serverless
             fi
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,22 +156,24 @@ jobs:
           if [ -n "$tagName" ]
           then
             git tag v$tagName
-            git push https://$GITHUB_TOKEN@github.com/serverless/serverless --tags
-            if [ $TRAVIS_BRANCH = master ]
+            if git push https://$GITHUB_TOKEN@github.com/serverless/serverless --tags
             then
-              # Ensure `release-fast-track` branch points latest release
-              git push -f https://$GITHUB_TOKEN@github.com/serverless/serverless master:release-fast-track
-            elif [ $TRAVIS_BRANCH = release-fast-track ]
-            then
-              # Fast forward to `master`
-              git fetch --unshallow
-              git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-              git fetch origin master
-              git checkout -b rebase-target
-              git rebase origin/master
-              git checkout master
-              git merge rebase-target
-              git push https://$GITHUB_TOKEN@github.com/serverless/serverless
+              if [ $TRAVIS_BRANCH = master ]
+              then
+                # Ensure `release-fast-track` branch points latest release
+                git push -f https://$GITHUB_TOKEN@github.com/serverless/serverless master:release-fast-track
+              elif [ $TRAVIS_BRANCH = release-fast-track ]
+              then
+                # Fast forward to `master`
+                git fetch --unshallow
+                git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+                git fetch origin master
+                git checkout -b rebase-target
+                git rebase origin/master
+                git checkout master
+                git merge rebase-target
+                git push https://$GITHUB_TOKEN@github.com/serverless/serverless
+              fi
             fi
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.59.3](https://github.com/serverless/serverless/compare/v1.59.2...v1.59.3) (2019-12-09)
+
+### Bug Fixes
+
+- Do not set optional ParallelizationFactor when not explicitly set ([e74d1a0](https://github.com/serverless/serverless/commit/e74d1a0a6486fba1ca09c5eb54b36fcf552d60f4)), closes [#7049](https://github.com/serverless/serverless/issues/7049)
+- Fix provisioned concurrency support ([be0ebb7](https://github.com/serverless/serverless/commit/be0ebb76e7d3860587a986c9da48209870e7990d)), closes [#7059](https://github.com/serverless/serverless/issues/7059)
+
 ### [1.59.2](https://github.com/serverless/serverless/compare/v1.59.1...v1.59.2) (2019-12-06)
 
 ### Bug Fixes

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -163,6 +163,9 @@ module.exports = {
       ''
     )}`;
   },
+  getLambdaOnlyVersionLogicalId(functionName) {
+    return `${this.getNormalizedFunctionName(functionName)}LambdaVersion`;
+  },
   getLambdaVersionOutputLogicalId(functionName) {
     return `${this.getLambdaLogicalId(functionName)}QualifiedArn`;
   },

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -133,14 +133,14 @@ class AwsCompileStreamEvents {
             );
 
             const funcRole = functionObj.role || this.serverless.service.provider.role;
-            let dependsOn = '"IamRoleLambdaExecution"';
+            let dependsOn = 'IamRoleLambdaExecution';
             if (funcRole) {
               if (
                 // check whether the custom role is an ARN
                 typeof funcRole === 'string' &&
                 funcRole.indexOf(':') !== -1
               ) {
-                dependsOn = '[]';
+                dependsOn = [];
               } else if (
                 // otherwise, check if we have an in-service reference to a role ARN
                 typeof funcRole === 'object' &&
@@ -151,36 +151,31 @@ class AwsCompileStreamEvents {
                 typeof funcRole['Fn::GetAtt'][1] === 'string' &&
                 funcRole['Fn::GetAtt'][1] === 'Arn'
               ) {
-                dependsOn = `"${funcRole['Fn::GetAtt'][0]}"`;
+                dependsOn = funcRole['Fn::GetAtt'][0];
               } else if (
                 // otherwise, check if we have an import or parameters ref
                 typeof funcRole === 'object' &&
                 ('Fn::ImportValue' in funcRole || 'Ref' in funcRole)
               ) {
-                dependsOn = '[]';
+                dependsOn = [];
               } else if (typeof funcRole === 'string') {
-                dependsOn = `"${funcRole}"`;
+                dependsOn = funcRole;
               }
             }
-            const streamTemplate = `
-              {
-                "Type": "AWS::Lambda::EventSourceMapping",
-                "DependsOn": ${dependsOn},
-                "Properties": {
-                  "BatchSize": ${BatchSize},
-                  "ParallelizationFactor": ${ParallelizationFactor},
-                  "EventSourceArn": ${JSON.stringify(EventSourceArn)},
-                  "FunctionName": {
-                    "Fn::GetAtt": [
-                      "${lambdaLogicalId}",
-                      "Arn"
-                    ]
-                  },
-                  "StartingPosition": "${StartingPosition}",
-                  "Enabled": "${Enabled}"
-                }
-              }
-            `;
+            const streamResource = {
+              Type: 'AWS::Lambda::EventSourceMapping',
+              DependsOn: dependsOn,
+              Properties: {
+                BatchSize,
+                ParallelizationFactor,
+                EventSourceArn,
+                FunctionName: {
+                  'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+                },
+                StartingPosition,
+                Enabled,
+              },
+            };
 
             // add event source ARNs to PolicyDocument statements
             if (streamType === 'dynamodb') {
@@ -197,8 +192,6 @@ class AwsCompileStreamEvents {
                 errorMessage
               );
             }
-
-            const streamResource = JSON.parse(streamTemplate);
 
             if (event.stream.batchWindow) {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -42,7 +42,7 @@ class AwsCompileStreamEvents {
           if (event.stream) {
             let EventSourceArn;
             let BatchSize = 10;
-            let ParallelizationFactor = 1;
+            let ParallelizationFactor;
             let StartingPosition = 'TRIM_HORIZON';
             let Enabled = 'True';
 
@@ -89,7 +89,9 @@ class AwsCompileStreamEvents {
               }
               EventSourceArn = event.stream.arn;
               BatchSize = event.stream.batchSize || BatchSize;
-              ParallelizationFactor = event.stream.parallelizationFactor || ParallelizationFactor;
+              if (event.stream.parallelizationFactor) {
+                ParallelizationFactor = event.stream.parallelizationFactor;
+              }
               StartingPosition = event.stream.startingPosition || StartingPosition;
               if (typeof event.stream.enabled !== 'undefined') {
                 Enabled = event.stream.enabled ? 'True' : 'False';

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -807,7 +807,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.ParallelizationFactor
-        ).to.equal(1);
+        ).to.equal(undefined);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.StartingPosition

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -117,166 +117,211 @@ class AwsCompileFunctions {
   }
 
   compileFunction(functionName) {
-    const newFunction = this.cfLambdaFunctionTemplate();
-    const functionObject = this.serverless.service.getFunction(functionName);
-    functionObject.package = functionObject.package || {};
+    return BbPromise.try(() => {
+      const newFunction = this.cfLambdaFunctionTemplate();
+      const functionObject = this.serverless.service.getFunction(functionName);
+      functionObject.package = functionObject.package || {};
 
-    const serviceArtifactFileName = this.provider.naming.getServiceArtifactName();
-    const functionArtifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
+      const serviceArtifactFileName = this.provider.naming.getServiceArtifactName();
+      const functionArtifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
 
-    let artifactFilePath =
-      functionObject.package.artifact || this.serverless.service.package.artifact;
+      let artifactFilePath =
+        functionObject.package.artifact || this.serverless.service.package.artifact;
 
-    if (
-      !artifactFilePath ||
-      (this.serverless.service.artifact && !functionObject.package.artifact)
-    ) {
-      let artifactFileName = serviceArtifactFileName;
-      if (this.serverless.service.package.individually || functionObject.package.individually) {
-        artifactFileName = functionArtifactFileName;
+      if (
+        !artifactFilePath ||
+        (this.serverless.service.artifact && !functionObject.package.artifact)
+      ) {
+        let artifactFileName = serviceArtifactFileName;
+        if (this.serverless.service.package.individually || functionObject.package.individually) {
+          artifactFileName = functionArtifactFileName;
+        }
+
+        artifactFilePath = path.join(
+          this.serverless.config.servicePath,
+          '.serverless',
+          artifactFileName
+        );
       }
 
-      artifactFilePath = path.join(
-        this.serverless.config.servicePath,
-        '.serverless',
-        artifactFileName
-      );
-    }
+      if (this.serverless.service.package.deploymentBucket) {
+        newFunction.Properties.Code.S3Bucket = this.serverless.service.package.deploymentBucket;
+      }
 
-    if (this.serverless.service.package.deploymentBucket) {
-      newFunction.Properties.Code.S3Bucket = this.serverless.service.package.deploymentBucket;
-    }
+      const s3Folder = this.serverless.service.package.artifactDirectoryName;
+      const s3FileName = artifactFilePath.split(path.sep).pop();
+      newFunction.Properties.Code.S3Key = `${s3Folder}/${s3FileName}`;
 
-    const s3Folder = this.serverless.service.package.artifactDirectoryName;
-    const s3FileName = artifactFilePath.split(path.sep).pop();
-    newFunction.Properties.Code.S3Key = `${s3Folder}/${s3FileName}`;
+      if (!functionObject.handler) {
+        const errorMessage = [
+          `Missing "handler" property in function "${functionName}".`,
+          ' Please make sure you point to the correct lambda handler.',
+          ' For example: handler.hello.',
+          ' Please check the docs for more info',
+        ].join('');
+        throw new this.serverless.classes.Error(errorMessage);
+      }
 
-    if (!functionObject.handler) {
-      const errorMessage = [
-        `Missing "handler" property in function "${functionName}".`,
-        ' Please make sure you point to the correct lambda handler.',
-        ' For example: handler.hello.',
-        ' Please check the docs for more info',
-      ].join('');
-      return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
-    }
+      const Handler = functionObject.handler;
+      const FunctionName = functionObject.name;
+      const MemorySize =
+        Number(functionObject.memorySize) ||
+        Number(this.serverless.service.provider.memorySize) ||
+        1024;
+      const Timeout =
+        Number(functionObject.timeout) || Number(this.serverless.service.provider.timeout) || 6;
+      const Runtime =
+        functionObject.runtime || this.serverless.service.provider.runtime || 'nodejs12.x';
 
-    const Handler = functionObject.handler;
-    const FunctionName = functionObject.name;
-    const MemorySize =
-      Number(functionObject.memorySize) ||
-      Number(this.serverless.service.provider.memorySize) ||
-      1024;
-    const Timeout =
-      Number(functionObject.timeout) || Number(this.serverless.service.provider.timeout) || 6;
-    const Runtime =
-      functionObject.runtime || this.serverless.service.provider.runtime || 'nodejs12.x';
+      newFunction.Properties.Handler = Handler;
+      newFunction.Properties.FunctionName = FunctionName;
+      newFunction.Properties.MemorySize = MemorySize;
+      newFunction.Properties.Timeout = Timeout;
+      newFunction.Properties.Runtime = Runtime;
 
-    newFunction.Properties.Handler = Handler;
-    newFunction.Properties.FunctionName = FunctionName;
-    newFunction.Properties.MemorySize = MemorySize;
-    newFunction.Properties.Timeout = Timeout;
-    newFunction.Properties.Runtime = Runtime;
+      // publish these properties to the platform
+      this.serverless.service.functions[functionName].memory = MemorySize;
+      this.serverless.service.functions[functionName].timeout = Timeout;
+      this.serverless.service.functions[functionName].runtime = Runtime;
 
-    // publish these properties to the platform
-    this.serverless.service.functions[functionName].memory = MemorySize;
-    this.serverless.service.functions[functionName].timeout = Timeout;
-    this.serverless.service.functions[functionName].runtime = Runtime;
+      if (functionObject.description) {
+        newFunction.Properties.Description = functionObject.description;
+      }
 
-    if (functionObject.description) {
-      newFunction.Properties.Description = functionObject.description;
-    }
+      if (functionObject.condition) {
+        newFunction.Condition = functionObject.condition;
+      }
 
-    if (functionObject.condition) {
-      newFunction.Condition = functionObject.condition;
-    }
+      if (functionObject.dependsOn) {
+        newFunction.DependsOn = (newFunction.DependsOn || []).concat(functionObject.dependsOn);
+      }
 
-    if (functionObject.dependsOn) {
-      newFunction.DependsOn = (newFunction.DependsOn || []).concat(functionObject.dependsOn);
-    }
+      if (functionObject.tags || this.serverless.service.provider.tags) {
+        const tags = Object.assign({}, this.serverless.service.provider.tags, functionObject.tags);
+        newFunction.Properties.Tags = [];
+        _.forEach(tags, (Value, Key) => {
+          newFunction.Properties.Tags.push({ Key, Value });
+        });
+      }
 
-    if (functionObject.tags || this.serverless.service.provider.tags) {
-      const tags = Object.assign({}, this.serverless.service.provider.tags, functionObject.tags);
-      newFunction.Properties.Tags = [];
-      _.forEach(tags, (Value, Key) => {
-        newFunction.Properties.Tags.push({ Key, Value });
-      });
-    }
+      if (functionObject.onError) {
+        const arn = functionObject.onError;
 
-    if (functionObject.onError) {
-      const arn = functionObject.onError;
+        if (typeof arn === 'string') {
+          const splittedArn = arn.split(':');
+          if (splittedArn[0] === 'arn' && (splittedArn[2] === 'sns' || splittedArn[2] === 'sqs')) {
+            const dlqType = splittedArn[2];
+            const iamRoleLambdaExecution = this.serverless.service.provider
+              .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
+            let stmt;
 
-      if (typeof arn === 'string') {
-        const splittedArn = arn.split(':');
-        if (splittedArn[0] === 'arn' && (splittedArn[2] === 'sns' || splittedArn[2] === 'sqs')) {
-          const dlqType = splittedArn[2];
-          const iamRoleLambdaExecution = this.serverless.service.provider
-            .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
-          let stmt;
+            newFunction.Properties.DeadLetterConfig = {
+              TargetArn: arn,
+            };
 
+            if (dlqType === 'sns') {
+              stmt = {
+                Effect: 'Allow',
+                Action: ['sns:Publish'],
+                Resource: [arn],
+              };
+            } else if (dlqType === 'sqs') {
+              const errorMessage = [
+                'onError currently only supports SNS topic arns due to a',
+                ' race condition when using SQS queue arns and updating the IAM role.',
+                ' Please check the docs for more info.',
+              ].join('');
+              throw new this.serverless.classes.Error(errorMessage);
+            }
+
+            // update the PolicyDocument statements (if default policy is used)
+            if (iamRoleLambdaExecution) {
+              iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement.push(stmt);
+            }
+          } else {
+            const errorMessage = 'onError config must be a SNS topic arn or SQS queue arn';
+            throw new this.serverless.classes.Error(errorMessage);
+          }
+        } else if (this.isArnRefGetAttOrImportValue(arn)) {
           newFunction.Properties.DeadLetterConfig = {
             TargetArn: arn,
           };
+        } else {
+          const errorMessage = [
+            'onError config must be provided as an arn string,',
+            ' Ref, Fn::GetAtt or Fn::ImportValue',
+          ].join('');
+          throw new this.serverless.classes.Error(errorMessage);
+        }
+      }
 
-          if (dlqType === 'sns') {
-            stmt = {
+      let kmsKeyArn;
+      const serviceObj = this.serverless.service.serviceObject;
+      if ('awsKmsKeyArn' in functionObject) {
+        kmsKeyArn = functionObject.awsKmsKeyArn;
+      } else if (serviceObj && 'awsKmsKeyArn' in serviceObj) {
+        kmsKeyArn = serviceObj.awsKmsKeyArn;
+      }
+
+      if (kmsKeyArn) {
+        const arn = kmsKeyArn;
+
+        if (typeof arn === 'string') {
+          const splittedArn = arn.split(':');
+          if (splittedArn[0] === 'arn' && splittedArn[2] === 'kms') {
+            const iamRoleLambdaExecution = this.serverless.service.provider
+              .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
+
+            newFunction.Properties.KmsKeyArn = arn;
+
+            const stmt = {
               Effect: 'Allow',
-              Action: ['sns:Publish'],
+              Action: ['kms:Decrypt'],
               Resource: [arn],
             };
-          } else if (dlqType === 'sqs') {
-            const errorMessage = [
-              'onError currently only supports SNS topic arns due to a',
-              ' race condition when using SQS queue arns and updating the IAM role.',
-              ' Please check the docs for more info.',
-            ].join('');
-            return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
-          }
 
-          // update the PolicyDocument statements (if default policy is used)
-          if (iamRoleLambdaExecution) {
-            iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement.push(stmt);
+            // update the PolicyDocument statements (if default policy is used)
+            if (iamRoleLambdaExecution) {
+              iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement = _.unionWith(
+                iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement,
+                [stmt],
+                _.isEqual
+              );
+            }
+          } else {
+            const errorMessage = 'awsKmsKeyArn config must be a KMS key arn';
+            throw new this.serverless.classes.Error(errorMessage);
           }
         } else {
-          const errorMessage = 'onError config must be a SNS topic arn or SQS queue arn';
-          return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
+          const errorMessage = 'awsKmsKeyArn config must be provided as a string';
+          throw new this.serverless.classes.Error(errorMessage);
         }
-      } else if (this.isArnRefGetAttOrImportValue(arn)) {
-        newFunction.Properties.DeadLetterConfig = {
-          TargetArn: arn,
-        };
-      } else {
-        const errorMessage = [
-          'onError config must be provided as an arn string,',
-          ' Ref, Fn::GetAtt or Fn::ImportValue',
-        ].join('');
-        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
       }
-    }
 
-    let kmsKeyArn;
-    const serviceObj = this.serverless.service.serviceObject;
-    if ('awsKmsKeyArn' in functionObject) {
-      kmsKeyArn = functionObject.awsKmsKeyArn;
-    } else if (serviceObj && 'awsKmsKeyArn' in serviceObj) {
-      kmsKeyArn = serviceObj.awsKmsKeyArn;
-    }
+      const tracing =
+        functionObject.tracing ||
+        (this.serverless.service.provider.tracing &&
+          this.serverless.service.provider.tracing.lambda);
 
-    if (kmsKeyArn) {
-      const arn = kmsKeyArn;
+      if (tracing) {
+        if (typeof tracing === 'boolean' || typeof tracing === 'string') {
+          let mode = tracing;
 
-      if (typeof arn === 'string') {
-        const splittedArn = arn.split(':');
-        if (splittedArn[0] === 'arn' && splittedArn[2] === 'kms') {
+          if (typeof tracing === 'boolean') {
+            mode = 'Active';
+          }
+
           const iamRoleLambdaExecution = this.serverless.service.provider
             .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
 
-          newFunction.Properties.KmsKeyArn = arn;
+          newFunction.Properties.TracingConfig = {
+            Mode: mode,
+          };
 
           const stmt = {
             Effect: 'Allow',
-            Action: ['kms:Decrypt'],
-            Resource: [arn],
+            Action: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
+            Resource: ['*'],
           };
 
           // update the PolicyDocument statements (if default policy is used)
@@ -288,263 +333,221 @@ class AwsCompileFunctions {
             );
           }
         } else {
-          const errorMessage = 'awsKmsKeyArn config must be a KMS key arn';
-          return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
+          const errorMessage =
+            'tracing requires a boolean value or the "mode" provided as a string';
+          throw new this.serverless.classes.Error(errorMessage);
         }
-      } else {
-        const errorMessage = 'awsKmsKeyArn config must be provided as a string';
-        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
-      }
-    }
-
-    const tracing =
-      functionObject.tracing ||
-      (this.serverless.service.provider.tracing && this.serverless.service.provider.tracing.lambda);
-
-    if (tracing) {
-      if (typeof tracing === 'boolean' || typeof tracing === 'string') {
-        let mode = tracing;
-
-        if (typeof tracing === 'boolean') {
-          mode = 'Active';
-        }
-
-        const iamRoleLambdaExecution = this.serverless.service.provider
-          .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution;
-
-        newFunction.Properties.TracingConfig = {
-          Mode: mode,
-        };
-
-        const stmt = {
-          Effect: 'Allow',
-          Action: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
-          Resource: ['*'],
-        };
-
-        // update the PolicyDocument statements (if default policy is used)
-        if (iamRoleLambdaExecution) {
-          iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement = _.unionWith(
-            iamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement,
-            [stmt],
-            _.isEqual
-          );
-        }
-      } else {
-        const errorMessage = 'tracing requires a boolean value or the "mode" provided as a string';
-        throw new this.serverless.classes.Error(errorMessage);
-      }
-    }
-
-    if (functionObject.environment || this.serverless.service.provider.environment) {
-      newFunction.Properties.Environment = {};
-      newFunction.Properties.Environment.Variables = Object.assign(
-        {},
-        this.serverless.service.provider.environment,
-        functionObject.environment
-      );
-
-      let invalidEnvVar = null;
-      _.forEach(_.keys(newFunction.Properties.Environment.Variables), key => {
-        // taken from the bash man pages
-        if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
-          invalidEnvVar = `Invalid characters in environment variable ${key}`;
-          return false; // break loop with lodash
-        }
-        const value = newFunction.Properties.Environment.Variables[key];
-        if (_.isObject(value)) {
-          const isCFRef =
-            _.isObject(value) && !_.some(value, (v, k) => k !== 'Ref' && !_.startsWith(k, 'Fn::'));
-          if (!isCFRef) {
-            invalidEnvVar = `Environment variable ${key} must contain string`;
-            return false;
-          }
-        }
-        return true;
-      });
-
-      if (invalidEnvVar) {
-        return BbPromise.reject(new this.serverless.classes.Error(invalidEnvVar));
-      }
-    }
-
-    if ('role' in functionObject) {
-      this.compileRole(newFunction, functionObject.role);
-    } else if ('role' in this.serverless.service.provider) {
-      this.compileRole(newFunction, this.serverless.service.provider.role);
-    } else {
-      this.compileRole(newFunction, 'IamRoleLambdaExecution');
-    }
-
-    if (!functionObject.vpc) functionObject.vpc = {};
-    if (!this.serverless.service.provider.vpc) this.serverless.service.provider.vpc = {};
-
-    newFunction.Properties.VpcConfig = {
-      SecurityGroupIds:
-        functionObject.vpc.securityGroupIds ||
-        this.serverless.service.provider.vpc.securityGroupIds,
-      SubnetIds: functionObject.vpc.subnetIds || this.serverless.service.provider.vpc.subnetIds,
-    };
-
-    if (
-      !newFunction.Properties.VpcConfig.SecurityGroupIds ||
-      !newFunction.Properties.VpcConfig.SubnetIds
-    ) {
-      delete newFunction.Properties.VpcConfig;
-    }
-
-    if (functionObject.reservedConcurrency || functionObject.reservedConcurrency === 0) {
-      // Try convert reservedConcurrency to integer
-      const reservedConcurrency = _.parseInt(functionObject.reservedConcurrency);
-
-      if (_.isInteger(reservedConcurrency)) {
-        newFunction.Properties.ReservedConcurrentExecutions = reservedConcurrency;
-      } else {
-        const errorMessage = [
-          'You should use integer as reservedConcurrency value on function: ',
-          `${newFunction.Properties.FunctionName}`,
-        ].join('');
-
-        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
-      }
-    }
-
-    newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)].concat(
-      newFunction.DependsOn || []
-    );
-
-    if (functionObject.layers && _.isArray(functionObject.layers)) {
-      newFunction.Properties.Layers = functionObject.layers;
-    } else if (
-      this.serverless.service.provider.layers &&
-      _.isArray(this.serverless.service.provider.layers)
-    ) {
-      newFunction.Properties.Layers = this.serverless.service.provider.layers;
-    }
-
-    const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-    const newFunctionObject = {
-      [functionLogicalId]: newFunction,
-    };
-
-    _.merge(
-      this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-      newFunctionObject
-    );
-
-    const versionFunction =
-      functionObject.versionFunction != null
-        ? functionObject.versionFunction
-        : this.serverless.service.provider.versionFunctions;
-
-    if (functionObject.provisionedConcurrency) {
-      if (versionFunction) {
-        const errorMessage = [
-          'Sorry, at this point,provisioned conncurrency for ' +
-            `${newFunction.Properties.FunctionName}\n`,
-          'cannot be setup together with lambda versioning enabled.\n\n',
-          'If you want to take advantage of provisioned concurrency, please turn off lambda versioning.\n\n',
-          "We're working on improving that experience, stay tuned for upcoming updates.",
-        ].join('');
-        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
       }
 
-      const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
-
-      if (!_.isInteger(provisionedConcurrency)) {
-        throw new this.serverless.classes.Error(
-          'You should use integer as provisionedConcurrency value on function: ' +
-            `${newFunction.Properties.FunctionName}`
+      if (functionObject.environment || this.serverless.service.provider.environment) {
+        newFunction.Properties.Environment = {};
+        newFunction.Properties.Environment.Variables = Object.assign(
+          {},
+          this.serverless.service.provider.environment,
+          functionObject.environment
         );
-      }
 
-      this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-        this.provider.naming.getLambdaOnlyVersionLogicalId(functionName)
-      ] = {
-        Type: 'AWS::Lambda::Version',
-        Properties: {
-          FunctionName: { Ref: functionLogicalId },
-          ProvisionedConcurrencyConfig: {
-            ProvisionedConcurrentExecutions: provisionedConcurrency,
-          },
-        },
-      };
-    }
-
-    if (!versionFunction) return BbPromise.resolve();
-
-    // Create hashes for the artifact and the logical id of the version resource
-    // The one for the version resource must include the function configuration
-    // to make sure that a new version is created on configuration changes and
-    // not only on source changes.
-    const fileHash = crypto.createHash('sha256');
-    const versionHash = crypto.createHash('sha256');
-    fileHash.setEncoding('base64');
-    versionHash.setEncoding('base64');
-
-    // Read the file in chunks and add them to the hash (saves memory and performance)
-    return BbPromise.fromCallback(cb => {
-      const readStream = fs.createReadStream(artifactFilePath);
-
-      readStream
-        .on('data', chunk => {
-          fileHash.write(chunk);
-          versionHash.write(chunk);
-        })
-        .on('close', () => {
-          cb();
-        })
-        .on('error', error => {
-          cb(error);
+        let invalidEnvVar = null;
+        _.forEach(_.keys(newFunction.Properties.Environment.Variables), key => {
+          // taken from the bash man pages
+          if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
+            invalidEnvVar = `Invalid characters in environment variable ${key}`;
+            return false; // break loop with lodash
+          }
+          const value = newFunction.Properties.Environment.Variables[key];
+          if (_.isObject(value)) {
+            const isCFRef =
+              _.isObject(value) &&
+              !_.some(value, (v, k) => k !== 'Ref' && !_.startsWith(k, 'Fn::'));
+            if (!isCFRef) {
+              invalidEnvVar = `Environment variable ${key} must contain string`;
+              return false;
+            }
+          }
+          return true;
         });
-    }).then(() => {
-      // Include function configuration in version id hash (without the Code part)
-      const properties = _.omit(_.get(newFunction, 'Properties', {}), 'Code');
-      _.forOwn(properties, value => {
-        const hashedValue = _.isObject(value) ? JSON.stringify(value) : _.toString(value);
-        versionHash.write(hashedValue);
-      });
 
-      // Finalize hashes
-      fileHash.end();
-      versionHash.end();
-
-      const fileDigest = fileHash.read();
-      const versionDigest = versionHash.read();
-
-      const newVersion = this.cfLambdaVersionTemplate();
-
-      newVersion.Properties.CodeSha256 = fileDigest;
-      newVersion.Properties.FunctionName = { Ref: functionLogicalId };
-      if (functionObject.description) {
-        newVersion.Properties.Description = functionObject.description;
+        if (invalidEnvVar) throw new this.serverless.classes.Error(invalidEnvVar);
       }
 
-      // use the version SHA in the logical resource ID of the version because
-      // AWS::Lambda::Version resource will not support updates
-      const versionLogicalId = this.provider.naming.getLambdaVersionLogicalId(
-        functionName,
-        versionDigest
+      if ('role' in functionObject) {
+        this.compileRole(newFunction, functionObject.role);
+      } else if ('role' in this.serverless.service.provider) {
+        this.compileRole(newFunction, this.serverless.service.provider.role);
+      } else {
+        this.compileRole(newFunction, 'IamRoleLambdaExecution');
+      }
+
+      if (!functionObject.vpc) functionObject.vpc = {};
+      if (!this.serverless.service.provider.vpc) this.serverless.service.provider.vpc = {};
+
+      newFunction.Properties.VpcConfig = {
+        SecurityGroupIds:
+          functionObject.vpc.securityGroupIds ||
+          this.serverless.service.provider.vpc.securityGroupIds,
+        SubnetIds: functionObject.vpc.subnetIds || this.serverless.service.provider.vpc.subnetIds,
+      };
+
+      if (
+        !newFunction.Properties.VpcConfig.SecurityGroupIds ||
+        !newFunction.Properties.VpcConfig.SubnetIds
+      ) {
+        delete newFunction.Properties.VpcConfig;
+      }
+
+      if (functionObject.reservedConcurrency || functionObject.reservedConcurrency === 0) {
+        // Try convert reservedConcurrency to integer
+        const reservedConcurrency = _.parseInt(functionObject.reservedConcurrency);
+
+        if (_.isInteger(reservedConcurrency)) {
+          newFunction.Properties.ReservedConcurrentExecutions = reservedConcurrency;
+        } else {
+          const errorMessage = [
+            'You should use integer as reservedConcurrency value on function: ',
+            `${newFunction.Properties.FunctionName}`,
+          ].join('');
+
+          throw new this.serverless.classes.Error(errorMessage);
+        }
+      }
+
+      newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)].concat(
+        newFunction.DependsOn || []
       );
-      const newVersionObject = {
-        [versionLogicalId]: newVersion,
+
+      if (functionObject.layers && _.isArray(functionObject.layers)) {
+        newFunction.Properties.Layers = functionObject.layers;
+      } else if (
+        this.serverless.service.provider.layers &&
+        _.isArray(this.serverless.service.provider.layers)
+      ) {
+        newFunction.Properties.Layers = this.serverless.service.provider.layers;
+      }
+
+      const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+      const newFunctionObject = {
+        [functionLogicalId]: newFunction,
       };
 
       _.merge(
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        newVersionObject
+        newFunctionObject
       );
 
-      // Add function versions to Outputs section
-      const functionVersionOutputLogicalId = this.provider.naming.getLambdaVersionOutputLogicalId(
-        functionName
-      );
-      const newVersionOutput = this.cfOutputLatestVersionTemplate();
+      const versionFunction =
+        functionObject.versionFunction != null
+          ? functionObject.versionFunction
+          : this.serverless.service.provider.versionFunctions;
 
-      newVersionOutput.Value = { Ref: versionLogicalId };
+      if (functionObject.provisionedConcurrency) {
+        if (versionFunction) {
+          const errorMessage = [
+            'Sorry, at this point,provisioned conncurrency for ' +
+              `${newFunction.Properties.FunctionName}\n`,
+            'cannot be setup together with lambda versioning enabled.\n\n',
+            'If you want to take advantage of provisioned concurrency, please turn off lambda versioning.\n\n',
+            "We're working on improving that experience, stay tuned for upcoming updates.",
+          ].join('');
+          throw new this.serverless.classes.Error(errorMessage);
+        }
 
-      _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-        [functionVersionOutputLogicalId]: newVersionOutput,
+        const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
+
+        if (!_.isInteger(provisionedConcurrency)) {
+          throw new this.serverless.classes.Error(
+            'You should use integer as provisionedConcurrency value on function: ' +
+              `${newFunction.Properties.FunctionName}`
+          );
+        }
+
+        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          this.provider.naming.getLambdaOnlyVersionLogicalId(functionName)
+        ] = {
+          Type: 'AWS::Lambda::Version',
+          Properties: {
+            FunctionName: { Ref: functionLogicalId },
+            ProvisionedConcurrencyConfig: {
+              ProvisionedConcurrentExecutions: provisionedConcurrency,
+            },
+          },
+        };
+      }
+
+      if (!versionFunction) return null;
+
+      // Create hashes for the artifact and the logical id of the version resource
+      // The one for the version resource must include the function configuration
+      // to make sure that a new version is created on configuration changes and
+      // not only on source changes.
+      const fileHash = crypto.createHash('sha256');
+      const versionHash = crypto.createHash('sha256');
+      fileHash.setEncoding('base64');
+      versionHash.setEncoding('base64');
+
+      // Read the file in chunks and add them to the hash (saves memory and performance)
+      return BbPromise.fromCallback(cb => {
+        const readStream = fs.createReadStream(artifactFilePath);
+
+        readStream
+          .on('data', chunk => {
+            fileHash.write(chunk);
+            versionHash.write(chunk);
+          })
+          .on('close', () => {
+            cb();
+          })
+          .on('error', error => {
+            cb(error);
+          });
+      }).then(() => {
+        // Include function configuration in version id hash (without the Code part)
+        const properties = _.omit(_.get(newFunction, 'Properties', {}), 'Code');
+        _.forOwn(properties, value => {
+          const hashedValue = _.isObject(value) ? JSON.stringify(value) : _.toString(value);
+          versionHash.write(hashedValue);
+        });
+
+        // Finalize hashes
+        fileHash.end();
+        versionHash.end();
+
+        const fileDigest = fileHash.read();
+        const versionDigest = versionHash.read();
+
+        const newVersion = this.cfLambdaVersionTemplate();
+
+        newVersion.Properties.CodeSha256 = fileDigest;
+        newVersion.Properties.FunctionName = { Ref: functionLogicalId };
+        if (functionObject.description) {
+          newVersion.Properties.Description = functionObject.description;
+        }
+
+        // use the version SHA in the logical resource ID of the version because
+        // AWS::Lambda::Version resource will not support updates
+        const versionLogicalId = this.provider.naming.getLambdaVersionLogicalId(
+          functionName,
+          versionDigest
+        );
+        const newVersionObject = {
+          [versionLogicalId]: newVersion,
+        };
+
+        _.merge(
+          this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+          newVersionObject
+        );
+
+        // Add function versions to Outputs section
+        const functionVersionOutputLogicalId = this.provider.naming.getLambdaVersionOutputLogicalId(
+          functionName
+        );
+        const newVersionOutput = this.cfOutputLatestVersionTemplate();
+
+        newVersionOutput.Value = { Ref: versionLogicalId };
+
+        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+          [functionVersionOutputLogicalId]: newVersionOutput,
+        });
       });
     });
   }

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -409,20 +409,6 @@ class AwsCompileFunctions {
       }
     }
 
-    const versionFunction =
-      functionObject.versionFunction != null
-        ? functionObject.versionFunction
-        : this.serverless.service.provider.versionFunctions;
-
-    if (functionObject.provisionedConcurrency && !versionFunction) {
-      return BbPromise.reject(
-        new this.serverless.classes.Error(
-          'Cannot setup provisioned conncurrency with lambda versioning disabled on function: ' +
-            `${newFunction.Properties.FunctionName}`
-        )
-      );
-    }
-
     newFunction.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)].concat(
       newFunction.DependsOn || []
     );
@@ -445,6 +431,45 @@ class AwsCompileFunctions {
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
       newFunctionObject
     );
+
+    const versionFunction =
+      functionObject.versionFunction != null
+        ? functionObject.versionFunction
+        : this.serverless.service.provider.versionFunctions;
+
+    if (functionObject.provisionedConcurrency) {
+      if (versionFunction) {
+        const errorMessage = [
+          'Sorry, at this point,provisioned conncurrency for ' +
+            `${newFunction.Properties.FunctionName}\n`,
+          'cannot be setup together with lambda versioning enabled.\n\n',
+          'If you want to take advantage of provisioned concurrency, please turn off lambda versioning.\n\n',
+          "We're working on improving that experience, stay tuned for upcoming updates.",
+        ].join('');
+        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
+      }
+
+      const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
+
+      if (!_.isInteger(provisionedConcurrency)) {
+        throw new this.serverless.classes.Error(
+          'You should use integer as provisionedConcurrency value on function: ' +
+            `${newFunction.Properties.FunctionName}`
+        );
+      }
+
+      this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+        this.provider.naming.getLambdaOnlyVersionLogicalId(functionName)
+      ] = {
+        Type: 'AWS::Lambda::Version',
+        Properties: {
+          FunctionName: { Ref: functionLogicalId },
+          ProvisionedConcurrencyConfig: {
+            ProvisionedConcurrentExecutions: provisionedConcurrency,
+          },
+        },
+      };
+    }
 
     if (!versionFunction) return BbPromise.resolve();
 
@@ -493,21 +518,6 @@ class AwsCompileFunctions {
       newVersion.Properties.FunctionName = { Ref: functionLogicalId };
       if (functionObject.description) {
         newVersion.Properties.Description = functionObject.description;
-      }
-
-      if (functionObject.provisionedConcurrency) {
-        const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
-
-        if (!_.isInteger(provisionedConcurrency)) {
-          throw new this.serverless.classes.Error(
-            'You should use integer as provisionedConcurrency value on function: ' +
-              `${newFunction.Properties.FunctionName}`
-          );
-        }
-
-        newVersion.Properties.ProvisionedConcurrencyConfig = {
-          ProvisionedConcurrentExecutions: provisionedConcurrency,
-        };
       }
 
       // use the version SHA in the logical resource ID of the version because

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -446,6 +446,8 @@ class AwsCompileFunctions {
       newFunctionObject
     );
 
+    if (!versionFunction) return BbPromise.resolve();
+
     // Create hashes for the artifact and the logical id of the version resource
     // The one for the version resource must include the function configuration
     // to make sure that a new version is created on configuration changes and
@@ -484,8 +486,6 @@ class AwsCompileFunctions {
 
       const fileDigest = fileHash.read();
       const versionDigest = versionHash.read();
-
-      if (!versionFunction) return;
 
       const newVersion = this.cfLambdaVersionTemplate();
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -498,16 +498,16 @@ class AwsCompileFunctions {
       if (functionObject.provisionedConcurrency) {
         const provisionedConcurrency = _.parseInt(functionObject.provisionedConcurrency);
 
-        if (_.isInteger(provisionedConcurrency)) {
-          newVersion.Properties.ProvisionedConcurrencyConfig = {
-            ProvisionedConcurrentExecutions: provisionedConcurrency,
-          };
-        } else {
+        if (!_.isInteger(provisionedConcurrency)) {
           throw new this.serverless.classes.Error(
             'You should use integer as provisionedConcurrency value on function: ' +
               `${newFunction.Properties.FunctionName}`
           );
         }
+
+        newVersion.Properties.ProvisionedConcurrencyConfig = {
+          ProvisionedConcurrentExecutions: provisionedConcurrency,
+        };
       }
 
       // use the version SHA in the logical resource ID of the version because

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2206,17 +2206,14 @@ describe('AwsCompileFunctions', () => {
           handler: 'func.function.handler',
           name: 'new-service-dev-func',
           provisionedConcurrency: 5,
+          versionFunction: false,
         },
       };
 
       return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
-        const resourceId =
-          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .FuncLambdaFunctionQualifiedArn.Value.Ref;
         expect(
-          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-            resourceId
-          ].Properties.ProvisionedConcurrencyConfig
+          awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FuncLambdaVersion.Properties.ProvisionedConcurrencyConfig
         ).to.deep.equal({ ProvisionedConcurrentExecutions: 5 });
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.59.2",
+  "version": "1.59.3",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
Fixes https://github.com/serverless/serverless/issues/7059, although with cost of limited support for provisioned concurrency (via CF means it seems there's no reliable mean to set it up with versioning enabled, I'm currently figuring it out on a side with AWS team).

Fixes https://github.com/serverless/serverless/issues/7049, by ensuring that `ParallelizationFactor` is not set, if not explicitly configured.

_Brought under one PR, to issue both under same patch release._

Additionally fixed few issues observed in recently published new CI config:
- Pushed commits from CI were not signed with recognizable email address. Fixed that by configuring expected email for git
- Fix issue with fast-forward merge to master
- There are duplicate tag create attempts in `master` or `release-fast-track` when they're updated after release being made from other branch. Added gentle handling of that case (it crashed the build, as obviously github rejected second publish of same tag)