### PR TITLE
Fix #7149 <WSS> Use AWS partition pseudo param

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -39,7 +39,7 @@ module.exports = {
       const websocketsPolicy = {
         Effect: 'Allow',
         Action: ['execute-api:ManageConnections'],
-        Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
+        Resource: [{ 'Fn::Sub': 'arn:${AWS::Partition}:execute-api:*:*:*/@connections/*' }],
       };
 
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources[

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
@@ -78,7 +78,9 @@ describe('#compileApi()', () => {
                   {
                     Action: ['execute-api:ManageConnections'],
                     Effect: 'Allow',
-                    Resource: ['arn:aws:execute-api:*:*:*/@connections/*'],
+                    Resource: [
+                      { 'Fn::Sub': 'arn:${AWS::Partition}:execute-api:*:*:*/@connections/*' },
+                    ],
                   },
                 ],
               },


### PR DESCRIPTION
## What did you implement?

During [`compileApi`](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/events/websockets/lib/api.js#L7), the websockets AWS policy generated currently assumes the standard 'aws' partition (see [here](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/events/websockets/lib/api.js#L42)). This PR replaces 'aws' with the `AWS::Partition` pseudo parameter.

Closes #7149

## How can we verify it?

A new websockets service using a non-standard region; for example:
```yml
service: api
frameworkVersion: '>=1.28.0 <2.0.0'

provider:
  name: aws
  runtime: go1.x

  stage: production
  region: us-gov-west-1
...
```

Will result in something like the following error:
```shell
Serverless: Packaging service...
Serverless: Excluding development dependencies...
...
CloudFormation - UPDATE_IN_PROGRESS - AWS::IAM::Role - IamRoleLambdaExecution
CloudFormation - UPDATE_FAILED - AWS::IAM::Role - IamRoleLambdaExecution
...
Serverless: Operation failed!
...
An error occurred: IamRoleLambdaExecution - Partition "aws" is not valid for resource "arn:aws:execute-api:*:*:*/@connections/*". (Service: AmazonIdentityManagement; Status Code: 400; Error Code: MalformedPolicyDocument...
...
```

Using the changes in this PR, while deploying in a non-standard partition (e.g., 'aws-us-gov'), will result in success!  :)

## Prior Art

- https://github.com/serverless/serverless/pull/7175

## Resources

- [AWS::Partition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition)

## Todos

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
