### PR TITLE
modify sample block to exclude insecure by default copy pasta

### DIFF
--- a/docs/providers/aws/guide/layers.md
+++ b/docs/providers/aws/guide/layers.md
@@ -36,8 +36,9 @@ layers:
     compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
       - python3.8
     licenseInfo: GPLv3 # optional, a string specifying license information
-    allowedAccounts: # optional, a list of AWS account IDs allowed to access this layer.
-      - '*'
+    # allowedAccounts: # optional, a list of AWS account IDs allowed to access this layer.
+    #   - '*'
+    # note: uncommenting this will give all AWS users access to this layer unconditionally.
     retain: false # optional, false by default. If true, layer versions are not deleted as new ones are created
 ```
 


### PR DESCRIPTION
## What did you implement

Modify the docs so that if someone copy pastes a block of text regarding lambda layers they don't inadvertently grant world read access.

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
