### PR TITLE
[AWS] Upload only updated artifacts to quicken deployment

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -84,6 +84,7 @@ module.exports = {
 
     return requestOldFileHash.then(oldHash => {
       if (oldHash === fileHash) {
+        this.serverless.cli.log(`Skipped uploading ${artifactFilePath}.`);
         return Promise.resolve();
       }
       return this.provider.request('S3', 'upload', params);

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -68,9 +68,9 @@ module.exports = {
       })
       .then(result => {
         this.serverless.cli.log(`Fetching metadata succeeded ${JSON.stringify(result)}`);
-        return result.Metadata.filesha256 || ''
+        return result.Metadata.filesha256 || '';
       })
-      .catch((err) => {
+      .catch(err => {
         this.serverless.cli.log(`Failed to get old hash ${err}.`);
         return '';
       });

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -59,6 +59,14 @@ module.exports = {
       .update(data)
       .digest('base64');
 
+    const requestOldFileHash = this.provider
+      .request('S3', 'headObject', {
+        Bucket: this.bucketName,
+        Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
+      })
+      .then(result => result.Metadata.filesha256 || '')
+      .catch(() => '');
+
     let params = {
       Bucket: this.bucketName,
       Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
@@ -74,7 +82,12 @@ module.exports = {
       params = setServersideEncryptionOptions(params, deploymentBucketObject);
     }
 
-    return this.provider.request('S3', 'upload', params);
+    return requestOldFileHash.then(oldHash => {
+      if (oldHash === fileHash) {
+        return Promise.resolve();
+      }
+      return this.provider.request('S3', 'upload', params);
+    });
   },
 
   uploadFunctionsAndLayers() {

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -83,6 +83,7 @@ module.exports = {
     }
 
     return requestOldFileHash.then(oldHash => {
+      this.serverless.cli.log(`Comparing old hash ${oldHash} and current hash ${fileHash}.`);
       if (oldHash === fileHash) {
         this.serverless.cli.log(`Skipped uploading ${artifactFilePath}.`);
         return Promise.resolve();

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -59,10 +59,12 @@ module.exports = {
       .update(data)
       .digest('base64');
 
+    // This object has timestamp-less prefix
+    const hashStoreFileKey = `${this.serverless.service.package.artifactParentDirectoryName}/${fileName}.hash`;
     const requestOldFileHash = this.provider
       .request('S3', 'headObject', {
         Bucket: this.bucketName,
-        Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
+        Key: `${hashStoreFileKey}`,
       })
       .then(result => {
         this.serverless.cli.log(`Fetching metadata succeeded ${JSON.stringify(result)}`);
@@ -94,7 +96,17 @@ module.exports = {
         this.serverless.cli.log(`Skipped uploading ${artifactFilePath}.`);
         return Promise.resolve();
       }
-      return this.provider.request('S3', 'upload', params);
+      return this.provider.request('S3', 'upload', params).then(() => {
+        return this.provider.request('S3', 'putObject', {
+          Bucket: this.bucketName,
+          Key: hashStoreFileKey,
+          ContentType: 'text/txt',
+          Body: '',
+          Metadata: {
+            filesha256: fileHash,
+          },
+        });
+      });
     });
   },
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -64,8 +64,14 @@ module.exports = {
         Bucket: this.bucketName,
         Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
       })
-      .then(result => result.Metadata.filesha256 || '')
-      .catch(() => '');
+      .then(result => {
+        this.serverless.cli.log(`Fetching metadata succeeded ${JSON.stringify(result)}`);
+        return result.Metadata.filesha256 || ''
+      })
+      .catch((err) => {
+        this.serverless.cli.log(`Failed to get old hash ${err}.`);
+        return '';
+      });
 
     let params = {
       Bucket: this.bucketName,

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -166,19 +166,25 @@ describe('uploadArtifacts', () => {
       expect(() => awsDeploy.uploadZipFile(null)).to.throw(Error);
     });
 
-    it('should upload the .zip file to the S3 bucket', () => {
+    it('should upload the .zip file to the S3 bucket if hash is not identical', () => {
       cryptoStub
         .createHash()
         .update()
         .digest.onCall(0)
         .returns('local-hash-zip-file');
 
+      uploadStub.onCall(0).resolves({
+        Metadata: {
+          filesha256: '42',
+        },
+      });
+
       const tmpDirPath = getTmpDirPath();
       const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(uploadStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledTwice;
         expect(readFileSyncStub).to.have.been.calledOnce;
         expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
           Bucket: awsDeploy.bucketName,
@@ -189,6 +195,30 @@ describe('uploadArtifacts', () => {
             filesha256: 'local-hash-zip-file',
           },
         });
+        expect(readFileSyncStub).to.have.been.calledWithExactly(artifactFilePath);
+      });
+    });
+
+    it('should not upload the .zip file to the S3 bucket when hash is identical', () => {
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(0)
+        .returns('local-hash-zip-file');
+
+      uploadStub.onCall(0).resolves({
+        Metadata: {
+          filesha256: 'local-hash-zip-file',
+        },
+      });
+
+      const tmpDirPath = getTmpDirPath();
+      const artifactFilePath = path.join(tmpDirPath, 'artifact.zip');
+      serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
+
+      return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
+        expect(uploadStub).to.have.been.calledOnce;
+        expect(readFileSyncStub).to.have.been.calledOnce;
         expect(readFileSyncStub).to.have.been.calledWithExactly(artifactFilePath);
       });
     });
@@ -208,7 +238,7 @@ describe('uploadArtifacts', () => {
       };
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(uploadStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledTwice;
         expect(readFileSyncStub).to.have.been.calledOnce;
         expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
           Bucket: awsDeploy.bucketName,
@@ -372,7 +402,7 @@ describe('uploadArtifacts', () => {
         .returns('local-hash-zip-file');
 
       return expect(awsDeploy.uploadCustomResources()).to.eventually.be.fulfilled.then(() => {
-        expect(uploadStub).to.have.been.calledOnce;
+        expect(uploadStub).to.have.been.calledTwice;
         expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
           Bucket: awsDeploy.bucketName,
           Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/custom-resources.zip`,

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -184,7 +184,7 @@ describe('uploadArtifacts', () => {
       serverless.utils.writeFileSync(artifactFilePath, 'artifact.zip file content');
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(uploadStub).to.have.been.calledTwice;
+        expect(uploadStub).to.have.been.calledThrice;
         expect(readFileSyncStub).to.have.been.calledOnce;
         expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
           Bucket: awsDeploy.bucketName,
@@ -238,7 +238,7 @@ describe('uploadArtifacts', () => {
       };
 
       return awsDeploy.uploadZipFile(artifactFilePath).then(() => {
-        expect(uploadStub).to.have.been.calledTwice;
+        expect(uploadStub).to.have.been.calledThrice;
         expect(readFileSyncStub).to.have.been.calledOnce;
         expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
           Bucket: awsDeploy.bucketName,
@@ -402,7 +402,7 @@ describe('uploadArtifacts', () => {
         .returns('local-hash-zip-file');
 
       return expect(awsDeploy.uploadCustomResources()).to.eventually.be.fulfilled.then(() => {
-        expect(uploadStub).to.have.been.calledTwice;
+        expect(uploadStub).to.have.been.calledThrice;
         expect(uploadStub).to.have.been.calledWithExactly('S3', 'upload', {
           Bucket: awsDeploy.bucketName,
           Key: `${awsDeploy.serverless.service.package.artifactDirectoryName}/custom-resources.zip`,

--- a/lib/plugins/aws/package/lib/generateArtifactDirectoryName.js
+++ b/lib/plugins/aws/package/lib/generateArtifactDirectoryName.js
@@ -11,6 +11,7 @@ module.exports = {
       const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
       const prefix = this.provider.getDeploymentPrefix();
       this.serverless.service.package.artifactDirectoryName = `${prefix}/${serviceStage}/${dateString}`;
+      this.serverless.service.package.artifactParentDirectoryName = `${prefix}/${serviceStage}`;
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -81,7 +81,6 @@ class AwsRollback {
         }
 
         service.package.artifactDirectoryName = `${prefix}/${dateString}`;
-        service.package.artifactParentDirectoryName = `${prefix}`;
         return BbPromise.resolve();
       });
   }

--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -81,6 +81,7 @@ class AwsRollback {
         }
 
         service.package.artifactDirectoryName = `${prefix}/${dateString}`;
+        service.package.artifactParentDirectoryName = `${prefix}`;
         return BbPromise.resolve();
       });
   }


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Upload only the updated (hash changed) artifacts.
This would reduce deployment time when some of function artifacts and/or layers artifacts are not modified.

Closes #7516

## How can we verify it

**WIP**
<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
