### PR TITLE
Implement redrivePolicy for SNS events

### DIFF
--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -146,3 +146,24 @@ functions:
               - dog
               - cat
 ```
+## Setting a redrive policy
+
+This event definition creates an SNS topic that sends messages to a Dead Letter Queue(defined by arn) when the associated lambda is not available. In this example, messages that aren't delivered to the `dispatcher` Lambda (because the lambda service is down or irresponsive) will end in `myDLQ`
+
+```yml
+functions:
+  dispatcher:
+    handler: dispatcher.handler
+    events:
+      - sns:
+          topicName: dispatcher
+          redrivePolicy:
+            deadLetterTargetArn: !Ref myDLQ
+
+resources:
+  Resources:
+    myDLQ:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: myDLQ
+```

--- a/docs/providers/aws/events/sns.md
+++ b/docs/providers/aws/events/sns.md
@@ -146,9 +146,10 @@ functions:
               - dog
               - cat
 ```
+
 ## Setting a redrive policy
 
-This event definition creates an SNS topic that sends messages to a Dead Letter Queue(defined by arn) when the associated lambda is not available. In this example, messages that aren't delivered to the `dispatcher` Lambda (because the lambda service is down or irresponsive) will end in `myDLQ`
+This event definition creates an SNS topic that sends messages to a Dead Letter Queue (defined by its ARN) when the associated lambda is not available. In this example, messages that aren't delivered to the `dispatcher` Lambda (because the lambda service is down or irresponsive) will end in `myDLQ`
 
 ```yml
 functions:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -252,6 +252,12 @@ functions:
       - sns:
           topicName: aggregate
           displayName: Data aggregation pipeline
+          filterPolicy:
+            pet:
+              - dog
+              - cat
+          redrivePolicy:
+            deadLetterTargetArn: arn:aws:sqs:region:XXXXXX:myDLQ
       - sqs:
           arn: arn:aws:sqs:region:XXXXXX:myQueue
           batchSize: 10

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -123,8 +123,7 @@ class AwsCompileSNSEvents {
             }
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-            const topicLogicalId = this.provider.naming.getTopicLogicalId(topicName);
-
+            
             const endpoint = {
               'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
             };
@@ -165,6 +164,8 @@ class AwsCompileSNSEvents {
                 ],
               };
 
+              const topicLogicalId = this.provider.naming.getTopicLogicalId(topicName);
+              
               const subscription = {
                 Endpoint: endpoint,
                 Protocol: 'lambda',
@@ -223,7 +224,7 @@ class AwsCompileSNSEvents {
             });
 
             if (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn) {
-              const queuePolicyLogicalId = this.provider.naming.getQueueLogicalId(functionName, `${topicLogicalId}DLQ`);
+              const queuePolicyLogicalId = this.provider.naming.getQueueLogicalId(functionName, `${topicName}DLQ`);
               _.merge(template.Resources, {
                 [queuePolicyLogicalId]: {
                   Type: 'AWS::SQS::QueuePolicy',

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -123,6 +123,7 @@ class AwsCompileSNSEvents {
             }
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+            const topicLogicalId = this.provider.naming.getTopicLogicalId(topicName);
 
             const endpoint = {
               'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
@@ -163,8 +164,6 @@ class AwsCompileSNSEvents {
                   ],
                 ],
               };
-
-              const topicLogicalId = this.provider.naming.getTopicLogicalId(topicName);
 
               const subscription = {
                 Endpoint: endpoint,
@@ -224,20 +223,34 @@ class AwsCompileSNSEvents {
             });
 
             if (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn) {
-              if (
-                this.serverless.service.provider.compiledCloudFormationTemplate.Resources
-                  .IamRoleLambdaExecution
-              ) {
-                const statement = this.serverless.service.provider.compiledCloudFormationTemplate
-                  .Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement;
-                statement.push({
-                  Effect: 'Allow',
-                  Action: ['sqs:SendMessage'],
-                  Resource: [
-                    event.sns.redrivePolicy.deadLetterTargetArn
-                  ],
-                });                
-              }
+              const queuePolicyLogicalId = this.provider.naming.getQueueLogicalId(functionName, `${topicLogicalId}DLQ`);
+              _.merge(template.Resources, {
+                [queuePolicyLogicalId]: {
+                  Type: 'AWS::SQS::QueuePolicy',
+                  Properties: {
+                    PolicyDocument: {
+                      Version: '2012-10-17',
+                      Id: queuePolicyLogicalId,
+                      Statement: [
+                        {
+                          Effect: 'Allow',
+                          Principal: {
+                            Service: 'sns.amazonaws.com'
+                          },
+                          Action: 'sqs:SendMessage',
+                          Resource: event.sns.redrivePolicy.deadLetterTargetArn,
+                          Condition: {
+                            ArnEquals: {
+                              'aws:SourceArn': topicArn
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    Queues: [event.sns.redrivePolicy.deadLetterTargetArn]
+                  }
+                },
+              });
             }
           }
         });

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -123,7 +123,7 @@ class AwsCompileSNSEvents {
             }
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-            
+
             const endpoint = {
               'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
             };
@@ -165,7 +165,7 @@ class AwsCompileSNSEvents {
               };
 
               const topicLogicalId = this.provider.naming.getTopicLogicalId(topicName);
-              
+
               const subscription = {
                 Endpoint: endpoint,
                 Protocol: 'lambda',
@@ -183,8 +183,9 @@ class AwsCompileSNSEvents {
                 });
               }
 
-              if (event.sns.filterPolicy ||
-                 (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn)
+              if (
+                event.sns.filterPolicy ||
+                (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn)
               ) {
                 _.merge(template.Resources, {
                   [subscriptionLogicalId]: {
@@ -194,7 +195,7 @@ class AwsCompileSNSEvents {
                         Ref: topicLogicalId,
                       },
                       FilterPolicy: event.sns.filterPolicy,
-                      RedrivePolicy: event.sns.redrivePolicy
+                      RedrivePolicy: event.sns.redrivePolicy,
                     }),
                   },
                 });
@@ -224,8 +225,11 @@ class AwsCompileSNSEvents {
             });
 
             if (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn) {
-              const queuePolicyLogicalId = this.provider.naming.getQueueLogicalId(functionName, `${topicName}DLQ`);
-              _.merge(template.Resources, {
+              const queuePolicyLogicalId = this.provider.naming.getQueueLogicalId(
+                functionName,
+                `${topicName}DLQ`
+              );
+              Object.assign(template.Resources, {
                 [queuePolicyLogicalId]: {
                   Type: 'AWS::SQS::QueuePolicy',
                   Properties: {
@@ -236,20 +240,20 @@ class AwsCompileSNSEvents {
                         {
                           Effect: 'Allow',
                           Principal: {
-                            Service: 'sns.amazonaws.com'
+                            Service: 'sns.amazonaws.com',
                           },
                           Action: 'sqs:SendMessage',
                           Resource: event.sns.redrivePolicy.deadLetterTargetArn,
                           Condition: {
                             ArnEquals: {
-                              'aws:SourceArn': topicArn
-                            }
-                          }
-                        }
-                      ]
+                              'aws:SourceArn': topicArn,
+                            },
+                          },
+                        },
+                      ],
                     },
-                    Queues: [event.sns.redrivePolicy.deadLetterTargetArn]
-                  }
+                    Queues: [event.sns.redrivePolicy.deadLetterTargetArn],
+                  },
                 },
               });
             }

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -142,6 +142,7 @@ class AwsCompileSNSEvents {
                     Protocol: 'lambda',
                     Endpoint: endpoint,
                     FilterPolicy: event.sns.filterPolicy,
+                    RedrivePolicy: event.sns.redrivePolicy,
                     Region: region,
                   },
                 },
@@ -182,7 +183,9 @@ class AwsCompileSNSEvents {
                 });
               }
 
-              if (event.sns.filterPolicy) {
+              if (event.sns.filterPolicy ||
+                 (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn)
+              ) {
                 _.merge(template.Resources, {
                   [subscriptionLogicalId]: {
                     Type: 'AWS::SNS::Subscription',
@@ -191,6 +194,7 @@ class AwsCompileSNSEvents {
                         Ref: topicLogicalId,
                       },
                       FilterPolicy: event.sns.filterPolicy,
+                      RedrivePolicy: event.sns.redrivePolicy
                     }),
                   },
                 });
@@ -218,6 +222,23 @@ class AwsCompileSNSEvents {
                 },
               },
             });
+
+            if (event.sns.redrivePolicy && event.sns.redrivePolicy.deadLetterTargetArn) {
+              if (
+                this.serverless.service.provider.compiledCloudFormationTemplate.Resources
+                  .IamRoleLambdaExecution
+              ) {
+                const statement = this.serverless.service.provider.compiledCloudFormationTemplate
+                  .Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement;
+                statement.push({
+                  Effect: 'Allow',
+                  Action: ['sqs:SendMessage'],
+                  Resource: [
+                    event.sns.redrivePolicy.deadLetterTargetArn
+                  ],
+                });                
+              }
+            }
           }
         });
       }

--- a/lib/plugins/aws/package/compile/events/sns/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.test.js
@@ -596,5 +596,60 @@ describe('AwsCompileSNSEvents', () => {
           .FirstLambdaPermissionBarSNS.Type
       ).to.equal('AWS::Lambda::Permission');
     });
+
+    it('should link topic to corresponding dlq when redrivePolicy is defined', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              sns: {
+                topicName: 'Topic 1',
+                displayName: 'Display name for topic 1',
+                redrivePolicy: {
+                  deadLetterTargetArn: {
+                    'Fn::GetAtt': ['SNSDLQ', 'Arn'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      Object.assign(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+        {
+          SNSDLQ: {
+            Type: 'AWS::SQS::Queue',
+            Properties: {
+              QueueName: 'SNSDLQ',
+            },
+          },
+        }
+      );
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .SNSTopicTopic1.Type
+      ).to.equal('AWS::SNS::Topic');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstLambdaPermissionTopic1SNS.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionTopic1.Type
+      ).to.equal('AWS::SNS::Subscription');
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstSnsSubscriptionTopic1.Properties.RedrivePolicy
+      ).to.eql({ deadLetterTargetArn: { 'Fn::GetAtt': ['SNSDLQ', 'Arn'] } });
+      expect(
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSTopic1DLQ.Type
+      ).to.equal('AWS::SQS::QueuePolicy');
+    });
   });
 });


### PR DESCRIPTION
## What did you implement

This allows to define the redrivepolicy for sns events (so messages that can't be delivered to lambda end in a SQS for future retries/error handling). This will also create a queuePolicy to allow the SNS topic to submit messages to the DLQ.

This is my first attempt ti create a PR to the serverless repo, so not sure what other parts could be missing.

Closes #7229

## How can we verify it

Should be possible to test this by adding to a SNS event:

````
redrivePolicy:
  deadLetterTargetArn: !Ref myDLQ
````
A queue must be defined on the resources section with

````
myDLQ:
  Type: AWS::SQS::Queue
  Properties:
    QueueName: myDLQ
````

## Todos

- [x] Create QueuePolicy for the DLQ so the SNS topic can send messages automatically
- [x] Guidance on how to write tests
- [x] Guidance on how to write documentation

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
