### PR TITLE
Ensure to use proper CLI params parser in a script

### DIFF
--- a/scripts/pkg/generate-choco-package.js
+++ b/scripts/pkg/generate-choco-package.js
@@ -6,7 +6,7 @@
 
 require('essentials');
 
-const argv = require('minimist')(process.argv.slice(2), {
+const argv = require('yargs-parser')(process.argv.slice(2), {
   boolean: ['help'],
   alias: { help: 'h' },
 });


### PR DESCRIPTION
When switching from `minimist` one place was left out.

It happened probably because two PR's (#7187 and #7109) were merged around same time (with one not being in sync with master after other was taken in) and we don't have linter setup on master which would pick this up afterwards.

To avoid such issues in a future, I've turned on (experimentally) "_Require branches to be up to date before merging_" setting. Hopefully it won't be too obtrusive.


