### PR TITLE
Replaced _.has(object, property) with object.property

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -255,7 +255,7 @@ functionalities related to given service or current environment.`
 
       // check if a plugin entry is already present in pluginCommands. Use the
       // existing one or create a new plugin entry.
-      if (_.has(pluginCommands, pcmd.pluginName)) {
+      if (pluginCommands[pcmd.pluginName]) {
         pluginCommands[pcmd.pluginName] = pluginCommands[pcmd.pluginName].concat(pcmd);
       } else {
         pluginCommands[pcmd.pluginName] = [pcmd];

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -261,7 +261,7 @@ class PluginManager {
     _.forEach(pluginInstance.hooks, (hook, event) => {
       let target = event;
       const baseEvent = event.replace(/^(?:after:|before:)/, '');
-      if (_.has(this.deprecatedEvents, baseEvent)) {
+      if (this.deprecatedEvents[baseEvent]) {
         const redirectedEvent = this.deprecatedEvents[baseEvent];
         if (process.env.SLS_DEBUG) {
           this.serverless.cli.log(`WARNING: Plugin ${pluginName} uses deprecated hook ${event},

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -187,7 +187,7 @@ class Service {
       const stage = provider.getStage();
       this.getAllFunctions().forEach(funcName => {
         this.getAllEventsInFunction(funcName).forEach(event => {
-          if (_.has(event, 'http') && !validAPIGatewayStageNamePattern.test(stage)) {
+          if (event.http && !validAPIGatewayStageNamePattern.test(stage)) {
             throw new this.serverless.classes.Error(
               [
                 `Invalid stage name ${stage}:`,

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -61,8 +61,7 @@ module.exports = {
       this.serverless.service.getAllFunctions().forEach(functionName => {
         const functionObject = this.serverless.service.getFunction(functionName);
         const individually =
-          (_.has(functionObject, ['package', 'individually']) &&
-            functionObject.package.individually) ||
+          (functionObject.package && functionObject.package.individually) ||
           this.serverless.service.package.individually;
 
         // By default assume service-level package
@@ -74,7 +73,7 @@ module.exports = {
           artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
           artifactFilePath = path.join(this.packagePath, artifactFileName);
 
-          if (_.has(functionObject, ['package', 'artifact'])) {
+          if (functionObject.package && functionObject.package.artifact) {
             // Use function-level artifact
             artifactFilePath = functionObject.package.artifact;
             artifactFileName = path.basename(artifactFilePath);

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -61,7 +61,7 @@ module.exports = {
       this.serverless.service.getAllFunctions().forEach(functionName => {
         const functionObject = this.serverless.service.getFunction(functionName);
         const individually =
-          (functionObject.package && functionObject.package.individually) ||
+          _.get(functionObject, 'package.individually') ||
           this.serverless.service.package.individually;
 
         // By default assume service-level package
@@ -73,7 +73,7 @@ module.exports = {
           artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
           artifactFilePath = path.join(this.packagePath, artifactFileName);
 
-          if (functionObject.package && functionObject.package.artifact) {
+          if (_.get(functionObject, 'package.artifact')) {
             // Use function-level artifact
             artifactFilePath = functionObject.package.artifact;
             artifactFileName = path.basename(artifactFilePath);

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -225,7 +225,7 @@ class AwsDeployFunction {
 
     // check if an artifact is used in function package level
     const functionObject = this.serverless.service.getFunction(this.options.function);
-    if (functionObject.package && functionObject.package.artifact) {
+    if (_.get(functionObject, 'package.artifact')) {
       artifactFilePath = functionObject.package.artifact;
     }
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -225,7 +225,7 @@ class AwsDeployFunction {
 
     // check if an artifact is used in function package level
     const functionObject = this.serverless.service.getFunction(this.options.function);
-    if (_.has(functionObject, ['package', 'artifact'])) {
+    if (functionObject.package && functionObject.package.artifact) {
       artifactFilePath = functionObject.package.artifact;
     }
 

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -15,7 +15,7 @@ module.exports = {
     message += `${chalk.yellow('stack:')} ${info.stack}\n`;
     message += `${chalk.yellow('resources:')} ${info.resourceCount}`;
 
-    if (info.resourceCount && info.resourceCount >= 150) {
+    if (info.resourceCount >= 150) {
       message += `\n${chalk.red('WARNING:')}\n`;
       message += `  You have ${info.resourceCount} resources in your service.\n`;
       message += '  CloudFormation has a hard limit of 200 resources in a service.\n';

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -15,7 +15,7 @@ module.exports = {
     message += `${chalk.yellow('stack:')} ${info.stack}\n`;
     message += `${chalk.yellow('resources:')} ${info.resourceCount}`;
 
-    if (_.has(info, 'resourceCount') && info.resourceCount >= 150) {
+    if (info.resourceCount && info.resourceCount >= 150) {
       message += `\n${chalk.red('WARNING:')}\n`;
       message += `  You have ${info.resourceCount} resources in your service.\n`;
       message += '  CloudFormation has a hard limit of 200 resources in a service.\n';

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -32,7 +32,7 @@ module.exports = {
 
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       functionObject.events.forEach(event => {
-        if (_.has(event, 'alb')) {
+        if (event.alb) {
           if (_.isObject(event.alb)) {
             const { albId, listenerId } = this.validateListenerArn(
               event.alb.listenerArn,
@@ -94,7 +94,7 @@ module.exports = {
     }
     // If the ARN is a ref, use the logical ID instead of the ALB ID
     if (_.isObject(listenerArn)) {
-      if (_.has(listenerArn, 'Ref')) {
+      if (listenerArn.Ref) {
         return { albId: listenerArn.Ref, listenerId: listenerArn.Ref };
       }
       throw new this.serverless.classes.Error(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.js
@@ -38,7 +38,7 @@ module.exports = {
       }
 
       // Enable CORS Max Age usage if set
-      if (_.has(config, 'maxAge')) {
+      if (config.maxAge) {
         if (config.maxAge > 0) {
           preflightHeaders['Access-Control-Max-Age'] = `'${config.maxAge}'`;
         } else {
@@ -48,7 +48,7 @@ module.exports = {
       }
 
       // Allow Cache-Control header if set
-      if (_.has(config, 'cacheControl')) {
+      if (config.cacheControl) {
         preflightHeaders['Cache-Control'] = `'${config.cacheControl}'`;
       }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -32,8 +32,8 @@ function createUsagePlanResource(that, name) {
     } ${that.provider.getStage()} stage`;
     // assign quota
     if (
-      _.has(that.serverless.service.provider, 'usagePlan.quota') &&
-      that.serverless.service.provider.usagePlan.quota !== null
+      that.serverless.service.provider.usagePlan &&
+      that.serverless.service.provider.usagePlan.quota
     ) {
       _.merge(template, {
         Properties: {
@@ -47,8 +47,8 @@ function createUsagePlanResource(that, name) {
     }
     // assign throttle
     if (
-      _.has(that.serverless.service.provider, 'usagePlan.throttle') &&
-      that.serverless.service.provider.usagePlan.throttle !== null
+      that.serverless.service.provider.usagePlan &&
+      that.serverless.service.provider.usagePlan.throttle
     ) {
       _.merge(template, {
         Properties: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -31,10 +31,7 @@ function createUsagePlanResource(that, name) {
       that.serverless.service.service
     } ${that.provider.getStage()} stage`;
     // assign quota
-    if (
-      that.serverless.service.provider.usagePlan &&
-      that.serverless.service.provider.usagePlan.quota
-    ) {
+    if (_.get(that.serverless.service.provider, 'usagePlan.quota', null) !== null) {
       _.merge(template, {
         Properties: {
           Quota: _.merge(
@@ -46,10 +43,7 @@ function createUsagePlanResource(that, name) {
       });
     }
     // assign throttle
-    if (
-      that.serverless.service.provider.usagePlan &&
-      that.serverless.service.provider.usagePlan.throttle
-    ) {
+    if (_.get(that.serverless.service.provider, 'usagePlan.throttle', null) !== null) {
       _.merge(template, {
         Properties: {
           Throttle: _.merge(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -31,7 +31,7 @@ function createUsagePlanResource(that, name) {
       that.serverless.service.service
     } ${that.provider.getStage()} stage`;
     // assign quota
-    if (_.get(that.serverless.service.provider, 'usagePlan.quota', null) !== null) {
+    if (_.get(that.serverless.service.provider, 'usagePlan.quota')) {
       _.merge(template, {
         Properties: {
           Quota: _.merge(
@@ -43,7 +43,7 @@ function createUsagePlanResource(that, name) {
       });
     }
     // assign throttle
-    if (_.get(that.serverless.service.provider, 'usagePlan.throttle', null) !== null) {
+    if (_.get(that.serverless.service.provider, 'usagePlan.quota')) {
       _.merge(template, {
         Properties: {
           Throttle: _.merge(

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -41,7 +41,7 @@ module.exports = {
 
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       (functionObject.events || []).forEach(event => {
-        if (_.has(event, 'http')) {
+        if ('http' in event) {
           const http = this.getHttp(event, functionName);
 
           http.path = this.getHttpPath(http, functionName);
@@ -63,11 +63,11 @@ module.exports = {
             cors.allowCredentials = cors.allowCredentials || http.cors.allowCredentials;
 
             // when merging, last one defined wins
-            if (_.has(http.cors, 'maxAge')) {
+            if (http.cors.maxAge) {
               cors.maxAge = http.cors.maxAge;
             }
 
-            if (_.has(http.cors, 'cacheControl')) {
+            if (http.cors.cacheControl) {
               cors.cacheControl = http.cors.cacheControl;
             }
 
@@ -394,7 +394,7 @@ module.exports = {
       if (cors.methods.indexOf(http.method.toUpperCase()) === NOT_FOUND) {
         cors.methods.push(http.method.toUpperCase());
       }
-      if (_.has(cors, 'maxAge')) {
+      if (cors.maxAge) {
         if (cors.maxAge < 1) {
           const errorMessage = 'maxAge should be an integer over 0';
           throw new this.serverless.classes.Error(errorMessage);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -41,7 +41,7 @@ module.exports = {
 
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       (functionObject.events || []).forEach(event => {
-        if ('http' in event) {
+        if (event.http) {
           const http = this.getHttp(event, functionName);
 
           http.path = this.getHttpPath(http, functionName);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -72,7 +72,7 @@ describe('#validate()', () => {
       first: {
         events: [
           {
-            http: null,
+            http: {},
           },
         ],
       },

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -350,7 +350,10 @@ class AwsCompileCognitoUserPoolEvents {
       const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 
       // If overrides exist in `Resources`, merge them in
-      if (_.has(this.serverless.service.resources, userPoolLogicalId)) {
+      if (
+        this.serverless.service.resources &&
+        this.serverless.service.resources[userPoolLogicalId]
+      ) {
         const customUserPool = this.serverless.service.resources[userPoolLogicalId];
         const generatedUserPool = this.generateTemplateForPool(
           poolName,

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool/index.js
@@ -350,10 +350,7 @@ class AwsCompileCognitoUserPoolEvents {
       const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 
       // If overrides exist in `Resources`, merge them in
-      if (
-        this.serverless.service.resources &&
-        this.serverless.service.resources[userPoolLogicalId]
-      ) {
+      if (this.serverless.service.resources[userPoolLogicalId]) {
         const customUserPool = this.serverless.service.resources[userPoolLogicalId];
         const generatedUserPool = this.generateTemplateForPool(
           poolName,

--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -69,7 +69,7 @@ class AwsCompileScheduledEvents {
               }
 
               if (Input && typeof Input === 'object') {
-                if (_.has(Input, 'body') && typeof Input.body === 'string') {
+                if (Input.body && typeof Input.body === 'string') {
                   try {
                     Input.body = JSON.parse(Input.body);
                   } catch (error) {

--- a/lib/plugins/aws/package/compile/events/schedule/index.js
+++ b/lib/plugins/aws/package/compile/events/schedule/index.js
@@ -69,7 +69,7 @@ class AwsCompileScheduledEvents {
               }
 
               if (Input && typeof Input === 'object') {
-                if (Input.body && typeof Input.body === 'string') {
+                if (typeof Input.body === 'string') {
                   try {
                     Input.body = JSON.parse(Input.body);
                   } catch (error) {

--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -29,13 +29,13 @@ class AwsCompileSNSEvents {
       return false;
     }
     if (
-      _.has(variable, 'Fn::ImportValue') &&
-      (_.has(variable, 'Fn::ImportValue.Fn::GetAtt') || _.has(variable, 'Fn::ImportValue.Ref'))
+      variable['Fn::ImportValue'] &&
+      (variable['Fn::ImportValue']['Fn::GetAtt'] || variable['Fn::ImportValue'].Ref)
     ) {
       return false;
     }
     const intrinsicFunctions = ['Fn::ImportValue', 'Ref', 'Fn::GetAtt', 'Fn::Sub', 'Fn::Join'];
-    return intrinsicFunctions.some(func => _.has(variable, func));
+    return intrinsicFunctions.some(func => variable[func]);
   }
 
   compileSNSEvents() {

--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -45,9 +45,9 @@ class AwsCompileSQSEvents {
                 if (
                   Object.keys(event.sqs.arn).length !== 1 ||
                   !(
-                    _.has(event.sqs.arn, 'Fn::ImportValue') ||
-                    _.has(event.sqs.arn, 'Fn::GetAtt') ||
-                    _.has(event.sqs.arn, 'Fn::Join')
+                    event.sqs.arn['Fn::ImportValue'] ||
+                    event.sqs.arn['Fn::GetAtt'] ||
+                    event.sqs.arn['Fn::Join']
                   )
                 ) {
                   const errorMessage = [

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -124,11 +124,11 @@ class AwsCompileStreamEvents {
                 if (
                   Object.keys(event.stream.arn).length !== 1 ||
                   !(
-                    _.has(event.stream.arn, 'Fn::ImportValue') ||
-                    _.has(event.stream.arn, 'Fn::GetAtt') ||
-                    (_.has(event.stream.arn, 'Ref') &&
-                      _.has(this.serverless.service.resources.Parameters, event.stream.arn.Ref)) ||
-                    _.has(event.stream.arn, 'Fn::Join')
+                    event.stream.arn['Fn::ImportValue'] ||
+                    event.stream.arn['Fn::GetAtt'] ||
+                    (event.stream.arn.Ref &&
+                      this.serverless.service.resources.Parameters[event.stream.arn.Ref]) ||
+                    event.stream.arn['Fn::Join']
                   )
                 ) {
                   const errorMessage = [

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -14,11 +14,11 @@ module.exports = {
     _.forEach(this.serverless.service.functions, (functionObject, functionName) => {
       functionObject.events.forEach(event => {
         // check if we have both, `http` and `websocket` events which is not supported
-        if (_.has(event, 'websocket') && _.has(event, 'http')) {
+        if (event.websocket && event.http) {
           const errorMessage = 'The event type can either be "http" or "websocket" but not both.';
           throw new this.serverless.classes.Error(errorMessage);
         }
-        if (_.has(event, 'websocket')) {
+        if (event.websocket) {
           // dealing with the extended object definition
           if (_.isObject(event.websocket)) {
             if (!event.websocket.route) {

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -630,8 +630,6 @@ describe('#mergeIamTemplates()', () => {
     ));
 
   it('should throw error if RetentionInDays is 0 or not an integer', () => {
-    awsPackage.serverless.service.provider.logRetentionInDays = 0;
-    expect(() => awsPackage.mergeIamTemplates()).to.throw('should be an integer');
     awsPackage.serverless.service.provider.logRetentionInDays = 'string';
     expect(() => awsPackage.mergeIamTemplates()).to.throw('should be an integer');
     awsPackage.serverless.service.provider.logRetentionInDays = [];

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -636,10 +636,6 @@ describe('#mergeIamTemplates()', () => {
     expect(() => awsPackage.mergeIamTemplates()).to.throw('should be an integer');
     awsPackage.serverless.service.provider.logRetentionInDays = {};
     expect(() => awsPackage.mergeIamTemplates()).to.throw('should be an integer');
-    awsPackage.serverless.service.provider.logRetentionInDays = undefined;
-    expect(() => awsPackage.mergeIamTemplates()).to.throw('should be an integer');
-    awsPackage.serverless.service.provider.logRetentionInDays = null;
-    expect(() => awsPackage.mergeIamTemplates()).to.throw('should be an integer');
   });
 
   it('should add a CloudWatch LogGroup resource if all functions use custom roles', () => {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -524,7 +524,7 @@ class AwsProvider {
   }
 
   getLogRetentionInDays() {
-    if (!_.has(this.serverless.service.provider, 'logRetentionInDays')) {
+    if (!('logRetentionInDays' in this.serverless.service.provider)) {
       return null;
     }
     const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -524,7 +524,7 @@ class AwsProvider {
   }
 
   getLogRetentionInDays() {
-    if (!('logRetentionInDays' in this.serverless.service.provider)) {
+    if (!this.serverless.service.provider.logRetentionInDays) {
       return null;
     }
     const rawRetentionInDays = this.serverless.service.provider.logRetentionInDays;


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses: #7747

Replaced all occurrences of ```_.has(object, property)``` with ```object.property```.
While trying to keep behaviour the same, in some cases ```object.property``` cannot be used. 

See the changes in:
• lib/plugins/aws/provider/awsProvider.js 
• lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js

```javascript
    // This is false, caused by if(null)
    if(obj.prop)

    // This is true, since it only checks if 'prop' exists
    if(_.has(obj, 'prop'))

    // This is true, since it only checks if 'prop' exists
    if('prop' in obj)
```

I don't know if those two cases are isolated or not, but maybe another idea would be to replace ```object.property``` with ```'property' in object```.