### PR TITLE
Using 'paths-ignore' to not execute the validate pipeline always

### DIFF
--- a/.github/verify_md_only_change.sh
+++ b/.github/verify_md_only_change.sh
@@ -16,7 +16,8 @@
 
 set -eou pipefail
 
-CHANGED_FILES=`git diff --name-only master`
+
+CHANGED_FILES=`git diff --name-only origin/master HEAD`
 
 # No changes return error/false
 [[ -z $CHANGED_FILES ]] && exit 1

--- a/.github/verify_md_only_change.sh
+++ b/.github/verify_md_only_change.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eou pipefail
+
+CHANGED_FILES=`git diff --name-only master`
+
+# No changes return error/false
+[[ -z $CHANGED_FILES ]] && exit 1
+
+for CHANGED_FILE in $CHANGED_FILES; do
+  if ! [[ $CHANGED_FILE =~ ^docs/ || $CHANGED_FILE =~ .md$ ]]; then
+    # if there is a file changed that isn't inside docs/ or is .md
+    # Return ok/true
+    exit 0
+  fi
+done
+# Return error/false if there were only docs/ or .md files
+exit 1

--- a/.github/verify_md_only_change.sh
+++ b/.github/verify_md_only_change.sh
@@ -17,7 +17,7 @@
 set -eou pipefail
 
 
-CHANGED_FILES=`git diff --name-only origin/master HEAD`
+CHANGED_FILES=$(git diff --name-only origin/master HEAD)
 
 # No changes return error/false
 [[ -z $CHANGED_FILES ]] && exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ on:
 env:
   SLS_IGNORE_WARNING: '*'
   FORCE_COLOR: 1
-  NOT_ALL_MD: ${{ ./.github/verify_md_only_change.sh }}
+  NOT_ALL_MD: ${{ bash ./.github/verify_md_only_change.sh || false }}
 
 jobs:
   linuxNode14:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,9 @@ name: Validate
 on:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 env:
   SLS_IGNORE_WARNING: '*'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,16 +5,22 @@ name: Validate
 on:
   pull_request:
     branches: [master]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
 
 env:
   SLS_IGNORE_WARNING: '*'
   FORCE_COLOR: 1
-  NOT_ALL_MD: ${{ bash ./.github/verify_md_only_change.sh || false }}
+  NOT_ALL_MD: ${{ needs.more_than_md.outputs.NOT_ALL_MD }}
+  # : ${{ bash ./.github/verify_md_only_change.sh || false }}
 
 jobs:
+  more_than_md:
+    runs-on: ubuntu-latest
+    outputs:
+      NOT_ALL_MD: ${{ steps.verify.outputs.NOT_ALL_MD}}
+    steps:
+      - id: verify
+        run: ./.github/verify_md_only_change.sh; echo "::set-output name=NOT_ALL_MD::$?"
+
   linuxNode14:
     name: '[Linux] Node.js 14: Lint, Formatting, Eventual Commitlint, Eventual Changelog & Unit tests'
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,7 @@ on:
 env:
   SLS_IGNORE_WARNING: '*'
   FORCE_COLOR: 1
+  NOT_ALL_MD: ${{ ./.github/verify_md_only_change.sh }}
 
 jobs:
   linuxNode14:
@@ -78,6 +79,7 @@ jobs:
         # Some tests depend on TTY support, which is missing in GA runner
         # Workaround taken from https://github.com/actions/runner/issues/241#issuecomment-577360161
         run: script -e -c "npm test -- -b"
+        if: ${{ $NOT_ALL_MD }}
 
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
@@ -116,10 +118,12 @@ jobs:
           npm update --save-dev --no-save
       - name: Unit tests
         run: npm test -- -b
+        if: ${{ $NOT_ALL_MD }}
 
   linuxNode12:
     name: '[Linux] Node.js 12: Isolated unit tests'
     runs-on: ubuntu-latest
+    if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -160,6 +164,7 @@ jobs:
   linuxNode10:
     name: '[Linux] Node.js v10: Unit tests with coverage'
     runs-on: ubuntu-latest
+    if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -206,6 +211,7 @@ jobs:
   linuxNode8:
     name: '[Linux] Node.js v8: Unit & packaging tests'
     runs-on: ubuntu-latest
+    if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -248,6 +254,7 @@ jobs:
   linuxNode6:
     name: '[Linux] Node.js v6: Unit tests'
     runs-on: ubuntu-latest
+    if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,8 +9,6 @@ on:
 env:
   SLS_IGNORE_WARNING: '*'
   FORCE_COLOR: 1
-  NOT_ALL_MD: ${{ needs.more_than_md.outputs.NOT_ALL_MD }}
-  # : ${{ bash ./.github/verify_md_only_change.sh || false }}
 
 jobs:
   more_than_md:
@@ -18,12 +16,17 @@ jobs:
     outputs:
       NOT_ALL_MD: ${{ steps.verify.outputs.NOT_ALL_MD}}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - id: verify
         run: ./.github/verify_md_only_change.sh; echo "::set-output name=NOT_ALL_MD::$?"
 
   linuxNode14:
     name: '[Linux] Node.js 14: Lint, Formatting, Eventual Commitlint, Eventual Changelog & Unit tests'
     runs-on: ubuntu-latest
+    needs: more_than_md
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -85,7 +88,7 @@ jobs:
         # Some tests depend on TTY support, which is missing in GA runner
         # Workaround taken from https://github.com/actions/runner/issues/241#issuecomment-577360161
         run: script -e -c "npm test -- -b"
-        if: ${{ $NOT_ALL_MD }}
+        if: ${{ needs.more_than_md.outputs.NOT_ALL_MD }}
 
   windowsNode14:
     name: '[Windows] Node.js v14: Unit tests'
@@ -124,12 +127,12 @@ jobs:
           npm update --save-dev --no-save
       - name: Unit tests
         run: npm test -- -b
-        if: ${{ $NOT_ALL_MD }}
+        # if: ${{ $NOT_ALL_MD }}
 
   linuxNode12:
     name: '[Linux] Node.js 12: Isolated unit tests'
     runs-on: ubuntu-latest
-    if: ${{ $NOT_ALL_MD }}
+    # if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -170,7 +173,7 @@ jobs:
   linuxNode10:
     name: '[Linux] Node.js v10: Unit tests with coverage'
     runs-on: ubuntu-latest
-    if: ${{ $NOT_ALL_MD }}
+    # if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -217,7 +220,7 @@ jobs:
   linuxNode8:
     name: '[Linux] Node.js v8: Unit & packaging tests'
     runs-on: ubuntu-latest
-    if: ${{ $NOT_ALL_MD }}
+    # if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -260,7 +263,7 @@ jobs:
   linuxNode6:
     name: '[Linux] Node.js v6: Unit tests'
     runs-on: ubuntu-latest
-    if: ${{ $NOT_ALL_MD }}
+    # if: ${{ $NOT_ALL_MD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

# Description
This pr uses `paths-ignore` to not execute the validate pipeline when the only changes are `.md` files or files inside the `docs` folder

Closes: #2699 
