### PR TITLE
Fix lamdba permissions setup when authorizer is involved

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -6,6 +6,7 @@ const awsArnRegExs = require('../../../../../utils/arnRegularExpressions');
 
 module.exports = {
   compilePermissions() {
+    const cfResources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     this.permissionMapping.forEach(
       ({ lambdaLogicalId, lambdaAliasName, lambdaAliasLogicalId, event }) => {
         const lambdaPermissionLogicalId = this.provider.naming.getLambdaApiGatewayPermissionLogicalId(
@@ -13,7 +14,7 @@ module.exports = {
         );
 
         const functionArnGetter = { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] };
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+        _.merge(cfResources, {
           [lambdaPermissionLogicalId]: {
             Type: 'AWS::Lambda::Permission',
             Properties: {
@@ -56,7 +57,7 @@ module.exports = {
             return;
           }
 
-          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+          _.merge(cfResources, {
             [authorizerPermissionLogicalId]: {
               Type: 'AWS::Lambda::Permission',
               Properties: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const BbPromise = require('bluebird');
 const awsArnRegExs = require('../../../../../utils/arnRegularExpressions');
 
@@ -57,7 +56,8 @@ module.exports = {
             return;
           }
 
-          _.merge(cfResources, {
+          if (cfResources[authorizerPermissionLogicalId]) return;
+          Object.assign(cfResources, {
             [authorizerPermissionLogicalId]: {
               Type: 'AWS::Lambda::Permission',
               Properties: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -14,7 +14,7 @@ module.exports = {
         );
 
         const functionArnGetter = { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] };
-        _.merge(cfResources, {
+        Object.assign(cfResources, {
           [lambdaPermissionLogicalId]: {
             Type: 'AWS::Lambda::Permission',
             Properties: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -12,21 +12,14 @@ module.exports = {
           event.functionName
         );
 
+        const functionArnGetter = { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] };
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
           [lambdaPermissionLogicalId]: {
             Type: 'AWS::Lambda::Permission',
             Properties: {
-              FunctionName: {
-                'Fn::Join': [
-                  ':',
-                  [
-                    {
-                      'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                    },
-                    ...(lambdaAliasName ? [lambdaAliasName] : []),
-                  ],
-                ],
-              },
+              FunctionName: lambdaAliasName
+                ? { 'Fn::Join': [':', [functionArnGetter, lambdaAliasName]] }
+                : functionArnGetter,
               Action: 'lambda:InvokeFunction',
               Principal: 'apigateway.amazonaws.com',
               SourceArn: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -185,6 +185,16 @@ describe('#awsCompilePermissions()', () => {
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.permissionMapping = [
       {
+        lambdaLogicalId: 'AuthorizerLambdaFunction',
+        event: {
+          http: {
+            path: 'foo/bar',
+            method: 'post',
+          },
+          functionName: 'authorizer',
+        },
+      },
+      {
         lambdaLogicalId: 'FirstLambdaFunction',
         resourceName: 'FooBar',
         event: {
@@ -203,8 +213,61 @@ describe('#awsCompilePermissions()', () => {
     return awsCompileApigEvents.compilePermissions().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .AuthorizerLambdaPermissionApiGateway.Properties.FunctionName['Fn::GetAtt'][0]
-      ).to.equal('AuthorizerLambdaFunction');
+          .AuthorizerLambdaPermissionApiGateway.Properties.FunctionName
+      ).to.deep.equal({ 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] });
+    });
+  });
+
+  it('should create permission resources for aliased authorizers', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          authorizer: {
+            name: 'authorizer',
+            arn: { 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] },
+          },
+          path: 'foo/bar',
+          method: 'post',
+        },
+      },
+    ];
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.permissionMapping = [
+      {
+        lambdaLogicalId: 'AuthorizerLambdaFunction',
+        lambdaAliasName: 'provisioned',
+        event: {
+          http: {
+            path: 'foo/bar',
+            method: 'post',
+          },
+          functionName: 'authorizer',
+        },
+      },
+      {
+        lambdaLogicalId: 'FirstLambdaFunction',
+        resourceName: 'FooBar',
+        event: {
+          http: {
+            authorizer: {
+              name: 'authorizer',
+              arn: { 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] },
+            },
+            path: 'foo/bar',
+            method: 'post',
+          },
+          functionName: 'First',
+        },
+      },
+    ];
+    return awsCompileApigEvents.compilePermissions().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .AuthorizerLambdaPermissionApiGateway.Properties.FunctionName
+      ).to.deep.equal({
+        'Fn::Join': [':', [{ 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] }, 'provisioned']],
+      });
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -46,9 +46,7 @@ describe('#awsCompilePermissions()', () => {
     return awsCompileApigEvents.compilePermissions().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .FirstLambdaPermissionApiGateway.Properties.FunctionName['Fn::Join'][1][0][
-          'Fn::GetAtt'
-        ][0]
+          .FirstLambdaPermissionApiGateway.Properties.FunctionName['Fn::GetAtt'][0]
       ).to.equal('FirstLambdaFunction');
 
       const deepObj = {
@@ -106,9 +104,7 @@ describe('#awsCompilePermissions()', () => {
     return awsCompileApigEvents.compilePermissions().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .FirstLambdaPermissionApiGateway.Properties.FunctionName['Fn::Join'][1][0][
-          'Fn::GetAtt'
-        ][0]
+          .FirstLambdaPermissionApiGateway.Properties.FunctionName['Fn::GetAtt'][0]
       ).to.equal('FirstLambdaFunction');
 
       const deepObj = {


### PR DESCRIPTION
Fixes #7189  (Regression introduced with https://github.com/serverless/serverless/pull/7102)

Additionally ensured old function arn format, when no provisioned concurrency setup is involved, this should help partially solve issues for users of plugins which relied on old template format -> https://github.com/davidgf/serverless-plugin-canary-deployments/issues/71