### PR TITLE
Fix access rules for CloudWatch logs creation

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -125,7 +125,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
             customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
               {
                 Effect: 'Allow',
-                Action: ['logs:CreateLogStream'],
+                Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
                 Resource: [
                   {
                     'Fn::Sub':

--- a/lib/plugins/aws/customResources/index.test.js
+++ b/lib/plugins/aws/customResources/index.test.js
@@ -378,7 +378,7 @@ describe('#addCustomResourceToService()', () => {
       expect(RoleProps.Policies[0].PolicyDocument.Statement).to.include.deep.members([
         {
           Effect: 'Allow',
-          Action: ['logs:CreateLogStream'],
+          Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
           Resource: [
             {
               'Fn::Sub':

--- a/lib/plugins/aws/package/lib/iam-role-lambda-execution-template.json
+++ b/lib/plugins/aws/package/lib/iam-role-lambda-execution-template.json
@@ -21,7 +21,7 @@
           "Statement": [
             {
               "Effect": "Allow",
-              "Action": ["logs:CreateLogStream"],
+              "Action": ["logs:CreateLogStream", "logs:CreateLogGroup"],
               "Resource": []
             },
             {

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -86,7 +86,7 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
                     Resource: [
                       {
                         'Fn::Sub':
@@ -172,7 +172,7 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
                     Resource: [
                       {
                         'Fn::Sub':
@@ -261,7 +261,7 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
                     Resource: [
                       {
                         'Fn::Sub':
@@ -356,7 +356,7 @@ describe('#mergeIamTemplates()', () => {
                 Statement: [
                   {
                     Effect: 'Allow',
-                    Action: ['logs:CreateLogStream'],
+                    Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
                     Resource: [
                       {
                         'Fn::Sub':


### PR DESCRIPTION
Since some recent changes on AWS side, IAM access rules we assign for lambda are no longer good enough to write CloudWatch logs.

This patch ensures our access rules are complete

Closes #6241 (is related to it, puts proposed solution out of a table)
Closes #6692 (implements it in safe way)