### PR TITLE
AWS HTTP API: Fix default log format

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -237,7 +237,7 @@ Object.defineProperties(
         }
         this.config.accessLogFormat =
           userLogsConfig.format ||
-          `{${JSON.stringify({
+          `${JSON.stringify({
             requestId: '$context.requestId',
             ip: '$context.identity.sourceIp',
             requestTime: '$context.requestTime',
@@ -246,7 +246,7 @@ Object.defineProperties(
             status: '$context.status',
             protocol: '$context.protocol',
             responseLength: '$context.responseLength',
-          })}}`;
+          })}`;
       }
 
       if (userConfig.timeout) {


### PR DESCRIPTION
Fixes #7559

