### PR TITLE
Fix HTTP API default stage handling

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -579,6 +579,7 @@ module.exports = {
     return `HttpApiIntegration${this.getNormalizedFunctionName(functionName)}`;
   },
   getHttpApiRouteLogicalId(routeKey) {
+    if (routeKey === '*') return 'HttpApiRouteDefault';
     return `HttpApiRoute${this.normalizePath(routeKey)}`;
   },
   getHttpApiAuthorizerLogicalId(authorizerName) {

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -51,10 +51,6 @@ class HttpApiEvents {
       Name: this.provider.naming.getHttpApiName(),
       ProtocolType: 'HTTP',
     };
-    if (this.config.routes.has('*')) {
-      properties.RouteKey = '$default';
-      properties.Target = resolveTargetConfig(this.config.routes.get('*').targetData);
-    }
     const cors = this.config.cors;
     if (cors) {
       properties.CorsConfiguration = {
@@ -72,16 +68,14 @@ class HttpApiEvents {
     };
   }
   compileStage() {
-    if (!this.config.routes.has('*')) {
-      this.cfTemplate.Resources[this.provider.naming.getHttpApiStageLogicalId()] = {
-        Type: 'AWS::ApiGatewayV2::Stage',
-        Properties: {
-          ApiId: { Ref: this.provider.naming.getHttpApiLogicalId() },
-          StageName: '$default',
-          AutoDeploy: true,
-        },
-      };
-    }
+    this.cfTemplate.Resources[this.provider.naming.getHttpApiStageLogicalId()] = {
+      Type: 'AWS::ApiGatewayV2::Stage',
+      Properties: {
+        ApiId: { Ref: this.provider.naming.getHttpApiLogicalId() },
+        StageName: '$default',
+        AutoDeploy: true,
+      },
+    };
     this.cfTemplate.Outputs.HttpApiUrl = {
       Description: 'URL of the HTTP API',
       Value: {
@@ -121,7 +115,6 @@ class HttpApiEvents {
   compileEndpoints() {
     for (const [routeKey, { targetData, authorizer, authorizationScopes }] of this.config.routes) {
       this.compileLambdaPermissions(targetData);
-      if (routeKey === '*') continue;
       this.compileIntegration(targetData);
       const resource = (this.cfTemplate.Resources[
         this.provider.naming.getHttpApiRouteLogicalId(routeKey)
@@ -129,7 +122,7 @@ class HttpApiEvents {
         Type: 'AWS::ApiGatewayV2::Route',
         Properties: {
           ApiId: { Ref: this.provider.naming.getHttpApiLogicalId() },
-          RouteKey: routeKey,
+          RouteKey: routeKey === '*' ? '$default' : routeKey,
           Target: {
             'Fn::Join': [
               '/',

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -106,19 +106,28 @@ describe('HttpApiEvents', () => {
       expect(resource.Properties.ProtocolType).to.equal('HTTP');
     });
 
-    it('Should configure default route', () => {
+    it('Should not configure default route', () => {
       const resource = cfResources[naming.getHttpApiLogicalId()];
-      expect(resource.Properties.RouteKey).to.equal('$default');
-      expect(resource.Properties).to.have.property('Target');
+      expect(resource.Properties).to.not.have.property('RouteKey');
+      expect(resource.Properties).to.not.have.property('Target');
     });
-    it('Should not configure stage resource', () => {
-      expect(cfResources).to.not.have.property(naming.getHttpApiStageLogicalId());
+    it('Should configure default stage resource', () => {
+      const resource = cfResources[naming.getHttpApiStageLogicalId()];
+      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Stage');
+      expect(resource.Properties.StageName).to.equal('$default');
+      expect(resource.Properties.AutoDeploy).to.equal(true);
     });
     it('Should configure output', () => {
       const output = cfOutputs.HttpApiUrl;
       expect(output).to.have.property('Value');
     });
     it('Should configure catch all endpoint', () => {
+      const routeKey = '*';
+      const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
+      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');
+      expect(resource.Properties.RouteKey).to.equal('$default');
+    });
+    it('Should configure method catch all endpoint', () => {
       const routeKey = 'ANY /foo';
       const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
       expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');


### PR DESCRIPTION
Addresses #7052 

To be able to enrich default stage with additional settings as log access, or be able to enrich default route with authorization or make it removable, we should not rely on default route configuration (that could be added with `AWS::ApiGatewayV2::Api` resource), but need to define stage and route explicitly.

This patch ensures we configure default route that way
