### PR TITLE
Fix #7149 Add AWS provider partition option

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -29,6 +29,7 @@ provider:
   name: aws
   runtime: nodejs12.x
   stage: ${opt:stage, 'dev'} # Set the default stage used. Default is dev
+  partition: ${opt:partition, 'aws'} # Overwrite the default partition used. Default is aws
   region: ${opt:region, 'us-east-1'} # Overwrite the default region used. Default is us-east-1
   stackName: custom-stack-name # Use a custom name for the CloudFormation stack
   apiName: custom-api-name # Use a custom name for the API Gateway API

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -39,7 +39,7 @@ module.exports = {
       const websocketsPolicy = {
         Effect: 'Allow',
         Action: ['execute-api:ManageConnections'],
-        Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
+        Resource: [`arn:${this.provider.getPartition()}:execute-api:*:*:*/@connections/*`],
       };
 
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources[

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
@@ -63,8 +63,8 @@ describe('#compileApi()', () => {
     });
   });
 
-  it('should add the websockets policy', () =>
-    awsCompileWebsocketsEvents.compileApi().then(() => {
+  it('should add the websockets policy', () => {
+    return awsCompileWebsocketsEvents.compileApi().then(() => {
       const resources =
         awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources;
@@ -84,9 +84,10 @@ describe('#compileApi()', () => {
               },
             },
           ],
-        },
+        }
       });
-    }));
+    });
+  });
 
   it('should NOT add the websockets policy if role resource does not exist', () => {
     awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources = {};

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
@@ -63,7 +63,7 @@ describe('#compileApi()', () => {
     });
   });
 
-  it('should add the websockets policy', () => {
+  it('should add the websockets policy and target the default partition', () => {
     return awsCompileWebsocketsEvents.compileApi().then(() => {
       const resources =
         awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
@@ -84,7 +84,34 @@ describe('#compileApi()', () => {
               },
             },
           ],
-        }
+        },
+      });
+    });
+  });
+
+  it('should add the websockets policy and target the configured partition', () => {
+    awsCompileWebsocketsEvents.serverless.service.provider.partition = 'aws-us-gov';
+    return awsCompileWebsocketsEvents.compileApi().then(() => {
+      const resources =
+        awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources;
+
+      expect(resources[roleLogicalId]).to.deep.equal({
+        Properties: {
+          Policies: [
+            {
+              PolicyDocument: {
+                Statement: [
+                  {
+                    Action: ['execute-api:ManageConnections'],
+                    Effect: 'Allow',
+                    Resource: ['arn:aws-us-gov:execute-api:*:*:*/@connections/*'],
+                  },
+                ],
+              },
+            },
+          ],
+        },
       });
     });
   });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -442,6 +442,20 @@ class AwsProvider {
     }, {});
   }
 
+  getPartitionSourceValue() {
+    const values = this.getValues(this, [
+      ['options', 'partition'],
+      ['serverless', 'config', 'partition'],
+      ['serverless', 'service', 'provider', 'partition'],
+    ]);
+    return this.firstValue(values);
+  }
+  getPartition() {
+    const defaultPartition = 'aws';
+    const partitionSourceValue = this.getPartitionSourceValue();
+    return partitionSourceValue.value || defaultPartition;
+  }
+
   getRegionSourceValue() {
     const values = this.getValues(this, [
       ['options', 'region'],

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -1198,6 +1198,55 @@ describe('AwsProvider', () => {
     });
   });
 
+  describe('#getPartition()', () => {
+    let newAwsProvider;
+
+    it('should prefer options over config or provider', () => {
+      const newOptions = {
+        partition: 'optionsPartition',
+      };
+      const config = {
+        partition: 'configPartition',
+      };
+      serverless = new Serverless(config);
+      serverless.service.provider.partition = 'providerPartition';
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getPartition()).to.equal(newOptions.partition);
+    });
+
+    it('should prefer config over provider in lieu of options', () => {
+      const newOptions = {};
+      const config = {
+        partition: 'configPartition',
+      };
+      serverless = new Serverless(config);
+      serverless.service.provider.partition = 'providerPartition';
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getPartition()).to.equal(config.partition);
+    });
+
+    it('should use provider in lieu of options and config', () => {
+      const newOptions = {};
+      const config = {};
+      serverless = new Serverless(config);
+      serverless.service.provider.partition = 'providerPartition';
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getPartition()).to.equal(serverless.service.provider.partition);
+    });
+
+    it('should use the default aws in lieu of options, config, and provider', () => {
+      const newOptions = {};
+      const config = {};
+      serverless = new Serverless(config);
+      newAwsProvider = new AwsProvider(serverless, newOptions);
+
+      expect(newAwsProvider.getPartition()).to.equal('aws');
+    });
+  });
+
   describe('#getRegion()', () => {
     let newAwsProvider;
 


### PR DESCRIPTION
## What did you implement?

During [`compileApi`](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/events/websockets/lib/api.js#L7), the websockets AWS policy generated currently assumes the standard 'aws' partition (see [here](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/events/websockets/lib/api.js#L42). This PR adds a partition property to `serverless.yml`, which is interpolated during policy preparation.

Closes #7149

## How can we verify it?

A new websockets service using a non-standard region; for example:
```yml
service: api
frameworkVersion: '>=1.28.0 <2.0.0'

provider:
  name: aws
  runtime: go1.x

  stage: production
  region: us-gov-west-1
...
```

Will result in something like the following error:
```shell
Serverless: Packaging service...
Serverless: Excluding development dependencies...
...
CloudFormation - UPDATE_IN_PROGRESS - AWS::IAM::Role - IamRoleLambdaExecution
CloudFormation - UPDATE_FAILED - AWS::IAM::Role - IamRoleLambdaExecution
...
Serverless: Operation failed!
...
An error occurred: IamRoleLambdaExecution - Partition "aws" is not valid for resource "arn:aws:execute-api:*:*:*/@connections/*". (Service: AmazonIdentityManagement; Status Code: 400; Error Code: MalformedPolicyDocument...
...
```

Using the changes in this PR, while adding a partition option configured to 'aws-us-gov', will result in success!  :)

## Todos

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
