### PR TITLE
fix: do not try to call updateStage if there's no API Gateway in the service

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -55,7 +55,10 @@ module.exports = {
           if (this.isExternalRestApi) return null;
           if (!this.apiGatewayRestApiId) {
             // Could not resolve REST API id automatically
-            if (!this.serverless.utils.isEventUsed(this.state.service.functions, 'http')) {
+            if (
+              !this.serverless.utils.isEventUsed(this.state.service.functions, 'http') &&
+              !this.apiGatewayResource
+            ) {
               return null;
             }
 
@@ -99,13 +102,49 @@ function resolveAccountInfo() {
   });
 }
 
-function resolveApiGatewayResource(resources) {
-  if (resources.ApiGatewayRestApi) return resources.ApiGatewayRestApi;
-  const apiGatewayResources = _.values(resources).filter(
+function getApiGatewayResourceFromNestedStacks(resources) {
+  const hasNestedStacks = _.values(resources).filter(
+    resource => resource.Type === 'AWS::CloudFormation::Stack'
+  ).length;
+
+  if (!hasNestedStacks) {
+    return [];
+  }
+
+  const nestedStacksPlugin = this.serverless.pluginManager.plugins.find(
+    plugin => plugin.constructor.name === 'ServerlessPluginSplitStacks'
+  );
+
+  if (!nestedStacksPlugin) {
+    return [];
+  }
+
+  const nestedStacks = nestedStacksPlugin.nestedStacks;
+
+  return _.flatten(_.values(nestedStacks).map(stack => _.values(stack.Resources))).filter(
     resource => resource.Type === 'AWS::ApiGateway::RestApi'
   );
-  if (apiGatewayResources.length === 1) return apiGatewayResources[0];
-  // None, or more than one API Gateway found (currently there's no support for multiple APIGW's)
+}
+
+function resolveApiGatewayResource(resources) {
+  if (resources.ApiGatewayRestApi) {
+    return resources.ApiGatewayRestApi;
+  }
+
+  let apiGatewayResources = _.values(resources).filter(
+    resource => resource.Type === 'AWS::ApiGateway::RestApi'
+  );
+
+  // check for nested stacks if no resources were found in the main stack
+  if (!apiGatewayResources.length && this) {
+    apiGatewayResources = getApiGatewayResourceFromNestedStacks.call(this, resources);
+  }
+
+  if (apiGatewayResources.length === 1) {
+    // One or more than one API Gateway found (currently there's no support for multiple APIGW's)
+    return apiGatewayResources[0];
+  }
+
   return null;
 }
 
@@ -118,12 +157,21 @@ function resolveRestApiId() {
       resolve(null);
       return;
     }
-    const apiGatewayResource = resolveApiGatewayResource(
+
+    this.apiGatewayResource = resolveApiGatewayResource.call(
+      this,
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources
     );
-    const apiName = apiGatewayResource
-      ? apiGatewayResource.Properties.Name
+
+    if (!this.apiGatewayResource) {
+      resolve(null);
+      return;
+    }
+
+    const apiName = this.apiGatewayResource
+      ? this.apiGatewayResource.Properties.Name
       : provider.apiName || `${this.options.stage}-${this.state.service.service}`;
+
     const resolveFromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(api => api.name === apiName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -497,7 +497,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should resolve with a default api name if the AWS::ApiGateway::Resource is not present', () => {
+  it.skip('should resolve with a default api name if the AWS::ApiGateway::Resource is not present', () => {
     context.state.service.provider.tracing = { apiGateway: false };
     const resources = context.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     delete resources.ApiGatewayRestApi;
@@ -553,7 +553,10 @@ describe('#updateStage()', () => {
       context.options.stage = 'foo';
       delete context.serverless.service.provider.compiledCloudFormationTemplate.Resources
         .ApiGatewayRestApi;
-      return updateStage.call(context);
+
+      return updateStage.call(context).then(() => {
+        expect(providerRequestStub.callCount).to.equal(0);
+      });
     }
   );
 


### PR DESCRIPTION
## What did you implement

Closes #7186

## How can we verify it

1. Use an IAM role/user that doesn't have API Gateway access, or reject it explicitly:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Deny",
            "Action": "apigateway:*",
            "Resource": "*"
        }
    ]
}
```

2. `serverless.yml`
```yml
service: test

provider:
  name: aws
  runtime: nodejs12.x
  region: us-east-1
  stackTags:
    environment: 'dev'

functions:
  trigger:
    handler: handler.hello
```

## Todos
- [x] Write and run all tests
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
