### PR TITLE
Allow customizing serverless file locations

### DIFF
--- a/lib/utils/config/index.js
+++ b/lib/utils/config/index.js
@@ -12,12 +12,11 @@ const readFileSync = require('../fs/readFileSync');
 const initialSetup = require('./initialSetup');
 
 let rcFileBase = 'serverless';
-let serverlessrcPath = p.join(os.homedir(), `.${rcFileBase}rc`);
-
 if (process.env.SERVERLESS_PLATFORM_STAGE && process.env.SERVERLESS_PLATFORM_STAGE !== 'prod') {
-  rcFileBase = 'serverlessdev';
-  serverlessrcPath = p.join(os.homedir(), `.${rcFileBase}rc`);
+  rcFileBase += 'dev';
 }
+const defaultRcFilePath = p.join(os.homedir(), `.${rcFileBase}rc`);
+const serverlessrcPath = process.env[`${rcFileBase}rc`.toUpperCase()] || defaultRcFilePath;
 
 function storeConfig(config) {
   try {

--- a/lib/utils/getServerlessDir.js
+++ b/lib/utils/getServerlessDir.js
@@ -5,7 +5,8 @@ const os = require('os');
 
 // get .serverless home path
 function getServerlessDir() {
-  return path.join(os.homedir(), '.serverless');
+  const defaultDir = path.join(os.homedir(), '.serverless');
+  return process.env.SERVERLESS_HOME || defaultDir;
 }
 
 module.exports = getServerlessDir;

--- a/lib/utils/getServerlessDir.test.js
+++ b/lib/utils/getServerlessDir.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { expect } = require('chai');
+
+const getServerlessDir = require('./getServerlessDir.js');
+
+describe('#getServerlessDir()', () => {
+  let initialVar;
+
+  beforeEach(() => {
+    initialVar = process.env.SERVERLESS_HOME;
+  });
+
+  it('should return the default when the environment variable is not set', () => {
+    delete process.env.SERVERLESS_HOME;
+    const expected = path.join(os.homedir(), '.serverless');
+    expect(getServerlessDir()).to.equal(expected);
+  });
+
+  it('should return the environment variable when it is set', () => {
+    process.env.SERVERLESS_HOME = 'foo';
+    expect(getServerlessDir()).to.equal('foo');
+  });
+
+  afterEach(() => {
+    process.env.SERVERLESS_HOME = initialVar;
+  });
+});


### PR DESCRIPTION
## What did you implement

You can now set environment variables to set custom locations for `~/.serverless` and `~/.serverlessrc`

## How can we verify it

Set `SERVERLESS_HOME` and/or `SERVERLESSRC` to something custom.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** yes
**_Is it a breaking change?:_** no

 I don't really know where to put documentation, so some guidance there would be nice.