### PR TITLE
Fixes #7609 - Improve invoke local docker performance

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -87,7 +87,7 @@ class AwsInvokeLocal {
             input => {
               this.options.data = input;
             },
-            () => {}
+            () => { }
           );
         })
         .then(() => {
@@ -469,7 +469,7 @@ class AwsInvokeLocal {
 
           const dockerArgsFromOptions = this.getDockerArgsFromOptions();
           const dockerArgs = _.concat(
-            ['run', '--rm', '-v', `${artifactPath}:/var/task`],
+            ['run', '--rm', '-v', `${artifactPath}:/var/task:ro,delegated`],
             envVarsDockerArgs,
             dockerArgsFromOptions,
             [imageName, handler, JSON.stringify(this.options.data)]
@@ -691,7 +691,7 @@ class AwsInvokeLocal {
         handlerPath
       );
       const handlersContainer = require(// eslint-disable-line global-require
-      pathToHandler);
+        pathToHandler);
       lambda = handlersContainer[handlerName];
     } catch (error) {
       this.serverless.cli.consoleLog(chalk.red(inspect(error)));

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -46,8 +46,8 @@ describe('AwsInvokeLocal', () => {
       stdoutBuffer: new Buffer('Mocked output'),
     });
     spawnStub = sinon.stub().returns({
-      stderr: new EventEmitter().on('data', () => {}),
-      stdout: new EventEmitter().on('data', () => {}),
+      stderr: new EventEmitter().on('data', () => { }),
+      stdout: new EventEmitter().on('data', () => { }),
       stdin: {
         write: writeChildStub,
         end: endChildStub,
@@ -979,7 +979,7 @@ describe('AwsInvokeLocal', () => {
     afterEach(afterEachCallback);
 
     describe('context.remainingTimeInMillis', () => {
-      it('should become lower over time', function() {
+      it('should become lower over time', function () {
         // skipping in CI for now due to handler loading issues
         // in the Windows machine on Travis CI
         if (process.env.CI) {
@@ -1028,7 +1028,7 @@ describe('AwsInvokeLocal', () => {
     afterEach(afterEachCallback);
 
     describe('context.remainingTimeInMillis', () => {
-      it('should become lower over time', function() {
+      it('should become lower over time', function () {
         awsInvokeLocal.serverless.config.servicePath = __dirname;
 
         return awsInvokeLocal.invokeLocalRuby('ruby', 'fixture/handler', 'withRemainingTime').then(
@@ -1047,7 +1047,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     describe('calling a class method', () => {
-      it('should execute', function() {
+      it('should execute', function () {
         awsInvokeLocal.serverless.config.servicePath = __dirname;
 
         return awsInvokeLocal
@@ -1226,7 +1226,7 @@ describe('AwsInvokeLocal', () => {
             'run',
             '--rm',
             '-v',
-            'servicePath:/var/task',
+            'servicePath:/var/task:ro,delegated',
             '--env',
             'AWS_REGION=us-east-1',
             '--env',


### PR DESCRIPTION
Use the recommended docker arg to mount `/var/task` as read only to
improve time spent running the command.

See https://github.com/lambci/docker-lambda#running-lambda-functions

**Without this commit**
```
$ time sls invoke local -f create --docker
REPORT RequestId: 95<SNIPPED> Init Duration: 24701.33 ms

real	0m39.686s
user	0m12.625s
sys	0m3.083s
```
**Using this commit with /var/task:ro,delegated**
```
$ time sls invoke local -f create --docker
REPORT RequestId: 59<SNIPPED> Init Duration: 12088.04 ms

real	0m24.492s
user	0m12.293s
sys	0m2.897s
```

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Use readonly docker volume for invoke local

Closes #7609 

## How can we verify it

unit tests updated
or run `time sls invoke local --docker ` with and without the commit to view performance improvement

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
