### PR TITLE
Upgrade `graceful-fs` to ^4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "fs-extra": "^0.30.0",
     "get-stdin": "^5.0.1",
     "globby": "^6.1.0",
-    "graceful-fs": "4.2.1",
+    "graceful-fs": "^4.2.3",
     "https-proxy-agent": "^4.0.0",
     "inquirer": "^6.5.2",
     "is-docker": "^1.1.0",


### PR DESCRIPTION
We were fixed on v4.2.1 due to critical bug in v4.2.2 (more info at  #6667) but that's fixed with v4.2.3.

While v4.2.1 might be responsible (not confirmed) for CI crashes which happen occasionally: https://travis-ci.org/serverless/serverless/jobs/632275541
