### PR TITLE
Fix Rest API id detection when no API GW involved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.60.3](https://github.com/serverless/serverless/compare/v1.60.2...v1.60.3) (2019-12-23)
+
+### Bug Fixes
+
+- **AWS APIGW:** Fix Rest API id detection when no API GW involved ([81096ca](https://github.com/serverless/serverless/commit/81096caf3d8e98932cd4314495a4fc107fab297a)), regression introduced with [#7126](https://github.com/serverless/serverless/issues/7126)
+
 ### [1.60.2](https://github.com/serverless/serverless/compare/v1.60.1...v1.60.2) (2019-12-23)
 
 ### Bug Fixes

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -55,6 +55,9 @@ module.exports = {
           if (this.isExternalRestApi) return null;
           if (!this.apiGatewayRestApiId) {
             // Could not resolve REST API id automatically
+            if (!this.serverless.utils.isEventUsed(this.state.service.functions, 'http')) {
+              return null;
+            }
 
             if (!this.hasTracingConfigured && !this.hasLogsConfigured) {
               // Do crash if there are no API Gateway customizations to apply

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -545,6 +545,18 @@ describe('#updateStage()', () => {
     }
   );
 
+  it(
+    'should not apply hack when restApiId could not be resolved and ' +
+      'no http events are detected',
+    () => {
+      context.state.service.provider.tracing = { apiGateway: true };
+      context.options.stage = 'foo';
+      delete context.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .ApiGatewayRestApi;
+      return updateStage.call(context);
+    }
+  );
+
   it('should update the stage with a custom APIGW log format if given', () => {
     context.state.service.provider.logs = {
       restApi: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.60.2",
+  "version": "1.60.3",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
Regression introduced with #7126. After which update stage logic complains it cannot find API id, when there's no API, no HTTP endpoints configured but there are some API rest settings configured (in case of dashboard they're automatically implied)