### PR TITLE
Allow symlink for config

### DIFF
--- a/lib/utils/fs/fileExistsSync.js
+++ b/lib/utils/fs/fileExistsSync.js
@@ -4,7 +4,7 @@ const fse = require('./fse');
 
 function fileExistsSync(filePath) {
   try {
-    const stats = fse.lstatSync(filePath);
+    const stats = fse.statSync(filePath);
     return stats.isFile();
   } catch (e) {
     return false;

--- a/lib/utils/fs/fileExistsSync.test.js
+++ b/lib/utils/fs/fileExistsSync.test.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const expect = require('chai').expect;
+const fse = require('./fse');
 const fileExistsSync = require('./fileExistsSync');
 
 describe('#fileExistsSync()', () => {
@@ -14,6 +15,34 @@ describe('#fileExistsSync()', () => {
     it("should detect if a file doesn't exist", () => {
       const noFile = fileExistsSync(path.join(__dirname, 'XYZ.json'));
       expect(noFile).to.equal(false);
+    });
+  });
+
+  describe('When reading a symlink to a file', () => {
+    it('should detect if the file exists', () => {
+      fse.symlinkSync(__filename, 'sym');
+      const found = fileExistsSync('sym');
+      expect(found).to.equal(true);
+      fse.unlinkSync('sym');
+    });
+
+    it("should detect if the file doesn't exist w/ bad symlink", () => {
+      fse.symlinkSync('oops', 'invalid-sym');
+      const found = fileExistsSync('invalid-sym');
+      expect(found).to.equal(false);
+      fse.unlinkSync('invalid-sym');
+    });
+
+    it("should detect if the file doesn't exist w/ symlink to dir", () => {
+      fse.symlinkSync(__dirname, 'dir-sym');
+      const found = fileExistsSync('dir-sym');
+      expect(found).to.equal(false);
+      fse.unlinkSync('dir-sym');
+    });
+
+    it("should detect if the file doesn't exist", () => {
+      const found = fileExistsSync('bogus');
+      expect(found).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Use normal `stat` instead of `lstat` for checking the configuration to allow symlinks for people that keep rc's in source control.

Closes #7369

## How can we verify it

Make your `.serverlessrc` a symlink and see that it changes every time you do anything.
Apply this change, and you'll see it no longer does that.


- [X] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
