### PR TITLE
chore: Fix broken link in docs and add clarifying information

### DIFF
--- a/docs/dashboard/monitoring/README.md
+++ b/docs/dashboard/monitoring/README.md
@@ -144,7 +144,7 @@ libraries are instrumented to capture HTTP & HTTPS requests.
 By default, requests to AWS are not captured because of the above AWS SDK instrumentation which
 provides more insight into the request.
 
-[Configuration docs](../sdk/README.md#configuring-http-spans)
+[Configuration docs](../sdk/#advanced-span-configuration)
 
 ## Custom function spans
 

--- a/docs/dashboard/sdk/README.md
+++ b/docs/dashboard/sdk/README.md
@@ -23,9 +23,13 @@ Dashboard without causing your lambda to error and custom function spans.
 
 [Python Documentation](../sdk/python.md)
 
-## Configuring HTTP spans
+## Advanced Span Configuration
 
-You can configure the HTTP spans with the following environment variables
+For most of the SDK configuration, like turning on/off span collection, follow the
+[Monitoring Configuration](../monitoring/#configuration) instructions to modify your
+serverless.yml appropriately.
+
+If needed, you can configure HTTP span collection with the following environment variables
 
 - `SERVERLESS_ENTERPRISE_SPANS_CAPTURE_HOSTS` - `*` by default. Set to a comma delimited list of
   host names to capture.


### PR DESCRIPTION
## What did you implement

Fix / update documents around enterprise-plugin configuration and usage

## How can we verify it

View the documents, make sure the updated link on https://serverless.com/framework/docs/dashboard/monitoring/#http-spans correctly pulls up the SDK page with the `advanced-span-configuration` anchor

## Todos

- [X] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
