### PR TITLE
fix: Fix http.cors.methods type

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -359,6 +359,9 @@ module.exports = {
     };
 
     if (typeof http.cors === 'object') {
+      if (typeof http.cors.methods === 'string') {
+        http.cors.methods = [http.cors.methods];
+      }
       cors = http.cors;
       cors.methods = cors.methods || [];
       cors.allowCredentials = Boolean(cors.allowCredentials);


### PR DESCRIPTION
I've tried to deploy an AWS Lambda today and I got an error from `serverless/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js:391` saying `cors.methods.push` is not a function.

This is could be an equivalent serverless.yml:

```
service: testservice

provider:
  name: aws
  runtime: nodejs12.x

functions:
  login:
    handler: handler.login
    events:
      - http:
          path: /login
          method: get
          cors:
            methods: 'GET'
            headers:
              - access-token
              - resource-type
              - uid
              - client
            allowCredentials: true
          private: true # I got the error when I removed this property and tried to deploy
```
