### PR TITLE
PLAT-2171 Fix bundling of dashboard plugin for standalone

### DIFF
--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -2,13 +2,14 @@
 
 'use strict';
 
-if (
-  process.argv[2] === 'binary-postinstall' &&
-  process.argv.length === 3 &&
-  require('../lib/utils/isStandaloneExecutable')
-) {
-  require('../scripts/postinstall');
-  return;
+const isStandaloneExecutable = require('../lib/utils/isStandaloneExecutable');
+
+if (isStandaloneExecutable) {
+  require('../lib/utils/standalone-patch');
+  if (process.argv[2] === 'binary-postinstall' && process.argv.length === 3) {
+    require('../scripts/postinstall');
+    return;
+  }
 }
 
 // global graceful-fs patch

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -11,16 +11,7 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      [
-        '',
-        'AWS APIGW',
-        'AWS Lambda',
-        'Binary Installer',
-        'CLI',
-        'Plugins',
-        'User Config',
-        'Variables',
-      ],
+      ['', 'AWS APIGW', 'AWS Lambda', 'CLI', 'Plugins', 'Standalone', 'User Config', 'Variables'],
     ],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],

--- a/lib/utils/standalone-patch.js
+++ b/lib/utils/standalone-patch.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// Workaround 'pkg' bug: https://github.com/zeit/pkg/issues/420
+// Copying files from snapshot via `fs.copyFileSync` crashes with ENOENT
+// Overriding copyFileSync with primitive alternative
+
+const fs = require('fs');
+
+if (!fs.copyFile) return;
+
+const path = require('path');
+
+const originalCopyFile = fs.copyFile;
+const originalCopyFileSync = fs.copyFileSync;
+
+fs.copyFile = function copyFile(src, dest, flags, callback) {
+  if (!path.resolve(src).startsWith('/snapshot/')) {
+    originalCopyFile(src, dest, flags, callback);
+    return;
+  }
+  if (typeof flags === 'function') {
+    callback = flags;
+    flags = 0;
+  } else if (typeof callback !== 'function') {
+    throw new TypeError('Callback must be a function');
+  }
+
+  fs.readFile(src, (readError, content) => {
+    if (readError) {
+      callback(readError);
+      return;
+    }
+    if (flags & fs.constants.COPYFILE_EXCL) {
+      fs.stat(dest, statError => {
+        if (!statError) {
+          callback(Object.assign(new Error('File already exists'), { code: 'EEXIST' }));
+          return;
+        }
+        if (statError.code !== 'ENOENT') {
+          callback(statError);
+          return;
+        }
+        fs.writeFile(dest, content, callback);
+      });
+    } else {
+      fs.writeFile(dest, content, callback);
+    }
+  });
+};
+
+fs.copyFileSync = function copyFileSync(src, dest, flags) {
+  if (!path.resolve(src).startsWith('/snapshot/')) {
+    originalCopyFileSync(src, dest, flags);
+    return;
+  }
+  const content = fs.readFileSync(src);
+  if (flags & fs.constants.COPYFILE_EXCL) {
+    try {
+      fs.statSync(dest);
+    } catch (statError) {
+      if (statError.code !== 'ENOENT') throw statError;
+      fs.writeFileSync(dest, content);
+      return;
+    }
+    throw Object.assign(new Error('File already exists'), { code: 'EEXIST' });
+  }
+  fs.writeFileSync(dest, content);
+};
+
+if (!fs.promises) return;
+
+const { promisify } = require('util');
+
+fs.promises.copyFile = promisify(fs.copyFile);

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
   },
   "dependencies": {
     "@serverless/cli": "^1.4.0",
-    "@serverless/enterprise-plugin": "^3.2.5",
+    "@serverless/enterprise-plugin": "^3.2.7",
     "archiver": "^1.3.0",
     "async": "^1.5.2",
     "aws-sdk": "^2.592.0",

--- a/scripts/pkg/config.js
+++ b/scripts/pkg/config.js
@@ -11,6 +11,9 @@ module.exports = {
     '../../lib/plugins/aws/package/lib/*.json',
     // Service templates
     '../../lib/plugins/create/templates',
+    // Dashboard wrappers
+    '../../node_modules/@serverless/enterprise-plugin/sdk-js/dist/index.js',
+    '../../node_modules/@serverless/enterprise-plugin/sdk-py',
     // Ensure npm is bundled as a dependency
     '../../node_modules/npm/bin/npm-cli.js',
     // Below module is not automatically traced by pkg, we need to point it manually

--- a/scripts/pkg/config.js
+++ b/scripts/pkg/config.js
@@ -11,6 +11,8 @@ module.exports = {
     '../../lib/plugins/aws/package/lib/*.json',
     // Service templates
     '../../lib/plugins/create/templates',
+    // Dashboard policies
+    '../../node_modules/@serverless/enterprise-plugin/lib/safeguards/policies',
     // Dashboard wrappers
     '../../node_modules/@serverless/enterprise-plugin/sdk-js/dist/index.js',
     '../../node_modules/@serverless/enterprise-plugin/sdk-py',


### PR DESCRIPTION
Some dynamically referenced files from dashboard plugin were not picked automatically.

Additionally it appeared that due to bug in pkg-> zeit/pkg#420 copying of wrapper files crashed, introduced a generic workaround for that issue.

Other issue is already fixed in https://github.com/serverless/enterprise-plugin/pull/339 which is bumped here to fixed version
