### PR TITLE
Fix issue parsing JSON variables from AWS Secret Manager

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -815,6 +815,11 @@ class Variables {
         // We cannot parse StringList types, so don't try
         if (type !== 'StringList' && param.startsWith('/aws/reference/secretsmanager')) {
           try {
+            // Sometimes Secrets Manger returns an Object
+            // Check if Object can be returned before parsing
+            if (typeof plainText === 'object') {
+              return BbPromise.resolve(plainText);
+            }
             const json = JSON.parse(plainText);
             return BbPromise.resolve(json);
           } catch (err) {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2362,6 +2362,23 @@ module.exports = {
           .then()
           .finally(() => ssmStub.restore());
       });
+      it('should NOT parse json if already in object form', () => {
+        const secretParam = '/aws/reference/secretsmanager/foo-bar';
+        const jsonObject = { str: 'abc', num: 123 };
+        const awsResponse = {
+          Parameter: {
+            Value: jsonObject,
+          },
+        };
+        const ssmStub = sinon
+          .stub(awsProvider, 'request')
+          .callsFake(() => BbPromise.resolve(awsResponse));
+        return serverless.variables
+          .getValueFromSsm(`ssm:${secretParam}~true`)
+          .should.become(jsonObject)
+          .then()
+          .finally(() => ssmStub.restore());
+      });
       it('should get value as text if returned value is NOT json-like', () => {
         const secretParam = '/aws/reference/secretsmanager/foo-bar';
         const plainText = 'I am plain text';


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
Implements a small fix for referencing AWS secret variables stored in JSON format. 

<!-- Briefly describe the scope of your PR -->
For this particular fix, I was referencing RDS information stored in JSON format. The returned value was already coming back as a JSON object from AWS. Trying to parse again was resulting in an error. 

This simple fix checks first if it is already an object before trying to parse. 

There don't appear to be any open issues but some referencing issues and PR's are:
https://github.com/serverless/serverless/issues/5838
https://github.com/serverless/serverless/pull/5842

## How can we verify it
How I was using this implementation
```
custom
  rdsCredentials: ${ssm:/aws/reference/secretsmanager/rds_credentials~true}

provider:
  name: aws
  runtime: nodejs8.10
  stage: development
  region: us-west-2
  environment:
      DB_HOST: ${self:custom.rdsCredentials.host}
```
<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
