### PR TITLE
Add operationId to support AWS API Gateway Method OperationName

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -531,7 +531,7 @@ functions:
 
 ### HTTP Endpoints with `operationId`
 
-Include `operationId` when you want to provide a name for the method endpoint.  This will set `OperationName` inside `AWS::ApiGateway::Method` accordingly.  One common use case for this is customizing method names in some code generators (e.g., swagger).
+Include `operationId` when you want to provide a name for the method endpoint. This will set `OperationName` inside `AWS::ApiGateway::Method` accordingly. One common use case for this is customizing method names in some code generators (e.g., swagger).
 
 ```yml
 functions:

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -22,6 +22,7 @@ layout: Doc
     - [Enabling CORS](#enabling-cors)
     - [HTTP Endpoints with `AWS_IAM` Authorizers](#http-endpoints-with-aws_iam-authorizers)
     - [HTTP Endpoints with Custom Authorizers](#http-endpoints-with-custom-authorizers)
+    - [HTTP Endpoints with `operationId`](#http-endpoints-with-operationId)
     - [Catching Exceptions In Your Lambda Function](#catching-exceptions-in-your-lambda-function)
     - [Setting API keys for your Rest API](#setting-api-keys-for-your-rest-api)
     - [Configuring endpoint types](#configuring-endpoint-types)
@@ -526,6 +527,21 @@ functions:
             claims:
               - email
               - nickname
+```
+
+### HTTP Endpoints with `operationId`
+
+Include `operationId` when you want to provide a name for the method endpoint.  This will set `OperationName` inside `AWS::ApiGateway::Method` accordingly.  One common use case for this is customizing method names in some code generators (e.g., swagger).
+
+```yml
+functions:
+  create:
+    handler: users.create
+    events:
+      - http:
+          path: users/create
+          method: post
+          operationId: createUser
 ```
 
 ### Using asynchronous integration

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -19,6 +19,7 @@ module.exports = {
           RequestParameters: requestParameters,
           ResourceId: resourceId,
           RestApiId: this.provider.getApiGatewayRestApiId(),
+          OperationName: event.http.operationId,
         },
       };
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1601,4 +1601,43 @@ describe('#compileMethods()', () => {
       });
     });
   });
+
+  it('should include operation id as OperationName when it is set', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          integration: 'AWS',
+          operationId: 'createUser',
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.OperationName
+      ).to.equal('createUser');
+    });
+  });
+
+  it('should not include operation id when it is not set', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          integration: 'AWS',
+        },
+      },
+    ];
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties
+      ).to.not.have.key('OperationName');
+    });
+  });
 });


### PR DESCRIPTION
## What did you implement 

Support `operationId` so it can be used in `Resources` of type `AWS::ApiGateway::Method`.  This enables lambda functions to have custom names associated with them, when exporting the api from API Gateway -- which can then be used in code generators (e.g., swagger).

Closes #7565 

## How can we verify it

```
functions:
  CreateUser:
    handler: functions/users.main
    events:
      - http:
          method: post
          path: users/create
          operationId: createUser
```

## Todos

<details>
<summary>Useful Scripts</summary>

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [X] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
