### PR TITLE
Fix multiple custom resource generation

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -1,10 +1,17 @@
 'use strict';
 
+const _ = require('lodash');
 const path = require('path');
 const crypto = require('crypto');
 const BbPromise = require('bluebird');
 const fse = BbPromise.promisifyAll(require('fs-extra'));
 const generateZip = require('./generateZip');
+
+const prepareCustomResourcePackage = _.memoize(zipFilePath =>
+  BbPromise.all([generateZip(), fse.mkdirsAsync(path.dirname(zipFilePath))])
+    .then(([cachedZipFilePath]) => fse.copyAsync(cachedZipFilePath, zipFilePath))
+    .then(() => path.basename(zipFilePath))
+);
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
   return BbPromise.try(() => {
@@ -25,7 +32,6 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
       awsProvider.naming.getCustomResourcesArtifactName()
     );
     const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
-    serverless.utils.writeFileDir(zipFilePath);
 
     // check which custom resource should be used
     if (resourceName === 's3') {
@@ -60,138 +66,136 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
 
     // TODO: check every once in a while if external packages are still necessary
     serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
-    return generateZip().then(cachedZipFilePath => {
-      const zipFileBasename = path.basename(zipFilePath);
-      return fse.copyAsync(cachedZipFilePath, zipFilePath).then(() => {
-        let S3Bucket = {
-          Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
-        };
-        if (serverless.service.package.deploymentBucket) {
-          S3Bucket = serverless.service.package.deploymentBucket;
-        }
-        const s3Folder = serverless.service.package.artifactDirectoryName;
-        const s3FileName = zipFileBasename;
-        const S3Key = `${s3Folder}/${s3FileName}`;
 
-        const cfnRoleArn = serverless.service.provider.cfnRole;
+    return prepareCustomResourcePackage(zipFilePath).then(zipFileBasename => {
+      let S3Bucket = {
+        Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
+      };
+      if (serverless.service.package.deploymentBucket) {
+        S3Bucket = serverless.service.package.deploymentBucket;
+      }
+      const s3Folder = serverless.service.package.artifactDirectoryName;
+      const s3FileName = zipFileBasename;
+      const S3Key = `${s3Folder}/${s3FileName}`;
 
-        if (!cfnRoleArn) {
-          let customResourceRole = Resources[customResourcesRoleLogicalId];
-          if (!customResourceRole) {
-            customResourceRole = {
-              Type: 'AWS::IAM::Role',
-              Properties: {
-                AssumeRolePolicyDocument: {
-                  Version: '2012-10-17',
-                  Statement: [
-                    {
-                      Effect: 'Allow',
-                      Principal: {
-                        Service: ['lambda.amazonaws.com'],
-                      },
-                      Action: ['sts:AssumeRole'],
-                    },
-                  ],
-                },
-                Policies: [
+      const cfnRoleArn = serverless.service.provider.cfnRole;
+
+      if (!cfnRoleArn) {
+        let customResourceRole = Resources[customResourcesRoleLogicalId];
+        if (!customResourceRole) {
+          customResourceRole = {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+              AssumeRolePolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
                   {
-                    PolicyName: {
-                      'Fn::Join': [
-                        '-',
-                        [
-                          awsProvider.getStage(),
-                          awsProvider.serverless.service.service,
-                          'custom-resources-lambda',
-                        ],
-                      ],
+                    Effect: 'Allow',
+                    Principal: {
+                      Service: ['lambda.amazonaws.com'],
                     },
-                    PolicyDocument: {
-                      Version: '2012-10-17',
-                      Statement: [],
-                    },
+                    Action: ['sts:AssumeRole'],
                   },
                 ],
               },
-            };
-            Resources[customResourcesRoleLogicalId] = customResourceRole;
-
-            if (shouldWriteLogs) {
-              const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
-              customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+              Policies: [
                 {
-                  Effect: 'Allow',
-                  Action: ['logs:CreateLogStream'],
-                  Resource: [
-                    {
-                      'Fn::Sub':
-                        'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                        `:log-group:${logGroupsPrefix}*:*`,
-                    },
-                  ],
+                  PolicyName: {
+                    'Fn::Join': [
+                      '-',
+                      [
+                        awsProvider.getStage(),
+                        awsProvider.serverless.service.service,
+                        'custom-resources-lambda',
+                      ],
+                    ],
+                  },
+                  PolicyDocument: {
+                    Version: '2012-10-17',
+                    Statement: [],
+                  },
                 },
-                {
-                  Effect: 'Allow',
-                  Action: ['logs:PutLogEvents'],
-                  Resource: [
-                    {
-                      'Fn::Sub':
-                        'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                        `:log-group:${logGroupsPrefix}*:*:*`,
-                    },
-                  ],
-                }
-              );
-            }
-          }
-          const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
-          iamRoleStatements.forEach(newStmt => {
-            if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
-              Statement.push(newStmt);
-            }
-          });
-        }
-
-        const customResourceFunction = {
-          Type: 'AWS::Lambda::Function',
-          Properties: {
-            Code: {
-              S3Bucket,
-              S3Key,
+              ],
             },
-            FunctionName: absoluteFunctionName,
-            Handler,
-            MemorySize: 1024,
-            Runtime: 'nodejs12.x',
-            Timeout: 180,
-          },
-          DependsOn: [],
-        };
-        Resources[customResourceFunctionLogicalId] = customResourceFunction;
-
-        if (cfnRoleArn) {
-          customResourceFunction.Properties.Role = cfnRoleArn;
-        } else {
-          customResourceFunction.Properties.Role = {
-            'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
           };
-          customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
-        }
+          Resources[customResourcesRoleLogicalId] = customResourceRole;
 
-        if (shouldWriteLogs) {
-          const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
-            functionName
-          );
-          customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
-          Object.assign(Resources, {
-            [customResourceLogGroupLogicalId]: {
-              Type: 'AWS::Logs::LogGroup',
-              Properties: {
-                LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+          if (shouldWriteLogs) {
+            const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
+            customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+              {
+                Effect: 'Allow',
+                Action: ['logs:CreateLogStream'],
+                Resource: [
+                  {
+                    'Fn::Sub':
+                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                      `:log-group:${logGroupsPrefix}*:*`,
+                  },
+                ],
               },
-            },
-          });
+              {
+                Effect: 'Allow',
+                Action: ['logs:PutLogEvents'],
+                Resource: [
+                  {
+                    'Fn::Sub':
+                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                      `:log-group:${logGroupsPrefix}*:*:*`,
+                  },
+                ],
+              }
+            );
+          }
         }
-      });
+        const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
+        iamRoleStatements.forEach(newStmt => {
+          if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
+            Statement.push(newStmt);
+          }
+        });
+      }
+
+      const customResourceFunction = {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          Code: {
+            S3Bucket,
+            S3Key,
+          },
+          FunctionName: absoluteFunctionName,
+          Handler,
+          MemorySize: 1024,
+          Runtime: 'nodejs12.x',
+          Timeout: 180,
+        },
+        DependsOn: [],
+      };
+      Resources[customResourceFunctionLogicalId] = customResourceFunction;
+
+      if (cfnRoleArn) {
+        customResourceFunction.Properties.Role = cfnRoleArn;
+      } else {
+        customResourceFunction.Properties.Role = {
+          'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+        };
+        customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
+      }
+
+      if (shouldWriteLogs) {
+        const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
+          functionName
+        );
+        customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
+        Object.assign(Resources, {
+          [customResourceLogGroupLogicalId]: {
+            Type: 'AWS::Logs::LogGroup',
+            Properties: {
+              LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+            },
+          },
+        });
+      }
     });
   });
 }

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -7,189 +7,191 @@ const fse = BbPromise.promisifyAll(require('fs-extra'));
 const generateZip = require('./generateZip');
 
 function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements) {
-  let functionName;
-  let absoluteFunctionName;
-  let Handler;
-  let customResourceFunctionLogicalId;
+  return BbPromise.try(() => {
+    let functionName;
+    let absoluteFunctionName;
+    let Handler;
+    let customResourceFunctionLogicalId;
 
-  const { serverless } = awsProvider;
-  const { cliOptions } = serverless.pluginManager;
-  const providerConfig = serverless.service.provider;
-  const shouldWriteLogs = providerConfig.logs && providerConfig.logs.frameworkLambda;
-  const { Resources } = providerConfig.compiledCloudFormationTemplate;
-  const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
-  const zipFilePath = path.join(
-    serverless.config.servicePath,
-    '.serverless',
-    awsProvider.naming.getCustomResourcesArtifactName()
-  );
-  const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
-  serverless.utils.writeFileDir(zipFilePath);
+    const { serverless } = awsProvider;
+    const { cliOptions } = serverless.pluginManager;
+    const providerConfig = serverless.service.provider;
+    const shouldWriteLogs = providerConfig.logs && providerConfig.logs.frameworkLambda;
+    const { Resources } = providerConfig.compiledCloudFormationTemplate;
+    const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
+    const zipFilePath = path.join(
+      serverless.config.servicePath,
+      '.serverless',
+      awsProvider.naming.getCustomResourcesArtifactName()
+    );
+    const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
+    serverless.utils.writeFileDir(zipFilePath);
 
-  // check which custom resource should be used
-  if (resourceName === 's3') {
-    functionName = awsProvider.naming.getCustomResourceS3HandlerFunctionName();
-    Handler = 's3/handler.handler';
-    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceS3HandlerFunctionLogicalId();
-  } else if (resourceName === 'cognitoUserPool') {
-    functionName = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName();
-    Handler = 'cognitoUserPool/handler.handler';
-    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
-  } else if (resourceName === 'eventBridge') {
-    functionName = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName();
-    Handler = 'eventBridge/handler.handler';
-    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();
-  } else if (resourceName === 'apiGatewayCloudWatchRole') {
-    functionName = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName();
-    Handler = 'apiGatewayCloudWatchRole/handler.handler';
-    customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
-  } else {
-    return BbPromise.reject(`No implementation found for Custom Resource "${resourceName}"`);
-  }
-  absoluteFunctionName = `${funcPrefix}-${functionName}`;
-  if (absoluteFunctionName.length > 64) {
-    // Function names cannot be longer than 64.
-    // Temporary solution until we have https://github.com/serverless/serverless/issues/6598
-    // (which doesn't change names of already deployed functions)
-    absoluteFunctionName = `${absoluteFunctionName.slice(0, 32)}${crypto
-      .createHash('md5')
-      .update(absoluteFunctionName)
-      .digest('hex')}`;
-  }
+    // check which custom resource should be used
+    if (resourceName === 's3') {
+      functionName = awsProvider.naming.getCustomResourceS3HandlerFunctionName();
+      Handler = 's3/handler.handler';
+      customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceS3HandlerFunctionLogicalId();
+    } else if (resourceName === 'cognitoUserPool') {
+      functionName = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionName();
+      Handler = 'cognitoUserPool/handler.handler';
+      customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId();
+    } else if (resourceName === 'eventBridge') {
+      functionName = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionName();
+      Handler = 'eventBridge/handler.handler';
+      customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();
+    } else if (resourceName === 'apiGatewayCloudWatchRole') {
+      functionName = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName();
+      Handler = 'apiGatewayCloudWatchRole/handler.handler';
+      customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
+    } else {
+      return BbPromise.reject(`No implementation found for Custom Resource "${resourceName}"`);
+    }
+    absoluteFunctionName = `${funcPrefix}-${functionName}`;
+    if (absoluteFunctionName.length > 64) {
+      // Function names cannot be longer than 64.
+      // Temporary solution until we have https://github.com/serverless/serverless/issues/6598
+      // (which doesn't change names of already deployed functions)
+      absoluteFunctionName = `${absoluteFunctionName.slice(0, 32)}${crypto
+        .createHash('md5')
+        .update(absoluteFunctionName)
+        .digest('hex')}`;
+    }
 
-  // TODO: check every once in a while if external packages are still necessary
-  serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
-  return generateZip().then(cachedZipFilePath => {
-    const zipFileBasename = path.basename(zipFilePath);
-    return fse.copyAsync(cachedZipFilePath, zipFilePath).then(() => {
-      let S3Bucket = {
-        Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
-      };
-      if (serverless.service.package.deploymentBucket) {
-        S3Bucket = serverless.service.package.deploymentBucket;
-      }
-      const s3Folder = serverless.service.package.artifactDirectoryName;
-      const s3FileName = zipFileBasename;
-      const S3Key = `${s3Folder}/${s3FileName}`;
-
-      const cfnRoleArn = serverless.service.provider.cfnRole;
-
-      if (!cfnRoleArn) {
-        let customResourceRole = Resources[customResourcesRoleLogicalId];
-        if (!customResourceRole) {
-          customResourceRole = {
-            Type: 'AWS::IAM::Role',
-            Properties: {
-              AssumeRolePolicyDocument: {
-                Version: '2012-10-17',
-                Statement: [
-                  {
-                    Effect: 'Allow',
-                    Principal: {
-                      Service: ['lambda.amazonaws.com'],
-                    },
-                    Action: ['sts:AssumeRole'],
-                  },
-                ],
-              },
-              Policies: [
-                {
-                  PolicyName: {
-                    'Fn::Join': [
-                      '-',
-                      [
-                        awsProvider.getStage(),
-                        awsProvider.serverless.service.service,
-                        'custom-resources-lambda',
-                      ],
-                    ],
-                  },
-                  PolicyDocument: {
-                    Version: '2012-10-17',
-                    Statement: [],
-                  },
-                },
-              ],
-            },
-          };
-          Resources[customResourcesRoleLogicalId] = customResourceRole;
-
-          if (shouldWriteLogs) {
-            const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
-            customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
-              {
-                Effect: 'Allow',
-                Action: ['logs:CreateLogStream'],
-                Resource: [
-                  {
-                    'Fn::Sub':
-                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                      `:log-group:${logGroupsPrefix}*:*`,
-                  },
-                ],
-              },
-              {
-                Effect: 'Allow',
-                Action: ['logs:PutLogEvents'],
-                Resource: [
-                  {
-                    'Fn::Sub':
-                      'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-                      `:log-group:${logGroupsPrefix}*:*:*`,
-                  },
-                ],
-              }
-            );
-          }
-        }
-        const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
-        iamRoleStatements.forEach(newStmt => {
-          if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
-            Statement.push(newStmt);
-          }
-        });
-      }
-
-      const customResourceFunction = {
-        Type: 'AWS::Lambda::Function',
-        Properties: {
-          Code: {
-            S3Bucket,
-            S3Key,
-          },
-          FunctionName: absoluteFunctionName,
-          Handler,
-          MemorySize: 1024,
-          Runtime: 'nodejs12.x',
-          Timeout: 180,
-        },
-        DependsOn: [],
-      };
-      Resources[customResourceFunctionLogicalId] = customResourceFunction;
-
-      if (cfnRoleArn) {
-        customResourceFunction.Properties.Role = cfnRoleArn;
-      } else {
-        customResourceFunction.Properties.Role = {
-          'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+    // TODO: check every once in a while if external packages are still necessary
+    serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
+    return generateZip().then(cachedZipFilePath => {
+      const zipFileBasename = path.basename(zipFilePath);
+      return fse.copyAsync(cachedZipFilePath, zipFilePath).then(() => {
+        let S3Bucket = {
+          Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
         };
-        customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
-      }
+        if (serverless.service.package.deploymentBucket) {
+          S3Bucket = serverless.service.package.deploymentBucket;
+        }
+        const s3Folder = serverless.service.package.artifactDirectoryName;
+        const s3FileName = zipFileBasename;
+        const S3Key = `${s3Folder}/${s3FileName}`;
 
-      if (shouldWriteLogs) {
-        const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
-          functionName
-        );
-        customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
-        Object.assign(Resources, {
-          [customResourceLogGroupLogicalId]: {
-            Type: 'AWS::Logs::LogGroup',
-            Properties: {
-              LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+        const cfnRoleArn = serverless.service.provider.cfnRole;
+
+        if (!cfnRoleArn) {
+          let customResourceRole = Resources[customResourcesRoleLogicalId];
+          if (!customResourceRole) {
+            customResourceRole = {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: {
+                        Service: ['lambda.amazonaws.com'],
+                      },
+                      Action: ['sts:AssumeRole'],
+                    },
+                  ],
+                },
+                Policies: [
+                  {
+                    PolicyName: {
+                      'Fn::Join': [
+                        '-',
+                        [
+                          awsProvider.getStage(),
+                          awsProvider.serverless.service.service,
+                          'custom-resources-lambda',
+                        ],
+                      ],
+                    },
+                    PolicyDocument: {
+                      Version: '2012-10-17',
+                      Statement: [],
+                    },
+                  },
+                ],
+              },
+            };
+            Resources[customResourcesRoleLogicalId] = customResourceRole;
+
+            if (shouldWriteLogs) {
+              const logGroupsPrefix = awsProvider.naming.getLogGroupName(funcPrefix);
+              customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
+                {
+                  Effect: 'Allow',
+                  Action: ['logs:CreateLogStream'],
+                  Resource: [
+                    {
+                      'Fn::Sub':
+                        'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                        `:log-group:${logGroupsPrefix}*:*`,
+                    },
+                  ],
+                },
+                {
+                  Effect: 'Allow',
+                  Action: ['logs:PutLogEvents'],
+                  Resource: [
+                    {
+                      'Fn::Sub':
+                        'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                        `:log-group:${logGroupsPrefix}*:*:*`,
+                    },
+                  ],
+                }
+              );
+            }
+          }
+          const { Statement } = customResourceRole.Properties.Policies[0].PolicyDocument;
+          iamRoleStatements.forEach(newStmt => {
+            if (!Statement.find(existingStmt => existingStmt.Resource === newStmt.Resource)) {
+              Statement.push(newStmt);
+            }
+          });
+        }
+
+        const customResourceFunction = {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket,
+              S3Key,
             },
+            FunctionName: absoluteFunctionName,
+            Handler,
+            MemorySize: 1024,
+            Runtime: 'nodejs12.x',
+            Timeout: 180,
           },
-        });
-      }
+          DependsOn: [],
+        };
+        Resources[customResourceFunctionLogicalId] = customResourceFunction;
+
+        if (cfnRoleArn) {
+          customResourceFunction.Properties.Role = cfnRoleArn;
+        } else {
+          customResourceFunction.Properties.Role = {
+            'Fn::GetAtt': [customResourcesRoleLogicalId, 'Arn'],
+          };
+          customResourceFunction.DependsOn.push(customResourcesRoleLogicalId);
+        }
+
+        if (shouldWriteLogs) {
+          const customResourceLogGroupLogicalId = awsProvider.naming.getLogGroupLogicalId(
+            functionName
+          );
+          customResourceFunction.DependsOn.push(customResourceLogGroupLogicalId);
+          Object.assign(Resources, {
+            [customResourceLogGroupLogicalId]: {
+              Type: 'AWS::Logs::LogGroup',
+              Properties: {
+                LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+              },
+            },
+          });
+        }
+      });
     });
   });
 }


### PR DESCRIPTION
Issue exposed occasionally in CI fails, e.g. https://travis-ci.org/serverless/serverless/jobs/627729256

It appears that for every custom resource registration we attempted to copy generated zip file into  a service folder.

In tests when multiple custom resources registrations are issues at same time, it introduced a race condition, where copying logic finding the custom resource already in a folder, was trying to delete (before again copying over), but on deletion it found it's no longer there.

On Windows it exposed as EPERM error, as second copy process didn't have write access to file as being created by other copy process.

This patch ensure we copy generated artifact only once in context of given service.