### PR TITLE
fix(AWS EventBridge): Truncate rule names, target ids longer than allowed 64 chars

### DIFF
--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/eventBridge.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/eventBridge.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EventBridge = require('aws-sdk/clients/eventbridge');
-const { getEventBusName } = require('./utils');
+const { getEventBusName, getEventBusTargetId } = require('./utils');
 
 function createEventBus(config) {
   const { eventBus, region } = config;
@@ -77,7 +77,7 @@ function updateTargetConfiguration(config) {
 
   let target = {
     Arn: lambdaArn,
-    Id: `${ruleName}-target`,
+    Id: getEventBusTargetId(ruleName),
   };
 
   if (input) {
@@ -107,7 +107,7 @@ function removeTargetConfiguration(config) {
 
   return eventBridge
     .removeTargets({
-      Ids: [`${ruleName}-target`],
+      Ids: [getEventBusTargetId(ruleName)],
       Rule: ruleName,
       EventBusName,
     })

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/utils.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+
 function getEventBusName(eventBus) {
   if (eventBus && eventBus.startsWith('arn')) {
     return eventBus.slice(eventBus.indexOf('/') + 1);
@@ -7,6 +9,21 @@ function getEventBusName(eventBus) {
   return eventBus;
 }
 
+function getEventBusTargetId(ruleName) {
+  const targetIdSuffix = 'target';
+  let targetId = `${ruleName}-${targetIdSuffix}`;
+  if (targetId.length > 64) {
+    // Target ids cannot be longer than 64.
+    targetId = `${targetId.slice(0, 31 - targetIdSuffix.length)}${crypto
+      .createHash('md5')
+      .update(targetId)
+      .digest('hex')}-${targetIdSuffix}`;
+  }
+
+  return targetId;
+}
+
 module.exports = {
   getEventBusName,
+  getEventBusTargetId,
 };

--- a/lib/plugins/aws/customResources/test/eventBridge.test.js
+++ b/lib/plugins/aws/customResources/test/eventBridge.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { expect } = require('chai');
+const { getEventBusTargetId } = require('../resources/eventBridge/lib/utils');
+
+describe('#getEventBusTargetId()', () => {
+  const assertions = [
+    { ruleName: 'some-function-name-rule-1' },
+    { ruleName: 'some-very-very-very-long-and-complicated-function-name-rule-1' },
+  ];
+
+  assertions.forEach(({ ruleName }) => {
+    it(`should append "target" suffix on ${ruleName} and ensure output targetId length is less than or equal 64`, () => {
+      const targetId = getEventBusTargetId(ruleName);
+
+      expect(targetId.endsWith('target')).to.be.true;
+      expect(targetId).lengthOf.lte(64);
+    });
+  });
+});

--- a/lib/plugins/aws/customResources/test/utils.test.js
+++ b/lib/plugins/aws/customResources/test/utils.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 const { expect } = require('chai');
-const { getLambdaArn, getEnvironment } = require('./utils');
+const { getLambdaArn, getEnvironment } = require('../resources/utils');
 
 describe('#getLambdaArn()', () => {
   it('should return the Lambda arn', () => {

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const crypto = require('crypto');
 const { addCustomResourceToService } = require('../../../../customResources');
 
 class AwsCompileEventBridgeEvents {
@@ -38,7 +39,16 @@ class AwsCompileEventBridgeEvents {
               const Input = event.eventBridge.input;
               const InputPath = event.eventBridge.inputPath;
               let InputTransformer = event.eventBridge.inputTransformer;
-              const RuleName = `${FunctionName}-rule-${idx}`;
+              const RuleNameSuffix = `rule-${idx}`;
+              let RuleName = `${FunctionName}-${RuleNameSuffix}`;
+              if (RuleName.length > 64) {
+                // Rule names cannot be longer than 64.
+                // Temporary solution until we have https://github.com/serverless/serverless/issues/6598
+                RuleName = `${RuleName.slice(0, 31 - RuleNameSuffix.length)}${crypto
+                  .createHash('md5')
+                  .update(RuleName)
+                  .digest('hex')}-${RuleNameSuffix}`;
+              }
 
               const eventFunctionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
               const customResourceFunctionLogicalId = this.provider.naming.getCustomResourceEventBridgeHandlerFunctionLogicalId();

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -206,6 +206,50 @@ describe('AwsCompileEventBridgeEvents', () => {
       );
     });
 
+    it('should shorten the rule name if it exceeds 64 chars', () => {
+      awsCompileEventBridgeEvents.serverless.service.functions = {
+        oneVeryLongAndVeryStrangeAndVeryComplicatedFunctionNameOver64Chars: {
+          name: 'one-very-long-and-very-strange-and-very-complicated-function-name-over-64-chars',
+          events: [
+            {
+              eventBridge: {
+                schedule: 'rate(10 minutes)',
+                pattern: {
+                  'source': ['aws.cloudformation'],
+                  'detail-type': ['AWS API Call via CloudTrail'],
+                  'detail': {
+                    eventSource: ['cloudformation.amazonaws.com'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(awsCompileEventBridgeEvents.compileEventBridgeEvents()).to.be.fulfilled.then(
+        () => {
+          const RuleNameFromLambdaConf = addCustomResourceToServiceStub.args[0][2][0].Resource[
+            'Fn::Join'
+          ][1]
+            .pop()
+            .replace('rule/', '');
+          expect(RuleNameFromLambdaConf.endsWith('rule-1')).to.be.true;
+          expect(RuleNameFromLambdaConf).lengthOf.lte(64);
+
+          const {
+            Resources,
+          } = awsCompileEventBridgeEvents.serverless.service.provider.compiledCloudFormationTemplate;
+          const RuleNameFromCustomResource =
+            Resources
+              .OneVeryLongAndVeryStrangeAndVeryComplicatedFunctionNameOver64CharsCustomEventBridge1
+              .Properties.EventBridgeConfig.RuleName;
+          expect(RuleNameFromCustomResource.endsWith('rule-1')).to.be.true;
+          expect(RuleNameFromCustomResource).lengthOf.lte(64);
+        }
+      );
+    });
+
     it('should create the necessary resources when using a complex configuration', () => {
       awsCompileEventBridgeEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
## What did you implement

AWS EventBridge RuleName and TargetId shortener in order to prevent exceeding max string length of 64 chars.

Closes https://github.com/serverless/serverless/issues/7356

## How can we verify it

```yml
service: myService

provider:
  name: aws
  runtime: nodejs12.x
  stage: dev
  region: eu-west-1

functions:
  myVeryLongAndVeryComplicatedFunction:
    handler: index.handler
    events:
      - eventBridge:
          eventBus: myBus
          pattern:
            source:
              - mySource
```

## Todos

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
