### PR TITLE
Pass allowCredentials directive to method and integration response (#7575)

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -285,6 +285,8 @@ Please note that since you can't send multiple values for [Access-Control-Allow-
 
 Configuring the `cors` property sets [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin), [Access-Control-Allow-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers), [Access-Control-Allow-Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods),[Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) headers in the CORS preflight response.
 
+If you use the lambda integration, the Access-Control-Allow-Origin and Access-Control-Allow-Credentials will also be provided to the method and integration responses.
+
 Please note that the [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)-Header is omitted when not explicitly set to `true`.
 
 To enable the `Access-Control-Max-Age` preflight response header, set the `maxAge` property in the `cors` object:

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1063,6 +1063,62 @@ describe('#compileMethods()', () => {
     });
   });
 
+  it('should set CORS allowCredentials to method only when specified', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          integration: 'AWS',
+          cors: {
+            origin: 'http://example.com',
+            allowCredentials: true,
+          },
+          response: {
+            statusCodes: {
+              200: {
+                pattern: '',
+              },
+            },
+          },
+        },
+      },
+      {
+        functionName: 'Second',
+        http: {
+          method: 'get',
+          path: 'users/list',
+          integration: 'AWS',
+          cors: {
+            origin: 'http://example.com',
+          },
+          response: {
+            statusCodes: {
+              200: {
+                pattern: '',
+              },
+            },
+          },
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
+      ).to.equal('true');
+
+      // allowCredentials not enabled
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[0]
+          .ResponseParameters['method.response.header.Access-Control-Allow-Credentials']
+      ).to.not.equal('true');
+    });
+  });
+
   describe('when dealing with request configuration', () => {
     it('should setup a default "application/json" template', () => {
       awsCompileApigEvents.validated.events = [

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -129,8 +129,9 @@ module.exports = {
       const integrationResponseHeaders = [];
 
       if (http.cors) {
-        // TODO remove once "origins" config is deprecated
         let origin = http.cors.origin;
+
+        // TODO remove once "origins" config is deprecated
         if (http.cors.origins && http.cors.origins.length) {
           origin = http.cors.origins.join(',');
         }
@@ -138,6 +139,11 @@ module.exports = {
         _.merge(integrationResponseHeaders, {
           'Access-Control-Allow-Origin': `'${origin}'`,
         });
+
+        // Only set Access-Control-Allow-Credentials when explicitly allowed (omit if false)
+        if (http.cors.allowCredentials) {
+          integrationResponseHeaders['Access-Control-Allow-Credentials'] = 'true';
+        }
       }
 
       if (http.response.headers) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/responses.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/responses.js
@@ -11,8 +11,9 @@ module.exports = {
         const methodResponseHeaders = [];
 
         if (http.cors) {
-          // TODO remove once "origins" config is deprecated
           let origin = http.cors.origin;
+
+          // TODO remove once "origins" config is deprecated
           if (http.cors.origins && http.cors.origins.length) {
             origin = http.cors.origins.join(',');
           }
@@ -20,6 +21,11 @@ module.exports = {
           _.merge(methodResponseHeaders, {
             'Access-Control-Allow-Origin': `'${origin}'`,
           });
+
+          // Only set Access-Control-Allow-Credentials when explicitly allowed (omit if false)
+          if (http.cors.allowCredentials) {
+            methodResponseHeaders['Access-Control-Allow-Credentials'] = 'true';
+          }
         }
 
         if (http.response.headers) {


### PR DESCRIPTION
## What did you implement

Closes #7575 

Pass down `allowCredentials` directive to method and integration responses: Enable browsers to read the request subsequent to the OPTIONS request without having to additionally specify the `Access-Control-Allow-Credentials` header.

## How can we verify it

```
functions:
  test:
    handler: functions/test.main
    events:
      - http:
          method: get
          path: api/test
          integration: lambda
          cors:
            origin: http://localhost:3000/
            allowCredentials: true
```

The `Access-Control-Allow-Credentials` header should be configured in the method and integration responses.

<img width="939" alt="api gateway" src="https://user-images.githubusercontent.com/38014240/79146290-73e90580-7dc2-11ea-839d-c6ccdc8a101f.png">

Inside a browser, the same header should be present in the responses, not only to the preflight request but also to the subsequent request.

<img width="459" alt="browser response" src="https://user-images.githubusercontent.com/38014240/79146407-ab57b200-7dc2-11ea-983b-979312e85b52.png">

## Todos

<details>
<summary>Useful Scripts</summary>

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
