### PR TITLE
Show Cloudwatch logs timestamps

### DIFF
--- a/lib/plugins/aws/logs/index.js
+++ b/lib/plugins/aws/logs/index.js
@@ -100,7 +100,7 @@ class AwsLogs {
     return this.provider.request('CloudWatchLogs', 'filterLogEvents', params).then(results => {
       if (results.events) {
         results.events.forEach(e => {
-          process.stdout.write(formatLambdaLogEvent(e.message));
+          process.stdout.write(formatLambdaLogEvent(e.message, e.timestamp));
         });
       }
 

--- a/lib/plugins/aws/utils/formatLambdaLogEvent.js
+++ b/lib/plugins/aws/utils/formatLambdaLogEvent.js
@@ -4,41 +4,92 @@ const dayjs = require('dayjs');
 const chalk = require('chalk');
 const os = require('os');
 
-module.exports = msgParam => {
+const timestampFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
+
+// isAWSMessage returns true when msg starts with one of the AWS keywords.
+const isAWSMessage = msg => {
+  const awsPrefixes = ['START', 'END', 'REPORT'];
+  return awsPrefixes.some(p => msg.startsWith(p));
+};
+
+// isExitedMessage returns true when msg represents a process crash.
+const isExitedMessage = msg => {
+  return msg.trim() === 'Process exited before completing request';
+};
+
+// isValidDate returns true is timestamp a string that can be parsed as a date.
+const isValidDate = timestamp => !isNaN(new Date(timestamp).getTime());
+
+// prefixDate takes two strings: msg and timestamp.
+// If timestamp is not empty it's parsed as a Date and formatted to a string
+// using `timestampFormat`.
+const prefixDate = (msg, timestamp) => {
+  if (!timestamp || !isValidDate(timestamp)) {
+    return msg;
+  }
+  const timestampStr = dayjs(timestamp).format(timestampFormat);
+  return `${chalk.green(timestampStr)}\t${msg}`;
+};
+
+// parseFields returns an object extracting some common fields from a log
+// message.
+//
+// It supports different log flavours:
+// Python:                   <level>\t<timestamp>\t<reqID>\t<message>
+// Node.js:                  <timestamp>\t<reqID>\t<message>
+// Go (and probably others): <message>
+const parseFields = msg => {
+  const splitted = msg.split('\t', 4);
+
+  if (splitted.length === 4 && isValidDate(splitted[1])) {
+    // Python flavour
+    return {
+      level: splitted[0],
+      timestamp: splitted[1],
+      reqID: splitted[2],
+      message: splitted[3],
+    };
+  }
+
+  if (splitted.length === 3 && isValidDate(splitted[0])) {
+    // Node.js flavour
+    return {
+      timestamp: splitted[0],
+      reqID: splitted[1],
+      message: splitted[2],
+    };
+  }
+
+  return { message: msg };
+};
+
+// formatLog tries to parse a log message using parseFields, then returns a
+// formatted string containing all available informations.
+const formatLog = (msg, fallbackTimestamp) => {
+  const fields = parseFields(msg);
+
+  const composedMsg = [fields.reqID && chalk.yellow(fields.reqID), fields.level, fields.message]
+    .filter(s => s)
+    .join('\t');
+
+  return prefixDate(composedMsg, fields.timestamp || fallbackTimestamp);
+};
+
+module.exports = (msgParam, timestamp = null) => {
   let msg = msgParam;
-  const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
 
   if (msg.startsWith('REPORT')) {
+    // add an empty line between different executions
     msg += os.EOL;
   }
 
-  if (msg.startsWith('START') || msg.startsWith('END') || msg.startsWith('REPORT')) {
-    return chalk.gray(msg);
-  } else if (msg.trim() === 'Process exited before completing request') {
-    return chalk.red(msg);
+  if (isAWSMessage(msg)) {
+    return prefixDate(chalk.gray(msg), timestamp);
   }
 
-  const splitted = msg.split('\t');
-
-  if (splitted.length < 3) {
-    return msg;
+  if (isExitedMessage(msg)) {
+    return prefixDate(chalk.red(msg), timestamp);
   }
 
-  let date = '';
-  let reqId = '';
-  let level = '';
-  if (!isNaN(new Date(splitted[0]).getTime())) {
-    date = splitted[0];
-    reqId = splitted[1];
-  } else if (!isNaN(new Date(splitted[1]).getTime())) {
-    date = splitted[1];
-    reqId = splitted[2];
-    level = `${splitted[0]}\t`;
-  } else {
-    return msg;
-  }
-  const text = msg.split(`${reqId}\t`)[1];
-  const time = chalk.green(dayjs(date).format(dateFormat));
-
-  return `${time}\t${chalk.yellow(reqId)}\t${level}${text}`;
+  return formatLog(msg, timestamp);
 };

--- a/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
+++ b/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
@@ -54,4 +54,26 @@ describe('#formatLambdaLogEvent()', () => {
 
     expect(formatLambdaLogEvent(tabLine)).to.equal(tabLine);
   });
+
+  it('should use passed timestamp if available', () => {
+    const msg = 'some message';
+    const timestamp = 1593765742709;
+    let expected = chalk.green(dayjs(timestamp).format('YYYY-MM-DD HH:mm:ss.SSS (Z)'));
+    expected += `\t${msg}`;
+    expect(formatLambdaLogEvent(msg, timestamp)).to.equal(expected);
+  });
+
+  it('should prefer log timestamp', () => {
+    const timestamp = 1593765742709;
+    const pythonLoggerLine =
+      '[INFO]\t2016-01-01T12:00:00Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\ttest'; // eslint-disable-line
+    let expectedLogMessage = '';
+    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS (Z)');
+    expectedLogMessage += `${chalk.green(date)}\t`;
+    expectedLogMessage += `${chalk.yellow('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
+    expectedLogMessage += `${'[INFO]'}\t`;
+    expectedLogMessage += 'test';
+
+    expect(formatLambdaLogEvent(pythonLoggerLine, timestamp)).to.equal(expectedLogMessage);
+  });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->



(I decided to go ahead and implement a solution instead of opening an issue since it's a small change)

### Use case description

I'm currently writing some lambda functions using Go.
When I run `sls logs -f myfunc` I usually see something like this:
```
START RequestId: XXXXXX Version: $LATEST
unexpected signing method
END RequestId: XXXXXX
REPORT RequestId: XXXXXX  Duration: 33.65 ms      Billed Duration: 100 ms Memory Size: 128 MB     Max Memory Used: 48 MB
```

It would be great to also have timestamps (which are available from cloudwatch console).

<!--
Q2: Propose solution (e.g. provide configuration example)

Note: This is optional, remove this section if you do not wish to propose anything at this point
-->

### Proposed solution

Format an output like this using CloudWatch timestamps:

```
2020-07-03 14:36:49.000 (+02:00)        START RequestId: XXXXXX Version: $LATEST
2020-07-03 14:36:49.294 (+02:00)        END RequestId: XXXXXX
2020-07-03 14:36:49.294 (+02:00)        REPORT RequestId: XXXXXX  Duration: 293.85 ms     Billed Duration: 300 ms Memory Size: 128 MB     Max Memory Used: 47 MBInit Duration: 205.52 ms
```

I did not break existing tests and usages, ran lint/prettifier, refactored a bit `formatLambdaLogEvent.js` to be easier to read, and added a couple of new tests for this new functionality.

Timestamps from console.log or python logger are still preferred, CloudWatch timestamps are used as a fallback.