### PR TITLE
Expose severless.logDeprecation for plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Ideally all breaking changes should be first (before being shipped with next maj
 
 Dprecation log can be configured with following steps:
 
-1. At logic point where deprecate feature is being used, write a deprecation log with `lib/utils/logDeprecation` util. It accepts two arguments:
+1. At logic point where deprecate feature is being used, write a deprecation log with `serverless._logDeprecation` util. It accepts two arguments:
 
 - `code` (e.g. `DEPRECATED_FEATURE_NAME`). Created to identify log programmatically, also used to construct link on documentation page
 - `mesage` Deprecation message to be displayed to user

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -4,6 +4,7 @@ const path = require('path');
 const BbPromise = require('bluebird');
 const os = require('os');
 const chalk = require('chalk');
+const ensureString = require('type/string/ensure');
 const updateNotifier = require('update-notifier');
 const pkg = require('../package.json');
 const CLI = require('./classes/CLI');
@@ -17,6 +18,7 @@ const ServerlessError = require('./classes/Error').ServerlessError;
 const Version = require('./../package.json').version;
 const isStandaloneExecutable = require('./utils/isStandaloneExecutable');
 const resolveCliInput = require('./utils/resolveCliInput');
+const logDeprecation = require('./utils/logDeprecation');
 
 const installationMaintananceCommands = new Set(['uninstall', 'upgrade']);
 
@@ -142,6 +144,16 @@ class Serverless {
 
   getVersion() {
     return this.version;
+  }
+
+  // Only for internal use
+  _logDeprecation(code, message) {
+    return logDeprecation(code, message, { serviceConfig: this.service });
+  }
+
+  // To be used by external plugins
+  logDeprecation(code, message) {
+    return this._logDeprecation(`EXT_${ensureString(code)}`, ensureString(message));
   }
 }
 

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const logDeprecation = require('../../../../../../../utils/logDeprecation');
 
 // eslint-disable-next-line max-len
 const CIDR_IPV6_PATTERN = /^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))$/;
@@ -208,7 +207,7 @@ module.exports = {
     const hasOnUnauthenticatedRequest = auth.onUnauthenticatedRequest != null;
 
     if (hasAllowUnauthenticated) {
-      logDeprecation(
+      this.serverless._logDeprecation(
         'AWS_ALB_ALLOW_UNAUTHENTICATED',
         'allowUnauthenticated is deprecated, use onUnauthenticatedRequest instead'
       );

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -5,7 +5,6 @@ const d = require('d');
 const memoizee = require('memoizee');
 const memoizeeMethods = require('memoizee/methods');
 const { logWarning } = require('../../../../../../classes/Error');
-const logDeprecation = require('../../../../../../utils/logDeprecation');
 
 const allowedMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'HEAD', 'DELETE']);
 const methodPathPattern = /^([a-zA-Z]+) (.+)$/;
@@ -456,7 +455,7 @@ Object.defineProperties(
       const userConfig = providerConfig.httpApi || {};
 
       if (!userConfig.payload) {
-        logDeprecation(
+        this.serverless._logDeprecation(
           'AWS_HTTP_API_VERSION',
           'Default HTTP API Payload version will be switched to 2.0 with next major release. Configure "httpApi.payload" explicitly to hide this message.'
         );

--- a/lib/utils/logDeprecation.js
+++ b/lib/utils/logDeprecation.js
@@ -25,11 +25,14 @@ const resolveDeprecatedByService = weakMemoizee(serviceConfig => {
 });
 
 function writeDeprecation(code, message) {
-  process.stdout.write(
-    `Serverless: ${chalk.redBright(`Deprecation Notice: ${message}`)}\n            ${chalk.dim(
-      `More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`
-    )}\n`
-  );
+  process.stdout.write(`Serverless: ${chalk.redBright(`Deprecation Notice: ${message}`)}\n`);
+  if (!code.startsWith('EXT_')) {
+    process.stdout.write(
+      `            ${chalk.dim(
+        `More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`
+      )}\n`
+    );
+  }
 }
 
 module.exports = (code, message, { serviceConfig } = {}) => {

--- a/lib/utils/logDeprecation.test.js
+++ b/lib/utils/logDeprecation.test.js
@@ -1,20 +1,20 @@
 'use strict';
+
 const sandbox = require('sinon');
 const expect = require('chai').expect;
 const mockRequire = require('mock-require');
 const overrideEnv = require('process-utils/override-env');
+const overrideStdoutWrite = require('process-utils/override-stdout-write');
 const runServerless = require('../../tests/utils/run-serverless');
 const fixtures = require('../../tests/fixtures');
 
 describe('#logDeprecation()', () => {
-  let stdoutWriteSpy;
   let restoreEnv;
   let originalEnv;
   let logDeprecation;
 
   beforeEach(() => {
     logDeprecation = mockRequire.reRequire('./logDeprecation');
-    stdoutWriteSpy = sandbox.spy(process.stdout, 'write');
     ({ originalEnv, restoreEnv } = overrideEnv());
   });
 
@@ -24,18 +24,26 @@ describe('#logDeprecation()', () => {
   });
 
   it('Should log deprecation message if not disabled and first time', () => {
-    logDeprecation('code1', 'Start using deprecation log');
-    const message = stdoutWriteSpy.args.join('\n');
-    expect(stdoutWriteSpy.called).to.equal(true);
-    expect(message).to.have.string('Deprecation Notice');
-    expect(message).to.have.string('https://www.serverless.com/framework/docs/deprecations/#code1');
+    let stdoutData = '';
+    overrideStdoutWrite(
+      data => (stdoutData += data),
+      () => logDeprecation('code1', 'Start using deprecation log')
+    );
+    expect(stdoutData).to.include('Start using deprecation log');
+
+    expect(stdoutData).to.include('Deprecation Notice');
+    expect(stdoutData).to.include('https://www.serverless.com/framework/docs/deprecations/#code1');
   });
 
   it('Should not log deprecation if disabled in env.SLS_DEPRECATION_DISABLE', () => {
     process.env.SLS_DEPRECATION_DISABLE = 'code1';
     logDeprecation = mockRequire.reRequire('./logDeprecation');
-    logDeprecation('code1', 'Start using deprecation log');
-    expect(stdoutWriteSpy.called).to.equal(false);
+    let stdoutData = '';
+    overrideStdoutWrite(
+      data => (stdoutData += data),
+      () => logDeprecation('code1', 'Start using deprecation log')
+    );
+    expect(stdoutData).to.equal('');
   });
 
   it('Should not log deprecation if disabled in serviceConfig', () => {
@@ -45,19 +53,25 @@ describe('#logDeprecation()', () => {
       .extend('function', { disabledDeprecations: ['code1'] })
       .then(fixturePath => runServerless({ cwd: fixturePath, cliArgs: ['package'] }))
       .then(({ serverless }) => {
-        stdoutWriteSpy.clear;
         const serviceConfig = serverless.service;
-        stdoutWriteSpy.resetHistory();
-        logDeprecation('code1', 'Start using deprecation log', { serviceConfig });
-        expect(stdoutWriteSpy.called).to.equal(false);
+        let stdoutData = '';
+        overrideStdoutWrite(
+          data => (stdoutData += data),
+          () => logDeprecation('code1', 'Start using deprecation log', { serviceConfig })
+        );
+        expect(stdoutData).to.equal('');
       });
   });
 
   it('Should not log deprecation if disabled by wildcard in env', () => {
     process.env.SLS_DEPRECATION_DISABLE = '*';
     logDeprecation = mockRequire.reRequire('./logDeprecation');
-    logDeprecation('code1', 'Start using deprecation log');
-    expect(stdoutWriteSpy.called).to.equal(false);
+    let stdoutData = '';
+    overrideStdoutWrite(
+      data => (stdoutData += data),
+      () => logDeprecation('code1', 'Start using deprecation log')
+    );
+    expect(stdoutData).to.equal('');
   });
 
   it('Should not log deprecation if disabled by wildcard in service config', () => {
@@ -66,35 +80,27 @@ describe('#logDeprecation()', () => {
       .extend('function', { disabledDeprecations: '*' })
       .then(fixturePath => runServerless({ cwd: fixturePath, cliArgs: ['package'] }))
       .then(({ serverless }) => {
-        stdoutWriteSpy.clear;
         const serviceConfig = serverless.service;
-        stdoutWriteSpy.resetHistory();
-        logDeprecation('code1', 'Start using deprecation log', { serviceConfig });
-        expect(stdoutWriteSpy.called).to.equal(false);
+        let stdoutData = '';
+        overrideStdoutWrite(
+          data => (stdoutData += data),
+          () => logDeprecation('code1', 'Start using deprecation log', { serviceConfig })
+        );
+        expect(stdoutData).to.equal('');
       });
   });
 
   it('Should not log deprecation twice', () => {
-    logDeprecation('code1', 'Start using deprecation log');
-    logDeprecation('code1', 'Start using deprecation log');
-    expect(stdoutWriteSpy.callCount).to.equal(1);
-  });
-
-  it('Should ignore serviceConfig.disabledDeprecations if it is an object without an error', () => {
-    Object.assign(process.env, originalEnv);
-    return fixtures
-      .extend('function', {
-        disabledDeprecations: {
-          code1: true,
-        },
-      })
-      .then(fixturePath => runServerless({ cwd: fixturePath, cliArgs: ['package'] }))
-      .then(({ serverless }) => {
-        stdoutWriteSpy.clear;
-        const serviceConfig = serverless.service;
-        stdoutWriteSpy.resetHistory();
-        logDeprecation('code1', 'Start using deprecation log', { serviceConfig });
-        expect(stdoutWriteSpy.called).to.equal(true);
-      });
+    let stdoutData = '';
+    overrideStdoutWrite(
+      data => (stdoutData += data),
+      () => {
+        logDeprecation('code1', 'Start using deprecation log');
+        expect(stdoutData).to.include('Start using deprecation log');
+        stdoutData = '';
+        logDeprecation('code1', 'Start using deprecation log');
+      }
+    );
+    expect(stdoutData).to.equal('');
   });
 });

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^9.0.1",
-    "@serverless/eslint-config": "^1.2.1",
+    "@serverless/eslint-config": "^1.3.0",
     "@serverless/test": "^4.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
External plugins should also be able to signal deprecated features, after that is in, it'll be possible via `serverless.logDeprecation(code, message)`

Used by https://github.com/serverless/enterprise-plugin/pull/449