### PR TITLE
Enable settings contentHandling per integration response

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1567,7 +1567,7 @@ provider:
 
 In your Lambda function you need to ensure that the correct `content-type` header is set. Furthermore you might want to return the response body in base64 format.
 
-To convert the request or response payload, you can set the [contentHandling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html) property.
+To convert the request or response payload, you can set the [contentHandling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html) property (if set, the response contentHandling property will be passed to integration responses with 2XXs method response statuses).
 
 ```yml
 functions:

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1583,6 +1583,22 @@ functions:
             contentHandling: CONVERT_TO_TEXT
 ```
 
+If needed, you can set the contentHandling property for integration responses with specific status codes.
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          response:
+            statusCodes:
+              200:
+                contentHandling: CONVERT_TO_TEXT
+```
+
 ## AWS X-Ray Tracing
 
 API Gateway supports a form of out of the box distributed tracing via [AWS X-Ray](https://aws.amazon.com/xray/) though enabling [active tracing](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html). To enable this feature for your serverless application's API Gateway add the following to your `serverless.yml`

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1205,7 +1205,7 @@ describe('#compileMethods()', () => {
       });
     });
 
-    it('should use defined content-handling behavior', () => {
+    it('should use defined content-handling behavior (request)', () => {
       awsCompileApigEvents.validated.events = [
         {
           functionName: 'First',
@@ -1231,6 +1231,42 @@ describe('#compileMethods()', () => {
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .ApiGatewayMethodUsersListGet.Properties.Integration.ContentHandling
         ).to.equal('CONVERT_TO_TEXT');
+      });
+    });
+
+    it('should use defined response content-handling behavior for 2XX only (response)', () => {
+      awsCompileApigEvents.validated.events = [
+        {
+          functionName: 'First',
+          http: {
+            method: 'GET',
+            path: 'users/list',
+            integration: 'AWS',
+            response: {
+              contentHandling: 'CONVERT_TO_BINARY',
+              statusCodes: {
+                200: {
+                  pattern: '',
+                },
+                400: {
+                  pattern: '400',
+                },
+              },
+            },
+          },
+        },
+      ];
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[0]
+            .ContentHandling
+        ).to.equal('CONVERT_TO_BINARY');
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
+            .ContentHandling
+        ).to.equal(undefined);
       });
     });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1234,6 +1234,43 @@ describe('#compileMethods()', () => {
       });
     });
 
+    it('should use defined content-handling behaviors (response)', () => {
+      awsCompileApigEvents.validated.events = [
+        {
+          functionName: 'First',
+          http: {
+            method: 'GET',
+            path: 'users/list',
+            integration: 'AWS',
+            response: {
+              statusCodes: {
+                200: {
+                  pattern: '',
+                  contentHandling: 'CONVERT_TO_BINARY',
+                },
+                400: {
+                  pattern: '400',
+                  contentHandling: 'CONVERT_TO_TEXT',
+                },
+              },
+            },
+          },
+        },
+      ];
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[0]
+            .ContentHandling
+        ).to.equal('CONVERT_TO_BINARY');
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
+            .ContentHandling
+        ).to.equal('CONVERT_TO_TEXT');
+      });
+    });
+
     it('should use defined response content-handling behavior for 2XX only (response)', () => {
       awsCompileApigEvents.validated.events = [
         {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -161,7 +161,7 @@ module.exports = {
           SelectionPattern: config.pattern || '',
           ResponseParameters: responseParameters,
           ResponseTemplates: {},
-          ContentHandling: http.response.contentHandling,
+          ContentHandling: statusCode.startsWith('2') ? http.response.contentHandling : undefined,
         };
 
         if (config.headers) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -161,7 +161,9 @@ module.exports = {
           SelectionPattern: config.pattern || '',
           ResponseParameters: responseParameters,
           ResponseTemplates: {},
-          ContentHandling: statusCode.startsWith('2') ? http.response.contentHandling : undefined,
+          ContentHandling:
+            config.contentHandling ||
+            (statusCode.startsWith('2') ? http.response.contentHandling : undefined),
         };
 
         if (config.headers) {


### PR DESCRIPTION
Closes: #7705

CloudFormation enables setting the contentHandling property on a per integration response basis. This PR implements it in Serverless.