### PR TITLE
feat: manual API Gateway deployment dependencies

### DIFF
--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -121,3 +121,27 @@ resources:
       Properties:
         RetentionInDays: '30'
 ```
+
+## Making your API Gateway deployment depend on resources defined in the Resources section
+
+If you define API endpoints using the `functions` shorthand, they are automatically added as dependencies
+to the API Gateway `Deployment`. However, sometimes your API also depends on other resources that are
+defined in the `resources` section.
+
+You can ensure that your API deployment waits for those other resources to be created by listing them
+in the `provider.apiGateway.deployment.dependsOn` attribute.
+
+Here's an example:
+
+```yml
+provider:
+  name: aws
+  apiGateway:
+    deployment:
+      dependsOn:
+        - SampleResource
+
+resources:
+  Resources:
+    SampleResource: ...
+```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -75,6 +75,8 @@ provider:
     description: Some Description # Optional description for the API Gateway stage deployment
     binaryMediaTypes: # Optional binary media types the API might return
       - '*/*'
+    deployment:
+      dependsOn: [] # Optional list of resource IDs that should be added to the `Deployment`'s `DependsOn` list
   alb:
     targetGroupPrefix: xxxxxxxxxx # Optional prefix to prepend when generating names for target groups
   usagePlan: # Optional usage plan configuration

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.js
@@ -17,7 +17,10 @@ module.exports = {
           StageName: this.provider.getStage(),
           Description: this.provider.getApiGatewayDescription(),
         },
-        DependsOn: this.apiGatewayMethodLogicalIds,
+        DependsOn: [
+          ...this.apiGatewayMethodLogicalIds,
+          ...this.provider.getApiGatewayDeploymentDependsOn(),
+        ],
       },
     });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
@@ -102,4 +102,43 @@ describe('#compileDeployment()', () => {
         },
       });
     }));
+
+  it('should set deployment DependsOn to method dependencies', () => {
+    return awsCompileApigEvents.compileDeployment().then(() => {
+      const apiGatewayDeploymentLogicalId = Object.keys(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+      )[0];
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          apiGatewayDeploymentLogicalId
+        ].DependsOn
+      ).to.deep.equal(['method-dependency1', 'method-dependency2']);
+    });
+  });
+
+  it('should add apiGateway.deployment.dependsOn values to deployment DependsOn when set', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      deployment: {
+        dependsOn: ['testDependsOn1', 'testDependsOn2'],
+      },
+    };
+
+    return awsCompileApigEvents.compileDeployment().then(() => {
+      const apiGatewayDeploymentLogicalId = Object.keys(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+      )[0];
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          apiGatewayDeploymentLogicalId
+        ].DependsOn
+      ).to.deep.equal([
+        'method-dependency1',
+        'method-dependency2',
+        'testDependsOn1',
+        'testDependsOn2',
+      ]);
+    });
+  });
 });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -650,6 +650,18 @@ class AwsProvider {
       return this.getStackResources(res.NextToken, allResources);
     });
   }
+
+  getApiGatewayDeploymentDependsOn() {
+    if (
+      this.serverless.service.provider.apiGateway &&
+      this.serverless.service.provider.apiGateway.deployment &&
+      this.serverless.service.provider.apiGateway.deployment.dependsOn
+    ) {
+      return this.serverless.service.provider.apiGateway.deployment.dependsOn;
+    }
+
+    return [];
+  }
 }
 
 module.exports = AwsProvider;


### PR DESCRIPTION
## What did you implement

Adds the ability to add manual `DependsOn` entries in the `AWS::ApiGateway::Deployment' resource.

The framework is great at automatically adding dependencies for the resources it creates. However, sometimes you need to ensure that the deployment waits for resources defined in the `resources` section to be created.

This adds a `provider.apiGateway.deployment.dependsOn` property that allows API creators to define dependencies for the `AWS::ApiGateway::Deployment`.

Closes #7338.

## How can we verify it

1. Copy the sample `serverless.yml` below to a file.
    <details>
    <summary>serverless.yml</summary>

    ```yml
    service: sample-service
    frameworkVersion: ">=1.63.0 <2.0.0"
    provider:
      name: aws
      apiGateway:
        deployment:
          dependsOn:
            - sample
    functions:
      sample:
        handler: bin/sample
        events:
          - http:
              method: get
              path: /sample
    package:
      excludes:
      - ./**
    ```

    </details>

2. Run `serverless package`.

3. Examine `.serverless/cloudformation-template-update-stack.json`. Verify that `sample` is present in the `DependsOn` list for the `AWS::ApiGateway::Deployment` resource (the ID for this resource is auto-generated at package time, so search for the resource type).

## Todos

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
