### PR TITLE
Modify cors headers validation to accept single value

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -329,6 +329,20 @@ functions:
             cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate' # Caches on browser and proxy for 10 minutes and doesnt allow proxy to serve out of date content
 ```
 
+CORS header accepts single value too
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          path: hello
+          method: get
+          cors:
+            headers: '*'
+```
+
 If you want to use CORS with the lambda-proxy integration, remember to include the `Access-Control-Allow-*` headers in your headers object, like this:
 
 ```javascript

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -364,10 +364,13 @@ module.exports = {
         throw new this.serverless.classes.Error(errorMessage);
       }
 
-      if (cors.headers) {
-        if (!Array.isArray(cors.headers)) {
+      const corsHeaders = cors.headers;
+      if (corsHeaders) {
+        if (typeof corsHeaders === 'string') {
+          cors.headers = [corsHeaders];
+        } else if (!Array.isArray(corsHeaders)) {
           const errorMessage = [
-            'CORS header values must be provided as an array.',
+            'CORS header values must be provided as an array or a single string value.',
             ' Please check the docs for more info.',
           ].join('');
           throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -719,7 +719,7 @@ describe('#validate()', () => {
     expect(() => awsCompileApigEvents.validate()).to.throw(Error);
   });
 
-  it('should throw if cors headers are not an array', () => {
+  it('should throw if cors headers are not an array or a string', () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [
@@ -737,6 +737,29 @@ describe('#validate()', () => {
     };
 
     expect(() => awsCompileApigEvents.validate()).to.throw(Error);
+  });
+
+  it('should accept cors headers as a single string value', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'POST',
+              path: '/foo/bar',
+              cors: {
+                headers: 'X-Foo-Bar',
+              },
+            },
+          },
+        ],
+      },
+    };
+    const validated = awsCompileApigEvents.validate();
+    expect(validated.events)
+      .to.be.an('Array')
+      .with.length(1);
+    expect(validated.events[0].http.cors.headers).to.deep.equal(['X-Foo-Bar']);
   });
 
   it('should process cors options', () => {


### PR DESCRIPTION
<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement
Modify CORS header validation to accept single string value

Closes #7652

## How can we verify it

```yml
service: test-service
provider:
  name: aws
functions:
  hello:
    handler: index.handler
    events:
      - http:
          path: product/{id}
          method: get
          cors:
            origin: '*' # <-- Specify allowed origin
            headers: '*'
            allowCredentials: false
```
Running `npx serverless deploy` shouldn't throw an error `CORS header values must be provided as an array ...`

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [x] Write and run all tests
- [x] Write documentation
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
