### PR TITLE
fix issue when role is set in destinations

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -598,7 +598,10 @@ class AwsCompileFunctions {
   // Memoized in a construtor
   ensureTargetExecutionPermission(functionAddress) {
     // If a role is specified, then there is no IamRoleLambdaExecution resource
-    if (!this.serverless.service.provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution) {
+    if (
+      !this.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .IamRoleLambdaExecution
+    ) {
       return;
     }
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -597,6 +597,11 @@ class AwsCompileFunctions {
 
   // Memoized in a construtor
   ensureTargetExecutionPermission(functionAddress) {
+    // If a role is specified, then there is no IamRoleLambdaExecution resource
+    if (!this.serverless.service.provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution) {
+      return;
+    }
+
     const iamPolicyStatements = this.serverless.service.provider.compiledCloudFormationTemplate
       .Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement;
 


### PR DESCRIPTION
## What did you implement
For lambda destinations, if you are using a **role** then it will fail to deploy.

The code fails at this [line](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/functions/index.js#L600):

```
const iamPolicyStatements = this.serverless.service.provider.compiledCloudFormationTemplate
      .Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement;
```
Because `IamRoleLambdaExecution` is undefined.

If you look at the file [mergeIamTemplates.js](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/lib/mergeIamTemplates.js#L45), at line 45, you can see the function returns if a role is set therefor no IamRoleLambdaExecution is set.

Closes #7448 

## How can we verify it

Use one of the example from your [blog](https://github.com/fernando-mc/serverless-event-destinations) and add a role. 
For example:
```
service: local-function-destinations

provider:
  name: aws
  runtime: python3.8
  role: arn:aws....  <-- ADD A ROLE HERE

functions:
  helloStarting:
    handler: handler.starting
    destinations:
      onSuccess: helloSuccess
      onFailure: helloFailure
  helloSuccess:
    handler: success.handler
  helloFailure:
    handler: failure.handler
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** yes
**_Is it a breaking change?:_** NO
