### PR TITLE
CLI: Ensure `--version` is only top level command option

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -69,52 +69,55 @@ class CLI {
     const commands = processedInput.commands;
     const options = processedInput.options;
 
-    if (options.version || options.v) return true;
     if (options.help || options.h) return true;
-    if (options['help-interactive']) return true;
 
-    if (commands.length !== 1) return false;
-    return helpCommandNames.has(commands[0]);
+    switch (commands.length) {
+      case 0:
+        if (options.version || options.v) return true;
+        if (options['help-interactive']) return true;
+        return false;
+      case 1:
+        return helpCommandNames.has(commands[0]);
+      default:
+        return false;
+    }
   }
 
   displayHelp(processedInput) {
     const commands = processedInput.commands;
     const options = processedInput.options;
 
-    // if asked for version explicitly
-    if (options.version || options.v || (commands.length === 1 && commands[0] === 'version')) {
-      this.getVersionNumber();
-      return true;
+    switch (commands.length) {
+      case 0:
+        if (options.version || options.v) {
+          this.getVersionNumber();
+          return true;
+        }
+        if (options['help-interactive']) {
+          this.generateInteractiveCliHelp();
+          return true;
+        }
+        if (options.verbose) this.generateVerboseHelp();
+        else this.generateMainHelp();
+        return true;
+      case 1:
+        if (commands[0] === 'version') {
+          this.getVersionNumber();
+          return true;
+        }
+        if (commands[0] === 'help') {
+          if (options.verbose) this.generateVerboseHelp();
+          else this.generateMainHelp();
+          return true;
+        }
+      // fallthrough
+      default:
+        if (options.help || options.h) {
+          this.generateCommandsHelp(commands);
+          return true;
+        }
+        return false;
     }
-
-    // if "--help-interactive" was entered
-    if (options['help-interactive']) {
-      this.generateInteractiveCliHelp();
-      return true;
-    }
-
-    if (
-      // if no commands (and unrecognized options, otherwise interactive CLI takes over anyway)
-      commands.length === 0 ||
-      // If no commands and asked for help specifically
-      (commands.length === 0 && (options.help || options.h)) ||
-      // If asked for help specifically via "help" command
-      (commands.length === 1 && commands[0] === 'help')
-    ) {
-      if (options.verbose) {
-        this.generateVerboseHelp();
-      } else {
-        this.generateMainHelp();
-      }
-      return true;
-    }
-
-    // if asked for specific command help
-    if (commands.length >= 1 && (options.help || options.h)) {
-      this.generateCommandsHelp(commands);
-      return true;
-    }
-    return false;
   }
 
   displayCommandUsage(commandObject, command, indents) {

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -675,4 +675,28 @@ describe('CLI [new tests]', () => {
     }).then(({ stdoutData }) => {
       expect(stdoutData).to.include('Documentation: http://slss.io/docs');
     }));
+
+  it('Should show version when requested and no commands are used', () =>
+    runServerless({
+      cwd: fixtures.map.function,
+      cliArgs: ['-v'],
+    }).then(({ stdoutData }) => {
+      expect(stdoutData).to.include('Framework Core: ');
+    }));
+
+  it('Should not show version with command', () =>
+    runServerless({
+      cwd: fixtures.map.customProvider,
+      cliArgs: ['info', '-v'],
+    })
+      .then(({ stdoutData }) => {
+        expect(stdoutData).to.not.include('Framework Core: ');
+        return runServerless({
+          cwd: fixtures.map.customProvider,
+          cliArgs: ['info', '--version'],
+        });
+      })
+      .then(({ stdoutData }) => {
+        expect(stdoutData).to.not.include('Framework Core: ');
+      }));
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #7944 (regression introduced with #7924)

Additionally `--help-interactive` was also configured to be only a top level command param
