### PR TITLE
AWS API Gateway: Fix handling of usagePlan array

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -50,8 +50,9 @@ module.exports = {
         const name = Object.keys(apiKeyDefinition)[0];
         if (
           _.isObject(apiKeyDefinition) &&
+          Array.isArray(this.serverless.service.provider.usagePlan) &&
           _.flatten(
-            (this.serverless.service.provider.usagePlan || []).map(item => Object.keys(item))
+            this.serverless.service.provider.usagePlan.map(item => Object.keys(item))
           ).includes(name)
         ) {
           keyNumber = 0;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
@@ -39,6 +39,11 @@ describe('#compileApiKeys()', () => {
       },
     ];
 
+    // Added purely to test https://github.com/serverless/serverless/issues/7844 regression
+    awsCompileApigEvents.serverless.service.provider.usagePlan = {
+      quota: { limit: 5000 },
+    };
+
     return awsCompileApigEvents.compileApiKeys().then(() => {
       const expectedApiKeys = [
         {


### PR DESCRIPTION
Improves leaky logic introduced with https://github.com/serverless/serverless/pull/5982 exposed by regression introduced with https://github.com/serverless/serverless/pull/7827

Closes: #7844 
