### PR TITLE
AWS Websockets: Fix response resource handling

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/lib/deployment.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/deployment.js
@@ -7,10 +7,16 @@ const pickWebsocketsTemplatePart = require('./pickWebsocketsTemplatePart');
 
 module.exports = {
   compileDeployment() {
-    const routeLogicalIds = this.validated.events.map(event => {
-      const routeLogicalId = this.provider.naming.getWebsocketsRouteLogicalId(event.route);
-      return routeLogicalId;
-    });
+    const dependentResourceIds = _.flatten(
+      this.validated.events.map(event => {
+        const result = [];
+        if (event.routeResponseSelectionExpression) {
+          result.push(this.provider.naming.getWebsocketsRouteResponseLogicalId(event.route));
+        }
+        result.push(this.provider.naming.getWebsocketsRouteLogicalId(event.route));
+        return result;
+      })
+    );
     const websocketsTemplatePart = pickWebsocketsTemplatePart(
       this.serverless.service.provider.compiledCloudFormationTemplate,
       this.provider.naming.getWebsocketsApiLogicalId()
@@ -27,7 +33,7 @@ module.exports = {
     _.merge(resources, {
       [this.websocketsDeploymentLogicalId]: {
         Type: 'AWS::ApiGatewayV2::Deployment',
-        DependsOn: routeLogicalIds,
+        DependsOn: dependentResourceIds,
         Properties: {
           ApiId: this.provider.getApiGatewayWebsocketApiId(),
           Description:


### PR DESCRIPTION
CloudFormation resources dependency chain was not marked as expected, ntot having that caused race condition where route response could have been created before deployment.

Exposed by randomly appearing CI fails as: https://travis-ci.org/github/serverless/serverless/jobs/699675795

After contacting AWS support, they indicated that we miss that setting