### PR TITLE
Support `code` on ServerlessError

### DIFF
--- a/lib/classes/Error.js
+++ b/lib/classes/Error.js
@@ -47,9 +47,9 @@ const writeMessage = (title, message) => {
 };
 
 class ServerlessError extends Error {
-  constructor(message, statusCode) {
+  constructor(message, code) {
     super(message);
-    this.statusCode = statusCode;
+    this.code = code;
     Error.captureStackTrace(this, this.constructor); // Not needed in Node.js v8+
   }
 }

--- a/lib/classes/Error.test.js
+++ b/lib/classes/Error.test.js
@@ -21,8 +21,8 @@ describe('ServerlessError', () => {
     });
 
     it('should store status code', () => {
-      const error = new ServerlessError('a message', 'a status code');
-      expect(error.statusCode).to.be.equal('a status code');
+      const error = new ServerlessError('a message', 'ERROR_CODE');
+      expect(error.code).to.be.equal('ERROR_CODE');
     });
 
     it('message should always resolve as string', () => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1229,7 +1229,7 @@ module.exports = {
       const awsProvider = new AwsProvider(serverless, options);
       const param = '/some/path/to/invalidparam';
       const property = `\${ssm:${param}}`;
-      const error = new serverless.classes.Error(`Parameter ${param} not found.`, 400);
+      const error = Object.assign(new Error(`Parameter ${param} not found.`), { statusCode: 400 });
       const requestStub = sinon
         .stub(awsProvider, 'request')
         .callsFake(() => BbPromise.reject(error));
@@ -2381,7 +2381,7 @@ module.exports = {
       });
     });
     it('should return undefined if SSM parameter does not exist', () => {
-      const error = new serverless.classes.Error(`Parameter ${param} not found.`, 400);
+      const error = Object.assign(new Error(`Parameter ${param} not found.`), { statusCode: 400 });
       const requestStub = sinon
         .stub(awsProvider, 'request')
         .callsFake(() => BbPromise.reject(error));

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -240,10 +240,12 @@ class AwsProvider {
           f()
             // We're resembling if/else logic, therefore single `then` instead of `then`/`catch` pair
             .then(resolve, e => {
+              const { providerError } = e;
               if (
                 numTry < MAX_TRIES &&
-                e.statusCode !== 403 && // Invalid credentials
-                ((e.providerError && e.providerError.retryable) || e.statusCode === 429)
+                providerError &&
+                ((providerError.retryable && providerError.statusCode !== 403) ||
+                  providerError.statusCode === 429)
               ) {
                 const nextTryNum = numTry + 1;
                 const jitter = Math.random() * 3000 - 1000;
@@ -317,14 +319,14 @@ class AwsProvider {
             userStats.track('user_awsCredentialsNotFound');
             // We do not want to trigger the retry mechanism for credential errors
             return BbPromise.reject(
-              Object.assign(new this.serverless.classes.Error(message, err.statusCode), {
+              Object.assign(new this.serverless.classes.Error(errorMessage), {
                 providerError: _.assign({}, err, { retryable: false }),
               })
             );
           }
 
           return BbPromise.reject(
-            Object.assign(new this.serverless.classes.Error(message, err.statusCode), {
+            Object.assign(new this.serverless.classes.Error(message), {
               providerError: err,
             })
           );


### PR DESCRIPTION
`code` allows to programmatically identify the errors, which is valuable when testing.

It's a common pattern used in Node.js and related projects.

I'm replacing `statusCode` (which is misleading as suggests HTTP request handling), which was added as internal aid with #2189 and doesn't seem to be used and documented, hence seems safe to remove.