### PR TITLE
Fix error message when s3 bucket is configured with invalid propery name

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -180,7 +180,9 @@ class AwsCompileS3Events {
               const errorMessage = [
                 `"${key}" is not a valid bucket property.`,
                 'A bucket could only be configured with the following properties:\n',
-                ['name'].concat(this.allowedBucketProperties.map(p => _.lowerFirst(p))).join(', '),
+                ['name']
+                  .concat(Object.keys(this.allowedBucketProperties).map(p => _.lowerFirst(p)))
+                  .join(', '),
               ].join('');
               throw new this.serverless.classes.Error(errorMessage);
             }

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -103,6 +103,28 @@ describe('AwsCompileS3Events', () => {
       expect(() => awsCompileS3Events.newS3Buckets()).to.throw(Error);
     });
 
+    it('should throw an error on unknown bucket properties', () => {
+      awsCompileS3Events.serverless.service.provider.s3 = {
+        bucketone: {
+          unknownKey: [1, 2, 3],
+        },
+      };
+
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              s3: {
+                bucket: 'bucketone',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileS3Events.newS3Buckets()).to.throw(serverless.classes.Error);
+    });
+
     it('should create corresponding resources when S3 events are given', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {


### PR DESCRIPTION
##  What did you implement
When you input an incorrect s3 bucket property you expect a nice error message, instead you get the following error: this.allowedBucketProperties.map is not a function

After the fix the correct error is shown again
${key}" is not a valid bucket property. ....

## How can we verify it

Create a bucket with a typo in one of the top level properties

 provider:
  s3:
    bulkJobBucket:
      name: some-bucket-name
      bucketEncryption1:
        ServerSideEncryptionConfiguration:
          - ServerSideEncryptionByDefault:
              SSEAlgorithm: "AES256"

Will end up with the following error message
this.allowedBucketProperties.map is not a function

- [x] Write and run all tests
- [x] ~Write documentation (N/A)~
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
