### PR TITLE
Integration tests: Recover from retryable errors

### DIFF
--- a/lib/plugins/aws/customResources/generateZip.js
+++ b/lib/plugins/aws/customResources/generateZip.js
@@ -12,15 +12,16 @@ const createZipFile = require('../../../utils/fs/createZipFile');
 const npmCommandDeferred = require('../../../utils/npm-command-deferred');
 
 const srcDirPath = path.join(__dirname, 'resources');
-const cachedZipFilePath = path.join(
-  os.homedir(),
-  '.serverless/cache/custom-resources',
-  version,
-  'custom-resources.zip'
-);
 
-module.exports = memoize(() =>
-  fse
+module.exports = memoize(() => {
+  const cachedZipFilePath = path.join(
+    os.homedir(),
+    '.serverless/cache/custom-resources',
+    version,
+    'custom-resources.zip'
+  );
+
+  return fse
     .lstatAsync(cachedZipFilePath)
     .then(
       stats => {
@@ -43,7 +44,5 @@ module.exports = memoize(() =>
         .then(() => ensureCachedDirDeferred)
         .then(() => createZipFile(tmpDirPath, cachedZipFilePath))
         .then(() => cachedZipFilePath);
-    })
-);
-
-module.exports.cachedZipFilePath = cachedZipFilePath;
+    });
+});

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -2,7 +2,6 @@
 
 /* eslint-disable no-unused-expressions */
 
-const fs = require('fs');
 const chai = require('chai');
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
@@ -12,7 +11,6 @@ const CLI = require('../../../classes/CLI');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const { createTmpDir } = require('../../../../tests/utils/fs');
 const { addCustomResourceToService } = require('./index.js');
-const customResourcesZipFilePath = require('./generateZip').cachedZipFilePath;
 
 const expect = chai.expect;
 chai.use(require('sinon-chai'));
@@ -103,7 +101,6 @@ describe('#addCustomResourceToService()', () => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
 
       expect(execAsyncStub).to.have.callCount(1);
-      expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
       // S3 Lambda Function
       expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction).to.deep.equal({
         Type: 'AWS::Lambda::Function',
@@ -260,7 +257,6 @@ describe('#addCustomResourceToService()', () => {
       ]),
     ]).then(() => {
       const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
-      expect(fs.existsSync(customResourcesZipFilePath)).to.equal(true);
       // S3 Lambda Function
       expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction).to.deep.equal({
         Type: 'AWS::Lambda::Function',

--- a/tests/integration-all/api-gateway/tests.js
+++ b/tests/integration-all/api-gateway/tests.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const path = require('path');
-const AWS = require('aws-sdk');
 const _ = require('lodash');
 const { expect } = require('chai');
 const log = require('log').get('serverless:test');
 
 const { getTmpDirPath, readYamlFile, writeYamlFile } = require('../../utils/fs');
-const { region, confirmCloudWatchLogs } = require('../../utils/misc');
+const { confirmCloudWatchLogs, awsRequest } = require('../../utils/misc');
 const {
   createTestService,
   deployService,
@@ -15,8 +14,6 @@ const {
   fetch,
 } = require('../../utils/integration');
 const { createRestApi, deleteRestApi, getResources } = require('../../utils/api-gateway');
-
-const CF = new AWS.CloudFormation({ region });
 
 describe('AWS - API Gateway Integration Test', function() {
   this.timeout(1000 * 60 * 10); // Involves time-taking deploys
@@ -31,7 +28,7 @@ describe('AWS - API Gateway Integration Test', function() {
   const stage = 'dev';
 
   const resolveEndpoint = async () => {
-    const result = await CF.describeStacks({ StackName: stackName }).promise();
+    const result = await awsRequest('CloudFormation', 'describeStacks', { StackName: stackName });
     const endpointOutput = _.find(result.Stacks[0].Outputs, { OutputKey: 'ServiceEndpoint' })
       .OutputValue;
     endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];

--- a/tests/integration-all/websocket/tests.js
+++ b/tests/integration-all/websocket/tests.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const path = require('path');
-const AWS = require('aws-sdk');
 const WebSocket = require('ws');
 const _ = require('lodash');
 const { expect } = require('chai');
 
 const { getTmpDirPath, readYamlFile, writeYamlFile } = require('../../utils/fs');
-const { region, confirmCloudWatchLogs, wait } = require('../../utils/misc');
+const { awsRequest, confirmCloudWatchLogs, wait } = require('../../utils/misc');
 const { createTestService, deployService, removeService } = require('../../utils/integration');
 const {
   createApi,
@@ -16,8 +15,6 @@ const {
   createStage,
   deleteStage,
 } = require('../../utils/websocket');
-
-const CF = new AWS.CloudFormation({ region });
 
 describe('AWS - API Gateway Websocket Integration Test', function() {
   this.timeout(1000 * 60 * 10); // Involves time-taking deploys
@@ -47,7 +44,7 @@ describe('AWS - API Gateway Websocket Integration Test', function() {
 
   describe('Minimal Setup', () => {
     it('should expose an accessible websocket endpoint', async () => {
-      const result = await CF.describeStacks({ StackName: stackName }).promise();
+      const result = await awsRequest('CloudFormation', 'describeStacks', { StackName: stackName });
       const webSocketServerUrl = _.find(result.Stacks[0].Outputs, {
         OutputKey: 'ServiceEndpointWebsocket',
       }).OutputValue;

--- a/tests/utils/api-gateway/index.js
+++ b/tests/utils/api-gateway/index.js
@@ -1,68 +1,55 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const _ = require('lodash');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createRestApi(name) {
-  const APIG = new AWS.APIGateway({ region });
-
   const params = {
     name,
   };
 
-  return APIG.createRestApi(params).promise();
+  return awsRequest('APIGateway', 'createRestApi', params);
 }
 
 function deleteRestApi(restApiId) {
-  const APIG = new AWS.APIGateway({ region });
-
   const params = {
     restApiId,
   };
 
-  return APIG.deleteRestApi(params).promise();
+  return awsRequest('APIGateway', 'deleteRestApi', params);
 }
 
 function getResources(restApiId) {
-  const APIG = new AWS.APIGateway({ region });
-
   const params = {
     restApiId,
   };
 
-  return APIG.getResources(params)
-    .promise()
-    .then(data => data.items);
+  return awsRequest('APIGateway', 'getResources', params).then(data => data.items);
 }
 
 function findRestApis(name) {
-  const APIG = new AWS.APIGateway({ region });
-
   const params = {
     limit: 500,
   };
 
   function recursiveFind(found, position) {
     if (position) params.position = position;
-    return APIG.getRestApis(params)
-      .promise()
-      .then(result => {
-        const matches = result.items.filter(restApi => restApi.name.match(name));
-        if (matches.length) {
-          _.merge(found, matches);
-        }
-        if (result.position) return recursiveFind(found, result.position);
-        return found;
-      });
+    return awsRequest('APIGateway', 'getRestApis', params).then(result => {
+      const matches = result.items.filter(restApi => restApi.name.match(name));
+      if (matches.length) {
+        _.merge(found, matches);
+      }
+      if (result.position) return recursiveFind(found, result.position);
+      return found;
+    });
   }
 
   return recursiveFind([]);
 }
 
 module.exports = {
-  createRestApi: persistentRequest.bind(this, createRestApi),
-  deleteRestApi: persistentRequest.bind(this, deleteRestApi),
-  getResources: persistentRequest.bind(this, getResources),
-  findRestApis: persistentRequest.bind(this, findRestApis),
+  createRestApi,
+  deleteRestApi,
+  getResources,
+  findRestApis,
 };

--- a/tests/utils/cloudformation/index.js
+++ b/tests/utils/cloudformation/index.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function findStacks(name, status) {
-  const CF = new AWS.CloudFormation({ region });
-
   const params = {};
   if (status) {
     params.StackStatusFilter = status;
@@ -13,66 +10,56 @@ function findStacks(name, status) {
 
   function recursiveFind(found, token) {
     if (token) params.NextToken = token;
-    return CF.listStacks(params)
-      .promise()
-      .then(result => {
-        const matches = result.StackSummaries.filter(stack => stack.StackName.match(name));
-        if (matches.length) {
-          found.push(...matches);
-        }
-        if (result.NextToken) return recursiveFind(found, result.NextToken);
-        return found;
-      });
+    return awsRequest('CloudFormation', 'listStacks', params).then(result => {
+      const matches = result.StackSummaries.filter(stack => stack.StackName.match(name));
+      if (matches.length) {
+        found.push(...matches);
+      }
+      if (result.NextToken) return recursiveFind(found, result.NextToken);
+      return found;
+    });
   }
 
   return recursiveFind([]);
 }
 
 function deleteStack(stack) {
-  const CF = new AWS.CloudFormation({ region });
-
   const params = {
     StackName: stack,
   };
 
-  return CF.deleteStack(params).promise();
+  return awsRequest('CloudFormation', 'deleteStack', params);
 }
 
 function listStackResources(stack) {
-  const CF = new AWS.CloudFormation({ region });
-
   const params = {
     StackName: stack,
   };
 
   function recursiveFind(resources, token) {
     if (token) params.NextToken = token;
-    return CF.listStackResources(params)
-      .promise()
-      .then(result => {
-        resources.push(...result.StackResourceSummaries);
-        if (result.NextToken) return recursiveFind(resources, result.NextToken);
-        return resources;
-      });
+    return awsRequest('CloudFormation', 'listStackResources', params).then(result => {
+      resources.push(...result.StackResourceSummaries);
+      if (result.NextToken) return recursiveFind(resources, result.NextToken);
+      return resources;
+    });
   }
 
   return recursiveFind([]);
 }
 
 function listStacks(status) {
-  const CF = new AWS.CloudFormation({ region });
-
   const params = {};
   if (status) {
     params.StackStatusFilter = status;
   }
 
-  return CF.listStacks(params).promise();
+  return awsRequest('CloudFormation', 'listStacks', params);
 }
 
 module.exports = {
-  findStacks: persistentRequest.bind(this, findStacks),
-  deleteStack: persistentRequest.bind(this, deleteStack),
-  listStackResources: persistentRequest.bind(this, listStackResources),
-  listStacks: persistentRequest.bind(this, listStacks),
+  findStacks,
+  deleteStack,
+  listStackResources,
+  listStacks,
 };

--- a/tests/utils/cloudwatch/index.js
+++ b/tests/utils/cloudwatch/index.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function putCloudWatchEvents(sources) {
-  const cwe = new AWS.CloudWatchEvents({ region });
-
   const entries = sources.map(source => ({
     Source: source,
     DetailType: 'serverlessDetailType',
@@ -14,9 +11,9 @@ function putCloudWatchEvents(sources) {
   const params = {
     Entries: entries,
   };
-  return cwe.putEvents(params).promise();
+  return awsRequest('CloudWatchEvents', 'putEvents', params);
 }
 
 module.exports = {
-  putCloudWatchEvents: persistentRequest.bind(this, putCloudWatchEvents),
+  putCloudWatchEvents,
 };

--- a/tests/utils/cognito/index.js
+++ b/tests/utils/cognito/index.js
@@ -1,39 +1,30 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const awsLog = require('log').get('aws');
-const log = require('log').get('serverless:test');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createUserPool(name, config = {}) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
   const params = Object.assign({}, { PoolName: name }, config);
-  return cognito.createUserPool(params).promise();
+  return awsRequest('CognitoIdentityServiceProvider', 'createUserPool', params);
 }
 
 function createUserPoolClient(name, userPoolId) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
   const params = {
     ClientName: name,
     UserPoolId: userPoolId,
     ExplicitAuthFlows: ['USER_PASSWORD_AUTH'],
   };
-  return cognito.createUserPoolClient(params).promise();
+  return awsRequest('CognitoIdentityServiceProvider', 'createUserPoolClient', params);
 }
 
 function deleteUserPool(name) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
   return findUserPoolByName(name).then(pool =>
-    cognito.deleteUserPool({ UserPoolId: pool.Id }).promise()
+    awsRequest('CognitoIdentityServiceProvider', 'deleteUserPool', { UserPoolId: pool.Id })
   );
 }
 
 function findUserPoolByName(name) {
   awsLog.debug('find cognito user pool by name %s', name);
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
 
   const params = {
     MaxResults: 60,
@@ -42,66 +33,52 @@ function findUserPoolByName(name) {
   const pools = [];
   function recursiveFind(nextToken) {
     if (nextToken) params.NextToken = nextToken;
-    return cognito
-      .listUserPools(params)
-      .promise()
-      .then(result => {
-        awsLog.debug('cognito.listUserPools %j', result);
-        pools.push(...result.UserPools.filter(pool => pool.Name === name));
-        if (result.NextToken) return recursiveFind(result.NextToken);
-        log.debug('found pools %o', pools);
-        switch (pools.length) {
-          case 0:
-            return null;
-          case 1:
-            return pools[0];
-          default:
-            throw new Error(`Found more than one pool named '${name}'`);
-        }
-      });
+    return awsRequest('CognitoIdentityServiceProvider', 'listUserPools', params).then(result => {
+      pools.push(...result.UserPools.filter(pool => pool.Name === name));
+      if (result.NextToken) return recursiveFind(result.NextToken);
+      switch (pools.length) {
+        case 0:
+          return null;
+        case 1:
+          return pools[0];
+        default:
+          throw new Error(`Found more than one pool named '${name}'`);
+      }
+    });
   }
 
   return recursiveFind();
 }
 
 function describeUserPool(userPoolId) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
-  return cognito
-    .describeUserPool({ UserPoolId: userPoolId })
-    .promise()
-    .then(result => {
-      awsLog.debug('cognito.describeUserPool %s %j', userPoolId, result);
-      return result;
-    });
+  return awsRequest('CognitoIdentityServiceProvider', 'describeUserPool', {
+    UserPoolId: userPoolId,
+  }).then(result => {
+    awsLog.debug('cognito.describeUserPool %s %j', userPoolId, result);
+    return result;
+  });
 }
 
 function createUser(userPoolId, username, password) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
   const params = {
     UserPoolId: userPoolId,
     Username: username,
     TemporaryPassword: password,
   };
-  return cognito.adminCreateUser(params).promise();
+  return awsRequest('CognitoIdentityServiceProvider', 'adminCreateUser', params);
 }
 
 function setUserPassword(userPoolId, username, password) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
   const params = {
     UserPoolId: userPoolId,
     Username: username,
     Password: password,
     Permanent: true,
   };
-  return cognito.adminSetUserPassword(params).promise();
+  return awsRequest('CognitoIdentityServiceProvider', 'adminSetUserPassword', params);
 }
 
 function initiateAuth(clientId, username, password) {
-  const cognito = new AWS.CognitoIdentityServiceProvider({ region });
-
   const params = {
     ClientId: clientId,
     AuthFlow: 'USER_PASSWORD_AUTH',
@@ -110,16 +87,16 @@ function initiateAuth(clientId, username, password) {
       PASSWORD: password,
     },
   };
-  return cognito.initiateAuth(params).promise();
+  return awsRequest('CognitoIdentityServiceProvider', 'initiateAuth', params);
 }
 
 module.exports = {
-  createUserPool: persistentRequest.bind(this, createUserPool),
-  deleteUserPool: persistentRequest.bind(this, deleteUserPool),
-  findUserPoolByName: persistentRequest.bind(this, findUserPoolByName),
-  describeUserPool: persistentRequest.bind(this, describeUserPool),
-  createUserPoolClient: persistentRequest.bind(this, createUserPoolClient),
-  createUser: persistentRequest.bind(this, createUser),
-  setUserPassword: persistentRequest.bind(this, setUserPassword),
-  initiateAuth: persistentRequest.bind(this, initiateAuth),
+  createUserPool,
+  deleteUserPool,
+  findUserPoolByName,
+  describeUserPool,
+  createUserPoolClient,
+  createUser,
+  setUserPassword,
+  initiateAuth,
 };

--- a/tests/utils/dynamodb/index.js
+++ b/tests/utils/dynamodb/index.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function putDynamoDbItem(tableName, item) {
-  const Ddb = new AWS.DynamoDB.DocumentClient({ region });
-
   const params = {
     TableName: tableName,
     Item: item,
   };
 
-  return Ddb.put(params).promise();
+  return awsRequest('DynamoDB.DocumentClient', 'put', params);
 }
 
 module.exports = {
-  putDynamoDbItem: persistentRequest.bind(this, putDynamoDbItem),
+  putDynamoDbItem,
 };

--- a/tests/utils/eventBridge/index.js
+++ b/tests/utils/eventBridge/index.js
@@ -1,32 +1,25 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createEventBus(name) {
-  const eventBridge = new AWS.EventBridge({ region });
-
-  return eventBridge.createEventBus({ Name: name }).promise();
+  return awsRequest('EventBridge', 'createEventBus', { Name: name });
 }
 
 function deleteEventBus(name) {
-  const eventBridge = new AWS.EventBridge({ region });
-
-  return eventBridge.deleteEventBus({ Name: name }).promise();
+  return awsRequest('EventBridge', 'deleteEventBus', { Name: name });
 }
 
 function putEvents(EventBusName, Entries) {
-  const eventBridge = new AWS.EventBridge({ region });
-
   Entries.map(entry => (entry.EventBusName = EventBusName));
   const params = {
     Entries,
   };
-  return eventBridge.putEvents(params).promise();
+  return awsRequest('EventBridge', 'putEvents', params);
 }
 
 module.exports = {
-  createEventBus: persistentRequest.bind(this, createEventBus),
-  deleteEventBus: persistentRequest.bind(this, deleteEventBus),
-  putEvents: persistentRequest.bind(this, putEvents),
+  createEventBus,
+  deleteEventBus,
+  putEvents,
 };

--- a/tests/utils/iot/index.js
+++ b/tests/utils/iot/index.js
@@ -1,25 +1,22 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function publishIotData(topic, message) {
-  const Iot = new AWS.Iot({ region });
+  return awsRequest('Iot', 'describeEndpoint').then(data => {
+    const params = {
+      topic,
+      payload: Buffer.from(message),
+    };
 
-  return Iot.describeEndpoint()
-    .promise()
-    .then(data => {
-      const IotData = new AWS.IotData({ region, endpoint: data.endpointAddress });
-
-      const params = {
-        topic,
-        payload: Buffer.from(message),
-      };
-
-      return IotData.publish(params).promise();
-    });
+    return awsRequest(
+      { name: 'IotData', params: { endpoint: data.endpointAddress } },
+      'publish',
+      params
+    );
+  });
 }
 
 module.exports = {
-  publishIotData: persistentRequest.bind(this, publishIotData),
+  publishIotData,
 };

--- a/tests/utils/kinesis/index.js
+++ b/tests/utils/kinesis/index.js
@@ -1,67 +1,55 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const BbPromise = require('bluebird');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function waitForKinesisStream(streamName) {
-  const Kinesis = new AWS.Kinesis({ region });
   const params = {
     StreamName: streamName,
   };
   return new BbPromise(resolve => {
     const interval = setInterval(() => {
-      Kinesis.describeStream(params)
-        .promise()
-        .then(data => {
-          const status = data.StreamDescription.StreamStatus;
-          if (status === 'ACTIVE') {
-            clearInterval(interval);
-            return resolve(data);
-          }
-          return null;
-        });
+      awsRequest('Kinesis', 'describeStream', params).then(data => {
+        const status = data.StreamDescription.StreamStatus;
+        if (status === 'ACTIVE') {
+          clearInterval(interval);
+          return resolve(data);
+        }
+        return null;
+      });
     }, 2000);
   });
 }
 
 function createKinesisStream(streamName) {
-  const Kinesis = new AWS.Kinesis({ region });
-
   const params = {
     ShardCount: 1, // prevent complications from shards being processed in parallel
     StreamName: streamName,
   };
 
-  return Kinesis.createStream(params)
-    .promise()
-    .then(() => waitForKinesisStream(streamName));
+  return awsRequest('Kinesis', 'createStream', params).then(() => waitForKinesisStream(streamName));
 }
 
 function deleteKinesisStream(streamName) {
-  const Kinesis = new AWS.Kinesis({ region });
-
   const params = {
     StreamName: streamName,
   };
 
-  return Kinesis.deleteStream(params).promise();
+  return awsRequest('Kinesis', 'deleteStream', params);
 }
 
 function putKinesisRecord(streamName, message) {
-  const Kinesis = new AWS.Kinesis({ region });
-
   const params = {
     StreamName: streamName,
     Data: message,
     PartitionKey: streamName, // test streams are single shards
   };
 
-  return Kinesis.putRecord(params).promise();
+  return awsRequest('Kinesis', 'putRecord', params);
 }
 
 module.exports = {
-  createKinesisStream: persistentRequest.bind(this, createKinesisStream),
-  deleteKinesisStream: persistentRequest.bind(this, deleteKinesisStream),
-  putKinesisRecord: persistentRequest.bind(this, putKinesisRecord),
+  createKinesisStream,
+  deleteKinesisStream,
+  putKinesisRecord,
 };

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -83,13 +83,13 @@ function wait(ms) {
 }
 
 module.exports = {
-  logger,
-  region,
   confirmCloudWatchLogs,
-  testServiceIdentifier,
-  serviceNameRegex,
   getServiceName,
-  replaceEnv,
+  logger,
   persistentRequest,
+  region,
+  replaceEnv,
+  serviceNameRegex,
+  testServiceIdentifier,
   wait,
 };

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -6,8 +6,6 @@ const awsLog = require('log').get('aws');
 
 const logger = console;
 
-const region = 'us-east-1';
-
 const getServiceInstance = _.memoize(name => {
   const Service = _.get(AWS, name);
   return new Service({ region: 'us-east-1' });
@@ -92,7 +90,6 @@ module.exports = {
   confirmCloudWatchLogs,
   getServiceName,
   logger,
-  region,
   replaceEnv,
   serviceNameRegex,
   testServiceIdentifier,

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const AWS = require('aws-sdk');
-const CloudWatchLogsSdk = require('aws-sdk/clients/cloudwatchlogs');
 const awsLog = require('log').get('aws');
 
 const logger = console;
@@ -42,8 +41,6 @@ function awsRequest(service, method, ...args) {
     );
 }
 
-const cloudWatchLogsSdk = new CloudWatchLogsSdk({ region });
-
 const testServiceIdentifier = 'integ-test';
 
 const serviceNameRegex = new RegExp(`${testServiceIdentifier}-d+`);
@@ -78,7 +75,7 @@ function replaceEnv(values) {
 function confirmCloudWatchLogs(logGroupName, trigger, timeout = 60000) {
   const startTime = Date.now();
   return trigger()
-    .then(() => cloudWatchLogsSdk.filterLogEvents({ logGroupName }).promise())
+    .then(() => awsRequest('CloudWatchLogs', 'filterLogEvents', { logGroupName }))
     .then(result => {
       if (result.events.length) return result.events;
       const duration = Date.now() - startTime;

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const BbPromise = require('bluebird');
 const AWS = require('aws-sdk');
 const awsLog = require('log').get('aws');
 
@@ -84,33 +83,6 @@ function confirmCloudWatchLogs(logGroupName, trigger, timeout = 60000) {
     });
 }
 
-function persistentRequest(...args) {
-  const func = args[0];
-  const funcArgs = args.slice(1);
-  const MAX_TRIES = 5;
-  return new BbPromise((resolve, reject) => {
-    const doCall = numTry => {
-      return func.apply(this, funcArgs).then(resolve, e => {
-        if (
-          numTry < MAX_TRIES &&
-          ((e.providerError && e.providerError.retryable) || e.statusCode === 429)
-        ) {
-          logger.log(
-            [
-              `Recoverable error occurred (${e.message}), sleeping for 5 seconds.`,
-              `Try ${numTry + 1} of ${MAX_TRIES}`,
-            ].join(' ')
-          );
-          setTimeout(doCall, 5000, numTry + 1);
-        } else {
-          reject(e);
-        }
-      });
-    };
-    return doCall(0);
-  });
-}
-
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -120,7 +92,6 @@ module.exports = {
   confirmCloudWatchLogs,
   getServiceName,
   logger,
-  persistentRequest,
   region,
   replaceEnv,
   serviceNameRegex,

--- a/tests/utils/s3/index.js
+++ b/tests/utils/s3/index.js
@@ -1,17 +1,12 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createBucket(bucket) {
-  const S3 = new AWS.S3({ region });
-
-  return S3.createBucket({ Bucket: bucket }).promise();
+  return awsRequest('S3', 'createBucket', { Bucket: bucket });
 }
 
 function createAndRemoveInBucket(bucket, opts = {}) {
-  const S3 = new AWS.S3({ region });
-
   const prefix = opts.prefix || '';
   const suffix = opts.suffix || '';
   const fileName = opts.fileName || 'object';
@@ -22,44 +17,36 @@ function createAndRemoveInBucket(bucket, opts = {}) {
     Body: 'hello world',
   };
 
-  return S3.putObject(params)
-    .promise()
-    .then(() => {
-      delete params.Body;
-      return S3.deleteObject(params).promise();
-    });
+  return awsRequest('S3', 'putObject', params).then(() => {
+    delete params.Body;
+    return awsRequest('S3', 'deleteObject', params);
+  });
 }
 
 function emptyBucket(bucket) {
-  const S3 = new AWS.S3({ region });
-
-  return S3.listObjects({ Bucket: bucket })
-    .promise()
-    .then(data => {
-      const items = data.Contents;
-      const numItems = items.length;
-      if (numItems) {
-        const keys = items.map(item => Object.assign({}, { Key: item.Key }));
-        return S3.deleteObjects({
-          Bucket: bucket,
-          Delete: {
-            Objects: keys,
-          },
-        }).promise();
-      }
-      return null;
-    });
+  return awsRequest('S3', 'listObjects', { Bucket: bucket }).then(data => {
+    const items = data.Contents;
+    const numItems = items.length;
+    if (numItems) {
+      const keys = items.map(item => Object.assign({}, { Key: item.Key }));
+      return awsRequest('S3', 'deleteObjects', {
+        Bucket: bucket,
+        Delete: {
+          Objects: keys,
+        },
+      });
+    }
+    return null;
+  });
 }
 
 function deleteBucket(bucket) {
-  const S3 = new AWS.S3({ region });
-
-  return emptyBucket(bucket).then(() => S3.deleteBucket({ Bucket: bucket }).promise());
+  return emptyBucket(bucket).then(() => awsRequest('S3', 'deleteBucket', { Bucket: bucket }));
 }
 
 module.exports = {
-  createBucket: persistentRequest.bind(this, createBucket),
-  createAndRemoveInBucket: persistentRequest.bind(this, createAndRemoveInBucket),
-  emptyBucket: persistentRequest.bind(this, emptyBucket),
-  deleteBucket: persistentRequest.bind(this, deleteBucket),
+  createBucket,
+  createAndRemoveInBucket,
+  emptyBucket,
+  deleteBucket,
 };

--- a/tests/utils/sns/index.js
+++ b/tests/utils/sns/index.js
@@ -1,58 +1,47 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createSnsTopic(topicName) {
-  const SNS = new AWS.SNS({ region });
-
   const params = {
     Name: topicName,
   };
 
-  return SNS.createTopic(params).promise();
+  return awsRequest('SNS', 'createTopic', params);
 }
 
 function removeSnsTopic(topicName) {
-  const SNS = new AWS.SNS({ region });
+  return awsRequest('SNS', 'listTopics').then(data => {
+    const topicArn = data.Topics.find(topic => RegExp(topicName, 'g').test(topic.TopicArn))
+      .TopicArn;
 
-  return SNS.listTopics()
-    .promise()
-    .then(data => {
-      const topicArn = data.Topics.find(topic => RegExp(topicName, 'g').test(topic.TopicArn))
-        .TopicArn;
+    const params = {
+      TopicArn: topicArn,
+    };
 
-      const params = {
-        TopicArn: topicArn,
-      };
-
-      return SNS.deleteTopic(params).promise();
-    });
+    return awsRequest('SNS', 'deleteTopic', params);
+  });
 }
 
 function publishSnsMessage(topicName, message, messageAttributes = null) {
-  const SNS = new AWS.SNS({ region });
+  return awsRequest('SNS', 'listTopics').then(data => {
+    const topicArn = data.Topics.find(topic => RegExp(topicName, 'g').test(topic.TopicArn))
+      .TopicArn;
 
-  return SNS.listTopics()
-    .promise()
-    .then(data => {
-      const topicArn = data.Topics.find(topic => RegExp(topicName, 'g').test(topic.TopicArn))
-        .TopicArn;
+    const params = {
+      Message: message,
+      TopicArn: topicArn,
+    };
+    if (messageAttributes) {
+      params.MessageAttributes = messageAttributes;
+    }
 
-      const params = {
-        Message: message,
-        TopicArn: topicArn,
-      };
-      if (messageAttributes) {
-        params.MessageAttributes = messageAttributes;
-      }
-
-      return SNS.publish(params).promise();
-    });
+    return awsRequest('SNS', 'publish', params);
+  });
 }
 
 module.exports = {
-  createSnsTopic: persistentRequest.bind(this, createSnsTopic),
-  removeSnsTopic: persistentRequest.bind(this, removeSnsTopic),
-  publishSnsMessage: persistentRequest.bind(this, publishSnsMessage),
+  createSnsTopic,
+  removeSnsTopic,
+  publishSnsMessage,
 };

--- a/tests/utils/sqs/index.js
+++ b/tests/utils/sqs/index.js
@@ -1,47 +1,36 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createSqsQueue(queueName) {
-  const SQS = new AWS.SQS({ region });
-
   const params = {
     QueueName: queueName,
   };
 
-  return SQS.createQueue(params).promise();
+  return awsRequest('SQS', 'createQueue', params);
 }
 
 function deleteSqsQueue(queueName) {
-  const SQS = new AWS.SQS({ region });
-
-  return SQS.getQueueUrl({ QueueName: queueName })
-    .promise()
-    .then(data => {
-      const params = {
-        QueueUrl: data.QueueUrl,
-      };
-      return SQS.deleteQueue(params).promise();
-    });
+  return awsRequest('SQS', 'getQueueUrl', { QueueName: queueName }).then(data => {
+    const params = {
+      QueueUrl: data.QueueUrl,
+    };
+    return awsRequest('SQS', 'deleteQueue', params);
+  });
 }
 
 function sendSqsMessage(queueName, message) {
-  const SQS = new AWS.SQS({ region });
-
-  return SQS.getQueueUrl({ QueueName: queueName })
-    .promise()
-    .then(data => {
-      const params = {
-        QueueUrl: data.QueueUrl,
-        MessageBody: message,
-      };
-      return SQS.sendMessage(params).promise();
-    });
+  return awsRequest('SQS', 'getQueueUrl', { QueueName: queueName }).then(data => {
+    const params = {
+      QueueUrl: data.QueueUrl,
+      MessageBody: message,
+    };
+    return awsRequest('SQS', 'sendMessage', params);
+  });
 }
 
 module.exports = {
-  createSqsQueue: persistentRequest.bind(this, createSqsQueue),
-  deleteSqsQueue: persistentRequest.bind(this, deleteSqsQueue),
-  sendSqsMessage: persistentRequest.bind(this, sendSqsMessage),
+  createSqsQueue,
+  deleteSqsQueue,
+  sendSqsMessage,
 };

--- a/tests/utils/websocket/index.js
+++ b/tests/utils/websocket/index.js
@@ -1,58 +1,45 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const { region, persistentRequest } = require('../misc');
+const { awsRequest } = require('../misc');
 
 function createApi(name) {
-  const APIG = new AWS.ApiGatewayV2({ region });
-
-  return APIG.createApi({
+  return awsRequest('ApiGatewayV2', 'createApi', {
     Name: name,
     ProtocolType: 'WEBSOCKET',
     RouteSelectionExpression: '$request.body.action',
-  }).promise();
+  });
 }
 
 function createStage(apiId, stageName) {
-  const APIG = new AWS.ApiGatewayV2({ region });
-
   const params = {
     ApiId: apiId,
     StageName: stageName,
   };
-  return APIG.createStage(params).promise();
+  return awsRequest('ApiGatewayV2', 'createStage', params);
 }
 
 function deleteApi(id) {
-  const APIG = new AWS.ApiGatewayV2({ region });
-
-  return APIG.deleteApi({
+  return awsRequest('ApiGatewayV2', 'deleteApi', {
     ApiId: id,
-  }).promise();
+  });
 }
 
 function deleteStage(apiId, stageName) {
-  const APIG = new AWS.ApiGatewayV2({ region });
-
   const params = {
     ApiId: apiId,
     StageName: stageName,
   };
-  return APIG.deleteStage(params).promise();
+  return awsRequest('ApiGatewayV2', 'deleteStage', params);
 }
 
 function getRoutes(apiId) {
-  const APIG = new AWS.ApiGatewayV2({ region });
-  APIG.getRoutes;
-  return APIG.getRoutes({ ApiId: apiId })
-    .promise()
-    .then(data => data.Items);
+  return awsRequest('ApiGatewayV2', 'getRoutes', { ApiId: apiId }).then(data => data.Items);
 }
 
 module.exports = {
-  createApi: persistentRequest.bind(this, createApi),
-  deleteApi: persistentRequest.bind(this, deleteApi),
-  getRoutes: persistentRequest.bind(this, getRoutes),
-  createStage: persistentRequest.bind(this, createStage),
-  deleteStage: persistentRequest.bind(this, deleteStage),
+  createApi,
+  deleteApi,
+  getRoutes,
+  createStage,
+  deleteStage,
 };


### PR DESCRIPTION
Addresses fail observed at: https://travis-ci.org/serverless/serverless/jobs/626693791

`Rate exceeded` is retryable error, from which test could recover.

Update tests to rely on common newly introduced `awsRequest` util, which will ensure recovery in such situations. Additionally `awsRequest` exposes all request logs if needed.