### PR TITLE
fix(AWS API Gateway) Enable detailed CloudWatch Metrics

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -53,6 +53,7 @@ layout: Doc
   - [Resource Policy](#resource-policy)
   - [Compression](#compression)
   - [Binary Media Types](#binary-media-types)
+  - [Detailed CloudWatch Metrics](#detailed-cloudwatch-metrics)
   - [AWS X-Ray Tracing](#aws-x-ray-tracing)
   - [Tags / Stack Tags](#tags--stack-tags)
   - [Logs](#logs)
@@ -1581,6 +1582,16 @@ functions:
             contentHandling: CONVERT_TO_TEXT
           response:
             contentHandling: CONVERT_TO_TEXT
+```
+
+## Detailed CloudWatch Metrics
+
+Use the following configuration to enable detailed CloudWatch Metrics:
+
+```yml
+provider:
+  apiGateway:
+    metrics: true
 ```
 
 ## AWS X-Ray Tracing

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -75,6 +75,7 @@ provider:
     description: Some Description # Optional description for the API Gateway stage deployment
     binaryMediaTypes: # Optional binary media types the API might return
       - '*/*'
+    metrics:  false # Optional detailed Cloud Watch Metrics
   alb:
     targetGroupPrefix: xxxxxxxxxx # Optional prefix to prepend when generating names for target groups
     authorizers:

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -227,10 +227,7 @@ function handleMetrics() {
   if (!this.hasMetricsConfigured) return;
   const metricsEnabled = this.state.service.provider.apiGateway.metrics;
 
-  let operation = { op: 'replace', path: '/*/*/metrics/enabled', value: 'false' };
-  if (metricsEnabled) {
-    operation = { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' };
-  }
+  const operation = { op: 'replace', path: '/*/*/metrics/enabled', value: metricsEnabled ? 'true' : 'false' };
   this.apiGatewayStagePatchOperations.push(operation);
 }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -31,11 +31,16 @@ module.exports = {
     return BbPromise.try(() => {
       const provider = this.state.service.provider;
       this.hasTracingConfigured = provider.tracing && provider.tracing.apiGateway != null;
-      this.hasMetricsConfigured = provider.metrics && provider.metrics.apiGateway != null;
+      this.hasMetricsConfigured = provider.apiGateway && provider.apiGateway.metrics != null;
       this.hasLogsConfigured = provider.logs && provider.logs.restApi != null;
       this.hasTagsConfigured = provider.tags != null || provider.stackTags != null;
 
-      if (!this.hasTracingConfigured && !this.hasLogsConfigured && !this.hasTagsConfigured) {
+      if (
+        !this.hasTracingConfigured &&
+        !this.hasLogsConfigured &&
+        !this.hasTagsConfigured &&
+        !this.hasMetricsConfigured
+      ) {
         return null;
       }
 
@@ -220,7 +225,7 @@ function handleTracing() {
 
 function handleMetrics() {
   if (!this.hasMetricsConfigured) return;
-  const metricsEnabled = this.state.service.provider.metrics.apiGateway;
+  const metricsEnabled = this.state.service.provider.apiGateway.metrics;
 
   let operation = { op: 'replace', path: '/*/*/metrics/enabled', value: 'false' };
   if (metricsEnabled) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -31,6 +31,7 @@ module.exports = {
     return BbPromise.try(() => {
       const provider = this.state.service.provider;
       this.hasTracingConfigured = provider.tracing && provider.tracing.apiGateway != null;
+      this.hasMetricsConfigured = provider.metrics && provider.metrics.apiGateway != null;
       this.hasLogsConfigured = provider.logs && provider.logs.restApi != null;
       this.hasTagsConfigured = provider.tags != null || provider.stackTags != null;
 
@@ -80,6 +81,7 @@ module.exports = {
             .then(resolveDeploymentId.bind(this))
             .then(ensureStage.bind(this))
             .then(handleTracing.bind(this))
+            .then(handleMetrics.bind(this))
             .then(handleLogs.bind(this))
             .then(handleTags.bind(this))
             .then(applyUpdates.bind(this))
@@ -212,6 +214,17 @@ function handleTracing() {
   let operation = { op: 'replace', path: '/tracingEnabled', value: 'false' };
   if (tracingEnabled) {
     operation = { op: 'replace', path: '/tracingEnabled', value: 'true' };
+  }
+  this.apiGatewayStagePatchOperations.push(operation);
+}
+
+function handleMetrics() {
+  if (!this.hasMetricsConfigured) return;
+  const metricsEnabled = this.state.service.provider.metrics.apiGateway;
+
+  let operation = { op: 'replace', path: '/*/*/metrics/enabled', value: 'false' };
+  if (metricsEnabled) {
+    operation = { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' };
   }
   this.apiGatewayStagePatchOperations.push(operation);
 }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -227,7 +227,11 @@ function handleMetrics() {
   if (!this.hasMetricsConfigured) return;
   const metricsEnabled = this.state.service.provider.apiGateway.metrics;
 
-  const operation = { op: 'replace', path: '/*/*/metrics/enabled', value: metricsEnabled ? 'true' : 'false' };
+  const operation = {
+    op: 'replace',
+    path: '/*/*/metrics/enabled',
+    value: metricsEnabled ? 'true' : 'false',
+  };
   this.apiGatewayStagePatchOperations.push(operation);
 }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -136,6 +136,9 @@ describe('#updateStage()', () => {
     context.state.service.provider.tracing = {
       apiGateway: true,
     };
+    context.state.service.provider.metrics = {
+      apiGateway: true,
+    };
     context.state.service.provider.logs = {
       restApi: true,
     };
@@ -143,6 +146,7 @@ describe('#updateStage()', () => {
     return updateStage.call(context).then(() => {
       const patchOperations = [
         { op: 'replace', path: '/tracingEnabled', value: 'true' },
+        { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' },
         {
           op: 'replace',
           path: '/accessLogSettings/destinationArn',
@@ -216,6 +220,9 @@ describe('#updateStage()', () => {
     context.state.service.provider.tracing = {
       apiGateway: true,
     };
+    context.state.service.provider.metrics = {
+      apiGateway: true,
+    };
     context.state.service.provider.logs = {
       restApi: true,
     };
@@ -223,6 +230,7 @@ describe('#updateStage()', () => {
     return updateStage.call(context).then(() => {
       const patchOperations = [
         { op: 'replace', path: '/tracingEnabled', value: 'true' },
+        { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' },
         {
           op: 'replace',
           path: '/accessLogSettings/destinationArn',
@@ -297,6 +305,9 @@ describe('#updateStage()', () => {
     context.state.service.provider.tracing = {
       apiGateway: true,
     };
+    context.state.service.provider.metrics = {
+      apiGateway: true,
+    };
     context.state.service.provider.logs = {
       restApi: true,
     };
@@ -304,6 +315,7 @@ describe('#updateStage()', () => {
     return updateStage.call(context).then(() => {
       const patchOperations = [
         { op: 'replace', path: '/tracingEnabled', value: 'true' },
+        { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' },
         {
           op: 'replace',
           path: '/accessLogSettings/destinationArn',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -136,8 +136,8 @@ describe('#updateStage()', () => {
     context.state.service.provider.tracing = {
       apiGateway: true,
     };
-    context.state.service.provider.metrics = {
-      apiGateway: true,
+    context.state.service.provider.apiGateway = {
+      metrics: true,
     };
     context.state.service.provider.logs = {
       restApi: true,
@@ -220,8 +220,8 @@ describe('#updateStage()', () => {
     context.state.service.provider.tracing = {
       apiGateway: true,
     };
-    context.state.service.provider.metrics = {
-      apiGateway: true,
+    context.state.service.provider.apiGateway = {
+      metrics: true,
     };
     context.state.service.provider.logs = {
       restApi: true,
@@ -305,8 +305,8 @@ describe('#updateStage()', () => {
     context.state.service.provider.tracing = {
       apiGateway: true,
     };
-    context.state.service.provider.metrics = {
-      apiGateway: true,
+    context.state.service.provider.apiGateway = {
+      metrics: true,
     };
     context.state.service.provider.logs = {
       restApi: true,


### PR DESCRIPTION
## Isuue 
#6112 

## Summary
I have changed code to be able to enable detailed cloud watch metrics for api gateway.
In my PR, if you define serverless.yml like below, api gateway enables detailed cloud watch metrics.

```
:
provider: aws
  metrics:
    restApi: true
:
```

However, I'm not sure this format in serverless.yml is really correct, so please let me know if I did something wrong.