### PR TITLE
Ensure no same object instances are shared across config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
-    'scope-enum': [2, 'always', ['', 'Binary Installer']],
+    'scope-enum': [2, 'always', ['', 'Binary Installer', 'Variables']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -10,6 +10,8 @@ const fse = require('../utils/fs/fse');
 const logWarning = require('./Error').logWarning;
 const PromiseTracker = require('./PromiseTracker');
 
+const resolvedValuesWeak = new WeakSet();
+
 /**
  * Maintainer's notes:
  *
@@ -576,7 +578,18 @@ class Variables {
       }
       ret = this.tracker.add(variableString, ret, propertyString);
     }
-    return ret;
+    return ret.then(resolvedValue => {
+      if (!Array.isArray(resolvedValue) && !_.isPlainObject(resolvedValue)) return resolvedValue;
+      if (resolvedValuesWeak.has(resolvedValue)) {
+        try {
+          return _.cloneDeep(resolvedValue);
+        } catch (error) {
+          return resolvedValue;
+        }
+      }
+      resolvedValuesWeak.add(resolvedValue);
+      return resolvedValue;
+    });
   }
 
   getValueFromSls(variableString) {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -226,6 +226,33 @@ describe('Variables', () => {
       });
     });
 
+    describe('ensure unique instances', () => {
+      it('should not produce same instances for same variable patters used more than once', () => {
+        serverless.variables.service.custom = {
+          settings1: '${file(~/config.yml)}',
+          settings2: '${file(~/config.yml)}',
+        };
+
+        const fileExistsStub = sinon.stub(serverless.utils, 'fileExistsSync').returns(true);
+        const realpathSync = sinon.stub(fse, 'realpathSync').returns(`${os.homedir()}/config.yml`);
+        const readFileSyncStub = sinon.stub(serverless.utils, 'readFileSync').returns({
+          test: 1,
+          test2: 'test2',
+        });
+
+        return serverless.variables
+          .populateService()
+          .should.be.fulfilled.then(result => {
+            expect(result.custom.settings1).to.not.equal(result.custom.settings2);
+          })
+          .finally(() => {
+            fileExistsStub.restore();
+            realpathSync.restore();
+            readFileSyncStub.restore();
+          });
+      });
+    });
+
     describe('aws-specific syntax', () => {
       let awsProvider;
       let requestStub;


### PR DESCRIPTION
Fixes #7098

When same variable declarations are used across configuration, the config ended with same shared instances of resolved object.

It affected situation where some normalization were made directly on resolved objects.

This patch ensures no duplicate instances are shared across config.