### PR TITLE
chore: reduce _.some usage

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -339,7 +339,7 @@ class PluginManager {
       _.forOwn(commands, (command, name) => {
         if (command.type !== 'entrypoint') {
           _.set(target, name, _.omit(command, 'commands'));
-          if (_.some(command.commands, childCommand => childCommand.type !== 'entrypoint')) {
+          if (_.values(command.commands).some(childCommand => childCommand.type !== 'entrypoint')) {
             target[name].commands = {};
             stack.push({ commands: command.commands, target: target[name].commands });
           }

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -159,7 +159,7 @@ module.exports = {
 
         // If any objects were changed after the last time the function was updated
         // there could have been a failed deploy.
-        const changedAfterDeploy = _.some(objects, object => {
+        const changedAfterDeploy = objects.some(object => {
           return object.LastModified && object.LastModified > funcLastModifiedDate;
         });
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -163,7 +163,7 @@ class AwsDeployFunction {
         functionObj.environment
       );
 
-      if (_.some(params.Environment.Variables, value => _.isObject(value))) {
+      if (_.values(params.Environment.Variables).some(value => _.isObject(value))) {
         delete params.Environment;
       } else {
         Object.keys(params.Environment.Variables).forEach(key => {

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -144,7 +144,7 @@ class AwsDeployFunction {
     if (
       'layers' in functionObj &&
       Array.isArray(functionObj.layers) &&
-      !_.some(functionObj.layers, _.isObject)
+      !functionObj.layers.some(_.isObject)
     ) {
       params.Layers = functionObj.layers;
     }
@@ -184,11 +184,11 @@ class AwsDeployFunction {
       const vpc = functionObj.vpc || providerObj.vpc;
       params.VpcConfig = {};
 
-      if (Array.isArray(vpc.securityGroupIds) && !_.some(vpc.securityGroupIds, _.isObject)) {
+      if (Array.isArray(vpc.securityGroupIds) && !vpc.securityGroupIds.some(_.isObject)) {
         params.VpcConfig.SecurityGroupIds = vpc.securityGroupIds;
       }
 
-      if (Array.isArray(vpc.subnetIds) && !_.some(vpc.subnetIds, _.isObject)) {
+      if (Array.isArray(vpc.subnetIds) && !vpc.subnetIds.some(_.isObject)) {
         params.VpcConfig.SubnetIds = vpc.subnetIds;
       }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/resources.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/resources.js
@@ -159,7 +159,7 @@ module.exports = {
     // if all methods have resource ID already, no need to validate resource trees
     if (
       this.validated.events.every(event =>
-        _.some(predefinedResourceNodes, node => node.path === event.http.path)
+        predefinedResourceNodes.some(node => node.path === event.http.path)
       )
     ) {
       return predefinedResources.reduce((resourceMap, resource) => {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -559,7 +559,7 @@ module.exports = {
       if (response.statusCodes) {
         response.statusCodes = Object.assign({}, response.statusCodes);
 
-        if (!_.some(response.statusCodes, code => code.pattern === '')) {
+        if (!_.values(response.statusCodes).some(code => code.pattern === '')) {
           response.statusCodes['200'] = DEFAULT_STATUS_CODES['200'];
         }
       } else {

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -359,7 +359,8 @@ class AwsCompileFunctions {
           const value = functionResource.Properties.Environment.Variables[key];
           if (_.isObject(value)) {
             const isCFRef =
-              _.isObject(value) && !_.some(value, (v, k) => k !== 'Ref' && !k.startsWith('Fn::'));
+              _.isObject(value) &&
+              !Object.keys(value).some(k => k !== 'Ref' && !k.startsWith('Fn::'));
             if (!isCFRef) {
               invalidEnvVar = `Environment variable ${key} must contain string`;
               return false;
@@ -630,7 +631,7 @@ class AwsCompileFunctions {
   isArnRefGetAttOrImportValue(arn) {
     return (
       typeof arn === 'object' &&
-      _.some(Object.keys(arn), k => ['Ref', 'Fn::GetAtt', 'Fn::ImportValue'].includes(k))
+      Object.keys(arn).some(k => ['Ref', 'Fn::GetAtt', 'Fn::ImportValue'].includes(k))
     );
   }
 

--- a/lib/plugins/aws/rollback/index.js
+++ b/lib/plugins/aws/rollback/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const BbPromise = require('bluebird');
 const validate = require('../lib/validate');
 const setBucketName = require('../lib/setBucketName');
@@ -67,11 +66,12 @@ class AwsRollback {
         }
 
         const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
-        const exists = _.some(deployments, deployment =>
-          _.some(deployment, {
-            directory: dateString,
-            file: this.provider.naming.getCompiledTemplateS3Suffix(),
-          })
+        const exists = deployments.some(deployment =>
+          deployment.some(
+            item =>
+              item.directory === dateString &&
+              item.file === this.provider.naming.getCompiledTemplateS3Suffix()
+          )
         );
 
         if (!exists) {


### PR DESCRIPTION
Replace `_.some` with `Array.some` whenever possible

This PR does not remove ALL `_.some` usage - there are still 3 instances of using `_.some` with objects that I didn't rewrite because they will be very easy to address with `Object.values` - that will be unblocked with https://github.com/serverless/serverless/issues/7362

If you strongly feel that this PR should remove all usages of `_.some` - I'm happy to give it a try :100: 

Addresses: https://github.com/serverless/serverless/issues/7747

