### PR TITLE
Fix #7103 Add source account to lambda permissions for s3 events

### DIFF
--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -26,6 +26,7 @@ function create(event, context) {
     bucketName: BucketName,
     partition: Partition,
     region: Region,
+    accountId: AccountId,
   }).then(() =>
     updateConfiguration({
       lambdaArn,

--- a/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
@@ -12,7 +12,7 @@ function getStatementId(functionName, bucketName) {
 }
 
 function addPermission(config) {
-  const { functionName, bucketName, partition, region } = config;
+  const { functionName, bucketName, partition, region, accountId } = config;
   const lambda = new AWS.Lambda({ region });
   const payload = {
     Action: 'lambda:InvokeFunction',
@@ -20,6 +20,7 @@ function addPermission(config) {
     Principal: 's3.amazonaws.com',
     StatementId: getStatementId(functionName, bucketName),
     SourceArn: `arn:${partition}:s3:::${bucketName}`,
+    SourceAccount: accountId,
   };
   return lambda.addPermission(payload).promise();
 }

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -257,6 +257,7 @@ class AwsCompileS3Events {
               ['arn:', { Ref: 'AWS::Partition' }, `:s3:::${s3EnabledFunction.bucketName}`],
             ],
           },
+          SourceAccount: { Ref: 'AWS::AccountId' },
         },
       };
       const lambdaPermissionLogicalId = this.provider.naming.getLambdaS3PermissionLogicalId(


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

This PR adds the `SourceAccount` condition with the current account to the lambda permission for s3 events.

Closes #7103 

## How can we verify it
Deploy a function with an s3 event trigger:
```yaml
photoupload:
    handler: photoupload.handler
    description: Process images dropped into S3
    events:
    - s3:
        bucket: mybucket
        event: s3:ObjectCreated:*
```
The lambda policy will now include the `AWS:SourceAccount` condition:
```json
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "autogensid",
      "Effect": "Allow",
      "Principal": {
        "Service": "s3.amazonaws.com"
      },
      "Action": "lambda:InvokeFunction",
      "Resource": "arn:aws:lambda:us-east-1:999999999999:function:photoupload",
      "Condition": {
        "StringEquals": {
          "AWS:SourceAccount": "999999999999"
        },
        "ArnLike": {
          "AWS:SourceArn": "arn:aws:s3:::mybucket"
        }
      }
    }
  ]
}
```


## Todos

- [ ] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** Only if users unintentionally rely on this behavior (which is unlikely and they really shouldn't).
