### PR TITLE
Plugins - now allow falsy default values.

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -12,8 +12,6 @@ const getCacheFilePath = require('../utils/getCacheFilePath');
 const serverlessConfigFileUtils = require('../utils/getServerlessConfigFile');
 const getCommandSuggestion = require('../utils/getCommandSuggestion');
 
-const validFalsyDefaultValues = new Set([0, '', false]);
-
 const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
     // TODO (BREAKING): Consider removing support for localPluginsPath with next major
@@ -625,10 +623,7 @@ class PluginManager {
 
   assignDefaultOptions(command) {
     _.forEach(command.options, (value, key) => {
-      if (
-        (value.default || validFalsyDefaultValues.has(value.default)) &&
-        (!this.cliOptions[key] || this.cliOptions[key] === true)
-      ) {
+      if (value.default != null && (!this.cliOptions[key] || this.cliOptions[key] === true)) {
         this.cliOptions[key] = value.default;
       }
     });

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -12,6 +12,8 @@ const getCacheFilePath = require('../utils/getCacheFilePath');
 const serverlessConfigFileUtils = require('../utils/getServerlessConfigFile');
 const getCommandSuggestion = require('../utils/getCommandSuggestion');
 
+const validFalsyDefaultValues = new Set([0, '', false]);
+
 const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
     // TODO (BREAKING): Consider removing support for localPluginsPath with next major
@@ -623,7 +625,10 @@ class PluginManager {
 
   assignDefaultOptions(command) {
     _.forEach(command.options, (value, key) => {
-      if (value.default && (!this.cliOptions[key] || this.cliOptions[key] === true)) {
+      if (
+        (value.default || validFalsyDefaultValues.has(value.default)) &&
+        (!this.cliOptions[key] || this.cliOptions[key] === true)
+      ) {
         this.cliOptions[key] = value.default;
       }
     });

--- a/lib/classes/PluginManager.test.js
+++ b/lib/classes/PluginManager.test.js
@@ -1320,6 +1320,26 @@ describe('PluginManager', () => {
 
       expect(pluginManager.cliOptions.bar).to.equal(100);
     });
+
+    [0, '', false].forEach(defaultValue => {
+      it(`assigns valid falsy default value '${defaultValue} to empty options`, () => {
+        pluginManager.commands = {
+          foo: {
+            options: {
+              bar: {
+                required: true,
+                default: defaultValue,
+              },
+            },
+          },
+        };
+
+        const foo = pluginManager.commands.foo;
+        pluginManager.assignDefaultOptions(foo);
+
+        expect(pluginManager.cliOptions.bar).to.equal(defaultValue);
+      });
+    });
   });
 
   describe('#validateServerlessConfigDependency()', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Previously, the plugin manager did not properly set the default value if the default value is `0`, `false`, or `''`. This PR fixes that.

Closes #XXXXX (none that I can find)

## How can we verify it

`serverless.yml`:

```yaml
service: foo

provider:
  name: aws
  runtime: nodejs10.x

plugins:
  - serverless-test-plugin
```

`.serverless_plugins/serverless-test-plugin.js`:

```js
'use strict';

class TestPlugin {
  constructor(serverless, options) {
    this.options = options;
    this.commands = {
      options: {
        usage: 'Options viewer',
        lifecycleEvents: ['options'],
        commands: {
          log: {
            usage: 'Log all options',
            options: {
              zero: { default: 0 },
              'empty-string': { default: '' },
              false: { default: false }
            },
            lifecycleEvents: ['log']
          }
        }
      }
    };

    this.hooks = {
      'options:log:log': () => this.log()
    };
  }

  log() {
    console.log('log()');
    console.log(JSON.stringify(this.options));
  }
}

module.exports = TestPlugin;
```

Then run

```sh
sls options log
```

Before:

```
log()
{}
```

After:

```
log()
{"zero":0,"empty-string":"","false":false}
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
