### PR TITLE
Fix cognito pool update handling

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,6 +14,7 @@ module.exports = {
         'AWS ALB',
         'AWS API Gateway',
         'AWS CloudFormation',
+        'AWS Cognito',
         'AWS Deploy',
         'AWS EventBridge',
         'AWS HTTP API',

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
@@ -17,6 +17,7 @@ function getUpdateConfigFromCurrentSetup(currentSetup) {
   delete updatedConfig.EmailConfigurationFailure;
   delete updatedConfig.Domain;
   delete updatedConfig.CustomDomain;
+  delete updatedConfig.UsernameConfiguration;
   delete updatedConfig.Arn;
   // necessary reassignments
   updatedConfig.Policies.PasswordPolicy.TemporaryPasswordValidityDays =


### PR DESCRIPTION
Fixes #7414 

In operation in which we read existing configuration to reliably update the configuration, one of the properties were not filtered as expected