### PR TITLE
Add support for `maximumEventAge` and `maximumRetryAttempts` directly on function instead of destinations

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,6 +6,18 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
+<a name="AWS_FUNCTION_DESTINATIONS_MAXIMUM_EVENT_AGE"><div>&nbsp;</div></a>
+
+## AWS Lambda Function Destinations `maximumEventAge`
+
+Please use `maximumEventAge` instead of `destinations.maximumEventAge`. Support for `destinations.maximumEventAge` will be removed with v2.0.0
+
+<a name="AWS_FUNCTION_DESTINATIONS_MAXIMUM_RETRY_ATTEMPTS"><div>&nbsp;</div></a>
+
+## AWS Lambda Function Destinations `maximumRetryAttempts`
+
+Please use `maximumRetryAttempts` instead of `destinations.maximumRetryAttempts`. Support for `destinations.maximumRetryAttempts` will be removed with v2.0.0
+
 <a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
 
 ## AWS HTTP API payload format

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,17 +6,11 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
-<a name="AWS_FUNCTION_DESTINATIONS_MAXIMUM_EVENT_AGE"><div>&nbsp;</div></a>
+<a name="AWS_FUNCTION_DESTINATIONS_ASYNC_CONFIG"><div>&nbsp;</div></a>
 
-## AWS Lambda Function Destinations `maximumEventAge`
+## AWS Lambda Function Destinations `maximumEventAge` & `maximumRetryAttempts`
 
-Please use `maximumEventAge` instead of `destinations.maximumEventAge`. Support for `destinations.maximumEventAge` will be removed with v2.0.0
-
-<a name="AWS_FUNCTION_DESTINATIONS_MAXIMUM_RETRY_ATTEMPTS"><div>&nbsp;</div></a>
-
-## AWS Lambda Function Destinations `maximumRetryAttempts`
-
-Please use `maximumRetryAttempts` instead of `destinations.maximumRetryAttempts`. Support for `destinations.maximumRetryAttempts` will be removed with v2.0.0
+`maximumEventAge` and `maximumRetryAttempts` should be defined directly at function level. Support for those settings on destinations level, will be removed with v2.0.0
 
 <a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -10,7 +10,7 @@ layout: Doc
 
 ## AWS Lambda Function Destinations `maximumEventAge` & `maximumRetryAttempts`
 
-`maximumEventAge` and `maximumRetryAttempts` should be defined directly at function level. Support for those settings on destinations level, will be removed with v2.0.0
+`maximumEventAge` and `maximumRetryAttempts` should be defined directly at function level. Support for those settings on `destinations` level, will be removed with v2.0.0
 
 <a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
 

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -472,9 +472,11 @@ functions:
 
 ## Asynchronous invocation
 
+When intention is to invoke function asynchronously you may want to configure following additional settings:
+
 ### Destinations
 
-When intention is to invoke function asynchronously you may want to configure [destination targets](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-destinations) for it.
+[destination targets](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-destinations)
 
 Target can be the other lambdas you also deploy with a service or other qualified target (externally managed lambda, EventBridge event bus, SQS queue or SNS topic) which you can address via its ARN
 
@@ -487,9 +489,7 @@ functions:
       onFailure: arn:aws:sns:us-east-1:xxxx:some-topic-name
 ```
 
-### Maximum Event Age and Maximum Retry Attempts for Asynchronous Invocations
-
-When intention is to invoke function asynchronously you may want to configure `maximumRetryAttempts` and/or `maximumEventAge` for it.
+### Maximum Event Age and Maximum Retry Attempts
 
 `maximumEventAge` accepts values between 60 seconds and 6 hours, provided in seconds.
 `maximumRetryAttempts` accepts values between 0 and 2.

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -484,3 +484,18 @@ functions:
       onSuccess: otherFunctionInService
       onFailure: arn:aws:sns:us-east-1:xxxx:some-topic-name
 ```
+
+## Maximum Event Age and Maximum Retry Attempts for Asynchronous Invocations
+
+When intention is to invoke function asynchronously you may want to configure `maximumRetryAttempts` and/or `maximumEventAge` for it.
+
+`maximumEventAge` accepts values between 60 seconds and 6 hours, provided in seconds.
+`maximumRetryAttempts` accepts values between 0 and 2.
+
+```yml
+functions:
+  asyncHello:
+    handler: handler.asyncHello
+    maximumEventAge: 7200
+    maximumRetryAttempts: 1
+```

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -470,7 +470,9 @@ functions:
     tracing: PassThrough
 ```
 
-## Destinations
+## Asynchronous invocation
+
+### Destinations
 
 When intention is to invoke function asynchronously you may want to configure [destination targets](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-destinations) for it.
 
@@ -485,7 +487,7 @@ functions:
       onFailure: arn:aws:sns:us-east-1:xxxx:some-topic-name
 ```
 
-## Maximum Event Age and Maximum Retry Attempts for Asynchronous Invocations
+### Maximum Event Age and Maximum Retry Attempts for Asynchronous Invocations
 
 When intention is to invoke function asynchronously you may want to configure `maximumRetryAttempts` and/or `maximumEventAge` for it.
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -558,17 +558,17 @@ class AwsCompileFunctions {
     const destinationConfig = {};
 
     if (destinations) {
-      if (destinations.maximumRetryAttempts !== undefined) {
+      if (destinations.maximumRetryAttempts != null) {
         this.serverless._logDeprecation(
-          'AWS_FUNCTION_DESTINATIONS_MAXIMUM_RETRY_ATTEMPTS',
+          'AWS_FUNCTION_DESTINATIONS_ASYNC_CONFIG',
           'destinations.maximumRetryAttempts is deprecated, use maximumRetryAttempts on function instead'
         );
         maximumRetryAttemptsOnDestinations = destinations.maximumRetryAttempts;
       }
 
-      if (destinations.maximumEventAge !== undefined) {
+      if (destinations.maximumEventAge) {
         this.serverless._logDeprecation(
-          'AWS_FUNCTION_DESTINATIONS_MAXIMUM_EVENT_AGE',
+          'AWS_FUNCTION_DESTINATIONS_ASYNC_CONFIG',
           'destinations.maximumEventAge is deprecated, use maximumEventAge on function instead'
         );
         maximumEventAgeOnDestinations = destinations.maximumEventAge;
@@ -605,7 +605,7 @@ class AwsCompileFunctions {
     const maximumEventAge = maximumEventAgeOnFunction || maximumEventAgeOnDestinations;
     // For maximumRetryAttempts we cannot rely on "||" as the value can be Falsy, 0
     const maximumRetryAttempts =
-      maximumRetryAttemptsOnFunction === undefined
+      maximumRetryAttemptsOnFunction == null
         ? maximumRetryAttemptsOnDestinations
         : maximumRetryAttemptsOnFunction;
 
@@ -614,11 +614,17 @@ class AwsCompileFunctions {
       Properties: {
         FunctionName: { Ref: functionLogicalId },
         DestinationConfig: destinationConfig,
-        MaximumEventAgeInSeconds: maximumEventAge,
-        MaximumRetryAttempts: maximumRetryAttempts,
         Qualifier: functionObject.targetAlias ? functionObject.targetAlias.name : '$LATEST',
       },
     };
+
+    if (maximumEventAge) {
+      resource.Properties.MaximumEventAgeInSeconds = maximumEventAge;
+    }
+
+    if (maximumRetryAttempts != null) {
+      resource.Properties.MaximumRetryAttempts = maximumRetryAttempts;
+    }
 
     cfResources[this.provider.naming.getLambdaEventConfigLogicalId(functionName)] = resource;
   }

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -537,52 +537,88 @@ class AwsCompileFunctions {
         versionCompilationPromise = BbPromise.resolve();
       }
 
-      return versionCompilationPromise.then(() => this.compileFunctionDestinations(functionName));
+      return versionCompilationPromise.then(() =>
+        this.compileFunctionEventInvokeConfig(functionName)
+      );
     });
   }
 
-  compileFunctionDestinations(functionName) {
+  compileFunctionEventInvokeConfig(functionName) {
     const functionObject = this.serverless.service.getFunction(functionName);
-    const { destinations } = functionObject;
-    if (!destinations) return;
+    const {
+      destinations,
+      maximumEventAge: maximumEventAgeOnFunction,
+      maximumRetryAttempts: maximumRetryAttemptsOnFunction,
+    } = functionObject;
+    let maximumEventAgeOnDestinations;
+    let maximumRetryAttemptsOnDestinations;
+
+    if (!destinations && !maximumEventAgeOnFunction && !maximumRetryAttemptsOnFunction) return;
+
+    const destinationConfig = {};
+
+    if (destinations) {
+      if (destinations.maximumRetryAttempts !== undefined) {
+        this.serverless._logDeprecation(
+          'AWS_FUNCTION_DESTINATIONS_MAXIMUM_RETRY_ATTEMPTS',
+          'destinations.maximumRetryAttempts is deprecated, use maximumRetryAttempts on function instead'
+        );
+        maximumRetryAttemptsOnDestinations = destinations.maximumRetryAttempts;
+      }
+
+      if (destinations.maximumEventAge !== undefined) {
+        this.serverless._logDeprecation(
+          'AWS_FUNCTION_DESTINATIONS_MAXIMUM_EVENT_AGE',
+          'destinations.maximumEventAge is deprecated, use maximumEventAge on function instead'
+        );
+        maximumEventAgeOnDestinations = destinations.maximumEventAge;
+      }
+
+      const hasAccessPoliciesHandledExternally = Boolean(
+        functionObject.role || this.serverless.service.provider.role
+      );
+      if (destinations.onSuccess) {
+        if (!hasAccessPoliciesHandledExternally) {
+          this.ensureTargetExecutionPermission(destinations.onSuccess);
+        }
+        destinationConfig.OnSuccess = {
+          Destination: destinations.onSuccess.startsWith('arn:')
+            ? destinations.onSuccess
+            : this.provider.resolveFunctionArn(destinations.onSuccess),
+        };
+      }
+      if (destinations.onFailure) {
+        if (!hasAccessPoliciesHandledExternally) {
+          this.ensureTargetExecutionPermission(destinations.onFailure);
+        }
+        destinationConfig.OnFailure = {
+          Destination: destinations.onFailure.startsWith('arn:')
+            ? destinations.onFailure
+            : this.provider.resolveFunctionArn(destinations.onFailure),
+        };
+      }
+    }
 
     const cfResources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+
+    const maximumEventAge = maximumEventAgeOnFunction || maximumEventAgeOnDestinations;
+    // For maximumRetryAttempts we cannot rely on "||" as the value can be Falsy, 0
+    const maximumRetryAttempts =
+      maximumRetryAttemptsOnFunction === undefined
+        ? maximumRetryAttemptsOnDestinations
+        : maximumRetryAttemptsOnFunction;
+
     const resource = {
       Type: 'AWS::Lambda::EventInvokeConfig',
       Properties: {
         FunctionName: { Ref: functionLogicalId },
-        DestinationConfig: {},
-        MaximumEventAgeInSeconds: destinations.maximumEventAge,
-        MaximumRetryAttempts: destinations.maximumRetryAttempts,
+        DestinationConfig: destinationConfig,
+        MaximumEventAgeInSeconds: maximumEventAge,
+        MaximumRetryAttempts: maximumRetryAttempts,
         Qualifier: functionObject.targetAlias ? functionObject.targetAlias.name : '$LATEST',
       },
     };
-    const destinationConfig = resource.Properties.DestinationConfig;
-
-    const hasAccessPoliciesHandledExternally = Boolean(
-      functionObject.role || this.serverless.service.provider.role
-    );
-    if (destinations.onSuccess) {
-      if (!hasAccessPoliciesHandledExternally) {
-        this.ensureTargetExecutionPermission(destinations.onSuccess);
-      }
-      destinationConfig.OnSuccess = {
-        Destination: destinations.onSuccess.startsWith('arn:')
-          ? destinations.onSuccess
-          : this.provider.resolveFunctionArn(destinations.onSuccess),
-      };
-    }
-    if (destinations.onFailure) {
-      if (!hasAccessPoliciesHandledExternally) {
-        this.ensureTargetExecutionPermission(destinations.onFailure);
-      }
-      destinationConfig.OnFailure = {
-        Destination: destinations.onFailure.startsWith('arn:')
-          ? destinations.onFailure
-          : this.provider.resolveFunctionArn(destinations.onFailure),
-      };
-    }
 
     cfResources[this.provider.naming.getLambdaEventConfigLogicalId(functionName)] = resource;
   }

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2602,7 +2602,7 @@ describe('AwsCompileFunctions', () => {
 describe('AwsCompileFunctions #2', () => {
   after(fixtures.cleanup);
 
-  describe('Destinations', () => {
+  describe('Asynchronous Invocations', () => {
     it('Should reference function from same service as destination', () =>
       runServerless({
         cwd: fixtures.map.functionDestinations,
@@ -2701,6 +2701,144 @@ describe('AwsCompileFunctions #2', () => {
           const dependsOn = cfResources[naming.getLambdaLogicalId('foo')].DependsOn;
           expect(dependsOn).to.be.undefined;
         });
+    });
+
+    it('Should support maximumEventAge defined on function', () => {
+      const maximumEventAge = 3600;
+      return fixtures
+        .extend('functionDestinations', {
+          functions: { trigger: { maximumEventAge } },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(({ awsNaming, cfTemplate }) => {
+            const cfResources = cfTemplate.Resources;
+            const naming = awsNaming;
+            const eventInvokeConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
+
+            expect(eventInvokeConfig.MaximumEventAgeInSeconds).to.equal(maximumEventAge);
+          })
+        );
+    });
+
+    it('Should support maximumEventAge defined on destination', () => {
+      const maximumEventAge = 3600;
+      return fixtures
+        .extend('functionDestinations', {
+          functions: { trigger: { destinations: { maximumEventAge } } },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(({ awsNaming, cfTemplate }) => {
+            const cfResources = cfTemplate.Resources;
+            const naming = awsNaming;
+            const eventInvokeConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
+
+            expect(eventInvokeConfig.MaximumEventAgeInSeconds).to.equal(maximumEventAge);
+          })
+        );
+    });
+
+    it('Should prefer maximumEventAge defined on function over defined on destination', () => {
+      const maximumEventAgeOnFunction = 3600;
+      const maximumEventAgeOnDestination = 7200;
+      return fixtures
+        .extend('functionDestinations', {
+          functions: {
+            trigger: {
+              maximumEventAge: maximumEventAgeOnFunction,
+              destinations: { maximumEventAge: maximumEventAgeOnDestination },
+            },
+          },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(({ awsNaming, cfTemplate }) => {
+            const cfResources = cfTemplate.Resources;
+            const naming = awsNaming;
+            const eventInvokeConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
+
+            expect(eventInvokeConfig.MaximumEventAgeInSeconds).to.equal(maximumEventAgeOnFunction);
+          })
+        );
+    });
+
+    it('Should support maximumRetryAttempts defined on function', () => {
+      const maximumRetryAttempts = 0;
+      return fixtures
+        .extend('functionDestinations', {
+          functions: { trigger: { maximumRetryAttempts } },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(({ awsNaming, cfTemplate }) => {
+            const cfResources = cfTemplate.Resources;
+            const naming = awsNaming;
+            const eventInvokeConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
+
+            expect(eventInvokeConfig.MaximumRetryAttempts).to.equal(maximumRetryAttempts);
+          })
+        );
+    });
+
+    it('Should support maximumRetryAttempts defined on destination', () => {
+      const maximumRetryAttempts = 0;
+      return fixtures
+        .extend('functionDestinations', {
+          functions: { trigger: { destinations: { maximumRetryAttempts } } },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(({ awsNaming, cfTemplate }) => {
+            const cfResources = cfTemplate.Resources;
+            const naming = awsNaming;
+            const eventInvokeConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
+
+            expect(eventInvokeConfig.MaximumRetryAttempts).to.equal(maximumRetryAttempts);
+          })
+        );
+    });
+
+    it('Should prefer maximumRetryAttempts defined on function over on destination', () => {
+      const maximumRetryAttemptsOnFunction = 0;
+      const maximumRetryAttemptsOnDestination = 1;
+      return fixtures
+        .extend('functionDestinations', {
+          functions: {
+            trigger: {
+              maximumRetryAttempts: maximumRetryAttemptsOnFunction,
+              destinations: { maximumRetryAttempts: maximumRetryAttemptsOnDestination },
+            },
+          },
+        })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['package'],
+          }).then(({ awsNaming, cfTemplate }) => {
+            const cfResources = cfTemplate.Resources;
+            const naming = awsNaming;
+            const eventInvokeConfig =
+              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
+
+            expect(eventInvokeConfig.MaximumRetryAttempts).to.equal(maximumRetryAttemptsOnFunction);
+          })
+        );
     });
   });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->
Adds support for defining `maximumEventAge` and `maximumRetryAttempts` directly on function level and deprecates the configuration on destinations.

Closes: #7678


Open questions:
- I wasn't sure about the approach to deprecation - I went with two separate deprecations for each parameter, but maybe it would make more sense to combine it into one instead? I would love to get your opinion on this one
- I followed the previous approach where I didn't notice any validation of the provided input e.g. if `maximumEventAge` is between 60 seconds and 6 hours. Would it make sense to add such validation or it's unnecessary at this point?