### PR TITLE
fix(Standalone): Fix bug where chalk is called as a method

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -80,9 +80,9 @@ class Serverless {
           notifier.notify({
             message:
               isStandaloneExecutable && notifier.update
-                ? `Update available ${chalk().dim(notifier.update.current)}${chalk().reset(
+                ? `Update available ${chalk.dim(notifier.update.current)}${chalk.reset(
                     ' → '
-                  )}${chalk().green(notifier.update.latest)} \nRun ${chalk().cyan(
+                  )}${chalk.green(notifier.update.latest)} \nRun ${chalk.cyan(
                     'serverless upgrade'
                   )} to update`
                 : null,


### PR DESCRIPTION
Fixes a bug in the Update logic for the Standalone binary: 
`TypeError: chalk(...).dim is not a function`

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Closes https://stackoverflow.com/questions/60457609/serverless-typeerror-chalk-dim-is-not-a-function

## How can we verify it

- [ ] Fetch the standalone binary 1.64.0
- [ ] run any `serverless` command.

Expected Result:
- [ ] You see a chalk message asking you to upgrade


**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
