### PR TITLE
Add documentation and test for default bool overwrite

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -602,6 +602,7 @@ provider:
 custom:
   myStage: ${opt:stage, self:provider.stage}
   myRegion: ${opt:region, 'us-west-1'}
+  enabled: ${opt:enabled, strToBool(true)}
 
 functions:
   hello:
@@ -684,3 +685,5 @@ ${strToBool(2)} => Error
 ${strToBool(null)} => Error
 ${strToBool(anything)} => Error
 ```
+
+`strToBool` can also be used as an overwrite as in `${opt:myBool, strToBool(true)}`.

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1224,6 +1224,13 @@ module.exports = {
         .should.eventually.eql('my stage is prod');
     });
 
+    it('should allow a boolean if overwrite syntax provided', () => {
+      // eslint-disable-next-line no-template-curly-in-string
+      const property = '${opt:stage, strToBool(true)}';
+      serverless.variables.options = {};
+      return serverless.variables.populateProperty(property).should.eventually.eql(true);
+    });
+
     it('should call getValueFromSource if no overwrite syntax provided', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const property = 'my stage is ${opt:stage}';


### PR DESCRIPTION
## What did you implement

Added a test to show the use of `strToBool` as an overwrite parameter and added relative documentation.

Closes #7462 

## How can we verify it

You can run `sls print` with the following `serverless.yml` and see the correct output :

```yml
service:
  name: test

plugins:
  - serverless-webpack

provider:
  name: aws
  runtime: nodejs10.x

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          method: get
          path: hello
          enabled: ${self:custom.doesnotexist, strToBool(false)}
```

and expect to see :

```yml
service:
  name: test
plugins:
  - serverless-webpack
provider:
  name: aws
  runtime: nodejs10.x
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          method: get
          path: hello
          enabled: false
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
