### PR TITLE
Downgrade uuid to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "tabtab": "^3.0.2",
     "untildify": "^3.0.3",
     "update-notifier": "^2.5.0",
-    "uuid": "^8.0.0",
+    "uuid": "^3.4.0",
     "write-file-atomic": "^2.4.3",
     "yaml-ast-parser": "0.0.43",
     "yargs-parser": "^18.1.3"


### PR DESCRIPTION
While v8 sort of works with Node.js v6, this version of Node.js is not advertised as supported by uuid v8, and we received reports that this upgrade is problematic (e.g. #7777)

Fixes #7718 
