### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "mkdirp": "^0.5.4",
     "nanomatch": "^1.2.13",
     "ncjsm": "^4.0.1",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^2.6.0",
     "object-hash": "^2.0.3",
     "p-limit": "^2.3.0",
     "promise-queue": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^8.1.1",
     "sinon-chai": "^3.5.0",
-    "standard-version": "^7.1.0",
+    "standard-version": "^8.0.0",
     "strip-ansi": "^5.2.0",
     "ws": "^7.2.5",
     "xml2js": "^0.4.23"

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "fast-levenshtein": "^2.0.6",
     "filesize": "^3.6.1",
     "fs-extra": "^0.30.0",
-    "get-stdin": "^5.0.1",
+    "get-stdin": "^6.0.0",
     "globby": "^6.1.0",
     "graceful-fs": "^4.2.4",
     "https-proxy-agent": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "prettier": "^1.19.1",
     "process-utils": "^3.1.0",
     "proxyquire": "^2.1.3",
-    "sinon": "^7.5.0",
+    "sinon": "^8.1.1",
     "sinon-chai": "^3.5.0",
     "standard-version": "^7.1.0",
     "strip-ansi": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "get-stdin": "^6.0.0",
     "globby": "^6.1.0",
     "graceful-fs": "^4.2.4",
-    "https-proxy-agent": "^4.0.0",
+    "https-proxy-agent": "^5.0.0",
     "inquirer": "^6.5.2",
     "is-docker": "^1.1.0",
     "is-wsl": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "mocha": "^6.2.3",
     "mocha-lcov-reporter": "^1.3.0",
     "mock-require": "^3.0.3",
-    "nyc": "^14.1.1",
+    "nyc": "^15.0.1",
     "pkg": "^4.4.8",
     "prettier": "^1.19.1",
     "process-utils": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -209,6 +209,6 @@
     "uuid": "^2.0.3",
     "write-file-atomic": "^2.4.3",
     "yaml-ast-parser": "0.0.43",
-    "yargs-parser": "^16.1.0"
+    "yargs-parser": "^18.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "rc": "^1.2.8",
     "replaceall": "^0.1.6",
     "semver": "^5.7.1",
-    "semver-regex": "^1.0.0",
+    "semver-regex": "^2.0.0",
     "stream-promise": "^3.2.0",
     "tabtab": "^3.0.2",
     "untildify": "^3.0.3",


### PR DESCRIPTION
Those which can be upgraded without necessary code changes

- `get-stdin` to v6
- `https-proxy-agent` to v5
- ~~`json-refs` to v3~~
- `node-fetch` to v2
- `semver-regex` to v2
- `yargs-parser` to v18
- `nyc` to v15
- `sinon` to v8
- `standard-version` to v8