### PR TITLE
Ensure lambda edge has no vpc or env

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -161,6 +161,10 @@ class AwsCompileCloudFrontEvents {
                 Resources[key].Properties.FunctionName === functionObj.name
             );
 
+            // Remove VPC & Env vars from lambda@Edge
+            delete Resources[lambdaFunctionLogicalId].Properties.VpcConfig;
+            delete Resources[lambdaFunctionLogicalId].Properties.Environment;
+
             // Retain Lambda@Edge functions to avoid issues when removing the CloudFormation stack
             Object.assign(Resources[lambdaFunctionLogicalId], { DeletionPolicy: 'Retain' });
 

--- a/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -5,6 +5,8 @@ const sandbox = require('sinon');
 const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileCloudFrontEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
+const runServerless = require('../../../../../../../tests/utils/run-serverless');
+const fixtures = require('../../../../../../../tests/fixtures');
 
 chai.use(require('sinon-chai'));
 
@@ -1598,6 +1600,102 @@ describe('AwsCompileCloudFrontEvents', () => {
         Error,
         'The event type of a function association must be unique in the cache behavior'
       );
+    });
+  });
+});
+
+describe('#AwsCompileCloudFrontEvents() Remove VPC & Env Vars', () => {
+  const fixtureName = 'functionCloudFront';
+  const edgeFunctionName = 'foo';
+  const otherFunctionName = 'bar';
+  function extendAndPackage(extension) {
+    return fixtures
+      .extend(fixtureName, extension)
+      .then(fixturePath => runServerless({ cwd: fixturePath, cliArgs: ['package'] }));
+  }
+
+  after(fixtures.cleanup);
+  it('Should ignore Environment variables if provided in function properties', () => {
+    return extendAndPackage({
+      functions: { [edgeFunctionName]: { environment: { HELLO: 'WORLD' } } },
+    }).then(serverless => {
+      const edgeResolvedName = serverless.providers.aws.naming.getLambdaLogicalId(edgeFunctionName);
+      expect(
+        serverless.service.provider.compiledCloudFormationTemplate.Resources[edgeResolvedName]
+          .Properties
+      ).not.to.contain.keys('Environment');
+    });
+  });
+
+  it('Should ignore VPC config if provided in function properties', () => {
+    return extendAndPackage({
+      functions: {
+        [edgeFunctionName]: {
+          vpc: {
+            securityGroupIds: ['sg-98f38XXX'],
+            subnetIds: ['subnet-978ffXXX', 'subnet-5e59fXXX'],
+          },
+        },
+      },
+    }).then(serverless => {
+      const edgeResolvedName = serverless.providers.aws.naming.getLambdaLogicalId(edgeFunctionName);
+      expect(
+        serverless.service.provider.compiledCloudFormationTemplate.Resources[edgeResolvedName]
+          .Properties
+      ).not.to.contain.keys('VpcConfig');
+    });
+  });
+
+  it('Should ignore Environment variables if provided in provider from lambda@Edge only', () => {
+    return extendAndPackage({
+      provider: { environment: { HELLO: 'WORLD' } },
+      functions: {
+        bar: {
+          handler: 'index.handler',
+        },
+      },
+    }).then(serverless => {
+      const edgeResolvedName = serverless.providers.aws.naming.getLambdaLogicalId(edgeFunctionName);
+      const otherResolvedName = serverless.providers.aws.naming.getLambdaLogicalId(
+        otherFunctionName
+      );
+      expect(
+        serverless.service.provider.compiledCloudFormationTemplate.Resources[edgeResolvedName]
+          .Properties
+      ).not.to.contain.keys('Environment');
+      expect(
+        serverless.service.provider.compiledCloudFormationTemplate.Resources[otherResolvedName]
+          .Properties
+      ).to.contain.keys('Environment');
+    });
+  });
+
+  it('Should ignore VPC config if provided in provider from lambda@Edge only', () => {
+    return extendAndPackage({
+      provider: {
+        vpc: {
+          securityGroupIds: ['sg-98f38XXX'],
+          subnetIds: ['subnet-978ffXXX', 'subnet-5e59fXXX'],
+        },
+      },
+      functions: {
+        bar: {
+          handler: 'index.handler',
+        },
+      },
+    }).then(serverless => {
+      const edgeResolvedName = serverless.providers.aws.naming.getLambdaLogicalId(edgeFunctionName);
+      const otherResolvedName = serverless.providers.aws.naming.getLambdaLogicalId(
+        otherFunctionName
+      );
+      expect(
+        serverless.service.provider.compiledCloudFormationTemplate.Resources[edgeResolvedName]
+          .Properties
+      ).not.to.contain.keys('VpcConfig');
+      expect(
+        serverless.service.provider.compiledCloudFormationTemplate.Resources[otherResolvedName]
+          .Properties
+      ).to.contain.keys('VpcConfig');
     });
   });
 });

--- a/tests/fixtures/functionCloudFront/index.js
+++ b/tests/fixtures/functionCloudFront/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.handler = (event, context, callback) => {
+  callback(null, {
+    statusCode: 200,
+    body: JSON.stringify({ message: 'cloudfront event', input: event }, null, 2),
+  });
+};

--- a/tests/fixtures/functionCloudFront/serverless.yml
+++ b/tests/fixtures/functionCloudFront/serverless.yml
@@ -1,0 +1,10 @@
+service: service
+provider:
+  name: aws
+functions:
+  foo:
+    handler: index.handler
+    events:
+      - cloudFront:
+          eventType: origin-request
+          origin: https://example.com


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

Closes: #7671


- [x] Ignore Variables & VPC provided in function properties
- [x] Ignore Variables & VPC provided in `provider` section only for lambda@Edge
- [x] Add a fixture for a function with `cloudFront` event
- [x] Used `runServerless`, `fixtures.cleanUp`, and `fixtures.extend`