### PR TITLE
Replace _.isArray with native Array.isArray

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -165,14 +165,14 @@ class PluginManager {
       path.join(this.serverless.config.servicePath, '.serverless_plugins');
     let modules = [];
 
-    if (_.isArray(servicePlugs)) {
+    if (Array.isArray(servicePlugs)) {
       modules = servicePlugs;
     } else if (servicePlugs) {
       localPath =
         servicePlugs.localPath && _.isString(servicePlugs.localPath)
           ? servicePlugs.localPath
           : localPath;
-      if (_.isArray(servicePlugs.modules)) {
+      if (Array.isArray(servicePlugs.modules)) {
         modules = servicePlugs.modules;
       }
     }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -173,7 +173,7 @@ class Service {
 
   validate() {
     _.forEach(this.functions, (functionObj, functionName) => {
-      if (!_.isArray(functionObj.events)) {
+      if (!Array.isArray(functionObj.events)) {
         throw new ServerlessError(
           `Events for "${functionName}" must be an array, not an ${typeof functionObj.events}`
         );

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -257,7 +257,7 @@ class Variables {
     }
     const addContext = (value, key) =>
       this.getProperties(root, false, value, context.concat(key), results);
-    if (_.isArray(current)) {
+    if (Array.isArray(current)) {
       _.map(current, addContext);
     } else if (
       _.isObject(current) &&
@@ -404,7 +404,7 @@ class Variables {
   populateValue(valueToPopulate, root) {
     const property = valueToPopulate;
     const matches = this.getMatches(property);
-    if (!_.isArray(matches)) {
+    if (!Array.isArray(matches)) {
       return BbPromise.resolve(property);
     }
     const populations = this.populateMatches(matches, valueToPopulate);

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -143,7 +143,7 @@ class AwsDeployFunction {
 
     if (
       'layers' in functionObj &&
-      _.isArray(functionObj.layers) &&
+      Array.isArray(functionObj.layers) &&
       !_.some(functionObj.layers, _.isObject)
     ) {
       params.Layers = functionObj.layers;
@@ -184,11 +184,11 @@ class AwsDeployFunction {
       const vpc = functionObj.vpc || providerObj.vpc;
       params.VpcConfig = {};
 
-      if (_.isArray(vpc.securityGroupIds) && !_.some(vpc.securityGroupIds, _.isObject)) {
+      if (Array.isArray(vpc.securityGroupIds) && !_.some(vpc.securityGroupIds, _.isObject)) {
         params.VpcConfig.SecurityGroupIds = vpc.securityGroupIds;
       }
 
-      if (_.isArray(vpc.subnetIds) && !_.some(vpc.subnetIds, _.isObject)) {
+      if (Array.isArray(vpc.subnetIds) && !_.some(vpc.subnetIds, _.isObject)) {
         params.VpcConfig.SubnetIds = vpc.subnetIds;
       }
 

--- a/lib/plugins/aws/info/getApiKeyValues.js
+++ b/lib/plugins/aws/info/getApiKeyValues.js
@@ -11,7 +11,7 @@ module.exports = {
     // check if the user has set api keys
     const apiKeyDefinitions = this.serverless.service.provider.apiKeys;
     const apiKeyNames = [];
-    if (_.isArray(apiKeyDefinitions) && apiKeyDefinitions.length) {
+    if (Array.isArray(apiKeyDefinitions) && apiKeyDefinitions.length) {
       _.forEach(apiKeyDefinitions, definition => {
         // different API key types are nested in separate arrays
         if (_.isObject(definition)) {

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -125,7 +125,7 @@ module.exports = {
       ].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }
-    if (!_.isArray(event.alb.conditions.header.values)) {
+    if (!Array.isArray(event.alb.conditions.header.values)) {
       const errorMessage = [messageTitle, ' Property "values" must be an array.'].join('');
       throw new this.serverless.classes.Error(errorMessage);
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -38,7 +38,7 @@ module.exports = {
   },
   compileApiKeys() {
     if (this.serverless.service.provider.apiKeys) {
-      if (!_.isArray(this.serverless.service.provider.apiKeys)) {
+      if (!Array.isArray(this.serverless.service.provider.apiKeys)) {
         throw new this.serverless.classes.Error('apiKeys property must be an array');
       }
       const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -111,7 +111,7 @@ module.exports = {
       const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       this.apiGatewayUsagePlanNames = [];
 
-      if (_.isArray(this.serverless.service.provider.usagePlan)) {
+      if (Array.isArray(this.serverless.service.provider.usagePlan)) {
         _.forEach(this.serverless.service.provider.usagePlan, planObject => {
           const usagePlanName = Object.keys(planObject)[0];
           const logicalId = this.provider.naming.getUsagePlanLogicalId(usagePlanName);

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -75,7 +75,7 @@ class AwsCompileS3Events {
                 notificationEvent = event.s3.event;
               }
               if (event.s3.rules) {
-                if (!_.isArray(event.s3.rules)) {
+                if (!Array.isArray(event.s3.rules)) {
                   const errorMessage = [
                     `S3 filter rules of function ${functionName} is not an array`,
                     ' The correct syntax is: rules: [{ Name: Value }]',

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -420,11 +420,11 @@ class AwsCompileFunctions {
         functionResource.DependsOn || []
       );
 
-      if (functionObject.layers && _.isArray(functionObject.layers)) {
+      if (functionObject.layers && Array.isArray(functionObject.layers)) {
         functionResource.Properties.Layers = functionObject.layers;
       } else if (
         this.serverless.service.provider.layers &&
-        _.isArray(this.serverless.service.provider.layers)
+        Array.isArray(this.serverless.service.provider.layers)
       ) {
         functionResource.Properties.Layers = this.serverless.service.provider.layers;
       }

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -229,7 +229,7 @@ module.exports = {
     if (!iamManagedPolicies) {
       return;
     }
-    if (!_.isArray(iamManagedPolicies)) {
+    if (!Array.isArray(iamManagedPolicies)) {
       throw new this.serverless.classes.Error('iamManagedPolicies should be an array of arns');
     }
   },

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -193,7 +193,7 @@ module.exports = {
       return;
     }
     let violationsFound;
-    if (!(statements instanceof Array)) {
+    if (!Array.isArray(statements)) {
       violationsFound = 'it is not an array';
     } else {
       const descriptions = statements.map((statement, i) => {

--- a/lib/plugins/aws/utils/findReferences.js
+++ b/lib/plugins/aws/utils/findReferences.js
@@ -20,7 +20,7 @@ function findReferences(root, value) {
 
     _.forOwn(property.propValue, (propValue, key) => {
       let propKey;
-      if (_.isArray(property.propValue)) {
+      if (Array.isArray(property.propValue)) {
         propKey = `[${key}]`;
       } else {
         propKey = _.isEmpty(property.path) ? `${key}` : `.${key}`;

--- a/lib/plugins/plugin/install/install.js
+++ b/lib/plugins/plugin/install/install.js
@@ -114,7 +114,7 @@ class PluginInstall {
       }
 
       const checkIsArrayPluginsObject = pluginsObject =>
-        _.isNil(pluginsObject) || _.isArray(pluginsObject);
+        _.isNil(pluginsObject) || Array.isArray(pluginsObject);
       // pluginsObject type determined based on the value loaded during the serverless init.
       if (_.last(_.split(serverlessFilePath, '.')) === 'json') {
         return fse.readJsonAsync(serverlessFilePath).then(serverlessFileObj => {

--- a/lib/plugins/plugin/uninstall/uninstall.js
+++ b/lib/plugins/plugin/uninstall/uninstall.js
@@ -86,7 +86,7 @@ class PluginUninstall {
 
       if (_.last(_.split(serverlessFilePath, '.')) === 'json') {
         return fse.readJsonAsync(serverlessFilePath).then(serverlessFileObj => {
-          const isArrayPluginsObject = _.isArray(serverlessFileObj.plugins);
+          const isArrayPluginsObject = Array.isArray(serverlessFileObj.plugins);
           const plugins = isArrayPluginsObject
             ? serverlessFileObj.plugins
             : serverlessFileObj.plugins && serverlessFileObj.plugins.modules;
@@ -111,7 +111,7 @@ class PluginUninstall {
         .then(serverlessFileObj =>
           yamlAstParser.removeExistingArrayItem(
             serverlessFilePath,
-            _.isArray(serverlessFileObj.plugins) ? 'plugins' : 'plugins.modules',
+            Array.isArray(serverlessFileObj.plugins) ? 'plugins' : 'plugins.modules',
             this.options.pluginName
           )
         );

--- a/lib/plugins/print/print.js
+++ b/lib/plugins/print/print.js
@@ -138,7 +138,7 @@ class Print {
         let out;
 
         if (format === 'text') {
-          if (_.isArray(conf)) {
+          if (Array.isArray(conf)) {
             out = conf.join(os.EOL);
           } else {
             if (_.isObject(conf)) {

--- a/lib/utils/config/index.js
+++ b/lib/utils/config/index.js
@@ -105,7 +105,7 @@ function deleteValue(key) {
   let config = getGlobalConfig();
   if (key && typeof key === 'string') {
     config = _.omit(config, [key]);
-  } else if (key && _.isArray(key)) {
+  } else if (key && Array.isArray(key)) {
     config = _.omit(config, key);
   }
   // write to .serverlessrc file

--- a/lib/utils/getCommandSuggestion.js
+++ b/lib/utils/getCommandSuggestion.js
@@ -4,7 +4,7 @@ const levenshtein = require('fast-levenshtein');
 
 const getCollectCommandWords = (commandObject, commandWordsArray) => {
   let wordsArray =
-    _.isArray(commandWordsArray) && !_.isEmpty(commandWordsArray) ? commandWordsArray : [];
+    Array.isArray(commandWordsArray) && !_.isEmpty(commandWordsArray) ? commandWordsArray : [];
   _.forEach(commandObject, (commandChildObject, commandChildName) => {
     wordsArray.push(commandChildName);
     if (commandChildObject.commands) {

--- a/lib/utils/yamlAstParser.js
+++ b/lib/utils/yamlAstParser.js
@@ -22,7 +22,7 @@ const findKeyChain = astContent => {
 
 const parseAST = (ymlAstContent, astObject) => {
   let newAstObject = astObject || {};
-  if (ymlAstContent.mappings && _.isArray(ymlAstContent.mappings)) {
+  if (ymlAstContent.mappings && Array.isArray(ymlAstContent.mappings)) {
     _.forEach(ymlAstContent.mappings, v => {
       if (!v.value) {
         const errorMessage = [
@@ -41,7 +41,7 @@ const parseAST = (ymlAstContent, astObject) => {
         newAstObject = parseAST(v.value, newAstObject);
       }
     });
-  } else if (ymlAstContent.items && _.isArray(ymlAstContent.items)) {
+  } else if (ymlAstContent.items && Array.isArray(ymlAstContent.items)) {
     _.forEach(ymlAstContent.items, (v, i) => {
       if (v.kind === 0) {
         const key = `${findKeyChain(ymlAstContent.parent)}[${i}]`;
@@ -55,7 +55,7 @@ const parseAST = (ymlAstContent, astObject) => {
 
 const constructPlainObject = (ymlAstContent, branchObject) => {
   const newbranchObject = branchObject || {};
-  if (ymlAstContent.mappings && _.isArray(ymlAstContent.mappings)) {
+  if (ymlAstContent.mappings && Array.isArray(ymlAstContent.mappings)) {
     _.forEach(ymlAstContent.mappings, v => {
       if (!v.value) {
         // no need to log twice, parseAST will log errors
@@ -100,7 +100,7 @@ const addNewArrayItem = (ymlFile, pathInYml, newValue) =>
 
     const arrayPropertyName = _.last(pathInYmlArray);
     let arrayProperty = currentNode[arrayPropertyName];
-    if (_.isUndefined(arrayProperty) || _.isArray(arrayProperty)) {
+    if (_.isUndefined(arrayProperty) || Array.isArray(arrayProperty)) {
       arrayProperty = arrayProperty || [];
     } else {
       throw new Error(`${arrayProperty} can only be undefined or an array!`);


### PR DESCRIPTION
<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

See https://github.com/serverless/serverless/pull/7680#discussion_r422044932

Let's minimize lodash dependency where native ways are available.

* Better performance thanks to native implementation
* Smaller bundle size thanks to depend only small portion of lodash (e.g. `require('lodash.pick')`)