### PR TITLE
Replace lodash utility with String native methods

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -182,7 +182,7 @@ class PluginManager {
 
   createCommandAlias(alias, command) {
     // Deny self overrides
-    if (_.startsWith(command, alias)) {
+    if (command.startsWith(alias)) {
       throw new this.serverless.classes.Error(`Command "${alias}" cannot be overriden by an alias`);
     }
 
@@ -252,7 +252,7 @@ class PluginManager {
       const command = this.loadCommand(pluginName, details, key);
       // Grab and extract deprecated events
       command.lifecycleEvents = _.map(command.lifecycleEvents, event => {
-        if (_.startsWith(event, 'deprecated#')) {
+        if (event.startsWith('deprecated#')) {
           // Extract event and optional redirect
           const transformedEvent = /^deprecated#(.*?)(?:->(.*?))?$/.exec(event);
           this.deprecatedEvents[`${command.key}:${transformedEvent[1]}`] =

--- a/lib/plugins/aws/common/lib/artifacts.js
+++ b/lib/plugins/aws/common/lib/artifacts.js
@@ -3,7 +3,6 @@
 const BbPromise = require('bluebird');
 const path = require('path');
 const fse = require('fs-extra');
-const _ = require('lodash');
 
 module.exports = {
   moveArtifactsToPackage() {
@@ -13,7 +12,7 @@ module.exports = {
       path.join(this.serverless.config.servicePath || '.', '.serverless');
 
     // Only move the artifacts if it was requested by the user
-    if (this.serverless.config.servicePath && !_.endsWith(packagePath, '.serverless')) {
+    if (this.serverless.config.servicePath && !packagePath.endsWith('.serverless')) {
       const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
@@ -36,7 +35,7 @@ module.exports = {
       path.join(this.serverless.config.servicePath || '.', '.serverless');
 
     // Only move the artifacts if it was requested by the user
-    if (this.serverless.config.servicePath && !_.endsWith(packagePath, '.serverless')) {
+    if (this.serverless.config.servicePath && !packagePath.endsWith('.serverless')) {
       const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
 
       if (this.serverless.utils.dirExistsSync(packagePath)) {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -48,7 +48,7 @@ module.exports = {
     return this.provider
       .request('S3', 'listObjectsV2', params)
       .catch(reason => {
-        if (!_.includes(reason.message, 'The specified bucket does not exist')) {
+        if (!reason.message.includes('The specified bucket does not exist')) {
           return BbPromise.reject(reason);
         }
         const stackName = this.provider.naming.getStackName();

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const path = require('path');
@@ -804,7 +803,7 @@ describe('AwsInvokeLocal', () => {
           .then(() => {
             expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
             const calls = serverless.cli.consoleLog.getCalls().reduce((acc, call) => {
-              return _.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc;
+              return call.args[0].includes('Succeed') ? [call].concat(acc) : acc;
             }, []);
             expect(calls.length).to.equal(1);
           });
@@ -831,7 +830,7 @@ describe('AwsInvokeLocal', () => {
           .then(() => {
             expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
             const calls = serverless.cli.consoleLog.getCalls().reduce((acc, call) => {
-              return _.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc;
+              return call.args[0].includes('Succeed') ? [call].concat(acc) : acc;
             }, []);
             expect(calls.length).to.equal(1);
           });
@@ -847,7 +846,7 @@ describe('AwsInvokeLocal', () => {
           .then(() => {
             expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
             const calls = serverless.cli.consoleLog.getCalls().reduce((acc, call) => {
-              return _.includes(call.args[0], 'Succeed') ? [call].concat(acc) : acc;
+              return call.args[0].includes('Succeed') ? [call].concat(acc) : acc;
             }, []);
             expect(calls.length).to.equal(1);
           });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -52,7 +52,7 @@ module.exports = {
         preflightHeaders['Cache-Control'] = `'${config.cacheControl}'`;
       }
 
-      if (_.includes(config.methods, 'ANY')) {
+      if (config.methods.includes('ANY')) {
         preflightHeaders['Access-Control-Allow-Methods'] = preflightHeaders[
           'Access-Control-Allow-Methods'
         ].replace('ANY', 'DELETE,GET,HEAD,PATCH,POST,PUT');

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -29,7 +29,7 @@ module.exports = {
         throw new this.serverless.classes.Error('endpointType must be a string');
       }
 
-      if (!_.includes(validEndpointTypes, endpointType.toUpperCase())) {
+      if (!validEndpointTypes.includes(endpointType.toUpperCase())) {
         const message =
           'endpointType must be one of "REGIONAL" or "EDGE" or "PRIVATE". ' +
           `You provided ${endpointType}.`;
@@ -99,7 +99,7 @@ module.exports = {
       const apiKeySourceType = apiGateway.apiKeySourceType.toUpperCase();
       const validApiKeySourceType = ['HEADER', 'AUTHORIZER'];
 
-      if (!_.includes(validApiKeySourceType, apiKeySourceType)) {
+      if (!validApiKeySourceType.includes(apiKeySourceType)) {
         const message =
           'apiKeySourceType must be one of "HEADER" or "AUTHORIZER". ' +
           `You provided ${apiKeySourceType}.`;

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -362,8 +362,7 @@ class AwsCompileFunctions {
           const value = functionResource.Properties.Environment.Variables[key];
           if (_.isObject(value)) {
             const isCFRef =
-              _.isObject(value) &&
-              !_.some(value, (v, k) => k !== 'Ref' && !_.startsWith(k, 'Fn::'));
+              _.isObject(value) && !_.some(value, (v, k) => k !== 'Ref' && !k.startsWith('Fn::'));
             if (!isCFRef) {
               invalidEnvVar = `Environment variable ${key} must contain string`;
               return false;

--- a/lib/plugins/aws/utils/findReferences.test.js
+++ b/lib/plugins/aws/utils/findReferences.test.js
@@ -52,7 +52,7 @@ describe('#findReferences()', () => {
     expect(paths)
       .to.be.a('Array')
       .to.have.lengthOf(4);
-    expect(_.every(paths, path => _.includes(expectedResult, path))).to.equal(true);
+    expect(_.every(paths, path => expectedResult.includes(path))).to.equal(true);
   });
 
   it('should not fail with circular references', () => {
@@ -91,6 +91,6 @@ describe('#findReferences()', () => {
     expect(paths)
       .to.be.a('Array')
       .to.have.lengthOf(4);
-    expect(_.every(paths, path => _.includes(expectedResult, path))).to.equal(true);
+    expect(_.every(paths, path => expectedResult.includes(path))).to.equal(true);
   });
 });

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -101,7 +101,7 @@ module.exports = {
               let mode = file.stat.mode;
               if (
                 normalizedFilesToChmodPlusX &&
-                _.includes(normalizedFilesToChmodPlusX, name) &&
+                normalizedFilesToChmodPlusX.includes(name) &&
                 file.stat.mode % 2 === 0
               ) {
                 mode += 1;


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

See https://github.com/serverless/serverless/pull/7680#discussion_r422044932

Let's minimize lodash dependency where native ways are available.

* Better performance thanks to native implementation
* Smaller bundle size thanks to depend only small portion of lodash (e.g. `require('lodash.pick')`)
