### PR TITLE
SQS 'Enabled' should be of type 'Boolean'

### DIFF
--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -27,7 +27,7 @@ class AwsCompileSQSEvents {
           if (event.sqs) {
             let EventSourceArn;
             let BatchSize = 10;
-            let Enabled = 'True';
+            let Enabled = true;
 
             // TODO validate arn syntax
             if (typeof event.sqs === 'object') {
@@ -62,7 +62,7 @@ class AwsCompileSQSEvents {
               EventSourceArn = event.sqs.arn;
               BatchSize = event.sqs.batchSize || BatchSize;
               if (typeof event.sqs.enabled !== 'undefined') {
-                Enabled = event.sqs.enabled ? 'True' : 'False';
+                Enabled = event.sqs.enabled;
               }
             } else if (typeof event.sqs === 'string') {
               EventSourceArn = event.sqs;
@@ -134,7 +134,7 @@ class AwsCompileSQSEvents {
                       "Arn"
                     ]
                   },
-                  "Enabled": "${Enabled}"
+                  "Enabled": ${Enabled}
                 }
               }
             `;

--- a/lib/plugins/aws/package/compile/events/sqs/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.test.js
@@ -349,7 +349,7 @@ describe('AwsCompileSQSEvents', () => {
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.Properties.Enabled
-        ).to.equal('False');
+        ).to.equal(false);
 
         // event 2
         expect(
@@ -368,10 +368,11 @@ describe('AwsCompileSQSEvents', () => {
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMySecondQueue.Properties.BatchSize
         ).to.equal(10);
+
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMySecondQueue.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
 
         // event 3
         expect(
@@ -393,7 +394,7 @@ describe('AwsCompileSQSEvents', () => {
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyThirdQueue.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
       });
 
       it('should allow specifying SQS Queues as CFN reference types', () => {


### PR DESCRIPTION
## What did you implement

The `Enabled` property on the `SQS` resource was typed as a `string` but should be a `boolean`

Closes #7438

## How can we verify it

Input `serverless.yml`
```
service: issue-7438

provider:
  name: aws
  runtime: nodejs12.x

functions:
  hello:
    handler: handler.hello
    events:
      - sqs:
          enabled: true
          arn:
            Fn::GetAtt:
              - notifyAppSyncAboutActivitySQSQueue
              - Arn
```

Run `> sls package`

Output `cloudformation-template-update-stack.json`
```
"HelloEventSourceMappingSQSNotifyAppSyncAboutActivitySQSQueue": {
  "Type": "AWS::Lambda::EventSourceMapping",
  "DependsOn": "IamRoleLambdaExecution",
  "Properties": {
    "BatchSize": 10,
    "EventSourceArn": {
      "Fn::GetAtt": [
        "notifyAppSyncAboutActivitySQSQueue",
        "Arn"
      ]
    },
    "FunctionName": {
      "Fn::GetAtt": [
        "HelloLambdaFunction",
        "Arn"
      ]
    },
    "Enabled": true
  }
}
```

Enabled is now being set to a boolean

Before the change `cloudformation-template-update-stack.json`

```
"HelloEventSourceMappingSQSNotifyAppSyncAboutActivitySQSQueue": {
  "Type": "AWS::Lambda::EventSourceMapping",
  "DependsOn": "IamRoleLambdaExecution",
  "Properties": {
    "BatchSize": 10,
    "EventSourceArn": {
      "Fn::GetAtt": [
        "notifyAppSyncAboutActivitySQSQueue",
        "Arn"
      ]
    },
    "FunctionName": {
      "Fn::GetAtt": [
        "HelloLambdaFunction",
        "Arn"
      ]
    },
    "Enabled": "True"
  }
}
```

Enabled was being set to a string

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [ ] Write documentation 
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** POTENTIALLY

I'm unsure how CloudFormation would have handled this property being set to a string.

For example did CloudFormation treat `"Enabled": 'True'` as `true` or `false`
