### PR TITLE
feat: support externally-managed custom authorizers

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -444,10 +444,31 @@ functions:
           method: post
           authorizer:
             arn: xxx:xxx:Lambda-Name
+            managedExternally: false
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization
             identityValidationExpression: someRegex
 ```
+
+If permissions for the Authorizer function are managed externally (for example, if the Authorizer function exists
+in a different AWS account), you can skip creating the permission for the function by setting `managedExternally: true`,
+as shown in the following example:
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          authorizer:
+            arn: xxx:xxx:Lambda-Name
+            managedExternally: true
+```
+
+**IMPORTANT NOTE**: The permission allowing the authorizer function to be called by API Gateway must exist
+before deploying the stack, otherwise deployment will fail.
 
 You can also use the Request Type Authorizer by setting the `type` property. In this case, your `identitySource` could contain multiple entries for your policy cache. The default `type` is 'token'.
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -57,6 +57,9 @@ module.exports = {
           }
 
           if (cfResources[authorizerPermissionLogicalId]) return;
+
+          if (authorizer.managedExternally) return;
+
           Object.assign(cfResources, {
             [authorizerPermissionLogicalId]: {
               Type: 'AWS::Lambda::Permission',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -324,4 +324,69 @@ describe('#awsCompilePermissions()', () => {
       ).to.deep.equal({});
     });
   });
+
+  it('should not create permission resources when the authorizer is managed externally', () => {
+    const event = {
+      functionName: 'First',
+      http: {
+        authorizer: {
+          name: 'authorizer',
+          arn: { 'Fn::GetAtt': ['AuthorizerLambdaFunction', 'Arn'] },
+          managedExternally: true,
+        },
+        path: 'foo/bar',
+        method: 'post',
+      },
+    };
+
+    awsCompileApigEvents.validated.events = [event];
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.permissionMapping = [
+      {
+        lambdaLogicalId: 'FirstLambdaFunction',
+        resourceName: 'FooBar',
+        event,
+      },
+    ];
+
+    // the important thing in this object is that it does *not* contain
+    // a permission allowing API Gateway to call the authorizer. If
+    // managedExternally was false (as it is in other tests), then the
+    // permission would be created.
+    const deepObj = {
+      FirstLambdaPermissionApiGateway: {
+        DependsOn: undefined,
+        Properties: {
+          Action: 'lambda:InvokeFunction',
+          FunctionName: {
+            'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'],
+          },
+          Principal: 'apigateway.amazonaws.com',
+          SourceArn: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':execute-api:',
+                { Ref: 'AWS::Region' },
+                ':',
+                { Ref: 'AWS::AccountId' },
+                ':',
+                { Ref: 'ApiGatewayRestApi' },
+                '/*/*',
+              ],
+            ],
+          },
+        },
+        Type: 'AWS::Lambda::Permission',
+      },
+    };
+
+    return awsCompileApigEvents.compilePermissions().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+      ).to.deep.equal(deepObj);
+    });
+  });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -225,6 +225,7 @@ module.exports = {
     let type;
     let name;
     let arn;
+    let managedExternally;
     let identitySource;
     let resultTtlInSeconds;
     let identityValidationExpression;
@@ -273,6 +274,18 @@ module.exports = {
 
       identitySource = authorizer.identitySource;
       identityValidationExpression = authorizer.identityValidationExpression;
+
+      if (typeof authorizer.managedExternally === 'undefined') {
+        managedExternally = false;
+      } else if (typeof authorizer.managedExternally === 'boolean') {
+        managedExternally = authorizer.managedExternally;
+      } else {
+        const errorMessage = [
+          `managedExternally property in authorizer for function ${functionName} is not boolean.`,
+          ' Please check the docs for more info.',
+        ].join('');
+        throw new this.serverless.classes.Error(errorMessage);
+      }
     } else {
       const errorMessage = [
         `authorizer property in function ${functionName} is not an object nor a string.`,
@@ -281,6 +294,10 @@ module.exports = {
         ' Please check the docs for more info.',
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
+    }
+
+    if (typeof managedExternally === 'undefined') {
+      managedExternally = false;
     }
 
     if (typeof identitySource === 'undefined') {
@@ -305,6 +322,7 @@ module.exports = {
       type,
       name,
       arn,
+      managedExternally,
       authorizerId,
       resultTtlInSeconds,
       identitySource,

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -449,6 +449,7 @@ describe('#validate()', () => {
     const authorizer = validated.events[0].http.authorizer;
     expect(authorizer.resultTtlInSeconds).to.equal(300);
     expect(authorizer.identitySource).to.equal('method.request.header.Authorization');
+    expect(authorizer.managedExternally).to.equal(false);
   });
 
   it('should accept authorizer config', () => {
@@ -465,6 +466,7 @@ describe('#validate()', () => {
                 resultTtlInSeconds: 500,
                 identitySource: 'method.request.header.Custom',
                 identityValidationExpression: 'foo',
+                managedExternally: true,
               },
             },
           },
@@ -477,6 +479,7 @@ describe('#validate()', () => {
     expect(authorizer.resultTtlInSeconds).to.equal(500);
     expect(authorizer.identitySource).to.equal('method.request.header.Custom');
     expect(authorizer.identityValidationExpression).to.equal('foo');
+    expect(authorizer.managedExternally).to.equal(true);
   });
 
   it('should accept authorizer config with a type', () => {
@@ -532,6 +535,31 @@ describe('#validate()', () => {
     expect(authorizer.resultTtlInSeconds).to.equal(0);
     expect(authorizer.identitySource).to.equal('method.request.header.Custom');
     expect(authorizer.identityValidationExpression).to.equal('foo');
+  });
+
+  it('should throw an error if authorizer "managedExternally" exists and is not a boolean', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      foo: {},
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'foo/bar',
+              authorizer: {
+                name: 'foo',
+                resultTtlInSeconds: 0,
+                identitySource: 'method.request.header.Custom',
+                identityValidationExpression: 'foo',
+                managedExternally: 'not a boolean',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.validate()).to.throw(Error, 'managedExternally property');
   });
 
   it('should throw an error if "origin" and "origins" CORS config is used', () => {


### PR DESCRIPTION
## What did you implement

There are use cases where an API creator does not have access to add permissions to the custom authorizer function; one example is when the custom authorizer function exists in a separate AWS account. In these cases, we need to be able to omit the `AWS::Lambda::Permission` resource that allows API Gateway to call the authorizer function from the stack.

This change adds the `managedExternally` attribute to the `authorizer`. When `managedExternally` is `true`, the stack will not create the `AWS::Lambda::Permission` resource that allows API Gateway to call the authorizer function.

**Important note:** The permission does still need to be created before the stack is deployed, or creating the authorizer will fail.

Closes #7296.

## How can we verify it

1. Copy `serverless.yml (before)` to `serverless.yml`.
2. Run `serverless package`.
3. Copy `.serverless/cloudformation-template-update-stack.json` to file `a`.
4. Copy `serverless.yml (managedExternally: true)` to `serverless.yml`. The only difference is the addition of the line `managedExternally: true` in the authorizer config.
5. Run `serverless package`.
6. Copy `.serverless/cloudformation-template-update-stack.json` to file `b`.
7. Compare `a` and `b`: the only differences should be:
   * the API Gateway Deployment ID will be different (it is updated for each run of `serverless package`)
   * the `S3Key` for the code will be different (it is updated for each run of `serverless package`)
   * the `AWS::Lambda::Permission` named `AuthorizerLambdaPermissionApiGateway` for running the authorizer will not be present in file `b`

<details>
<summary>serverless.yml (before)</summary>

```yml
service: sample-service

provider:
  name: aws
  runtime: go1.x
  stage: ${opt:stage, 'dev'}

package:
  exclude:
    - ./**
  include:
    - ./bin/**

functions:
  sample:
    handler: bin/sample
    events:
      - http:
          path: /
          method: get
          authorizer:
            name: authorizer
            arn: arn:aws:lambda:us-east-1:111111111111:function:sample-authorizer-dev
            # authorizer result will be cached for this long
            resultTtlInSeconds: 0
            type: request
```

</details>

<details>
<summary>serverless.yml (managedExternally: true)</summary>

```yml
service: sample-service

provider:
  name: aws
  runtime: go1.x
  stage: ${opt:stage, 'dev'}

package:
  exclude:
    - ./**
  include:
    - ./bin/**

functions:
  sample:
    handler: bin/sample
    events:
      - http:
          path: /
          method: get
          authorizer:
            name: authorizer
            managedExternally: true
            arn: arn:aws:lambda:us-east-1:111111111111:function:sample-authorizer-dev
            # authorizer result will be cached for this long
            resultTtlInSeconds: 0
            type: request
```

</details>

There are also new and updated tests that verify the functionality.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO

cc @medikoo 