### PR TITLE
Make it easier to use a CognitoUserPool authorizer when the pool is configured in the same service.

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -546,6 +546,32 @@ functions:
               - nickname
 ```
 
+If you are creating the Cognito User Pool in the `resources` section of the same template, you can refer to the ARN using the `Fn::GetAtt` attribute from CloudFormation. To do so, you _must_ give your authorizer a name and specify a type of `COGNITO_USER_POOLS`:
+
+```yml
+functions:
+  create:
+    handler: posts.create
+    events:
+      - http:
+          path: posts/create
+          method: post
+          integration: lambda
+          authorizer:
+            name: MyAuthorizer
+            type: COGNITO_USER_POOLS
+            arn:
+              Fn::GetAtt:
+                - CognitoUserPool
+                - Arn
+---
+resources:
+  Resources:
+    CognitoUserPool:
+      Type: 'AWS::Cognito::UserPool'
+      Properties: ...
+```
+
 ### HTTP Endpoints with `operationId`
 
 Include `operationId` when you want to provide a name for the method endpoint. This will set `OperationName` inside `AWS::ApiGateway::Method` accordingly. One common use case for this is customizing method names in some code generators (e.g., swagger).

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.js
@@ -25,8 +25,9 @@ module.exports = {
         const authorizerLogicalId = this.provider.naming.getAuthorizerLogicalId(authorizer.name);
 
         if (
-          typeof authorizer.arn === 'string' &&
-          awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn)
+          (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOL' ||
+          (typeof authorizer.arn === 'string' &&
+            awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn))
         ) {
           authorizerProperties.Type = 'COGNITO_USER_POOLS';
           authorizerProperties.ProviderARNs = [authorizer.arn];

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.js
@@ -25,7 +25,7 @@ module.exports = {
         const authorizerLogicalId = this.provider.naming.getAuthorizerLogicalId(authorizer.name);
 
         if (
-          (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOL' ||
+          (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOLS' ||
           (typeof authorizer.arn === 'string' &&
             awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn))
         ) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
@@ -190,4 +190,36 @@ describe('#compileAuthorizers()', () => {
       expect(resource.Properties.Type).to.equal('COGNITO_USER_POOLS');
     });
   });
+
+  it('should create a valid cognito user pool authorizer using Fn::GetAtt', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            type: 'COGNITO_USER_POOLS',
+            arn: {
+              'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+            },
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource =
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Properties.Name).to.equal('authorizer');
+
+      expect(resource.Properties.ProviderARNs[0]).to.deep.equal({
+        'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+      });
+
+      expect(resource.Properties.Type).to.equal('COGNITO_USER_POOLS');
+    });
+  });
 });

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -37,7 +37,7 @@ module.exports = {
 
       let authorizationType;
       if (
-        (http.authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOL' ||
+        (http.authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOLS' ||
         (typeof authorizerArn === 'string' && awsArnRegExs.cognitoIdpArnExpr.test(authorizerArn))
       ) {
         authorizationType = 'COGNITO_USER_POOLS';

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -36,7 +36,10 @@ module.exports = {
       const authorizerArn = http.authorizer.arn;
 
       let authorizationType;
-      if (typeof authorizerArn === 'string' && awsArnRegExs.cognitoIdpArnExpr.test(authorizerArn)) {
+      if (
+        (http.authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOL' ||
+        (typeof authorizerArn === 'string' && awsArnRegExs.cognitoIdpArnExpr.test(authorizerArn))
+      ) {
         authorizationType = 'COGNITO_USER_POOLS';
         const cognitoReturn = {
           Properties: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -679,6 +679,51 @@ describe('#compileMethods()', () => {
     });
   });
 
+  it('should set authorizer config for a cognito user pool when given cognito arn object', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          authorizer: {
+            name: 'authorizer',
+            type: 'COGNITO_USER_POOLS',
+            arn: {
+              'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+            },
+            scopes: ['myapp/read', 'myapp/write'],
+          },
+          integration: 'AWS',
+          path: 'users/create',
+          method: 'post',
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileMethods().then(() => {
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.AuthorizationType
+      ).to.equal('COGNITO_USER_POOLS');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.AuthorizationScopes
+      ).to.contain('myapp/read');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.AuthorizerId.Ref
+      ).to.equal('AuthorizerApiGatewayAuthorizer');
+
+      expect(
+        awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .ApiGatewayMethodUsersCreatePost.Properties.Integration.RequestTemplates[
+          'application/json'
+        ]
+      ).to.not.match(/undefined/);
+    });
+  });
+
   it('should not scopes for a cognito user pool when given empty scopes array', () => {
     awsCompileApigEvents.validated.events = [
       {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -50,7 +50,7 @@ module.exports = {
           );
 
           if (
-            (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOL' ||
+            (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOLS' ||
             (typeof authorizer.arn === 'string' &&
               awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn))
           ) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.js
@@ -50,8 +50,9 @@ module.exports = {
           );
 
           if (
-            typeof authorizer.arn === 'string' &&
-            awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn)
+            (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOL' ||
+            (typeof authorizer.arn === 'string' &&
+              awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn))
           ) {
             return;
           }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -255,11 +255,11 @@ module.exports = {
           name = authorizer.name;
         } else if (
           authorizer.type &&
-          authorizer.type.toUpperCase() === 'COGNITO_USER_POOL' &&
+          authorizer.type.toUpperCase() === 'COGNITO_USER_POOLS' &&
           _.isObject(authorizer.arn)
         ) {
           throw new this.serverless.classes.Error(
-            'Please provide an authorizer name for authorizers of type COGNITO_USER_POOL'
+            'Please provide an authorizer name for authorizers of type COGNITO_USER_POOLS'
           );
         } else {
           name = this.provider.naming.extractAuthorizerNameFromArn(arn);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -253,6 +253,14 @@ module.exports = {
         arn = authorizer.arn;
         if (_.isString(authorizer.name)) {
           name = authorizer.name;
+        } else if (
+          authorizer.type &&
+          authorizer.type.toUpperCase() === 'COGNITO_USER_POOL' &&
+          _.isObject(authorizer.arn)
+        ) {
+          throw new this.serverless.classes.Error(
+            'Please provide an authorizer name for authorizers of type COGNITO_USER_POOL'
+          );
         } else {
           name = this.provider.naming.extractAuthorizerNameFromArn(arn);
         }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -352,6 +352,55 @@ describe('#validate()', () => {
     expect(() => awsCompileApigEvents.validate()).not.to.throw(Error);
   });
 
+  it('should throw when using a cognito authorizer without a name', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              path: '/{proxy+}',
+              method: 'ANY',
+              integration: 'lambda-proxy',
+              authorizer: {
+                type: 'COGNITO_USER_POOLS',
+                arn: {
+                  'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.validate()).to.throw(Error);
+  });
+
+  it('should not throw when using an object cognito authorizer with a name', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              path: '/{proxy+}',
+              method: 'ANY',
+              integration: 'lambda-proxy',
+              authorizer: {
+                type: 'COGNITO_USER_POOLS',
+                name: 'MyAuthorizer',
+                arn: {
+                  'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => awsCompileApigEvents.validate()).not.to.throw(Error);
+  });
+
   it('should accept AWS_IAM as authorizer', () => {
     awsCompileApigEvents.serverless.service.functions = {
       foo: {},


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

Note: Remove this section if it's documentation update or obvious bug fix that has no corresponding issue. In such case provide a short description of made changes
-->

This update makes it easier to use a Cognito User Pool as an APIGW authorizer when the pool is created in the same service.

Before this fix, it required this ([suggested here](https://github.com/serverless/serverless/issues/3212#issuecomment-450574093)):

```yaml
...

functions:
  getStuff:
    handler: path/to/handler
    events:
      - http:
          path: /path/to/whatever
          method: get
          authorizer:
            type: COGNITO_USER_POOLS
            authorizerId:
              Ref: ApiGatewayAuthorizer

...

resources:
  Resources:
    CognitoUserPool:
      Type: AWS::Cognito::UserPool
      Properties:
        UserPoolName: whatever
    ApiGatewayAuthorizer:
      DependsOn:
        - ApiGatewayRestApi
      Type: AWS::ApiGateway::Authorizer
      Properties:
        Name: whatever
        IdentitySource: method.request.header.Authorization
        RestApiId:
          Ref: ApiGatewayRestApi
        Type: COGNITO_USER_POOLS
        ProviderARNs:
          - Fn::GetAtt: [CognitoUserPool, Arn]

...
```

Now you can achieve the same thing with this:

```yaml
functions:
  getStuff:
    handler: path/to/handler
    events:
      - http:
          path: /path/to/whatever
          method: get
          authorizer:
            type: COGNITO_USER_POOLS
            name: 'MyAuthorizer'
            arn:
              Fn::GetAtt:
                - CognitoUserPool
                - Arn
```

Hattip to @brettstack for [some pointers](https://github.com/serverless/serverless/issues/3212#issuecomment-620126812).
