### PR TITLE
Ensure to update API Gateway stage only for deployed API's

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -100,13 +100,23 @@ function resolveAccountInfo() {
 }
 
 function resolveApiGatewayResource(resources) {
-  if (resources.ApiGatewayRestApi) return resources.ApiGatewayRestApi;
-  const apiGatewayResources = _.values(resources).filter(
+  const apiGatewayResources = _.pickBy(
+    resources,
     resource => resource.Type === 'AWS::ApiGateway::RestApi'
   );
-  if (apiGatewayResources.length === 1) return apiGatewayResources[0];
-  // None, or more than one API Gateway found (currently there's no support for multiple APIGW's)
-  return null;
+  const apiGatewayResourcesIds = Object.keys(apiGatewayResources);
+  if (apiGatewayResourcesIds.length !== 1) return null;
+  const apiGatewayResourceId = apiGatewayResourcesIds[0];
+  if (
+    !_.findKey(resources, resource => {
+      if (resource.Type !== 'AWS::ApiGateway::Deployment') return false;
+      if (!resource.Properties || !resource.Properties.RestApiId) return false;
+      return resource.Properties.RestApiId.Ref === apiGatewayResourceId;
+    })
+  ) {
+    return null;
+  }
+  return apiGatewayResources[apiGatewayResourceId];
 }
 
 function resolveRestApiId() {
@@ -121,9 +131,11 @@ function resolveRestApiId() {
     const apiGatewayResource = resolveApiGatewayResource(
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources
     );
-    const apiName = apiGatewayResource
-      ? apiGatewayResource.Properties.Name
-      : provider.apiName || `${this.options.stage}-${this.state.service.service}`;
+    if (!apiGatewayResource) {
+      resolve(null);
+      return;
+    }
+    const apiName = apiGatewayResource.Properties.Name;
     const resolveFromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(api => api.name === apiName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -46,6 +46,14 @@ describe('#updateStage()', () => {
             Name: 'dev-my-service',
           },
         },
+        ApiGatewayRestApiDeployment: {
+          Type: 'AWS::ApiGateway::Deployment',
+          Properties: {
+            RestApiId: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          },
+        },
       },
     };
 
@@ -492,18 +500,19 @@ describe('#updateStage()', () => {
     resources.CustomApiGatewayRestApi = resources.ApiGatewayRestApi;
     delete resources.ApiGatewayRestApi;
     resources.CustomApiGatewayRestApi.Properties.Name = 'custom-rest-api-name';
+    resources.ApiGatewayRestApiDeployment.Properties.RestApiId.Ref = 'CustomApiGatewayRestApi';
     return updateStage.call(context).then(() => {
       expect(context.apiGatewayRestApiId).to.equal('customRestApiId');
     });
   });
 
-  it('should resolve with a default api name if the AWS::ApiGateway::Resource is not present', () => {
+  it('should not resolve if the AWS::ApiGateway::Resource is not present', () => {
     context.state.service.provider.tracing = { apiGateway: false };
     const resources = context.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     delete resources.ApiGatewayRestApi;
     options.stage = 'prod';
     return updateStage.call(context).then(() => {
-      expect(context.apiGatewayRestApiId).to.equal('prodRestApiId');
+      expect(context.apiGatewayRestApiId).to.equal(null);
     });
   });
 


### PR DESCRIPTION
So far `updateStage` logic was invoked also when it shouldn't be applied, and that produced different issues.

This implementation ensures that `updateStage` logic applies only if Rest API is defined in top level stack and has also deployment configured (so is actually deployed with a stack deployment).

This will bring regression to users which eventually had REST API defined in a nested stack, but such configuration worked so far only by blind assumption on settings in `serverless.yml`, and cannot be resolved easily directly from a nested CF stack.

I feel it's more important to fix this broken cases, which were reported many times in different issues. 

Fixes #7186 #7650 #6699

Confirmed nothing is broken, also by running integration tests

