### PR TITLE
fix: Limited permission for authorizers

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -64,6 +64,22 @@ module.exports = {
                 FunctionName: authorizer.arn,
                 Action: 'lambda:InvokeFunction',
                 Principal: 'apigateway.amazonaws.com',
+                SourceArn: {
+                  'Fn::Join': [
+                    '',
+                    [
+                      'arn:',
+                      { Ref: 'AWS::Partition' },
+                      ':execute-api:',
+                      { Ref: 'AWS::Region' },
+                      ':',
+                      { Ref: 'AWS::AccountId' },
+                      ':',
+                      this.provider.getApiGatewayRestApiId(),
+                      '/*/*',
+                    ],
+                  ],
+                },
               },
             },
           });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -168,7 +168,7 @@ describe('#awsCompilePermissions()', () => {
     });
   });
 
-  it('should create permission resources for authorizers', () => {
+  it('should create limited permission resources for authorizers', () => {
     awsCompileApigEvents.validated.events = [
       {
         functionName: 'First',
@@ -210,15 +210,37 @@ describe('#awsCompilePermissions()', () => {
         },
       },
     ];
+
+    const deepObj = {
+      'Fn::Join': [
+        '',
+        [
+          'arn:',
+          { Ref: 'AWS::Partition' },
+          ':execute-api:',
+          { Ref: 'AWS::Region' },
+          ':',
+          { Ref: 'AWS::AccountId' },
+          ':',
+          { Ref: 'ApiGatewayRestApi' },
+          '/*/*',
+        ],
+      ],
+    };
+
     return awsCompileApigEvents.compilePermissions().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .AuthorizerLambdaPermissionApiGateway.Properties.FunctionName
       ).to.deep.equal({ 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .AuthorizerLambdaPermissionApiGateway.Properties.SourceArn
+      ).to.deep.equal(deepObj);
     });
   });
 
-  it('should create permission resources for aliased authorizers', () => {
+  it('should create limited permission resources for aliased authorizers', () => {
     awsCompileApigEvents.validated.events = [
       {
         functionName: 'First',
@@ -261,6 +283,24 @@ describe('#awsCompilePermissions()', () => {
         },
       },
     ];
+
+    const deepObj = {
+      'Fn::Join': [
+        '',
+        [
+          'arn:',
+          { Ref: 'AWS::Partition' },
+          ':execute-api:',
+          { Ref: 'AWS::Region' },
+          ':',
+          { Ref: 'AWS::AccountId' },
+          ':',
+          { Ref: 'ApiGatewayRestApi' },
+          '/*/*',
+        ],
+      ],
+    };
+
     return awsCompileApigEvents.compilePermissions().then(() => {
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
@@ -268,6 +308,10 @@ describe('#awsCompilePermissions()', () => {
       ).to.deep.equal({
         'Fn::Join': [':', [{ 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] }, 'provisioned']],
       });
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .AuthorizerLambdaPermissionApiGateway.Properties.SourceArn
+      ).to.deep.equal(deepObj);
     });
   });
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Fixes a permission issue when using custom authorizers for API Gateways.

❗️ **NOTE:** Note entirely sure about the impact, but thus could result in a breaking change... ❗️

## How can we verify it

The easiest way would be to run the integration tests. Other than that you could use this service config (provided by @glb):

```yaml
service: test

provider:
  name: aws
  runtime: nodejs10.x

functions:
  example:
    role: exampleRole
    handler: bin/example
    events:
      - http:
          path: /echo
          method: GET
          authorizer:
            name: authorizer
            arn: arn:aws:lambda:us-east-1:111111111111:function:sample
```

## Todos

- [x] Write and run all tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** MAYBE