### PR TITLE
Add `includeBody` param for Lambda@edge

### DIFF
--- a/docs/providers/aws/events/cloudfront.md
+++ b/docs/providers/aws/events/cloudfront.md
@@ -147,6 +147,7 @@ functions:
     events:
       - cloudFront:
           eventType: viewer-response
+          includeBody: true
           origin: s3://bucketname.s3.amazonaws.com/files
       - cloudFront:
           eventType: viewer-response

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -206,11 +206,14 @@ class AwsCompileCloudFrontEvents {
               Object.assign(behavior, event.cloudFront.behavior);
             }
 
+            const { includeBody = false } = event.cloudFront;
+
             Object.assign(behavior, {
               TargetOriginId: origin.Id,
               LambdaFunctionAssociations: [
                 {
                   EventType: event.cloudFront.eventType,
+                  IncludeBody: includeBody,
                   LambdaFunctionARN: {
                     Ref: lambdaVersionLogicalId,
                   },

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -53,7 +53,7 @@ class AwsCompileCloudFrontEvents {
       const functionObj = this.serverless.service.getFunction(functionName);
       functionObj.events.forEach(({ cloudFront }) => {
         if (!cloudFront) return;
-        const { eventType = 'default' } = cloudFront;
+        const { eventType = 'default', includeBody = false } = cloudFront;
         const { maxMemorySize, maxTimeout } = this.lambdaEdgeLimits[eventType];
         if (functionObj.memorySize && functionObj.memorySize > maxMemorySize) {
           throw new Error(
@@ -64,6 +64,10 @@ class AwsCompileCloudFrontEvents {
           throw new Error(
             `"${functionName}" timeout is greater than ${maxTimeout} which is not supported by Lambda@Edge functions of type "${eventType}"`
           );
+        }
+
+        if (typeof includeBody !== Boolean) {
+          throw new Error(`"${functionName}" includeBody needs to be boolean`);
         }
       });
     });

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -275,6 +275,27 @@ describe('AwsCompileCloudFrontEvents', () => {
         awsCompileCloudFrontEvents.validate();
       }).to.throw(Error, 'greater than 30');
     });
+
+    it('should throw if includeBody is not boolean', () => {
+      awsCompileCloudFrontEvents.serverless.service.functions = {
+        first: {
+          timeout: 30,
+          events: [
+            {
+              cloudFront: {
+                eventType: 'origin-request',
+                includeBody: 'true',
+                origin: 's3://bucketname.s3.amazonaws.com/files',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => {
+        awsCompileCloudFrontEvents.validate();
+      }).to.throw(Error, '"first" includeBody needs to be boolean');
+    });
   });
 
   describe('#prepareFunctions()', () => {
@@ -583,6 +604,7 @@ describe('AwsCompileCloudFrontEvents', () => {
           .LambdaFunctionAssociations[0]
       ).to.eql({
         EventType: 'viewer-request',
+        IncludeBody: false,
         LambdaFunctionARN: {
           Ref: 'FirstLambdaVersion',
         },
@@ -1046,6 +1068,7 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'SecondLambdaVersion',
             },
@@ -1066,6 +1089,7 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'FirstLambdaVersion',
             },
@@ -1136,6 +1160,7 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'FirstLambdaVersion',
             },
@@ -1231,6 +1256,7 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'FirstLambdaVersion',
             },
@@ -1251,6 +1277,7 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'SecondLambdaVersion',
             },
@@ -1394,12 +1421,14 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'FirstLambdaVersion',
             },
           },
           {
             EventType: 'origin-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'SecondLambdaVersion',
             },
@@ -1469,6 +1498,7 @@ describe('AwsCompileCloudFrontEvents', () => {
         LambdaFunctionAssociations: [
           {
             EventType: 'viewer-request',
+            IncludeBody: false,
             LambdaFunctionARN: {
               Ref: 'FirstLambdaVersion',
             },


### PR DESCRIPTION
## Add `includeBody` param for Lambda@edge

Currently, Lambda@edge implementation is missing the `includeBody` options in `serverless.yml`

## How can we verify it
```
functions:
  myLambdaAtEdge:
    handler: myLambdaAtEdge.handler
    events:
      - cloudFront:
          eventType: viewer-response
          includeBody: true
          origin: s3://bucketname.s3.amazonaws.com/files
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- 

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
