### PR TITLE
 Fix default APIGW resource policy configuration

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -3,23 +3,6 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 
-const defaultPolicy = {
-  Version: '2012-10-17',
-  Statement: [
-    {
-      Effect: 'Allow',
-      Principal: '*',
-      Action: 'execute-api:Invoke',
-      Resource: ['execute-api:/*/*/*'],
-      Condition: {
-        IpAddress: {
-          'aws:SourceIp': ['0.0.0.0/0', '::/0'],
-        },
-      },
-    },
-  ],
-};
-
 module.exports = {
   compileRestApi() {
     const apiGateway = this.serverless.service.provider.apiGateway || {};
@@ -87,9 +70,7 @@ module.exports = {
         this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
           this.apiGatewayRestApiLogicalId
         ].Properties,
-        {
-          Policy: defaultPolicy,
-        }
+        { Policy: '' }
       );
     }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -49,22 +49,7 @@ describe('#compileRestApi()', () => {
           EndpointConfiguration: {
             Types: ['EDGE'],
           },
-          Policy: {
-            Statement: [
-              {
-                Action: 'execute-api:Invoke',
-                Condition: {
-                  IpAddress: {
-                    'aws:SourceIp': ['0.0.0.0/0', '::/0'],
-                  },
-                },
-                Effect: 'Allow',
-                Principal: '*',
-                Resource: ['execute-api:/*/*/*'],
-              },
-            ],
-            Version: '2012-10-17',
-          },
+          Policy: '',
         },
       });
     }));
@@ -129,22 +114,7 @@ describe('#compileRestApi()', () => {
           EndpointConfiguration: {
             Types: ['EDGE'],
           },
-          Policy: {
-            Version: '2012-10-17',
-            Statement: [
-              {
-                Effect: 'Allow',
-                Principal: '*',
-                Action: 'execute-api:Invoke',
-                Resource: ['execute-api:/*/*/*'],
-                Condition: {
-                  IpAddress: {
-                    'aws:SourceIp': ['0.0.0.0/0', '::/0'],
-                  },
-                },
-              },
-            ],
-          },
+          Policy: '',
         },
       });
     });
@@ -178,22 +148,7 @@ describe('#compileRestApi()', () => {
             Types: ['EDGE'],
           },
           Name: 'dev-new-service',
-          Policy: {
-            Statement: [
-              {
-                Action: 'execute-api:Invoke',
-                Condition: {
-                  IpAddress: {
-                    'aws:SourceIp': ['0.0.0.0/0', '::/0'],
-                  },
-                },
-                Effect: 'Allow',
-                Principal: '*',
-                Resource: ['execute-api:/*/*/*'],
-              },
-            ],
-            Version: '2012-10-17',
-          },
+          Policy: '',
         },
       });
     });


### PR DESCRIPTION
Regression introduced with #7138

After contacting AWS Support, I've learned that default policy (so no policy) can be ensured by passing an empty string with a setting

Fixes #7194 #7211

