### PR TITLE
Fix generation of custom resource lambda zip

### DIFF
--- a/lib/plugins/aws/customResources/generateZip.js
+++ b/lib/plugins/aws/customResources/generateZip.js
@@ -37,12 +37,17 @@ module.exports = memoize(() => {
       if (isCached) return cachedZipFilePath;
       const ensureCachedDirDeferred = fse.ensureDirAsync(path.dirname(cachedZipFilePath));
       const tmpDirPath = getTmpDirPath();
+      const tmpInstalledLambdaPath = path.resolve(tmpDirPath, 'resource-lambda');
+      const tmpZipFilePath = path.resolve(tmpDirPath, 'resource-lambda.zip');
       return fse
-        .copyAsync(srcDirPath, tmpDirPath)
+        .copyAsync(srcDirPath, tmpInstalledLambdaPath)
         .then(() => npmCommandDeferred)
-        .then(npmCommand => childProcess.execAsync(`${npmCommand} install`, { cwd: tmpDirPath }))
+        .then(npmCommand =>
+          childProcess.execAsync(`${npmCommand} install`, { cwd: tmpInstalledLambdaPath })
+        )
         .then(() => ensureCachedDirDeferred)
-        .then(() => createZipFile(tmpDirPath, cachedZipFilePath))
+        .then(() => createZipFile(tmpInstalledLambdaPath, tmpZipFilePath))
+        .then(() => fse.moveAsync(tmpZipFilePath, cachedZipFilePath))
         .then(() => cachedZipFilePath);
     });
 });


### PR DESCRIPTION
In case of custom resource lambda packaging process being stopped in a middle, we were left with broken zip that was accepted for further deployment.

Fix is to generate zip to temporary directory and move it once generation of archive is finalized

Closes: #7242
