### PR TITLE
Make serverless platform dependencies optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,9 +174,11 @@
     "ws": "^7.3.0",
     "xml2js": "^0.4.23"
   },
+  "optionalDependencies": {
+    "@serverless/components": "^2.30.11"
+  },
   "dependencies": {
     "@serverless/cli": "^1.4.0",
-    "@serverless/components": "^2.30.11",
     "@serverless/enterprise-plugin": "^3.6.12",
     "archiver": "^3.1.1",
     "async": "^1.5.2",


### PR DESCRIPTION
Its usage is already optional in components-v2.js

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

Addresses: #7751