### PR TITLE
Improve java invoke-bridge build error handling

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -632,15 +632,38 @@ class AwsInvokeLocal {
             'Building Java bridge, first invocation might take a bit longer.'
           );
 
-          mvn.stderr.on('data', buf => this.serverless.cli.consoleLog(`mvn - ${buf.toString()}`));
-
-          mvn.on('close', () =>
-            this.callJavaBridge(artifactPath, className, handlerName, input).then(resolve)
+          mvn.stderr.on('data', buf =>
+            this.serverless.cli.consoleLog(`mvn(stderr) - ${buf.toString()}`)
           );
+          const chunk = [];
+          if (process.env.SLS_DEBUG) {
+            mvn.stdout.on('data', buf => chunk.push(buf));
+          }
+
           let isRejected = false;
           mvn.on('error', error => {
-            isRejected = true;
-            reject(error);
+            if (!isRejected) {
+              isRejected = true;
+              reject(error);
+            }
+          });
+
+          mvn.on('exit', (code, signal) => {
+            if (code === 0) {
+              this.callJavaBridge(artifactPath, className, handlerName, input).then(resolve);
+            } else if (!isRejected) {
+              if (process.env.SLS_DEBUG) {
+                chunk
+                  .map(elem => elem.toString())
+                  .join('')
+                  .split(/\n/)
+                  .forEach(line => {
+                    this.serverless.cli.consoleLog(`mvn(stdout) - ${line}`);
+                  });
+              }
+              isRejected = true;
+              reject(`Failed to build the Java bridge. exit code=${code} signal=${signal}`);
+            }
           });
 
           process.nextTick(() => {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -662,7 +662,9 @@ class AwsInvokeLocal {
                   });
               }
               isRejected = true;
-              reject(`Failed to build the Java bridge. exit code=${code} signal=${signal}`);
+              reject(
+                new Error(`Failed to build the Java bridge. exit code=${code} signal=${signal}`)
+              );
             }
           });
 


### PR DESCRIPTION
The change helps us to narrow down issues like #4415.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses:  #4415

We get the following error messages.

```
% sls invoke local -f hello
Serverless: Building Java bridge, first invocation might take a bit longer.
 
 Exception -----------------------------------------------
 
  'Failed to build the Java bridge. exit code=1 signal=null'
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
```

```
% env SLS_DEBUG='*' sls invoke local -f hello
Serverless: Load command interactiveCli
Serverless: Load command config
Serverless: Load command config:credentials
Serverless: Load command config:tabcompletion
Serverless: Load command config:tabcompletion:install
Serverless: Load command config:tabcompletion:uninstall
Serverless: Load command create
Serverless: Load command install
Serverless: Load command package
Serverless: Load command deploy
Serverless: Load command deploy:function
Serverless: Load command deploy:list
Serverless: Load command deploy:list:functions
Serverless: Load command invoke
Serverless: Load command invoke:local
Serverless: Load command info
Serverless: Load command logs
Serverless: Load command metrics
Serverless: Load command print
Serverless: Load command remove
Serverless: Load command rollback
Serverless: Load command rollback:function
Serverless: Load command slstats
Serverless: Load command plugin
Serverless: Load command plugin
Serverless: Load command plugin:install
Serverless: Load command plugin
Serverless: Load command plugin:uninstall
Serverless: Load command plugin
Serverless: Load command plugin:list
Serverless: Load command plugin
Serverless: Load command plugin:search
Serverless: Load command config
Serverless: Load command config:credentials
Serverless: Load command rollback
Serverless: Load command rollback:function
Serverless: Load command upgrade
Serverless: Load command uninstall
Serverless: Load command login
Serverless: Load command logout
Serverless: Load command generate-event
Serverless: Load command test
Serverless: Load command dashboard
Serverless: Load command output
Serverless: Load command output:get
Serverless: Load command output:list
Serverless: Load command param
Serverless: Load command param:get
Serverless: Load command param:list
Serverless: Load command studio
Serverless: Load command dev
Serverless: Invoke invoke:local
Serverless: Building Java bridge, first invocation might take a bit longer.
mvn(stdout) - [INFO] Scanning for projects...
mvn(stdout) - [INFO] 
mvn(stdout) - [INFO] --------------------< com.serverless:invoke-bridge >--------------------
mvn(stdout) - [INFO] Building invoke-bridge 1.0.1
mvn(stdout) - [INFO] --------------------------------[ jar ]---------------------------------
mvn(stdout) - [INFO] 
mvn(stdout) - [INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ invoke-bridge ---
mvn(stdout) - [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
mvn(stdout) - [INFO] skip non existing resourceDirectory /Users/yyamano/work/serverless/lib/plugins/aws/invokeLocal/java/src/main/resources
mvn(stdout) - [INFO] 
mvn(stdout) - [INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ invoke-bridge ---
mvn(stdout) - [INFO] Changes detected - recompiling the module!
mvn(stdout) - [WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
mvn(stdout) - [INFO] Compiling 3 source files to /Users/yyamano/work/serverless/lib/plugins/aws/invokeLocal/java/target/classes
mvn(stdout) - [INFO] ------------------------------------------------------------------------
mvn(stdout) - [INFO] BUILD FAILURE
mvn(stdout) - [INFO] ------------------------------------------------------------------------
mvn(stdout) - [INFO] Total time:  0.767 s
mvn(stdout) - [INFO] Finished at: 2020-07-22T18:51:27+09:00
mvn(stdout) - [INFO] ------------------------------------------------------------------------
mvn(stdout) - [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project invoke-bridge: Fatal error compiling: ディレクトリがありません: /Users/yyamano/work/serverless/lib/plugins/aws/invokeLocal/java/target/classes -> [Help 1]
mvn(stdout) - [ERROR] 
mvn(stdout) - [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
mvn(stdout) - [ERROR] Re-run Maven using the -X switch to enable full debug logging.
mvn(stdout) - [ERROR] 
mvn(stdout) - [ERROR] For more information about the errors and possible solutions, please read the following articles:
mvn(stdout) - [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
mvn(stdout) - 
 
 Exception -----------------------------------------------
 
  'Failed to build the Java bridge. exit code=1 signal=null'
```