### PR TITLE
feat: Add support for maximumRecordAgeInSeconds property

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -161,6 +161,26 @@ functions:
           enabled: false
 ```
 
+## Setting the MaximumRecordAgeInSeconds
+
+This configuration sets up the maximum age of a record that Lambda sends to a function for processing.
+
+**Note:** Serverless only sets this property if you explicitly add it to the stream configuration (see example below).
+
+[Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumrecordageinseconds)
+
+**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
+
+```yml
+functions:
+  preprocess:
+    handler: handler.preprocess
+    events:
+      - stream:
+          arn: arn:aws:kinesis:region:XXXXXX:stream/foo
+          maximumRecordAgeInSeconds: 120
+```
+
 ## Setting the OnFailure destination
 
 This configuration sets up the onFailure location for events to be sent to once it has reached the maximum number of times to retry when the function returns an error.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -345,6 +345,7 @@ functions:
       - stream:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           batchSize: 100
+          maximumRecordAgeInSeconds: 120
           startingPosition: LATEST
           enabled: false
       - alexaSkill:

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -265,6 +265,11 @@ class AwsCompileStreamEvents {
                 event.stream.bisectBatchOnFunctionError;
             }
 
+            if (event.stream.maximumRecordAgeInSeconds) {
+              streamResource.Properties.MaximumRecordAgeInSeconds =
+                event.stream.maximumRecordAgeInSeconds;
+            }
+
             if (event.stream.destinations) {
               if (event.stream.destinations.onFailure) {
                 let OnFailureDestinationArn;

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -399,6 +399,7 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:dynamodb:region:account:table/buzz/stream/4',
                   bisectBatchOnFunctionError: true,
+                  maximumRecordAgeInSeconds: 120,
                 },
               },
               {
@@ -509,6 +510,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.BisectBatchOnFunctionError
         ).to.equal(undefined);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBaz.Properties.MaximumRecordAgeInSeconds
+        ).to.equal(undefined);
 
         // event 4
         expect(
@@ -539,6 +544,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.BisectBatchOnFunctionError
         ).to.equal(true);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.MaximumRecordAgeInSeconds
+        ).to.equal(120);
 
         // event 5
         expect(
@@ -1255,6 +1264,7 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/buzz',
                   bisectBatchOnFunctionError: true,
+                  maximumRecordAgeInSeconds: 180,
                 },
               },
               {
@@ -1394,6 +1404,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.BisectBatchOnFunctionError
         ).to.equal(undefined);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBaz.Properties.MaximumRecordAgeInSeconds
+        ).to.equal(undefined);
 
         // event 4
         expect(
@@ -1428,6 +1442,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBuzz.Properties.BisectBatchOnFunctionError
         ).to.equal(true);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisBuzz.Properties.MaximumRecordAgeInSeconds
+        ).to.equal(180);
 
         // event 5
         expect(
@@ -1543,6 +1561,10 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.BisectBatchOnFunctionError
+        ).to.equal(undefined);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.MaximumRecordAgeInSeconds
         ).to.equal(undefined);
       });
 


### PR DESCRIPTION
Added support for property `MaximumRecordAgeInSeconds` to be used in DynamoDB and Kinesis streams. [Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumrecordageinseconds)

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses issue https://github.com/serverless/serverless/issues/7042