### PR TITLE
Fix disabled LogGroup exists in DependsOn

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -413,9 +413,11 @@ class AwsCompileFunctions {
         }
       }
 
-      functionResource.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)].concat(
-        functionResource.DependsOn || []
-      );
+      if (!functionObject.disableLogs) {
+        functionResource.DependsOn = [
+          this.provider.naming.getLogGroupLogicalId(functionName),
+        ].concat(functionResource.DependsOn || []);
+      }
 
       if (functionObject.layers && Array.isArray(functionObject.layers)) {
         functionResource.Properties.Layers = functionObject.layers;

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2714,5 +2714,17 @@ describe('AwsCompileFunctions #2', () => {
             expect(destinationConfig).to.not.have.property('OnFailure');
           })
         ));
+
+    it('Should not have logGroup in depends on if disableLogs is true', () => {
+      return fixtures
+        .extend('function', { functions: { foo: { disableLogs: true } } })
+        .then(fixturePath => runServerless({ cwd: fixturePath, cliArgs: ['package'] }))
+        .then(serverless => {
+          const cfResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+          const naming = serverless.getProvider('aws').naming;
+          const dependsOn = cfResources[naming.getLambdaLogicalId('foo')].DependsOn;
+          expect(dependsOn).to.be.undefined;
+        });
+    });
   });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

Fixes a bug introduced in PR #7720  which closes issue #7599 

## The Bug:

In `mergeIamTemplates.js` LogGroup Resource creation is skipped if `disableLogs` is `true`. In `compile/function/index.js` the `LogGroup` still apears in `DependsOn` section

This caused a crash error on `deploy` command, in the `validating template` stage