### PR TITLE
Fix path resolving

### DIFF
--- a/lib/plugins/aws/lib/getServiceState.js
+++ b/lib/plugins/aws/lib/getServiceState.js
@@ -8,7 +8,7 @@ module.exports = {
     const servicePath = this.serverless.config.servicePath;
     const packageDirName = this.options.package || '.serverless';
 
-    const stateFilePath = path.join(servicePath, packageDirName, stateFileName);
+    const stateFilePath = path.resolve(servicePath, packageDirName, stateFileName);
     return this.serverless.utils.readFileSync(stateFilePath);
   },
 };

--- a/lib/plugins/aws/lib/getServiceState.test.js
+++ b/lib/plugins/aws/lib/getServiceState.test.js
@@ -32,14 +32,14 @@ describe('#getServiceState()', () => {
   });
 
   it('should use the default state file path if the "package" option is not used', () => {
-    const stateFilePath = path.join('my-service', '.serverless', 'serverless-state.json');
+    const stateFilePath = path.resolve('my-service', '.serverless', 'serverless-state.json');
     awsPlugin.getServiceState();
 
     expect(readFileSyncStub).to.be.calledWithExactly(stateFilePath);
   });
 
   it('should use the argument-based state file path if the "package" option is used ', () => {
-    const stateFilePath = path.join('my-service', 'some-package-path', 'serverless-state.json');
+    const stateFilePath = path.resolve('my-service', 'some-package-path', 'serverless-state.json');
     options.package = 'some-package-path';
 
     awsPlugin.getServiceState();


### PR DESCRIPTION
## What did you implement

Should resolve #7318 by using `path.resolve` instead of `path.join`

## How can we verify it

For arbitrary project, run commands that were described in the issue #7318:
`serverless package --package {somePath}`
`serverless deploy --package {somePath}`
The result should be no error thrown and usual info regarding project deployment is shown.

## Todos

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** Yes
**_Is it a breaking change?:_** No
