### PR TITLE
AWS HTTP API: improve timeout warning messages

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -398,8 +398,8 @@ Object.defineProperties(
             logWarning(
               `HTTP API endpoint timeout setting (${routeTargetData.timeout}s) is ` +
                 `lower or equal to function (${functionName}) timeout (${functionTimeout}s). ` +
-                'This may introduce situations where endpoint times out ' +
-                'for succesful lambda invocation.'
+                'This may introduce a situation where endpoint times out ' +
+                'for a succesful lambda invocation.'
             );
           }
         } else {
@@ -407,8 +407,8 @@ Object.defineProperties(
             logWarning(
               `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
                 'maximum allowed timeout for HTTP API endpoint (29s). ' +
-                'This may introduce situation where endpoint times out ' +
-                'for succesful lambda invocation.'
+                'This may introduce a situation where endpoint times out ' +
+                'for a succesful lambda invocation.'
             );
           } else if (functionTimeout === 29) {
             logWarning(

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -403,12 +403,19 @@ Object.defineProperties(
             );
           }
         } else {
-          if (functionTimeout >= 29) {
+          if (functionTimeout > 29) {
             logWarning(
               `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
                 'maximum allowed timeout for HTTP API endpoint (29s). ' +
                 'This may introduce situation where endpoint times out ' +
                 'for succesful lambda invocation.'
+            );
+          } else if (functionTimeout === 29) {
+            logWarning(
+              `Function (${functionName}) timeout setting (${functionTimeout}) may not provide ` +
+                'enough room to process an HTTP API request (of which timeout is limited to 29s). ' +
+                'This may introduce a situation where endpoint times out ' +
+                'for a succesful lambda invocation.'
             );
           }
           // Ensure endpoint has slightly larger timeout than a function,


### PR DESCRIPTION
Fixes #7496 

An error message for case where function has 29s timeout is confusing. This patch improves that