### PR TITLE
CosmosDB documentation: Show how to set http out

### DIFF
--- a/docs/providers/azure/events/cosmosdb.md
+++ b/docs/providers/azure/events/cosmosdb.md
@@ -39,6 +39,10 @@ functions:
           methods:
             - POST
           authLevel: anonymous
+      - http: true
+        x-azure-settings:
+          direction: out
+          name: res
       - cosmosDB:
         x-azure-settings:
           direction: out
@@ -86,5 +90,10 @@ module.exports.write = async function(context, req) {
   context.bindings.record = output;
 
   context.log('Finish writing to CosmosDB');
+  
+  context.res = {
+    status: 201,
+    body: 'Created'
+  };
 };
 ```

--- a/docs/providers/azure/events/cosmosdb.md
+++ b/docs/providers/azure/events/cosmosdb.md
@@ -68,11 +68,11 @@ functions:
 ```javascript
 // src/handlers/cosmos.js
 
-'use strict';
-const uuidv4 = require('uuid/v4');
+"use strict";
+const uuidv4 = require("uuid/v4");
 
 module.exports.write = async function(context, req) {
-  context.log('JavaScript HTTP trigger function processed a request.');
+  context.log("JavaScript HTTP trigger function processed a request.");
 
   const input = req.body;
 
@@ -84,16 +84,16 @@ module.exports.write = async function(context, req) {
     name: input.name,
     employeeId: input.employeeId,
     address: input.address,
-    timestamp: timestamp,
+    timestamp: timestamp
   });
 
   context.bindings.record = output;
 
-  context.log('Finish writing to CosmosDB');
-  
+  context.log("Finish writing to CosmosDB");
+
   context.res = {
     status: 201,
-    body: 'Created'
+    body: "Created"
   };
 };
 ```


### PR DESCRIPTION
If you follow the example, requests to http endpoints always returns "204 No Content", independently of the status you set in "context.res". This is because the function.json generated doesn't has the output binding:

   {
      "type": "http",
      "direction": "out",
      "name": "res"
    }

This only happens if you combine http and cosmosDB events. Only with http and without cosmosDB, it works fine (only setting the first event without the http out event). Maybe is a bug, because with cosmosdb event, http event works in a different way than without.

It is necessary to set the http out event explicitly to work. This way you can return 201, 400, or whatever you need (and with the resulting json in the body if you want).

This occurs with other endpoints like GET too.

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Event and code added to the example

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

Create a function with the example code

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
