### PR TITLE
Deprecate bin/serverless binary

### DIFF
--- a/bin/serverless
+++ b/bin/serverless
@@ -6,4 +6,9 @@
 
 'use strict';
 
+require('../lib/utils/logDeprecation')(
+  'BIN_SERVERLESS',
+  'bin/serverless is deprecated, use bin/serverless.js instead'
+);
+
 require('./serverless.js');

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -5,3 +5,9 @@ layout: Doc
 -->
 
 # Serverless Framework Deprecations
+
+<a name="BIN_SERVERLESS"><div>&nbsp;</div></a>
+
+## `bin/serverless`
+
+Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0


### PR DESCRIPTION
Deprecate `bin/sererverless` in favor of `bin/serverless.js`

It's a first _deprecation_ to pave path for further deprecations in a project (which will be used to ease migration between different major releases, as documented here: https://github.com/serverless/serverless/issues/7422)

/cc @AhmedFat7y 



