### PR TITLE
Support China mirror for standalone downloads

### DIFF
--- a/lib/plugins/executable/index.js
+++ b/lib/plugins/executable/index.js
@@ -7,6 +7,7 @@ const streamPromise = require('stream-promise');
 const fse = BbPromise.promisifyAll(require('fs-extra'));
 const isStandaloneExecutable =
   require('../../utils/isStandaloneExecutable') && process.platform !== 'win32';
+const isInChina = require('../../utils/isInChina');
 const currentVersion = require('../../../package').version;
 const fetch = require('node-fetch');
 
@@ -78,10 +79,11 @@ module.exports = class Executable {
           }
         })();
         this.serverless.cli.log('Downloading new version...');
-        return fetch(
-          `https://github.com/serverless/serverless/releases/download/${tagName}/` +
-            `serverless-${platform}-${arch}`
-        )
+        const executableUrl = isInChina
+          ? `https://binary.serverlesscloud.cn/${tagName}/serverless-${platform}-${arch}`
+          : `https://github.com/serverless/serverless/releases/download/${tagName}/` +
+            `serverless-${platform}-${arch}`;
+        return fetch(executableUrl)
           .then(response => {
             if (!response.ok) {
               throw new this.serverless.classes.Error(

--- a/lib/utils/isInChina.js
+++ b/lib/utils/isInChina.js
@@ -1,0 +1,10 @@
+'use strict';
+
+if (process.env.SLS_GEO_LOCATION === 'cn') {
+  module.exports = true;
+  return;
+}
+
+module.exports = new Intl.DateTimeFormat('en', { timeZoneName: 'long' })
+  .format()
+  .includes('China Standard Time');

--- a/lib/utils/isInChina.test.js
+++ b/lib/utils/isInChina.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { expect } = require('chai');
+const requireUncached = require('ncjsm/require-uncached');
+
+describe('isInChina', () => {
+  it('should return boolean', () => {
+    expect(typeof require('./isInChina')).to.equal('boolean');
+  });
+
+  it('should support SLS_GEO_LOCATION', () => {
+    process.env.SLS_GEO_LOCATION = 'cn';
+    expect(requireUncached(require.resolve('./isInChina'), () => require('./isInChina'))).to.equal(
+      true
+    );
+  });
+});

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -38,7 +38,17 @@ BINARIES_DIR_PATH=$HOME/.serverless/bin
 BINARY_PATH=$BINARIES_DIR_PATH/serverless
 mkdir -p $BINARIES_DIR_PATH
 printf "$yellow Downloading binary...$reset\n"
-curl -L -o $BINARY_PATH https://github.com/serverless/serverless/releases/download/$LATEST_TAG/serverless-$PLATFORM-$ARCH
+
+TIMEZONE_OFFSET=`date +"%Z %z"`
+if [[ $TIMEZONE_OFFSET == "CST +0800" ]]
+then
+	# In China download from location in China (Github API download is slow and times out)
+	BINARY_URL=https://binary.serverlesscloud.cn/$LATEST_TAG/serverless-$PLATFORM-$ARCH
+else
+	BINARY_URL=https://github.com/serverless/serverless/releases/download/$LATEST_TAG/serverless-$PLATFORM-$ARCH
+fi
+
+curl -L -o $BINARY_PATH $BINARY_URL
 chmod +x $BINARY_PATH
 
 # Ensure aliases


### PR DESCRIPTION
Fix https://github.com/serverless/serverless/issues/7332

Downloads from GitHub API appear slow in China. We were provided with a mirror at which binaries of new releases will be uploaded.

Mirror is used whenever we detect that user is most likely in China (by investigating system timezone or locale setting)