### PR TITLE
Update object-hash to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "nanomatch": "^1.2.13",
     "ncjsm": "^4.0.1",
     "node-fetch": "^1.7.3",
-    "object-hash": "^1.3.1",
+    "object-hash": "^2.0.3",
     "p-limit": "^2.2.2",
     "promise-queue": "^2.2.5",
     "raven": "^1.2.1",


### PR DESCRIPTION
## What did you implement

Updates `object-hash` to use the current version that dropped support for old versions of node

Closes #7403

## How can we verify it

`npm install` or `yarn install`

**_Is this ready for review?: Yes
**_Is it a breaking change?: No
