### PR TITLE
Binary installer improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,8 +166,7 @@ jobs:
           tagName=`git diff HEAD^ package.json | grep '"version": "' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
           if [ -n "$tagName" ]
           then
-            git tag v$tagName
-            if git push https://$GITHUB_TOKEN@github.com/serverless/serverless --tags
+            if git tag v$tagName && git push https://$GITHUB_TOKEN@github.com/serverless/serverless --tags
             then
               if [ $TRAVIS_BRANCH = master ]
               then

--- a/.travis.yml
+++ b/.travis.yml
@@ -210,7 +210,7 @@ jobs:
             travis_terminate 1
           fi
         - npx github-release-from-cc-changelog $TRAVIS_TAG
-        - npm run pkg:upload
+        - npm run pkg:upload -- $TRAVIS_TAG
       deploy:
         provider: npm
         email: services@serverless.com

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
-    'scope-enum': [2, 'always', ['']],
+    'scope-enum': [2, 'always', ['', 'Binary Installer']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/scripts/pkg/build.js
+++ b/scripts/pkg/build.js
@@ -23,7 +23,7 @@ const spawnOptions = { cwd: serverlessPath, stdio: 'inherit' };
   // It's due to fact that npm tends to issue buggy releases
   // Node.js confirms on given version before including it within its bundle
   // Version mappings reference: https://nodejs.org/en/download/releases/
-  await spawn('npm', ['install', '--no-save', 'npm@6.12.1'], spawnOptions);
+  await spawn('npm', ['install', '--no-save', 'npm@6.13.4'], spawnOptions);
 
   try {
     process.stdout.write('Build binaries\n');


### PR DESCRIPTION
- Ensure upload of binaries to GitHub release (with missing tag, it didn't happen, I've already fixed it manually for v1.60.0
- Ensure to bundle binary with latest stable npm (as validated by Node.js)

Additionally fixed CI fail observed here: https://travis-ci.org/serverless/serverless/jobs/626651988
(It appears that tags for taken commits are visible in trimmed repository, and failed happened in a command which was not secured to ignore it)
