### PR TITLE
Allow use of Ref, Fn::GetAtt and Fn::ImportValue in awsKmsKeyArn

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -292,8 +292,13 @@ class AwsCompileFunctions {
             const errorMessage = 'awsKmsKeyArn config must be a KMS key arn';
             throw new this.serverless.classes.Error(errorMessage);
           }
+        } else if (this.isArnRefGetAttOrImportValue(arn)) {
+          newFunction.Properties.KmsKeyArn = arn;
         } else {
-          const errorMessage = 'awsKmsKeyArn config must be provided as a string';
+          const errorMessage = [
+            'awsKmsKeyArn config must be provided as an arn string,',
+            ' Ref, Fn::GetAtt or Fn::ImportValue',
+          ].join('');
           throw new this.serverless.classes.Error(errorMessage);
         }
       }

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -1085,11 +1085,122 @@ describe('AwsCompileFunctions', () => {
         };
 
         return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(
-          'provided as a string'
+          'provided as an arn string'
         );
       });
 
-      it('should reject if config is provided as an object', () => {
+      it('should allow if config is provided as a Fn::GetAtt', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsKmsKeyArn: {
+              'Fn::GetAtt': ['MyKms', 'Arn'],
+            },
+          },
+        };
+
+        const compiledFunction = {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              S3Key: 'somedir/new-service.zip',
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs12.x',
+            Timeout: 6,
+            KmsKeyArn: { 'Fn::GetAtt': ['MyKms', 'Arn'] },
+          },
+          DependsOn: ['FuncLogGroup', 'IamRoleLambdaExecution'],
+        };
+
+        return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
+          const compiledCfTemplate =
+            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate;
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
+      });
+
+      it('should allow if config is provided as a Ref', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsKmsKeyArn: {
+              Ref: 'foobar',
+            },
+          },
+        };
+
+        const compiledFunction = {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              S3Key: 'somedir/new-service.zip',
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs12.x',
+            Timeout: 6,
+            KmsKeyArn: { Ref: 'foobar' },
+          },
+          DependsOn: ['FuncLogGroup', 'IamRoleLambdaExecution'],
+        };
+
+        return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
+          const compiledCfTemplate =
+            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate;
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
+      });
+
+      it('should allow if config is provided as a Fn::ImportValue', () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'func.function.handler',
+            name: 'new-service-dev-func',
+            awsKmsKeyArn: {
+              'Fn::ImportValue': 'KmsKey',
+            },
+          },
+        };
+
+        const compiledFunction = {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+              S3Key: 'somedir/new-service.zip',
+            },
+            FunctionName: 'new-service-dev-func',
+            Handler: 'func.function.handler',
+            MemorySize: 1024,
+            Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
+            Runtime: 'nodejs12.x',
+            Timeout: 6,
+            KmsKeyArn: { 'Fn::ImportValue': 'KmsKey' },
+          },
+          DependsOn: ['FuncLogGroup', 'IamRoleLambdaExecution'],
+        };
+
+        return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
+          const compiledCfTemplate =
+            awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate;
+          const functionResource = compiledCfTemplate.Resources.FuncLambdaFunction;
+          expect(functionResource).to.deep.equal(compiledFunction);
+        });
+      });
+
+      it('should reject if config is provided as an invalid object', () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'func.function.handler',
@@ -1101,7 +1212,7 @@ describe('AwsCompileFunctions', () => {
         };
 
         return expect(awsCompileFunctions.compileFunctions()).to.be.rejectedWith(
-          'provided as a string'
+          'provided as an arn string'
         );
       });
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

Allows to use Ref, Fn::GetAtt or Fn::ImportValue in awsKmsKeyArn config.

My first PR to this project so not sure how good approach this is but tried to mimic stuff that already exists. 

I'm mainly interested in Fn:GetAtt and Fn::ImportValue in my own project but used the ready-made function which now also supports the Ref. Not sure if needed here?

Modified error message a bit and added a couple of simple test cases. 
<!-- Briefly describe the scope of your PR -->

Closes https://github.com/serverless/serverless/issues/7057
## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

```
service:
  name: test-service
  awsKmsKeyArn: !GetAtt ['MyKmsKey', 'Arn']

resources:
  Resources:
    CustomKmsKey:
      Type: "AWS::KMS::Key"
      Properties:
        KeyPolicy:
          Version: "2012-10-17"
          Id: "CustomKmsKey"
          Statement:
            - Sid: "Enable IAM User Permissions"
              Effect: "Allow"
              Principal:
                AWS: <aws account_id>
              Action:
                - "kms:*"
              Resource: "*"

```


## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ X ] Write and run all tests
- [ ] Write documentation
- [ X ] Enable "Allow edits from maintainers" for this PR
- [ X ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
