### PR TITLE
Upgrade https-proxy-agent to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "get-stdin": "^5.0.1",
     "globby": "^6.1.0",
     "graceful-fs": "4.2.1",
-    "https-proxy-agent": "^3.0.1",
+    "https-proxy-agent": "^4.0.0",
     "inquirer": "^6.5.2",
     "is-docker": "^1.1.0",
     "is-wsl": "^2.1.1",


### PR DESCRIPTION
Closes #7168 

Seems safe to do, as support for Node.js v6 is maintained