### PR TITLE
Display error message on duplictate conf path

### DIFF
--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const yargsParser = require('yargs-parser');
+const ServerlessError = require('../classes/Error').ServerlessError;
 
 const yargsOptions = {
   boolean: ['help', 'version', 'verbose'],
@@ -26,6 +27,16 @@ module.exports = _.memoize(inputArray => {
     delete options.v;
   }
   if (!options.verbose) delete options.verbose;
+
+  if (options.config && options.config.length > 1) {
+    const configPaths = options.config;
+    throw new ServerlessError(
+      [
+        `Got ${configPaths.length} config paths: [${configPaths.join(', ')}].`,
+        'Expected single value',
+      ].join('')
+    );
+  }
 
   return { commands, options };
 });

--- a/lib/utils/resolveCliInput.test.js
+++ b/lib/utils/resolveCliInput.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { expect } = require('chai');
+const resolveCliInput = require('./resolveCliInput');
+
+describe('#resolveCliInput', () => {
+  it('Should crash on multiple config paths', () => {
+    expect(() => resolveCliInput('--config world --config hello')).to.throw(
+      /Expected single value/
+    );
+    expect(() => resolveCliInput('--config world --c hello')).to.throw(/Expected single value/);
+    expect(() => resolveCliInput('--c world --c hello')).to.throw(/Expected single value/);
+  });
+});


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

Closes: #7683

If multiple `--config` options are provided, crash with `ServerlessError`

example

`node .\bin\serverless.js --config hello --config world`

Error
```
Serverless Error --------------------------------------- 

  Got 2 config paths: [hello, world].Expected single value 

  Get Support -------------------------------------------- 
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
```
