### PR TITLE
Ensure API GW stage settings are applied when no endpoints are configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
   # Minimize git history, but ensure to not break things:
   # - Merging multiple PR's around same time may introduce a case where it's not
   #   the last merge commit that is to be tested
-  depth: 10
+  depth: 30
 
 cache:
   # Not relying on 'npm' shortcut, as per Travis docs it's the only 'node_modules' that it'll cache

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -75,10 +75,6 @@ class AwsCompileApigEvents {
         const getServiceState = require('../../../../lib/getServiceState').getServiceState;
 
         const state = getServiceState.call(this);
-        if (!this.serverless.utils.isEventUsed(state.service.functions, 'http')) {
-          return BbPromise.resolve();
-        }
-
         const updateStage = require('./lib/hack/updateStage').updateStage;
 
         this.state = state;

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -142,7 +142,7 @@ describe('AwsCompileApigEvents', () => {
         });
       });
 
-      it('should skip the updateStage step when no http events are found', () => {
+      it('should not skip the updateStage step when no http events are found', () => {
         getServiceStateStub.returns({
           service: {
             functions: {
@@ -154,7 +154,7 @@ describe('AwsCompileApigEvents', () => {
         });
 
         return awsCompileApigEvents.hooks['after:deploy:deploy']().then(() => {
-          expect(updateStageStub.calledOnce).to.equal(false);
+          expect(updateStageStub.calledOnce).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
Fixes #7036 

Sometimes users create a service in which they just configure the API Gateway, and configure endpoints in other services which reference it.
We didn't support applying stage settings on API Gateways configured that way. This patch fixes that.

Additionally increased git history depth in `.travis.yml` to avoid CI fails as:  https://travis-ci.org/serverless/serverless/jobs/628681233