### PR TITLE
Fix IAM role and policy name resolution

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -89,7 +89,15 @@ module.exports = {
   },
   getRoleName() {
     return {
-      'Fn::Join': ['-', [this.getStackName(), { Ref: 'AWS::Region' }, 'lambdaRole']],
+      'Fn::Join': [
+        '-',
+        [
+          this.provider.serverless.service.service,
+          this.provider.getStage(),
+          { Ref: 'AWS::Region' },
+          'lambdaRole',
+        ],
+      ],
     };
   },
   getRoleLogicalId() {
@@ -99,7 +107,10 @@ module.exports = {
   // Policy
   getPolicyName() {
     return {
-      'Fn::Join': ['-', [this.getStackName(), 'lambda']],
+      'Fn::Join': [
+        '-',
+        [this.provider.serverless.service.service, this.provider.getStage(), 'lambda'],
+      ],
     };
   },
 

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -111,7 +111,15 @@ describe('#naming()', () => {
     it('uses the service name, stage, and region to generate a role name', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getRoleName()).to.eql({
-        'Fn::Join': ['-', [sdk.naming.getStackName(), { Ref: 'AWS::Region' }, 'lambdaRole']],
+        'Fn::Join': [
+          '-',
+          [
+            serverless.service.service,
+            sdk.naming.provider.getStage(),
+            { Ref: 'AWS::Region' },
+            'lambdaRole',
+          ],
+        ],
       });
     });
   });
@@ -126,7 +134,7 @@ describe('#naming()', () => {
     it('should use the stage and service name', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getPolicyName()).to.eql({
-        'Fn::Join': ['-', [sdk.naming.getStackName(), 'lambda']],
+        'Fn::Join': ['-', [serverless.service.service, sdk.naming.provider.getStage(), 'lambda']],
       });
     });
   });

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -76,7 +76,10 @@ describe('#mergeIamTemplates()', () => {
           Policies: [
             {
               PolicyName: {
-                'Fn::Join': ['-', [awsPackage.provider.naming.getStackName(), 'lambda']],
+                'Fn::Join': [
+                  '-',
+                  [awsPackage.serverless.service.service, awsPackage.provider.getStage(), 'lambda'],
+                ],
               },
               PolicyDocument: {
                 Version: '2012-10-17',
@@ -111,7 +114,8 @@ describe('#mergeIamTemplates()', () => {
             'Fn::Join': [
               '-',
               [
-                awsPackage.provider.naming.getStackName(),
+                awsPackage.serverless.service.service,
+                awsPackage.provider.getStage(),
                 {
                   Ref: 'AWS::Region',
                 },
@@ -158,7 +162,10 @@ describe('#mergeIamTemplates()', () => {
           Policies: [
             {
               PolicyName: {
-                'Fn::Join': ['-', [awsPackage.provider.naming.getStackName(), 'lambda']],
+                'Fn::Join': [
+                  '-',
+                  [awsPackage.serverless.service.service, awsPackage.provider.getStage(), 'lambda'],
+                ],
               },
               PolicyDocument: {
                 Version: '2012-10-17',
@@ -193,7 +200,8 @@ describe('#mergeIamTemplates()', () => {
             'Fn::Join': [
               '-',
               [
-                awsPackage.provider.naming.getStackName(),
+                awsPackage.serverless.service.service,
+                awsPackage.provider.getStage(),
                 {
                   Ref: 'AWS::Region',
                 },
@@ -243,7 +251,10 @@ describe('#mergeIamTemplates()', () => {
           Policies: [
             {
               PolicyName: {
-                'Fn::Join': ['-', [awsPackage.provider.naming.getStackName(), 'lambda']],
+                'Fn::Join': [
+                  '-',
+                  [awsPackage.serverless.service.service, awsPackage.provider.getStage(), 'lambda'],
+                ],
               },
               PolicyDocument: {
                 Version: '2012-10-17',
@@ -278,7 +289,8 @@ describe('#mergeIamTemplates()', () => {
             'Fn::Join': [
               '-',
               [
-                awsPackage.provider.naming.getStackName(),
+                awsPackage.serverless.service.service,
+                awsPackage.provider.getStage(),
                 {
                   Ref: 'AWS::Region',
                 },
@@ -334,7 +346,10 @@ describe('#mergeIamTemplates()', () => {
           Policies: [
             {
               PolicyName: {
-                'Fn::Join': ['-', [awsPackage.provider.naming.getStackName(), 'lambda']],
+                'Fn::Join': [
+                  '-',
+                  [awsPackage.serverless.service.service, awsPackage.provider.getStage(), 'lambda'],
+                ],
               },
               PolicyDocument: {
                 Version: '2012-10-17',
@@ -379,7 +394,8 @@ describe('#mergeIamTemplates()', () => {
             'Fn::Join': [
               '-',
               [
-                awsPackage.provider.naming.getStackName(),
+                awsPackage.serverless.service.service,
+                awsPackage.provider.getStage(),
                 {
                   Ref: 'AWS::Region',
                 },


### PR DESCRIPTION
Custom stack name should be used only for naming CloudFormation stack, however with #7357 it was used to generate role and policy name, and that was precedence.

It also imposed a various issues for users (as outlined in #7357 comments)

This PR reverts that behavior