### PR TITLE
Respect external IAM role at lambda destinations

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -575,8 +575,13 @@ class AwsCompileFunctions {
     };
     const destinationConfig = resource.Properties.DestinationConfig;
 
+    const hasAccessPoliciesHandledExternally = Boolean(
+      functionObject.role || this.serverless.service.provider.role
+    );
     if (destinations.onSuccess) {
-      this.ensureTargetExecutionPermission(destinations.onSuccess);
+      if (!hasAccessPoliciesHandledExternally) {
+        this.ensureTargetExecutionPermission(destinations.onSuccess);
+      }
       destinationConfig.OnSuccess = {
         Destination: destinations.onSuccess.startsWith('arn:')
           ? destinations.onSuccess
@@ -584,7 +589,9 @@ class AwsCompileFunctions {
       };
     }
     if (destinations.onFailure) {
-      this.ensureTargetExecutionPermission(destinations.onFailure);
+      if (!hasAccessPoliciesHandledExternally) {
+        this.ensureTargetExecutionPermission(destinations.onFailure);
+      }
       destinationConfig.OnFailure = {
         Destination: destinations.onFailure.startsWith('arn:')
           ? destinations.onFailure

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2622,9 +2622,9 @@ describe('AwsCompileFunctions', () => {
 });
 
 describe('AwsCompileFunctions #2', () => {
-  describe('Destinations', () => {
-    after(fixtures.cleanup);
+  after(fixtures.cleanup);
 
+  describe('Destinations', () => {
     it('Should reference function from same service as destination', () =>
       runServerless({
         cwd: fixtures.map.functionDestinations,

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2691,5 +2691,29 @@ describe('AwsCompileFunctions #2', () => {
           })
         );
     });
+
+    it('Should respect `role` setting', () =>
+      fixtures
+        .extend('functionDestinations', { provider: { role: ' arn:aws:iam::XXXXXX:role/role' } })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(serverless => {
+            const cfResources =
+              serverless.service.provider.compiledCloudFormationTemplate.Resources;
+            const naming = serverless.getProvider('aws').naming;
+            const destinationConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties
+                .DestinationConfig;
+
+            expect(destinationConfig).to.deep.equal({
+              OnSuccess: {
+                Destination: { 'Fn::GetAtt': [naming.getLambdaLogicalId('target'), 'Arn'] },
+              },
+            });
+            expect(destinationConfig).to.not.have.property('OnFailure');
+          })
+        ));
   });
 });


### PR DESCRIPTION
Locally created role was uncoditionally assumed when configuring lambda destinations.
This patch fixes that.

Fixes #7448 