### PR TITLE
Support non-function exports when including variables from js files

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -428,16 +428,13 @@ functions:
 
 You can reference JavaScript files to add dynamic data into your variables.
 
-References can be either named or unnamed exports. To use the exported `someModule` in `myFile.js` you'd use the following code `${file(./myFile.js):someModule}`. For an unnamed export you'd write `${file(./myFile.js)}`. The first argument to your export will be a reference to the Serverless object, containing your configuration.
+References can be either named or unnamed exports. To use the exported `someModule` in `myFile.js` you'd use the following code `${file(./myFile.js):someModule}`. For an unnamed export you'd write `${file(./myFile.js)}`. If you export a function, the first argument will be a reference to the Serverless object, containing your configuration.
 
-Here are other examples:
+Here are some examples:
 
 ```js
 // scheduleConfig.js
-module.exports.rate = () => {
-  // Code that generates dynamic data
-  return 'rate (10 minutes)';
-};
+module.exports.rate = 'rate(10 minutes)';
 ```
 
 ```js

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -12,6 +12,9 @@ const PromiseTracker = require('./PromiseTracker');
 
 const resolvedValuesWeak = new WeakSet();
 
+// Used when resolving variables from a JS file
+const unsupportedJsTypes = new Set(['undefined', 'symbol', 'function']);
+
 /**
  * Maintainer's notes:
  *
@@ -704,7 +707,7 @@ class Variables {
         deepProperties.splice(0, 1);
         return this.getDeeperValue(deepProperties, valueToPopulateResolved).then(
           deepValueToPopulateResolved => {
-            if (['undefined', 'symbol', 'function'].includes(typeof deepValueToPopulateResolved)) {
+            if (unsupportedJsTypes.has(typeof deepValueToPopulateResolved)) {
               const errorMessage = [
                 'Invalid variable syntax when referencing',
                 ` file "${referencedFileRelativePath}".`,

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -704,7 +704,7 @@ class Variables {
         deepProperties.splice(0, 1);
         return this.getDeeperValue(deepProperties, valueToPopulateResolved).then(
           deepValueToPopulateResolved => {
-            if (typeof deepValueToPopulateResolved === 'undefined') {
+            if (['undefined', 'symbol', 'function'].includes(typeof deepValueToPopulateResolved)) {
               const errorMessage = [
                 'Invalid variable syntax when referencing',
                 ` file "${referencedFileRelativePath}".`,

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -683,24 +683,20 @@ class Variables {
       // eslint-disable-next-line global-require, import/no-dynamic-require
       const jsFile = require(referencedFileFullPath);
       const variableArray = variableString.split(':');
-      let returnValueFunction;
+      let returnValue;
       if (variableArray[1]) {
         let jsModule = variableArray[1];
         jsModule = jsModule.split('.')[0];
-        returnValueFunction = jsFile[jsModule];
+        returnValue = jsFile[jsModule];
       } else {
-        returnValueFunction = jsFile;
+        returnValue = jsFile;
       }
 
-      if (typeof returnValueFunction !== 'function') {
-        const errorMessage = [
-          'Invalid variable syntax when referencing',
-          ` file "${referencedFileRelativePath}".`,
-          ' Check if your javascript is exporting a function that returns a value.',
-        ].join('');
-        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
+      if (typeof returnValue === 'function') {
+        valueToPopulate = returnValue.call(jsFile, this.serverless);
+      } else {
+        valueToPopulate = returnValue;
       }
-      valueToPopulate = returnValueFunction.call(jsFile, this.serverless);
 
       return BbPromise.resolve(valueToPopulate).then(valueToPopulateResolved => {
         let deepProperties = variableString.replace(matchedFileRefString, '');

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1870,7 +1870,7 @@ module.exports = {
         .should.become(configYml.test2.sub);
     });
 
-    it('should populate from a javascript file', () => {
+    it('should populate from a javascript file that exports a function', () => {
       const SUtils = new Utils();
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports.hello=function(){return "hello world";};';
@@ -1881,7 +1881,18 @@ module.exports = {
         .should.become('hello world');
     });
 
-    it('should populate an entire variable exported by a javascript file', () => {
+    it('should populate from a javascript file that exports an object', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = getTmpDirPath();
+      const jsData = 'module.exports.hello="hello world";';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+      serverless.config.update({ servicePath: tmpDirPath });
+      return serverless.variables
+        .getValueFromFile('file(./hello.js):hello')
+        .should.become('hello world');
+    });
+
+    it('should populate an entire variable exported by a javascript file function', () => {
       const SUtils = new Utils();
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports=function(){return { hello: "hello world" };};';
@@ -1892,7 +1903,7 @@ module.exports = {
         .should.become({ hello: 'hello world' });
     });
 
-    it('should throw if property exported by a javascript file is not a function', () => {
+    it('should populate an entire variable exported by a javascript file object', () => {
       const SUtils = new Utils();
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports={ hello: "hello world" };';
@@ -1900,7 +1911,7 @@ module.exports = {
       serverless.config.update({ servicePath: tmpDirPath });
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
-        .should.be.rejectedWith(serverless.classes.Error);
+        .should.become({ hello: 'hello world' });
     });
 
     it('should populate deep object from a javascript file', () => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1881,7 +1881,7 @@ module.exports = {
         .should.become('hello world');
     });
 
-    it('should populate from a javascript file that exports an object', () => {
+    it('should populate from a javascript file that exports a string', () => {
       const SUtils = new Utils();
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports.hello="hello world";';
@@ -1912,6 +1912,17 @@ module.exports = {
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
         .should.become({ hello: 'hello world' });
+    });
+
+    it('should populate an entire variable exported by a javascript file literal', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = getTmpDirPath();
+      const jsData = 'module.exports="hello world";';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+      serverless.config.update({ servicePath: tmpDirPath });
+      return serverless.variables
+        .getValueFromFile('file(./hello.js)')
+        .should.become('hello world');
     });
 
     it('should populate deep object from a javascript file', () => {
@@ -1957,6 +1968,39 @@ module.exports = {
       serverless.config.update({ servicePath: tmpDirPath });
       return serverless.variables
         .getValueFromFile('file(./config.yml).testObj.sub')
+        .should.be.rejectedWith(serverless.classes.Error);
+    });
+
+    it('should throw an error if resolved value is undefined', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = getTmpDirPath();
+      const jsData = 'module.exports=undefined;';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+      serverless.config.update({ servicePath: tmpDirPath });
+      return serverless.variables
+        .getValueFromFile('file(./hello.js)')
+        .should.be.rejectedWith(serverless.classes.Error);
+    });
+
+    it('should throw an error if resolved value is a symbol', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = getTmpDirPath();
+      const jsData = 'module.exports=Symbol()';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+      serverless.config.update({ servicePath: tmpDirPath });
+      return serverless.variables
+        .getValueFromFile('file(./hello.js)')
+        .should.be.rejectedWith(serverless.classes.Error);
+    });
+
+    it('should throw an error if resolved value is a function', () => {
+      const SUtils = new Utils();
+      const tmpDirPath = getTmpDirPath();
+      const jsData = 'module.exports=function(){ return function(){}; };';
+      SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
+      serverless.config.update({ servicePath: tmpDirPath });
+      return serverless.variables
+        .getValueFromFile('file(./hello.js)')
         .should.be.rejectedWith(serverless.classes.Error);
     });
   });

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1920,9 +1920,7 @@ module.exports = {
       const jsData = 'module.exports="hello world";';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
       serverless.config.update({ servicePath: tmpDirPath });
-      return serverless.variables
-        .getValueFromFile('file(./hello.js)')
-        .should.become('hello world');
+      return serverless.variables.getValueFromFile('file(./hello.js)').should.become('hello world');
     });
 
     it('should populate deep object from a javascript file', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Currently, when you import a `.js` file in your configuration, serverless only supports functions.  This change also allows referencing non-function exports from a `.js` file.

Closes #7443 

## How can we verify it

`config.js`
```
module.exports = {
  foo: 'bar',
  doesWork: true
}
```

`serverless.yml`
```
service: test
provider:
  name: 'test'
custom:
  from-js: ${file(./config.js)}
```

Command:
```
sls print
```

Expected output:
```
service: test
provider:
  name: test
custom:
  from-js:
    foo: bar
    doesWork: true
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
