### PR TITLE
Replace minimist with yargs-parser

### DIFF
--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -34,7 +34,7 @@ serverless invoke local --function functionName
 * `--env` or `-e` String representing an environment variable to set when invoking your function, in the form `<name>=<value>`. Can be repeated for more than one environment variable.
 * `--docker` Enable docker support for NodeJS/Python/Ruby/Java. Enabled by default for other
   runtimes.
-* `--docker-arg` Pass additional arguments to docker run command when `--docker` is option used. e.g. `--docker-arg '-p 9229:9229' --docker-arg '-v /var:/host_var'`
+* `--docker-arg` Pass additional arguments to docker run command when `--docker` is option used. e.g. `--docker-arg='-p 9229:9229' --docker-arg='-v /var:/host_var'`
 
 ## Environment
 

--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
-const minimist = require('minimist');
+const yargsParser = require('yargs-parser');
 
-const minimistOptions = {
+const yargsOptions = {
   boolean: ['help', 'version', 'verbose'],
   string: ['config'],
   alias: { config: 'c', help: 'h', version: 'v' },
@@ -17,7 +17,7 @@ module.exports = _.memoize(inputArray => {
     if (valueStr.startsWith('-')) {
       if (valueStr.indexOf('=') !== -1) {
         // do not encode argument names, since those are parsed by
-        // minimist, and thus need to be there unconverted:
+        // yargs-parser, and thus need to be there unconverted:
         const splitted = valueStr.split('=', 2);
         // splitted[1] values, however, need to be encoded, since we
         // decode them later back to utf8
@@ -42,8 +42,8 @@ module.exports = _.memoize(inputArray => {
   // encode all the options values to base64
   const valuesToParse = _.map(inputArray, toBase64Helper);
 
-  // parse the options with minimist
-  const argvToParse = minimist(valuesToParse, minimistOptions);
+  // parse the options with yargs-parser
+  const argvToParse = yargsParser(valuesToParse, yargsOptions);
 
   // decode all values back to utf8 strings
   const argv = _.mapValues(argvToParse, decodedArgsHelper);

--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -15,10 +15,11 @@ module.exports = _.memoize(inputArray => {
   const toBase64Helper = value => {
     const valueStr = value.toString();
     if (valueStr.startsWith('-')) {
-      if (valueStr.indexOf('=') !== -1) {
+      const equalsIndex = valueStr.indexOf('=');
+      if (equalsIndex !== -1) {
         // do not encode argument names, since those are parsed by
         // yargs-parser, and thus need to be there unconverted:
-        const splitted = valueStr.split('=', 2);
+        const splitted = [valueStr.substring(0, equalsIndex), valueStr.substring(equalsIndex + 1)];
         // splitted[1] values, however, need to be encoded, since we
         // decode them later back to utf8
         const encodedValue = base64Encode(splitted[1]);

--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -7,47 +7,11 @@ const yargsOptions = {
   boolean: ['help', 'version', 'verbose'],
   string: ['config'],
   alias: { config: 'c', help: 'h', version: 'v' },
+  configuration: { 'parse-numbers': false },
 };
 
 module.exports = _.memoize(inputArray => {
-  const base64Encode = valueStr => Buffer.from(valueStr).toString('base64');
-
-  const toBase64Helper = value => {
-    const valueStr = value.toString();
-    if (valueStr.startsWith('-')) {
-      const equalsIndex = valueStr.indexOf('=');
-      if (equalsIndex !== -1) {
-        // do not encode argument names, since those are parsed by
-        // yargs-parser, and thus need to be there unconverted:
-        const splitted = [valueStr.substring(0, equalsIndex), valueStr.substring(equalsIndex + 1)];
-        // splitted[1] values, however, need to be encoded, since we
-        // decode them later back to utf8
-        const encodedValue = base64Encode(splitted[1]);
-        return `${splitted[0]}=${encodedValue}`;
-      }
-      // do not encode plain flags, for the same reason as above
-      return valueStr;
-    }
-    return base64Encode(valueStr);
-  };
-
-  const decodedArgsHelper = arg => {
-    if (_.isString(arg)) {
-      return Buffer.from(arg, 'base64').toString();
-    } else if (_.isArray(arg)) {
-      return _.map(arg, decodedArgsHelper);
-    }
-    return arg;
-  };
-
-  // encode all the options values to base64
-  const valuesToParse = _.map(inputArray, toBase64Helper);
-
-  // parse the options with yargs-parser
-  const argvToParse = yargsParser(valuesToParse, yargsOptions);
-
-  // decode all values back to utf8 strings
-  const argv = _.mapValues(argvToParse, decodedArgsHelper);
+  const argv = yargsParser(inputArray, yargsOptions);
 
   const commands = [].concat(argv._);
   const options = _.omit(argv, ['_']);

--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "jszip": "^3.2.2",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.15",
-    "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nanomatch": "^1.2.13",
     "ncjsm": "^4.0.1",
@@ -203,6 +202,7 @@
     "update-notifier": "^2.5.0",
     "uuid": "^2.0.3",
     "write-file-atomic": "^2.4.3",
-    "yaml-ast-parser": "0.0.43"
+    "yaml-ast-parser": "0.0.43",
+    "yargs-parser": "^16.1.0"
   }
 }

--- a/scripts/pkg/upload.js
+++ b/scripts/pkg/upload.js
@@ -6,7 +6,7 @@
 
 require('essentials');
 
-const argv = require('minimist')(process.argv.slice(2), {
+const argv = require('yargs-parser')(process.argv.slice(2), {
   boolean: ['help'],
   alias: { help: 'h' },
 });


### PR DESCRIPTION
## What did you implement

Replaces minimist with yargs-parser

Also fixes an issue where "nested" arguments contain an equals sign

Closes https://github.com/serverless/serverless/issues/6083

## How can we verify it

invoke local --function hello --docker --docker-arg="-e AWS_ACCESS_KEY_ID=1" --docker-arg="-e AWS_SECRET_ACCESS_KEY=1"

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
