### PR TITLE
Enable association of VPC endpoint ids on AWS private API Gateways

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -655,6 +655,24 @@ functions:
           method: get
 ```
 
+API Gateway also supports the association of VPC endpoints if you have an API Gateway REST API using the PRIVATE endpoint configuration. This feature simplifies the invocation of a private API through the generation of the following AWS Route 53 alias: 
+
+```
+https://<rest_api_id>-<vpc_endpoint_id>.execute-api.<aws_region>.amazonaws.com
+```
+
+Here's an example configuration:
+
+```yml
+service: my-service
+provider:
+  name: aws
+  endpointType: PRIVATE
+  vpcEndpointIds:
+    - vpce-123
+    - vpce-456
+```
+
 ### Request Parameters
 
 To pass optional and required parameters to your functions, so you can use them in API Gateway tests and SDK generation, marking them as `true` will make them required, `false` will make them optional.

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -655,7 +655,7 @@ functions:
           method: get
 ```
 
-API Gateway also supports the association of VPC endpoints if you have an API Gateway REST API using the PRIVATE endpoint configuration. This feature simplifies the invocation of a private API through the generation of the following AWS Route 53 alias: 
+API Gateway also supports the association of VPC endpoints if you have an API Gateway REST API using the PRIVATE endpoint configuration. This feature simplifies the invocation of a private API through the generation of the following AWS Route 53 alias:
 
 ```
 https://<rest_api_id>-<vpc_endpoint_id>.execute-api.<aws_region>.amazonaws.com

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -38,7 +38,6 @@ module.exports = {
       endpointType = endpointType.toUpperCase();
 
       if (this.serverless.service.provider.vpcEndpointIds) {
-        console.log('Vpc Endpoint Id List: ' + this.serverless.service.provider.vpcEndpointIds)
         vpcEndpointIds = this.serverless.service.provider.vpcEndpointIds;
 
         if (endpointType !== 'PRIVATE') {
@@ -51,16 +50,21 @@ module.exports = {
       }
     }
 
+    const EndpointConfiguration = {
+        Types: [endpointType],
+    }
+
+    if (vpcEndpointIds) {
+      EndpointConfiguration.VpcEndpointIds = vpcEndpointIds
+    }
+
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.apiGatewayRestApiLogicalId]: {
         Type: 'AWS::ApiGateway::RestApi',
         Properties: {
           Name: this.provider.naming.getApiGatewayName(),
           BinaryMediaTypes,
-          EndpointConfiguration: {
-            Types: [endpointType],
-            ...vpcEndpointIds && {VpcEndpointIds: vpcEndpointIds}
-          },
+          EndpointConfiguration
         },
       },
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -38,13 +38,14 @@ module.exports = {
       endpointType = endpointType.toUpperCase();
 
       if (this.serverless.service.provider.vpcEndpointIds) {
+        console.log('Vpc Endpoint Id List: ' + this.serverless.service.provider.vpcEndpointIds)
         vpcEndpointIds = this.serverless.service.provider.vpcEndpointIds;
 
         if (endpointType !== 'PRIVATE') {
           throw new this.serverless.classes.Error('VPC endpoint IDs are only available for private APIs')
         }
 
-        if (Array.isArray(vpcEndpointIds)) {
+        if (!Array.isArray(vpcEndpointIds)) {
           throw new this.serverless.classes.Error('vpcEndpointIds must be an array');
         }
       }
@@ -58,7 +59,7 @@ module.exports = {
           BinaryMediaTypes,
           EndpointConfiguration: {
             Types: [endpointType],
-            VpcEndpointIds: vpcEndpointIds != null ? vpcEndpointIds: undefined,
+            ...vpcEndpointIds && {VpcEndpointIds: vpcEndpointIds}
           },
         },
       },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -15,6 +15,7 @@ module.exports = {
     this.apiGatewayRestApiLogicalId = this.provider.naming.getRestApiLogicalId();
 
     let endpointType = 'EDGE';
+    let vpcEndpointIds;
     let BinaryMediaTypes;
     if (apiGateway.binaryMediaTypes) {
       BinaryMediaTypes = apiGateway.binaryMediaTypes;
@@ -35,6 +36,18 @@ module.exports = {
         throw new this.serverless.classes.Error(message);
       }
       endpointType = endpointType.toUpperCase();
+
+      if (this.serverless.service.provider.vpcEndpointIds) {
+        vpcEndpointIds = this.serverless.service.provider.vpcEndpointIds;
+
+        if (endpointType !== 'PRIVATE') {
+          throw new this.serverless.classes.Error('VPC endpoint IDs are only available for private APIs')
+        }
+
+        if (Array.isArray(vpcEndpointIds)) {
+          throw new this.serverless.classes.Error('vpcEndpointIds must be an array');
+        }
+      }
     }
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
@@ -45,6 +58,7 @@ module.exports = {
           BinaryMediaTypes,
           EndpointConfiguration: {
             Types: [endpointType],
+            VpcEndpointIds: vpcEndpointIds != null ? vpcEndpointIds: undefined,
           },
         },
       },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -41,7 +41,9 @@ module.exports = {
         vpcEndpointIds = this.serverless.service.provider.vpcEndpointIds;
 
         if (endpointType !== 'PRIVATE') {
-          throw new this.serverless.classes.Error('VPC endpoint IDs are only available for private APIs')
+          throw new this.serverless.classes.Error(
+            'VPC endpoint IDs are only available for private APIs'
+          );
         }
 
         if (!Array.isArray(vpcEndpointIds)) {
@@ -51,11 +53,11 @@ module.exports = {
     }
 
     const EndpointConfiguration = {
-        Types: [endpointType],
-    }
+      Types: [endpointType],
+    };
 
     if (vpcEndpointIds) {
-      EndpointConfiguration.VpcEndpointIds = vpcEndpointIds
+      EndpointConfiguration.VpcEndpointIds = vpcEndpointIds;
     }
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
@@ -64,7 +66,7 @@ module.exports = {
         Properties: {
           Name: this.provider.naming.getApiGatewayName(),
           BinaryMediaTypes,
-          EndpointConfiguration
+          EndpointConfiguration,
         },
       },
     });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -169,6 +169,24 @@ describe('#compileRestApi()', () => {
     expect(() => awsCompileApigEvents.compileRestApi()).to.not.throw(Error);
   });
 
+  it('should compile if endpointType property is PRIVATE and vpcEndpointIds property is [id1]', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = 'PRIVATE';
+    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1']
+    expect(() => awsCompileApigEvents.compileRestApi()).to.not.throw(Error);
+  });
+
+  it('should throw error if endpointType property is PRIVATE and vpcEndpointIds property is not an array', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = 'PRIVATE';
+    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = 'id1'
+    expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
+  });
+
+  it('should throw error if endpointType property is not PRIVATE and vpcEndpointIds property is [id1]', () => {
+    awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
+    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1']
+    expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
+  });
+
   it('throw error if endpointType property is not EDGE or REGIONAL', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw('endpointType must be one of');

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -171,19 +171,19 @@ describe('#compileRestApi()', () => {
 
   it('should compile if endpointType property is PRIVATE and vpcEndpointIds property is [id1]', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'PRIVATE';
-    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1']
+    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1'];
     expect(() => awsCompileApigEvents.compileRestApi()).to.not.throw(Error);
   });
 
   it('should throw error if endpointType property is PRIVATE and vpcEndpointIds property is not an array', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'PRIVATE';
-    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = 'id1'
+    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = 'id1';
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
   });
 
   it('should throw error if endpointType property is not PRIVATE and vpcEndpointIds property is [id1]', () => {
     awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
-    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1']
+    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1'];
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
   });
 


### PR DESCRIPTION
## What did you implement

Amazon API Gateway support associating your API with an interface VPC endpoint. This is supported in cloudformation via EndpointConfiguration. Associating your API with the VPCE creates a custom DNS alias which allows you to access your private gateway through the VPCE without the need of a Host header, which is necessary in certain situations, particularly if you want to make ajax calls to your private API from a browser.

Closes #6715 & #7112 

## How can we verify it

```
service: api-private-test

provider:
name: aws
runtime: nodejs10.x
stage: ${env:AWS_ENV}
region: ${env:AWS_DEFAULT_REGION}
timeout: 30
memorySize: 128
endpointType: PRIVATE
endpointVpcIds: 
  - vpce-0250d95e899edfa1b
  - vpce-0250d95e899edfa1c
resourcePolicy:
  - Effect: Allow
    Principal: ''
    Action: execute-api:Invoke
    Resource:
      - execute-api:///
    Condition:
      IpAddress:
        aws:SourceIp:
          - '123.123.123.123'

functions:
  currentTime:
    handler: handler.endpoint
    events:
      - http:
          path: ping
          method: get
```

## Todos

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
