### PR TITLE
Fix/event eventbridge error msg

### DIFF
--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -123,7 +123,7 @@ class AwsCompileEventBridgeEvents {
 
                 // Handle Intrinsic Functions
                 if (typeof EventBus === 'object' || EventBus.startsWith('!')) {
-                  throw new this.serverless.classes.Error('EventBus name must be a string');
+                  throw new this.serverless.classes.Error('EventBus key must be a string');
                 }
 
                 if (EventBus.startsWith('arn')) {

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -120,6 +120,12 @@ class AwsCompileEventBridgeEvents {
               };
               if (EventBus) {
                 let eventBusName = EventBus;
+
+                // Handle Intrinsic Functions
+                if (typeof EventBus === 'object' || EventBus.startsWith('!')) {
+                  throw new this.serverless.classes.Error('EventBus name must be a string');
+                }
+
                 if (EventBus.startsWith('arn')) {
                   eventBusName = EventBus.slice(EventBus.indexOf('/') + 1);
                 }

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -351,6 +351,72 @@ describe('AwsCompileEventBridgeEvents', () => {
       );
     });
 
+    it('should throw if event bus is an object', () => {
+      awsCompileEventBridgeEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              eventBridge: {
+                eventBus: { 'Fn::ImportValue': 'TestBusName' },
+                schedule: 'rate(10 minutes)',
+                pattern: {
+                  'source': ['aws.cloudformation'],
+                  'detail-type': ['AWS API Call via CloudTrail'],
+                  'detail': {
+                    eventSource: ['cloudformation.amazonaws.com'],
+                  },
+                },
+                input: {
+                  key1: 'value1',
+                  key2: {
+                    nested: 'value2',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileEventBridgeEvents.compileEventBridgeEvents()).to.throw(
+        /EventBus key must be a string/
+      );
+    });
+
+    it('should throw if event bus key uses intrinsic shortcode', () => {
+      awsCompileEventBridgeEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              eventBridge: {
+                eventBus: '!ImportValue TestBusName',
+                schedule: 'rate(10 minutes)',
+                pattern: {
+                  'source': ['aws.cloudformation'],
+                  'detail-type': ['AWS API Call via CloudTrail'],
+                  'detail': {
+                    eventSource: ['cloudformation.amazonaws.com'],
+                  },
+                },
+                input: {
+                  key1: 'value1',
+                  key2: {
+                    nested: 'value2',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileEventBridgeEvents.compileEventBridgeEvents()).to.throw(
+        /EventBus key must be a string/
+      );
+    });
+
     it('should create the necessary resources when using an own event bus arn', () => {
       awsCompileEventBridgeEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Added some error handling for event bridge events around using intrinsic functions to more gracefully handle the EventBus key being an object. (#7063 ), this doesn't fix the referenced issue but while I'm stuck on it it makes sense to have better error handling.


## How can we verify it

I used a boilerplate template for aws nodejs and updated the serverless to look like this:

```yaml
service: test-import-event-bus

custom:
  defaults: ${file(.env.yml)}

provider:
  name: aws
  profile: ${opt:aws-profile, self:custom.defaults.profile}
  region: ${opt:region, self:custom.defaults.region}
  runtime: nodejs12.x

functions:
  testFunc:
    handler: test-func.handler
    events:
      - eventBridge:
          existing: true
          eventBus:
            Fn::ImportValue: TestBusName
          pattern:
            account:
              Ref: AWS::AccountId
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
