### PR TITLE
Replace _.map with array.map

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -250,7 +250,7 @@ class PluginManager {
     _.forEach(pluginInstance.commands, (details, key) => {
       const command = this.loadCommand(pluginName, details, key);
       // Grab and extract deprecated events
-      command.lifecycleEvents = _.map(command.lifecycleEvents, event => {
+      command.lifecycleEvents = (command.lifecycleEvents || []).map(event => {
         if (event.startsWith('deprecated#')) {
           // Extract event and optional redirect
           const transformedEvent = /^deprecated#(.*?)(?:->(.*?))?$/.exec(event);

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -261,7 +261,7 @@ class Variables {
     const addContext = (value, key) =>
       this.getProperties(root, false, value, context.concat(key), results);
     if (Array.isArray(current)) {
-      _.map(current, addContext);
+      current.map(addContext);
     } else if (
       _.isObject(current) &&
       !_.isDate(current) &&
@@ -291,7 +291,7 @@ class Variables {
     const variables = properties.filter(
       property => typeof property.value === 'string' && property.value.match(this.variableSyntax)
     );
-    return _.map(variables, variable =>
+    return variables.map(variable =>
       this.populateValue(variable.value, false).then(populated =>
         Object.assign({}, variable, { populated })
       )
@@ -367,7 +367,7 @@ class Variables {
     if (!matches || !matches.length) {
       return property;
     }
-    return _.map(matches, match => ({
+    return matches.map(match => ({
       match,
       variable: this.cleanVariable(match),
     }));
@@ -379,7 +379,7 @@ class Variables {
    * @returns {Promise[]} Promises for the eventual populated values of the given matches
    */
   populateMatches(matches, property) {
-    return _.map(matches, match => this.splitAndGet(match, property));
+    return matches.map(match => this.splitAndGet(match, property));
   }
   /**
    * Render the given matches and their associated results to the given value

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -83,7 +83,7 @@ module.exports = {
 
     const functionNames = this.serverless.service.getAllFunctions();
     let artifactFilePaths = _.uniq(
-      _.map(functionNames, name => {
+      functionNames.map(name => {
         const functionArtifactFileName = this.provider.naming.getFunctionArtifactName(name);
         const functionObject = this.serverless.service.getFunction(name);
         functionObject.package = functionObject.package || {};
@@ -107,19 +107,21 @@ module.exports = {
 
     const layerNames = this.serverless.service.getAllLayers();
     artifactFilePaths = artifactFilePaths.concat(
-      _.map(layerNames, name => {
-        const layerObject = this.serverless.service.getLayer(name);
-        if (layerObject.artifactAlreadyUploaded) {
-          this.serverless.cli.log(`Skip uploading ${name}`);
-          return null;
-        }
-        return getLambdaLayerArtifactPath(
-          this.packagePath,
-          name,
-          this.provider.serverless.service,
-          this.provider.naming
-        );
-      }).filter(Boolean)
+      layerNames
+        .map(name => {
+          const layerObject = this.serverless.service.getLayer(name);
+          if (layerObject.artifactAlreadyUploaded) {
+            this.serverless.cli.log(`Skip uploading ${name}`);
+            return null;
+          }
+          return getLambdaLayerArtifactPath(
+            this.packagePath,
+            name,
+            this.provider.serverless.service,
+            this.provider.naming
+          );
+        })
+        .filter(Boolean)
     );
 
     return BbPromise.map(

--- a/lib/plugins/aws/deployList/index.js
+++ b/lib/plugins/aws/deployList/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const _ = require('lodash');
 const validate = require('../lib/validate');
 const findAndGroupDeployments = require('../utils/findAndGroupDeployments');
 const setBucketName = require('../lib/setBucketName');
@@ -78,7 +77,7 @@ class AwsDeployList {
       };
 
       return this.provider.request('Lambda', 'getFunction', params);
-    }).then(result => _.map(result, item => item.Configuration));
+    }).then(result => result.map(item => item.Configuration));
   }
 
   getFunctionPaginatedVersions(params, totalVersions) {

--- a/lib/plugins/aws/info/getApiKeyValues.js
+++ b/lib/plugins/aws/info/getApiKeyValues.js
@@ -39,7 +39,7 @@ module.exports = {
             .map(resource => resource.PhysicalResourceId)
             .value();
           return Promise.all(
-            _.map(apiKeys, apiKey =>
+            apiKeys.map(apiKey =>
               this.provider.request('APIGateway', 'getApiKey', {
                 apiKey,
                 includeValue: true,
@@ -49,7 +49,7 @@ module.exports = {
         })
         .then(apiKeys => {
           if (apiKeys && apiKeys.length) {
-            info.apiKeys = _.map(apiKeys, apiKey =>
+            info.apiKeys = apiKeys.map(apiKey =>
               _.pick(apiKey, ['name', 'value', 'description', 'customerId'])
             );
           }

--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -42,8 +42,8 @@ const yamlType = (name, kind) => {
 
 const createSchema = () => {
   const types = _.flatten(
-    _.map(functionNames, functionName =>
-      _.map(['mapping', 'scalar', 'sequence'], kind => yamlType(functionName, kind))
+    functionNames.map(functionName =>
+      ['mapping', 'scalar', 'sequence'].map(kind => yamlType(functionName, kind))
     )
   );
   return YAML.Schema.create(types);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -51,7 +51,9 @@ module.exports = {
         if (
           _.isObject(apiKeyDefinition) &&
           _.includes(
-            _.flatten(_.map(this.serverless.service.provider.usagePlan, item => Object.keys(item))),
+            _.flatten(
+              (this.serverless.service.provider.usagePlan || []).map(item => Object.keys(item))
+            ),
             name
           )
         ) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -65,7 +65,7 @@ module.exports = {
       let extraCognitoPoolClaims;
       if (event.http.authorizer) {
         const claims = event.http.authorizer.claims || [];
-        extraCognitoPoolClaims = _.map(claims, claim => {
+        extraCognitoPoolClaims = claims.map(claim => {
           if (typeof claim === 'string') {
             const colonIndex = claim.indexOf(':');
             if (colonIndex !== -1) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -116,7 +116,7 @@ module.exports = {
                 const requestWarningMessage = [
                   `Warning! You're using the ${http.integration} in combination with a request`,
                   ` configuration in your function "${functionName}". Only the `,
-                  _.map(allowedKeys, value => `request.${value}`).join(', '),
+                  allowedKeys.map(value => `request.${value}`).join(', '),
                   ` configs are available in conjunction with ${http.integration}.`,
                   ' Serverless will remove this configuration automatically',
                   ' before deployment.',

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -326,7 +326,7 @@ class AwsCompileCognitoUserPoolEvents {
     const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 
     // Attach `DependsOn` for any relevant Lambdas
-    const DependsOn = _.map(currentPoolTriggerFunctions, value =>
+    const DependsOn = currentPoolTriggerFunctions.map(value =>
       this.provider.naming.getLambdaLogicalId(value.functionName)
     );
 

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -315,7 +315,7 @@ class AwsCompileS3Events {
               throw new this.serverless.classes.Error(errorMessage);
             }
 
-            rules = _.map(event.s3.rules, rule => {
+            rules = (event.s3.rules || []).map(rule => {
               const key = Object.keys(rule)[0];
               const value = rule[key];
               return {

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -31,7 +31,7 @@ module.exports = {
       if (!_.isEmpty(deploymentBucketObject.tags)) {
         const tags = deploymentBucketObject.tags;
 
-        const bucketTags = _.map(Object.keys(tags), key => ({
+        const bucketTags = Object.keys(tags).map(key => ({
           Key: key,
           Value: tags[key],
         }));

--- a/lib/plugins/aws/utils/findAndGroupDeployments.js
+++ b/lib/plugins/aws/utils/findAndGroupDeployments.js
@@ -14,7 +14,7 @@ module.exports = (s3Response, prefix, service, stage) => {
       };
     });
     const grouped = _.groupBy(names, 'directory');
-    return _.map(grouped, value => value);
+    return Object.values(grouped);
   }
   return [];
 };

--- a/lib/plugins/aws/utils/findAndGroupDeployments.js
+++ b/lib/plugins/aws/utils/findAndGroupDeployments.js
@@ -14,7 +14,7 @@ module.exports = (s3Response, prefix, service, stage) => {
       };
     });
     const grouped = _.groupBy(names, 'directory');
-    return Object.values(grouped);
+    return _.values(grouped);
   }
   return [];
 };

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -63,7 +63,7 @@ module.exports = {
     this.serverless.cli.log('Packaging service...');
     let shouldPackageService = false;
     const allFunctions = this.serverless.service.getAllFunctions();
-    let packagePromises = _.map(allFunctions, functionName => {
+    let packagePromises = allFunctions.map(functionName => {
       const functionObject = this.serverless.service.getFunction(functionName);
       functionObject.package = functionObject.package || {};
       if (functionObject.package.disable) {
@@ -81,7 +81,7 @@ module.exports = {
     });
     const allLayers = this.serverless.service.getAllLayers();
     packagePromises = packagePromises.concat(
-      _.map(allLayers, layerName => {
+      allLayers.map(layerName => {
         const layerObject = this.serverless.service.getLayer(layerName);
         layerObject.package = layerObject.package || {};
         if (layerObject.package.artifact) {


### PR DESCRIPTION
Addresses: #7747

Some variables are enclosed in `(var || [])` to avoid *cannot read property map of undefined*. The test results are OK, but I'm not sure about the probability of the other variables being `undefined`. Please tell me if they need to be enclosed as well.