### PR TITLE
Allow parameters to be passed in by plugins

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -466,7 +466,7 @@ resources:
     ParameterName:
       Type: String | Number | List | CommaDelimitedList | etc.
       NoEcho: true | false # used to mask the parameter's value
-      
+
   Resources:
     usersTable:
       Type: AWS::DynamoDB::Table

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -164,6 +164,9 @@ provider:
       - subnetId2
   notificationArns: # List of existing Amazon SNS topics in the same region where notifications about stack events are sent.
     - 'arn:aws:sns:us-east-1:XXXXXX:mytopic'
+  stackParameters:
+    - ParameterKey: 'Keyname'
+      ParameterValue: 'Value'
   resourcePolicy:
     - Effect: Allow
       Principal: '*'
@@ -457,6 +460,13 @@ layers:
 
 # The "Resources" your "Functions" use.  Raw AWS CloudFormation goes in here.
 resources:
+  Parameters:
+    # Parameters have all the attributes available from cloudformation parameter's capabilities
+    # To see more options: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+    ParameterName:
+      Type: String | Number | List | CommaDelimitedList | etc.
+      NoEcho: true | false # used to mask the parameter's value
+      
   Resources:
     usersTable:
       Type: AWS::DynamoDB::Table

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -460,13 +460,6 @@ layers:
 
 # The "Resources" your "Functions" use.  Raw AWS CloudFormation goes in here.
 resources:
-  Parameters:
-    # Parameters have all the attributes available from cloudformation parameter's capabilities
-    # To see more options: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
-    ParameterName:
-      Type: String | Number | List | CommaDelimitedList | etc.
-      NoEcho: true | false # used to mask the parameter's value
-
   Resources:
     usersTable:
       Type: AWS::DynamoDB::Table

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -46,8 +46,10 @@ module.exports = {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
 
-    if (this.serverless.service.provider.parameters) {
-      params.Parameters = this.serverless.service.provider.parameters;
+    console.log('Reached stack parameters');
+    if (this.serverless.service.provider.stackParameters) {
+      console.log('Setting stack parameters');
+      params.Parameters = this.serverless.service.provider.stackParameters;
     }
 
     return this.provider
@@ -92,8 +94,8 @@ module.exports = {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
 
-    if (this.serverless.service.provider.parameters) {
-      params.Parameters = this.serverless.service.provider.parameters;
+    if (this.serverless.service.provider.stackParameters) {
+      params.Parameters = this.serverless.service.provider.stackParameters;
     }
 
     // Policy must have at least one statement, otherwise no updates would be possible at all

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -45,6 +45,10 @@ module.exports = {
     if (this.serverless.service.provider.notificationArns) {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
+    
+    if (this.serverless.service.provider.parameters) {
+      params.Parameters = this.serverless.service.provider.parameters;
+    }
 
     return this.provider
       .request('CloudFormation', 'createStack', params)
@@ -86,6 +90,10 @@ module.exports = {
 
     if (this.serverless.service.provider.notificationArns) {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
+    }
+    
+    if (this.serverless.service.provider.parameters) {
+      params.Parameters = this.serverless.service.provider.parameters;
     }
 
     // Policy must have at least one statement, otherwise no updates would be possible at all

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -46,9 +46,7 @@ module.exports = {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
 
-    console.log('Reached stack parameters');
     if (this.serverless.service.provider.stackParameters) {
-      console.log('Setting stack parameters');
       params.Parameters = this.serverless.service.provider.stackParameters;
     }
 

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -45,7 +45,7 @@ module.exports = {
     if (this.serverless.service.provider.notificationArns) {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
-    
+
     if (this.serverless.service.provider.parameters) {
       params.Parameters = this.serverless.service.provider.parameters;
     }
@@ -91,7 +91,7 @@ module.exports = {
     if (this.serverless.service.provider.notificationArns) {
       params.NotificationARNs = this.serverless.service.provider.notificationArns;
     }
-    
+
     if (this.serverless.service.provider.parameters) {
       params.Parameters = this.serverless.service.provider.parameters;
     }

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -101,14 +101,15 @@ describe('updateStack', () => {
       });
     });
 
-    
     it('should add Stack Parameters on createFallback', () => {
       awsDeploy.serverless.service.provider.stackParameters = [
-        { ParameterKey: 'key', ParameterValue: 'value' }
+        { ParameterKey: 'key', ParameterValue: 'value' },
       ];
 
       return awsDeploy.createFallback().then(() => {
-        expect(createStackStub.args[0][2].Parameters).to.deep.equal(awsDeploy.serverless.service.provider.stackParameters);
+        expect(createStackStub.args[0][2].Parameters).to.deep.equal(
+          awsDeploy.serverless.service.provider.stackParameters
+        );
       });
     });
   });
@@ -224,11 +225,13 @@ describe('updateStack', () => {
 
     it('should add Stack Parameters on update', () => {
       awsDeploy.serverless.service.provider.stackParameters = [
-        { ParameterKey: 'key', ParameterValue: 'value' }
+        { ParameterKey: 'key', ParameterValue: 'value' },
       ];
 
       return awsDeploy.update().then(() => {
-        expect(updateStackStub.args[0][2].Parameters).to.deep.equal(awsDeploy.serverless.service.provider.stackParameters);
+        expect(updateStackStub.args[0][2].Parameters).to.deep.equal(
+          awsDeploy.serverless.service.provider.stackParameters
+        );
       });
     });
   });

--- a/lib/plugins/aws/lib/updateStack.test.js
+++ b/lib/plugins/aws/lib/updateStack.test.js
@@ -100,6 +100,17 @@ describe('updateStack', () => {
         expect(createStackStub.args[0][2].NotificationARNs).to.deep.equal([mytopicArn]);
       });
     });
+
+    
+    it('should add Stack Parameters on createFallback', () => {
+      awsDeploy.serverless.service.provider.stackParameters = [
+        { ParameterKey: 'key', ParameterValue: 'value' }
+      ];
+
+      return awsDeploy.createFallback().then(() => {
+        expect(createStackStub.args[0][2].Parameters).to.deep.equal(awsDeploy.serverless.service.provider.stackParameters);
+      });
+    });
   });
 
   describe('#update()', () => {
@@ -208,6 +219,16 @@ describe('updateStack', () => {
         expect(updateStackStub.args[0][2].RollbackConfiguration).to.deep.equal(
           myRollbackConfiguration
         );
+      });
+    });
+
+    it('should add Stack Parameters on update', () => {
+      awsDeploy.serverless.service.provider.stackParameters = [
+        { ParameterKey: 'key', ParameterValue: 'value' }
+      ];
+
+      return awsDeploy.update().then(() => {
+        expect(updateStackStub.args[0][2].Parameters).to.deep.equal(awsDeploy.serverless.service.provider.stackParameters);
       });
     });
   });


### PR DESCRIPTION
This change allows parameters to be passed in leveraging plugins.  There are occasions when parameters offer a better option than directly compiling values into the cloudformation.  One example of this is passwords.   If a password were embedded into a cloudformation, anyone with read access could see the password.  Using a parameter for this field with NoEcho, will result in the parameter being masked.

<!-- Please fill out THE WHOLE PR TEMPLATE. Otherwise we probably have to close the PR due to missing information -->

## What did you implement

This PR allows plugins to leverage the cloudformation parameters, which helps with specific use cases where embedding values (such as passwords) is not preferable and can create security issues in accounts.

Closes #No Bug

## How can we verify it

This enables plugins, and is not directly accessible by the yml file.

## Todos

<details>
<summary>Useful Scripts</summary>
<!-- You might want to use the following scripts to streamline your development workflow -->

- `npm run test:ci` --> Run all validation checks on proposed changes
- `npm run lint:updated` --> Lint all the updated files
- `npm run lint:fix` --> Automatically fix lint problems (if possible)
- `npm run prettier-check:updated` --> Check if updated files adhere to Prettier config
- `npm run prettify:updated` --> Prettify all the updated files

</details>

- [N/A] Write and run all tests
- [N/A] Write documentation
- [x ] Enable "Allow edits from maintainers" for this PR
- [ x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
