### PR TITLE
Implement bool primitive overwrite

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -615,6 +615,8 @@ provider:
 custom:
   myStage: ${opt:stage, self:provider.stage}
   myRegion: ${opt:region, 'us-west-1'}
+  myCfnRole: ${opt:role, false}
+  myLambdaMemory: ${opt:memory, 1024}
 
 functions:
   hello:

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -54,6 +54,7 @@ class Variables {
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
     this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
+    this.boolRefSyntax = RegExp(/(?:(true|false))/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(?:\.([a-zA-Z0-9-]+))?:(.+?)\.(.+)$/);
     this.ssmRefSyntax = RegExp(
@@ -80,6 +81,7 @@ class Variables {
         serviceName: 'S3',
       },
       { regex: this.stringRefSyntax, resolver: this.getValueFromString.bind(this) },
+      { regex: this.boolRefSyntax, resolver: this.getValueFromBool.bind(this) },
       {
         regex: this.ssmRefSyntax,
         resolver: this.getValueFromSsm.bind(this),
@@ -618,6 +620,11 @@ class Variables {
   getValueFromString(variableString) {
     // eslint-disable-line class-methods-use-this
     const valueToPopulate = variableString.replace(/^['"]|['"]$/g, '');
+    return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromBool(variableString) {
+    const valueToPopulate = variableString === 'true';
     return BbPromise.resolve(valueToPopulate);
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -53,8 +53,8 @@ class Variables {
     this.envRefSyntax = RegExp(/^env:/g);
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
-    this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
-    this.boolRefSyntax = RegExp(/(?:\b(true|false)\b)/g);
+    this.stringRefSyntax = RegExp(/(?:^('|").*?\1$)/g);
+    this.boolRefSyntax = RegExp(/(?:^(true|false)$)/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(?:\.([a-zA-Z0-9-]+))?:(.+?)\.(.+)$/);
     this.ssmRefSyntax = RegExp(
@@ -478,15 +478,16 @@ class Variables {
    * @param string The string to split by comma.
    */
   splitByComma(string) {
+    const quotedWordSyntax = RegExp(/(?:('|").*?\1)/g);
     const input = string.trim();
     const stringMatches = [];
-    let match = this.stringRefSyntax.exec(input);
+    let match = quotedWordSyntax.exec(input);
     while (match) {
       stringMatches.push({
         start: match.index,
-        end: this.stringRefSyntax.lastIndex,
+        end: quotedWordSyntax.lastIndex,
       });
-      match = this.stringRefSyntax.exec(input);
+      match = quotedWordSyntax.exec(input);
     }
     const commaReplacements = [];
     const contained = (

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -55,6 +55,7 @@ class Variables {
     this.selfRefSyntax = RegExp(/^self:/g);
     this.stringRefSyntax = RegExp(/(?:^('|").*?\1$)/g);
     this.boolRefSyntax = RegExp(/(?:^(true|false)$)/g);
+    this.intRefSyntax = RegExp(/(?:^\d+$)/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(?:\.([a-zA-Z0-9-]+))?:(.+?)\.(.+)$/);
     this.ssmRefSyntax = RegExp(
@@ -82,6 +83,7 @@ class Variables {
       },
       { regex: this.stringRefSyntax, resolver: this.getValueFromString.bind(this) },
       { regex: this.boolRefSyntax, resolver: this.getValueFromBool.bind(this) },
+      { regex: this.intRefSyntax, resolver: this.getValueFromInt.bind(this) },
       {
         regex: this.ssmRefSyntax,
         resolver: this.getValueFromSsm.bind(this),
@@ -626,6 +628,11 @@ class Variables {
 
   getValueFromBool(variableString) {
     const valueToPopulate = variableString === 'true';
+    return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromInt(variableString) {
+    const valueToPopulate = parseInt(variableString, 10);
     return BbPromise.resolve(valueToPopulate);
   }
 

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -54,7 +54,7 @@ class Variables {
     this.optRefSyntax = RegExp(/^opt:/g);
     this.selfRefSyntax = RegExp(/^self:/g);
     this.stringRefSyntax = RegExp(/(?:('|").*?\1)/g);
-    this.boolRefSyntax = RegExp(/(?:(true|false))/g);
+    this.boolRefSyntax = RegExp(/(?:\b(true|false)\b)/g);
     this.s3RefSyntax = RegExp(/^(?:\${)?s3:(.+?)\/(.+)$/);
     this.cfRefSyntax = RegExp(/^(?:\${)?cf(?:\.([a-zA-Z0-9-]+))?:(.+?)\.(.+)$/);
     this.ssmRefSyntax = RegExp(

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1236,6 +1236,21 @@ module.exports = {
       return serverless.variables.populateProperty(property).should.eventually.eql(false);
     });
 
+    it('should not match a boolean with value containing word true or false if overwrite syntax provided', () => {
+      const property = '${opt:stage, foofalsebar}';
+      serverless.variables.options = {};
+      const warnIfNotFoundSpy = sinon.spy(serverless.variables, 'warnIfNotFound');
+      return serverless.variables
+        .populateProperty(property)
+        .should.become(undefined)
+        .then(() => {
+          expect(warnIfNotFoundSpy.callCount).to.equal(1);
+        })
+        .finally(() => {
+          warnIfNotFoundSpy.restore();
+        });
+    });
+
     it('should call getValueFromSource if no overwrite syntax provided', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const property = 'my stage is ${opt:stage}';

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1224,6 +1224,18 @@ module.exports = {
         .should.eventually.eql('my stage is prod');
     });
 
+    it('should allow a boolean with value true if overwrite syntax provided', () => {
+      const property = '${opt:stage, true}';
+      serverless.variables.options = {};
+      return serverless.variables.populateProperty(property).should.eventually.eql(true);
+    });
+
+    it('should allow a boolean with value false if overwrite syntax provided', () => {
+      const property = '${opt:stage, false}';
+      serverless.variables.options = {};
+      return serverless.variables.populateProperty(property).should.eventually.eql(false);
+    });
+
     it('should call getValueFromSource if no overwrite syntax provided', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const property = 'my stage is ${opt:stage}';
@@ -1520,7 +1532,7 @@ module.exports = {
         .stub(serverless.variables.variableResolvers[6], 'resolver')
         .resolves('variableValue');
       getValueFromSsmStub = sinon
-        .stub(serverless.variables.variableResolvers[8], 'resolver')
+        .stub(serverless.variables.variableResolvers[9], 'resolver')
         .resolves('variableValue');
     });
 
@@ -1532,7 +1544,7 @@ module.exports = {
       serverless.variables.variableResolvers[4].resolver.restore();
       serverless.variables.variableResolvers[5].resolver.restore();
       serverless.variables.variableResolvers[6].resolver.restore();
-      serverless.variables.variableResolvers[8].resolver.restore();
+      serverless.variables.variableResolvers[9].resolver.restore();
     });
 
     it('should call getValueFromSls if referencing sls var', () =>
@@ -1630,7 +1642,7 @@ module.exports = {
           variableString: 's3:test-bucket/path/to/ke',
         },
         {
-          functionIndex: 8,
+          functionIndex: 9,
           function: 'getValueFromSsm',
           variableString: 'ssm:/test/path/to/param',
         },

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1224,6 +1224,21 @@ module.exports = {
         .should.eventually.eql('my stage is prod');
     });
 
+    it('should not allow partially double-quoted string', () => {
+      const property = '${opt:stage, prefix"prod"suffix}';
+      serverless.variables.options = {};
+      const warnIfNotFoundSpy = sinon.spy(serverless.variables, 'warnIfNotFound');
+      return serverless.variables
+        .populateProperty(property)
+        .should.become(undefined)
+        .then(() => {
+          expect(warnIfNotFoundSpy.callCount).to.equal(1);
+        })
+        .finally(() => {
+          warnIfNotFoundSpy.restore();
+        });
+    });
+
     it('should allow a boolean with value true if overwrite syntax provided', () => {
       const property = '${opt:stage, true}';
       serverless.variables.options = {};

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -1266,6 +1266,12 @@ module.exports = {
         });
     });
 
+    it('should allow an integer if overwrite syntax provided', () => {
+      const property = '${opt:quantity, 123}';
+      serverless.variables.options = {};
+      return serverless.variables.populateProperty(property).should.eventually.eql(123);
+    });
+
     it('should call getValueFromSource if no overwrite syntax provided', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const property = 'my stage is ${opt:stage}';
@@ -1562,7 +1568,7 @@ module.exports = {
         .stub(serverless.variables.variableResolvers[6], 'resolver')
         .resolves('variableValue');
       getValueFromSsmStub = sinon
-        .stub(serverless.variables.variableResolvers[9], 'resolver')
+        .stub(serverless.variables.variableResolvers[10], 'resolver')
         .resolves('variableValue');
     });
 
@@ -1574,7 +1580,7 @@ module.exports = {
       serverless.variables.variableResolvers[4].resolver.restore();
       serverless.variables.variableResolvers[5].resolver.restore();
       serverless.variables.variableResolvers[6].resolver.restore();
-      serverless.variables.variableResolvers[9].resolver.restore();
+      serverless.variables.variableResolvers[10].resolver.restore();
     });
 
     it('should call getValueFromSls if referencing sls var', () =>
@@ -1672,7 +1678,7 @@ module.exports = {
           variableString: 's3:test-bucket/path/to/ke',
         },
         {
-          functionIndex: 9,
+          functionIndex: 10,
           function: 'getValueFromSsm',
           variableString: 'ssm:/test/path/to/param',
         },


### PR DESCRIPTION
## What did you implement

Added syntax matcher for true|false bool in overwrite syntax.
Wanted to include int overwrite syntax as well, but a similar pattern for int brakes 40+ tests, I have to rethink the way to do it for this primitive.

Closes #7462 

## How can we verify it

You can run `sls print` with the following `serverless.yml` and see the correct output :

```yml
service:
  name: test

plugins:
  - serverless-webpack

provider:
  name: aws
  runtime: nodejs10.x

functions:
  hello:
    handler: handler.hello
    events:
      - http:
          method: get
          path: hello
          enabled: ${self:custom.doesnotexist, false}
```

and expect to see :

```yml
service:
  name: test
plugins:
  - serverless-webpack
provider:
  name: aws
  runtime: nodejs10.x
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          method: get
          path: hello
          enabled: false
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
