### PR TITLE
docs: Update links to app.serverless.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,14 +41,14 @@ Develop, deploy, troubleshoot and secure your serverless applications with radic
 
 **Are you new to serverless application development?**
 
-Sign up for our [hosted dashboard](https://dashboard.serverless.com) (it’s free) and we’ll help deploy your first serverless app in minutes.
+Sign up for our [hosted dashboard](https://app.serverless.com) (it’s free) and we’ll help deploy your first serverless app in minutes.
 
 If you prefer to start on the CLI, use our [get started](https://serverless.com/framework/docs/getting-started/) guide.
 
 **If you are an experienced user of the Serverless Framework**
 
 Our [Pro dashboard](https://serverless.com/pro/) allows you to import existing projects. Track performance, troubleshoot, configure CI/CD and deployment policies, and get end-to-end serverless application lifecycle management.
-[Get started](https://dashboard.serverless.com) for free.
+[Get started](https://app.serverless.com) for free.
 
 Have questions? Visit our [Forum](https://forum.serverless.com/).
 

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -12,7 +12,7 @@ layout: Doc
 
 # Serverless Dashboard
 
-The [Serverless Framework Dashboard](https://dashboard.serverless.com/) is a SaaS solution that augments the Serverless Framework open source CLI to provide a powerful, unified experience to develop, deploy, test, secure and monitor your serverless applications.
+The [Serverless Framework Dashboard](https://app.serverless.com/) is a SaaS solution that augments the Serverless Framework open source CLI to provide a powerful, unified experience to develop, deploy, test, secure and monitor your serverless applications.
 
 The Serverless Framework free tier gives developers full access to all features included in the Serverless Framework Dashboard, but is limited to 1,000,000 function invocations per month. If you are interested in expanding your usage of the Serverless Framework beyond the free tier [contact us](https://serverless.com/enterprise/contact/) for details re available plans and pricing.
 
@@ -38,7 +38,7 @@ To get started with the Serverless Framework Dashboard, follow the [Getting Star
 
 If you have an existing Serverless Framework service, it is incredibly easy to enable the Serverless Framework Dashboard features. Just follow the [Getting Started with the Serverless Framework and AWS](/framework/docs/getting-started/) guide to install update the Serverless Framework to the latest release.
 
-If you don't already have a Serverless account, create a new account at [https://dashboard.serverless.com](https://dashboard.serverless.com).
+If you don't already have a Serverless account, create a new account at [https://app.serverless.com](https://app.serverless.com).
 
 After you create your account, run `serverless login` on the CLI to authenticate your CLI with the dashboard.
 

--- a/docs/dashboard/access-roles.md
+++ b/docs/dashboard/access-roles.md
@@ -23,7 +23,7 @@ If you do not use the Serverless Framework Dashboard to set up an AWS Access Rol
 
 ## Link your AWS Account
 
-1. Open the [Dashboard](https://dashboard.serverless.com/)
+1. Open the [Dashboard](https://app.serverless.com/)
 2. Once logged in, click "**profiles**" near the top of the page.
 3. Navigate to the profile you would like to configure with the AWS Access Role.
 4. In the **AWS account** tab, click **connect aws** button.

--- a/docs/dashboard/cicd/README.md
+++ b/docs/dashboard/cicd/README.md
@@ -31,7 +31,7 @@ As is the case with deployments from the Serverless Framework CLI, Serverless CI
 
 If you’ve already setup an AWS Access Role in a Profile you can skip this step.
 
-1. To setup the AWS Access Role, login to [https://dashboard.serverless.com/](https://dashboard.serverless.com/) and navigate to the “profiles” tab.
+1. To setup the AWS Access Role, login to [https://app.serverless.com/](https://app.serverless.com/) and navigate to the “profiles” tab.
 2. Select the “default” profile, and go to the “AWS Access Role” tab.
 3. Follow the provided instructions, supply the AWS Access Role ARN, and save your changes.
 
@@ -45,7 +45,7 @@ You can add more stages and profiles later.
 
 ### Step 2: Connect to Github
 
-1. Login to [https://dashboard.serverless.com/](https://dashboard.serverless.com/).
+1. Login to [https://app.serverless.com/](https://app.serverless.com/).
 2. Navigate to the app which contains the service you want to deploy.
 3. Next to the service name, you’ll see the status “Automatic deployments are disabled”; click “enable”.
 4. In the “repository connection” section, click “connect to Github” and follow the instructions to authenticate with Github and install the Serverless Framework app.

--- a/docs/dashboard/cicd/running-in-your-own-cicd.md
+++ b/docs/dashboard/cicd/running-in-your-own-cicd.md
@@ -41,7 +41,7 @@ When using the the Serverless Framework open-source CLI with Serverless Framewor
 
 Follow these steps to create an access token:
 
-1. Login to the dashboard at https://dashboard.serverless.com/
+1. Login to the dashboard at https://app.serverless.com/
 2. Open the username dropdown in the upper-right corner.
 3. Select "personal access keys" from the dropdown.
 4. Click “+ add” button.

--- a/docs/dashboard/monitoring/alerts.md
+++ b/docs/dashboard/monitoring/alerts.md
@@ -12,7 +12,7 @@ layout: Doc
 
 # Alerts
 
-Serverless Insights include pre-configured alerts designed to help you develop and optimize the performance and security of your serverless applications. These events are presented in the "alerts" tab within the Serverless Framework [dashboard](https://dashboard.serverless.com/). Preconfigured alerts include the following:
+Serverless Insights include pre-configured alerts designed to help you develop and optimize the performance and security of your serverless applications. These events are presented in the "alerts" tab within the Serverless Framework [dashboard](https://app.serverless.com/). Preconfigured alerts include the following:
 
 ## Memory: Out of Memory
 

--- a/docs/dashboard/parameters.md
+++ b/docs/dashboard/parameters.md
@@ -13,13 +13,13 @@ layout: Doc
 
 # Parameters
 
-The Serverless Framework Dashboard enables you to create and manage parameters, helping you to configure and secure your services by securely storing parameters used by your Serverless Framework services. The [Serverless Framework Dashboard](https://dashboard.serverless.com/) provides an interface to store and encrypt parameters and manage access to those parameters from your services. The Serverless Framework loads the parameters when the service is deployed.
+The Serverless Framework Dashboard enables you to create and manage parameters, helping you to configure and secure your services by securely storing parameters used by your Serverless Framework services. The [Serverless Framework Dashboard](https://app.serverless.com/) provides an interface to store and encrypt parameters and manage access to those parameters from your services. The Serverless Framework loads the parameters when the service is deployed.
 
 All parameters are treated as sensitive values, therefore they are not visible in the dashboard once saved, they are always encrypted at rest, and only decrypted during deployment.
 
 ## Creating a new Parameters
 
-Create a new parameter by navigating to **profiles** in the [Serverless Framework Dashboard](https://dashboard.serverless.com).
+Create a new parameter by navigating to **profiles** in the [Serverless Framework Dashboard](https://app.serverless.com).
 
 1. Navigate into the profile you would like to use for the Parameter.
 2. Navigate into the **parameters** tab.

--- a/docs/dashboard/profiles.md
+++ b/docs/dashboard/profiles.md
@@ -17,11 +17,11 @@ Deployment Profiles enable each stage of your Serverless application to use a un
 
 ## Use Deployment Profiles
 
-Deployment profiles are managed in the [Serverless Framework Dashboard](https://dashboard.serverless.com). When you run `serverless deploy`, the CLI obtains the Safeguard policies, Parameters, and the generated AWS Credentials.
+Deployment profiles are managed in the [Serverless Framework Dashboard](https://app.serverless.com). When you run `serverless deploy`, the CLI obtains the Safeguard policies, Parameters, and the generated AWS Credentials.
 
 ### Creating a new Deployment Profile
 
-Create a new deployment profile by navigating to **profiles** in the [Serverless Framework Dashboard](https://dashboard.serverless.com) and click **add**.
+Create a new deployment profile by navigating to **profiles** in the [Serverless Framework Dashboard](https://app.serverless.com) and click **add**.
 
 #### name
 
@@ -41,7 +41,7 @@ Access Roles, Parameters and Safeguards have individual configuration guides:
 
 ### Add a deployment profile to your application and stage
 
-Create a new stage by navigating to **applications** in the [Serverless Framework Dashboard](https://dashboard.serverless.com).
+Create a new stage by navigating to **applications** in the [Serverless Framework Dashboard](https://app.serverless.com).
 
 1. Expand the application and click into the **stages** tab.
 2. Click **add stage** in the tab

--- a/docs/dashboard/safeguards/README.md
+++ b/docs/dashboard/safeguards/README.md
@@ -17,7 +17,7 @@ Safeguards performs a series of policy checks when running the `serverless deplo
 
 ## Configuring Policies
 
-Safeguard policies are managed in the [Serverless Framework Dashboard](https://dashboard.serverless.com/). When you run `serverless deploy`, the CLI obtains the latest list of Safeguard policies and performs the checks before any resources are provisioned or deployed.
+Safeguard policies are managed in the [Serverless Framework Dashboard](https://app.serverless.com/). When you run `serverless deploy`, the CLI obtains the latest list of Safeguard policies and performs the checks before any resources are provisioned or deployed.
 
 The list of available Safeguards can be found by navigating to the "profiles" page, selecting the individual profile and opening the "safeguards" tab. The guide on [using deployment profiles to deploy](/framework/docs/dashboard/profiles#using-a-deployment-profile-to-deploy) provides instructions to identify the profile used by your application and stage.
 

--- a/docs/dashboard/safeguards/available.md
+++ b/docs/dashboard/safeguards/available.md
@@ -13,7 +13,7 @@ layout: Doc
 # List of all available safeguards
 
 The following policies are included and configurable in the [Serverless
-Framework Dashboard](https://dashboard.serverless.com/).
+Framework Dashboard](https://app.serverless.com/).
 
 ### No "\*" in IAM Role statements
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ npm update -g serverless
 
 ## Set up your free Pro account
 
-Learn more about [Serverless Framework Pro](https://serverless.com/pro/) and [sign up for free](https://dashboard.serverless.com).
+Learn more about [Serverless Framework Pro](https://serverless.com/pro/) and [sign up for free](https://app.serverless.com).
 
 Once you’ve signed up for Pro, login to your Pro dashboard from the CLI:
 

--- a/docs/providers/aws/cli-reference/slstats.md
+++ b/docs/providers/aws/cli-reference/slstats.md
@@ -55,6 +55,6 @@ The following is a list of the events that we collect:
 
 ## Signed in to the Dashboard
 
-If you are signed in to the [Serverless Dashboard](<(https://dashboard.serverless.com)>), we do receive your userId as part of the event payloads. We can use this information to understand your tenant and users interactions with the CLI and building services.
+If you are signed in to the [Serverless Dashboard](<(https://app.serverless.com)>), we do receive your userId as part of the event payloads. We can use this information to understand your tenant and users interactions with the CLI and building services.
 
 If you are not signed in, we do not send any identifying information, such as an userId, within any of the event payloads.


### PR DESCRIPTION
This updates the docs to use the new dashboard link, app.serverless.com, replacing the old dashboard link, dashboard.serverless.com. No other changes are included in this PR. Making this a draft PR until we are ready to launch the new dashboard.