### PR TITLE
Updating stream event properties "MaximumRetryAttempts" & "BisectBatchOnFunctionError" when value is falsy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 npm-debug.log
 /package-lock.json
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /node_modules
 npm-debug.log
 /package-lock.json
-/.idea

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -256,11 +256,11 @@ class AwsCompileStreamEvents {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 
-            if (event.stream.maximumRetryAttempts != null) {
+            if (event.stream.maximumRetryAttempts !== null) {
               streamResource.Properties.MaximumRetryAttempts = event.stream.maximumRetryAttempts;
             }
 
-            if (event.stream.bisectBatchOnFunctionError != null) {
+            if (event.stream.bisectBatchOnFunctionError !== null) {
               streamResource.Properties.BisectBatchOnFunctionError = event.stream.bisectBatchOnFunctionError;
             }
 

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -261,7 +261,8 @@ class AwsCompileStreamEvents {
             }
 
             if (event.stream.bisectBatchOnFunctionError != null) {
-              streamResource.Properties.BisectBatchOnFunctionError = event.stream.bisectBatchOnFunctionError;
+              streamResource.Properties.BisectBatchOnFunctionError =
+                event.stream.bisectBatchOnFunctionError;
             }
 
             if (event.stream.destinations) {

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -256,11 +256,11 @@ class AwsCompileStreamEvents {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 
-            if (event.stream.maximumRetryAttempts !== null) {
+            if (event.stream.maximumRetryAttempts != null) {
               streamResource.Properties.MaximumRetryAttempts = event.stream.maximumRetryAttempts;
             }
 
-            if (event.stream.bisectBatchOnFunctionError !== null) {
+            if (event.stream.bisectBatchOnFunctionError != null) {
               streamResource.Properties.BisectBatchOnFunctionError = event.stream.bisectBatchOnFunctionError;
             }
 

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -252,16 +252,14 @@ class AwsCompileStreamEvents {
               );
             }
 
+            streamResource.Properties.BisectBatchOnFunctionError = (event.stream.bisectBatchOnFunctionError === true);
+
             if (event.stream.batchWindow) {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 
-            if (event.stream.maximumRetryAttempts) {
+            if (event.stream.maximumRetryAttempts >= 0) {
               streamResource.Properties.MaximumRetryAttempts = event.stream.maximumRetryAttempts;
-            }
-
-            if (event.stream.bisectBatchOnFunctionError) {
-              streamResource.Properties.BisectBatchOnFunctionError = true;
             }
 
             if (event.stream.destinations) {

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -252,14 +252,16 @@ class AwsCompileStreamEvents {
               );
             }
 
-            streamResource.Properties.BisectBatchOnFunctionError = (event.stream.bisectBatchOnFunctionError === true);
-
             if (event.stream.batchWindow) {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 
-            if (event.stream.maximumRetryAttempts >= 0) {
+            if (event.stream.maximumRetryAttempts != null) {
               streamResource.Properties.MaximumRetryAttempts = event.stream.maximumRetryAttempts;
+            }
+
+            if (event.stream.bisectBatchOnFunctionError != null) {
+              streamResource.Properties.BisectBatchOnFunctionError = event.stream.bisectBatchOnFunctionError;
             }
 
             if (event.stream.destinations) {


### PR DESCRIPTION
This will fix below minor bug in event stream mapping.

**Issues it will resolve**

1. In the event of stream if i want to specify `maximumRetryAttempts` to `0` then i can't due to falsy condition of 0 in code. And

2. Once i set `bisectBatchOnFunctionError` to `true` and again if i want to make it `false` then i am not able to do that due to falsy condition of the code.

When this merge request will be approved then we will able to define mapping of stream event
`maximumRetryAttempts` and `bisectBatchOnFunctionError` to `0` and `false` respectively.

**Is this ready for review?: Yes
Is it a breaking change?: NO**
