### PR TITLE
checkForChanges should consider user-defined artifact

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -133,6 +133,10 @@ module.exports = {
 
       // create hashes for all the zip files
       const zipFiles = globby.sync(['**.zip'], { cwd: serverlessDirPath, dot: true, silent: true });
+      if (this.serverless.service.package.artifact) {
+        const arficatPath = path.join(serverlessDirPath, this.serverless.service.package.artifact);
+        zipFiles.push(arficatPath);
+      }
       const zipFilePaths = zipFiles.map(zipFile => path.join(serverlessDirPath, zipFile));
 
       const readFile = BbPromise.promisify(fs.readFile);

--- a/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -604,6 +604,48 @@ describe('checkForChanges', () => {
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
       });
     });
+
+    it('should not set a flag if the remote and local hashes are different for package.artifact', () => {
+      awsDeploy.serverless.service.package = {
+        artifact: 'foo/bar/my-own.zip',
+      };
+
+      globbySyncStub.returns([]);
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(0)
+        .returns('hash-cf-template');
+      cryptoStub
+        .createHash()
+        .update()
+        .digest.onCall(1)
+        .returns('local-my-own-hash');
+
+      const input = [
+        { Metadata: { filesha256: 'hash-cf-template' } },
+        { Metadata: { filesha256: 'remote-my-own-hash' } },
+      ];
+
+      return expect(awsDeploy.checkIfDeploymentIsNecessary(input)).to.be.fulfilled.then(() => {
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledOnce;
+        expect(globbySyncStub).to.have.been.calledOnce;
+        expect(readFileStub).to.have.been.calledOnce;
+        expect(awsDeploy.serverless.cli.log).not.to.be.called;
+        expect(normalizeCloudFormationTemplateStub).to.have.been.calledWithExactly(
+          awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
+        );
+        expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
+          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          dot: true,
+          silent: true,
+        });
+        expect(readFileStub).to.have.been.calledWith(
+          path.join('my-service/.serverless/my-service/.serverless/foo/bar/my-own.zip')
+        );
+        expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
+      });
+    });
   });
 
   describe('#checkLogGroupSubscriptionFilterResourceLimitExceeded', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

Closes: #6030

`checkIfDeploymentIsNecessary` in `checkForChanges` now consider user-packed artifact from `package.artifact`, so deployment will not be skipped when local artifact is updated.