### PR TITLE
Fix "Request Schema Validators" TOC link

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -26,7 +26,7 @@ layout: Doc
     - [Setting API keys for your Rest API](#setting-api-keys-for-your-rest-api)
     - [Configuring endpoint types](#configuring-endpoint-types)
     - [Request Parameters](#request-parameters)
-    - [Request Schema Validation](#request-schema-validation)
+    - [Request Schema Validators](#request-schema-validators)
     - [Setting source of API key for metering requests](#setting-source-of-api-key-for-metering-requests)
   - [Lambda Integration](#lambda-integration)
     - [Example "LAMBDA" event (before customization)](#example-lambda-event-before-customization)


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

The link is broken because the section is called "Request Schema **Validators**", but in the Table of Contents it's "Request Schema **Validation**".

This commit updates the section name in the TOC with the correct one.

## How can we verify it

You can check out the problem trying to open the "Request Schema Validation" link in the following page: 
https://serverless.com/framework/docs/providers/aws/events/apigateway

## Todos
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
