### PR TITLE
Fix handling of stage specific setting for split stacks case

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -134,11 +134,18 @@ function resolveRestApiId() {
     const apiGatewayResource = resolveApiGatewayResource(
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources
     );
-    if (!apiGatewayResource) {
+    if (
+      !apiGatewayResource &&
+      // If there are 'http' events, assume that there is API Gateway configured
+      // it's just probably hidden in nested stack (some rely on plugins that split stacks)
+      !this.serverless.utils.isEventUsed(this.state.service.functions, 'http')
+    ) {
       resolve(null);
       return;
     }
-    const apiName = apiGatewayResource.Properties.Name;
+    const apiName = apiGatewayResource
+      ? apiGatewayResource.Properties.Name
+      : provider.apiName || `${this.options.stage}-${this.state.service.service}`;
     const resolveFromAws = position =>
       this.provider.request('APIGateway', 'getRestApis', { position, limit: 500 }).then(result => {
         const restApi = result.items.find(api => api.name === apiName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -51,9 +51,13 @@ module.exports = {
         .call(this)
         .then(resolveRestApiId.bind(this))
         .then(() => {
+          if (this.apiGatewayRestApiId) return resolveDeploymentId.call(this);
+          return null;
+        })
+        .then(() => {
           // Do not update APIGW-wide settings, in case external APIGW is referenced
           if (this.isExternalRestApi) return null;
-          if (!this.apiGatewayRestApiId) {
+          if (!this.apiGatewayDeploymentId) {
             // Could not resolve REST API id automatically
             if (!this.serverless.utils.isEventUsed(this.state.service.functions, 'http')) {
               return null;
@@ -77,7 +81,6 @@ module.exports = {
           }
           return resolveStage
             .call(this)
-            .then(resolveDeploymentId.bind(this))
             .then(ensureStage.bind(this))
             .then(handleTracing.bind(this))
             .then(handleLogs.bind(this))

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -77,6 +77,14 @@ describe('#updateStage()', () => {
         ],
       });
     providerRequestStub
+      .withArgs('APIGateway', 'getDeployments', {
+        restApiId: 'devRestApiId',
+        limit: 500,
+      })
+      .resolves({
+        items: [{ id: 'someDeploymentId' }],
+      });
+    providerRequestStub
       .withArgs('APIGateway', 'getStage', {
         restApiId: 'devRestApiId',
         stageName: 'dev',
@@ -159,29 +167,29 @@ describe('#updateStage()', () => {
       ];
 
       expect(providerGetAccountInfoStub).to.be.calledOnce;
-      expect(providerRequestStub.args).to.have.length(5);
+      expect(providerRequestStub.args).to.have.length(6);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
       expect(providerRequestStub.args[0][2]).to.deep.equal({
         limit: 500,
         position: undefined,
       });
-      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[1][1]).to.equal('getStage');
-      expect(providerRequestStub.args[1][2]).to.deep.equal({
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
       });
-      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
-      expect(providerRequestStub.args[2][2]).to.deep.equal({
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
         patchOperations,
       });
-      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[3][1]).to.equal('tagResource');
-      expect(providerRequestStub.args[3][2]).to.deep.equal({
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('tagResource');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
         resourceArn: 'arn:aws:apigateway:us-east-1::/restapis/devRestApiId/stages/dev',
         tags: {
           'Containing Space': 'bar',
@@ -189,9 +197,9 @@ describe('#updateStage()', () => {
           'num': '123',
         },
       });
-      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[4][1]).to.equal('untagResource');
-      expect(providerRequestStub.args[4][2]).to.deep.equal({
+      expect(providerRequestStub.args[5][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[5][1]).to.equal('untagResource');
+      expect(providerRequestStub.args[5][2]).to.deep.equal({
         resourceArn: 'arn:aws:apigateway:us-east-1::/restapis/devRestApiId/stages/dev',
         tagKeys: ['old'],
       });
@@ -240,29 +248,29 @@ describe('#updateStage()', () => {
       ];
 
       expect(providerGetAccountInfoStub).to.be.calledOnce;
-      expect(providerRequestStub.args).to.have.length(5);
+      expect(providerRequestStub.args).to.have.length(6);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
       expect(providerRequestStub.args[0][2]).to.deep.equal({
         limit: 500,
         position: undefined,
       });
-      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[1][1]).to.equal('getStage');
-      expect(providerRequestStub.args[1][2]).to.deep.equal({
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
       });
-      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
-      expect(providerRequestStub.args[2][2]).to.deep.equal({
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
         patchOperations,
       });
-      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[3][1]).to.equal('tagResource');
-      expect(providerRequestStub.args[3][2]).to.deep.equal({
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('tagResource');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
         resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/devRestApiId/stages/dev',
         tags: {
           'Containing Space': 'bar',
@@ -270,9 +278,9 @@ describe('#updateStage()', () => {
           'num': '123',
         },
       });
-      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[4][1]).to.equal('untagResource');
-      expect(providerRequestStub.args[4][2]).to.deep.equal({
+      expect(providerRequestStub.args[5][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[5][1]).to.equal('untagResource');
+      expect(providerRequestStub.args[5][2]).to.deep.equal({
         resourceArn: 'arn:aws-us-gov:apigateway:us-gov-east-1::/restapis/devRestApiId/stages/dev',
         tagKeys: ['old'],
       });
@@ -320,29 +328,29 @@ describe('#updateStage()', () => {
       ];
 
       expect(providerGetAccountInfoStub).to.be.calledOnce;
-      expect(providerRequestStub.args).to.have.length(5);
+      expect(providerRequestStub.args).to.have.length(6);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
       expect(providerRequestStub.args[0][2]).to.deep.equal({
         limit: 500,
         position: undefined,
       });
-      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[1][1]).to.equal('getStage');
-      expect(providerRequestStub.args[1][2]).to.deep.equal({
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
       });
-      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
-      expect(providerRequestStub.args[2][2]).to.deep.equal({
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
         patchOperations,
       });
-      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[3][1]).to.equal('tagResource');
-      expect(providerRequestStub.args[3][2]).to.deep.equal({
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('tagResource');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
         resourceArn: 'arn:aws-cn:apigateway:cn-northwest-1::/restapis/devRestApiId/stages/dev',
         tags: {
           'Containing Space': 'bar',
@@ -350,9 +358,9 @@ describe('#updateStage()', () => {
           'num': '123',
         },
       });
-      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[4][1]).to.equal('untagResource');
-      expect(providerRequestStub.args[4][2]).to.deep.equal({
+      expect(providerRequestStub.args[5][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[5][1]).to.equal('untagResource');
+      expect(providerRequestStub.args[5][2]).to.deep.equal({
         resourceArn: 'arn:aws-cn:apigateway:cn-northwest-1::/restapis/devRestApiId/stages/dev',
         tagKeys: ['old'],
       });
@@ -365,22 +373,22 @@ describe('#updateStage()', () => {
     };
     return updateStage.call(context).then(() => {
       expect(providerGetAccountInfoStub).to.be.calledOnce;
-      expect(providerRequestStub.args).to.have.length(3);
+      expect(providerRequestStub.args).to.have.length(4);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
       expect(providerRequestStub.args[0][2]).to.deep.equal({
         limit: 500,
         position: undefined,
       });
-      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[1][1]).to.equal('getStage');
-      expect(providerRequestStub.args[1][2]).to.deep.equal({
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
       });
-      expect(providerRequestStub.args[2][0]).to.equal('CloudWatchLogs');
-      expect(providerRequestStub.args[2][1]).to.equal('deleteLogGroup');
-      expect(providerRequestStub.args[2][2]).to.deep.equal({
+      expect(providerRequestStub.args[3][0]).to.equal('CloudWatchLogs');
+      expect(providerRequestStub.args[3][1]).to.equal('deleteLogGroup');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
         logGroupName: '/aws/api-gateway/my-service-dev',
       });
     });
@@ -424,16 +432,16 @@ describe('#updateStage()', () => {
         position: undefined,
       });
       expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[1][1]).to.equal('getStage');
+      expect(providerRequestStub.args[1][1]).to.equal('getDeployments');
       expect(providerRequestStub.args[1][2]).to.deep.equal({
         restApiId: 'devRestApiId',
-        stageName: 'dev',
+        limit: 500,
       });
       expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[2][1]).to.equal('getDeployments');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
       expect(providerRequestStub.args[2][2]).to.deep.equal({
         restApiId: 'devRestApiId',
-        limit: 500,
+        stageName: 'dev',
       });
       expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[3][1]).to.equal('createStage');
@@ -477,6 +485,14 @@ describe('#updateStage()', () => {
         items: [{ name: 'custom-api-gateway-name', id: 'restapicus' }],
       });
     providerRequestStub
+      .withArgs('APIGateway', 'getDeployments', {
+        restApiId: 'restapicus',
+        limit: 500,
+      })
+      .resolves({
+        items: [{ id: 'someDeploymentId' }],
+      });
+    providerRequestStub
       .withArgs('APIGateway', 'getStage', {
         restApiId: 'restapicus',
         stageName: 'dev',
@@ -501,6 +517,14 @@ describe('#updateStage()', () => {
     delete resources.ApiGatewayRestApi;
     resources.CustomApiGatewayRestApi.Properties.Name = 'custom-rest-api-name';
     resources.ApiGatewayRestApiDeployment.Properties.RestApiId.Ref = 'CustomApiGatewayRestApi';
+    providerRequestStub
+      .withArgs('APIGateway', 'getDeployments', {
+        restApiId: 'customRestApiId',
+        limit: 500,
+      })
+      .resolves({
+        items: [{ id: 'someDeploymentId' }],
+      });
     return updateStage.call(context).then(() => {
       expect(context.apiGatewayRestApiId).to.equal('customRestApiId');
     });
@@ -590,22 +614,22 @@ describe('#updateStage()', () => {
       ];
 
       expect(providerGetAccountInfoStub).to.be.calledOnce;
-      expect(providerRequestStub.args).to.have.length(3);
+      expect(providerRequestStub.args).to.have.length(4);
       expect(providerRequestStub.args[0][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[0][1]).to.equal('getRestApis');
       expect(providerRequestStub.args[0][2]).to.deep.equal({
         limit: 500,
         position: undefined,
       });
-      expect(providerRequestStub.args[1][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[1][1]).to.equal('getStage');
-      expect(providerRequestStub.args[1][2]).to.deep.equal({
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
       });
-      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
-      expect(providerRequestStub.args[2][1]).to.equal('updateStage');
-      expect(providerRequestStub.args[2][2]).to.deep.equal({
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
         restApiId: 'devRestApiId',
         stageName: 'dev',
         patchOperations,
@@ -614,7 +638,7 @@ describe('#updateStage()', () => {
   });
 
   function expectPatchOperation(patchOperation) {
-    const patchOperations = providerRequestStub.args[2][2].patchOperations;
+    const patchOperations = providerRequestStub.args[3][2].patchOperations;
     expect(patchOperations).to.include.deep.members([patchOperation]);
   }
 
@@ -690,9 +714,9 @@ describe('#updateStage()', () => {
     };
 
     return updateStage.call(context).then(() => {
-      expect(providerRequestStub.args[3][0]).to.equal('CloudWatchLogs');
-      expect(providerRequestStub.args[3][1]).to.equal('deleteLogGroup');
-      expect(providerRequestStub.args[3][2]).to.deep.equal({
+      expect(providerRequestStub.args[4][0]).to.equal('CloudWatchLogs');
+      expect(providerRequestStub.args[4][1]).to.equal('deleteLogGroup');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
         logGroupName: '/aws/api-gateway/my-service-dev',
       });
     });


### PR DESCRIPTION
In setup where resources are distributed into nested stacks, API Gateway resource may not be present in main stack.

With https://github.com/serverless/serverless/pull/7663 we've changed behavior, and assume there's no API Gateway if it doesn't appear in main stack. Still it broke for services relying on e.g. `serverless-plugin-split-stacks` plugin.

This patch ensures that if there are `http` events configured we unconditionally attempt to find the Rest API Id and it's deployment.

Additionally improved configuration check to be based on deployment id and not just rest API id (if there's no deployment, then we're also incapable on applying any stage settings)