### PR TITLE
CI: Fix npm update related issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ install:
   # - There seems no way to update all project dependency groups in one run
   #   Hence different calls for prod and dev dependencies
   # - The bigger depth, the longer update takes (-9999 as proposed in npm docs hangs the process).
-  #   Therefore we keep at 4 which should ensure most of dependencies are at latest versions
+  #   Therefore we keep at 3 which should ensure most of dependencies are at latest versions
   # - npm documents --dev option for dev dependencies update, but it's only --save-dev that works
-  - npm update --depth 4 --no-save
-  - npm update --depth 4 --save-dev --no-save
+  - npm update --depth 3 --no-save
+  - npm update --depth 3 --save-dev --no-save
 
 branches:
   only: # Do not build PR branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@ cache:
 
 # Ensure to install dependencies at their latest versions
 install:
-  # Note: with `npm update` there seems no way to update all project dependency groups in one run
-  - npm update --depth 4 --no-save # Updates just dependencies
-  # Note: npm documents --dev option for dev dependencies update, but it's only --save-dev that works
-  - npm update --depth 4 --save-dev --no-save # Updates just devDependencies
+  # Note: `npm update` has issues which we need to workaround:
+  # - There seems no way to update all project dependency groups in one run
+  #   Hence different calls for prod and dev dependencies
+  # - The bigger depth, the longer update takes (-9999 as proposed in npm docs hangs the process).
+  #   Therefore we keep at 4 which should ensure most of dependencies are at latest versions
+  # - npm documents --dev option for dev dependencies update, but it's only --save-dev that works
+  - npm update --depth 4 --no-save
+  - npm update --depth 4 --save-dev --no-save
 
 branches:
   only: # Do not build PR branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ install:
   #   Hence different calls for prod and dev dependencies
   # - The bigger depth, the longer update takes (-9999 as proposed in npm docs hangs the process).
   #   Therefore we keep at 3 which should ensure most of dependencies are at latest versions
+  # - Depth setting makes optional dependencies not optional (install error crashes process)
+  #   Hence we skip install of optional dependencies completely, with --no-optional
   # - npm documents --dev option for dev dependencies update, but it's only --save-dev that works
-  - npm update --depth 3 --no-save
+  - npm update --depth 3 --no-optional --no-save
   - npm update --depth 3 --save-dev --no-save
 
 branches:


### PR DESCRIPTION
It's to fix issue observed here: https://travis-ci.org/serverless/serverless/jobs/623555231

It appears that `--depth` setting for some npm versions makes optional dependencies not optional. Workaround it with `--no-optional` with that npm will not attempt to install optional dependencies.

Additionally decreased `--depth` to make npm updates a bit faster

--- 

Based against `release-fast-track`, so we have that fix available also for eventual patch releases
