### PR TITLE
HTTP API: Switch to default stage deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,12 @@ jobs:
           then
             export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
           fi
+      install:
+        # Note: `--no-optional` seems to be ineffective (with `--depth`) on Windows in some cases
+        # See: https://travis-ci.org/serverless/serverless/jobs/651220714
+        # Therefore no deep install on Windows
+        - npm update --no-save
+        - npm update --save-dev --no-save
 
     - name: 'Isolated Unit Tests, Package Integration Tests - Node.js v13'
       node_js: 13

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -46,14 +46,16 @@ class HttpApiEvents {
     };
   }
   compileStage() {
-    this.cfTemplate.Resources[this.provider.naming.getHttpApiStageLogicalId()] = {
-      Type: 'AWS::ApiGatewayV2::Stage',
-      Properties: {
-        ApiId: { Ref: this.provider.naming.getHttpApiLogicalId() },
-        StageName: this.provider.getStage(),
-        AutoDeploy: true,
-      },
-    };
+    if (!this.config.routes.has('*')) {
+      this.cfTemplate.Resources[this.provider.naming.getHttpApiStageLogicalId()] = {
+        Type: 'AWS::ApiGatewayV2::Stage',
+        Properties: {
+          ApiId: { Ref: this.provider.naming.getHttpApiLogicalId() },
+          StageName: '$default',
+          AutoDeploy: true,
+        },
+      };
+    }
     this.cfTemplate.Outputs.HttpApiUrl = {
       Description: 'URL of the HTTP API',
       Value: {
@@ -66,7 +68,6 @@ class HttpApiEvents {
             { Ref: 'AWS::Region' },
             '.',
             { Ref: 'AWS::URLSuffix' },
-            `/${this.provider.getStage()}`,
           ],
         ],
       },

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -46,7 +46,7 @@ describe('HttpApiEvents', () => {
 
     it('Should not configure default route', () => {
       const resource = cfResources[naming.getHttpApiLogicalId()];
-      expect(resource.Properties).to.not.have.property('RputeKey');
+      expect(resource.Properties).to.not.have.property('RouteKey');
       expect(resource.Properties).to.not.have.property('Target');
     });
     it('Should configure stage resource', () => {

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -52,7 +52,7 @@ describe('HttpApiEvents', () => {
     it('Should configure stage resource', () => {
       const resource = cfResources[naming.getHttpApiStageLogicalId()];
       expect(resource.Type).to.equal('AWS::ApiGatewayV2::Stage');
-      expect(resource.Properties.StageName).to.equal('dev');
+      expect(resource.Properties.StageName).to.equal('$default');
       expect(resource.Properties.AutoDeploy).to.equal(true);
     });
     it('Should configure output', () => {
@@ -107,11 +107,8 @@ describe('HttpApiEvents', () => {
       expect(resource.Properties.RouteKey).to.equal('$default');
       expect(resource.Properties).to.have.property('Target');
     });
-    it('Should configure stage resource', () => {
-      const resource = cfResources[naming.getHttpApiStageLogicalId()];
-      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Stage');
-      expect(resource.Properties.StageName).to.equal('dev');
-      expect(resource.Properties.AutoDeploy).to.equal(true);
+    it('Should not configure stage resource', () => {
+      expect(cfResources).to.not.have.property(naming.getHttpApiStageLogicalId());
     });
     it('Should configure output', () => {
       const output = cfOutputs.HttpApiUrl;

--- a/tests/integration-all/http-api/tests.js
+++ b/tests/integration-all/http-api/tests.js
@@ -26,7 +26,7 @@ describe('HTTP API Integration Test', function() {
     const result = await awsRequest('CloudFormation', 'describeStacks', { StackName: stackName });
     const endpointOutput = _.find(result.Stacks[0].Outputs, { OutputKey: 'HttpApiUrl' })
       .OutputValue;
-    endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+    endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com/)[0];
   };
 
   describe('Specific endpoints', () => {
@@ -53,7 +53,7 @@ describe('HTTP API Integration Test', function() {
 
       const response = await fetch(testEndpoint, { method: 'GET' });
       const json = await response.json();
-      expect(json).to.deep.equal({ method: 'GET', path: '/dev/foo' });
+      expect(json).to.deep.equal({ method: 'GET', path: '/foo' });
     });
 
     it('should expose an accessible POST HTTP endpoint', async () => {
@@ -61,7 +61,7 @@ describe('HTTP API Integration Test', function() {
 
       const response = await fetch(testEndpoint, { method: 'POST' });
       const json = await response.json();
-      expect(json).to.deep.equal({ method: 'POST', path: '/dev/some-post' });
+      expect(json).to.deep.equal({ method: 'POST', path: '/some-post' });
     });
 
     it('should expose an accessible paramed GET HTTP endpoint', async () => {
@@ -69,7 +69,7 @@ describe('HTTP API Integration Test', function() {
 
       const response = await fetch(testEndpoint, { method: 'GET' });
       const json = await response.json();
-      expect(json).to.deep.equal({ method: 'GET', path: '/dev/bar/whatever' });
+      expect(json).to.deep.equal({ method: 'GET', path: '/bar/whatever' });
     });
 
     it('should return 404 on not supported method', async () => {
@@ -111,7 +111,7 @@ describe('HTTP API Integration Test', function() {
 
       const response = await fetch(testEndpoint, { method: 'GET' });
       const json = await response.json();
-      expect(json).to.deep.equal({ method: 'GET', path: '/dev' });
+      expect(json).to.deep.equal({ method: 'GET', path: '/' });
     });
 
     it('should catch all whatever endpoint', async () => {
@@ -119,7 +119,7 @@ describe('HTTP API Integration Test', function() {
 
       const response = await fetch(testEndpoint, { method: 'PATCH' });
       const json = await response.json();
-      expect(json).to.deep.equal({ method: 'PATCH', path: '/dev/whatever' });
+      expect(json).to.deep.equal({ method: 'PATCH', path: '/whatever' });
     });
 
     it('should catch all methods on method catch all endpoint', async () => {
@@ -127,7 +127,7 @@ describe('HTTP API Integration Test', function() {
 
       const response = await fetch(testEndpoint, { method: 'PATCH' });
       const json = await response.json();
-      expect(json).to.deep.equal({ method: 'PATCH', path: '/dev/foo' });
+      expect(json).to.deep.equal({ method: 'PATCH', path: '/foo' });
     });
   });
 });


### PR DESCRIPTION
As @Nemo64 suggested here: https://github.com/serverless/serverless/issues/7052#issuecomment-584267234 There's no valid point to nest endpoint behind stage prefixes.

This PR improves that, so we rely on `$default` stage instead