### PR TITLE
Fix config option handling

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -11,7 +11,16 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['', 'AWS APIGW', 'AWS Lambda', 'Binary Installer', 'Plugins', 'User Config', 'Variables'],
+      [
+        '',
+        'AWS APIGW',
+        'AWS Lambda',
+        'Binary Installer',
+        'CLI',
+        'Plugins',
+        'User Config',
+        'Variables',
+      ],
     ],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -36,9 +36,9 @@ class Serverless {
     this.pluginManager = new PluginManager(this);
 
     // use the servicePath from the options or try to find it in the CWD
+    this.cliInputArgv = process.argv.slice(2);
     configObject.servicePath =
-      configObject.servicePath ||
-      this.utils.findServicePath(minimist(process.argv.slice(2)).config);
+      configObject.servicePath || this.utils.findServicePath(minimist(this.cliInputArgv).config);
 
     this.config = new Config(this, configObject);
 
@@ -60,7 +60,7 @@ class Serverless {
     this.instanceId = new Date().getTime().toString();
 
     // create a new CLI instance
-    this.cli = new this.classes.CLI(this);
+    this.cli = new this.classes.CLI(this, this.cliInputArgv);
 
     // get an array of commands and options that should be processed
     this.processedInput = this.cli.processInput();

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -5,7 +5,6 @@ const BbPromise = require('bluebird');
 const os = require('os');
 const chalk = require('chalk');
 const updateNotifier = require('update-notifier');
-const minimist = require('minimist');
 const pkg = require('../package.json');
 const CLI = require('./classes/CLI');
 const Config = require('./classes/Config');
@@ -17,6 +16,7 @@ const Variables = require('./classes/Variables');
 const ServerlessError = require('./classes/Error').ServerlessError;
 const Version = require('./../package.json').version;
 const isStandaloneExecutable = require('./utils/isStandaloneExecutable');
+const resolveCliInput = require('./utils/resolveCliInput');
 
 const installationMaintananceCommands = new Set(['uninstall', 'upgrade']);
 
@@ -38,7 +38,8 @@ class Serverless {
     // use the servicePath from the options or try to find it in the CWD
     this.cliInputArgv = process.argv.slice(2);
     configObject.servicePath =
-      configObject.servicePath || this.utils.findServicePath(minimist(this.cliInputArgv).config);
+      configObject.servicePath ||
+      this.utils.findServicePath(resolveCliInput(this.cliInputArgv).options.config);
 
     this.config = new Config(this, configObject);
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -3,11 +3,11 @@
 const version = require('../../package.json').version;
 const enterpriseVersion = require('@serverless/enterprise-plugin/package.json').version;
 const { sdkVersion } = require('@serverless/enterprise-plugin');
-const minimist = require('minimist');
 const _ = require('lodash');
 const os = require('os');
 const chalk = require('chalk');
 const getCommandSuggestion = require('../utils/getCommandSuggestion');
+const resolveCliInput = require('../utils/resolveCliInput');
 
 class CLI {
   constructor(serverless, inputArray) {
@@ -36,48 +36,7 @@ class CLI {
       inputArray = process.argv.slice(2);
     }
 
-    const base64Encode = valueStr => Buffer.from(valueStr).toString('base64');
-
-    const toBase64Helper = value => {
-      const valueStr = value.toString();
-      if (valueStr.startsWith('-')) {
-        if (valueStr.indexOf('=') !== -1) {
-          // do not encode argument names, since those are parsed by
-          // minimist, and thus need to be there unconverted:
-          const splitted = valueStr.split('=', 2);
-          // splitted[1] values, however, need to be encoded, since we
-          // decode them later back to utf8
-          const encodedValue = base64Encode(splitted[1]);
-          return `${splitted[0]}=${encodedValue}`;
-        }
-        // do not encode plain flags, for the same reason as above
-        return valueStr;
-      }
-      return base64Encode(valueStr);
-    };
-
-    const decodedArgsHelper = arg => {
-      if (_.isString(arg)) {
-        return Buffer.from(arg, 'base64').toString();
-      } else if (_.isArray(arg)) {
-        return _.map(arg, decodedArgsHelper);
-      }
-      return arg;
-    };
-
-    // encode all the options values to base64
-    const valuesToParse = _.map(inputArray, toBase64Helper);
-
-    // parse the options with minimist
-    const argvToParse = minimist(valuesToParse);
-
-    // decode all values back to utf8 strings
-    const argv = _.mapValues(argvToParse, decodedArgsHelper);
-
-    const commands = [].concat(argv._);
-    const options = _.omit(argv, ['_']);
-
-    return { commands, options };
+    return resolveCliInput(inputArray);
   }
 
   suppressLogIfPrintCommand(processedInput) {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -129,7 +129,7 @@ class CLI {
       (commands.length === 0 && (options.help || options.h)) ||
       (commands.length === 1 && commands.indexOf('help') > -1)
     ) {
-      if (options.verbose || options.v) {
+      if (options.verbose) {
         this.generateVerboseHelp();
       } else {
         this.generateMainHelp();

--- a/lib/plugins/plugin/install/install.test.js
+++ b/lib/plugins/plugin/install/install.test.js
@@ -49,6 +49,7 @@ describe('PluginInstall', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.cli = new CLI(serverless);
+    serverless.processedInput = serverless.cli.processInput();
     const options = {};
     pluginInstall = new PluginInstall(serverless, options);
     consoleLogStub = sinon.stub(serverless.cli, 'consoleLog').returns();

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -4,10 +4,9 @@ const fetch = require('node-fetch');
 const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
-const path = require('path');
 const chalk = require('chalk');
 const _ = require('lodash');
-const fileExists = require('../../../utils/fs/fileExists');
+const { getServerlessConfigFilePath } = require('../../../utils/getServerlessConfigFile');
 
 module.exports = {
   validate() {
@@ -21,29 +20,10 @@ module.exports = {
   },
 
   getServerlessFilePath() {
-    const servicePath = this.serverless.config.servicePath;
-    const ymlFilePath = path.join(servicePath, 'serverless.yml');
-    const yamlFilePath = path.join(servicePath, 'serverless.yaml');
-    const jsonFilePath = path.join(servicePath, 'serverless.json');
-    const jsFilePath = path.join(servicePath, 'serverless.js');
-
-    return BbPromise.props({
-      json: fileExists(jsonFilePath),
-      yml: fileExists(ymlFilePath),
-      yaml: fileExists(yamlFilePath),
-      js: fileExists(jsFilePath),
-    }).then(exists => {
-      if (exists.yml) {
-        return ymlFilePath;
-      } else if (exists.yaml) {
-        return yamlFilePath;
-      } else if (exists.json) {
-        return jsonFilePath;
-      } else if (exists.js) {
-        return jsFilePath;
-      }
-      return BbPromise.reject(
-        new this.serverless.classes.Error('Could not find any serverless service definition file.')
+    return getServerlessConfigFilePath(this.serverless).then(filePath => {
+      if (filePath) return filePath;
+      throw new this.serverless.classes.Error(
+        'Could not find any serverless service definition file.'
       );
     });
   },

--- a/lib/plugins/plugin/lib/utils.test.js
+++ b/lib/plugins/plugin/lib/utils.test.js
@@ -40,6 +40,7 @@ describe('PluginUtils', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.cli = new CLI(serverless);
+    serverless.processedInput = serverless.cli.processInput();
     const options = {};
     pluginUtils = new PluginInstall(serverless, options);
     consoleLogStub = sinon.stub(serverless.cli, 'consoleLog').returns();

--- a/lib/plugins/plugin/uninstall/uninstall.test.js
+++ b/lib/plugins/plugin/uninstall/uninstall.test.js
@@ -43,6 +43,7 @@ describe('PluginUninstall', () => {
   beforeEach(() => {
     serverless = new Serverless();
     serverless.cli = new CLI(serverless);
+    serverless.processedInput = serverless.cli.processInput();
     const options = {};
     pluginUninstall = new PluginUninstall(serverless, options);
     consoleLogStub = sinon.stub(serverless.cli, 'consoleLog').returns();

--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const _ = require('lodash');
+const minimist = require('minimist');
+
+module.exports = _.memoize(inputArray => {
+  const base64Encode = valueStr => Buffer.from(valueStr).toString('base64');
+
+  const toBase64Helper = value => {
+    const valueStr = value.toString();
+    if (valueStr.startsWith('-')) {
+      if (valueStr.indexOf('=') !== -1) {
+        // do not encode argument names, since those are parsed by
+        // minimist, and thus need to be there unconverted:
+        const splitted = valueStr.split('=', 2);
+        // splitted[1] values, however, need to be encoded, since we
+        // decode them later back to utf8
+        const encodedValue = base64Encode(splitted[1]);
+        return `${splitted[0]}=${encodedValue}`;
+      }
+      // do not encode plain flags, for the same reason as above
+      return valueStr;
+    }
+    return base64Encode(valueStr);
+  };
+
+  const decodedArgsHelper = arg => {
+    if (_.isString(arg)) {
+      return Buffer.from(arg, 'base64').toString();
+    } else if (_.isArray(arg)) {
+      return _.map(arg, decodedArgsHelper);
+    }
+    return arg;
+  };
+
+  // encode all the options values to base64
+  const valuesToParse = _.map(inputArray, toBase64Helper);
+
+  // parse the options with minimist
+  const argvToParse = minimist(valuesToParse);
+
+  // decode all values back to utf8 strings
+  const argv = _.mapValues(argvToParse, decodedArgsHelper);
+
+  const commands = [].concat(argv._);
+  const options = _.omit(argv, ['_']);
+
+  return { commands, options };
+});

--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -3,6 +3,12 @@
 const _ = require('lodash');
 const minimist = require('minimist');
 
+const minimistOptions = {
+  boolean: ['help', 'version', 'verbose'],
+  string: ['config'],
+  alias: { config: 'c', help: 'h', version: 'v' },
+};
+
 module.exports = _.memoize(inputArray => {
   const base64Encode = valueStr => Buffer.from(valueStr).toString('base64');
 
@@ -37,13 +43,24 @@ module.exports = _.memoize(inputArray => {
   const valuesToParse = _.map(inputArray, toBase64Helper);
 
   // parse the options with minimist
-  const argvToParse = minimist(valuesToParse);
+  const argvToParse = minimist(valuesToParse, minimistOptions);
 
   // decode all values back to utf8 strings
   const argv = _.mapValues(argvToParse, decodedArgsHelper);
 
   const commands = [].concat(argv._);
   const options = _.omit(argv, ['_']);
+
+  // Do not expose `false` defaults for booleans as it interfers with interactive CLI detection
+  if (!options.help) {
+    delete options.help;
+    delete options.h;
+  }
+  if (!options.version) {
+    delete options.version;
+    delete options.v;
+  }
+  if (!options.verbose) delete options.verbose;
 
   return { commands, options };
 });


### PR DESCRIPTION
Fixes #7106 and #7130 

Problems:
- We document `-c` shortcut for `--config`, while support for it never seamed to be implemented
- Plugin install logic, relies on some side serverless config file path resolver

Solution:
- Unified resolution of input arguments, and provided basic minimist configuration (never used before) to ensure that e.g. `-c` is always aliased to `--config`
- Ensure plugin logic relies on commonly used serverless config file resolver