### PR TITLE
Added deprecation warning for when aws http api payload version is not set

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,6 +6,14 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
+<a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
+
+## AWS HTTP API payload format
+
+Default HTTP API Payload version will be switched to 2.0 with next major release (For more details see [payload format documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format))
+
+Configure httpApi.payload explicitly to ensure seamless migration.
+
 <a name="OUTDATED_NODEJS"><div>&nbsp;</div></a>
 
 ## Outdated Node.js version
@@ -19,12 +27,6 @@ Please upgrade to use at least Node.js v10 (It's recommended to use LTS version,
 ## AWS ALB `allowUnauthenticated`
 
 Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be removed with v2.0.0
-
-<a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
-
-## AWS HTTP API payload format
-
-Default HTTP API Payload version will be switched to 2.0 with next major release. Please configure `payload` explicitly.
 
 <a name="BIN_SERVERLESS"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -12,7 +12,7 @@ layout: Doc
 
 Default HTTP API Payload version will be switched to 2.0 with next major release (For more details see [payload format documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format))
 
-Configure httpApi.payload explicitly to ensure seamless migration.
+Configure `httpApi.payload` explicitly to ensure seamless migration.
 
 <a name="OUTDATED_NODEJS"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -20,6 +20,12 @@ Please upgrade to use at least Node.js v10 (It's recommended to use LTS version,
 
 Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be removed with v2.0.0
 
+<a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
+
+## AWS HTTP API payload format
+
+Default HTTP API Payload version will be switched to 2.0 with next major release. Please configure `payload` explicitly.
+
 <a name="BIN_SERVERLESS"><div>&nbsp;</div></a>
 
 ## `bin/serverless`

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -5,6 +5,7 @@ const d = require('d');
 const memoizee = require('memoizee');
 const memoizeeMethods = require('memoizee/methods');
 const { logWarning } = require('../../../../../../classes/Error');
+const logDeprecation = require('../../../../../../utils/logDeprecation');
 
 const allowedMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'HEAD', 'DELETE']);
 const methodPathPattern = /^([a-zA-Z]+) (.+)$/;
@@ -453,6 +454,14 @@ Object.defineProperties(
     compileIntegration: d(function(routeTargetData) {
       const providerConfig = this.serverless.service.provider;
       const userConfig = providerConfig.httpApi || {};
+
+      if (!userConfig.payload) {
+        logDeprecation(
+          'AWS_HTTP_API_VERSION',
+          'Default HTTP API Payload version will be switched to 2.0 with next major release. Configure "payload" explicitly to hide this message.'
+        );
+      }
+
       const properties = {
         ApiId: this.getApiIdConfig(),
         IntegrationType: 'AWS_PROXY',

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -458,7 +458,7 @@ Object.defineProperties(
       if (!userConfig.payload) {
         logDeprecation(
           'AWS_HTTP_API_VERSION',
-          'Default HTTP API Payload version will be switched to 2.0 with next major release. Configure "payload" explicitly to hide this message.'
+          'Default HTTP API Payload version will be switched to 2.0 with next major release. Configure "httpApi.payload" explicitly to hide this message.'
         );
       }
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses: #7917
