### PR TITLE
Add BisectBatchOnFunctionError option for Dynamo and Kinesis event sourcing

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -110,6 +110,26 @@ functions:
           batchWindow: 10
 ```
 
+## Setting the BisectBatchOnFunctionError
+
+This configuration provides the ability to recursively split a failed batch and retry on a smaller subset of records, eventually isolating the metadata causing the error.
+
+**Note:** Serverless only sets this property if you explicitly add it to the stream configuration (see example below).
+
+[Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-bisectbatchonfunctionerror)
+
+**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - stream:
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+          bisectBatchOnFunctionError: true
+```
+
 ## Setting the MaximumRetryAttempts
 
 This configuration sets up the maximum number of times to retry when the function returns an error.

--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -110,7 +110,7 @@ functions:
           batchWindow: 10
 ```
 
-## Setting the BisectBatchOnFunctionError
+## Setting BisectBatchOnFunctionError
 
 This configuration provides the ability to recursively split a failed batch and retry on a smaller subset of records, eventually isolating the metadata causing the error.
 

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -204,8 +204,7 @@ class AwsCompileStreamEvents {
             }
 
             if (event.stream.bisectBatchOnFunctionError) {
-              streamResource.Properties.BisectBatchOnFunctionError =
-                event.stream.bisectBatchOnFunctionError;
+              streamResource.Properties.BisectBatchOnFunctionError = true;
             }
 
             const newStreamObject = {

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -204,7 +204,8 @@ class AwsCompileStreamEvents {
             }
 
             if (event.stream.bisectBatchOnFunctionError) {
-              streamResource.Properties.BisectBatchOnFunctionError = event.stream.bisectBatchOnFunctionError;
+              streamResource.Properties.BisectBatchOnFunctionError =
+                event.stream.bisectBatchOnFunctionError;
             }
 
             const newStreamObject = {

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -203,6 +203,10 @@ class AwsCompileStreamEvents {
               streamResource.Properties.MaximumRetryAttempts = event.stream.maximumRetryAttempts;
             }
 
+            if (event.stream.bisectBatchOnFunctionError) {
+              streamResource.Properties.BisectBatchOnFunctionError = event.stream.bisectBatchOnFunctionError;
+            }
+
             const newStreamObject = {
               [streamLogicalId]: streamResource,
             };

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -481,6 +481,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.Enabled
         ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBaz.Properties.BisectBatchOnFunctionError
+        ).to.equal(undefined);
 
         // event 4
         expect(
@@ -898,6 +902,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.Enabled
         ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBaz.Properties.BisectBatchOnFunctionError
+        ).to.equal(undefined);
 
         // event 4
         expect(

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -382,8 +382,8 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: {
                   arn: 'arn:aws:dynamodb:region:account:table/buzz/stream/4',
-                  bisectBatchOnFunctionError: true
-                }
+                  bisectBatchOnFunctionError: true,
+                },
               },
             ],
           },
@@ -792,8 +792,8 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/buzz',
-                  bisectBatchOnFunctionError: true
-                }
+                  bisectBatchOnFunctionError: true,
+                },
               },
             ],
           },
@@ -917,7 +917,8 @@ describe('AwsCompileStreamEvents', () => {
             .Resources.FirstEventSourceMappingKinesisBuzz.DependsOn
         ).to.equal('IamRoleLambdaExecution');
         expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBuzz.Properties.EventSourceArn
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.EventSourceArn
         ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[3].stream.arn);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -379,6 +379,12 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: 'arn:aws:dynamodb:region:account:table/baz/stream/3',
               },
+              {
+                stream: {
+                  arn: 'arn:aws:dynamodb:region:account:table/buzz/stream/4',
+                  bisectBatchOnFunctionError: true
+                }
+              },
             ],
           },
         };
@@ -475,6 +481,36 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.Enabled
         ).to.equal('True');
+
+        // event 4
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Type
+        ).to.equal('AWS::Lambda::EventSourceMapping');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.DependsOn
+        ).to.equal('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.EventSourceArn
+        ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[3].stream.arn);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.BatchSize
+        ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.StartingPosition
+        ).to.equal('TRIM_HORIZON');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.Enabled
+        ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.BisectBatchOnFunctionError
+        ).to.equal(true);
       });
 
       it('should allow specifying DynamoDB and Kinesis streams as CFN reference types', () => {
@@ -749,6 +785,12 @@ describe('AwsCompileStreamEvents', () => {
               {
                 stream: 'arn:aws:kinesis:region:account:stream/baz',
               },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/buzz',
+                  bisectBatchOnFunctionError: true
+                }
+              },
             ],
           },
         };
@@ -856,6 +898,39 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.Enabled
         ).to.equal('True');
+
+        // event 4
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Type
+        ).to.equal('AWS::Lambda::EventSourceMapping');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.DependsOn
+        ).to.equal('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources.FirstEventSourceMappingKinesisBuzz.Properties.EventSourceArn
+        ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[3].stream.arn);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.BatchSize
+        ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.ParallelizationFactor
+        ).to.equal(undefined);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.StartingPosition
+        ).to.equal('TRIM_HORIZON');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.Enabled
+        ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.BisectBatchOnFunctionError
+        ).to.equal(true);
       });
 
       it('should add the necessary IAM role statements', () => {


### PR DESCRIPTION
What did you implement

Add the ability to configure the BisectBatchOnFunctionError feature for failure handling on Kinesis and DynamoDB streams.

<!-- Briefly describe the scope of your PR -->

Closes #7041 

## How can we verify it

Sample serverless.yml:

```yml
functions:
  preprocess:
    handler: handler.preprocess
    events:
      - stream:
          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
          bisectBatchOnFunctionError: true
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
