### PR TITLE
Tests:  Improve Websocket integration test

### DIFF
--- a/tests/integration-all/websocket/tests.js
+++ b/tests/integration-all/websocket/tests.js
@@ -68,15 +68,20 @@ describe('AWS - API Gateway Websocket Integration Test', function() {
           }
         })(reject);
 
-        ws.on('error', reject);
-        ws.on('open', () => {
+        let timeoutId;
+        const sendMessage = () => {
           log.debug("Sending message to 'hello' route");
           ws.send(JSON.stringify({ action: 'hello', name: 'serverless' }));
-        });
+          timeoutId = setTimeout(sendMessage, 1000);
+        };
+
+        ws.on('error', reject);
+        ws.on('open', sendMessage);
 
         ws.on('close', resolve);
 
         ws.on('message', event => {
+          clearTimeout(timeoutId);
           try {
             log.debug(`Received WebSocket message: ${event}`);
             expect(event).to.equal('Hello, serverless');


### PR DESCRIPTION
We observe occasional fails as follows: https://travis-ci.org/github/serverless/serverless/jobs/678119380

They most likely occur because message is not delivered (this technically can happen with Websockets). I updated the tests, to resend message if delivery is not confirmed in one second.


