### PR TITLE
Clarify HTTP API Gateway desc with comparison link

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -14,7 +14,7 @@ layout: Doc
 
 # HTTP API
 
-HTTP APIs are a special flavored [API Gateway](https://aws.amazon.com/api-gateway/) implementation which offer more features and improved performance.
+HTTP APIs are a special flavored [API Gateway](https://aws.amazon.com/api-gateway/) implementation which offer lower latency and cost. To compare with REST APIs (which currently have more features) see [API Gateway Comparison Matrix](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html).
 
 The Serverless Framework makes it possible to setup [API Gateway](https://aws.amazon.com/api-gateway/) HTTP APIs via the `httpApi` event.
 


### PR DESCRIPTION
## What did you implement

Update HTTP API Gateway Docs to clarify HTTP APIs are faster and cheaper but currently have fewer features with link to AWS Comparison Matrix.

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
