### PR TITLE
Add plan command to aws provider

### DIFF
--- a/docs/providers/aws/cli-reference/plan.md
+++ b/docs/providers/aws/cli-reference/plan.md
@@ -1,0 +1,67 @@
+<!--
+title: Serverless Framework Commands - AWS Lambda - Plan
+menuText: plan
+menuOrder: 23
+description: Display local changes compared to your deployed service and the AWS Lambda Functions, Events and AWS Resources it contains.
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/aws/cli-reference/plan)
+
+<!-- DOCS-SITE-LINK:END -->
+
+# AWS - Plan
+
+Display local changes compared to the deployed CloudFormation stack.
+
+```bash
+serverless plan
+```
+
+## Options
+
+- `--stage` or `-s` The stage in your service you want to display information about.
+- `--region` or `-r` The region in your stage that you want to display information about.
+- `--verbose` or `-v` Shows displays any Stack Output.
+
+## Examples
+
+### AWS
+
+On AWS the plan plugin uses the `ChangeSet` feature of the CloudFormation stack and the AWS SDK to gather the necessary information.
+See the example below for an example output.
+
+**Example:**
+
+```bash
+$ serverless plan
+
+Service Information
+service: aws-sls
+stage: dev
+region: us-east-1
+stack: aws-sls-dev
+resources: 2
+api keys:
+  None
+endpoints:
+  None
+functions:
+  helloWorld: aws-sls-dev-helloWorld
+layers:
+  None
+
+Serverless: Resource Changes
+[+] ApiGatewayDeployment123456789 (AWS::ApiGateway::Deployment)
+[+] ApiGatewayMethodHelloDashworldGet (AWS::ApiGateway::Method)
+[+] ApiGatewayMethodHelloDashworldOptions (AWS::ApiGateway::Method)
+[+] ApiGatewayResourceHelloDashworld (AWS::ApiGateway::Resource)
+[+] ApiGatewayRestApi (AWS::ApiGateway::RestApi)
+[+] HelloWorldLambdaFunction (AWS::Lambda::Function)
+[+] HelloWorldLambdaPermissionApiGateway (AWS::Lambda::Permission)
+[+] HelloWorldLambdaVersiongEpdahBTvlhd7JMpuxPOshvfZYKD4wX7CKg (AWS::Lambda::Version)
+[+] HelloWorldLogGroup (AWS::Logs::LogGroup)
+[+] IamRoleLambdaExecution (AWS::IAM::Role)
+```

--- a/lib/plugins/aws/plan/index.js
+++ b/lib/plugins/aws/plan/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const setBucketName = require('../lib/setBucketName')
+const setBucketName = require('../lib/setBucketName');
 const createChangeSet = require('./lib/createChangeSet');
 const waitForChangeSetCreateComplete = require('./lib/waitForChangeSetCreateComplete');
 const runAnalysis = require('./lib/runAnalysis');
@@ -10,7 +10,6 @@ const deleteChangeSet = require('./lib/deleteChangeSet');
 const deleteChangeSetFromS3 = require('./lib/deleteChangeSetFromS3');
 
 class AwsPlan {
-
   constructor(serverless, options) {
     Object.assign(
       this,
@@ -30,10 +29,8 @@ class AwsPlan {
     this.commands = {
       type: 'entrypoint',
       plan: {
-        lifecycleEvents: [
-          'deploy'
-        ],
-      }
+        lifecycleEvents: ['deploy'],
+      },
     };
 
     this.hooks = {
@@ -42,8 +39,7 @@ class AwsPlan {
         return this.serverless.pluginManager.spawn('deploy');
       },
       'before:aws:deploy:deploy:updateStack': () =>
-        BbPromise.bind(this)
-          .then(this.lockStackDeployment),
+        BbPromise.bind(this).then(this.lockStackDeployment),
       'aws:deploy:deploy:updateStack': () =>
         this.callIfPlanning([
           this.setBucketName,
@@ -51,14 +47,12 @@ class AwsPlan {
           this.waitForChangeSetCreateComplete,
           this.runAnalysis,
           this.deleteChangeSet,
-          this.deleteChangeSetFromS3]),
+          this.deleteChangeSetFromS3,
+        ]),
       'after:aws:deploy:deploy:updateStack': () =>
-        this.callIfPlanning([
-          this.unlockStackDeployment]),
-      'after:deploy:deploy': () =>
-        this.callIfPlanning([
-          this.printAnalysis]),
-    }
+        this.callIfPlanning([this.unlockStackDeployment]),
+      'after:deploy:deploy': () => this.callIfPlanning([this.printAnalysis]),
+    };
   }
 
   callIfPlanning(functions) {
@@ -66,24 +60,23 @@ class AwsPlan {
       let promise = BbPromise.bind(this);
       functions.forEach(fn => {
         promise = promise.then(fn);
-      })
+      });
       return promise;
     }
     return BbPromise.resolve();
   }
 
   lockStackDeployment() {
-    this.shouldNotDeploy = this.serverless.service.provider.shouldNotDeploy
+    this.shouldNotDeploy = this.serverless.service.provider.shouldNotDeploy;
     this.planning = this.planning && !this.shouldNotDeploy;
     if (this.planning) {
-      this.serverless.service.provider.shouldNotDeploy = true
+      this.serverless.service.provider.shouldNotDeploy = true;
     }
   }
 
   unlockStackDeployment() {
-    this.serverless.service.provider.shouldNotDeploy = this.shouldNotDeploy
+    this.serverless.service.provider.shouldNotDeploy = this.shouldNotDeploy;
   }
-
 }
 
 module.exports = AwsPlan;

--- a/lib/plugins/aws/plan/index.js
+++ b/lib/plugins/aws/plan/index.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const setBucketName = require('../lib/setBucketName')
+const createChangeSet = require('./lib/createChangeSet');
+const waitForChangeSetCreateComplete = require('./lib/waitForChangeSetCreateComplete');
+const runAnalysis = require('./lib/runAnalysis');
+const printAnalysis = require('./lib/printAnalysis');
+const deleteChangeSet = require('./lib/deleteChangeSet');
+const deleteChangeSetFromS3 = require('./lib/deleteChangeSetFromS3');
+
+class AwsPlan {
+
+  constructor(serverless, options) {
+    Object.assign(
+      this,
+      setBucketName,
+      createChangeSet,
+      waitForChangeSetCreateComplete,
+      runAnalysis,
+      printAnalysis,
+      deleteChangeSet,
+      deleteChangeSetFromS3
+    );
+
+    this.serverless = serverless;
+    this.options = options;
+    this.planning = false;
+    this.provider = this.serverless.getProvider('aws');
+    this.commands = {
+      type: 'entrypoint',
+      plan: {
+        lifecycleEvents: [
+          'deploy'
+        ],
+      }
+    };
+
+    this.hooks = {
+      'plan:deploy': () => {
+        this.planning = true;
+        return this.serverless.pluginManager.spawn('deploy');
+      },
+      'before:aws:deploy:deploy:updateStack': () =>
+        BbPromise.bind(this)
+          .then(this.lockStackDeployment),
+      'aws:deploy:deploy:updateStack': () =>
+        this.callIfPlanning([
+          this.setBucketName,
+          this.createChangeSet,
+          this.waitForChangeSetCreateComplete,
+          this.runAnalysis,
+          this.deleteChangeSet,
+          this.deleteChangeSetFromS3]),
+      'after:aws:deploy:deploy:updateStack': () =>
+        this.callIfPlanning([
+          this.unlockStackDeployment]),
+      'after:deploy:deploy': () =>
+        this.callIfPlanning([
+          this.printAnalysis]),
+    }
+  }
+
+  callIfPlanning(functions) {
+    if (this.planning) {
+      let promise = BbPromise.bind(this);
+      functions.forEach(fn => {
+        promise = promise.then(fn);
+      })
+      return promise;
+    }
+    return BbPromise.resolve();
+  }
+
+  lockStackDeployment() {
+    this.shouldNotDeploy = this.serverless.service.provider.shouldNotDeploy
+    this.planning = this.planning && !this.shouldNotDeploy;
+    if (this.planning) {
+      this.serverless.service.provider.shouldNotDeploy = true
+    }
+  }
+
+  unlockStackDeployment() {
+    this.serverless.service.provider.shouldNotDeploy = this.shouldNotDeploy
+  }
+
+}
+
+module.exports = AwsPlan;

--- a/lib/plugins/aws/plan/index.test.js
+++ b/lib/plugins/aws/plan/index.test.js
@@ -22,36 +22,28 @@ describe('AwsPlan', () => {
     serverless.config.servicePath = 'foo';
     serverless.cli = new CLI(serverless);
     awsPlan = new AwsPlan(serverless, options);
-
   });
 
   describe('#constructor()', () => {
-    it('should set the serverless instance', () =>
-      expect(awsPlan.serverless).to.equal(serverless));
+    it('should set the serverless instance', () => expect(awsPlan.serverless).to.equal(serverless));
 
-    it('should set options', () =>
-      expect(awsPlan.options).to.equal(options));
+    it('should set options', () => expect(awsPlan.options).to.equal(options));
 
     it('should set the provider variable to an instance of AwsProvider', () =>
       expect(awsPlan.provider).to.be.instanceof(AwsProvider));
 
-    it('should have commands', () =>
-      expect(awsPlan.commands).to.be.not.empty);
+    it('should have commands', () => expect(awsPlan.commands).to.be.not.empty);
 
-    it('should have hooks', () =>
-      expect(awsPlan.hooks).to.be.not.empty);
+    it('should have hooks', () => expect(awsPlan.hooks).to.be.not.empty);
 
     it('should call planning functions if plan command called', () => {
       awsPlan.planning = true;
-      return awsPlan.callIfPlanning([() => true])
-        .then(result => expect(result).to.be.true);
+      return awsPlan.callIfPlanning([() => true]).then(result => expect(result).to.be.true);
     });
 
     it('should not call planning functions if plan command not called', () => {
-      return awsPlan.callIfPlanning([() => true])
-        .then(result => expect(result).to.be.undefined);
+      return awsPlan.callIfPlanning([() => true]).then(result => expect(result).to.be.undefined);
     });
-
   });
 
   describe('hooks', () => {
@@ -73,7 +65,9 @@ describe('AwsPlan', () => {
       unlockStackDeploymentStub = sinon.stub(awsPlan, 'unlockStackDeployment').resolves();
       setBucketNameStub = sinon.stub(awsPlan, 'setBucketName').resolves();
       createChangeSetStub = sinon.stub(awsPlan, 'createChangeSet').resolves();
-      waitForChangeSetCreateCompleteStub = sinon.stub(awsPlan, 'waitForChangeSetCreateComplete').resolves();
+      waitForChangeSetCreateCompleteStub = sinon
+        .stub(awsPlan, 'waitForChangeSetCreateComplete')
+        .resolves();
       runAnalysisStub = sinon.stub(awsPlan, 'runAnalysis').resolves();
       deleteChangeSetStub = sinon.stub(awsPlan, 'deleteChangeSet').resolves();
       deleteChangeSetFromS3Stub = sinon.stub(awsPlan, 'deleteChangeSetFromS3').resolves();
@@ -132,7 +126,5 @@ describe('AwsPlan', () => {
         expect(printAnalysisStub.calledOnce).to.equal(true);
       });
     });
-
   });
-
 });

--- a/lib/plugins/aws/plan/index.test.js
+++ b/lib/plugins/aws/plan/index.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const AwsProvider = require('../provider/awsProvider');
+const AwsPlan = require('./index');
+const Serverless = require('../../../Serverless');
+const CLI = require('../../../classes/CLI');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('AwsPlan', () => {
+  let awsPlan;
+  let serverless;
+  let options;
+
+  beforeEach(() => {
+    serverless = new Serverless();
+    options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    serverless.config.servicePath = 'foo';
+    serverless.cli = new CLI(serverless);
+    awsPlan = new AwsPlan(serverless, options);
+
+  });
+
+  describe('#constructor()', () => {
+    it('should set the serverless instance', () =>
+      expect(awsPlan.serverless).to.equal(serverless));
+
+    it('should set options', () =>
+      expect(awsPlan.options).to.equal(options));
+
+    it('should set the provider variable to an instance of AwsProvider', () =>
+      expect(awsPlan.provider).to.be.instanceof(AwsProvider));
+
+    it('should have commands', () =>
+      expect(awsPlan.commands).to.be.not.empty);
+
+    it('should have hooks', () =>
+      expect(awsPlan.hooks).to.be.not.empty);
+
+    it('should call planning functions if plan command called', () => {
+      awsPlan.planning = true;
+      return awsPlan.callIfPlanning([() => true])
+        .then(result => expect(result).to.be.true);
+    });
+
+    it('should not call planning functions if plan command not called', () => {
+      return awsPlan.callIfPlanning([() => true])
+        .then(result => expect(result).to.be.undefined);
+    });
+
+  });
+
+  describe('hooks', () => {
+    let spawnStub;
+    let lockStackDeploymentStub;
+    let unlockStackDeploymentStub;
+
+    let setBucketNameStub;
+    let createChangeSetStub;
+    let waitForChangeSetCreateCompleteStub;
+    let runAnalysisStub;
+    let deleteChangeSetStub;
+    let deleteChangeSetFromS3Stub;
+    let printAnalysisStub;
+
+    beforeEach(() => {
+      spawnStub = sinon.stub(serverless.pluginManager, 'spawn');
+      lockStackDeploymentStub = sinon.stub(awsPlan, 'lockStackDeployment').resolves();
+      unlockStackDeploymentStub = sinon.stub(awsPlan, 'unlockStackDeployment').resolves();
+      setBucketNameStub = sinon.stub(awsPlan, 'setBucketName').resolves();
+      createChangeSetStub = sinon.stub(awsPlan, 'createChangeSet').resolves();
+      waitForChangeSetCreateCompleteStub = sinon.stub(awsPlan, 'waitForChangeSetCreateComplete').resolves();
+      runAnalysisStub = sinon.stub(awsPlan, 'runAnalysis').resolves();
+      deleteChangeSetStub = sinon.stub(awsPlan, 'deleteChangeSet').resolves();
+      deleteChangeSetFromS3Stub = sinon.stub(awsPlan, 'deleteChangeSetFromS3').resolves();
+      printAnalysisStub = sinon.stub(awsPlan, 'printAnalysis').resolves();
+    });
+
+    afterEach(() => {
+      serverless.pluginManager.spawn.restore();
+      awsPlan.lockStackDeployment.restore();
+      awsPlan.unlockStackDeployment.restore();
+      awsPlan.setBucketName.restore();
+      awsPlan.createChangeSet.restore();
+      awsPlan.waitForChangeSetCreateComplete.restore();
+      awsPlan.runAnalysis.restore();
+      awsPlan.deleteChangeSet.restore();
+      awsPlan.deleteChangeSetFromS3.restore();
+      awsPlan.printAnalysis.restore();
+    });
+
+    it('should run "plan:deploy" hook', () => {
+      const spawnPlanDeployStub = spawnStub.withArgs('deploy').resolves();
+      return awsPlan.hooks['plan:deploy']().then(() => {
+        expect(awsPlan.planning).to.be.true;
+        expect(spawnPlanDeployStub.calledOnce).to.equal(true);
+      });
+    });
+
+    it('should run "before:aws:deploy:deploy:updateStack" hook', () => {
+      return awsPlan.hooks['before:aws:deploy:deploy:updateStack']().then(() => {
+        expect(lockStackDeploymentStub.calledOnce).to.equal(true);
+      });
+    });
+
+    it('should run "aws:deploy:deploy:updateStack" hook', () => {
+      awsPlan.planning = true;
+      return awsPlan.hooks['aws:deploy:deploy:updateStack']().then(() => {
+        expect(setBucketNameStub.calledOnce).to.equal(true);
+        expect(createChangeSetStub.calledOnce).to.equal(true);
+        expect(waitForChangeSetCreateCompleteStub.calledOnce).to.equal(true);
+        expect(runAnalysisStub.calledOnce).to.equal(true);
+        expect(deleteChangeSetStub.calledOnce).to.equal(true);
+        expect(deleteChangeSetFromS3Stub.calledOnce).to.equal(true);
+      });
+    });
+
+    it('should run "after:aws:deploy:deploy:updateStack" hook', () => {
+      awsPlan.planning = true;
+      return awsPlan.hooks['after:aws:deploy:deploy:updateStack']().then(() => {
+        expect(unlockStackDeploymentStub.calledOnce).to.equal(true);
+      });
+    });
+
+    it('should run "after:deploy:deploy" hook', () => {
+      awsPlan.planning = true;
+      return awsPlan.hooks['after:deploy:deploy']().then(() => {
+        expect(printAnalysisStub.calledOnce).to.equal(true);
+      });
+    });
+
+  });
+
+});

--- a/lib/plugins/aws/plan/lib/analysis.js
+++ b/lib/plugins/aws/plan/lib/analysis.js
@@ -1,0 +1,266 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+const _ = require('lodash')
+
+const lo = {
+  groupBy: _.groupBy
+}
+
+/**
+ * Analyze the changes included in the changeset.
+ *
+ * @param {AWS.CloudFormation.DescribeChangeSetOutput} data - the data object returned by describe-change-set
+ */
+function analyzeResourceChanges (data) {
+  const changes = data.Changes
+  const added = []
+  const removed = []
+  const modified = []
+
+  changes.forEach((change) => {
+    if (change.ResourceChange.Action === 'Add') {
+      added.push(change.ResourceChange)
+    } else if (change.ResourceChange.Action === 'Remove') {
+      removed.push(change.ResourceChange)
+    } else if (change.ResourceChange.Action === 'Modify') {
+      modified.push(change.ResourceChange)
+    } else {
+      throw new Error(`Unexpected change type:${change.ResourceChange.Action}`)
+    }
+  })
+
+  return {
+    added, removed, modified: analyzeModifications(modified, added)
+  }
+}
+
+/**
+ * @typedef KeyValueChange
+ * @property {String} Key
+ * @property {String} Value
+ * @property {String} [OldValue]
+ */
+
+/**
+ * @typedef KeyValueChanges
+ * @property {KeyValueChange[]} added
+ * @property {KeyValueChange[]} removed
+ * @property {KeyValueChange[]} modified
+ */
+
+/**
+ * Analyze changes made to stack tags.
+ *
+ * @param {AWS.CloudFormation.DescribeChangeSetOutput} changeset - changeset with new tags
+ * @param {AWS.CloudFormation.Stack} stack - stack with old tags
+ * @returns {KeyValueChanges} an object containing tag changes
+ */
+function analyzeTagChanges (changeset, stack) {
+  const next = {}
+  const prev = {}
+
+  changeset.Tags.forEach(t => { next[t.Key] = t.Value })
+  stack.Tags.forEach(t => { prev[t.Key] = t.Value })
+
+  return generateKeyValueChanges(prev, next)
+}
+
+/**
+ * Analyze changes made to stack parameters.
+ *
+ * @param {AWS.CloudFormation.DescribeChangeSetOutput} changeset - changeset with new parameters
+ * @param {AWS.CloudFormation.Stack} stack - stack with current parameters
+ * @returns {KeyValueChanges} an object containing changed params
+ */
+function analyzeParameterChanges (changeset, stack) {
+  const prev = {}
+  const next = {}
+
+  stack.Parameters.forEach(p => { prev[p.ParameterKey] = p.ParameterValue })
+  changeset.Parameters.forEach(p => {
+    next[p.ParameterKey] = p.UsePreviousValue ? prev[p.ParameterKey] : p.ParameterValue
+  })
+
+  return generateKeyValueChanges(prev, next)
+}
+
+/**
+ * Helper to compare contents of two objects. The method splits
+ * changes into three arrays: added keys, removed keys and modified
+ * keys.
+ *
+ * @param {Object} prev - old key-value pairs
+ * @param {Object} next - new key-value pairs
+ * @returns {KeyValueChanges}
+ */
+function generateKeyValueChanges (prev, next) {
+  const nextKeys = Object.keys(next)
+  const prevKeys = Object.keys(prev)
+
+  const added = nextKeys
+    .filter(k => !prev[k])
+    .map(k => ({ Key: k, Value: next[k] }))
+
+  const removed = prevKeys
+    .filter(k => !next[k])
+    .map(k => ({ Key: k, Value: prev[k] }))
+
+  const modified = nextKeys
+    .filter(k => prev[k] && next[k] && prev[k] !== next[k])
+    .map(k => ({ Key: k, Value: next[k], OldValue: prev[k] }))
+
+  return { added, removed, modified }
+}
+
+/**
+ * Analyzes modifications of a changeset.
+ *
+ * @param {AWS.CloudFormation.ResourceChange[]} modified - list of resource changes for modified resources
+ * @param {AWS.CloudFormation.ResourceChange[]} added - list of resource changes for added resources
+ */
+function analyzeModifications (modified, added) {
+  for (const change of modified) {
+    change.Details = analyzeChangeDetails(change.Details)
+    for (const detail of change.Details) {
+      detail.Summary = analyzeChangeDetail(detail)
+      detail.Causes = analyzeChangeDetailCause(modified, added, detail)
+    }
+  }
+  return modified
+}
+
+/**
+ * @param {AWS.CloudFormation.ResourceChangeDetail[]} details
+ * @returns {AWS.CloudFormation.ResourceChangeDetail[]}
+ */
+function analyzeChangeDetails (details) {
+  if (details.length === 1) {
+    // Fast path: only one change detail; nothing to be done
+    return details
+  }
+
+  let result = details
+
+  const detailsByTarget = lo.groupBy(details, d => `${d.Target.Attribute}.${d.Target.Name}`)
+
+  for (const target of Object.keys(detailsByTarget)) {
+    const detailsForTarget = detailsByTarget[target]
+    if (detailsForTarget.length < 2) {
+      // Fast path: all the analysis require at least two change details
+      // for a single target
+      continue
+    }
+
+    // Fixup #1: Parameter change causes two change details to be emitted:
+    // one static ParameterReference and second dynamic DirectModification.
+    // Let's combine these two to make things simpler
+    const dynamicDirects = detailsForTarget.filter(d => d.ChangeSource === 'DirectModification' && d.Evaluation === 'Dynamic')
+    const staticParameters = detailsForTarget.filter(d => d.ChangeSource === 'ParameterReference' && d.Evaluation === 'Static')
+    if (dynamicDirects.length > 0 && staticParameters.length > 0) {
+      result = result.filter(d => dynamicDirects.indexOf(d) === -1)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Summarizes the given change detail.
+ *
+ * @param {AWS.CloudFormation.ResourceChangeDetail} detail - a single change detail
+ * @return {String} a human readable summary of the change detail
+ */
+function analyzeChangeDetail (detail) {
+  let value;
+  switch (detail.Target.Attribute) {
+    case 'Properties':
+      if (detail.Evaluation === 'Static') {
+        value = `resource property ${detail.Target.Name} will change`
+      } else if (detail.Evaluation === 'Dynamic') {
+        value = `resource property ${detail.Target.Name} might change`
+      }
+      break 
+    case 'Metadata':
+    case 'CreationPolicy':
+    case 'UpdatePolicy':
+    case 'DeletionPolicy':
+    case 'Tags':
+      value = `resource ${formatTargetAttribute(detail.Target.Attribute)} changed`
+      break;
+    default:
+      throw new Error(`Unknown change detail target attribute ${detail.Target.Attribute}`)
+  }
+  return value;
+}
+
+/**
+ * Analyzes the cause (the chain of changes) that triggers this change.
+ *
+ * @param {AWS.CloudFormation.ResourceChange[]} modified - list of resource changes for modified resources
+ * @param {AWS.CloudFormation.ResourceChange[]} added - list of resource changes for added resources
+ * @param {AWS.CloudFormation.ResourceChangeDetail} detail - a single change detail
+ */
+function analyzeChangeDetailCause (modified, added, detail) {
+  if (!detail) {
+    // New resources do not have any details on why a change was made
+    return ['creation of the resource']
+  }
+
+  if (detail.Causes) {
+    // Been here already
+    return detail.Causes
+  }
+
+  switch (detail.ChangeSource) {
+    case 'DirectModification':
+      return [
+        `direct modification of resource ${formatTargetAttribute(detail.Target.Attribute)}`
+      ]
+    case 'Automatic':
+      return [
+        `automatic update of ${detail.CausingEntity}`
+      ]
+    case 'ParameterReference':
+      return [
+        `changed parameter value of ${detail.CausingEntity}`
+      ]
+    case 'ResourceReference':
+    case 'ResourceAttribute':
+      // eslint-disable-next-line no-case-declarations
+      const parentChangeDetail = findChangeDetail(modified, added, detail.CausingEntity.split('.')[0]) 
+      // eslint-disable-next-line no-case-declarations
+      const parentChangeCauses = analyzeChangeDetailCause(modified, added, parentChangeDetail)
+      return [
+        `changed output value of ${detail.CausingEntity}`
+      ].concat(parentChangeCauses)
+    default:
+      if (detail.ChangeSource === undefined && detail.Target.Attribute === 'Tags') {
+        // Special case: tag changes made at stack level has
+        // ChangeSource === null and Attribute === 'Tags'
+        return [
+          'changed stack tags'
+        ]
+      }
+
+      throw new Error(`Unknown ChangeSource ${detail.ChangeSource}`)
+  }
+}
+
+function findChangeDetail (modified, added, logicalId) {
+  for (const change of modified.concat(added)) {
+    if (change.LogicalResourceId === logicalId) {
+      // TODO: Handle multiple changes to the same resource
+      return change.Details[0]
+    }
+  }
+
+  throw new Error(`Couldn't find changes to ${logicalId}`)
+}
+
+function formatTargetAttribute (attribute) {
+  return attribute.replace('Policy', ' Policy').toLowerCase()
+}
+
+module.exports = {
+  analyzeResourceChanges, analyzeTagChanges, analyzeParameterChanges, generateKeyValueChanges
+}

--- a/lib/plugins/aws/plan/lib/analysis.js
+++ b/lib/plugins/aws/plan/lib/analysis.js
@@ -1,37 +1,39 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
-const _ = require('lodash')
+'use strict';
+const _ = require('lodash');
 
 const lo = {
-  groupBy: _.groupBy
-}
+  groupBy: _.groupBy,
+};
 
 /**
  * Analyze the changes included in the changeset.
  *
  * @param {AWS.CloudFormation.DescribeChangeSetOutput} data - the data object returned by describe-change-set
  */
-function analyzeResourceChanges (data) {
-  const changes = data.Changes
-  const added = []
-  const removed = []
-  const modified = []
+function analyzeResourceChanges(data) {
+  const changes = data.Changes;
+  const added = [];
+  const removed = [];
+  const modified = [];
 
-  changes.forEach((change) => {
+  changes.forEach(change => {
     if (change.ResourceChange.Action === 'Add') {
-      added.push(change.ResourceChange)
+      added.push(change.ResourceChange);
     } else if (change.ResourceChange.Action === 'Remove') {
-      removed.push(change.ResourceChange)
+      removed.push(change.ResourceChange);
     } else if (change.ResourceChange.Action === 'Modify') {
-      modified.push(change.ResourceChange)
+      modified.push(change.ResourceChange);
     } else {
-      throw new Error(`Unexpected change type:${change.ResourceChange.Action}`)
+      throw new Error(`Unexpected change type:${change.ResourceChange.Action}`);
     }
-  })
+  });
 
   return {
-    added, removed, modified: analyzeModifications(modified, added)
-  }
+    added,
+    removed,
+    modified: analyzeModifications(modified, added),
+  };
 }
 
 /**
@@ -55,14 +57,18 @@ function analyzeResourceChanges (data) {
  * @param {AWS.CloudFormation.Stack} stack - stack with old tags
  * @returns {KeyValueChanges} an object containing tag changes
  */
-function analyzeTagChanges (changeset, stack) {
-  const next = {}
-  const prev = {}
+function analyzeTagChanges(changeset, stack) {
+  const next = {};
+  const prev = {};
 
-  changeset.Tags.forEach(t => { next[t.Key] = t.Value })
-  stack.Tags.forEach(t => { prev[t.Key] = t.Value })
+  changeset.Tags.forEach(t => {
+    next[t.Key] = t.Value;
+  });
+  stack.Tags.forEach(t => {
+    prev[t.Key] = t.Value;
+  });
 
-  return generateKeyValueChanges(prev, next)
+  return generateKeyValueChanges(prev, next);
 }
 
 /**
@@ -72,16 +78,18 @@ function analyzeTagChanges (changeset, stack) {
  * @param {AWS.CloudFormation.Stack} stack - stack with current parameters
  * @returns {KeyValueChanges} an object containing changed params
  */
-function analyzeParameterChanges (changeset, stack) {
-  const prev = {}
-  const next = {}
+function analyzeParameterChanges(changeset, stack) {
+  const prev = {};
+  const next = {};
 
-  stack.Parameters.forEach(p => { prev[p.ParameterKey] = p.ParameterValue })
+  stack.Parameters.forEach(p => {
+    prev[p.ParameterKey] = p.ParameterValue;
+  });
   changeset.Parameters.forEach(p => {
-    next[p.ParameterKey] = p.UsePreviousValue ? prev[p.ParameterKey] : p.ParameterValue
-  })
+    next[p.ParameterKey] = p.UsePreviousValue ? prev[p.ParameterKey] : p.ParameterValue;
+  });
 
-  return generateKeyValueChanges(prev, next)
+  return generateKeyValueChanges(prev, next);
 }
 
 /**
@@ -93,23 +101,19 @@ function analyzeParameterChanges (changeset, stack) {
  * @param {Object} next - new key-value pairs
  * @returns {KeyValueChanges}
  */
-function generateKeyValueChanges (prev, next) {
-  const nextKeys = Object.keys(next)
-  const prevKeys = Object.keys(prev)
+function generateKeyValueChanges(prev, next) {
+  const nextKeys = Object.keys(next);
+  const prevKeys = Object.keys(prev);
 
-  const added = nextKeys
-    .filter(k => !prev[k])
-    .map(k => ({ Key: k, Value: next[k] }))
+  const added = nextKeys.filter(k => !prev[k]).map(k => ({ Key: k, Value: next[k] }));
 
-  const removed = prevKeys
-    .filter(k => !next[k])
-    .map(k => ({ Key: k, Value: prev[k] }))
+  const removed = prevKeys.filter(k => !next[k]).map(k => ({ Key: k, Value: prev[k] }));
 
   const modified = nextKeys
     .filter(k => prev[k] && next[k] && prev[k] !== next[k])
-    .map(k => ({ Key: k, Value: next[k], OldValue: prev[k] }))
+    .map(k => ({ Key: k, Value: next[k], OldValue: prev[k] }));
 
-  return { added, removed, modified }
+  return { added, removed, modified };
 }
 
 /**
@@ -118,50 +122,54 @@ function generateKeyValueChanges (prev, next) {
  * @param {AWS.CloudFormation.ResourceChange[]} modified - list of resource changes for modified resources
  * @param {AWS.CloudFormation.ResourceChange[]} added - list of resource changes for added resources
  */
-function analyzeModifications (modified, added) {
+function analyzeModifications(modified, added) {
   for (const change of modified) {
-    change.Details = analyzeChangeDetails(change.Details)
+    change.Details = analyzeChangeDetails(change.Details);
     for (const detail of change.Details) {
-      detail.Summary = analyzeChangeDetail(detail)
-      detail.Causes = analyzeChangeDetailCause(modified, added, detail)
+      detail.Summary = analyzeChangeDetail(detail);
+      detail.Causes = analyzeChangeDetailCause(modified, added, detail);
     }
   }
-  return modified
+  return modified;
 }
 
 /**
  * @param {AWS.CloudFormation.ResourceChangeDetail[]} details
  * @returns {AWS.CloudFormation.ResourceChangeDetail[]}
  */
-function analyzeChangeDetails (details) {
+function analyzeChangeDetails(details) {
   if (details.length === 1) {
     // Fast path: only one change detail; nothing to be done
-    return details
+    return details;
   }
 
-  let result = details
+  let result = details;
 
-  const detailsByTarget = lo.groupBy(details, d => `${d.Target.Attribute}.${d.Target.Name}`)
+  const detailsByTarget = lo.groupBy(details, d => `${d.Target.Attribute}.${d.Target.Name}`);
 
   for (const target of Object.keys(detailsByTarget)) {
-    const detailsForTarget = detailsByTarget[target]
+    const detailsForTarget = detailsByTarget[target];
     if (detailsForTarget.length < 2) {
       // Fast path: all the analysis require at least two change details
       // for a single target
-      continue
+      continue;
     }
 
     // Fixup #1: Parameter change causes two change details to be emitted:
     // one static ParameterReference and second dynamic DirectModification.
     // Let's combine these two to make things simpler
-    const dynamicDirects = detailsForTarget.filter(d => d.ChangeSource === 'DirectModification' && d.Evaluation === 'Dynamic')
-    const staticParameters = detailsForTarget.filter(d => d.ChangeSource === 'ParameterReference' && d.Evaluation === 'Static')
+    const dynamicDirects = detailsForTarget.filter(
+      d => d.ChangeSource === 'DirectModification' && d.Evaluation === 'Dynamic'
+    );
+    const staticParameters = detailsForTarget.filter(
+      d => d.ChangeSource === 'ParameterReference' && d.Evaluation === 'Static'
+    );
     if (dynamicDirects.length > 0 && staticParameters.length > 0) {
-      result = result.filter(d => dynamicDirects.indexOf(d) === -1)
+      result = result.filter(d => dynamicDirects.indexOf(d) === -1);
     }
   }
 
-  return result
+  return result;
 }
 
 /**
@@ -170,25 +178,25 @@ function analyzeChangeDetails (details) {
  * @param {AWS.CloudFormation.ResourceChangeDetail} detail - a single change detail
  * @return {String} a human readable summary of the change detail
  */
-function analyzeChangeDetail (detail) {
+function analyzeChangeDetail(detail) {
   let value;
   switch (detail.Target.Attribute) {
     case 'Properties':
       if (detail.Evaluation === 'Static') {
-        value = `resource property ${detail.Target.Name} will change`
+        value = `resource property ${detail.Target.Name} will change`;
       } else if (detail.Evaluation === 'Dynamic') {
-        value = `resource property ${detail.Target.Name} might change`
+        value = `resource property ${detail.Target.Name} might change`;
       }
-      break 
+      break;
     case 'Metadata':
     case 'CreationPolicy':
     case 'UpdatePolicy':
     case 'DeletionPolicy':
     case 'Tags':
-      value = `resource ${formatTargetAttribute(detail.Target.Attribute)} changed`
+      value = `resource ${formatTargetAttribute(detail.Target.Attribute)} changed`;
       break;
     default:
-      throw new Error(`Unknown change detail target attribute ${detail.Target.Attribute}`)
+      throw new Error(`Unknown change detail target attribute ${detail.Target.Attribute}`);
   }
   return value;
 }
@@ -200,67 +208,64 @@ function analyzeChangeDetail (detail) {
  * @param {AWS.CloudFormation.ResourceChange[]} added - list of resource changes for added resources
  * @param {AWS.CloudFormation.ResourceChangeDetail} detail - a single change detail
  */
-function analyzeChangeDetailCause (modified, added, detail) {
+function analyzeChangeDetailCause(modified, added, detail) {
   if (!detail) {
     // New resources do not have any details on why a change was made
-    return ['creation of the resource']
+    return ['creation of the resource'];
   }
 
   if (detail.Causes) {
     // Been here already
-    return detail.Causes
+    return detail.Causes;
   }
 
   switch (detail.ChangeSource) {
     case 'DirectModification':
-      return [
-        `direct modification of resource ${formatTargetAttribute(detail.Target.Attribute)}`
-      ]
+      return [`direct modification of resource ${formatTargetAttribute(detail.Target.Attribute)}`];
     case 'Automatic':
-      return [
-        `automatic update of ${detail.CausingEntity}`
-      ]
+      return [`automatic update of ${detail.CausingEntity}`];
     case 'ParameterReference':
-      return [
-        `changed parameter value of ${detail.CausingEntity}`
-      ]
+      return [`changed parameter value of ${detail.CausingEntity}`];
     case 'ResourceReference':
     case 'ResourceAttribute':
       // eslint-disable-next-line no-case-declarations
-      const parentChangeDetail = findChangeDetail(modified, added, detail.CausingEntity.split('.')[0]) 
+      const parentChangeDetail = findChangeDetail(
+        modified,
+        added,
+        detail.CausingEntity.split('.')[0]
+      );
       // eslint-disable-next-line no-case-declarations
-      const parentChangeCauses = analyzeChangeDetailCause(modified, added, parentChangeDetail)
-      return [
-        `changed output value of ${detail.CausingEntity}`
-      ].concat(parentChangeCauses)
+      const parentChangeCauses = analyzeChangeDetailCause(modified, added, parentChangeDetail);
+      return [`changed output value of ${detail.CausingEntity}`].concat(parentChangeCauses);
     default:
       if (detail.ChangeSource === undefined && detail.Target.Attribute === 'Tags') {
         // Special case: tag changes made at stack level has
         // ChangeSource === null and Attribute === 'Tags'
-        return [
-          'changed stack tags'
-        ]
+        return ['changed stack tags'];
       }
 
-      throw new Error(`Unknown ChangeSource ${detail.ChangeSource}`)
+      throw new Error(`Unknown ChangeSource ${detail.ChangeSource}`);
   }
 }
 
-function findChangeDetail (modified, added, logicalId) {
+function findChangeDetail(modified, added, logicalId) {
   for (const change of modified.concat(added)) {
     if (change.LogicalResourceId === logicalId) {
       // TODO: Handle multiple changes to the same resource
-      return change.Details[0]
+      return change.Details[0];
     }
   }
 
-  throw new Error(`Couldn't find changes to ${logicalId}`)
+  throw new Error(`Couldn't find changes to ${logicalId}`);
 }
 
-function formatTargetAttribute (attribute) {
-  return attribute.replace('Policy', ' Policy').toLowerCase()
+function formatTargetAttribute(attribute) {
+  return attribute.replace('Policy', ' Policy').toLowerCase();
 }
 
 module.exports = {
-  analyzeResourceChanges, analyzeTagChanges, analyzeParameterChanges, generateKeyValueChanges
-}
+  analyzeResourceChanges,
+  analyzeTagChanges,
+  analyzeParameterChanges,
+  generateKeyValueChanges,
+};

--- a/lib/plugins/aws/plan/lib/analysis.test.js
+++ b/lib/plugins/aws/plan/lib/analysis.test.js
@@ -1,74 +1,82 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
-const analysis = require('./analysis')
+const chai = require('chai');
+const analysis = require('./analysis');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan analysis module', () => {
   describe('generateKeyValueChanges()', () => {
-    const cases = [{
-      desc: 'empty objects',
-      input: {
-        prev: {},
-        next: {}
+    const cases = [
+      {
+        desc: 'empty objects',
+        input: {
+          prev: {},
+          next: {},
+        },
+        output: {
+          added: [],
+          removed: [],
+          modified: [],
+        },
       },
-      output: {
-        added: [],
-        removed: [],
-        modified: []
-      }
-    }, {
-      desc: 'new properties',
-      input: {
-        prev: {},
-        next: { test: 123 }
+      {
+        desc: 'new properties',
+        input: {
+          prev: {},
+          next: { test: 123 },
+        },
+        output: {
+          added: [{ Key: 'test', Value: 123 }],
+          removed: [],
+          modified: [],
+        },
       },
-      output: {
-        added: [{ Key: 'test', Value: 123 }],
-        removed: [],
-        modified: []
-      }
-    }, {
-      desc: 'removed properties',
-      input: {
-        prev: { test: 123 },
-        next: {}
+      {
+        desc: 'removed properties',
+        input: {
+          prev: { test: 123 },
+          next: {},
+        },
+        output: {
+          added: [],
+          removed: [{ Key: 'test', Value: 123 }],
+          modified: [],
+        },
       },
-      output: {
-        added: [],
-        removed: [{ Key: 'test', Value: 123 }],
-        modified: []
-      }
-    }, {
-      desc: 'modified properties',
-      input: {
-        prev: { a: 123 },
-        next: { a: 456 }
+      {
+        desc: 'modified properties',
+        input: {
+          prev: { a: 123 },
+          next: { a: 456 },
+        },
+        output: {
+          added: [],
+          removed: [],
+          modified: [{ Key: 'a', Value: 456, OldValue: 123 }],
+        },
       },
-      output: {
-        added: [],
-        removed: [],
-        modified: [{ Key: 'a', Value: 456, OldValue: 123 }]
-      }
-    }, {
-      desc: 'unchanged properties',
-      input: {
-        prev: { a: 123 },
-        next: { a: 123 }
+      {
+        desc: 'unchanged properties',
+        input: {
+          prev: { a: 123 },
+          next: { a: 123 },
+        },
+        output: {
+          added: [],
+          removed: [],
+          modified: [],
+        },
       },
-      output: {
-        added: [],
-        removed: [],
-        modified: []
-      }
-    }]
+    ];
 
     cases.forEach(test => {
       it(`should handle ${test.desc}`, () => {
-        expect(analysis.generateKeyValueChanges(test.input.prev, test.input.next)).to.deep.equal(test.output)
-      })
-    })
-  })
-})
+        expect(analysis.generateKeyValueChanges(test.input.prev, test.input.next)).to.deep.equal(
+          test.output
+        );
+      });
+    });
+  });
+});

--- a/lib/plugins/aws/plan/lib/analysis.test.js
+++ b/lib/plugins/aws/plan/lib/analysis.test.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const analysis = require('./analysis')
+
+const expect = chai.expect
+
+describe('AWSPlan analysis module', () => {
+  describe('generateKeyValueChanges()', () => {
+    const cases = [{
+      desc: 'empty objects',
+      input: {
+        prev: {},
+        next: {}
+      },
+      output: {
+        added: [],
+        removed: [],
+        modified: []
+      }
+    }, {
+      desc: 'new properties',
+      input: {
+        prev: {},
+        next: { test: 123 }
+      },
+      output: {
+        added: [{ Key: 'test', Value: 123 }],
+        removed: [],
+        modified: []
+      }
+    }, {
+      desc: 'removed properties',
+      input: {
+        prev: { test: 123 },
+        next: {}
+      },
+      output: {
+        added: [],
+        removed: [{ Key: 'test', Value: 123 }],
+        modified: []
+      }
+    }, {
+      desc: 'modified properties',
+      input: {
+        prev: { a: 123 },
+        next: { a: 456 }
+      },
+      output: {
+        added: [],
+        removed: [],
+        modified: [{ Key: 'a', Value: 456, OldValue: 123 }]
+      }
+    }, {
+      desc: 'unchanged properties',
+      input: {
+        prev: { a: 123 },
+        next: { a: 123 }
+      },
+      output: {
+        added: [],
+        removed: [],
+        modified: []
+      }
+    }]
+
+    cases.forEach(test => {
+      it(`should handle ${test.desc}`, () => {
+        expect(analysis.generateKeyValueChanges(test.input.prev, test.input.next)).to.deep.equal(test.output)
+      })
+    })
+  })
+})

--- a/lib/plugins/aws/plan/lib/analysisPrinter.js
+++ b/lib/plugins/aws/plan/lib/analysisPrinter.js
@@ -1,0 +1,84 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+const chalk = require('chalk');
+const analysis = require('./analysis');
+const renderers = require('./analysisRenderers');
+
+/**
+ * @param {Function} logger
+ * @param {KeyValueChanges} changes
+ */
+function printKeyValueChanges(logger, changes, title) {
+  if (!changes.added.length && !changes.removed.length && !changes.modified.length) {
+    // No tag changes!
+    return
+  }
+
+  logger.log() // Print empty line to separate this from previous section
+  logger.log(chalk.bold(title))
+  /**
+   * @param {String} action
+   * @param {KeyValueChange[]} valueChanges
+   */
+  function doPrintKeyValueChanges(action, valueChanges) {
+    for (const change of valueChanges) {
+      const type = renderers.renderAction({ Action: action })
+      const summary = renderers.renderKeyValueChange(change)
+      logger.log(`${type} ${summary}`)
+    }
+  }
+
+  doPrintKeyValueChanges('Add', changes.added)
+  doPrintKeyValueChanges('Remove', changes.removed)
+  doPrintKeyValueChanges('Modify', changes.modified)
+}
+
+/**
+ * @param {Function} logger
+ * @param {Object} changes
+ * @param {AWS.CloudFormation.ResourceChange[]} changes.added
+ * @param {AWS.CloudFormation.ResourceChange[]} changes.removed
+ * @param {AWS.CloudFormation.ResourceChange[]} changes.modified
+ */
+function printResourceChanges(logger, changes) {
+  /**
+   * @param {AWS.CloudFormation.ResourceChange[]} resourceChanges
+   */
+  function doPrintResources(resourceChanges) {
+    for (const change of resourceChanges) {
+      const type = renderers.renderAction(change)
+      const resource = renderers.renderResourceSummary(change)
+      const replacement = renderers.renderReplacement(change)
+      logger.log(`${type} ${resource}${replacement}`)
+
+      for (const detail of change.Details) {
+        const recreation = renderers.renderRecreation(detail)
+        logger.log(`    - ${detail.Summary}${recreation}`)
+        for (const cause of (detail.Causes || [])) {
+          logger.log(`        caused by ${cause}`)
+        }
+      }
+    }
+  }
+
+  logger.log(chalk.bold('Resource Changes'))
+  doPrintResources(changes.added)
+  doPrintResources(changes.removed)
+  doPrintResources(changes.modified)
+}
+
+function print(logger, stack, changeSet) {
+  const resourceChanges = analysis.analyzeResourceChanges(changeSet)
+  printResourceChanges(logger, resourceChanges)
+
+  const tagChanges = analysis.analyzeTagChanges(changeSet, stack)
+  printKeyValueChanges(logger, tagChanges, 'Tag Changes')
+
+  const parameterChanges = analysis.analyzeParameterChanges(changeSet, stack)
+  printKeyValueChanges(logger, parameterChanges, 'Parameter Changes')
+}
+
+
+module.exports = {
+  print
+}

--- a/lib/plugins/aws/plan/lib/analysisPrinter.js
+++ b/lib/plugins/aws/plan/lib/analysisPrinter.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
+'use strict';
 const chalk = require('chalk');
 const analysis = require('./analysis');
 const renderers = require('./analysisRenderers');
@@ -11,26 +11,26 @@ const renderers = require('./analysisRenderers');
 function printKeyValueChanges(logger, changes, title) {
   if (!changes.added.length && !changes.removed.length && !changes.modified.length) {
     // No tag changes!
-    return
+    return;
   }
 
-  logger.log() // Print empty line to separate this from previous section
-  logger.log(chalk.bold(title))
+  logger.log(); // Print empty line to separate this from previous section
+  logger.log(chalk.bold(title));
   /**
    * @param {String} action
    * @param {KeyValueChange[]} valueChanges
    */
   function doPrintKeyValueChanges(action, valueChanges) {
     for (const change of valueChanges) {
-      const type = renderers.renderAction({ Action: action })
-      const summary = renderers.renderKeyValueChange(change)
-      logger.log(`${type} ${summary}`)
+      const type = renderers.renderAction({ Action: action });
+      const summary = renderers.renderKeyValueChange(change);
+      logger.log(`${type} ${summary}`);
     }
   }
 
-  doPrintKeyValueChanges('Add', changes.added)
-  doPrintKeyValueChanges('Remove', changes.removed)
-  doPrintKeyValueChanges('Modify', changes.modified)
+  doPrintKeyValueChanges('Add', changes.added);
+  doPrintKeyValueChanges('Remove', changes.removed);
+  doPrintKeyValueChanges('Modify', changes.modified);
 }
 
 /**
@@ -46,39 +46,38 @@ function printResourceChanges(logger, changes) {
    */
   function doPrintResources(resourceChanges) {
     for (const change of resourceChanges) {
-      const type = renderers.renderAction(change)
-      const resource = renderers.renderResourceSummary(change)
-      const replacement = renderers.renderReplacement(change)
-      logger.log(`${type} ${resource}${replacement}`)
+      const type = renderers.renderAction(change);
+      const resource = renderers.renderResourceSummary(change);
+      const replacement = renderers.renderReplacement(change);
+      logger.log(`${type} ${resource}${replacement}`);
 
       for (const detail of change.Details) {
-        const recreation = renderers.renderRecreation(detail)
-        logger.log(`    - ${detail.Summary}${recreation}`)
-        for (const cause of (detail.Causes || [])) {
-          logger.log(`        caused by ${cause}`)
+        const recreation = renderers.renderRecreation(detail);
+        logger.log(`    - ${detail.Summary}${recreation}`);
+        for (const cause of detail.Causes || []) {
+          logger.log(`        caused by ${cause}`);
         }
       }
     }
   }
 
-  logger.log(chalk.bold('Resource Changes'))
-  doPrintResources(changes.added)
-  doPrintResources(changes.removed)
-  doPrintResources(changes.modified)
+  logger.log(chalk.bold('Resource Changes'));
+  doPrintResources(changes.added);
+  doPrintResources(changes.removed);
+  doPrintResources(changes.modified);
 }
 
 function print(logger, stack, changeSet) {
-  const resourceChanges = analysis.analyzeResourceChanges(changeSet)
-  printResourceChanges(logger, resourceChanges)
+  const resourceChanges = analysis.analyzeResourceChanges(changeSet);
+  printResourceChanges(logger, resourceChanges);
 
-  const tagChanges = analysis.analyzeTagChanges(changeSet, stack)
-  printKeyValueChanges(logger, tagChanges, 'Tag Changes')
+  const tagChanges = analysis.analyzeTagChanges(changeSet, stack);
+  printKeyValueChanges(logger, tagChanges, 'Tag Changes');
 
-  const parameterChanges = analysis.analyzeParameterChanges(changeSet, stack)
-  printKeyValueChanges(logger, parameterChanges, 'Parameter Changes')
+  const parameterChanges = analysis.analyzeParameterChanges(changeSet, stack);
+  printKeyValueChanges(logger, parameterChanges, 'Parameter Changes');
 }
-
 
 module.exports = {
-  print
-}
+  print,
+};

--- a/lib/plugins/aws/plan/lib/analysisPrinter.test.js
+++ b/lib/plugins/aws/plan/lib/analysisPrinter.test.js
@@ -1,69 +1,71 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
-const printer = require('./analysisPrinter')
+const chai = require('chai');
+const printer = require('./analysisPrinter');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 const stack = {
-  'Parameters': [],
-  'Tags': [
+  Parameters: [],
+  Tags: [
     {
-      'Key': 'STAGE',
-      'Value': 'dev'
-    }
-  ]
+      Key: 'STAGE',
+      Value: 'dev',
+    },
+  ],
 };
 
 const changeSet = {
-  'StackName': 'aws-sls-dev',
-  'Parameters': [],
-  'Tags': [
+  StackName: 'aws-sls-dev',
+  Parameters: [],
+  Tags: [
     {
-      'Key': 'STAGE',
-      'Value': 'dev1'
-    }
+      Key: 'STAGE',
+      Value: 'dev1',
+    },
   ],
-  'Changes': [
+  Changes: [
     {
-      'Type': 'Resource',
-      'ResourceChange': {
-        'Action': 'Modify',
-        'LogicalResourceId': 'HelloLambdaFunction',
-        'ResourceType': 'AWS::Lambda::Function',
-        'Replacement': 'False',
-        'Details': [
+      Type: 'Resource',
+      ResourceChange: {
+        Action: 'Modify',
+        LogicalResourceId: 'HelloLambdaFunction',
+        ResourceType: 'AWS::Lambda::Function',
+        Replacement: 'False',
+        Details: [
           {
-            'Target': {
-              'Attribute': 'Properties',
-              'Name': 'Code',
-              'RequiresRecreation': 'Never'
+            Target: {
+              Attribute: 'Properties',
+              Name: 'Code',
+              RequiresRecreation: 'Never',
             },
-            'Evaluation': 'Static',
-            'ChangeSource': 'DirectModification'
-          }
-        ]
-      }
-    }
-  ]
+            Evaluation: 'Static',
+            ChangeSource: 'DirectModification',
+          },
+        ],
+      },
+    },
+  ],
 };
 
 describe('AWSPlan analysis printer module', () => {
-
   let message = '';
-  printer.print({
-    log: (msg) => {
-      message += `${msg}\n`
-    }
-  }, stack, changeSet);
+  printer.print(
+    {
+      log: msg => {
+        message += `${msg}\n`;
+      },
+    },
+    stack,
+    changeSet
+  );
 
   it('should print code change', () => {
-    expect(message).to.have.string('Code will change')
-  })
+    expect(message).to.have.string('Code will change');
+  });
 
   it('should print tag change', () => {
-    expect(message).to.have.string('Tag Changes')
-  })
-
-})
+    expect(message).to.have.string('Tag Changes');
+  });
+});

--- a/lib/plugins/aws/plan/lib/analysisPrinter.test.js
+++ b/lib/plugins/aws/plan/lib/analysisPrinter.test.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const printer = require('./analysisPrinter')
+
+const expect = chai.expect
+
+const stack = {
+  'Parameters': [],
+  'Tags': [
+    {
+      'Key': 'STAGE',
+      'Value': 'dev'
+    }
+  ]
+};
+
+const changeSet = {
+  'StackName': 'aws-sls-dev',
+  'Parameters': [],
+  'Tags': [
+    {
+      'Key': 'STAGE',
+      'Value': 'dev1'
+    }
+  ],
+  'Changes': [
+    {
+      'Type': 'Resource',
+      'ResourceChange': {
+        'Action': 'Modify',
+        'LogicalResourceId': 'HelloLambdaFunction',
+        'ResourceType': 'AWS::Lambda::Function',
+        'Replacement': 'False',
+        'Details': [
+          {
+            'Target': {
+              'Attribute': 'Properties',
+              'Name': 'Code',
+              'RequiresRecreation': 'Never'
+            },
+            'Evaluation': 'Static',
+            'ChangeSource': 'DirectModification'
+          }
+        ]
+      }
+    }
+  ]
+};
+
+describe('AWSPlan analysis printer module', () => {
+
+  let message = '';
+  printer.print({
+    log: (msg) => {
+      message += `${msg}\n`
+    }
+  }, stack, changeSet);
+
+  it('should print code change', () => {
+    expect(message).to.have.string('Code will change')
+  })
+
+  it('should print tag change', () => {
+    expect(message).to.have.string('Tag Changes')
+  })
+
+})

--- a/lib/plugins/aws/plan/lib/analysisRenderers.js
+++ b/lib/plugins/aws/plan/lib/analysisRenderers.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
-const chalk = require('chalk')
+'use strict';
+const chalk = require('chalk');
 
 /**
  * Renders a label that indicates if the given resource will be
@@ -9,17 +9,17 @@ const chalk = require('chalk')
  * @param {AWS.CloudFormation.ResourceChange} change
  * @return {String}
  */
-function renderReplacement (change) {
+function renderReplacement(change) {
   switch (change.Replacement) {
     case 'True':
-      return ` ${chalk.yellow('[Replacement: True]')}`
+      return ` ${chalk.yellow('[Replacement: True]')}`;
     case 'Conditional':
-      return ` ${chalk.yellow('[Replacement: Conditional]')}`
+      return ` ${chalk.yellow('[Replacement: Conditional]')}`;
     case 'False':
     case undefined: // not a modify
-      return ''
+      return '';
     default:
-      throw new Error(`Unknown value for replacement ${change.Replacement}`)
+      throw new Error(`Unknown value for replacement ${change.Replacement}`);
   }
 }
 
@@ -29,16 +29,16 @@ function renderReplacement (change) {
  * @param {AWS.CloudFormation.ResourceChange} change
  * @return {String}
  */
-function renderAction (change) {
+function renderAction(change) {
   switch (change.Action) {
     case 'Add':
-      return chalk.green('[+]')
+      return chalk.green('[+]');
     case 'Remove':
-      return chalk.red('[-]')
+      return chalk.red('[-]');
     case 'Modify':
-      return chalk.yellow('[*]')
+      return chalk.yellow('[*]');
     default:
-      throw new Error(`Unknown action ${change.Action}`)
+      throw new Error(`Unknown action ${change.Action}`);
   }
 }
 
@@ -48,11 +48,11 @@ function renderAction (change) {
  * @param {AWS.CloudFormation.ResourceChange} change
  * @return {String}
  */
-function renderResourceSummary (change) {
+function renderResourceSummary(change) {
   if (change.PhysicalResourceId) {
-    return `${change.LogicalResourceId} - ${change.PhysicalResourceId} (${change.ResourceType})`
-  } 
-  return `${change.LogicalResourceId} (${change.ResourceType})`
+    return `${change.LogicalResourceId} - ${change.PhysicalResourceId} (${change.ResourceType})`;
+  }
+  return `${change.LogicalResourceId} (${change.ResourceType})`;
 }
 
 /**
@@ -62,16 +62,16 @@ function renderResourceSummary (change) {
  * @param {AWS.CloudFormation.ResourceChangeDetail} detail
  * @return {String}
  */
-function renderRecreation (detail) {
+function renderRecreation(detail) {
   switch (detail.Target.RequiresRecreation) {
     case 'Always':
-      return ` ${chalk.yellow('[Recreation: Always]')}`
+      return ` ${chalk.yellow('[Recreation: Always]')}`;
     case 'Conditionally':
-      return ` ${chalk.yellow('[Recreation: Conditional]')}`
+      return ` ${chalk.yellow('[Recreation: Conditional]')}`;
     case 'Never':
-      return ''
+      return '';
     default:
-      throw new Error(`Unknown value for RequiresRecreation ${detail.Target.RequiresRecreation}`)
+      throw new Error(`Unknown value for RequiresRecreation ${detail.Target.RequiresRecreation}`);
   }
 }
 
@@ -83,13 +83,17 @@ function renderRecreation (detail) {
  * @param {String} change.Value - new value of the key
  * @param {String} [change.OldValue] - old value of the key
  */
-function renderKeyValueChange (change) {
+function renderKeyValueChange(change) {
   if (change.OldValue) {
-    return `${change.Key}: ${change.OldValue} --> ${change.Value}`
+    return `${change.Key}: ${change.OldValue} --> ${change.Value}`;
   }
-  return `${change.Key}: ${change.Value}`
+  return `${change.Key}: ${change.Value}`;
 }
 
 module.exports = {
-  renderAction, renderResourceSummary, renderReplacement, renderRecreation, renderKeyValueChange
-}
+  renderAction,
+  renderResourceSummary,
+  renderReplacement,
+  renderRecreation,
+  renderKeyValueChange,
+};

--- a/lib/plugins/aws/plan/lib/analysisRenderers.js
+++ b/lib/plugins/aws/plan/lib/analysisRenderers.js
@@ -1,0 +1,95 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+const chalk = require('chalk')
+
+/**
+ * Renders a label that indicates if the given resource will be
+ * replaced.
+ *
+ * @param {AWS.CloudFormation.ResourceChange} change
+ * @return {String}
+ */
+function renderReplacement (change) {
+  switch (change.Replacement) {
+    case 'True':
+      return ` ${chalk.yellow('[Replacement: True]')}`
+    case 'Conditional':
+      return ` ${chalk.yellow('[Replacement: Conditional]')}`
+    case 'False':
+    case undefined: // not a modify
+      return ''
+    default:
+      throw new Error(`Unknown value for replacement ${change.Replacement}`)
+  }
+}
+
+/**
+ * Renders a label that indicates the action made to the given resource.
+ *
+ * @param {AWS.CloudFormation.ResourceChange} change
+ * @return {String}
+ */
+function renderAction (change) {
+  switch (change.Action) {
+    case 'Add':
+      return chalk.green('[+]')
+    case 'Remove':
+      return chalk.red('[-]')
+    case 'Modify':
+      return chalk.yellow('[*]')
+    default:
+      throw new Error(`Unknown action ${change.Action}`)
+  }
+}
+
+/**
+ * Renders a summary of the resource the given change touches.
+ *
+ * @param {AWS.CloudFormation.ResourceChange} change
+ * @return {String}
+ */
+function renderResourceSummary (change) {
+  if (change.PhysicalResourceId) {
+    return `${change.LogicalResourceId} - ${change.PhysicalResourceId} (${change.ResourceType})`
+  } 
+  return `${change.LogicalResourceId} (${change.ResourceType})`
+}
+
+/**
+ * Renders a label that indicates if the given change requires the resource
+ * to be recreated.
+ *
+ * @param {AWS.CloudFormation.ResourceChangeDetail} detail
+ * @return {String}
+ */
+function renderRecreation (detail) {
+  switch (detail.Target.RequiresRecreation) {
+    case 'Always':
+      return ` ${chalk.yellow('[Recreation: Always]')}`
+    case 'Conditionally':
+      return ` ${chalk.yellow('[Recreation: Conditional]')}`
+    case 'Never':
+      return ''
+    default:
+      throw new Error(`Unknown value for RequiresRecreation ${detail.Target.RequiresRecreation}`)
+  }
+}
+
+/**
+ * Render a KeyValueChange object.
+ *
+ * @param {Object} change
+ * @param {String} change.Key - changed key
+ * @param {String} change.Value - new value of the key
+ * @param {String} [change.OldValue] - old value of the key
+ */
+function renderKeyValueChange (change) {
+  if (change.OldValue) {
+    return `${change.Key}: ${change.OldValue} --> ${change.Value}`
+  }
+  return `${change.Key}: ${change.Value}`
+}
+
+module.exports = {
+  renderAction, renderResourceSummary, renderReplacement, renderRecreation, renderKeyValueChange
+}

--- a/lib/plugins/aws/plan/lib/analysisRenderers.test.js
+++ b/lib/plugins/aws/plan/lib/analysisRenderers.test.js
@@ -1,0 +1,102 @@
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const renderer = require('./analysisRenderers')
+
+const expect = chai.expect
+
+describe('AWSPlan analysis renderers module', () => {
+
+  describe('#renderAction', () => {
+
+    it('should render Add action', () => {
+      const value = renderer.renderAction({ Action: 'Add' });
+      expect(value).to.equal('[+]');
+    })
+
+    it('should render Remove action', () => {
+      const value = renderer.renderAction({ Action: 'Remove' });
+      expect(value).to.equal('[-]');
+    })
+
+    it('should render Modify action', () => {
+      const value = renderer.renderAction({ Action: 'Modify' });
+      expect(value).to.equal('[*]');
+    })
+
+  });
+
+  describe('#renderResourceSummary', () => {
+
+    it('should render PhysicalResourceId if present', () => {
+      const value = renderer.renderResourceSummary({
+        PhysicalResourceId: 'foo',
+        LogicalResourceId: 'bar',
+        ResourceType: 'baz'
+      });
+      expect(value).to.equal('bar - foo (baz)');
+    })
+
+    it('should hide PhysicalResourceId if not present', () => {
+      const value = renderer.renderResourceSummary({
+        LogicalResourceId: 'bar',
+        ResourceType: 'baz'
+      });
+      expect(value).to.equal('bar (baz)');
+    })
+
+  });
+
+  describe('#renderRecreation', () => {
+
+    it('should render Recreation.Always', () => {
+      const value = renderer.renderRecreation({
+        Target: {
+          RequiresRecreation: 'Always'
+        }
+      });
+      expect(value).to.equal(' [Recreation: Always]');
+    })
+
+    it('should render Recreation.Conditionally', () => {
+      const value = renderer.renderRecreation({
+        Target: {
+          RequiresRecreation: 'Conditionally'
+        }
+      });
+      expect(value).to.equal(' [Recreation: Conditional]');
+    })
+
+    it('should render Recreation.Never', () => {
+      const value = renderer.renderRecreation({
+        Target: {
+          RequiresRecreation: 'Never'
+        }
+      });
+      expect(value).to.equal('');
+    })
+
+  });
+
+  describe('#renderKeyValueChange', () => {
+
+    it('should render old value if present', () => {
+      const value = renderer.renderKeyValueChange({ 
+        Key: 'foo',
+        Value: 'bar',
+        OldValue: 'baz'
+      });
+      expect(value).to.equal('foo: baz --> bar');
+    })
+
+    it('should hide old value if not present', () => {
+      const value = renderer.renderKeyValueChange({ 
+        Key: 'foo',
+        Value: 'bar'
+      });
+      expect(value).to.equal('foo: bar');
+    })
+
+  });
+
+})

--- a/lib/plugins/aws/plan/lib/analysisRenderers.test.js
+++ b/lib/plugins/aws/plan/lib/analysisRenderers.test.js
@@ -1,102 +1,92 @@
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
-const renderer = require('./analysisRenderers')
+const chai = require('chai');
+const renderer = require('./analysisRenderers');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan analysis renderers module', () => {
-
   describe('#renderAction', () => {
-
     it('should render Add action', () => {
       const value = renderer.renderAction({ Action: 'Add' });
       expect(value).to.equal('[+]');
-    })
+    });
 
     it('should render Remove action', () => {
       const value = renderer.renderAction({ Action: 'Remove' });
       expect(value).to.equal('[-]');
-    })
+    });
 
     it('should render Modify action', () => {
       const value = renderer.renderAction({ Action: 'Modify' });
       expect(value).to.equal('[*]');
-    })
-
+    });
   });
 
   describe('#renderResourceSummary', () => {
-
     it('should render PhysicalResourceId if present', () => {
       const value = renderer.renderResourceSummary({
         PhysicalResourceId: 'foo',
         LogicalResourceId: 'bar',
-        ResourceType: 'baz'
+        ResourceType: 'baz',
       });
       expect(value).to.equal('bar - foo (baz)');
-    })
+    });
 
     it('should hide PhysicalResourceId if not present', () => {
       const value = renderer.renderResourceSummary({
         LogicalResourceId: 'bar',
-        ResourceType: 'baz'
+        ResourceType: 'baz',
       });
       expect(value).to.equal('bar (baz)');
-    })
-
+    });
   });
 
   describe('#renderRecreation', () => {
-
     it('should render Recreation.Always', () => {
       const value = renderer.renderRecreation({
         Target: {
-          RequiresRecreation: 'Always'
-        }
+          RequiresRecreation: 'Always',
+        },
       });
       expect(value).to.equal(' [Recreation: Always]');
-    })
+    });
 
     it('should render Recreation.Conditionally', () => {
       const value = renderer.renderRecreation({
         Target: {
-          RequiresRecreation: 'Conditionally'
-        }
+          RequiresRecreation: 'Conditionally',
+        },
       });
       expect(value).to.equal(' [Recreation: Conditional]');
-    })
+    });
 
     it('should render Recreation.Never', () => {
       const value = renderer.renderRecreation({
         Target: {
-          RequiresRecreation: 'Never'
-        }
+          RequiresRecreation: 'Never',
+        },
       });
       expect(value).to.equal('');
-    })
-
+    });
   });
 
   describe('#renderKeyValueChange', () => {
-
     it('should render old value if present', () => {
-      const value = renderer.renderKeyValueChange({ 
+      const value = renderer.renderKeyValueChange({
         Key: 'foo',
         Value: 'bar',
-        OldValue: 'baz'
+        OldValue: 'baz',
       });
       expect(value).to.equal('foo: baz --> bar');
-    })
+    });
 
     it('should hide old value if not present', () => {
-      const value = renderer.renderKeyValueChange({ 
+      const value = renderer.renderKeyValueChange({
         Key: 'foo',
-        Value: 'bar'
+        Value: 'bar',
       });
       expect(value).to.equal('foo: bar');
-    })
-
+    });
   });
-
-})
+});

--- a/lib/plugins/aws/plan/lib/analysisRenderers.test.js
+++ b/lib/plugins/aws/plan/lib/analysisRenderers.test.js
@@ -2,6 +2,7 @@
 /* eslint-env mocha */
 const chai = require('chai');
 const renderer = require('./analysisRenderers');
+const stripAnsi = require('strip-ansi')
 
 const expect = chai.expect;
 
@@ -9,17 +10,17 @@ describe('AWSPlan analysis renderers module', () => {
   describe('#renderAction', () => {
     it('should render Add action', () => {
       const value = renderer.renderAction({ Action: 'Add' });
-      expect(value).to.equal('[+]');
+      expect(stripAnsi(value)).to.equal('[+]');
     });
 
     it('should render Remove action', () => {
       const value = renderer.renderAction({ Action: 'Remove' });
-      expect(value).to.equal('[-]');
+      expect(stripAnsi(value)).to.equal('[-]');
     });
 
     it('should render Modify action', () => {
       const value = renderer.renderAction({ Action: 'Modify' });
-      expect(value).to.equal('[*]');
+      expect(stripAnsi(value)).to.equal('[*]');
     });
   });
 
@@ -30,7 +31,7 @@ describe('AWSPlan analysis renderers module', () => {
         LogicalResourceId: 'bar',
         ResourceType: 'baz',
       });
-      expect(value).to.equal('bar - foo (baz)');
+      expect(stripAnsi(value)).to.equal('bar - foo (baz)');
     });
 
     it('should hide PhysicalResourceId if not present', () => {
@@ -38,7 +39,7 @@ describe('AWSPlan analysis renderers module', () => {
         LogicalResourceId: 'bar',
         ResourceType: 'baz',
       });
-      expect(value).to.equal('bar (baz)');
+      expect(stripAnsi(value)).to.equal('bar (baz)');
     });
   });
 
@@ -49,7 +50,7 @@ describe('AWSPlan analysis renderers module', () => {
           RequiresRecreation: 'Always',
         },
       });
-      expect(value).to.equal(' [Recreation: Always]');
+      expect(stripAnsi(value)).to.equal(' [Recreation: Always]');
     });
 
     it('should render Recreation.Conditionally', () => {
@@ -58,7 +59,7 @@ describe('AWSPlan analysis renderers module', () => {
           RequiresRecreation: 'Conditionally',
         },
       });
-      expect(value).to.equal(' [Recreation: Conditional]');
+      expect(stripAnsi(value)).to.equal(' [Recreation: Conditional]');
     });
 
     it('should render Recreation.Never', () => {
@@ -67,7 +68,7 @@ describe('AWSPlan analysis renderers module', () => {
           RequiresRecreation: 'Never',
         },
       });
-      expect(value).to.equal('');
+      expect(stripAnsi(value)).to.equal('');
     });
   });
 
@@ -78,7 +79,7 @@ describe('AWSPlan analysis renderers module', () => {
         Value: 'bar',
         OldValue: 'baz',
       });
-      expect(value).to.equal('foo: baz --> bar');
+      expect(stripAnsi(value)).to.equal('foo: baz --> bar');
     });
 
     it('should hide old value if not present', () => {
@@ -86,7 +87,7 @@ describe('AWSPlan analysis renderers module', () => {
         Key: 'foo',
         Value: 'bar',
       });
-      expect(value).to.equal('foo: bar');
+      expect(stripAnsi(value)).to.equal('foo: bar');
     });
   });
 });

--- a/lib/plugins/aws/plan/lib/analysisRenderers.test.js
+++ b/lib/plugins/aws/plan/lib/analysisRenderers.test.js
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 const chai = require('chai');
 const renderer = require('./analysisRenderers');
-const stripAnsi = require('strip-ansi')
+const stripAnsi = require('strip-ansi');
 
 const expect = chai.expect;
 

--- a/lib/plugins/aws/plan/lib/createChangeSet.js
+++ b/lib/plugins/aws/plan/lib/createChangeSet.js
@@ -1,0 +1,65 @@
+// copyright Copyright (c) 2017 Trek10
+'use strict'
+const _ = require('lodash')
+const naming = require('./naming')
+
+function execute(plugin, changeSetType) {
+  const stackName = naming.getStackName(plugin);
+  const changeSetName = naming.getChangeSetName(plugin);
+  const templateUrl = naming.getChangeSetS3CompiledTemplateUrl(plugin)
+
+  let stackTags = {
+    STAGE: plugin.provider.getStage()
+  }
+
+  // Merge additional stack tags
+  if (typeof plugin.serverless.service.provider.stackTags === 'object') {
+    stackTags = _.extend(stackTags, plugin.serverless.service.provider.stackTags)
+  }
+
+  const params = {
+    StackName: stackName,
+    ChangeSetName: changeSetName,
+    Capabilities: [
+      'CAPABILITY_IAM',
+      'CAPABILITY_NAMED_IAM'
+    ],
+    ChangeSetType: changeSetType,
+    Parameters: [],
+    TemplateURL: templateUrl,
+    Tags: Object.keys(stackTags).map((key) => ({
+      Key: key,
+      Value: stackTags[key]
+    }))
+  }
+
+  if (plugin.serverless.service.provider.cfnRole) {
+    params.RoleARN = plugin.serverless.service.provider.cfnRole
+  }
+
+  return plugin.provider
+    .request(
+      'CloudFormation',
+      'createChangeSet',
+      params
+    )
+}
+
+function createChangeSet(changeSetSuffix) {
+  changeSetSuffix = changeSetSuffix || Date.now() 
+  const stackName = this.provider.naming.getStackName()
+  const changeSetName = `${stackName}-${changeSetSuffix}`
+  this.changeSetName = changeSetName
+  this.serverless.cli.log(`Creating ChangeSet [${changeSetName}]`)
+  return execute(this, 'UPDATE')
+    .catch(e => {
+      if (e.message.indexOf('does not exist') > -1) {
+        return execute(this, 'CREATE')
+      }
+      throw e
+    })
+}
+
+module.exports = {
+  createChangeSet
+};

--- a/lib/plugins/aws/plan/lib/createChangeSet.js
+++ b/lib/plugins/aws/plan/lib/createChangeSet.js
@@ -1,65 +1,56 @@
 // copyright Copyright (c) 2017 Trek10
-'use strict'
-const _ = require('lodash')
-const naming = require('./naming')
+'use strict';
+const _ = require('lodash');
+const naming = require('./naming');
 
 function execute(plugin, changeSetType) {
   const stackName = naming.getStackName(plugin);
   const changeSetName = naming.getChangeSetName(plugin);
-  const templateUrl = naming.getChangeSetS3CompiledTemplateUrl(plugin)
+  const templateUrl = naming.getChangeSetS3CompiledTemplateUrl(plugin);
 
   let stackTags = {
-    STAGE: plugin.provider.getStage()
-  }
+    STAGE: plugin.provider.getStage(),
+  };
 
   // Merge additional stack tags
   if (typeof plugin.serverless.service.provider.stackTags === 'object') {
-    stackTags = _.extend(stackTags, plugin.serverless.service.provider.stackTags)
+    stackTags = _.extend(stackTags, plugin.serverless.service.provider.stackTags);
   }
 
   const params = {
     StackName: stackName,
     ChangeSetName: changeSetName,
-    Capabilities: [
-      'CAPABILITY_IAM',
-      'CAPABILITY_NAMED_IAM'
-    ],
+    Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
     ChangeSetType: changeSetType,
     Parameters: [],
     TemplateURL: templateUrl,
-    Tags: Object.keys(stackTags).map((key) => ({
+    Tags: Object.keys(stackTags).map(key => ({
       Key: key,
-      Value: stackTags[key]
-    }))
-  }
+      Value: stackTags[key],
+    })),
+  };
 
   if (plugin.serverless.service.provider.cfnRole) {
-    params.RoleARN = plugin.serverless.service.provider.cfnRole
+    params.RoleARN = plugin.serverless.service.provider.cfnRole;
   }
 
-  return plugin.provider
-    .request(
-      'CloudFormation',
-      'createChangeSet',
-      params
-    )
+  return plugin.provider.request('CloudFormation', 'createChangeSet', params);
 }
 
 function createChangeSet(changeSetSuffix) {
-  changeSetSuffix = changeSetSuffix || Date.now() 
-  const stackName = this.provider.naming.getStackName()
-  const changeSetName = `${stackName}-${changeSetSuffix}`
-  this.changeSetName = changeSetName
-  this.serverless.cli.log(`Creating ChangeSet [${changeSetName}]`)
-  return execute(this, 'UPDATE')
-    .catch(e => {
-      if (e.message.indexOf('does not exist') > -1) {
-        return execute(this, 'CREATE')
-      }
-      throw e
-    })
+  changeSetSuffix = changeSetSuffix || Date.now();
+  const stackName = this.provider.naming.getStackName();
+  const changeSetName = `${stackName}-${changeSetSuffix}`;
+  this.changeSetName = changeSetName;
+  this.serverless.cli.log(`Creating ChangeSet [${changeSetName}]`);
+  return execute(this, 'UPDATE').catch(e => {
+    if (e.message.indexOf('does not exist') > -1) {
+      return execute(this, 'CREATE');
+    }
+    throw e;
+  });
 }
 
 module.exports = {
-  createChangeSet
+  createChangeSet,
 };

--- a/lib/plugins/aws/plan/lib/createChangeSet.test.js
+++ b/lib/plugins/aws/plan/lib/createChangeSet.test.js
@@ -1,17 +1,15 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
-const _ = require('lodash')
+const chai = require('chai');
+const _ = require('lodash');
 const sinon = require('sinon');
-const createChangeSet = require('./createChangeSet')
+const createChangeSet = require('./createChangeSet');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan createChangeSet', () => {
-
   describe('#createChangeSet', () => {
-
     let plugin = {};
 
     beforeEach(() => {
@@ -19,40 +17,43 @@ describe('AWSPlan createChangeSet', () => {
       _.set(plugin, 'bucketName', 'bucketName');
       _.set(plugin, 'provider.getStage', () => 'dev');
       _.set(plugin, 'provider.naming.getStackName', () => 'stackName');
-      _.set(plugin, 'provider.naming.getCompiledTemplateS3Suffix', () =>
-        'changeSetName/compiled-template.json');
-      _.set(plugin, 'serverless.cli.log', () => { });
-      _.set(plugin, 'serverless.service.package.artifactDirectoryName',
-        'serverless/dev/artifactname');
+      _.set(
+        plugin,
+        'provider.naming.getCompiledTemplateS3Suffix',
+        () => 'changeSetName/compiled-template.json'
+      );
+      _.set(plugin, 'serverless.cli.log', () => {});
+      _.set(
+        plugin,
+        'serverless.service.package.artifactDirectoryName',
+        'serverless/dev/artifactname'
+      );
       _.set(plugin, 'serverless.service.provider', plugin.provider);
-    })
-
+    });
 
     it('should create a new changeset', () => {
-
       const request = sinon.fake.returns(Promise.resolve(true));
       _.set(plugin, 'provider.request', request);
       const fn = createChangeSet.createChangeSet.bind(plugin);
-      return fn('changeSetSuffix')
-        .then(response => {
-          sinon.assert.calledOnce(request);
-          sinon.assert.calledWith(request,
-            'CloudFormation',
-            'createChangeSet',
+      return fn('changeSetSuffix').then(response => {
+        sinon.assert.calledOnce(request);
+        sinon.assert.calledWith(request, 'CloudFormation', 'createChangeSet', {
+          StackName: 'stackName',
+          ChangeSetName: 'stackName-changeSetSuffix',
+          Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+          ChangeSetType: 'UPDATE',
+          Parameters: [],
+          TemplateURL:
+            'https://s3.amazonaws.com/bucketName/serverless/dev/artifactname/changeSetName/compiled-template.json',
+          Tags: [
             {
-              'StackName': 'stackName',
-              'ChangeSetName': 'stackName-changeSetSuffix',
-              'Capabilities': ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-              'ChangeSetType': 'UPDATE', 'Parameters': [],
-              'TemplateURL': 'https://s3.amazonaws.com/bucketName/serverless/dev/artifactname/changeSetName/compiled-template.json',
-              'Tags': [{
-                'Key': 'STAGE', 'Value': 'dev'
-              }]
-            })
-          expect(response).to.be.true
+              Key: 'STAGE',
+              Value: 'dev',
+            },
+          ],
         });
-    })
-
+        expect(response).to.be.true;
+      });
+    });
   });
-
-})
+});

--- a/lib/plugins/aws/plan/lib/createChangeSet.test.js
+++ b/lib/plugins/aws/plan/lib/createChangeSet.test.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const _ = require('lodash')
+const sinon = require('sinon');
+const createChangeSet = require('./createChangeSet')
+
+const expect = chai.expect
+
+describe('AWSPlan createChangeSet', () => {
+
+  describe('#createChangeSet', () => {
+
+    let plugin = {};
+
+    beforeEach(() => {
+      plugin = {};
+      _.set(plugin, 'bucketName', 'bucketName');
+      _.set(plugin, 'provider.getStage', () => 'dev');
+      _.set(plugin, 'provider.naming.getStackName', () => 'stackName');
+      _.set(plugin, 'provider.naming.getCompiledTemplateS3Suffix', () =>
+        'changeSetName/compiled-template.json');
+      _.set(plugin, 'serverless.cli.log', () => { });
+      _.set(plugin, 'serverless.service.package.artifactDirectoryName',
+        'serverless/dev/artifactname');
+      _.set(plugin, 'serverless.service.provider', plugin.provider);
+    })
+
+
+    it('should create a new changeset', () => {
+
+      const request = sinon.fake.returns(Promise.resolve(true));
+      _.set(plugin, 'provider.request', request);
+      const fn = createChangeSet.createChangeSet.bind(plugin);
+      return fn('changeSetSuffix')
+        .then(response => {
+          sinon.assert.calledOnce(request);
+          sinon.assert.calledWith(request,
+            'CloudFormation',
+            'createChangeSet',
+            {
+              'StackName': 'stackName',
+              'ChangeSetName': 'stackName-changeSetSuffix',
+              'Capabilities': ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+              'ChangeSetType': 'UPDATE', 'Parameters': [],
+              'TemplateURL': 'https://s3.amazonaws.com/bucketName/serverless/dev/artifactname/changeSetName/compiled-template.json',
+              'Tags': [{
+                'Key': 'STAGE', 'Value': 'dev'
+              }]
+            })
+          expect(response).to.be.true
+        });
+    })
+
+  });
+
+})

--- a/lib/plugins/aws/plan/lib/deleteChangeSet.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSet.js
@@ -1,0 +1,15 @@
+'use strict'
+
+function deleteChangeSet() {
+  const stackName = this.provider.naming.getStackName()
+  const changeSetName = this.changeSetName
+  return this.provider.request(
+    'CloudFormation',
+    'deleteChangeSet',
+    { StackName: stackName, ChangeSetName: changeSetName }
+  );
+}
+
+module.exports = {
+  deleteChangeSet
+};

--- a/lib/plugins/aws/plan/lib/deleteChangeSet.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSet.js
@@ -1,15 +1,14 @@
-'use strict'
+'use strict';
 
 function deleteChangeSet() {
-  const stackName = this.provider.naming.getStackName()
-  const changeSetName = this.changeSetName
-  return this.provider.request(
-    'CloudFormation',
-    'deleteChangeSet',
-    { StackName: stackName, ChangeSetName: changeSetName }
-  );
+  const stackName = this.provider.naming.getStackName();
+  const changeSetName = this.changeSetName;
+  return this.provider.request('CloudFormation', 'deleteChangeSet', {
+    StackName: stackName,
+    ChangeSetName: changeSetName,
+  });
 }
 
 module.exports = {
-  deleteChangeSet
+  deleteChangeSet,
 };

--- a/lib/plugins/aws/plan/lib/deleteChangeSet.test.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSet.test.js
@@ -1,16 +1,14 @@
 // Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
+const chai = require('chai');
 const sinon = require('sinon');
-const deleteChangeSet = require('./deleteChangeSet')
+const deleteChangeSet = require('./deleteChangeSet');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan deleteChangeSet', () => {
-
   describe('#deleteChangeSet', () => {
-
     let plugin;
 
     beforeEach(() => {
@@ -23,17 +21,16 @@ describe('AWSPlan deleteChangeSet', () => {
 
     it('should delete a changeset2', () => {
       const request = sinon.stub();
-      request.withArgs(
-        'CloudFormation',
-        'deleteChangeSet',
-        { 'StackName': 'stackName', 'ChangeSetName': 'changeSetName' }
-      ).returns(true);
+      request
+        .withArgs('CloudFormation', 'deleteChangeSet', {
+          StackName: 'stackName',
+          ChangeSetName: 'changeSetName',
+        })
+        .returns(true);
       plugin.provider.request = request;
       const fn = deleteChangeSet.deleteChangeSet.bind(plugin);
       const response = fn();
       expect(response).to.be.true;
-    })
-
+    });
   });
-
-})
+});

--- a/lib/plugins/aws/plan/lib/deleteChangeSet.test.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSet.test.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Sami Jaktholm <sjakthol@outlook.com>
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const sinon = require('sinon');
+const deleteChangeSet = require('./deleteChangeSet')
+
+const expect = chai.expect
+
+describe('AWSPlan deleteChangeSet', () => {
+
+  describe('#deleteChangeSet', () => {
+
+    let plugin;
+
+    beforeEach(() => {
+      plugin = {};
+      plugin.provider = {};
+      plugin.provider.naming = {};
+      plugin.provider.naming.getStackName = () => 'stackName';
+      plugin.changeSetName = 'changeSetName';
+    });
+
+    it('should delete a changeset2', () => {
+      const request = sinon.stub();
+      request.withArgs(
+        'CloudFormation',
+        'deleteChangeSet',
+        { 'StackName': 'stackName', 'ChangeSetName': 'changeSetName' }
+      ).returns(true);
+      plugin.provider.request = request;
+      const fn = deleteChangeSet.deleteChangeSet.bind(plugin);
+      const response = fn();
+      expect(response).to.be.true;
+    })
+
+  });
+
+})

--- a/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.js
@@ -1,0 +1,25 @@
+'use strict'
+const naming = require('./naming')
+
+function deleteChangeSetFromS3() {
+  const provider = this.provider;
+  const s3FolderPath = naming.getChangeSetS3FolderPath(this);
+  const bucketName = this.bucketName;
+  return provider.request(
+    'S3',
+    'listObjectsV2',
+    { Bucket: bucketName, Prefix: s3FolderPath }
+  ).then(response => {
+    const files = response.Contents.map(entry => ({ Key: entry.Key }));
+    files.push({ Key: s3FolderPath });
+    return provider.request(
+      'S3',
+      'deleteObjects',
+      { Bucket: bucketName, Delete: { Objects: files } }
+    )
+  })
+}
+
+module.exports = {
+  deleteChangeSetFromS3
+};

--- a/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.js
@@ -1,25 +1,22 @@
-'use strict'
-const naming = require('./naming')
+'use strict';
+const naming = require('./naming');
 
 function deleteChangeSetFromS3() {
   const provider = this.provider;
   const s3FolderPath = naming.getChangeSetS3FolderPath(this);
   const bucketName = this.bucketName;
-  return provider.request(
-    'S3',
-    'listObjectsV2',
-    { Bucket: bucketName, Prefix: s3FolderPath }
-  ).then(response => {
-    const files = response.Contents.map(entry => ({ Key: entry.Key }));
-    files.push({ Key: s3FolderPath });
-    return provider.request(
-      'S3',
-      'deleteObjects',
-      { Bucket: bucketName, Delete: { Objects: files } }
-    )
-  })
+  return provider
+    .request('S3', 'listObjectsV2', { Bucket: bucketName, Prefix: s3FolderPath })
+    .then(response => {
+      const files = response.Contents.map(entry => ({ Key: entry.Key }));
+      files.push({ Key: s3FolderPath });
+      return provider.request('S3', 'deleteObjects', {
+        Bucket: bucketName,
+        Delete: { Objects: files },
+      });
+    });
 }
 
 module.exports = {
-  deleteChangeSetFromS3
+  deleteChangeSetFromS3,
 };

--- a/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.test.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.test.js
@@ -1,0 +1,62 @@
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const sinon = require('sinon');
+const deleteChangeSetFromS3 = require('./deleteChangeSetFromS3')
+
+const expect = chai.expect
+
+describe('AWSPlan deleteChangeSetFromS3', () => {
+
+  describe('#deleteChangeSetFromS3', () => {
+
+    let plugin;
+
+    beforeEach(() => {
+      plugin = {};
+      plugin.bucketName = 'bucketName';
+      plugin.provider = {};
+      plugin.provider.naming = {};
+      plugin.provider.naming.getChangeSetS3FolderPath = () => 'folder';
+      plugin.serverless = {};
+      plugin.serverless.service = {};
+      plugin.serverless.service.package = {};
+      plugin.serverless.service.package.artifactDirectoryName = 'artifactDirectoryName';
+    });
+
+    it('should delete a changeset from S3', () => {
+      const request = sinon.stub();
+
+      // setup list request
+      request.withArgs('S3', 'listObjectsV2',
+        {
+          'Bucket': 'bucketName',
+          'Prefix': 'artifactDirectoryName'
+        })
+        .returns(Promise.resolve({ Contents: [{ Key: 'artifactDirectoryName/foo' }] }));
+
+      // setup delete request
+      request.withArgs('S3', 'deleteObjects',
+        {
+          Bucket: 'bucketName',
+          Delete: {
+            Objects: [
+              { Key: 'artifactDirectoryName/foo' },
+              { Key: 'artifactDirectoryName' }
+            ]
+          }
+        })
+        .returns(Promise.resolve(true));
+
+      // execute
+      plugin.provider.request = request;
+      const fn = deleteChangeSetFromS3.deleteChangeSetFromS3.bind(plugin);
+      return fn().then(response => {
+        expect(response).to.be.true;
+      })
+
+    });
+
+  });
+
+});

--- a/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.test.js
+++ b/lib/plugins/aws/plan/lib/deleteChangeSetFromS3.test.js
@@ -1,15 +1,13 @@
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
+const chai = require('chai');
 const sinon = require('sinon');
-const deleteChangeSetFromS3 = require('./deleteChangeSetFromS3')
+const deleteChangeSetFromS3 = require('./deleteChangeSetFromS3');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan deleteChangeSetFromS3', () => {
-
   describe('#deleteChangeSetFromS3', () => {
-
     let plugin;
 
     beforeEach(() => {
@@ -28,23 +26,20 @@ describe('AWSPlan deleteChangeSetFromS3', () => {
       const request = sinon.stub();
 
       // setup list request
-      request.withArgs('S3', 'listObjectsV2',
-        {
-          'Bucket': 'bucketName',
-          'Prefix': 'artifactDirectoryName'
+      request
+        .withArgs('S3', 'listObjectsV2', {
+          Bucket: 'bucketName',
+          Prefix: 'artifactDirectoryName',
         })
         .returns(Promise.resolve({ Contents: [{ Key: 'artifactDirectoryName/foo' }] }));
 
       // setup delete request
-      request.withArgs('S3', 'deleteObjects',
-        {
+      request
+        .withArgs('S3', 'deleteObjects', {
           Bucket: 'bucketName',
           Delete: {
-            Objects: [
-              { Key: 'artifactDirectoryName/foo' },
-              { Key: 'artifactDirectoryName' }
-            ]
-          }
+            Objects: [{ Key: 'artifactDirectoryName/foo' }, { Key: 'artifactDirectoryName' }],
+          },
         })
         .returns(Promise.resolve(true));
 
@@ -53,10 +48,7 @@ describe('AWSPlan deleteChangeSetFromS3', () => {
       const fn = deleteChangeSetFromS3.deleteChangeSetFromS3.bind(plugin);
       return fn().then(response => {
         expect(response).to.be.true;
-      })
-
+      });
     });
-
   });
-
 });

--- a/lib/plugins/aws/plan/lib/naming.js
+++ b/lib/plugins/aws/plan/lib/naming.js
@@ -1,0 +1,38 @@
+'use strict'
+
+function getStackName(plugin) {
+  return plugin.provider.naming.getStackName();
+}
+
+function getChangeSetName(plugin) {
+  return plugin.changeSetName;
+}
+
+function getS3BucketName(plugin) {
+  return plugin.bucketName;
+}
+
+function getChangeSetS3FolderPath(plugin) {
+  return plugin.serverless.service.package.artifactDirectoryName
+}
+
+function getChangeSetS3FolderUrl(plugin) {
+  const bucketName = getS3BucketName(plugin);
+  const s3Folder = getChangeSetS3FolderPath(plugin);
+  return `https://s3.amazonaws.com/${bucketName}/${s3Folder}`;
+}
+
+function getChangeSetS3CompiledTemplateUrl(plugin) {
+  const s3FolderUrl = getChangeSetS3FolderUrl(plugin)
+  const compiledTemplateFileName = plugin.provider.naming.getCompiledTemplateS3Suffix();
+  return `${s3FolderUrl}/${compiledTemplateFileName}`
+}
+
+module.exports = {
+  getStackName,
+  getChangeSetName,
+  getS3BucketName,
+  getChangeSetS3FolderPath,
+  getChangeSetS3FolderUrl,
+  getChangeSetS3CompiledTemplateUrl
+};

--- a/lib/plugins/aws/plan/lib/naming.js
+++ b/lib/plugins/aws/plan/lib/naming.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 function getStackName(plugin) {
   return plugin.provider.naming.getStackName();
@@ -13,7 +13,7 @@ function getS3BucketName(plugin) {
 }
 
 function getChangeSetS3FolderPath(plugin) {
-  return plugin.serverless.service.package.artifactDirectoryName
+  return plugin.serverless.service.package.artifactDirectoryName;
 }
 
 function getChangeSetS3FolderUrl(plugin) {
@@ -23,9 +23,9 @@ function getChangeSetS3FolderUrl(plugin) {
 }
 
 function getChangeSetS3CompiledTemplateUrl(plugin) {
-  const s3FolderUrl = getChangeSetS3FolderUrl(plugin)
+  const s3FolderUrl = getChangeSetS3FolderUrl(plugin);
   const compiledTemplateFileName = plugin.provider.naming.getCompiledTemplateS3Suffix();
-  return `${s3FolderUrl}/${compiledTemplateFileName}`
+  return `${s3FolderUrl}/${compiledTemplateFileName}`;
 }
 
 module.exports = {
@@ -34,5 +34,5 @@ module.exports = {
   getS3BucketName,
   getChangeSetS3FolderPath,
   getChangeSetS3FolderUrl,
-  getChangeSetS3CompiledTemplateUrl
+  getChangeSetS3CompiledTemplateUrl,
 };

--- a/lib/plugins/aws/plan/lib/naming.test.js
+++ b/lib/plugins/aws/plan/lib/naming.test.js
@@ -1,13 +1,12 @@
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
-const _ = require('lodash')
-const naming = require('./naming')
+const chai = require('chai');
+const _ = require('lodash');
+const naming = require('./naming');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan naming', () => {
-
   let plugin;
 
   beforeEach(() => {
@@ -18,45 +17,48 @@ describe('AWSPlan naming', () => {
     it('should return the stack name', () => {
       _.set(plugin, 'provider.naming.getStackName', () => 'stackName');
       expect(naming.getStackName(plugin)).to.equal('stackName');
-    })
-  })
+    });
+  });
 
   describe('#getChangeSetName', () => {
     it('should return the changeSetName', () => {
       plugin.changeSetName = 'changeSetName';
       expect(naming.getChangeSetName(plugin)).to.equal('changeSetName');
-    })
-  })
+    });
+  });
 
   describe('#getS3BucketName', () => {
     it('should return the S3BucketName', () => {
       plugin.bucketName = 'bucketName';
       expect(naming.getS3BucketName(plugin)).to.equal('bucketName');
-    })
+    });
   });
 
   describe('#getChangeSetS3FolderPath', () => {
     it('should return the ChangeSetS3FolderPath', () => {
       _.set(plugin, 'serverless.service.package.artifactDirectoryName', 'foo');
       expect(naming.getChangeSetS3FolderPath(plugin)).to.equal('foo');
-    })
+    });
   });
 
   describe('#getChangeSetS3FolderUrl', () => {
     it('should return the ChangeSetS3FolderUrl', () => {
       plugin.bucketName = 'bucketName';
       _.set(plugin, 'serverless.service.package.artifactDirectoryName', 'foo');
-      expect(naming.getChangeSetS3FolderUrl(plugin)).to.equal('https://s3.amazonaws.com/bucketName/foo');
-    })
-  });  
+      expect(naming.getChangeSetS3FolderUrl(plugin)).to.equal(
+        'https://s3.amazonaws.com/bucketName/foo'
+      );
+    });
+  });
 
   describe('#getChangeSetS3CompiledTemplateUrl', () => {
     it('should return the ChangeSetS3CompiledTemplateUrl', () => {
       plugin.bucketName = 'bucketName';
       _.set(plugin, 'serverless.service.package.artifactDirectoryName', 'foo');
       _.set(plugin, 'provider.naming.getCompiledTemplateS3Suffix', () => 'suffix');
-      expect(naming.getChangeSetS3CompiledTemplateUrl(plugin)).to.equal('https://s3.amazonaws.com/bucketName/foo/suffix');
-    })
-  }); 
-
-})
+      expect(naming.getChangeSetS3CompiledTemplateUrl(plugin)).to.equal(
+        'https://s3.amazonaws.com/bucketName/foo/suffix'
+      );
+    });
+  });
+});

--- a/lib/plugins/aws/plan/lib/naming.test.js
+++ b/lib/plugins/aws/plan/lib/naming.test.js
@@ -1,0 +1,62 @@
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const _ = require('lodash')
+const naming = require('./naming')
+
+const expect = chai.expect
+
+describe('AWSPlan naming', () => {
+
+  let plugin;
+
+  beforeEach(() => {
+    plugin = {};
+  });
+
+  describe('#getStackName', () => {
+    it('should return the stack name', () => {
+      _.set(plugin, 'provider.naming.getStackName', () => 'stackName');
+      expect(naming.getStackName(plugin)).to.equal('stackName');
+    })
+  })
+
+  describe('#getChangeSetName', () => {
+    it('should return the changeSetName', () => {
+      plugin.changeSetName = 'changeSetName';
+      expect(naming.getChangeSetName(plugin)).to.equal('changeSetName');
+    })
+  })
+
+  describe('#getS3BucketName', () => {
+    it('should return the S3BucketName', () => {
+      plugin.bucketName = 'bucketName';
+      expect(naming.getS3BucketName(plugin)).to.equal('bucketName');
+    })
+  });
+
+  describe('#getChangeSetS3FolderPath', () => {
+    it('should return the ChangeSetS3FolderPath', () => {
+      _.set(plugin, 'serverless.service.package.artifactDirectoryName', 'foo');
+      expect(naming.getChangeSetS3FolderPath(plugin)).to.equal('foo');
+    })
+  });
+
+  describe('#getChangeSetS3FolderUrl', () => {
+    it('should return the ChangeSetS3FolderUrl', () => {
+      plugin.bucketName = 'bucketName';
+      _.set(plugin, 'serverless.service.package.artifactDirectoryName', 'foo');
+      expect(naming.getChangeSetS3FolderUrl(plugin)).to.equal('https://s3.amazonaws.com/bucketName/foo');
+    })
+  });  
+
+  describe('#getChangeSetS3CompiledTemplateUrl', () => {
+    it('should return the ChangeSetS3CompiledTemplateUrl', () => {
+      plugin.bucketName = 'bucketName';
+      _.set(plugin, 'serverless.service.package.artifactDirectoryName', 'foo');
+      _.set(plugin, 'provider.naming.getCompiledTemplateS3Suffix', () => 'suffix');
+      expect(naming.getChangeSetS3CompiledTemplateUrl(plugin)).to.equal('https://s3.amazonaws.com/bucketName/foo/suffix');
+    })
+  }); 
+
+})

--- a/lib/plugins/aws/plan/lib/printAnalysis.js
+++ b/lib/plugins/aws/plan/lib/printAnalysis.js
@@ -6,5 +6,5 @@ function printAnalysis() {
 }
 
 module.exports = {
-  printAnalysis
+  printAnalysis,
 };

--- a/lib/plugins/aws/plan/lib/printAnalysis.js
+++ b/lib/plugins/aws/plan/lib/printAnalysis.js
@@ -1,0 +1,10 @@
+'use strict';
+function printAnalysis() {
+  if (this.analysis) {
+    this.serverless.cli.log(this.analysis);
+  }
+}
+
+module.exports = {
+  printAnalysis
+};

--- a/lib/plugins/aws/plan/lib/printAnalysis.test.js
+++ b/lib/plugins/aws/plan/lib/printAnalysis.test.js
@@ -1,0 +1,28 @@
+'use strict'
+/* eslint-env mocha */
+const _ = require('lodash')
+const sinon = require('sinon')
+const printAnalysis = require('./printAnalysis')
+
+describe('AWSPlan printAnalysis', () => {
+
+  let plugin;
+
+  beforeEach(() => {
+    plugin = {};
+  });
+
+  describe('#printAnalysis', () => {
+
+    it('should print te message', () => {
+      const log = sinon.spy();
+      _.set(plugin, 'analysis', 'foo');
+      _.set(plugin, 'serverless.cli.log', log);
+      printAnalysis.printAnalysis.bind(plugin)();
+      sinon.assert.calledOnce(log);
+      sinon.assert.calledWith(log, 'foo');
+    })
+
+  })
+
+})

--- a/lib/plugins/aws/plan/lib/printAnalysis.test.js
+++ b/lib/plugins/aws/plan/lib/printAnalysis.test.js
@@ -1,11 +1,10 @@
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const _ = require('lodash')
-const sinon = require('sinon')
-const printAnalysis = require('./printAnalysis')
+const _ = require('lodash');
+const sinon = require('sinon');
+const printAnalysis = require('./printAnalysis');
 
 describe('AWSPlan printAnalysis', () => {
-
   let plugin;
 
   beforeEach(() => {
@@ -13,7 +12,6 @@ describe('AWSPlan printAnalysis', () => {
   });
 
   describe('#printAnalysis', () => {
-
     it('should print te message', () => {
       const log = sinon.spy();
       _.set(plugin, 'analysis', 'foo');
@@ -21,8 +19,6 @@ describe('AWSPlan printAnalysis', () => {
       printAnalysis.printAnalysis.bind(plugin)();
       sinon.assert.calledOnce(log);
       sinon.assert.calledWith(log, 'foo');
-    })
-
-  })
-
-})
+    });
+  });
+});

--- a/lib/plugins/aws/plan/lib/runAnalysis.js
+++ b/lib/plugins/aws/plan/lib/runAnalysis.js
@@ -1,0 +1,45 @@
+'use strict'
+const BbPromise = require('bluebird');
+const printer = require('./analysisPrinter');
+const naming = require('./naming')
+
+function describeStack(provider, stackName, region) {
+  return provider.request(
+    'CloudFormation',
+    'describeStacks',
+    { StackName: stackName },
+    { region }
+  );
+}
+
+function describeChangeSet(provider, stackName, changeSetName, region) {
+  return provider
+    .request(
+      'CloudFormation',
+      'describeChangeSet',
+      { StackName: stackName, ChangeSetName: changeSetName },
+      { region }
+    );
+}
+
+function runAnalysis() {
+  const region = this.provider.getRegion();
+  const stackName = naming.getStackName(this);
+  const changeSetName = naming.getChangeSetName(this);
+  this.analysis = '';
+  const logger = {
+    log: (msg) => {
+      this.analysis += `${msg}\n`
+    }
+  };
+  return BbPromise.join(
+    describeStack(this.provider, stackName, region),
+    describeChangeSet(this.provider, stackName, changeSetName, region)
+  ).then(([stacks, changeSet]) =>
+    printer.print(logger, stacks.Stacks[0], changeSet)
+  );
+}
+
+module.exports = {
+  runAnalysis
+};

--- a/lib/plugins/aws/plan/lib/runAnalysis.js
+++ b/lib/plugins/aws/plan/lib/runAnalysis.js
@@ -1,25 +1,19 @@
-'use strict'
+'use strict';
 const BbPromise = require('bluebird');
 const printer = require('./analysisPrinter');
-const naming = require('./naming')
+const naming = require('./naming');
 
 function describeStack(provider, stackName, region) {
-  return provider.request(
-    'CloudFormation',
-    'describeStacks',
-    { StackName: stackName },
-    { region }
-  );
+  return provider.request('CloudFormation', 'describeStacks', { StackName: stackName }, { region });
 }
 
 function describeChangeSet(provider, stackName, changeSetName, region) {
-  return provider
-    .request(
-      'CloudFormation',
-      'describeChangeSet',
-      { StackName: stackName, ChangeSetName: changeSetName },
-      { region }
-    );
+  return provider.request(
+    'CloudFormation',
+    'describeChangeSet',
+    { StackName: stackName, ChangeSetName: changeSetName },
+    { region }
+  );
 }
 
 function runAnalysis() {
@@ -28,18 +22,16 @@ function runAnalysis() {
   const changeSetName = naming.getChangeSetName(this);
   this.analysis = '';
   const logger = {
-    log: (msg) => {
-      this.analysis += `${msg}\n`
-    }
+    log: msg => {
+      this.analysis += `${msg}\n`;
+    },
   };
   return BbPromise.join(
     describeStack(this.provider, stackName, region),
     describeChangeSet(this.provider, stackName, changeSetName, region)
-  ).then(([stacks, changeSet]) =>
-    printer.print(logger, stacks.Stacks[0], changeSet)
-  );
+  ).then(([stacks, changeSet]) => printer.print(logger, stacks.Stacks[0], changeSet));
 }
 
 module.exports = {
-  runAnalysis
+  runAnalysis,
 };

--- a/lib/plugins/aws/plan/lib/runAnalysis.test.js
+++ b/lib/plugins/aws/plan/lib/runAnalysis.test.js
@@ -1,0 +1,52 @@
+'use strict'
+/* eslint-env mocha */
+const chai = require('chai')
+const _ = require('lodash')
+const sinon = require('sinon')
+const runAnalysis = require('./runAnalysis')
+
+const expect = chai.expect
+
+describe('AWSPlan runAnalysis', () => {
+
+  let plugin;
+
+  beforeEach(() => {
+    plugin = {};
+  });
+
+  describe('#runAnalysis', () => {
+
+    it('should run the changeSetAnalysis', () => {
+      _.set(plugin, 'provider.getRegion', () => 'us-east-1');
+      _.set(plugin, 'provider.naming.getStackName', () => 'stackName');
+      _.set(plugin, 'changeSetName', 'changeSetName');
+      const request = sinon.stub();
+      _.set(plugin, 'provider.request', request);
+      request.withArgs(
+        'CloudFormation',
+        'describeStacks',
+        { StackName: 'stackName' },
+        { region: 'us-east-1' })
+        .returns(Promise.resolve({ Stacks: [{ 'Parameters': [], 'Tags': [] }] }));
+      request.withArgs(
+        'CloudFormation',
+        'describeChangeSet',
+        { StackName: 'stackName', ChangeSetName: 'changeSetName' },
+        { region: 'us-east-1' })
+        .returns(Promise.resolve({
+          'StackName': 'aws-sls-dev',
+          'Parameters': [],
+          'Tags': [],
+          'Changes': []
+        }));
+      return runAnalysis.runAnalysis.bind(plugin)()
+        .then(() => {
+          expect(plugin.analysis).to.have.string('Resource Changes');
+          sinon.assert.calledTwice(request)
+        });
+    })
+
+  })
+
+})

--- a/lib/plugins/aws/plan/lib/runAnalysis.test.js
+++ b/lib/plugins/aws/plan/lib/runAnalysis.test.js
@@ -1,14 +1,13 @@
-'use strict'
+'use strict';
 /* eslint-env mocha */
-const chai = require('chai')
-const _ = require('lodash')
-const sinon = require('sinon')
-const runAnalysis = require('./runAnalysis')
+const chai = require('chai');
+const _ = require('lodash');
+const sinon = require('sinon');
+const runAnalysis = require('./runAnalysis');
 
-const expect = chai.expect
+const expect = chai.expect;
 
 describe('AWSPlan runAnalysis', () => {
-
   let plugin;
 
   beforeEach(() => {
@@ -16,37 +15,41 @@ describe('AWSPlan runAnalysis', () => {
   });
 
   describe('#runAnalysis', () => {
-
     it('should run the changeSetAnalysis', () => {
       _.set(plugin, 'provider.getRegion', () => 'us-east-1');
       _.set(plugin, 'provider.naming.getStackName', () => 'stackName');
       _.set(plugin, 'changeSetName', 'changeSetName');
       const request = sinon.stub();
       _.set(plugin, 'provider.request', request);
-      request.withArgs(
-        'CloudFormation',
-        'describeStacks',
-        { StackName: 'stackName' },
-        { region: 'us-east-1' })
-        .returns(Promise.resolve({ Stacks: [{ 'Parameters': [], 'Tags': [] }] }));
-      request.withArgs(
-        'CloudFormation',
-        'describeChangeSet',
-        { StackName: 'stackName', ChangeSetName: 'changeSetName' },
-        { region: 'us-east-1' })
-        .returns(Promise.resolve({
-          'StackName': 'aws-sls-dev',
-          'Parameters': [],
-          'Tags': [],
-          'Changes': []
-        }));
-      return runAnalysis.runAnalysis.bind(plugin)()
+      request
+        .withArgs(
+          'CloudFormation',
+          'describeStacks',
+          { StackName: 'stackName' },
+          { region: 'us-east-1' }
+        )
+        .returns(Promise.resolve({ Stacks: [{ Parameters: [], Tags: [] }] }));
+      request
+        .withArgs(
+          'CloudFormation',
+          'describeChangeSet',
+          { StackName: 'stackName', ChangeSetName: 'changeSetName' },
+          { region: 'us-east-1' }
+        )
+        .returns(
+          Promise.resolve({
+            StackName: 'aws-sls-dev',
+            Parameters: [],
+            Tags: [],
+            Changes: [],
+          })
+        );
+      return runAnalysis.runAnalysis
+        .bind(plugin)()
         .then(() => {
           expect(plugin.analysis).to.have.string('Resource Changes');
-          sinon.assert.calledTwice(request)
+          sinon.assert.calledTwice(request);
         });
-    })
-
-  })
-
-})
+    });
+  });
+});

--- a/lib/plugins/aws/plan/lib/waitForChangeSetCreateComplete.js
+++ b/lib/plugins/aws/plan/lib/waitForChangeSetCreateComplete.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const naming = require('./naming');
+
+function waitForChangeSetCreateComplete() {
+    const credentials = Object.assign({}, this.provider.getCredentials());
+    credentials.region = this.provider.getRegion();
+    const cf = new AWS.CloudFormation(credentials);
+    return cf.waitFor('changeSetCreateComplete',{
+        StackName: naming.getStackName(this),
+        ChangeSetName: naming.getChangeSetName(this)
+    }).promise();
+}
+
+module.exports = {
+    waitForChangeSetCreateComplete
+}

--- a/lib/plugins/aws/plan/lib/waitForChangeSetCreateComplete.js
+++ b/lib/plugins/aws/plan/lib/waitForChangeSetCreateComplete.js
@@ -4,15 +4,17 @@ const AWS = require('aws-sdk');
 const naming = require('./naming');
 
 function waitForChangeSetCreateComplete() {
-    const credentials = Object.assign({}, this.provider.getCredentials());
-    credentials.region = this.provider.getRegion();
-    const cf = new AWS.CloudFormation(credentials);
-    return cf.waitFor('changeSetCreateComplete',{
-        StackName: naming.getStackName(this),
-        ChangeSetName: naming.getChangeSetName(this)
-    }).promise();
+  const credentials = Object.assign({}, this.provider.getCredentials());
+  credentials.region = this.provider.getRegion();
+  const cf = new AWS.CloudFormation(credentials);
+  return cf
+    .waitFor('changeSetCreateComplete', {
+      StackName: naming.getStackName(this),
+      ChangeSetName: naming.getChangeSetName(this),
+    })
+    .promise();
 }
 
 module.exports = {
-    waitForChangeSetCreateComplete
-}
+  waitForChangeSetCreateComplete,
+};

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -27,6 +27,7 @@ module.exports = [
   require('./aws/deploy/index.js'),
   require('./aws/invoke/index.js'),
   require('./aws/info/index.js'),
+  require('./aws/plan/index.js'),
   require('./aws/logs/index.js'),
   require('./aws/metrics/awsMetrics.js'),
   require('./aws/remove/index.js'),


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
Add serverless plan command to AWS provider

- create a new AWS provider-specific command called plan
- when plan is called then do the following
    - spawn serverless deploy preventing the execution of the stack update
    - create a changeset from the stack update
    - print the changeset details to the console
    - destroy the changeset and its corresponding files

<!-- Briefly describe the scope of your PR -->

Closes #7449

## How can we verify it

Run `sls plan` in any sls project.

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

```
provider:
  name: aws
  runtime: nodejs10.x

functions:
  helloWorld:
    handler: src/helloWorld.handler
    events:
      - http:
          path: hello-world
          method: get
          cors: true

```

## Todos


<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->
- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files
</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
