### PR TITLE
AWS HTTP API: Do not validate timeout when no httpApi event

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -261,8 +261,10 @@ Object.defineProperties(
           functionAlias: functionData.targetAlias,
           functionLogicalId: this.provider.naming.getLambdaLogicalId(functionName),
         };
+        let hasHttpApiEvents = false;
         for (const event of functionData.events) {
           if (!event.httpApi) continue;
+          hasHttpApiEvents = true;
           let method;
           let path;
           let authorizer;
@@ -384,6 +386,7 @@ Object.defineProperties(
             }
           }
         }
+        if (!hasHttpApiEvents) continue;
         const functionTimeout =
           Number(functionData.timeout) || Number(this.serverless.service.provider.timeout) || 6;
         if (routeTargetData.timeout) {

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -397,7 +397,7 @@ Object.defineProperties(
           if (functionTimeout >= routeTargetData.timeout) {
             logWarning(
               `HTTP API endpoint timeout setting (${routeTargetData.timeout}s) is ` +
-                `lower or equal to function timeout (${functionTimeout}s). ` +
+                `lower or equal to function (${functionName}) timeout (${functionTimeout}s). ` +
                 'This may introduce situations where endpoint times out ' +
                 'for succesful lambda invocation.'
             );
@@ -405,7 +405,7 @@ Object.defineProperties(
         } else {
           if (functionTimeout >= 29) {
             logWarning(
-              `Function timeout setting (${functionTimeout}) is greater than ` +
+              `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
                 'maximum allowed timeout for HTTP API endpoint (29s). ' +
                 'This may introduce situation where endpoint times out ' +
                 'for succesful lambda invocation.'


### PR DESCRIPTION
Fixes #7440 

In case when there's a function with a timeout over 29s and no `httpApi` events configured, an invalid log warning is issued.

```
 Function timeout setting (x) is greater than maximum allowed timeout for HTTP API endpoint...
```

This patch fixes that.

Additionally improved log warning so it includes a function name to which it refers