### PR TITLE
Update aws-csharp to .NET Core 3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     volumes:
       - ./tmp/serverless-integration-test-aws-scala-sbt:/app
   aws-csharp:
-    image: microsoft/dotnet:2.0-sdk
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1
     volumes:
       - ./tmp/serverless-integration-test-aws-csharp:/app
   aws-fsharp:

--- a/docs/providers/aws/examples/hello-world/csharp/README.md
+++ b/docs/providers/aws/examples/hello-world/csharp/README.md
@@ -39,7 +39,7 @@ Using the `create` command we can specify one of the available [templates](https
 
 The `--path` or shorthand `-p` is the location to be created with the template service files. Change directories into this new folder.
 
-## 2. Build using .NET Core 2.X CLI tools and create zip package
+## 2. Build using .NET Core 3.1 CLI tools and create zip package
 
 ```
 # Linux or Mac OS

--- a/lib/plugins/create/templates/aws-csharp/Handler.cs
+++ b/lib/plugins/create/templates/aws-csharp/Handler.cs
@@ -27,11 +27,5 @@ namespace AwsDotnetCsharp
       public string Key1 {get; set;}
       public string Key2 {get; set;}
       public string Key3 {get; set;}
-
-      public Request(string key1, string key2, string key3){
-        Key1 = key1;
-        Key2 = key2;
-        Key3 = key3;
-      }
     }
 }

--- a/lib/plugins/create/templates/aws-csharp/Handler.cs
+++ b/lib/plugins/create/templates/aws-csharp/Handler.cs
@@ -1,8 +1,6 @@
 using Amazon.Lambda.Core;
-using System;
 
-[assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
-
+[assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 namespace AwsDotnetCsharp
 {
     public class Handler

--- a/lib/plugins/create/templates/aws-csharp/aws-csharp.csproj
+++ b/lib/plugins/create/templates/aws-csharp/aws-csharp.csproj
@@ -1,19 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>CsharpHandlers</AssemblyName>
     <PackageId>aws-csharp</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Amazon.Lambda.Tools" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/lib/plugins/create/templates/aws-csharp/build.cmd
+++ b/lib/plugins/create/templates/aws-csharp/build.cmd
@@ -1,2 +1,3 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp2.1 --output-package bin/release/netcoreapp2.1/hello.zip
+dotnet tool install -g Amazon.Lambda.Tools --framework netcoreapp3.1
+dotnet lambda package --configuration Release --framework netcoreapp3.1 --output-package bin/Release/netcoreapp3.1/hello.zip

--- a/lib/plugins/create/templates/aws-csharp/build.sh
+++ b/lib/plugins/create/templates/aws-csharp/build.sh
@@ -8,4 +8,5 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp2.1 --output-package bin/release/netcoreapp2.1/hello.zip
+dotnet tool install -g Amazon.Lambda.Tools --framework netcoreapp3.1
+dotnet lambda package --configuration Release --framework netcoreapp3.1 --output-package bin/Release/netcoreapp3.1/hello.zip

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -22,7 +22,7 @@ service: aws-csharp # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: dotnetcore2.1
+  runtime: dotnetcore3.1
 
 # you can overwrite defaults here
 #  stage: dev
@@ -57,7 +57,7 @@ functions:
 
     # you can add packaging information here
     package:
-      artifact: bin/release/netcoreapp2.1/hello.zip
+      artifact: bin/release/netcoreapp3.1/hello.zip
     #  exclude:
     #    - exclude-me.js
     #    - exclude-me-dir/**

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -57,7 +57,7 @@ functions:
 
     # you can add packaging information here
     package:
-      artifact: bin/release/netcoreapp3.1/hello.zip
+      artifact: bin/Release/netcoreapp3.1/hello.zip
     #  exclude:
     #    - exclude-me.js
     #    - exclude-me-dir/**


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

There is no issue for this pull request, but suffice to say it updates the aws-csharp template from 2.x (which is no longer supported by Microsoft) to 3.1 (which has LTS support) [inline with the AWS 3.1 support post](https://aws.amazon.com/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/).
