### PR TITLE
Remove -v from rollback command

### DIFF
--- a/docs/providers/aws/cli-reference/rollback-function.md
+++ b/docs/providers/aws/cli-reference/rollback-function.md
@@ -25,7 +25,7 @@ serverless rollback function --function <name> --function-version <version>
 ## Options
 
 - `--function` or `-f` The name of the function which should be rolled back
-- `--function-version` or `-v` The version to which the function should be rolled back
+- `--function-version` The version to which the function should be rolled back
 
 ## Examples
 
@@ -34,4 +34,4 @@ serverless rollback function --function <name> --function-version <version>
 At first you want to run `serverless deploy list functions` to see all the deployed functions of your service and their corresponding versions.
 After picking a function and the version you can run the `serverless rollback function` command to rollback the function.
 
-E.g. `serverless rollback function -f my-function -v 23` rolls back the function `my-function` to the version `23`.
+E.g. `serverless rollback function -f my-function --function-version 23` rolls back the function `my-function` to the version `23`.

--- a/lib/plugins/aws/rollbackFunction/index.js
+++ b/lib/plugins/aws/rollbackFunction/index.js
@@ -26,7 +26,6 @@ class AwsRollbackFunction {
               },
               'function-version': {
                 usage: 'Version of the function',
-                shortcut: 'v',
                 required: true,
               },
               'stage': {

--- a/lib/plugins/rollback/index.js
+++ b/lib/plugins/rollback/index.js
@@ -35,7 +35,6 @@ class Rollback {
               },
               'function-version': {
                 usage: 'Version of the function',
-                shortcut: 'v',
                 required: true,
               },
               'stage': {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

Removed `-v` shortcut for `function-version` as it's till confused with `-v` for version
Closes #7645

## How can we verify it

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** YES
