### PR TITLE
Fixes serverless#7609 - Improve invoke local docker performance

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -469,7 +469,7 @@ class AwsInvokeLocal {
 
           const dockerArgsFromOptions = this.getDockerArgsFromOptions();
           const dockerArgs = _.concat(
-            ['run', '--rm', '-v', `${artifactPath}:/var/task`],
+            ['run', '--rm', '-v', `${artifactPath}:/var/task:ro,delegated`],
             envVarsDockerArgs,
             dockerArgsFromOptions,
             [imageName, handler, JSON.stringify(this.options.data)]

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1226,7 +1226,7 @@ describe('AwsInvokeLocal', () => {
             'run',
             '--rm',
             '-v',
-            'servicePath:/var/task',
+            'servicePath:/var/task:ro,delegated',
             '--env',
             'AWS_REGION=us-east-1',
             '--env',


### PR DESCRIPTION
Use the recommended docker arg to mount `/var/task` as read only to
improve time spent running the command.

See https://github.com/lambci/docker-lambda#running-lambda-functions

**Without this commit**
```
$ time sls invoke local -f create --docker
REPORT RequestId: 95<SNIPPED> Init Duration: 24701.33 ms

real	0m39.686s
user	0m12.625s
sys	0m3.083s
```
**Using this commit with /var/task:ro,delegated**
```
$ time sls invoke local -f create --docker
REPORT RequestId: 59<SNIPPED> Init Duration: 12088.04 ms

real	0m24.492s
user	0m12.293s
sys	0m2.897s
```

## What did you implement

Mount docker volume read-only when running `sls invoke local --docker`

Closes #7609 

## How can we verify it

run `time sls invoke local --docker` with and without this commit to observe performance improvements
## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [X] Write and run all tests
- [ ] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
