### PR TITLE
fix: Auto-delete on AWS stack create failure when using a custom deployment bucket

### DIFF
--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -24,7 +24,7 @@ module.exports = {
 
     const params = {
       StackName: stackName,
-      OnFailure: 'ROLLBACK',
+      OnFailure: 'DELETE',
       Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
       Parameters: [],
       TemplateURL: templateUrl,

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -51,7 +51,7 @@ describe('updateStack', () => {
         expect(
           createStackStub.calledWithExactly('CloudFormation', 'createStack', {
             StackName: awsDeploy.provider.naming.getStackName(),
-            OnFailure: 'ROLLBACK',
+            OnFailure: 'DELETE',
             Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
             Parameters: [],
             TemplateURL: `https://s3.amazonaws.com/${awsDeploy.bucketName}/${awsDeploy.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`,


### PR DESCRIPTION
## What did you implement

Until now, failed stack deploys when using deploymentBucket to specify an existing bucket were left in ROLLBACK_COMPLETE state. This required manual 'sls remove' before a redeploy.

This was partly addressed by #5631, which changed createStack to auto-delete CloudFormation stacks on failure. However, it looks like when using a custom deploymentBucket, the stacks are lazily created via some duplicated code in updateStack.js. This code still used the ROLLBACK setting for newly created stacks.

Closes #6612.

## How can we verify it

Create an S3 bucket named `some.unique.s3.bucket.that.serverless.can.access`
Deploy this `serverless.yml`:

```
service: test-service
provider:
  name: aws
  deploymentBucket:
    name: some.unique.s3.bucket.that.serverless.can.access

resources:
  Resources:
    Bucket:
      Type: AWS::S3::Bucket
      Properties:
        # This will trigger a stack deploy failure, because the bucket already exists
        BucketName: some.unique.s3.bucket.that.serverless.can.access
```

Before the change, the stack is left in ROLLBACK_COMPLETE stage. After the change, it is deleted.
Would be great to have this in the fast-track release, it won't have any merge conflicts.

## Todos

- [x ] Write and run all tests [Updated the existing test]
- [x ] Write documentation [not applicable]
- [x ] Enable "Allow edits from maintainers" for this PR
- [x ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
