### PR TITLE
Switch to @commitlint/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,13 +128,13 @@
     }
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.3.3",
     "@serverless/eslint-config": "^1.2.1",
     "@serverless/test": "^3.2.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "child-process-ext": "^2.1.0",
     "cli-progress-footer": "^1.1.1",
-    "commitlint": "^8.2.0",
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.19.1",
     "git-list-updated": "^1.2.1",


### PR DESCRIPTION
We've relied on `commitlint` which is now an alias to `@commitlint/cli`.

Still `commitlint` started to crash badly with `The "path" argument must be of type string. Received type undefined` as we can see here: https://travis-ci.org/serverless/serverless/jobs/632251308

Issue seems not shared by `@commitlint/cli`