### PR TITLE
fix(Variables): fix regexp for raw strings

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -53,7 +53,7 @@ class Variables {
     this.envRefSyntax = RegExp(/^env:/g);
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
-    this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
+    this.stringRefSyntax = RegExp(/^('|").*?\1$/g);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(\.[a-zA-Z0-9-]+)?:/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/);
@@ -476,13 +476,14 @@ class Variables {
   splitByComma(string) {
     const input = string.trim();
     const stringMatches = [];
-    let match = this.stringRefSyntax.exec(input);
+    const regex = /(?:('|").*?\1)/g;
+    let match = regex.exec(input);
     while (match) {
       stringMatches.push({
         start: match.index,
-        end: this.stringRefSyntax.lastIndex,
+        end: regex.lastIndex,
       });
-      match = this.stringRefSyntax.exec(input);
+      match = regex.exec(input);
     }
     const commaReplacements = [];
     const contained = (

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1594,10 +1594,18 @@ module.exports = {
           expect(getValueFromSsmStub).to.have.been.calledWith('ssm:/test/path/to/param');
         }));
 
-    it('should reject invalid sources', () =>
-      serverless.variables
-        .getValueFromSource('weird:source')
-        .should.be.rejectedWith(serverless.classes.Error));
+    it('should reject invalid sources', () => {
+      const testCase = variable =>
+        serverless.variables
+          .getValueFromSource(variable)
+          .should.be.rejectedWith(serverless.classes.Error);
+
+      return Promise.all([
+        testCase('weird:source'),
+        testCase('weird:"source"'),
+        testCase("weird:'source'"),
+      ]);
+    });
 
     describe('caching', () => {
       const sources = [


### PR DESCRIPTION
## What did you implement

Closes #7223

## How can we verify it

Using the example repo at #7223.

Without this change, values like `${scope:"something"}` were resolving as a raw string value, in case it wasn't matched by another resolver previously, because the original regexp would match `"something"` just and call it a string.

## Todos

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
