### PR TITLE
Fix `pkg` issue workaround, so it works on Windows

### DIFF
--- a/lib/utils/standalone-patch.js
+++ b/lib/utils/standalone-patch.js
@@ -13,8 +13,10 @@ const path = require('path');
 const originalCopyFile = fs.copyFile;
 const originalCopyFileSync = fs.copyFileSync;
 
+const isBundled = RegExp.prototype.test.bind(/^(?:\/snapshot\/|[A-Z]+:\\snapshot\\)/);
+
 fs.copyFile = function copyFile(src, dest, flags, callback) {
-  if (!path.resolve(src).startsWith('/snapshot/')) {
+  if (!isBundled(path.resolve(src))) {
     originalCopyFile(src, dest, flags, callback);
     return;
   }
@@ -49,7 +51,7 @@ fs.copyFile = function copyFile(src, dest, flags, callback) {
 };
 
 fs.copyFileSync = function copyFileSync(src, dest, flags) {
-  if (!path.resolve(src).startsWith('/snapshot/')) {
+  if (!isBundled(path.resolve(src))) {
     originalCopyFileSync(src, dest, flags);
     return;
   }


### PR DESCRIPTION
Closes #7696 

It appears workaround was not prepared to work on Windows, hence it failed over there.