### PR TITLE
Use dayjs instead of moment in the aws-clojurescript-gradle template to fix an invocation error.

### DIFF
--- a/lib/plugins/create/templates/aws-clojurescript-gradle/scripts/node_repl.clj
+++ b/lib/plugins/create/templates/aws-clojurescript-gradle/scripts/node_repl.clj
@@ -9,7 +9,7 @@
                        :optimizations :none,
                        :target :nodejs,
                        :verbose true
-                       :npm-deps {"moment" "2.22.2"}})
+                       :npm-deps {"dayjs" "1.8.17"}})
 
 (cljs.repl/repl (cljs.repl.node/repl-env)
                 :watch "src"

--- a/lib/plugins/create/templates/aws-clojurescript-gradle/src/main/clojurescript/serverless/functions.cljs
+++ b/lib/plugins/create/templates/aws-clojurescript-gradle/src/main/clojurescript/serverless/functions.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.nodejs :as nodejs]))
 
 (nodejs/enable-util-print!)
-(defonce moment (nodejs/require "moment"))
+(defonce dayjs (nodejs/require "dayjs"))
 
 (defn hello [event ctx cb]
   (println ctx)
@@ -17,7 +17,7 @@
   (cb nil (clj->js
             {:statusCode 200
              :headers    {"Content-Type" "text/html"}
-             :body       (str "<h1>"(.format (moment.) "LLLL")"</h1>")}))) ; call nodejs package
+             :body       (str "<h1>"(.format (dayjs.) "dddd, MMMM D, YYYY h:mm A")"</h1>")}))) ; call nodejs package
 
 (set! (.-exports js/module) #js
     {:hello hello


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #7960

invoke local works fine with the change.

```
% sls invoke local -f hello
#js {:awsRequestId id, :invokeid id, :logGroupName /aws/lambda/aws-clojurescript-gradle2-dev-hello, :logStreamName 2015/09/22/[HEAD]13370a84ca4ed8b77c427af260, :functionVersion HEAD, :isDefaultFunctionVersion true, :functionName aws-clojurescript-gradle2-dev-hello, :memoryLimitInMB 1024, :succeed #object[succeed], :fail #object[fail], :done #object[done], :getRemainingTimeInMillis #object[getRemainingTimeInMillis]}
{
    "statusCode": 200,
    "headers": {
        "Content-Type": "text/html"
    },
    "body": "<h1>Hello, World!</h1>"
}
% sls invoke local -f now
#js {:awsRequestId id, :invokeid id, :logGroupName /aws/lambda/aws-clojurescript-gradle2-dev-now, :logStreamName 2015/09/22/[HEAD]13370a84ca4ed8b77c427af260, :functionVersion HEAD, :isDefaultFunctionVersion true, :functionName aws-clojurescript-gradle2-dev-now, :memoryLimitInMB 1024, :succeed #object[succeed], :fail #object[fail], :done #object[done], :getRemainingTimeInMillis #object[getRemainingTimeInMillis]}
{
    "statusCode": 200,
    "headers": {
        "Content-Type": "text/html"
    },
    "body": "<h1>Tuesday, July 21, 2020 11:52 AM</h1>"
}
```
