### PR TITLE
PLAT-2173 Separate AWS region and credentials resolution concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.61.2](https://github.com/serverless/serverless/compare/v1.61.1...v1.61.2) (2020-01-15)
+
+### Bug Fixes
+
+- Separate AWS region and credentials resolution concern ([91525e8](https://github.com/serverless/serverless/commit/91525e889f08eefe0451df65e1207d53978030ef)). Fixes [serverless/enterprise-plugin#340](https://github.com/serverless/enterprise-plugin/issues/340)
+
 ### [1.61.1](https://github.com/serverless/serverless/compare/v1.61.0...v1.61.1) (2020-01-14)
 
 ### Bug Fixes

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -224,6 +224,7 @@ class AwsProvider {
   request(service, method, params, options) {
     const that = this;
     const credentials = Object.assign({}, that.getCredentials());
+    credentials.region = this.getRegion();
     // Make sure options is an object (honors wrong calls of request)
     const requestOptions = _.isObject(options) ? options : {};
     const shouldCache = _.get(requestOptions, 'useCache', false);
@@ -377,7 +378,6 @@ class AwsProvider {
     if (this.options['aws-profile']) {
       impl.addProfileCredentials(result, this.options['aws-profile']); // CLI option profile
     }
-    result.region = this.getRegion();
 
     const deploymentBucketObject = this.serverless.service.provider.deploymentBucketObject;
     if (

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -381,7 +381,6 @@ describe('AwsProvider', () => {
           },
         },
       };
-      expect(awsProvider.getCredentials().region).to.eql(options.region);
 
       return awsProvider
         .request(
@@ -392,8 +391,6 @@ describe('AwsProvider', () => {
         )
         .then(data => {
           expect(data).to.eql({ region: 'ap-northeast-1' });
-          // Requesting different region should not affect region in credentials
-          expect(awsProvider.getCredentials().region).to.eql(options.region);
         });
     });
 
@@ -974,15 +971,10 @@ describe('AwsProvider', () => {
       serverless.service.provider.credentials = originalProviderCredentials;
     });
 
-    it('should set region for credentials', () => {
-      const credentials = newAwsProvider.getCredentials();
-      expect(credentials.region).to.equal(newOptions.region);
-    });
-
     it('should not set credentials if credentials is an empty object', () => {
       serverless.service.provider.credentials = {};
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(credentials).to.eql({});
     });
 
     it('should not set credentials if credentials has undefined values', () => {
@@ -992,7 +984,7 @@ describe('AwsProvider', () => {
         sessionToken: undefined,
       };
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(credentials).to.eql({});
     });
 
     it('should not set credentials if credentials has empty string values', () => {
@@ -1002,7 +994,7 @@ describe('AwsProvider', () => {
         sessionToken: '',
       };
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(credentials).to.eql({});
     });
 
     it('should get credentials from provider declared credentials', () => {
@@ -1040,19 +1032,19 @@ describe('AwsProvider', () => {
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(credentials).to.eql({});
     });
 
     it('should not set credentials if profile is not set', () => {
       serverless.service.provider.profile = undefined;
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(credentials).to.eql({});
     });
 
     it('should not set credentials if empty profile is set', () => {
       serverless.service.provider.profile = '';
       const credentials = newAwsProvider.getCredentials();
-      expect(credentials).to.eql({ region: newOptions.region });
+      expect(credentials).to.eql({});
     });
 
     it('should get credentials from provider declared temporary profile', () => {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     }
   },
   "devDependencies": {
-    "@commitlint/cli": "^8.3.4",
+    "@commitlint/cli": "^8.3.5",
     "@serverless/eslint-config": "^1.2.1",
     "@serverless/test": "^3.4.0",
     "chai": "^4.2.0",
@@ -160,7 +160,7 @@
     "@serverless/enterprise-plugin": "^3.2.7",
     "archiver": "^1.3.0",
     "async": "^1.5.2",
-    "aws-sdk": "^2.602.0",
+    "aws-sdk": "^2.603.0",
     "bluebird": "^3.7.2",
     "boxen": "^3.2.0",
     "cachedir": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "1.61.1",
+  "version": "1.61.2",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
Fixes https://github.com/serverless/enterprise-plugin/issues/340

Dashboard plugin at initialization eventually resolves credentials for a framework, and as region resolution comes with it, it also ensures that [region is resolved](https://github.com/serverless/enterprise-plugin/blob/961d33b303af3e3811d6af74269492b083a5fd3f/lib/deployProfile.js#L16)

Still this is taken care of prior variables resolution and there's no guarantee that region value is resolved, hence if region is configured with variables, then unresolved value is passed to AWS SDK, resulting with crash.
