### PR TITLE
Fix AWS partition reference in APIGW CloudWatch role setup

### DIFF
--- a/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.js
+++ b/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.js
@@ -30,7 +30,10 @@ module.exports = memoize(provider =>
       {
         Effect: 'Allow',
         Resource: {
-          'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWS::AccountId' }, 'role/*']],
+          'Fn::Join': [
+            ':',
+            ['arn', { Ref: 'AWS::Partition' }, 'iam:', { Ref: 'AWS::AccountId' }, 'role/*'],
+          ],
         },
         Action: [
           'iam:AttachRolePolicy',
@@ -41,7 +44,9 @@ module.exports = memoize(provider =>
       },
       {
         Effect: 'Allow',
-        Resource: 'arn:aws:apigateway:*::/account',
+        Resource: {
+          'Fn::Join': [':', ['arn', { Ref: 'AWS::Partition' }, 'apigateway:*::/account']],
+        },
         Action: ['apigateway:GET', 'apigateway:PATCH'],
       },
     ]);


### PR DESCRIPTION
Addresses issue mentioned in #7100

Run all integration tests (including those that involve creation of APIGW logs) to confirm it doesn't break anything by accident