### PR TITLE
Refactor get

### DIFF
--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -61,7 +61,6 @@ module.exports = {
       this.serverless.service.getAllFunctions().forEach(functionName => {
         const functionObject = this.serverless.service.getFunction(functionName);
         const individually =
-          _.get(functionObject, 'package.individually') ||
           this.serverless.service.package.individually;
 
         // By default assume service-level package
@@ -73,7 +72,7 @@ module.exports = {
           artifactFileName = this.provider.naming.getFunctionArtifactName(functionName);
           artifactFilePath = path.join(this.packagePath, artifactFileName);
 
-          if (_.get(functionObject, 'package.artifact')) {
+          if (functionObject.package.artifact) {
             // Use function-level artifact
             artifactFilePath = functionObject.package.artifact;
             artifactFileName = path.basename(artifactFilePath);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const awsArnRegExs = require('../../../../../../utils/arnRegularExpressions');
 
 module.exports = {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -5,7 +5,8 @@ const awsArnRegExs = require('../../../../../../utils/arnRegularExpressions');
 
 module.exports = {
   getMethodAuthorization(http) {
-    if (_.get(http, 'authorizer.type') === 'AWS_IAM') {
+
+    if (http.authorizer.type.toUpperCase() === 'AWS_IAM'){
       return {
         Properties: {
           AuthorizationType: 'AWS_IAM',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -1,11 +1,11 @@
 'use strict';
 
+const _ = require('lodash');
 const awsArnRegExs = require('../../../../../../utils/arnRegularExpressions');
 
 module.exports = {
   getMethodAuthorization(http) {
-
-    if (http.authorizer.type.toUpperCase() === 'AWS_IAM'){
+      if (_.get(http, 'authorizer.type') === 'AWS_IAM') {
       return {
         Properties: {
           AuthorizationType: 'AWS_IAM',

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -15,10 +15,8 @@ module.exports = {
       serviceStateFileName
     );
 
-    const artifact = '';
-    if (this.serverless.service.package.artifact)
-        artifact = _.last(this.serverless.service.package.artifact).split(path.sep);
-    
+    const artifact = _.last(_.get(this.serverless.service, 'package.artifact', '').split(path.sep));
+
     const strippedService = Object.assign(
       {},
       _.omit(this.serverless.service, ['serverless', 'package'])

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -16,7 +16,6 @@ module.exports = {
     );
 
     const artifact = _.last(_.get(this.serverless.service, 'package.artifact', '').split(path.sep));
-
     const strippedService = Object.assign(
       {},
       _.omit(this.serverless.service, ['serverless', 'package'])

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -15,8 +15,10 @@ module.exports = {
       serviceStateFileName
     );
 
-    const artifact = _.last(_.get(this.serverless.service, 'package.artifact', '').split(path.sep));
-
+    const artifact = '';
+    if (this.serverless.service.package.artifact)
+        artifact = _.last(this.serverless.service.package.artifact).split(path.sep);
+    
     const strippedService = Object.assign(
       {},
       _.omit(this.serverless.service, ['serverless', 'package'])


### PR DESCRIPTION
Addresses: #7747 

Looked for areas where `_.get()` was used and see if object properties are suitable for refactoring. Based on `_.has()` issue, these changes can be updated to perform optional chaining and nullish coalescing operator.

Files with `.get()`:

- https://github.com/serverless/serverless/blob/053f5f420b45e9dec794e82d1bc23a2731a077ff/lib/plugins/aws/package/lib/saveServiceState.js
- https://github.com/serverless/serverless/blob/003696260c43acf2415fa6b05a212ea57bdec3d4/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
- https://github.com/serverless/serverless/blob/c9a6b75d49502cb429ad34ef4a917f6d286db60e/lib/plugins/aws/package/compile/events/apiGateway/index.js
- https://github.com/serverless/serverless/blob/f71649cdb5c141f2493b45d77c91d7e866d47fcf/lib/plugins/aws/deploy/lib/extendedValidate.js
-https://github.com/serverless/serverless/blob/9f0131fedf60e9104f38702d01e103b9a3b0f629/lib/plugins/aws/package/compile/events/websockets/lib/pickWebsocketsTemplatePart.js (Deep level properties so ignored)