### PR TITLE
Update download deps to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "chalk": "^2.4.2",
     "ci-info": "^1.6.0",
     "dayjs": "^1.8.18",
-    "download": "^5.0.3",
+    "download": "^7.1.0",
     "essentials": "^1.1.1",
     "fast-levenshtein": "^2.0.6",
     "filesize": "^3.6.1",


### PR DESCRIPTION
## What did you implement

I noticed the version of download was pretty old (almost 3 years old).

The new version (which is still from 2018) fix a moderate vulnerability (download > caw > tunnel-agent, see https://www.npmjs.com/advisories/598).

## How can we verify it

From the repo, I tried theses install option to validate everything went fine:

```bash
./bin/serverless install -u https://github.com/serverless/examples/tree/master/openwhisk-node-simple-http-endpoint -n github
./bin/serverless install -u https://gitlab.com/laardee/serverless-template-example -n gitlab
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
