### PR TITLE
Add option to disable aws credential validation

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -32,6 +32,7 @@ serverless deploy
 - `--conceal` Hides secrets from the output (e.g. API Gateway key values).
 - `--aws-s3-accelerate` Enables S3 Transfer Acceleration making uploading artifacts much faster. You can read more about it [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html). It requires additional `s3:PutAccelerateConfiguration` permissions. **Note: When using Transfer Acceleration, additional data transfer charges may apply.**
 - `--no-aws-s3-accelerate` Explicitly disables S3 Transfer Acceleration. It also requires additional `s3:PutAccelerateConfiguration` permissions.
+- `--no-aws-credential-validation` Explicitly disables AWS Credential Validation.
 
 ## Artifacts
 

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -184,6 +184,14 @@ You can always specify the profile which should be used via the `aws-profile` op
 serverless deploy --aws-profile devProfile
 ```
 
+##### Disable aws credential validation
+
+By default serverless validates the aws credentials. This can be deactivated, if you would like to use features such as ECSCredentials or TokenFileWebIdentityCredentials where the serverless validation fails.
+
+```bash
+serverless deploy --no-aws-credential-validation
+```
+
 #### Per Stage Profiles
 
 As an advanced use-case, you can deploy different stages to different accounts by using different profiles per stage. In order to use different profiles per stage, you must leverage [variables](https://serverless.com/framework/docs/providers/aws/guide/variables) and the provider profile setting.

--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -28,7 +28,10 @@ module.exports = {
     delete creds.region;
     delete creds.signatureVersion;
 
+    const validateAwsCredentials = this.provider.shouldValidateAwsCredentials();
+
     if (
+      validateAwsCredentials &&
       Object.keys(creds).length === 0 &&
       !process.env.ECS_CONTAINER_METADATA_FILE &&
       !process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI &&

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -432,6 +432,10 @@ class AwsProvider {
     credentials.useAccelerateEndpoint = true; // eslint-disable-line no-param-reassign
   }
 
+  shouldValidateAwsCredentials() {
+    return !this.options['no-aws-credential-validation'];
+  }
+
   getValues(source, paths) {
     return paths.map(path => ({
       path,

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -1529,4 +1529,15 @@ describe('AwsProvider', () => {
       return expect(awsProvider.options['aws-s3-accelerate']).to.be.undefined;
     });
   });
+
+  describe('#shouldValidateAwsCredentials()', () => {
+    it('should return false by default', () => {
+      awsProvider.options['no-aws-credential-validation'] = undefined;
+      return expect(awsProvider.shouldValidateAwsCredentials()).to.equal(false);
+    });
+    it('should return true when CLI option is provided', () => {
+      awsProvider.options['no-aws-credential-validation'] = true;
+      return expect(awsProvider.shouldValidateAwsCredentials()).to.equal(true);
+    });
+  });
 });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -1531,13 +1531,13 @@ describe('AwsProvider', () => {
   });
 
   describe('#shouldValidateAwsCredentials()', () => {
-    it('should return false by default', () => {
+    it('should return true by default', () => {
       awsProvider.options['no-aws-credential-validation'] = undefined;
-      return expect(awsProvider.shouldValidateAwsCredentials()).to.equal(false);
-    });
-    it('should return true when CLI option is provided', () => {
-      awsProvider.options['no-aws-credential-validation'] = true;
       return expect(awsProvider.shouldValidateAwsCredentials()).to.equal(true);
+    });
+    it('should return false when CLI option is provided', () => {
+      awsProvider.options['no-aws-credential-validation'] = true;
+      return expect(awsProvider.shouldValidateAwsCredentials()).to.equal(false);
     });
   });
 });

--- a/lib/plugins/deploy/deploy.js
+++ b/lib/plugins/deploy/deploy.js
@@ -52,6 +52,9 @@ class Deploy {
           'aws-s3-accelerate': {
             usage: 'Enables S3 Transfer Acceleration making uploading artifacts much faster.',
           },
+          'no-aws-credential-validation': {
+            usage: 'Disable AWS Credential Validation.',
+          },
         },
         commands: {
           function: {


### PR DESCRIPTION
Add option to disable aws credential validation.

Maybe this is an alternative to #7428 or #7442 

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
