### PR TITLE
Add support for Kinesis Data Streams Enhanced Fan-out (Consumers)

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -62,6 +62,14 @@ functions:
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
                 - stream/MyOtherKinesisStream
+      - stream:
+          type: kinesis
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foobar
+          consumer: true
+      - stream:
+          type: kinesis
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foobar
+          consumer: preExistingName
 ```
 
 ## Setting the BatchSize and StartingPosition
@@ -238,3 +246,39 @@ functions:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           parallelizationFactor: 10
 ```
+
+## Using a Kinesis Data Streams Enhanced Fan-out
+
+This configuration controls the optional usage of Kinesis data streams enhanced fan-out. It can only be used for Kinesis data stream events.
+
+The `consumer` property can be used to put a [stream consumer](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-streamconsumer.html) between your function's [event source mapping](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html) and the stream it consumes.
+
+The configuration below creates a new stream consumer.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - stream:
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+          consumer: true
+```
+
+The configuration below uses the pre-existing stream consumer with the given ARN.
+
+**Note:** When you register a consumer, Kinesis Data Streams generates an ARN for it.
+If you delete a consumer and then create a new one with the same name, it won't have the same ARN.
+That's because consumer ARNs contain the creation timestamp.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - stream:
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+          consumer: arn:aws:kinesis:region:XXXXXX:stream/foo/consumer/foobar:1558544531
+```
+
+For more information, read this [AWS blog post](https://aws.amazon.com/blogs/compute/increasing-real-time-stream-processing-performance-with-amazon-kinesis-data-streams-enhanced-fan-out-and-aws-lambda/) or this [AWS documentation](https://docs.aws.amazon.com/streams/latest/dev/introduction-to-enhanced-consumers.html).

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -350,6 +350,12 @@ module.exports = {
       streamType
     )}${this.normalizeNameToAlphaNumericOnly(streamName)}`;
   },
+  getStreamConsumerName(functionName, streamName) {
+    return `${functionName}${streamName}Consumer`;
+  },
+  getStreamConsumerLogicalId(streamConsumerName) {
+    return `${this.getNormalizedFunctionName(streamConsumerName)}StreamConsumer`;
+  },
 
   // IoT
   getIotLogicalId(functionName, iotIndex) {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -528,6 +528,22 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getStreamConsumerName()', () => {
+    it('should add the standard suffix', () => {
+      expect(sdk.naming.getStreamConsumerName('functionName', 'streamName')).to.equal(
+        'functionNamestreamNameConsumer'
+      );
+    });
+  });
+
+  describe('#getStreamConsumerLogicalId()', () => {
+    it('should normalize the stream consumer name and add the standard suffix', () => {
+      expect(sdk.naming.getStreamConsumerLogicalId('streamConsumerName')).to.equal(
+        'StreamConsumerNameStreamConsumer'
+      );
+    });
+  });
+
   describe('#getCloudWatchEventId()', () => {
     it('should add the standard suffix', () => {
       expect(sdk.naming.getCloudWatchEventId('functionName')).to.equal(

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -40,14 +40,6 @@ class AwsCompileStreamEvents {
     ].join('\n');
   }
 
-  resolveInvalidKinesisConsumerErrorMessage(functionName) {
-    return [
-      `Invalid "consumer" property for stream event in function "${functionName}"`,
-      'This property should contain either "true" or a consumer ARN.',
-      'Please check the docs for more info.',
-    ].join('\n');
-  }
-
   compileStreamEvents() {
     this.serverless.service.getAllFunctions().forEach(functionName => {
       const functionObj = this.serverless.service.getFunction(functionName);
@@ -157,48 +149,16 @@ class AwsCompileStreamEvents {
               if (typeof event.stream.enabled !== 'undefined') {
                 Enabled = event.stream.enabled ? 'True' : 'False';
               }
-              if (typeof event.stream.consumer !== 'undefined') {
-                if (typeof event.stream.consumer === 'boolean') {
-                  if (event.stream.consumer !== true) {
-                    throw new this.serverless.classes.Error(
-                      this.resolveInvalidKinesisConsumerErrorMessage(functionName)
-                    );
-                  }
-                } else if (typeof event.stream.consumer === 'string') {
-                  if (event.stream.consumer.indexOf('arn:') < 0) {
-                    throw new this.serverless.classes.Error(
-                      this.resolveInvalidKinesisConsumerErrorMessage(functionName)
-                    );
-                  }
-                } else if (typeof event.stream.consumer === 'object') {
-                  if (
-                    Object.keys(event.stream.consumer).length !== 1 ||
-                    !(
-                      _.has(event.stream.consumer, 'Fn::ImportValue') ||
-                      _.has(event.stream.consumer, 'Fn::GetAtt') ||
-                      (_.has(event.stream.consumer, 'Ref') &&
-                        (_.has(
-                          this.serverless.service.resources.Parameters,
-                          event.stream.consumer.Ref
-                        ) ||
-                          _.has(
-                            this.serverless.service.resources.Resources,
-                            event.stream.consumer.Ref
-                          ))) ||
-                      _.has(event.stream.consumer, 'Fn::Join')
-                    )
-                  ) {
-                    const errorMessage = [
-                      `'${JSON.stringify(
-                        event.stream
-                      )}'Bad dynamic property on stream event in function "${functionName}"`,
-                      ' If you use a dynamic "consumer" (such as with Fn::GetAtt, Fn::Join, Ref',
-                      ' or Fn::ImportValue) there must only be one key (either Fn::GetAtt, Fn::Join, Ref',
-                      ' or Fn::ImportValue) in the consumer object. Please check the docs for more info.',
-                    ].join('');
-                    throw new this.serverless.classes.Error(errorMessage);
-                  }
-                }
+              if (
+                event.stream.consumer &&
+                ['boolean', 'string', 'object'].indexOf(typeof event.stream.consumer) < 0
+              ) {
+                const errorMessage = [
+                  `Invalid "consumer" property for stream event in function "${functionName}"`,
+                  'This property should contain either "true" or a stream consumer ARN.',
+                  'Please check the docs for more info.',
+                ].join('\n');
+                throw new this.serverless.classes.Error(errorMessage);
               }
             } else if (typeof event.stream === 'string') {
               EventSourceArn = event.stream;
@@ -399,7 +359,7 @@ class AwsCompileStreamEvents {
 
             if (event.stream.consumer) {
               if (streamType === 'kinesis') {
-                if (typeof event.stream.consumer === 'boolean') {
+                if (event.stream.consumer === true) {
                   const consumerName = this.provider.naming.getStreamConsumerName(
                     functionName,
                     streamName

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -149,17 +149,6 @@ class AwsCompileStreamEvents {
               if (typeof event.stream.enabled !== 'undefined') {
                 Enabled = event.stream.enabled ? 'True' : 'False';
               }
-              if (
-                event.stream.consumer &&
-                ['boolean', 'string', 'object'].indexOf(typeof event.stream.consumer) < 0
-              ) {
-                const errorMessage = [
-                  `Invalid "consumer" property for stream event in function "${functionName}"`,
-                  'This property should contain either "true" or a stream consumer ARN.',
-                  'Please check the docs for more info.',
-                ].join('\n');
-                throw new this.serverless.classes.Error(errorMessage);
-              }
             } else if (typeof event.stream === 'string') {
               EventSourceArn = event.stream;
             } else {
@@ -357,39 +346,37 @@ class AwsCompileStreamEvents {
               [streamLogicalId]: streamResource,
             };
 
-            if (event.stream.consumer) {
-              if (streamType === 'kinesis') {
-                if (event.stream.consumer === true) {
-                  const consumerName = this.provider.naming.getStreamConsumerName(
-                    functionName,
-                    streamName
-                  );
-                  const consumerResource = {
-                    Type: 'AWS::Kinesis::StreamConsumer',
-                    Properties: {
-                      StreamARN: EventSourceArn,
-                      ConsumerName: consumerName,
-                    },
-                  };
-                  const consumerLogicalId = this.provider.naming.getStreamConsumerLogicalId(
-                    consumerName
-                  );
-                  newStreamObject[consumerLogicalId] = consumerResource;
-                  if (Array.isArray(streamResource.DependsOn)) {
-                    streamResource.DependsOn.push(consumerLogicalId);
-                  } else {
-                    streamResource.DependsOn = [streamResource.DependsOn, consumerLogicalId];
-                  }
-                  const consumerArnRef = {
-                    Ref: consumerLogicalId,
-                  };
-                  streamResource.Properties.EventSourceArn = consumerArnRef;
-                  kinesisConsumerStatement.Resource.push(consumerArnRef);
+            if (event.stream.consumer && streamType === 'kinesis') {
+              if (event.stream.consumer === true) {
+                const consumerName = this.provider.naming.getStreamConsumerName(
+                  functionName,
+                  streamName
+                );
+                const consumerResource = {
+                  Type: 'AWS::Kinesis::StreamConsumer',
+                  Properties: {
+                    StreamARN: EventSourceArn,
+                    ConsumerName: consumerName,
+                  },
+                };
+                const consumerLogicalId = this.provider.naming.getStreamConsumerLogicalId(
+                  consumerName
+                );
+                newStreamObject[consumerLogicalId] = consumerResource;
+                if (Array.isArray(streamResource.DependsOn)) {
+                  streamResource.DependsOn.push(consumerLogicalId);
                 } else {
-                  const consumerArn = event.stream.consumer;
-                  streamResource.Properties.EventSourceArn = consumerArn;
-                  kinesisConsumerStatement.Resource.push(consumerArn);
+                  streamResource.DependsOn = [streamResource.DependsOn, consumerLogicalId];
                 }
+                const consumerArnRef = {
+                  Ref: consumerLogicalId,
+                };
+                streamResource.Properties.EventSourceArn = consumerArnRef;
+                kinesisConsumerStatement.Resource.push(consumerArnRef);
+              } else {
+                const consumerArn = event.stream.consumer;
+                streamResource.Properties.EventSourceArn = consumerArn;
+                kinesisConsumerStatement.Resource.push(consumerArn);
               }
             }
 

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -40,6 +40,14 @@ class AwsCompileStreamEvents {
     ].join('\n');
   }
 
+  resolveInvalidKinesisConsumerErrorMessage(functionName) {
+    return [
+      `Invalid "consumer" property for stream event in function "${functionName}"`,
+      'This property should contain either "true" or a consumer ARN.',
+      'Please check the docs for more info.',
+    ].join('\n');
+  }
+
   compileStreamEvents() {
     this.serverless.service.getAllFunctions().forEach(functionName => {
       const functionObj = this.serverless.service.getFunction(functionName);
@@ -63,6 +71,21 @@ class AwsCompileStreamEvents {
             'kinesis:DescribeStream',
             'kinesis:ListStreams',
           ],
+          Resource: [],
+        };
+        const kinesisStreamWithConsumerStatement = {
+          Effect: 'Allow',
+          Action: [
+            'kinesis:GetRecords',
+            'kinesis:GetShardIterator',
+            'kinesis:DescribeStreamSummary',
+            'kinesis:ListShards',
+          ],
+          Resource: [],
+        };
+        const kinesisConsumerStatement = {
+          Effect: 'Allow',
+          Action: ['kinesis:SubscribeToShard'],
           Resource: [],
         };
         const onFailureSnsStatement = {
@@ -133,6 +156,49 @@ class AwsCompileStreamEvents {
               StartingPosition = event.stream.startingPosition || StartingPosition;
               if (typeof event.stream.enabled !== 'undefined') {
                 Enabled = event.stream.enabled ? 'True' : 'False';
+              }
+              if (typeof event.stream.consumer !== 'undefined') {
+                if (typeof event.stream.consumer === 'boolean') {
+                  if (event.stream.consumer !== true) {
+                    throw new this.serverless.classes.Error(
+                      this.resolveInvalidKinesisConsumerErrorMessage(functionName)
+                    );
+                  }
+                } else if (typeof event.stream.consumer === 'string') {
+                  if (event.stream.consumer.indexOf('arn:') < 0) {
+                    throw new this.serverless.classes.Error(
+                      this.resolveInvalidKinesisConsumerErrorMessage(functionName)
+                    );
+                  }
+                } else if (typeof event.stream.consumer === 'object') {
+                  if (
+                    Object.keys(event.stream.consumer).length !== 1 ||
+                    !(
+                      _.has(event.stream.consumer, 'Fn::ImportValue') ||
+                      _.has(event.stream.consumer, 'Fn::GetAtt') ||
+                      (_.has(event.stream.consumer, 'Ref') &&
+                        (_.has(
+                          this.serverless.service.resources.Parameters,
+                          event.stream.consumer.Ref
+                        ) ||
+                          _.has(
+                            this.serverless.service.resources.Resources,
+                            event.stream.consumer.Ref
+                          ))) ||
+                      _.has(event.stream.consumer, 'Fn::Join')
+                    )
+                  ) {
+                    const errorMessage = [
+                      `'${JSON.stringify(
+                        event.stream
+                      )}'Bad dynamic property on stream event in function "${functionName}"`,
+                      ' If you use a dynamic "consumer" (such as with Fn::GetAtt, Fn::Join, Ref',
+                      ' or Fn::ImportValue) there must only be one key (either Fn::GetAtt, Fn::Join, Ref',
+                      ' or Fn::ImportValue) in the consumer object. Please check the docs for more info.',
+                    ].join('');
+                    throw new this.serverless.classes.Error(errorMessage);
+                  }
+                }
               }
             } else if (typeof event.stream === 'string') {
               EventSourceArn = event.stream;
@@ -221,7 +287,11 @@ class AwsCompileStreamEvents {
             if (streamType === 'dynamodb') {
               dynamodbStreamStatement.Resource.push(EventSourceArn);
             } else if (streamType === 'kinesis') {
-              kinesisStreamStatement.Resource.push(EventSourceArn);
+              if (event.stream.consumer) {
+                kinesisStreamWithConsumerStatement.Resource.push(EventSourceArn);
+              } else {
+                kinesisStreamStatement.Resource.push(EventSourceArn);
+              }
             } else {
               const errorMessage = [
                 `Stream event of function '${functionName}' had unsupported stream type of`,
@@ -327,6 +397,42 @@ class AwsCompileStreamEvents {
               [streamLogicalId]: streamResource,
             };
 
+            if (event.stream.consumer) {
+              if (streamType === 'kinesis') {
+                if (typeof event.stream.consumer === 'boolean') {
+                  const consumerName = this.provider.naming.getStreamConsumerName(
+                    functionName,
+                    streamName
+                  );
+                  const consumerResource = {
+                    Type: 'AWS::Kinesis::StreamConsumer',
+                    Properties: {
+                      StreamARN: EventSourceArn,
+                      ConsumerName: consumerName,
+                    },
+                  };
+                  const consumerLogicalId = this.provider.naming.getStreamConsumerLogicalId(
+                    consumerName
+                  );
+                  newStreamObject[consumerLogicalId] = consumerResource;
+                  if (Array.isArray(streamResource.DependsOn)) {
+                    streamResource.DependsOn.push(consumerLogicalId);
+                  } else {
+                    streamResource.DependsOn = [streamResource.DependsOn, consumerLogicalId];
+                  }
+                  const consumerArnRef = {
+                    Ref: consumerLogicalId,
+                  };
+                  streamResource.Properties.EventSourceArn = consumerArnRef;
+                  kinesisConsumerStatement.Resource.push(consumerArnRef);
+                } else {
+                  const consumerArn = event.stream.consumer;
+                  streamResource.Properties.EventSourceArn = consumerArn;
+                  kinesisConsumerStatement.Resource.push(consumerArn);
+                }
+              }
+            }
+
             _.merge(
               this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
               newStreamObject
@@ -346,6 +452,12 @@ class AwsCompileStreamEvents {
           }
           if (kinesisStreamStatement.Resource.length) {
             statement.push(kinesisStreamStatement);
+          }
+          if (kinesisStreamWithConsumerStatement.Resource.length) {
+            statement.push(kinesisStreamWithConsumerStatement);
+          }
+          if (kinesisConsumerStatement.Resource.length) {
+            statement.push(kinesisConsumerStatement);
           }
           if (onFailureSnsStatement.Resource.length) {
             statement.push(onFailureSnsStatement);

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -37,7 +37,7 @@ describe('AwsCompileStreamEvents', () => {
   });
 
   describe('#compileStreamEvents()', () => {
-    it('should throw an error if the "consumer" property is not a string or a boolean', () => {
+    it('should throw an error if the "consumer" property is not a string, object, or boolean', () => {
       awsCompileStreamEvents.serverless.service.functions = {
         first: {
           events: [
@@ -51,65 +51,6 @@ describe('AwsCompileStreamEvents', () => {
           ],
         },
       };
-    });
-
-    it('fails if keys other than Fn::GetAtt/ImportValue/Join are used for dynamic "consumer" ARN', () => {
-      awsCompileStreamEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              stream: {
-                arn: 'arn:aws:kinesis:region:account:stream/foo',
-                consumer: {
-                  'Fn::GetAtt': ['SomeSNS', 'Arn'],
-                  'batchSize': 1,
-                },
-              },
-            },
-          ],
-        },
-      };
-
-      expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
-    });
-
-    it('fails if Fn::ImportValue is misused for "consumer" ARN', () => {
-      awsCompileStreamEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              stream: {
-                arn: 'arn:aws:kinesis:region:account:stream/foo',
-                consumer: {
-                  'Fn::ImportValue': {
-                    'Fn::GetAtt': ['SomeSNS', 'Arn'],
-                  },
-                },
-                type: 'invalidType',
-              },
-            },
-          ],
-        },
-      };
-
-      expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
-    });
-
-    it('fails if "consumer" ARN is given as a string that does not start with arn', () => {
-      awsCompileStreamEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              stream: {
-                arn: 'arn:aws:kinesis:region:account:stream/foo',
-                consumer: 'invalidARN',
-              },
-            },
-          ],
-        },
-      };
-
-      expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
     });
 
     it('should throw an error if stream event type is not a string or an object', () => {
@@ -1336,6 +1277,12 @@ describe('AwsCompileStreamEvents', () => {
                   consumer: 'arn:aws:kinesis:region:account:stream/xyz/consumer/foobar:1558544531',
                 },
               },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/def',
+                  consumer: false,
+                },
+              },
             ],
           },
         };
@@ -1567,6 +1514,36 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisXyz.Properties.Enabled
         ).to.equal('True');
+
+        // event 8
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Type
+        ).to.equal('AWS::Lambda::EventSourceMapping');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.DependsOn
+        ).to.equal('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.EventSourceArn
+        ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[7].stream.arn);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.BatchSize
+        ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.StartingPosition
+        ).to.equal('TRIM_HORIZON');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.Enabled
+        ).to.equal('True');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.BisectBatchOnFunctionError
+        ).to.equal(undefined);
       });
 
       it('should create stream consumer when a Kinesis stream with consumer "true" is given', () => {

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -37,6 +37,81 @@ describe('AwsCompileStreamEvents', () => {
   });
 
   describe('#compileStreamEvents()', () => {
+    it('should throw an error if the "consumer" property is not a string or a boolean', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              stream: {
+                type: 'kinesis',
+                arn: 'arn:aws:kinesis:us-east-1:123456789012:stream/myStream',
+                consumer: 42,
+              },
+            },
+          ],
+        },
+      };
+    });
+
+    it('fails if keys other than Fn::GetAtt/ImportValue/Join are used for dynamic "consumer" ARN', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              stream: {
+                arn: 'arn:aws:kinesis:region:account:stream/foo',
+                consumer: {
+                  'Fn::GetAtt': ['SomeSNS', 'Arn'],
+                  'batchSize': 1,
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
+    });
+
+    it('fails if Fn::ImportValue is misused for "consumer" ARN', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              stream: {
+                arn: 'arn:aws:kinesis:region:account:stream/foo',
+                consumer: {
+                  'Fn::ImportValue': {
+                    'Fn::GetAtt': ['SomeSNS', 'Arn'],
+                  },
+                },
+                type: 'invalidType',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
+    });
+
+    it('fails if "consumer" ARN is given as a string that does not start with arn', () => {
+      awsCompileStreamEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              stream: {
+                arn: 'arn:aws:kinesis:region:account:stream/foo',
+                consumer: 'invalidARN',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileStreamEvents.compileStreamEvents()).to.throw(Error);
+    });
+
     it('should throw an error if stream event type is not a string or an object', () => {
       awsCompileStreamEvents.serverless.service.functions = {
         first: {
@@ -1249,6 +1324,18 @@ describe('AwsCompileStreamEvents', () => {
                   },
                 },
               },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/abc',
+                  consumer: true,
+                },
+              },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/xyz',
+                  consumer: 'arn:aws:kinesis:region:account:stream/xyz/consumer/foobar:1558544531',
+                },
+              },
             ],
           },
         };
@@ -1428,6 +1515,88 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.functions.first.events[4].stream.destinations
             .onFailure
         );
+
+        // event 6
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisAbc.Type
+        ).to.equal('AWS::Lambda::EventSourceMapping');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisAbc.DependsOn
+        ).to.eql(['IamRoleLambdaExecution', 'FirstabcConsumerStreamConsumer']);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisAbc.Properties.EventSourceArn
+        ).to.eql({ Ref: 'FirstabcConsumerStreamConsumer' });
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisAbc.Properties.BatchSize
+        ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisAbc.Properties.StartingPosition
+        ).to.equal('TRIM_HORIZON');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisAbc.Properties.Enabled
+        ).to.equal('True');
+
+        // event 7
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.Type
+        ).to.equal('AWS::Lambda::EventSourceMapping');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.DependsOn
+        ).to.equal('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.Properties.EventSourceArn
+        ).to.equal('arn:aws:kinesis:region:account:stream/xyz/consumer/foobar:1558544531');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.Properties.BatchSize
+        ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.Properties.StartingPosition
+        ).to.equal('TRIM_HORIZON');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.Properties.Enabled
+        ).to.equal('True');
+      });
+
+      it('should create stream consumer when a Kinesis stream with consumer "true" is given', () => {
+        awsCompileStreamEvents.serverless.service.functions = {
+          first: {
+            events: [
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/abc',
+                  consumer: true,
+                },
+              },
+            ],
+          },
+        };
+
+        awsCompileStreamEvents.compileStreamEvents();
+
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstabcConsumerStreamConsumer.Type
+        ).to.equal('AWS::Kinesis::StreamConsumer');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstabcConsumerStreamConsumer.Properties.ConsumerName
+        ).to.equal('firstabcConsumer');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstabcConsumerStreamConsumer.Properties.StreamARN
+        ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.arn);
       });
 
       it('should add the necessary IAM role statements', () => {
@@ -1439,6 +1608,20 @@ describe('AwsCompileStreamEvents', () => {
               },
               {
                 stream: 'arn:aws:kinesis:region:account:stream/bar',
+              },
+              {
+                stream: {
+                  type: 'kinesis',
+                  arn: 'arn:aws:kinesis:region:account:stream/fizz',
+                  consumer: true,
+                },
+              },
+              {
+                stream: {
+                  type: 'kinesis',
+                  arn: 'arn:aws:kinesis:region:account:stream/buzz',
+                  consumer: 'arn:aws:kinesis:region:account:stream/buzz/consumer/abc:1558544531',
+                },
               },
             ],
           },
@@ -1456,6 +1639,27 @@ describe('AwsCompileStreamEvents', () => {
             Resource: [
               'arn:aws:kinesis:region:account:stream/foo',
               'arn:aws:kinesis:region:account:stream/bar',
+            ],
+          },
+          {
+            Effect: 'Allow',
+            Action: [
+              'kinesis:GetRecords',
+              'kinesis:GetShardIterator',
+              'kinesis:DescribeStreamSummary',
+              'kinesis:ListShards',
+            ],
+            Resource: [
+              'arn:aws:kinesis:region:account:stream/fizz',
+              'arn:aws:kinesis:region:account:stream/buzz',
+            ],
+          },
+          {
+            Effect: 'Allow',
+            Action: ['kinesis:SubscribeToShard'],
+            Resource: [
+              { Ref: 'FirstfizzConsumerStreamConsumer' },
+              'arn:aws:kinesis:region:account:stream/buzz/consumer/abc:1558544531',
             ],
           },
         ];


### PR DESCRIPTION
## What did you implement

Closes #5510

I added the a new configuration property for Kinesis data stream events which configures the event source mapping to use a stream consumer instead of shard iterator.

It creates a new stream consumer when set to `true` and uses an existing consumer if given the ARN of one.

It manages the necessary IAM permissions and supports functions such as `Ref` and `ImportValue` (essential since stream consumer ARNs are AWS generated with timestamps in them).

This is my first PR of this size to this project, so apologies if I didn't quite get some conventions right.

## How can we verify it

```yaml
service: dct

provider:
  name: aws
  runtime: nodejs12.x

functions:
  hello:
    handler: handler.hello
    events:
      - stream:
          batchSize: 1
          type: kinesis
          arn:
            Fn::GetAtt:
              - ExampleStream
              - Arn
          consumer: true
      - stream:
          batchSize: 1
          type: kinesis
          arn:
            Fn::GetAtt:
              - ExampleStream
              - Arn
          consumer:
            Ref: ExampleStreamConsumer

resources:
  Resources:
    ExampleStream: 
      Type: AWS::Kinesis::Stream 
      Properties: 
          ShardCount: 1
    ExampleStreamConsumer: 
      Type: AWS::Kinesis::StreamConsumer
      Properties: 
          StreamARN:
            Fn::GetAtt:
              - ExampleStream
              - Arn
          ConsumerName: whatever
```

## Todos

No todos at the moment.

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
