### PR TITLE
feat(httpApi): external authorizer

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -130,7 +130,7 @@ provider:
           - ${client2Id}
 ```
 
-#### 2. Configure endpoints which are expected to have restricted access:
+#### 2. Configure endpoints which are expected to have restricted access
 
 ```yaml
 functions:
@@ -193,7 +193,64 @@ provider:
     id: xxxx # id of externally created HTTP API to which endpoints should be attached.
 ```
 
-In such case no API and stage resources are created, therefore extending HTTP API with CORS or access logs settings is not supported.
+In such case no API and stage resources are created, therefore extending HTTP API with CORS, access logs settings or authorizers is not supported.
+
+## Shared Authorizer
+
+For external HTTP API you can use shared authorizer in similar manner to RestApi. Example configuration could look like:
+
+```yml
+httpApi:
+    id: xxxx # Required
+
+functions:
+  createUser:
+     ...
+    events:
+      - httpApi:
+          path: /users
+          ...
+          authorizer:
+            # Provide authorizerId
+            id:
+              Ref: ApiGatewayAuthorizer  # or hard-code Authorizer ID
+            scopes: # Optional - List of Oauth2 scopes
+              - myapp/myscope
+
+  deleteUser:
+     ...
+    events:
+      - httpApi:
+          path: /users/{userId}
+          ...
+          authorizer:
+            # Provide authorizerId
+            id:
+              Ref: ApiGatewayAuthorizer  # or hard-code Authorizer ID
+            scopes: # Optional - List of Oauth2 scopes
+              - myapp/anotherscope
+
+resources:
+  Resources:
+    ApiGatewayAuthorizer:
+      Type: AWS::ApiGatewayV2::Authorizer
+      Properties:
+        ApiId:
+          Ref: YourApiGatewayName
+        AuthorizerType: JWT
+        IdentitySource:
+          - $request.header.Authorization
+        JwtConfiguration:
+          Audience:
+            - Ref: YourCognitoUserPoolClientName
+          Issuer:
+            Fn::Join:
+              - ""
+              - - "https://cognito-idp."
+                - "${opt:region, self:provider.region}"
+                - ".amazonaws.com/"
+                - Ref: YourCognitoUserPoolName
+```
 
 ### Event / payload format
 

--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -130,7 +130,7 @@ provider:
           - ${client2Id}
 ```
 
-#### 2. Configure endpoints which are expected to have restricted access
+#### 2. Configure endpoints which are expected to have restricted access:
 
 ```yaml
 functions:

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -28,7 +28,11 @@ module.exports = {
           if (result) stackData.outputs = result.Stacks[0].Outputs;
         }),
     ];
-    if (this.serverless.service.provider.httpApi && this.serverless.service.provider.httpApi.id) {
+    if (
+      this.serverless.service.provider.httpApi &&
+      this.serverless.service.provider.httpApi.id &&
+      typeof this.serverless.service.provider.httpApi.id === 'string'
+    ) {
       sdkRequests.push(
         this.provider
           .request('ApiGatewayV2', 'getApi', { ApiId: this.serverless.service.provider.httpApi.id })

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -28,11 +28,7 @@ module.exports = {
           if (result) stackData.outputs = result.Stacks[0].Outputs;
         }),
     ];
-    if (
-      this.serverless.service.provider.httpApi &&
-      this.serverless.service.provider.httpApi.id &&
-      typeof this.serverless.service.provider.httpApi.id === 'string'
-    ) {
+    if (this.serverless.service.provider.httpApi && this.serverless.service.provider.httpApi.id) {
       sdkRequests.push(
         this.provider
           .request('ApiGatewayV2', 'getApi', { ApiId: this.serverless.service.provider.httpApi.id })

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -162,9 +162,10 @@ class HttpApiEvents {
         DependsOn: this.provider.naming.getHttpApiIntegrationLogicalId(targetData.functionName),
       });
       if (authorizer) {
+        const { authorizerId } = authorizer;
         Object.assign(resource.Properties, {
           AuthorizationType: 'JWT',
-          AuthorizerId: {
+          AuthorizerId: authorizerId || {
             Ref: this.provider.naming.getHttpApiAuthorizerLogicalId(authorizer.name),
           },
           AuthorizationScopes: authorizationScopes && Array.from(authorizationScopes),
@@ -351,17 +352,20 @@ Object.defineProperties(
           }
           const routeConfig = { targetData: routeTargetData };
           if (authorizer) {
-            const { name, scopes } = (() => {
+            const { name, scopes, authorizerId } = (() => {
               if (_.isObject(authorizer)) return authorizer;
               return { name: authorizer };
             })();
-            if (!authorizers.has(name)) {
+            if (authorizerId) {
+              routeConfig.authorizer = { authorizerId };
+            } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(
                 `Event references not configured authorizer '${name}'`,
                 'UNRECOGNIZED_HTTP_API_AUTHORIZER'
               );
+            } else {
+              routeConfig.authorizer = authorizers.get(name);
             }
-            routeConfig.authorizer = authorizers.get(name);
             if (scopes) routeConfig.authorizationScopes = toSet(scopes);
           }
           if (!timeout) timeout = userConfig.timeout || null;

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -189,7 +189,7 @@ Object.defineProperties(
       if (userCors) {
         if (userConfig.id) {
           throw new this.serverless.classes.Error(
-            'Cannot setup CORS rules for externally confugured HTTP API',
+            'Cannot setup CORS rules for externally configured HTTP API',
             'EXTERNAL_HTTP_API_CORS_CONFIG'
           );
         }
@@ -218,6 +218,12 @@ Object.defineProperties(
       const userAuthorizers = userConfig.authorizers;
       const authorizers = (this.config.authorizers = new Map());
       if (userAuthorizers) {
+        if (userConfig.id) {
+          throw new this.serverless.classes.Error(
+            'Cannot setup authorizers for externally configured HTTP API',
+            'EXTERNAL_HTTP_API_AUTHORIZERS_CONFIG'
+          );
+        }
         for (const [name, authorizerConfig] of _.entries(userAuthorizers)) {
           authorizers.set(name, {
             name: authorizerConfig.name || name,

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -369,12 +369,6 @@ Object.defineProperties(
                   'EXTERNAL_HTTP_API_AUTHORIZER_WITHOUT_EXTERNAL_HTTP_API'
                 );
               }
-              if (name) {
-                throw new this.serverless.classes.Error(
-                  `Event references external authorizer and provide a local name property in function ${functionName}.`,
-                  'EXTERNAL_HTTP_API_AUTHORIZER_NAME_PROVIDED'
-                );
-              }
               routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -162,10 +162,10 @@ class HttpApiEvents {
         DependsOn: this.provider.naming.getHttpApiIntegrationLogicalId(targetData.functionName),
       });
       if (authorizer) {
-        const { authorizerId } = authorizer;
+        const { id } = authorizer;
         Object.assign(resource.Properties, {
           AuthorizationType: 'JWT',
-          AuthorizerId: authorizerId || {
+          AuthorizerId: id || {
             Ref: this.provider.naming.getHttpApiAuthorizerLogicalId(authorizer.name),
           },
           AuthorizationScopes: authorizationScopes && Array.from(authorizationScopes),
@@ -358,12 +358,12 @@ Object.defineProperties(
           }
           const routeConfig = { targetData: routeTargetData };
           if (authorizer) {
-            const { name, scopes, authorizerId } = (() => {
+            const { name, scopes, id } = (() => {
               if (_.isObject(authorizer)) return authorizer;
               return { name: authorizer };
             })();
-            if (authorizerId) {
-              routeConfig.authorizer = { authorizerId };
+            if (id) {
+              routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(
                 `Event references not configured authorizer '${name}'`,

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -363,6 +363,18 @@ Object.defineProperties(
               return { name: authorizer };
             })();
             if (id) {
+              if (!userConfig.id) {
+                throw new this.serverless.classes.Error(
+                  `Event references external authorizer '${id}', but httpApi is part of the current stack.`,
+                  'EXTERNAL_HTTP_API_AUTHORIZER_WITHOUT_EXTERNAL_HTTP_API'
+                );
+              }
+              if (name) {
+                throw new this.serverless.classes.Error(
+                  `Event references external authorizer and provide a local name property in function ${functionName}.`,
+                  'EXTERNAL_HTTP_API_AUTHORIZER_NAME_PROVIDED'
+                );
+              }
               routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -424,44 +424,113 @@ describe('HttpApiEvents', () => {
   });
 
   describe('External authorizers: JWT', () => {
-    let cfResources;
-    let naming;
-    before(() =>
-      fixtures
-        .extend('httpApi', {
-          functions: {
-            foo: {
-              events: [
-                {
-                  httpApi: {
-                    authorizer: {
-                      id: 'externalAuthorizer',
-                      scopes: 'foo',
+    const apiId = 'external-http-api';
+    describe('correct configuration', () => {
+      let cfResources;
+      let naming;
+      before(() =>
+        fixtures
+          .extend('httpApi', {
+            provider: { httpApi: { id: apiId } },
+            functions: {
+              foo: {
+                events: [
+                  {
+                    httpApi: {
+                      authorizer: {
+                        id: 'externalAuthorizer',
+                        scopes: 'foo',
+                      },
                     },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        })
-        .then(fixturePath =>
-          runServerless({
-            cwd: fixturePath,
-            cliArgs: ['package'],
-          }).then(serverless => {
-            cfResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
-            naming = serverless.getProvider('aws').naming;
           })
-        )
-    );
+          .then(fixturePath =>
+            runServerless({
+              cwd: fixturePath,
+              cliArgs: ['package'],
+            }).then(serverless => {
+              cfResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+              naming = serverless.getProvider('aws').naming;
+            })
+          )
+      );
 
-    it('Should setup authorizer properties on an endpoint', () => {
-      const routeResourceProps =
-        cfResources[naming.getHttpApiRouteLogicalId('GET /foo')].Properties;
+      it('Should setup authorizer properties on an endpoint', () => {
+        const routeResourceProps =
+          cfResources[naming.getHttpApiRouteLogicalId('GET /foo')].Properties;
 
-      expect(routeResourceProps.AuthorizerId).to.equal('externalAuthorizer');
-      expect(routeResourceProps.AuthorizationType).to.equal('JWT');
-      expect(routeResourceProps.AuthorizationScopes).to.deep.equal(['foo']);
+        expect(routeResourceProps.AuthorizerId).to.equal('externalAuthorizer');
+        expect(routeResourceProps.AuthorizationType).to.equal('JWT');
+        expect(routeResourceProps.AuthorizationScopes).to.deep.equal(['foo']);
+      });
+    });
+
+    describe('disallowed configurations', () => {
+      it('Should not allow external authorizer without external httpApi', () => {
+        return expect(
+          fixtures
+            .extend('httpApi', {
+              functions: {
+                foo: {
+                  events: [
+                    {
+                      httpApi: {
+                        authorizer: {
+                          id: 'externalAuthorizer',
+                          scopes: 'foo',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            })
+            .then(fixturePath =>
+              runServerless({
+                cwd: fixturePath,
+                cliArgs: ['package'],
+              })
+            )
+        ).to.eventually.be.rejected.and.have.property(
+          'code',
+          'EXTERNAL_HTTP_API_AUTHORIZER_WITHOUT_EXTERNAL_HTTP_API'
+        );
+      });
+
+      it('Should not allow mixing name and id on external authorizer', () => {
+        return expect(
+          fixtures
+            .extend('httpApi', {
+              provider: { httpApi: { id: apiId } },
+              functions: {
+                foo: {
+                  events: [
+                    {
+                      httpApi: {
+                        authorizer: {
+                          id: 'externalAuthorizer',
+                          name: 'someAuthorizer',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            })
+            .then(fixturePath =>
+              runServerless({
+                cwd: fixturePath,
+                cliArgs: ['package'],
+              })
+            )
+        ).to.eventually.be.rejected.and.have.property(
+          'code',
+          'EXTERNAL_HTTP_API_AUTHORIZER_NAME_PROVIDED'
+        );
+      });
     });
   });
 
@@ -569,9 +638,7 @@ describe('HttpApiEvents', () => {
                 cliArgs: ['package'],
               })
             )
-        ).to.eventually.be.rejectedWith(
-          'Cannot setup CORS rules for externally configured HTTP API'
-        );
+        ).to.eventually.be.rejected.and.have.property('code', 'EXTERNAL_HTTP_API_CORS_CONFIG');
       });
       it('Should not allow defined authorizers', () => {
         return expect(
@@ -596,8 +663,9 @@ describe('HttpApiEvents', () => {
                 cliArgs: ['package'],
               })
             )
-        ).to.eventually.be.rejectedWith(
-          'Cannot setup authorizers for externally configured HTTP API'
+        ).to.eventually.be.rejected.and.have.property(
+          'code',
+          'EXTERNAL_HTTP_API_AUTHORIZERS_CONFIG'
         );
       });
       it('Should not allow defined logs', () => {
@@ -619,9 +687,7 @@ describe('HttpApiEvents', () => {
                 cliArgs: ['package'],
               })
             )
-        ).to.eventually.be.rejectedWith(
-          'Cannot setup access logs for externally configured HTTP API'
-        );
+        ).to.eventually.be.rejected.and.have.property('code', 'EXTERNAL_HTTP_API_LOGS_CONFIG');
       });
     });
   });

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -499,38 +499,6 @@ describe('HttpApiEvents', () => {
           'EXTERNAL_HTTP_API_AUTHORIZER_WITHOUT_EXTERNAL_HTTP_API'
         );
       });
-
-      it('Should not allow mixing name and id on external authorizer', () => {
-        return expect(
-          fixtures
-            .extend('httpApi', {
-              provider: { httpApi: { id: apiId } },
-              functions: {
-                foo: {
-                  events: [
-                    {
-                      httpApi: {
-                        authorizer: {
-                          id: 'externalAuthorizer',
-                          name: 'someAuthorizer',
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            })
-            .then(fixturePath =>
-              runServerless({
-                cwd: fixturePath,
-                cliArgs: ['package'],
-              })
-            )
-        ).to.eventually.be.rejected.and.have.property(
-          'code',
-          'EXTERNAL_HTTP_API_AUTHORIZER_NAME_PROVIDED'
-        );
-      });
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const { expect } = require('chai');
+const chai = require('chai');
 const runServerless = require('../../../../../../../tests/utils/run-serverless');
 const fixtures = require('../../../../../../../tests/fixtures');
+
+chai.use(require('chai-as-promised'));
+
+const { expect } = chai;
 
 describe('HttpApiEvents', () => {
   after(fixtures.cleanup);

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -503,46 +503,122 @@ describe('HttpApiEvents', () => {
     let naming;
     const apiId = 'external-api-id';
 
-    before(() =>
-      fixtures.extend('httpApi', { provider: { httpApi: { id: apiId } } }).then(fixturePath =>
-        runServerless({
-          cwd: fixturePath,
-          cliArgs: ['package'],
-        }).then(serverless => {
-          ({
-            Resources: cfResources,
-            Outputs: cfOutputs,
-          } = serverless.service.provider.compiledCloudFormationTemplate);
-          naming = serverless.getProvider('aws').naming;
-        })
-      )
-    );
+    describe('correct configuration', () => {
+      before(() =>
+        fixtures.extend('httpApi', { provider: { httpApi: { id: apiId } } }).then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(serverless => {
+            ({
+              Resources: cfResources,
+              Outputs: cfOutputs,
+            } = serverless.service.provider.compiledCloudFormationTemplate);
+            naming = serverless.getProvider('aws').naming;
+          })
+        )
+      );
 
-    it('Should not configure API resource', () => {
-      expect(cfResources).to.not.have.property(naming.getHttpApiLogicalId());
+      it('Should not configure API resource', () => {
+        expect(cfResources).to.not.have.property(naming.getHttpApiLogicalId());
+      });
+      it('Should not configure stage resource', () => {
+        expect(cfResources).to.not.have.property(naming.getHttpApiStageLogicalId());
+      });
+      it('Should not configure output', () => {
+        expect(cfOutputs).to.not.have.property('HttpApiUrl');
+      });
+      it('Should configure endpoint that attaches to external API', () => {
+        const routeKey = 'POST /some-post';
+        const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
+        expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');
+        expect(resource.Properties.RouteKey).to.equal(routeKey);
+        expect(resource.Properties.ApiId).to.equal(apiId);
+      });
+      it('Should configure endpoint integration', () => {
+        const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
+        expect(resource.Type).to.equal('AWS::ApiGatewayV2::Integration');
+        expect(resource.Properties.IntegrationType).to.equal('AWS_PROXY');
+      });
+      it('Should configure lambda permissions', () => {
+        const resource = cfResources[naming.getLambdaHttpApiPermissionLogicalId('foo')];
+        expect(resource.Type).to.equal('AWS::Lambda::Permission');
+        expect(resource.Properties.Action).to.equal('lambda:InvokeFunction');
+      });
     });
-    it('Should not configure stage resource', () => {
-      expect(cfResources).to.not.have.property(naming.getHttpApiStageLogicalId());
-    });
-    it('Should not configure output', () => {
-      expect(cfOutputs).to.not.have.property('HttpApiUrl');
-    });
-    it('Should configure endpoint that attaches to external API', () => {
-      const routeKey = 'POST /some-post';
-      const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
-      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');
-      expect(resource.Properties.RouteKey).to.equal(routeKey);
-      expect(resource.Properties.ApiId).to.equal(apiId);
-    });
-    it('Should configure endpoint integration', () => {
-      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
-      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Integration');
-      expect(resource.Properties.IntegrationType).to.equal('AWS_PROXY');
-    });
-    it('Should configure lambda permissions', () => {
-      const resource = cfResources[naming.getLambdaHttpApiPermissionLogicalId('foo')];
-      expect(resource.Type).to.equal('AWS::Lambda::Permission');
-      expect(resource.Properties.Action).to.equal('lambda:InvokeFunction');
+
+    describe('disallowed configurations', () => {
+      it('Should not allow defined cors rules', () => {
+        return expect(
+          fixtures
+            .extend('httpApi', {
+              provider: {
+                httpApi: {
+                  id: apiId,
+                  cors: true,
+                },
+              },
+            })
+            .then(fixturePath =>
+              runServerless({
+                cwd: fixturePath,
+                cliArgs: ['package'],
+              })
+            )
+        ).to.eventually.be.rejectedWith(
+          'Cannot setup CORS rules for externally configured HTTP API'
+        );
+      });
+      it('Should not allow defined authorizers', () => {
+        return expect(
+          fixtures
+            .extend('httpApi', {
+              provider: {
+                httpApi: {
+                  id: apiId,
+                  authorizers: {
+                    someAuthorizer: {
+                      identitySource: '$request.header.Authorization',
+                      issuerUrl: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxx',
+                      audience: 'audiencexxx',
+                    },
+                  },
+                },
+              },
+            })
+            .then(fixturePath =>
+              runServerless({
+                cwd: fixturePath,
+                cliArgs: ['package'],
+              })
+            )
+        ).to.eventually.be.rejectedWith(
+          'Cannot setup authorizers for externally configured HTTP API'
+        );
+      });
+      it('Should not allow defined logs', () => {
+        return expect(
+          fixtures
+            .extend('httpApi', {
+              provider: {
+                httpApi: {
+                  id: apiId,
+                },
+                logs: {
+                  httpApi: true,
+                },
+              },
+            })
+            .then(fixturePath =>
+              runServerless({
+                cwd: fixturePath,
+                cliArgs: ['package'],
+              })
+            )
+        ).to.eventually.be.rejectedWith(
+          'Cannot setup access logs for externally configured HTTP API'
+        );
+      });
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -419,6 +419,48 @@ describe('HttpApiEvents', () => {
     });
   });
 
+  describe('External authorizers: JWT', () => {
+    let cfResources;
+    let naming;
+    before(() =>
+      fixtures
+        .extend('httpApi', {
+          functions: {
+            foo: {
+              events: [
+                {
+                  httpApi: {
+                    authorizer: {
+                      authorizerId: 'externalAuthorizer',
+                      scopes: 'foo',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(serverless => {
+            cfResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+            naming = serverless.getProvider('aws').naming;
+          })
+        )
+    );
+
+    it('Should setup authorizer properties on an endpoint', () => {
+      const routeResourceProps =
+        cfResources[naming.getHttpApiRouteLogicalId('GET /foo')].Properties;
+
+      expect(routeResourceProps.AuthorizerId).to.equal('externalAuthorizer');
+      expect(routeResourceProps.AuthorizationType).to.equal('JWT');
+      expect(routeResourceProps.AuthorizationScopes).to.deep.equal(['foo']);
+    });
+  });
+
   describe('Access logs', () => {
     let cfResources;
     let naming;

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -435,7 +435,7 @@ describe('HttpApiEvents', () => {
                 {
                   httpApi: {
                     authorizer: {
-                      authorizerId: 'externalAuthorizer',
+                      id: 'externalAuthorizer',
                       scopes: 'foo',
                     },
                   },


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

This allows to add external authorizer to `httpApi` event in similar manner to `http` event. 

Closes: #7598
