### PR TITLE
Add support for VPC Endpoint associations in AWS

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -15,6 +15,7 @@ module.exports = {
     this.apiGatewayRestApiLogicalId = this.provider.naming.getRestApiLogicalId();
 
     let endpointType = 'EDGE';
+    let endpointVpcIds = ''
     let BinaryMediaTypes;
     if (apiGateway.binaryMediaTypes) {
       BinaryMediaTypes = apiGateway.binaryMediaTypes;
@@ -36,6 +37,14 @@ module.exports = {
       }
       endpointType = endpointType.toUpperCase();
     }
+    
+    if (this.serverless.service.provider.endpointVpcIds) {
+      endpointVpcIds = this.serverless.service.provider.endpointVpcIds;
+
+      if (typeof endpointVpcIds !== 'string') {
+        throw new this.serverless.classes.Error('endpointVpcIds must be a string');
+      }
+    }
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.apiGatewayRestApiLogicalId]: {
@@ -45,6 +54,7 @@ module.exports = {
           BinaryMediaTypes,
           EndpointConfiguration: {
             Types: [endpointType],
+            VpcEndpointIds: [endpointVpcIds],
           },
         },
       },


### PR DESCRIPTION
## What did you implement

Amazon API Gateway support associating your API with an interface VPC endpoint. This is supported in cloudformation via EndpointConfiguration. Associating your API with the VPCE creates a custom DNS alias which allows you to access your private gateway through the VPCE without the need of a Host header, which is necessary in certain situations, particularly if you want to make ajax calls to your private API from a browser.

Closes #6715

## How can we verify it

`service: api-private-test

frameworkVersion: '>=1.1.0 <2.0.0'

provider:
  name: aws
  runtime: nodejs10.x
  stage: ${env:AWS_ENV}
  region: ${env:AWS_DEFAULT_REGION}
  timeout: 30 # Timeout for this function call
  memorySize: 128 # Max Memory for execution
  endpointType: PRIVATE
  endpointVpcIds: vpce-0250d95e899edfa1b
  resourcePolicy:
    - Effect: Allow
      Principal: '*'
      Action: execute-api:Invoke
      Resource:
        - execute-api:/*/*/*
      Condition:
        IpAddress:
          aws:SourceIp:
            - '123.123.123.123'

functions:
  currentTime:
    handler: handler.endpoint
    events:
      - http:
          path: ping
          method: get
`

## Todos

<details>
<summary>Useful Scripts</summary>

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
