### PR TITLE
Increase stats request timeout

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -337,15 +337,23 @@ describe('uploadArtifacts', () => {
   describe('#uploadCustomResources()', () => {
     let uploadStub;
     let serviceDirPath;
+    let customResourcesFilePath;
 
     beforeEach(() => {
       uploadStub = sinon.stub(awsDeploy.provider, 'request').resolves();
       serviceDirPath = createTmpDir();
+      customResourcesFilePath = path.join(serviceDirPath, '.serverless', 'custom-resources.zip');
+      // Ensure no file stream is created, as by having provider.request mocked it'll be not consumed.
+      // File stream points file in temporary home folder which is cleaned after this test file is run.
+      // There were observed race conditions (mostly in Node.js v6) where this temporary home
+      // folder was cleaned before stream initialized fully, hence throwing uncaught
+      // ENOENT exception into the air.
+      sinon.stub(fs, 'createReadStream').returns({ path: customResourcesFilePath });
       serverless.config.servicePath = serviceDirPath;
     });
 
     afterEach(() => {
-      uploadStub.restore();
+      sinon.restore();
     });
 
     it('should not attempt to upload a custom resources if the artifact does not exist', () => {
@@ -355,11 +363,6 @@ describe('uploadArtifacts', () => {
     });
 
     it('should upload the custom resources .zip file to the S3 bucket', () => {
-      const customResourcesFilePath = path.join(
-        serviceDirPath,
-        '.serverless',
-        'custom-resources.zip'
-      );
       fse.ensureFileSync(customResourcesFilePath);
 
       cryptoStub

--- a/lib/utils/tracking.js
+++ b/lib/utils/tracking.js
@@ -72,7 +72,7 @@ function request(type, event, { id, timeout } = {}) {
     },
     method: 'POST',
     // Ensure reasonable timeout to not block process from exiting
-    timeout: timeout || 1500,
+    timeout: timeout || 3500,
     body: JSON.stringify(event),
   }).then(
     response => {


### PR DESCRIPTION
While being in New Zealand on good cable internet connection I've observed that technically no stats requests succeed, as on average they take 2s, sometimes leaning over 3s.

Therefore I think we should increase timeout, to ensure we cover more remote areas.

--- 

Additionally addressed test race condition issue, exposed by CI fail: https://travis-ci.org/serverless/serverless/jobs/652705887

