### PR TITLE
Use the correct glob pattern to zip all needed files

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -246,7 +246,7 @@ module.exports = {
     // NOTE: please keep this order of concatenating the include params
     // rather than doing it the other way round!
     // see https://github.com/serverless/serverless/pull/5825 for more information
-    return globby(['**'].concat(params.include), {
+    return globby(['**/*'].concat(params.include), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,
       silent: true,

--- a/lib/plugins/package/lib/packageService.test.js
+++ b/lib/plugins/package/lib/packageService.test.js
@@ -622,7 +622,7 @@ describe('#packageService()', () => {
 
     it('should exclude all and include function/handler.js', () => {
       const params = {
-        exclude: ['**'],
+        exclude: ['**/*'],
         include: [handlerFile],
       };
       serverless.config.servicePath = servicePath;
@@ -634,7 +634,7 @@ describe('#packageService()', () => {
 
     it('should include file specified with `!` in exclude params', () => {
       const params = {
-        exclude: ['**', `!${utilsFile}`],
+        exclude: ['**/*', `!${utilsFile}`],
         include: [handlerFile],
       };
       serverless.config.servicePath = servicePath;

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -235,7 +235,7 @@ function excludeNodeDevDependencies(servicePath) {
                     const packageJson = JSON.parse(packageJsonFile);
                     const bin = packageJson.bin;
 
-                    const baseGlobs = [path.join(item, '**')];
+                    const baseGlobs = [path.join(item, '**/*')];
 
                     // NOTE: pkg.bin can be object, string, or undefined
                     if (typeof bin === 'object') {

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -338,10 +338,10 @@ describe('zipService', () => {
             expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              path.join('node_modules', 'module-1', '**'),
-              path.join('node_modules', 'module-2', '**'),
-              path.join('1st', '2nd', 'node_modules', 'module-1', '**'),
-              path.join('1st', '2nd', 'node_modules', 'module-2', '**'),
+              path.join('node_modules', 'module-1', '**/*'),
+              path.join('node_modules', 'module-2', '**/*'),
+              path.join('1st', '2nd', 'node_modules', 'module-1', '**/*'),
+              path.join('1st', '2nd', 'node_modules', 'module-2', '**/*'),
             ]);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -391,8 +391,8 @@ describe('zipService', () => {
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              path.join('node_modules', 'module-1', '**'),
-              path.join('node_modules', 'module-2', '**'),
+              path.join('node_modules', 'module-1', '**/*'),
+              path.join('node_modules', 'module-2', '**/*'),
             ]);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -470,12 +470,12 @@ describe('zipService', () => {
             expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              path.join('node_modules', 'module-1', '**'),
-              path.join('node_modules', 'module-2', '**'),
-              path.join('1st', 'node_modules', 'module-1', '**'),
-              path.join('1st', 'node_modules', 'module-2', '**'),
-              path.join('1st', '2nd', 'node_modules', 'module-1', '**'),
-              path.join('1st', '2nd', 'node_modules', 'module-2', '**'),
+              path.join('node_modules', 'module-1', '**/*'),
+              path.join('node_modules', 'module-2', '**/*'),
+              path.join('1st', 'node_modules', 'module-1', '**/*'),
+              path.join('1st', 'node_modules', 'module-2', '**/*'),
+              path.join('1st', '2nd', 'node_modules', 'module-1', '**/*'),
+              path.join('1st', '2nd', 'node_modules', 'module-2', '**/*'),
             ]);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -524,7 +524,7 @@ describe('zipService', () => {
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              path.join('node_modules', 'module-1', '**'),
+              path.join('node_modules', 'module-1', '**/*'),
             ]);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -582,11 +582,11 @@ describe('zipService', () => {
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              path.join('node_modules', 'bro-module', '**'),
+              path.join('node_modules', 'bro-module', '**/*'),
               path.join('node_modules', '.bin', 'bro-module'),
-              path.join('node_modules', 'lumo-clj', '**'),
+              path.join('node_modules', 'lumo-clj', '**/*'),
               path.join('node_modules', '.bin', 'lumo'),
-              path.join('node_modules', 'meowmix', '**'),
+              path.join('node_modules', 'meowmix', '**/*'),
               path.join('node_modules', '.bin', 'meow'),
               path.join('node_modules', '.bin', 'mix'),
             ]);
@@ -658,17 +658,17 @@ describe('zipService', () => {
 
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
-              path.join('node_modules', 'module-1', '**'),
+              path.join('node_modules', 'module-1', '**/*'),
               path.join('node_modules', '.bin', 'cool-module'),
-              path.join('node_modules', 'module-2', '**'),
+              path.join('node_modules', 'module-2', '**/*'),
               path.join('node_modules', '.bin/module-2'),
-              path.join('1st', 'node_modules', 'module-1', '**'),
+              path.join('1st', 'node_modules', 'module-1', '**/*'),
               path.join('1st', 'node_modules', '.bin', 'cool-module'),
-              path.join('1st', 'node_modules', 'module-2', '**'),
+              path.join('1st', 'node_modules', 'module-2', '**/*'),
               path.join('1st', 'node_modules', '.bin', 'module-2'),
-              path.join('1st', '2nd', 'node_modules', 'module-1', '**'),
+              path.join('1st', '2nd', 'node_modules', 'module-1', '**/*'),
               path.join('1st', '2nd', 'node_modules', '.bin', 'cool-module'),
-              path.join('1st', '2nd', 'node_modules', 'module-2', '**'),
+              path.join('1st', '2nd', 'node_modules', 'module-2', '**/*'),
               path.join('1st', '2nd', 'node_modules', '.bin', 'module-2'),
             ]);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

This is the [updated version of this PR](https://github.com/serverless-components/aws-lambda/pull/26), to work with the new GA components.

The glob `'**'` would not match files such as `[...file].js`. This is critical for the NextJS component to utilize a catch-all API route, and breaks all deployments that try to use them.

Included files before PR:

```
.file.js
[file].js
file.js
```

Included files after PR:

```
.file.js
[...file].js
[file].js
file.js
```

## How can we verify it

Any `serverless.yml` file should work, as long as one of the files in the target project is named something like `[...file].js`.

## TODO

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
