### PR TITLE
Tests: Fix download template race condition

### DIFF
--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -100,12 +100,13 @@ describe('downloadTemplateFromRepo', () => {
       const url = 'https://github.com/johndoe/service-to-be-downloaded';
       const name = 'new-service-name';
 
-      downloadStub.resolves(
-        remove(newServicePath).then(() => {
+      downloadStub.resolves({
+        then: callback => {
           const slsYml = path.join(process.cwd(), 'new-service-name', 'serverless.yml');
           writeFileSync(slsYml, 'service: service-name');
-        })
-      );
+          callback();
+        },
+      });
 
       return expect(downloadTemplateFromRepo(url, name)).to.be.fulfilled.then(serviceName => {
         expect(downloadStub.calledOnce).to.equal(true);


### PR DESCRIPTION
Suddenly I've started to observe downloadTemplateFromRepo test failing for me locally.

It might have been influenced by #7155, still real issue was that successful run depended on order in which two async operations proceed their tasks.

Applied a patch that ensures fixed order