### PR TITLE
Add `includeBody` param for Lambda@edge

### DIFF
--- a/docs/providers/aws/events/cloudfront.md
+++ b/docs/providers/aws/events/cloudfront.md
@@ -147,6 +147,7 @@ functions:
     events:
       - cloudFront:
           eventType: viewer-response
+          includeBody: true
           origin: s3://bucketname.s3.amazonaws.com/files
       - cloudFront:
           eventType: viewer-response

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -436,6 +436,7 @@ functions:
             inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
       - cloudFront:
           eventType: viewer-response
+          includeBody: true
           pathPattern: /docs*
           origin:
             DomainName: serverless.com

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -213,10 +213,7 @@ class AwsCompileCloudFrontEvents {
               },
             };
 
-            if (
-              event.cloudFront.includeBody !== null &&
-              event.cloudFront.includeBody !== undefined
-            ) {
+            if (event.cloudFront.includeBody != null) {
               lambdaFunctionAssociation.IncludeBody = event.cloudFront.includeBody;
             }
 

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -53,7 +53,7 @@ class AwsCompileCloudFrontEvents {
       const functionObj = this.serverless.service.getFunction(functionName);
       functionObj.events.forEach(({ cloudFront }) => {
         if (!cloudFront) return;
-        const { eventType = 'default' } = cloudFront;
+        const { eventType = 'default', includeBody = undefined } = cloudFront;
         const { maxMemorySize, maxTimeout } = this.lambdaEdgeLimits[eventType];
         if (functionObj.memorySize && functionObj.memorySize > maxMemorySize) {
           throw new Error(
@@ -206,16 +206,20 @@ class AwsCompileCloudFrontEvents {
               Object.assign(behavior, event.cloudFront.behavior);
             }
 
+            const lambdaFunctionAssociation = {
+              EventType: event.cloudFront.eventType,
+              LambdaFunctionARN: {
+                Ref: lambdaVersionLogicalId,
+              },
+            };
+
+            if (event.cloudFront.includeBody) {
+              lambdaFunctionAssociation.IncludeBody = event.cloudFront.includeBody;
+            }
+
             Object.assign(behavior, {
               TargetOriginId: origin.Id,
-              LambdaFunctionAssociations: [
-                {
-                  EventType: event.cloudFront.eventType,
-                  LambdaFunctionARN: {
-                    Ref: lambdaVersionLogicalId,
-                  },
-                },
-              ],
+              LambdaFunctionAssociations: [lambdaFunctionAssociation],
             });
 
             if (pathPattern) {

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -213,7 +213,10 @@ class AwsCompileCloudFrontEvents {
               },
             };
 
-            if (event.cloudFront.includeBody !== null) {
+            if (
+              event.cloudFront.includeBody !== null &&
+              event.cloudFront.includeBody !== undefined
+            ) {
               lambdaFunctionAssociation.IncludeBody = event.cloudFront.includeBody;
             }
 

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -53,7 +53,7 @@ class AwsCompileCloudFrontEvents {
       const functionObj = this.serverless.service.getFunction(functionName);
       functionObj.events.forEach(({ cloudFront }) => {
         if (!cloudFront) return;
-        const { eventType = 'default', includeBody = undefined } = cloudFront;
+        const { eventType = 'default' } = cloudFront;
         const { maxMemorySize, maxTimeout } = this.lambdaEdgeLimits[eventType];
         if (functionObj.memorySize && functionObj.memorySize > maxMemorySize) {
           throw new Error(
@@ -213,7 +213,7 @@ class AwsCompileCloudFrontEvents {
               },
             };
 
-            if (event.cloudFront.includeBody) {
+            if (event.cloudFront.includeBody !== null) {
               lambdaFunctionAssociation.IncludeBody = event.cloudFront.includeBody;
             }
 


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## Add `includeBody` param for Lambda@edge

Currently, Lambda@edge implementation is missing the `includeBody` option in `serverless.yml`

## How can we verify it

```
functions:
  myLambdaAtEdge:
    handler: myLambdaAtEdge.handler
    events:
      - cloudFront:
          eventType: viewer-response
          includeBody: true
          origin: s3://bucketname.s3.amazonaws.com/files
```

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
