### PR TITLE
fix: Use API Gateway response contentHandling property only for integration responses with 2XXs status codes

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1567,7 +1567,7 @@ provider:
 
 In your Lambda function you need to ensure that the correct `content-type` header is set. Furthermore you might want to return the response body in base64 format.
 
-To convert the request or response payload, you can set the [contentHandling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html) property.
+To convert the request or response payload, you can set the [contentHandling](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-workflow.html) property (if set, the response contentHandling property will be passed to integration responses with 2XXs method response statuses).
 
 ```yml
 functions:

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1205,7 +1205,7 @@ describe('#compileMethods()', () => {
       });
     });
 
-    it('should use defined content-handling behavior', () => {
+    it('should use defined content-handling behavior (request)', () => {
       awsCompileApigEvents.validated.events = [
         {
           functionName: 'First',
@@ -1231,6 +1231,42 @@ describe('#compileMethods()', () => {
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .ApiGatewayMethodUsersListGet.Properties.Integration.ContentHandling
         ).to.equal('CONVERT_TO_TEXT');
+      });
+    });
+
+    it('should use defined response content-handling behavior for 2XX only (response)', () => {
+      awsCompileApigEvents.validated.events = [
+        {
+          functionName: 'First',
+          http: {
+            method: 'GET',
+            path: 'users/list',
+            integration: 'AWS',
+            response: {
+              contentHandling: 'CONVERT_TO_BINARY',
+              statusCodes: {
+                200: {
+                  pattern: '',
+                },
+                400: {
+                  pattern: '400',
+                },
+              },
+            },
+          },
+        },
+      ];
+      return awsCompileApigEvents.compileMethods().then(() => {
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[0]
+            .ContentHandling
+        ).to.equal('CONVERT_TO_BINARY');
+        expect(
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .ApiGatewayMethodUsersListGet.Properties.Integration.IntegrationResponses[1]
+            .ContentHandling
+        ).to.equal(undefined);
       });
     });
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -161,7 +161,7 @@ module.exports = {
           SelectionPattern: config.pattern || '',
           ResponseParameters: responseParameters,
           ResponseTemplates: {},
-          ContentHandling: http.response.contentHandling,
+          ContentHandling: statusCode.startsWith('2') ? http.response.contentHandling : undefined,
         };
 
         if (config.headers) {


### PR DESCRIPTION
Use API Gateway response contentHandling property only for integration responses with 2XXs status codes

Closes: #7705 
