### PR TITLE
Add support for Ruby 2.7

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -215,7 +215,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (runtime === 'ruby2.5') {
+    if (_.includes(['ruby2.5', 'ruby2.7'], runtime)) {
       const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents[0];
       const handlerName = handlerComponents.slice(1).join('.');

--- a/lib/plugins/create/templates/aws-ruby/serverless.yml
+++ b/lib/plugins/create/templates/aws-ruby/serverless.yml
@@ -22,7 +22,7 @@ service: aws-ruby # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: ruby2.5
+  runtime: ruby2.7
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
Updated serverless.yml template for aws-ruby to use ruby2.7.

https://aws.amazon.com/about-aws/whats-new/2020/02/aws-lambda-supports-ruby-2-7/

Closes #7527

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
