### PR TITLE
Refactor conditional logic flaw in deployment monitoring logic

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -109,11 +109,11 @@ module.exports = {
                 });
                 // Handle stack create/update/delete failures
                 if (
-                  (stackLatestError && !this.options.verbose) ||
-                  (stackStatus &&
-                    (stackStatus.endsWith('ROLLBACK_COMPLETE') ||
-                      stackStatus === 'DELETE_FAILED') &&
-                    this.options.verbose)
+                  stackLatestError &&
+                  (!this.options.verbose ||
+                    (stackStatus &&
+                      (stackStatus.endsWith('ROLLBACK_COMPLETE') ||
+                        stackStatus === 'DELETE_FAILED')))
                 ) {
                   // empty console.log for a prettier output
                   if (!this.options.verbose) this.serverless.cli.consoleLog('');


### PR DESCRIPTION
Conditional made impression that `stackLatestError` is optional. While in body of it we may see it's required.

Updated conditional to better reflect the intention