### PR TITLE
fix: support ssh format download template url

### DIFF
--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -52,7 +52,7 @@ function validateUrl({ url, hostname, service, owner, repo }) {
  * @param {String} url
  */
 function isPlainGitURL(url) {
-  return url.startsWith('https') && url.endsWith('.git');
+  return (url.startsWith('https') || url.startsWith('git@')) && url.endsWith('.git');
 }
 
 /**
@@ -220,7 +220,7 @@ function parseRepoURL(inputUrl) {
     const url = URL.parse(inputUrl.replace(/\/$/, ''));
 
     // check if url parameter is a valid url
-    if (!url.host) {
+    if (!url.host && !url.href.startsWith('git@')) {
       return reject(new ServerlessError('The URL you passed is not valid'));
     }
 

--- a/lib/utils/downloadTemplateFromRepo.test.js
+++ b/lib/utils/downloadTemplateFromRepo.test.js
@@ -126,6 +126,42 @@ describe('downloadTemplateFromRepo', () => {
       });
     });
 
+    it('should download the service based on a regular .git URL start with git@', () => {
+      const url = 'git@example.com/sample-service.git';
+
+      return expect(downloadTemplateFromRepo(url)).to.be.fulfilled.then(() => {
+        expect(spawnStub.calledOnce).to.equal(true);
+        expect(downloadStub.calledOnce).to.equal(false);
+        expect(spawnStub.args[0][0]).to.equal('git');
+        expect(spawnStub.args[0][1][0]).to.equal('clone');
+        expect(spawnStub.args[0][1][1]).to.equal(url);
+      });
+    });
+
+    it('should download and rename the service based on a regular .git URL start with git@', () => {
+      const url = 'git@example.com/sample-service.git';
+      const name = 'new-service-name';
+
+      spawnStub.resolves({
+        then: callback => {
+          const slsYml = path.join(process.cwd(), 'new-service-name', 'serverless.yml');
+          writeFileSync(slsYml, 'service: sample-service');
+          callback();
+        },
+      });
+
+      return expect(downloadTemplateFromRepo(url, name)).to.be.fulfilled.then(serviceName => {
+        expect(spawnStub.calledOnce).to.equal(true);
+        expect(downloadStub.calledOnce).to.equal(false);
+        expect(spawnStub.args[0][0]).to.equal('git');
+        expect(spawnStub.args[0][1][0]).to.equal('clone');
+        expect(spawnStub.args[0][1][1]).to.equal(url);
+        const yml = readFileSync(path.join(newServicePath, 'serverless.yml'));
+        expect(yml.service).to.equal(name);
+        expect(serviceName).to.equal('sample-service');
+      });
+    });
+
     it('should download the service based on the GitHub URL', () => {
       const url = 'https://github.com/johndoe/service-to-be-downloaded';
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

<!-- Briefly describe the scope of your PR -->

Support ssh format template url, like `git@example.com/sample-service.git`, actually, many company has their private gitlab, so I think supporting these format template urls is a must.

## How can we verify it

<!-- A copy-and-pasteable `serverless.yml` file with optional steps to verify the implementation -->

I have add unit test for it:

```js
it('should download the service based on a regular .git URL start with git@', () => {
  const url = 'git@example.com/sample-service.git';

  return expect(downloadTemplateFromRepo(url)).to.be.fulfilled.then(() => {
    expect(spawnStub.calledOnce).to.equal(true);
    expect(downloadStub.calledOnce).to.equal(false);
    expect(spawnStub.args[0][0]).to.equal('git');
    expect(spawnStub.args[0][1][0]).to.equal('clone');
    expect(spawnStub.args[0][1][1]).to.equal(url);
  });
});

it('should download and rename the service based on a regular .git URL start with git@', () => {
  const url = 'git@example.com/sample-service.git';
  const name = 'new-service-name';

  spawnStub.resolves({
    then: callback => {
      const slsYml = path.join(process.cwd(), 'new-service-name', 'serverless.yml');
      writeFileSync(slsYml, 'service: sample-service');
      callback();
    },
  });

  return expect(downloadTemplateFromRepo(url, name)).to.be.fulfilled.then(serviceName => {
    expect(spawnStub.calledOnce).to.equal(true);
    expect(downloadStub.calledOnce).to.equal(false);
    expect(spawnStub.args[0][0]).to.equal('git');
    expect(spawnStub.args[0][1][0]).to.equal('clone');
    expect(spawnStub.args[0][1][1]).to.equal(url);
    const yml = readFileSync(path.join(newServicePath, 'serverless.yml'));
    expect(yml.service).to.equal(name);
    expect(serviceName).to.equal('sample-service');
  });
});
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
