### PR TITLE
Improve binary installer documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,8 @@ Run following code in your terminal:
 curl -o- -L https://slss.io/install | bash
 ```
 
+_**Note**: To use newly installed binary you need to open another terminal window._
+
 To upgrade already installed version:
 
 ```bash


### PR DESCRIPTION
An additional note to inform users that they newly installed binary will work only in new terminal windows