### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   #   Therefore we keep at 3 which should ensure most of dependencies are at latest versions
   # - Depth setting makes optional dependencies not optional (install error crashes process)
   #   Hence we skip install of optional dependencies completely, with --no-optional
+  #   Note: this patch works only for npm@5+
   # - npm documents --dev option for dev dependencies update, but it's only --save-dev that works
   - npm update --depth 3 --no-optional --no-save
   - npm update --depth 3 --save-dev --no-save
@@ -142,6 +143,10 @@ jobs:
 
     - name: 'Unit Tests - Node.js v6'
       node_js: 6
+      before_install:
+        # npm@3 doesn't seem handle `--no-optional` option of `npm update` command.
+        # Upgrade npm to version which is distributed with Node.js v8
+        - npm i -g npm@6.4.1
 
     - stage: Integration Test
       name: 'Integration Tests, Tag on version bump - Node.js v12'

--- a/tests/mocha-reporter.js
+++ b/tests/mocha-reporter.js
@@ -2,7 +2,19 @@
 
 const path = require('path');
 const disableServerlessStatsRequests = require('@serverless/test/disable-serverless-stats-requests');
+const customResourceZipGenerator = require('../lib/plugins/aws/customResources/generateZip');
 
 disableServerlessStatsRequests(path.resolve(__dirname, '..'));
 
 module.exports = require('@serverless/test/setup/mocha-reporter');
+
+module.exports.deferredRunner.then(runner => {
+  runner.on('suite end', suite => {
+    if (!suite.parent || !suite.parent.root) return;
+
+    // Ensure to reset memoization on custom resource zip generator after each test file run.
+    // Reason is that homedir is automatically cleaned for each test,
+    // therefore eventually built custom resource file is also removed
+    customResourceZipGenerator.cache.clear();
+  });
+});


### PR DESCRIPTION
Addresses two exposed CI issues:

- https://travis-ci.org/serverless/serverless/jobs/623639175
  It's likely caused by fact that for each test file run home dir is cleared, hence once generated `custom-resources.zip` is not available to further tests.
This issues seems to expose occasionally (it probably depends on order in which tests are run).
Ensured that for each test run generation cache is cleared, hence further test runs do not start with assumption that this file was already generated.
- https://travis-ci.org/serverless/serverless/jobs/623639182
It appears that `--no-optional` patch for npm update fails with npm@3. In this case upgrade to npm version that comes with Node.js v8
