### PR TITLE
Workaround Travis CI regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,6 +219,7 @@ jobs:
         - npx github-release-from-cc-changelog $TRAVIS_TAG
         - npm run pkg:upload -- $TRAVIS_TAG
       deploy:
+        edge: true # Workaround Travis regression: https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761
         provider: npm
         email: services@serverless.com
         on:


### PR DESCRIPTION
As in case of other repos, it hit that one.

https://travis-ci.org/serverless/serverless/jobs/652173262

In light of above crash I've published v1.64.0 manually, and ensure standalone binaries are generated