### PR TITLE
Adding in configurable MaximumRetryAttempts for SQS

### DIFF
--- a/docs/providers/aws/events/sqs.md
+++ b/docs/providers/aws/events/sqs.md
@@ -59,6 +59,29 @@ functions:
       - sqs:
           arn: arn:aws:sqs:region:XXXXXX:myQueue
           batchSize: 10
+          maximumRetryAttempts: 2
+```
+
+
+## Setting the MaximumRetryAttempts
+
+This configuration sets up the maximum number of times to retry when the function returns an error.
+
+**Note:** Serverless only sets this property if you explicitly add it to the sqs configuration (see example below).
+
+[Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumretryattempts)
+
+**Note:** The `sqs` event will hook up your existing sqs to a Lambda function. Serverless won't create a new sqs for you.
+
+```yml
+functions:
+  compute:
+    handler: handler.compute
+    events:
+      - sqs:
+          arn: arn:aws:sqs:region:XXXXXX:stream/foo
+          batchSize: 10
+          maximumRetryAttempts: 10
 ```
 
 ## IAM Permissions

--- a/docs/providers/aws/events/sqs.md
+++ b/docs/providers/aws/events/sqs.md
@@ -62,7 +62,6 @@ functions:
           maximumRetryAttempts: 2
 ```
 
-
 ## Setting the MaximumRetryAttempts
 
 This configuration sets up the maximum number of times to retry when the function returns an error.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -328,6 +328,7 @@ functions:
       - sqs:
           arn: arn:aws:sqs:region:XXXXXX:myQueue
           batchSize: 10
+          maximumRetryAttempts: 5
       - stream:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           batchSize: 100

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -146,7 +146,7 @@ class AwsCompileSQSEvents {
               [queueLogicalId]: JSON.parse(sqsTemplate),
             };
 
-            if (event.sqs.batchSize) {
+            if (event.sqs.maximumRetryAttempts) {
               newSQSObject[queueLogicalId].Properties.MaximumRetryAttempts =
                 event.sqs.maximumRetryAttempts;
             }

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -147,13 +147,8 @@ class AwsCompileSQSEvents {
             };
 
             if (event.sqs.batchSize) {
-              _.merge(newSQSObject, {
-                [queueLogicalId]: {
-                  Properties: {
-                    MaximumRetryAttempts: event.sqs.maximumRetryAttempts,
-                  },
-                },
-              });
+              newSQSObject[queueLogicalId].Properties.MaximumRetryAttempts =
+                event.sqs.maximumRetryAttempts;
             }
 
             _.merge(

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -62,7 +62,7 @@ class AwsCompileSQSEvents {
               }
               EventSourceArn = event.sqs.arn;
               BatchSize = event.sqs.batchSize || BatchSize;
-              MaximumRetryAttempts = evex.sqs.maximumRetryAttempts || MaximumRetryAttempts;
+              MaximumRetryAttempts = event.sqs.maximumRetryAttempts || MaximumRetryAttempts;
               if (typeof event.sqs.enabled !== 'undefined') {
                 Enabled = event.sqs.enabled;
               }

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -28,7 +28,6 @@ class AwsCompileSQSEvents {
             let EventSourceArn;
             let BatchSize = 10;
             let Enabled = true;
-            let MaximumRetryAttempts = 2;
 
             // TODO validate arn syntax
             if (typeof event.sqs === 'object') {
@@ -62,7 +61,6 @@ class AwsCompileSQSEvents {
               }
               EventSourceArn = event.sqs.arn;
               BatchSize = event.sqs.batchSize || BatchSize;
-              MaximumRetryAttempts = event.sqs.maximumRetryAttempts || MaximumRetryAttempts;
               if (typeof event.sqs.enabled !== 'undefined') {
                 Enabled = event.sqs.enabled;
               }
@@ -130,7 +128,6 @@ class AwsCompileSQSEvents {
                 "Properties": {
                   "BatchSize": ${BatchSize},
                   "EventSourceArn": ${JSON.stringify(EventSourceArn)},
-                  "MaximumRetryAttempts": ${MaximumRetryAttempts},
                   "FunctionName": {
                     "Fn::GetAtt": [
                       "${lambdaLogicalId}",
@@ -148,6 +145,16 @@ class AwsCompileSQSEvents {
             const newSQSObject = {
               [queueLogicalId]: JSON.parse(sqsTemplate),
             };
+
+            if (event.sqs.batchSize) {
+              _.merge(newSQSObject, {
+                [queueLogicalId]: {
+                  Properties: {
+                    MaximumRetryAttempts: event.sqs.maximumRetryAttempts,
+                  },
+                },
+              });
+            }
 
             _.merge(
               this.serverless.service.provider.compiledCloudFormationTemplate.Resources,

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -28,6 +28,7 @@ class AwsCompileSQSEvents {
             let EventSourceArn;
             let BatchSize = 10;
             let Enabled = true;
+            let MaximumRetryAttempts = 2;
 
             // TODO validate arn syntax
             if (typeof event.sqs === 'object') {
@@ -61,6 +62,7 @@ class AwsCompileSQSEvents {
               }
               EventSourceArn = event.sqs.arn;
               BatchSize = event.sqs.batchSize || BatchSize;
+              MaximumRetryAttempts = evex.sqs.maximumRetryAttempts || MaximumRetryAttempts;
               if (typeof event.sqs.enabled !== 'undefined') {
                 Enabled = event.sqs.enabled;
               }
@@ -128,6 +130,7 @@ class AwsCompileSQSEvents {
                 "Properties": {
                   "BatchSize": ${BatchSize},
                   "EventSourceArn": ${JSON.stringify(EventSourceArn)},
+                  "MaximumRetryAttempts": ${MaximumRetryAttempts},
                   "FunctionName": {
                     "Fn::GetAtt": [
                       "${lambdaLogicalId}",

--- a/lib/plugins/aws/package/compile/events/sqs/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.test.js
@@ -313,6 +313,7 @@ describe('AwsCompileSQSEvents', () => {
                   arn: 'arn:aws:sqs:region:account:MyFirstQueue',
                   batchSize: 1,
                   enabled: false,
+                  maximumRetryAttempts: 5
                 },
               },
               {
@@ -346,6 +347,10 @@ describe('AwsCompileSQSEvents', () => {
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.Properties.BatchSize
         ).to.equal(awsCompileSQSEvents.serverless.service.functions.first.events[0].sqs.batchSize);
+        expect(
+          awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FirstEventSourceMappingSQSMyFirstQueue.Properties.MaximumRetryAttempts
+        ).to.equal(awsCompileSQSEvents.serverless.service.functions.first.events[0].sqs.maximumRetryAttempts);
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.Properties.Enabled

--- a/lib/plugins/aws/package/compile/events/sqs/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.test.js
@@ -375,7 +375,10 @@ describe('AwsCompileSQSEvents', () => {
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMySecondQueue.Properties.BatchSize
         ).to.equal(10);
-
+        expect(
+          awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FirstEventSourceMappingSQSMySecondQueue.Properties.MaximumRetryAttempts
+        ).to.equal(undefined);
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMySecondQueue.Properties.Enabled
@@ -398,6 +401,10 @@ describe('AwsCompileSQSEvents', () => {
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyThirdQueue.Properties.BatchSize
         ).to.equal(10);
+        expect(
+          awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FirstEventSourceMappingSQSMyThirdQueue.Properties.MaximumRetryAttempts
+        ).to.equal(undefined);
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyThirdQueue.Properties.Enabled

--- a/lib/plugins/aws/package/compile/events/sqs/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.test.js
@@ -313,7 +313,7 @@ describe('AwsCompileSQSEvents', () => {
                   arn: 'arn:aws:sqs:region:account:MyFirstQueue',
                   batchSize: 1,
                   enabled: false,
-                  maximumRetryAttempts: 5
+                  maximumRetryAttempts: 5,
                 },
               },
               {
@@ -350,7 +350,9 @@ describe('AwsCompileSQSEvents', () => {
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.Properties.MaximumRetryAttempts
-        ).to.equal(awsCompileSQSEvents.serverless.service.functions.first.events[0].sqs.maximumRetryAttempts);
+        ).to.equal(
+          awsCompileSQSEvents.serverless.service.functions.first.events[0].sqs.maximumRetryAttempts
+        );
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.Properties.Enabled


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

I added Max retry to SQS because support just became available

<!-- Briefly describe the scope of your PR -->

Addresses #7012



## How can we verify it

functions:
  compute:
    handler: handler.compute
    events:
      - sqs:
          arn: arn:aws:sqs:region:XXXXXX:stream/foo
          batchSize: 10
          maximumRetryAttempts: 10

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
