### PR TITLE
Test setup improvements

### DIFF
--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -40,7 +40,8 @@ describe('Variables', () => {
     serverless = new Serverless();
   });
 
-  afterEach(() => restoreEnv());
+  const afterCallback = () => restoreEnv();
+  afterEach(afterCallback);
 
   describe('#constructor()', () => {
     it('should attach serverless instance', () => {
@@ -1787,7 +1788,7 @@ module.exports = {
       try {
         fse.ensureSymlinkSync(realFilePath, symlinkPath);
       } catch (error) {
-        skipOnDisabledSymlinksInWindows(error, this);
+        skipOnDisabledSymlinksInWindows(error, this, afterCallback);
         throw error;
       }
       serverless.config.update({ servicePath: tmpDirPath });

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -56,52 +56,50 @@ describe('#addCustomResourceToService()', () => {
     childProcess.execAsync.restore();
   });
 
-  it('should add one IAM role and the custom resources to the service', () => {
-    return expect(
-      BbPromise.all([
-        // add the custom S3 resource
-        addCustomResourceToService(provider, 's3', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: 'arn:aws:s3:::some-bucket',
-            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
-          },
-        ]),
-        // add the custom Cognito User Pool resource
-        addCustomResourceToService(provider, 'cognitoUserPool', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: '*',
-            Action: [
-              'cognito-idp:ListUserPools',
-              'cognito-idp:DescribeUserPool',
-              'cognito-idp:UpdateUserPool',
-            ],
-          },
-        ]),
-        // add the custom Event Bridge resource
-        addCustomResourceToService(provider, 'eventBridge', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: 'arn:aws:events:*:*:rule/some-rule',
-            Action: [
-              'events:PutRule',
-              'events:RemoveTargets',
-              'events:PutTargets',
-              'events:DeleteRule',
-            ],
-          },
-          {
-            Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
-            Effect: 'Allow',
-            Resource: 'arn:aws:events:*:*:event-bus/some-event-bus',
-          },
-        ]),
-      ])
-    ).to.be.fulfilled.then(() => {
+  it('should add one IAM role and the custom resources to the service', () =>
+    BbPromise.all([
+      // add the custom S3 resource
+      addCustomResourceToService(provider, 's3', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::some-bucket',
+          Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+        },
+      ]),
+      // add the custom Cognito User Pool resource
+      addCustomResourceToService(provider, 'cognitoUserPool', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: '*',
+          Action: [
+            'cognito-idp:ListUserPools',
+            'cognito-idp:DescribeUserPool',
+            'cognito-idp:UpdateUserPool',
+          ],
+        },
+      ]),
+      // add the custom Event Bridge resource
+      addCustomResourceToService(provider, 'eventBridge', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:events:*:*:rule/some-rule',
+          Action: [
+            'events:PutRule',
+            'events:RemoveTargets',
+            'events:PutTargets',
+            'events:DeleteRule',
+          ],
+        },
+        {
+          Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:events:*:*:event-bus/some-event-bus',
+        },
+      ]),
+    ]).then(() => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
 
       expect(execAsyncStub).to.have.callCount(1);
@@ -213,57 +211,54 @@ describe('#addCustomResourceToService()', () => {
           Effect: 'Allow',
         },
       ]);
-    });
-  });
+    }));
 
   it('Should not setup new IAM role, when cfnRole is provided', () => {
     const cfnRoleArn = (serverless.service.provider.cfnRole =
       'arn:aws:iam::999999999999:role/some-role');
-    return expect(
-      BbPromise.all([
-        // add the custom S3 resource
-        addCustomResourceToService(provider, 's3', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: 'arn:aws:s3:::some-bucket',
-            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
-          },
-        ]),
-        // add the custom Cognito User Pool resource
-        addCustomResourceToService(provider, 'cognitoUserPool', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: '*',
-            Action: [
-              'cognito-idp:ListUserPools',
-              'cognito-idp:DescribeUserPool',
-              'cognito-idp:UpdateUserPool',
-            ],
-          },
-        ]),
-        // add the custom Event Bridge resource
-        addCustomResourceToService(provider, 'eventBridge', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: 'arn:aws:events:*:*:rule/some-rule',
-            Action: [
-              'events:PutRule',
-              'events:RemoveTargets',
-              'events:PutTargets',
-              'events:DeleteRule',
-            ],
-          },
-          {
-            Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
-            Effect: 'Allow',
-            Resource: 'arn:aws:events:*:*:event-bus/some-event-bus',
-          },
-        ]),
-      ])
-    ).to.be.fulfilled.then(() => {
+    return BbPromise.all([
+      // add the custom S3 resource
+      addCustomResourceToService(provider, 's3', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::some-bucket',
+          Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+        },
+      ]),
+      // add the custom Cognito User Pool resource
+      addCustomResourceToService(provider, 'cognitoUserPool', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: '*',
+          Action: [
+            'cognito-idp:ListUserPools',
+            'cognito-idp:DescribeUserPool',
+            'cognito-idp:UpdateUserPool',
+          ],
+        },
+      ]),
+      // add the custom Event Bridge resource
+      addCustomResourceToService(provider, 'eventBridge', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:events:*:*:rule/some-rule',
+          Action: [
+            'events:PutRule',
+            'events:RemoveTargets',
+            'events:PutTargets',
+            'events:DeleteRule',
+          ],
+        },
+        {
+          Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+          Effect: 'Allow',
+          Resource: 'arn:aws:events:*:*:event-bus/some-event-bus',
+        },
+      ]),
+    ]).then(() => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
       expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
       // S3 Lambda Function
@@ -419,19 +414,17 @@ describe('#addCustomResourceToService()', () => {
 
   it("should ensure function name doesn't extend maximum length", () => {
     serverless.service.service = 'some-unexpectedly-long-service-name';
-    return expect(
-      BbPromise.all([
-        // add the custom S3 resource
-        addCustomResourceToService(provider, 's3', [
-          ...iamRoleStatements,
-          {
-            Effect: 'Allow',
-            Resource: 'arn:aws:s3:::some-bucket',
-            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
-          },
-        ]),
-      ])
-    ).to.be.fulfilled.then(() => {
+    return BbPromise.all([
+      // add the custom S3 resource
+      addCustomResourceToService(provider, 's3', [
+        ...iamRoleStatements,
+        {
+          Effect: 'Allow',
+          Resource: 'arn:aws:s3:::some-bucket',
+          Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
+        },
+      ]),
+    ]).then(() => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
       // S3 Lambda Function
       expect(

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -6,26 +6,12 @@ const expect = require('chai').expect;
 
 chai.use(require('chai-as-promised'));
 
-const runServelessOptions = {
-  pluginPathsWhitelist: ['./lib/plugins/aws/package', './lib/plugins/aws/common'],
-  lifecycleHookNamesWhitelist: [
-    'package:cleanup',
-    'package:initialize',
-    'aws:common:validate:validate',
-  ],
-};
-
 describe('#generateCoreTemplate()', () => {
   it('should reject non-HTTPS requests to the deployment bucket', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: { service: 'irrelevant', provider: 'aws' },
-          cliArgs: ['package'],
-        },
-        runServelessOptions
-      )
-    ).then(serverless => {
+    runServerless({
+      config: { service: 'irrelevant', provider: 'aws' },
+      cliArgs: ['package'],
+    }).then(serverless => {
       const serverlessDeploymentBucketPolicy =
         serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ServerlessDeploymentBucketPolicy;
@@ -67,18 +53,13 @@ describe('#generateCoreTemplate()', () => {
   it('should use a custom bucket if specified', () => {
     const bucketName = 'com.serverless.deploys';
 
-    return runServerless(
-      Object.assign(
-        {
-          config: {
-            service: 'irrelevant',
-            provider: { name: 'aws', deploymentBucket: bucketName },
-          },
-          cliArgs: ['package'],
-        },
-        runServelessOptions
-      )
-    ).then(serverless => {
+    return runServerless({
+      config: {
+        service: 'irrelevant',
+        provider: { name: 'aws', deploymentBucket: bucketName },
+      },
+      cliArgs: ['package'],
+    }).then(serverless => {
       const template = serverless.service.provider.compiledCloudFormationTemplate;
       expect(template.Outputs.ServerlessDeploymentBucketName.Value).to.equal(bucketName);
       expect(template.Resources.ServerlessDeploymentBucket).to.not.exist;
@@ -87,23 +68,18 @@ describe('#generateCoreTemplate()', () => {
   });
 
   it('should enable S3 Block Public Access if specified', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: {
-            service: 'irrelevant',
-            provider: {
-              name: 'aws',
-              deploymentBucketObject: {
-                blockPublicAccess: true,
-              },
-            },
+    runServerless({
+      config: {
+        service: 'irrelevant',
+        provider: {
+          name: 'aws',
+          deploymentBucketObject: {
+            blockPublicAccess: true,
           },
-          cliArgs: ['package'],
         },
-        runServelessOptions
-      )
-    ).then(serverless => {
+      },
+      cliArgs: ['package'],
+    }).then(serverless => {
       expect(
         serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ServerlessDeploymentBucket.Properties
@@ -118,26 +94,21 @@ describe('#generateCoreTemplate()', () => {
     }));
 
   it('should add resource tags to the bucket if present', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: {
-            service: 'irrelevant',
-            provider: {
-              name: 'aws',
-              deploymentBucketObject: {
-                tags: {
-                  FOO: 'bar',
-                  BAZ: 'qux',
-                },
-              },
+    runServerless({
+      config: {
+        service: 'irrelevant',
+        provider: {
+          name: 'aws',
+          deploymentBucketObject: {
+            tags: {
+              FOO: 'bar',
+              BAZ: 'qux',
             },
           },
-          cliArgs: ['package'],
         },
-        runServelessOptions
-      )
-    ).then(serverless => {
+      },
+      cliArgs: ['package'],
+    }).then(serverless => {
       expect(
         serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ServerlessDeploymentBucket
@@ -164,21 +135,16 @@ describe('#generateCoreTemplate()', () => {
   it('should use a custom bucket if specified, even with S3 transfer acceleration', () => {
     const bucketName = 'com.serverless.deploys';
 
-    return runServerless(
-      Object.assign(
-        {
-          config: {
-            service: 'irrelevant',
-            provider: {
-              name: 'aws',
-              deploymentBucket: bucketName,
-            },
-          },
-          cliArgs: ['package', '--aws-s3-accelerate'],
+    return runServerless({
+      config: {
+        service: 'irrelevant',
+        provider: {
+          name: 'aws',
+          deploymentBucket: bucketName,
         },
-        runServelessOptions
-      )
-    ).then(serverless => {
+      },
+      cliArgs: ['package', '--aws-s3-accelerate'],
+    }).then(serverless => {
       const template = serverless.service.provider.compiledCloudFormationTemplate;
       expect(template.Outputs.ServerlessDeploymentBucketName.Value).to.equal(bucketName);
       // eslint-disable-next-line no-unused-expressions
@@ -189,15 +155,10 @@ describe('#generateCoreTemplate()', () => {
   });
 
   it('should use a auto generated bucket if you does not specify deploymentBucket', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: { service: 'irrelevant', provider: 'aws' },
-          cliArgs: ['package'],
-        },
-        runServelessOptions
-      )
-    ).then(serverless => {
+    runServerless({
+      config: { service: 'irrelevant', provider: 'aws' },
+      cliArgs: ['package'],
+    }).then(serverless => {
       expect(
         serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ServerlessDeploymentBucket
@@ -218,30 +179,20 @@ describe('#generateCoreTemplate()', () => {
     }));
 
   it('should add a custom output if S3 Transfer Acceleration is enabled', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: { service: 'irrelevant', provider: 'aws' },
-          cliArgs: ['package', '--aws-s3-accelerate'],
-        },
-        runServelessOptions
-      )
-    ).then(serverless => {
+    runServerless({
+      config: { service: 'irrelevant', provider: 'aws' },
+      cliArgs: ['package', '--aws-s3-accelerate'],
+    }).then(serverless => {
       const template = serverless.service.provider.coreCloudFormationTemplate;
       expect(template.Outputs.ServerlessDeploymentBucketAccelerated).to.not.equal(null);
       expect(template.Outputs.ServerlessDeploymentBucketAccelerated.Value).to.equal(true);
     }));
 
   it('should explicitly disable S3 Transfer Acceleration, if requested', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: { service: 'irrelevant', provider: 'aws' },
-          cliArgs: ['package', '--no-aws-s3-accelerate'],
-        },
-        runServelessOptions
-      )
-    ).then(serverless => {
+    runServerless({
+      config: { service: 'irrelevant', provider: 'aws' },
+      cliArgs: ['package', '--no-aws-s3-accelerate'],
+    }).then(serverless => {
       const template = serverless.service.provider.coreCloudFormationTemplate;
       expect(template.Resources.ServerlessDeploymentBucket).to.be.deep.equal({
         Type: 'AWS::S3::Bucket',
@@ -263,15 +214,10 @@ describe('#generateCoreTemplate()', () => {
     }));
 
   it('should exclude AccelerateConfiguration for govcloud region', () =>
-    runServerless(
-      Object.assign(
-        {
-          config: { service: 'irrelevant', provider: { name: 'aws', region: 'us-gov-west-1' } },
-          cliArgs: ['package', '--no-aws-s3-accelerate'],
-        },
-        runServelessOptions
-      )
-    ).then(serverless => {
+    runServerless({
+      config: { service: 'irrelevant', provider: { name: 'aws', region: 'us-gov-west-1' } },
+      cliArgs: ['package', '--no-aws-s3-accelerate'],
+    }).then(serverless => {
       const template = serverless.service.provider.coreCloudFormationTemplate;
       expect(template.Resources.ServerlessDeploymentBucket).to.be.deep.equal({
         Type: 'AWS::S3::Bucket',

--- a/lib/plugins/config/config.test.js
+++ b/lib/plugins/config/config.test.js
@@ -20,24 +20,18 @@ describe('Config', () => {
     runServerless({
       config: { service: 'foo', provider: 'aws' },
       cliArgs: ['config', 'credentials', '--provider', 'aws', '-k', 'foo', '-s', 'bar'],
-      pluginPathsWhitelist: ['./lib/plugins/config/config'],
-      lifecycleHookNamesWhitelist: ['before:config:credentials:config'],
     }));
 
   it('should have a required option "provider" for the "credentials" sub-command', () =>
     runServerless({
       config: { service: 'foo', provider: 'aws' },
       cliArgs: ['config', 'credentials', '-k', 'foo', '-s', 'bar'],
-      pluginPathsWhitelist: ['./lib/plugins/config/config'],
-      lifecycleHookNamesWhitelist: ['before:config:credentials:config'],
     }).then(unexpected, error => expect(error).to.be.instanceof(ServerlessError)));
 
   it('should throw an error if user passed unsupported "provider" option', () =>
     runServerless({
       config: { service: 'foo', provider: 'aws' },
       cliArgs: ['config', 'credentials', '--provider', 'not-supported', '-k', 'foo', '-s', 'bar'],
-      pluginPathsWhitelist: ['./lib/plugins/config/config'],
-      lifecycleHookNamesWhitelist: ['before:config:credentials:config'],
     }).then(unexpected, error => expect(error).to.be.instanceof(ServerlessError)));
 
   if (isTabCompletionSupported) {
@@ -46,8 +40,6 @@ describe('Config', () => {
         cwd: os.homedir(),
         env: { SHELL: 'bash' },
         cliArgs: ['config', 'tabcompletion', 'install'],
-        pluginPathsWhitelist: ['./lib/plugins/config/config'],
-        lifecycleHookNamesWhitelist: ['config:tabcompletion:install:install'],
       }).then(() =>
         Promise.all([
           fs
@@ -66,15 +58,11 @@ describe('Config', () => {
         cwd: os.homedir(),
         env: { SHELL: 'bash' },
         cliArgs: ['config', 'tabcompletion', 'install'],
-        pluginPathsWhitelist: ['./lib/plugins/config/config'],
-        lifecycleHookNamesWhitelist: ['config:tabcompletion:install:install'],
       }).then(() =>
         runServerless({
           cwd: os.homedir(),
           env: { SHELL: 'bash' },
           cliArgs: ['config', 'tabcompletion', 'uninstall'],
-          pluginPathsWhitelist: ['./lib/plugins/config/config'],
-          lifecycleHookNamesWhitelist: ['config:tabcompletion:uninstall:uninstall'],
         }).then(() =>
           Promise.all([
             fs

--- a/lib/plugins/interactiveCli/initializeService.test.js
+++ b/lib/plugins/interactiveCli/initializeService.test.js
@@ -10,6 +10,11 @@ const inquirer = require('./inquirer');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 
 const fixturesPath = join(__dirname, 'test/fixtures');
+const lifecycleHookNamesBlacklist = [
+  'before:interactiveCli:setupAws',
+  'interactiveCli:setupAws',
+  'interactiveCli:tabCompletion',
+];
 
 describe('interactiveCli: initializeService', () => {
   const existingProjectName = 'some-other-service';
@@ -28,8 +33,7 @@ describe('interactiveCli: initializeService', () => {
   it('Should be ineffective, when at service path', () =>
     runServerless({
       cwd: join(fixturesPath, 'some-other-service'),
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:initializeService'],
+      lifecycleHookNamesBlacklist,
     }));
 
   it("Should abort if user doesn't want setup", () => {
@@ -39,7 +43,7 @@ describe('interactiveCli: initializeService', () => {
     return runServerless({
       cwd: fixturesPath,
       pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:initializeService'],
+      lifecycleHookNamesBlacklist,
     });
   });
 
@@ -51,7 +55,7 @@ describe('interactiveCli: initializeService', () => {
     return runServerless({
       cwd: fixturesPath,
       pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:initializeService'],
+      lifecycleHookNamesBlacklist,
     });
   });
 
@@ -67,7 +71,7 @@ describe('interactiveCli: initializeService', () => {
       return runServerless({
         cwd: fixturesPath,
         pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:initializeService'],
+        lifecycleHookNamesBlacklist,
       })
         .then(() => lstat(join(newProjectPath, 'serverless.yml')))
         .then(stats => expect(stats.isFile()).to.be.true);
@@ -83,7 +87,7 @@ describe('interactiveCli: initializeService', () => {
     return runServerless({
       cwd: fixturesPath,
       pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:initializeService'],
+      lifecycleHookNamesBlacklist,
     }).then(
       () => {
         throw new Error('Unexpected');
@@ -101,7 +105,7 @@ describe('interactiveCli: initializeService', () => {
     return runServerless({
       cwd: fixturesPath,
       pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:initializeService'],
+      lifecycleHookNamesBlacklist,
     }).then(
       () => {
         throw new Error('Unexpected');

--- a/lib/plugins/interactiveCli/setupAws.test.js
+++ b/lib/plugins/interactiveCli/setupAws.test.js
@@ -16,6 +16,11 @@ const configureInquirerStub = require('@serverless/test/configure-inquirer-stub'
 const runServerless = require('../../../tests/utils/run-serverless');
 
 const fixturesPath = join(__dirname, 'test/fixtures');
+const lifecycleHookNamesBlacklist = [
+  'before:interactiveCli:setupAws',
+  'interactiveCli:initializeService',
+  'interactiveCli:tabCompletion',
+];
 
 const openBrowserUrls = [];
 const modulesCacheStub = {
@@ -47,31 +52,27 @@ describe('interactiveCli: setupAws', () => {
   it('Should be ineffective, when not at service path', () =>
     runServerless({
       cwd: fixturesPath,
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+      lifecycleHookNamesBlacklist,
     }));
 
   it('Should be ineffective, when not at AWS service', () =>
     runServerless({
       cwd: join(fixturesPath, 'some-other-service'),
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+      lifecycleHookNamesBlacklist,
     }));
 
   it('Should be ineffective, when credentials are set in environment', () =>
     runServerless({
       cwd: awsProjectPath,
       env: { AWS_ACCESS_KEY_ID: accessKeyId, AWS_SECRET_ACCESS_KEY: secretAccessKey },
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+      lifecycleHookNamesBlacklist,
     }));
 
   it("Should not setup if user doesn't the setup", () => {
     configureInquirerStub(inquirer, { confirm: { shouldSetupAwsCredentials: false } });
     return runServerless({
       cwd: awsProjectPath,
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+      lifecycleHookNamesBlacklist,
     });
   });
 
@@ -110,8 +111,7 @@ describe('interactiveCli: setupAws', () => {
       it('Should be ineffective, When credentials are set in AWS config', () =>
         runServerless({
           cwd: awsProjectPath,
-          pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-          lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+          lifecycleHookNamesBlacklist,
         }));
     });
 
@@ -127,8 +127,7 @@ describe('interactiveCli: setupAws', () => {
       });
       return runServerless({
         cwd: awsProjectPath,
-        pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+        lifecycleHookNamesBlacklist,
         modulesCacheStub,
       }).then(() => {
         expect(openBrowserUrls.length).to.equal(2);
@@ -147,8 +146,7 @@ describe('interactiveCli: setupAws', () => {
       });
       return runServerless({
         cwd: awsProjectPath,
-        pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+        lifecycleHookNamesBlacklist,
         modulesCacheStub,
       }).then(() => {
         expect(openBrowserUrls.length).to.equal(1);
@@ -166,8 +164,7 @@ describe('interactiveCli: setupAws', () => {
       });
       return runServerless({
         cwd: awsProjectPath,
-        pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+        lifecycleHookNamesBlacklist,
         modulesCacheStub,
       }).then(
         () => {
@@ -184,8 +181,7 @@ describe('interactiveCli: setupAws', () => {
       });
       return runServerless({
         cwd: awsProjectPath,
-        pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:setupAws'],
+        lifecycleHookNamesBlacklist,
         modulesCacheStub,
       }).then(
         () => {

--- a/lib/plugins/interactiveCli/tabCompletion.test.js
+++ b/lib/plugins/interactiveCli/tabCompletion.test.js
@@ -14,6 +14,12 @@ const promptDisabledConfigPropertyName = require('../../utils/tabCompletion/prom
 const isTabCompletionSupported = require('../../utils/tabCompletion/isSupported');
 const inquirer = require('./inquirer');
 
+const lifecycleHookNamesBlacklist = [
+  'before:interactiveCli:setupAws',
+  'interactiveCli:initializeService',
+  'interactiveCli:setupAws',
+];
+
 BbPromise.promisifyAll(fs);
 
 describe('interactiveCli: tabCompletion', () => {
@@ -36,8 +42,7 @@ describe('interactiveCli: tabCompletion', () => {
     it('Should not suggest tab completion setup in non supported environments', () => {
       return runServerless({
         cwd: os.homedir(),
-        pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:tabCompletion'],
+        lifecycleHookNamesBlacklist,
       });
     });
     return;
@@ -49,8 +54,7 @@ describe('interactiveCli: tabCompletion', () => {
     });
     return runServerless({
       cwd: os.homedir(),
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:tabCompletion'],
+      lifecycleHookNamesBlacklist,
     });
   });
 
@@ -60,14 +64,12 @@ describe('interactiveCli: tabCompletion', () => {
     });
     return runServerless({
       cwd: os.homedir(),
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:tabCompletion'],
+      lifecycleHookNamesBlacklist,
     }).then(() => {
       inquirer.prompt.restore();
       return runServerless({
         cwd: os.homedir(),
-        pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-        lifecycleHookNamesWhitelist: ['interactiveCli:tabCompletion'],
+        lifecycleHookNamesBlacklist,
       });
     });
   });
@@ -80,8 +82,7 @@ describe('interactiveCli: tabCompletion', () => {
     return runServerless({
       cwd: os.homedir(),
       env: { SHELL: 'bash' },
-      pluginPathsWhitelist: ['./lib/plugins/interactiveCli'],
-      lifecycleHookNamesWhitelist: ['interactiveCli:tabCompletion'],
+      lifecycleHookNamesBlacklist,
     }).then(() =>
       Promise.all([
         fs

--- a/lib/utils/fs/copyDirContentsSync.test.js
+++ b/lib/utils/fs/copyDirContentsSync.test.js
@@ -10,10 +10,11 @@ const writeFileSync = require('./writeFileSync');
 const skipOnDisabledSymlinksInWindows = require('@serverless/test/skip-on-disabled-symlinks-in-windows');
 
 describe('#copyDirContentsSync()', () => {
-  afterEach(() => {
+  const afterCallback = () => {
     removeFileSync(path.join(process.cwd(), 'testSrc'));
     removeFileSync(path.join(process.cwd(), 'testDest'));
-  });
+  };
+  afterEach(afterCallback);
 
   it('should recursively copy directory files including symbolic links', function() {
     const tmpSrcDirPath = path.join(process.cwd(), 'testSrc');
@@ -32,7 +33,7 @@ describe('#copyDirContentsSync()', () => {
     try {
       fs.symlinkSync(srcFile2, srcFile3);
     } catch (error) {
-      skipOnDisabledSymlinksInWindows(error, this);
+      skipOnDisabledSymlinksInWindows(error, this, afterCallback);
       throw error;
     }
 
@@ -60,7 +61,7 @@ describe('#copyDirContentsSync()', () => {
     try {
       fs.symlinkSync(srcFile2, srcFile3);
     } catch (error) {
-      skipOnDisabledSymlinksInWindows(error, this);
+      skipOnDisabledSymlinksInWindows(error, this, afterCallback);
       throw error;
     }
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^1.2.1",
-    "@serverless/test": "^2.5.0",
+    "@serverless/test": "^3.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "child-process-ext": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
       "@serverless/test/setup/async-leaks-detector",
       "@serverless/test/setup/async-leaks-detector/bluebird-patch",
       "@serverless/test/setup/mock-homedir",
-      "@serverless/test/setup/restore-cwd"
+      "@serverless/test/setup/restore-cwd",
+      "@serverless/test/setup/restore-env"
     ],
     "timeout": 15000
   },
@@ -116,7 +117,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^1.2.1",
-    "@serverless/test": "^3.0.0",
+    "@serverless/test": "^3.1.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "child-process-ext": "^2.1.0",


### PR DESCRIPTION
- Improve error information in case of a test fail in custom resource tests
- Upgrade to `@serverless/test` v3 - it replaced _whitelist_ approach with _blacklist_ which makes test configured with `runServerless` more reliable, and also makes tests configuration significantly easier (diff nicely confirms on that)
- Ensure to pass _after_ callbacks to dynamic skip conditionals. Not doing that, resulted with `process.env` being altered for further test file runs, which most likely was responsible for some CI fails as: https://travis-ci.org/serverless/serverless/jobs/623668512 (observed mostly on Windows)
- Ensure to start each test file run with `process.env` being at state in which it was before any tests were run. Thanks to that any uncleaned `process.env` modifications will not affect any further test file runs.