### PR TITLE
docs: add missing colons to AWSAccountID

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -57,7 +57,7 @@ provider:
   iamManagedPolicies:
     - 'some:aws:arn:xxx:*:*'
     - 'someOther:aws:arn:xxx:*:*'
-    - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSA::ccountId' }, 'some/path']] }
+    - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWS::AccountId' }, 'some/path']] }
 ```
 
 ## Custom IAM Roles

--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -57,7 +57,7 @@ provider:
   iamManagedPolicies:
     - 'some:aws:arn:xxx:*:*'
     - 'someOther:aws:arn:xxx:*:*'
-    - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSAccountId' }, 'some/path']] }
+    - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSA::ccountId' }, 'some/path']] }
 ```
 
 ## Custom IAM Roles


### PR DESCRIPTION
CloudFormation gives an error otherwise (when using  - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWSAccountId' }, 'some/path']] } as it is currently documented): 

"Error: The CloudFormation template is invalid: Template format error: Unresolved resource dependencies [AWSAccountId] in the Resources block of the template"

see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html 

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Closes: dont know. I just fixed it without a bug report by clicking the link in the docs


## How can we verify it

Try using the code in the current docs without the colons in a serverless.yml
It will give the error mentioned above.

Then try it with a serverless.yml that uses the "AWS::AccountID instead"

## Todos

It's a documentation change - it cannot be tested automatically I believe.

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
