### PR TITLE
fix(AWS Events): I don't know why you did this, but that's not how booleans work

### DIFF
--- a/docs/providers/kubeless/guide/deploying.md
+++ b/docs/providers/kubeless/guide/deploying.md
@@ -95,7 +95,7 @@ provider:
       endpoint: http://minio.local
       bucket: workbench
       region: eu-central-1
-      s3ForcePathStyle: True
+      s3ForcePathStyle: true
 ```
 
 ## Deploy Function

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -97,7 +97,7 @@ class AwsCompileStreamEvents {
             let BatchSize = 10;
             let ParallelizationFactor;
             let StartingPosition = 'TRIM_HORIZON';
-            let Enabled = 'True';
+            let Enabled = true;
 
             // TODO validate arn syntax
             if (typeof event.stream === 'object') {
@@ -147,7 +147,7 @@ class AwsCompileStreamEvents {
               }
               StartingPosition = event.stream.startingPosition || StartingPosition;
               if (typeof event.stream.enabled !== 'undefined') {
-                Enabled = event.stream.enabled ? 'True' : 'False';
+                Enabled = event.stream.enabled;
               }
             } else if (typeof event.stream === 'string') {
               EventSourceArn = event.stream;

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -444,7 +444,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.Enabled
-        ).to.equal('False');
+        ).to.equal(false);
 
         // event 2
         expect(
@@ -470,7 +470,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.MaximumBatchingWindowInSeconds
@@ -504,7 +504,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.BisectBatchOnFunctionError
@@ -534,7 +534,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.BisectBatchOnFunctionError
@@ -564,7 +564,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFizz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFizz.Properties.DestinationConfig.OnFailure
@@ -1325,7 +1325,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.Enabled
-        ).to.equal('False');
+        ).to.equal(false);
 
         // event 2
         expect(
@@ -1355,7 +1355,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.MaximumBatchingWindowInSeconds
@@ -1389,7 +1389,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.BisectBatchOnFunctionError
@@ -1423,7 +1423,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBuzz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBuzz.Properties.BisectBatchOnFunctionError
@@ -1453,7 +1453,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFizz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFizz.Properties.DestinationConfig.OnFailure
@@ -1487,7 +1487,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisAbc.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
 
         // event 7
         expect(
@@ -1513,7 +1513,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisXyz.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
 
         // event 8
         expect(
@@ -1539,7 +1539,7 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.Enabled
-        ).to.equal('True');
+        ).to.equal(true);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.BisectBatchOnFunctionError


### PR DESCRIPTION
## What did you implement

This changes the generated CloudFormation for AWS events to actually use the boolean values true and false, instead of the strings 'True' and 'False'. Right now, these trigger a warning from AWS' cfn-lint tool saying that boolean values are expected.

## How can we verify it

The tests have been altered to test for the correct values as well.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] <del>Write documentation</del> (N/A)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO