### PR TITLE
Filter out duplicate create/delete event bus custom policies

### DIFF
--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -20,6 +20,7 @@ class AwsCompileEventBridgeEvents {
     const { provider } = service;
     const { compiledCloudFormationTemplate } = provider;
     const iamRoleStatements = [];
+    const eventBusIamRoleStatements = new Map();
 
     service.getAllFunctions().forEach(functionName => {
       let funcUsesEventBridge = false;
@@ -159,11 +160,14 @@ class AwsCompileEventBridgeEvents {
                     ],
                   ],
                 };
-                iamRoleStatements.push({
-                  Effect: 'Allow',
-                  Resource: eventBusResource,
-                  Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
-                });
+
+                if (!eventBusIamRoleStatements.has(eventBusName)) {
+                  eventBusIamRoleStatements.set(eventBusName, {
+                    Effect: 'Allow',
+                    Resource: eventBusResource,
+                    Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+                  });
+                }
               }
 
               iamRoleStatements.push({
@@ -208,6 +212,8 @@ class AwsCompileEventBridgeEvents {
         });
       }
     });
+
+    iamRoleStatements.unshift(...eventBusIamRoleStatements.values());
 
     if (iamRoleStatements.length) {
       return addCustomResourceToService(this.provider, 'eventBridge', iamRoleStatements);

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -395,6 +395,216 @@ describe('AwsCompileEventBridgeEvents', () => {
       );
     });
 
+    it('should create the necessary resources with only one create/delete event bus policy', () => {
+      awsCompileEventBridgeEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              eventBridge: {
+                eventBus: 'some-event-bus',
+                schedule: 'rate(10 minutes)',
+                pattern: {
+                  'source': ['aws.cloudformation'],
+                  'detail-type': ['AWS API Call via CloudTrail'],
+                  'detail': {
+                    eventSource: ['cloudformation.amazonaws.com'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+        second: {
+          name: 'second',
+          events: [
+            {
+              eventBridge: {
+                eventBus: 'some-event-bus',
+                schedule: 'rate(10 minutes)',
+                pattern: {
+                  'source': ['aws.cloudformation'],
+                  'detail-type': ['AWS API Call via CloudTrail'],
+                  'detail': {
+                    eventSource: ['cloudformation.amazonaws.com'],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      return expect(awsCompileEventBridgeEvents.compileEventBridgeEvents()).to.be.fulfilled.then(
+        () => {
+          const {
+            Resources,
+          } = awsCompileEventBridgeEvents.serverless.service.provider.compiledCloudFormationTemplate;
+
+          expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
+          expect(addCustomResourceToServiceStub.args[0][1]).to.equal('eventBridge');
+          expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
+            {
+              Action: ['events:CreateEventBus', 'events:DeleteEventBus'],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    'events',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'event-bus/some-event-bus',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: [
+                'events:PutRule',
+                'events:RemoveTargets',
+                'events:PutTargets',
+                'events:DeleteRule',
+              ],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    'events',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'rule/some-event-bus/first-rule-1',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    'lambda',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'function',
+                    'first',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: [
+                'events:PutRule',
+                'events:RemoveTargets',
+                'events:PutTargets',
+                'events:DeleteRule',
+              ],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    'events',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'rule/some-event-bus/second-rule-1',
+                  ],
+                ],
+              },
+            },
+            {
+              Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+              Effect: 'Allow',
+              Resource: {
+                'Fn::Join': [
+                  ':',
+                  [
+                    'arn',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    'lambda',
+                    {
+                      Ref: 'AWS::Region',
+                    },
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    'function',
+                    'second',
+                  ],
+                ],
+              },
+            },
+          ]);
+          expect(Resources.FirstCustomEventBridge1).to.deep.equal({
+            Type: 'Custom::EventBridge',
+            Version: 1,
+            DependsOn: [
+              'FirstLambdaFunction',
+              'CustomDashresourceDasheventDashbridgeLambdaFunction',
+            ],
+            Properties: {
+              ServiceToken: {
+                'Fn::GetAtt': ['CustomDashresourceDasheventDashbridgeLambdaFunction', 'Arn'],
+              },
+              FunctionName: 'first',
+              EventBridgeConfig: {
+                EventBus: 'some-event-bus',
+                Input: undefined,
+                InputPath: undefined,
+                InputTransformer: undefined,
+                Pattern: {
+                  'detail': {
+                    eventSource: ['cloudformation.amazonaws.com'],
+                  },
+                  'detail-type': ['AWS API Call via CloudTrail'],
+                  'source': ['aws.cloudformation'],
+                },
+                RuleName: 'first-rule-1',
+                Schedule: 'rate(10 minutes)',
+              },
+            },
+          });
+        }
+      );
+    });
+
     it('should create the necessary resources when using an own event bus arn', () => {
       awsCompileEventBridgeEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
## What did you implement

Closes #7643 

On my project, I deployed a stack with 20+ lambdas connected to EventBridge and ran into a "Maximum policy size" error during deployment for the IamRoleCustomResourcesLa policy.

Upon inspection, I found that a policy for event bus creation/deletion is duplicated for each lambda. I managed to reduce the size of the custom resources policy  by ~30% by removing this duplication (in the case where it contains only lambdas using event bridges).

## How can we verify it

```
service:
  name: serverless-issue-7643

package:
  exclude:
    - .git/**
    - .gitignore

plugins:
  - serverless-webpack

provider:
  name: aws
  runtime: nodejs10.x
  region: eu-west-2
  stage: ${opt:stage, 'dev'}
  usagePlan:
    quota:
      limit: 5000
      offset: 2
      period: MONTH
    throttle:
      burstLimit: 200
      rateLimit: 100

functions:
  test1:
    handler: test.handler
    events:
      - eventBridge:
          eventBus: ${self:custom.eventBusArn}
          pattern:
            source:
              - whatever
            detail-type:
              - whatever
  test2:
    handler: test.handler
    events:
      - eventBridge:
          eventBus: ${self:custom.eventBusArn}
          pattern:
            source:
              - whatever
            detail-type:
              - whatever
...
  test25:
    handler: test.handler
    events:
      - eventBridge:
          eventBus: ${self:custom.eventBusArn}
          pattern:
            source:
              - whatever
            detail-type:
              - whatever


custom:
  eventBusArn: arn:aws:events:#{AWS::Region}:#{AWS::AccountId}:event-bus/event-bus-issue-7643
```

The deployment should not fail. You should see the following policy **only once** in the IamRoleCustomResourcesLa policy:

```
{
  "Effect":"Allow",
  "Resource":{"Fn::Join":[":",["arn",{"Ref":"AWS::Partition"},"events",{"Ref":"AWS::Region"},{"Ref":"AWS::AccountId"},"event-bus/event-bus-issue-7643"]]},
  "Action":["events:CreateEventBus","events:DeleteEventBus"]
}
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
