### PR TITLE
Improve error message when providing an invalid config path

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -115,7 +115,8 @@ class Utils {
     let servicePath = null;
 
     if (customPath) {
-      if (fileExistsSync(path.join(process.cwd(), customPath))) {
+      customPath = path.join(process.cwd(), customPath);
+      if (fileExistsSync(customPath)) {
         servicePath = process.cwd();
       } else {
         throw new Error(`Config file ${customPath} not found`);


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Absolute paths are not supported in `serverless xxx -c /tmp/serverless.yml`. That's fine, paths must be relative.

However, the resulting error message is not clear enough.

Before:

```
$ serverless logs -c /Users/matthieu/foo/bar/serverless.yml

  Error --------------------------------------------------

  Error: Config file /Users/matthieu/foo/bar/serverless.yml not found
```

After:

```
$ serverless logs -c /Users/matthieu/foo/bar/serverless.yml

  Error --------------------------------------------------

  Error: Config file /Users/matthieu/current-directory/Users/matthieu/foo/bar/serverless.yml not found
```

The new error message is clearer: we immediately see that the path was transformed.

## How can we verify it

Run the command with an absolute path, e.g.:

```
serverless logs -c /tmp/serverless.yml
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
