### PR TITLE
Fix AWS API Gateway key names resolution

### DIFF
--- a/lib/plugins/aws/info/getApiKeyValues.js
+++ b/lib/plugins/aws/info/getApiKeyValues.js
@@ -16,7 +16,11 @@ module.exports = {
         // different API key types are nested in separate arrays
         if (_.isObject(definition)) {
           const keyTypeName = Object.keys(definition)[0];
-          definition[keyTypeName].forEach(keyName => apiKeyNames.push(keyName));
+          if (Array.isArray(definition[keyTypeName])) {
+            definition[keyTypeName].forEach(keyName => apiKeyNames.push(keyName));
+          } else if (definition.name) {
+            apiKeyNames.push(definition.name);
+          }
         } else if (_.isString(definition)) {
           // plain strings are simple, non-nested API keys
           apiKeyNames.push(definition);


### PR DESCRIPTION
Regression introduced by #5982, with which new format was introduced but resolution of API key names was not updated to it.

Exposed by changes introduced with #7748 in CI run: https://travis-ci.org/github/serverless/serverless/jobs/692075909

