### PR TITLE
fix(AWS HTTP API): set correct api name

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -79,6 +79,7 @@ provider:
     targetGroupPrefix: xxxxxxxxxx # Optional prefix to prepend when generating names for target groups
   httpApi:
     id: # If we want to attach to externally created HTTP API its id should be provided here
+    name: # Use custom name for the API Gateway API, default is ${self:provider.stage}-${self:service}
     cors: true # Implies default behavior, can be fine tuned with specficic options
     authorizers:
       # JWT authorizers to back HTTP API endpoints

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -571,8 +571,11 @@ module.exports = {
 
   // HTTP API
   getHttpApiName() {
-    if (this.provider.serverless.service.provider.httpApiName) {
-      return `${String(this.provider.serverless.service.provider.apiName)}`;
+    if (
+      this.provider.serverless.service.provider.httpApi &&
+      this.provider.serverless.service.provider.httpApi.name
+    ) {
+      return `${String(this.provider.serverless.service.provider.httpApi.name)}`;
     }
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;
   },

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -89,6 +89,28 @@ describe('HttpApiEvents', () => {
     });
   });
 
+  describe('Custom API name', () => {
+    let cfHttpApi;
+
+    before(() =>
+      fixtures
+        .extend('httpApi', { provider: { httpApi: { name: 'TestHttpApi' } } })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(serverless => {
+            const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+            cfHttpApi = Resources[serverless.getProvider('aws').naming.getHttpApiLogicalId()];
+          })
+        )
+    );
+
+    it('Should configure API name', () => {
+      expect(cfHttpApi.Properties.Name).to.equal('TestHttpApi');
+    });
+  });
+
   describe('Catch-all endpoints', () => {
     let cfResources;
     let cfOutputs;


### PR DESCRIPTION
## What did you implement

Fix configuring custom HTTP API name

Closes #7433 

## How can we verify it

```
service: http-api-service

provider:
  name: aws
  httpApiName: http-api

functions:
  test-function:
    handler: index.handler
    events:
      -  httpApi: 'GET /'
```

Without this change, the API name would be "undefined" (literally)

## Todos

- [x] Write and run all tests
- [x] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO