### PR TITLE
change api name for serachable

### DIFF
--- a/docs/providers/google/guide/credentials.md
+++ b/docs/providers/google/guide/credentials.md
@@ -43,10 +43,10 @@ You need to enable the following APIs so that Serverless can create the correspo
 
 Go to the <a href="https://console.cloud.google.com/apis/dashboard" target="_blank">API dashboard</a>, select your project and enable the following APIs (if not already enabled):
 
-- Google Cloud Functions
-- Google Cloud Deployment Manager
-- Google Cloud Storage
-- Stackdriver Logging
+- Cloud Functions API
+- Cloud Deployment Manager V2 API
+- Cloud Storage
+- Cloud Logging API
 
 ## Get credentials & assign roles
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

- Change [https://www.serverless.com/framework/docs/providers/google/guide/credentials#enable-the-necessary-apis](https://www.serverless.com/framework/docs/providers/google/guide/credentials#enable-the-necessary-apis) page.

In my change, user can copy api name and serach api.  
For example, when search `Stackdriver Logging`, result is `No results found`.  
So I thought, docs should be written real api service name.  
With my change, user can access the API directly by searching for the API name in the docs.

