### PR TITLE
Fixed typos in http-api.md

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -183,7 +183,7 @@ provider:
 
 See [AWS HTTP API Logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging-variables.html) documentation for more info on variables that can be used
 
-### Resuing HTTP API in different services
+### Reusing HTTP API in different services
 
 We may attach configured endpoints to HTTP API creted externally. For that provide HTTP API id in provider settings as follows:
 

--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -185,7 +185,7 @@ See [AWS HTTP API Logging](https://docs.aws.amazon.com/apigateway/latest/develop
 
 ### Reusing HTTP API in different services
 
-We may attach configured endpoints to HTTP API creted externally. For that provide HTTP API id in provider settings as follows:
+We may attach configured endpoints to HTTP API created externally. For that provide HTTP API id in provider settings as follows:
 
 ```yaml
 provider:


### PR DESCRIPTION
Typos found in https://serverless.com/framework/docs/providers/aws/events/http-api/

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Just fixed two typos in documentation

## How can we verify it

Open the URL provided in the first line of this description.

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
