### PR TITLE
Fix event bridge related integration tests

### DIFF
--- a/tests/integration-all/event-bridge/tests.js
+++ b/tests/integration-all/event-bridge/tests.js
@@ -4,14 +4,10 @@ const path = require('path');
 const { expect } = require('chai');
 
 const { getTmpDirPath, readYamlFile, writeYamlFile } = require('../../utils/fs');
+const { confirmCloudWatchLogs } = require('../../utils/misc');
 const { createEventBus, putEvents, deleteEventBus } = require('../../utils/eventBridge');
 
-const {
-  createTestService,
-  deployService,
-  removeService,
-  waitForFunctionLogs,
-} = require('../../utils/integration');
+const { createTestService, deployService, removeService } = require('../../utils/integration');
 const { getMarkers } = require('../shared/utils');
 
 describe('AWS - Event Bridge Integration Test', function() {
@@ -78,13 +74,20 @@ describe('AWS - Event Bridge Integration Test', function() {
       const functionName = 'eventBusDefault';
       const markers = getMarkers(functionName);
 
-      return putEvents('default', putEventEntries)
-        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
-        .then(logs => {
-          expect(logs).to.include(`"source":"${eventSource}"`);
-          expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
-          expect(logs).to.include(`"detail":${putEventEntries[0].Detail}`);
-        });
+      return confirmCloudWatchLogs(
+        `/aws/lambda/${stackName}-${functionName}`,
+        () => putEvents('default', putEventEntries),
+        {
+          checkIsComplete: events =>
+            events.find(event => event.message.includes(markers.start)) &&
+            events.find(event => event.message.includes(markers.end)),
+        }
+      ).then(events => {
+        const logs = events.map(event => event.message).join('\n');
+        expect(logs).to.include(`"source":"${eventSource}"`);
+        expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
+        expect(logs).to.include(`"detail":${putEventEntries[0].Detail}`);
+      });
     });
   });
 
@@ -93,13 +96,20 @@ describe('AWS - Event Bridge Integration Test', function() {
       const functionName = 'eventBusCustom';
       const markers = getMarkers(functionName);
 
-      return putEvents(namedEventBusName, putEventEntries)
-        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
-        .then(logs => {
-          expect(logs).to.include(`"source":"${eventSource}"`);
-          expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
-          expect(logs).to.include(`"detail":${putEventEntries[0].Detail}`);
-        });
+      return confirmCloudWatchLogs(
+        `/aws/lambda/${stackName}-${functionName}`,
+        () => putEvents(namedEventBusName, putEventEntries),
+        {
+          checkIsComplete: events =>
+            events.find(event => event.message.includes(markers.start)) &&
+            events.find(event => event.message.includes(markers.end)),
+        }
+      ).then(events => {
+        const logs = events.map(event => event.message).join('\n');
+        expect(logs).to.include(`"source":"${eventSource}"`);
+        expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
+        expect(logs).to.include(`"detail":${putEventEntries[0].Detail}`);
+      });
     });
   });
 
@@ -108,13 +118,20 @@ describe('AWS - Event Bridge Integration Test', function() {
       const functionName = 'eventBusArn';
       const markers = getMarkers(functionName);
 
-      return putEvents(arnEventBusName, putEventEntries)
-        .then(() => waitForFunctionLogs(tmpDirPath, functionName, markers.start, markers.end))
-        .then(logs => {
-          expect(logs).to.include(`"source":"${eventSource}"`);
-          expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
-          expect(logs).to.include(`"detail":${putEventEntries[0].Detail}`);
-        });
+      return confirmCloudWatchLogs(
+        `/aws/lambda/${stackName}-${functionName}`,
+        () => putEvents(arnEventBusName, putEventEntries),
+        {
+          checkIsComplete: events =>
+            events.find(event => event.message.includes(markers.start)) &&
+            events.find(event => event.message.includes(markers.end)),
+        }
+      ).then(events => {
+        const logs = events.map(event => event.message).join('\n');
+        expect(logs).to.include(`"source":"${eventSource}"`);
+        expect(logs).to.include(`"detail-type":"${putEventEntries[0].DetailType}"`);
+        expect(logs).to.include(`"detail":${putEventEntries[0].Detail}`);
+      });
     });
   });
 });

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -74,11 +74,21 @@ function confirmCloudWatchLogs(logGroupName, trigger, options = {}) {
   const timeout = options.timeout || 60000;
   return trigger()
     .then(() => awsRequest('CloudWatchLogs', 'filterLogEvents', { logGroupName }))
-    .then(result => {
-      if (result.events.length) return result.events;
+    .then(({ events }) => {
+      if (events.length) {
+        if (options.checkIsComplete) {
+          if (options.checkIsComplete(events)) return events;
+        } else {
+          return events;
+        }
+      }
       const duration = Date.now() - startTime;
       if (duration > timeout) return [];
-      return confirmCloudWatchLogs(logGroupName, trigger, { timeout: timeout - duration });
+      return confirmCloudWatchLogs(
+        logGroupName,
+        trigger,
+        Object.assign({}, options, { timeout: timeout - duration })
+      );
     });
 }
 

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -69,15 +69,16 @@ function replaceEnv(values) {
  * This function allows to confirm that new setting (turned on cloudwatch logs)
  * is effective after stack deployment
  */
-function confirmCloudWatchLogs(logGroupName, trigger, timeout = 60000) {
+function confirmCloudWatchLogs(logGroupName, trigger, options = {}) {
   const startTime = Date.now();
+  const timeout = options.timeout || 60000;
   return trigger()
     .then(() => awsRequest('CloudWatchLogs', 'filterLogEvents', { logGroupName }))
     .then(result => {
       if (result.events.length) return result.events;
       const duration = Date.now() - startTime;
       if (duration > timeout) return [];
-      return confirmCloudWatchLogs(logGroupName, trigger, timeout - duration);
+      return confirmCloudWatchLogs(logGroupName, trigger, { timeout: timeout - duration });
     });
 }
 


### PR DESCRIPTION
It's to address observed CI fail: https://travis-ci.org/serverless/serverless/jobs/632251893

There's a possible race condition where events issued right after deployment do not trigger lambda yet.

Similar issue was observed when testing Websocket logs, and for that then I've created an utility which invokes the lambda trigger until logs are written (or until timeout occurs).

Updated  event bridge tests to rely on same util.