### PR TITLE
Region selection for SSM variables

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -265,6 +265,7 @@ functions:
 ```
 
 In the above example, the value for `myKey` in the `myBucket` S3 bucket will be looked up and used to populate the variable.
+Buckets from all regions can be used without any additional specification due to AWS S3 global strategy.
 
 ## Reference Variables using the SSM Parameter Store
 
@@ -308,6 +309,18 @@ functions:
     handler: handler.hello
 custom:
   myArrayVar: ${ssm:/path/to/stringlistparam~split}
+```
+
+You can also reference SSM Parameters in another region with the `ssm.REGION:/path/to/param` syntax. For example:
+
+```yml
+service: ${ssm.us-west-2:/path/to/service/id}-service
+provider:
+  name: aws
+functions:
+  hello:
+    name: ${ssm.ap-northeast-1:/path/to/service/myParam}-hello
+    handler: handler.hello
 ```
 
 ## Reference Variables using AWS Secrets Manager

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -744,18 +744,27 @@ class Variables {
     return BbPromise.resolve(valueToPopulate);
   }
 
+  buildOptions(regionSuffix) {
+    const options = { useCache: true };
+    if (!_.isUndefined(regionSuffix)) {
+      options.region = regionSuffix;
+    }
+    return options;
+  }
+
   getValueFromCf(variableString) {
     const groups = variableString.match(this.cfRefSyntax);
     const regionSuffix = groups[1];
     const stackName = groups[2];
     const outputLogicalId = groups[3];
-    const options = { useCache: true };
-    if (!_.isUndefined(regionSuffix)) {
-      options.region = regionSuffix;
-    }
     return this.serverless
       .getProvider('aws')
-      .request('CloudFormation', 'describeStacks', { StackName: stackName }, options)
+      .request(
+        'CloudFormation',
+        'describeStacks',
+        { StackName: stackName },
+        this.buildOptions(regionSuffix)
+      )
       .then(result => {
         const outputs = result.Stacks[0].Outputs;
         const output = outputs.find(x => x.OutputKey === outputLogicalId);
@@ -800,10 +809,6 @@ class Variables {
     const param = groups[2];
     const decrypt = groups[3] === 'true';
     const split = groups[3] === 'split';
-    const options = { useCache: true };
-    if (!_.isUndefined(regionSuffix)) {
-      options.region = regionSuffix;
-    }
     return this.serverless
       .getProvider('aws')
       .request(
@@ -813,7 +818,7 @@ class Variables {
           Name: param,
           WithDecryption: decrypt,
         },
-        options
+        this.buildOptions(regionSuffix)
       ) // Use request cache
       .then(
         response => {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -54,8 +54,8 @@ class Variables {
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
     this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
-    this.cfRefSyntax = RegExp(/^(?:\${)?cf(\.[a-zA-Z0-9-]+)?:/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
+    this.cfRefSyntax = RegExp(/^(?:\${)?cf(?:\.([a-zA-Z0-9-]+))?:(.+?)\.(.+)$/);
     this.ssmRefSyntax = RegExp(
       /^(?:\${)?ssm(?:\.([a-zA-Z0-9-]+))?:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/
     );
@@ -745,10 +745,10 @@ class Variables {
   }
 
   getValueFromCf(variableString) {
-    const regionSuffix = variableString.split(':')[0].split('.')[1];
-    const variableStringWithoutSource = variableString.split(':')[1].split('.');
-    const stackName = variableStringWithoutSource[0];
-    const outputLogicalId = variableStringWithoutSource[1];
+    const groups = variableString.match(this.cfRefSyntax);
+    const regionSuffix = groups[1];
+    const stackName = groups[2];
+    const outputLogicalId = groups[3];
     const options = { useCache: true };
     if (!_.isUndefined(regionSuffix)) {
       options.region = regionSuffix;

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -56,7 +56,9 @@ class Variables {
     this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(\.[a-zA-Z0-9-]+)?:/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
-    this.ssmRefSyntax = RegExp(/^(?:\${)?ssm:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/);
+    this.ssmRefSyntax = RegExp(
+      /^(?:\${)?ssm(?:\.([a-zA-Z0-9-]+))?:([a-zA-Z0-9_.\-/]+)[~]?(true|false|split)?/
+    );
     this.strToBoolRefSyntax = RegExp(/^(?:\${)?strToBool\(([a-zA-Z0-9_.\-/]+)\)/);
 
     this.variableResolvers = [
@@ -794,9 +796,14 @@ class Variables {
 
   getValueFromSsm(variableString) {
     const groups = variableString.match(this.ssmRefSyntax);
-    const param = groups[1];
-    const decrypt = groups[2] === 'true';
-    const split = groups[2] === 'split';
+    const regionSuffix = groups[1];
+    const param = groups[2];
+    const decrypt = groups[3] === 'true';
+    const split = groups[3] === 'split';
+    const options = { useCache: true };
+    if (!_.isUndefined(regionSuffix)) {
+      options.region = regionSuffix;
+    }
     return this.serverless
       .getProvider('aws')
       .request(
@@ -806,7 +813,7 @@ class Variables {
           Name: param,
           WithDecryption: decrypt,
         },
-        { useCache: true }
+        options
       ) // Use request cache
       .then(
         response => {

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2159,6 +2159,27 @@ module.exports = {
         })
         .finally(() => ssmStub.restore());
     });
+    it('should get variable from Ssm of different region', () => {
+      const ssmStub = sinon
+        .stub(awsProvider, 'request')
+        .callsFake(() => BbPromise.resolve(awsResponseMock));
+      return serverless.variables
+        .getValueFromSsm(`ssm.us-east-1:${param}`)
+        .should.become(value)
+        .then(() => {
+          expect(ssmStub).to.have.been.calledOnce;
+          expect(ssmStub).to.have.been.calledWithExactly(
+            'SSM',
+            'getParameter',
+            {
+              Name: param,
+              WithDecryption: false,
+            },
+            { region: 'us-east-1', useCache: true }
+          );
+        })
+        .finally(() => ssmStub.restore());
+    });
     it('should get variable from Ssm using path-style param', () => {
       const ssmStub = sinon
         .stub(awsProvider, 'request')


### PR DESCRIPTION
## What did you implement

Aligned SSM variables parsing features to existing CloudFormation variable by enabling region selection.
You can now use `ssm.REGION:/path/to/param` in serverless.yml files like you could `cf.REGION:stackName.outputKey`.

Closes #7416 

## How can we verify it

```yml
service: new-service
provider:
  name: aws
  region: us-east-1
functions:
  hello:
    name: ${ssm.ap-northeast-1:/path/to/service/myParam}-hello
    handler: handler.hello
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
