### PR TITLE
Change version to function-version in rollback command

### DIFF
--- a/docs/providers/aws/cli-reference/rollback-function.md
+++ b/docs/providers/aws/cli-reference/rollback-function.md
@@ -17,7 +17,7 @@ layout: Doc
 Rollback a function service to a specific version.
 
 ```bash
-serverless rollback function --function <name> --version <version>
+serverless rollback function --function <name> --function-version <version>
 ```
 
 **Note:** You can only rollback a function which was previously deployed through `serverless deploy`. Functions are not versioned when running `serverless deploy function`.
@@ -25,7 +25,7 @@ serverless rollback function --function <name> --version <version>
 ## Options
 
 - `--function` or `-f` The name of the function which should be rolled back
-- `--version` or `-v` The version to which the function should be rolled back
+- `--function-version` or `-v` The version to which the function should be rolled back
 
 ## Examples
 

--- a/lib/plugins/aws/rollbackFunction/index.js
+++ b/lib/plugins/aws/rollbackFunction/index.js
@@ -19,21 +19,21 @@ class AwsRollbackFunction {
             usage: 'Rollback the function to a specific version',
             lifecycleEvents: ['rollback'],
             options: {
-              function: {
+              'function': {
                 usage: 'Name of the function',
                 shortcut: 'f',
                 required: true,
               },
-              version: {
+              'function-version': {
                 usage: 'Version of the function',
                 shortcut: 'v',
                 required: true,
               },
-              stage: {
+              'stage': {
                 usage: 'Stage of the function',
                 shortcut: 's',
               },
-              region: {
+              'region': {
                 usage: 'Region of the function',
                 shortcut: 'r',
               },
@@ -55,10 +55,10 @@ class AwsRollbackFunction {
 
   getFunctionToBeRestored() {
     const funcName = this.options.function;
-    let funcVersion = this.options.version;
+    let funcVersion = this.options['function-version'];
 
     // versions need to be string so that AWS understands it
-    funcVersion = String(this.options.version);
+    funcVersion = String(this.options['function-version']);
 
     this.serverless.cli.log(`Rolling back function "${funcName}" to version "${funcVersion}"...`);
 

--- a/lib/plugins/aws/rollbackFunction/index.test.js
+++ b/lib/plugins/aws/rollbackFunction/index.test.js
@@ -101,7 +101,7 @@ describe('AwsRollbackFunction', () => {
 
       it('should return the requested function', () => {
         awsRollbackFunction.options.function = 'hello';
-        awsRollbackFunction.options.version = '4711';
+        awsRollbackFunction.options['function-version'] = '4711';
 
         return awsRollbackFunction.getFunctionToBeRestored().then(result => {
           expect(getFunctionStub.calledOnce).to.equal(true);
@@ -132,7 +132,7 @@ describe('AwsRollbackFunction', () => {
 
       it('should translate the error message to a custom error message', () => {
         awsRollbackFunction.options.function = 'hello';
-        awsRollbackFunction.options.version = '4711';
+        awsRollbackFunction.options['function-version'] = '4711';
 
         return awsRollbackFunction.getFunctionToBeRestored().catch(error => {
           expect(error.message.match(/Function "hello" with version "4711" not found/));
@@ -163,7 +163,7 @@ describe('AwsRollbackFunction', () => {
 
       it('should re-throw the error without translating it to a custom error message', () => {
         awsRollbackFunction.options.function = 'hello';
-        awsRollbackFunction.options.version = '4711';
+        awsRollbackFunction.options['function-version'] = '4711';
 
         return awsRollbackFunction.getFunctionToBeRestored().catch(error => {
           expect(error.message.match(/something went wrong/));

--- a/lib/plugins/rollback/index.js
+++ b/lib/plugins/rollback/index.js
@@ -28,21 +28,21 @@ class Rollback {
             usage: 'Rollback the function to the previous version',
             lifecycleEvents: ['rollback'],
             options: {
-              function: {
+              'function': {
                 usage: 'Name of the function',
                 shortcut: 'f',
                 required: true,
               },
-              version: {
+              'function-version': {
                 usage: 'Version of the function',
                 shortcut: 'v',
                 required: true,
               },
-              stage: {
+              'stage': {
                 usage: 'Stage of the function',
                 shortcut: 's',
               },
-              region: {
+              'region': {
                 usage: 'Region of the function',
                 shortcut: 'r',
               },


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Changed `version` option in rollback command to `function-version` to avoid confusion with `version` option from core

Closes #7645

## How can we verify it
```
service: test-rollback

provider:
    name: aws
    region: us-east-2
    runtime: nodejs12.x
    stage: ${env:NODE_ENV}
    timeout: 900
functions:
  app:
    handler: index.handler
```

If you try to rollback with the following command before the fix, it will throw an error that `1 is not a sub command of version`
`npx serverless rollback -f app --version 1`

If you try this command after the fix, it will not throw that error
`npx serverless rollback -f app --function-version 1`

_Please note that this test keeps failing on my side (I'm using windows currently) `calls docker with packaged artifact`_

## Todos

- I'm not sure if we should change/remove the shortcut `v`

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** YES
