### PR TITLE
Fix deployment error when removing event bridge lambda

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -16,7 +16,12 @@ module.exports = {
     const stackUrl = `${baseCfUrl}?${cfQueryString}`;
 
     // Monitor stack creation/update/removal
-    const validStatuses = ['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'DELETE_COMPLETE'];
+    const validStatuses = [
+      'CREATE_COMPLETE',
+      'UPDATE_COMPLETE',
+      'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS',
+      'DELETE_COMPLETE',
+    ];
     const loggedEvents = [];
 
     let monitoredSince = null;
@@ -107,14 +112,24 @@ module.exports = {
                     loggedEvents.push(event.EventId);
                   }
                 });
+
                 // Handle stack create/update/delete failures
+                let shouldReject = this.options.verbose
+                  ? stackStatus &&
+                    (stackStatus.endsWith('ROLLBACK_COMPLETE') || stackStatus === 'DELETE_FAILED')
+                  : stackLatestError;
+
                 if (
-                  (stackLatestError && !this.options.verbose) ||
-                  (stackStatus &&
-                    (stackStatus.endsWith('ROLLBACK_COMPLETE') ||
-                      stackStatus === 'DELETE_FAILED') &&
-                    this.options.verbose)
+                  stackLatestError &&
+                  stackLatestError.PhysicalResourceId === 'CustomResourceEventBridge' &&
+                  stackLatestError.ResourceStatus === 'DELETE_FAILED' &&
+                  stackLatestError.ResourceStatusReason.includes('lambda:RemovePermission') &&
+                  stackStatus === 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS'
                 ) {
+                  shouldReject = false;
+                }
+
+                if (shouldReject) {
                   // empty console.log for a prettier output
                   if (!this.options.verbose) this.serverless.cli.consoleLog('');
                   this.serverless.cli.log('Operation failed!');


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Closes #7655

When removing a Lambda function connected to EventBridge, the deployment appear to fail with the following message:

*An error occurred: CustomEventBridge1 - Failed to delete resource. User: ...-custom-resource-event-bridge is not authorized to perform: lambda:RemovePermission on resource: ...my-lambda-function-name See details in CloudWatch Log: ...*

I checked and it seems that the correct role (with the correct lambda::RemovePermission policy) is given to the custom resource deployment lambda in previous deployment.

The source of the error seems to be that the new policy, that doesn't contain this right anymore (as the lambda has been removed from the serverless.yml), is deployed before the lambda is deleted.

However, the error itself seems to be a false positive: The stack updates as it should, and the lambda function is deleted during the `UPDATE_COMPLETE_CLEANUP_IN_PROGRESS` stack phase.

My solution is a bit hacky but I can't come up with a better one: I filtered out this specific error from the `monitorStack` rejections. The code is not perfect and not tested but I wanted to hear your opinion before going further.

## How can we verify it

```
provider:
  name: aws
  runtime: nodejs10.x
  region: eu-west-2
  stage: test
  usagePlan:
    quota:
      limit: 5000
      offset: 2
      period: MONTH
    throttle:
      burstLimit: 200
      rateLimit: 100

functions:
  test1:
    handler: test.handler
    events:
      - eventBridge:
          eventBus: ${self:custom.eventBusArn}
          pattern:
            source:
              - whatever
            detail-type:
              - whatever
  test2:
    handler: test.handler
    events:
      - eventBridge:
          eventBus: ${self:custom.eventBusArn}
          pattern:
            source:
              - whatever
            detail-type:
              - whatever

custom:
  eventBusArn: arn:aws:events:#{AWS::Region}:#{AWS::AccountId}:event-bus/my-bus
```

Deploy, then remove test2 lambda function, and re-deploy. The deployment should not fail and you should not see the error mentioned above.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [ ] Write and run all tests
- [ ] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
