### PR TITLE
Fix schema validation missings

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -32,6 +32,7 @@ module.exports = {
         'AWS Websocket',
         'CLI',
         'Components',
+        'Config Schema',
         'Plugins',
         'Standalone',
         'Templates',

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -8,6 +8,20 @@ const normalizeAjvErrors = require('./normalizeAjvErrors');
 const FUNCTION_NAME_PATTERN = '^[a-zA-Z0-9-_]+$';
 const ERROR_PREFIX = 'Configuration error';
 
+const normalizeSchemaObject = (object, instanceSchema) => {
+  for (const [key, value] of _.entries(object)) {
+    if (!_.isObject(value)) continue;
+    if (!value.$ref) {
+      normalizeSchemaObject(value, instanceSchema);
+      continue;
+    }
+    if (!value.$ref.startsWith('#/definitions/')) {
+      throw new Error(`Unsupported reference ${value.$ref}`);
+    }
+    object[key] = _.get(instanceSchema, value.$ref.slice(2).split('/'));
+  }
+};
+
 class ConfigSchemaHandler {
   constructor(serverless) {
     this.serverless = serverless;
@@ -55,7 +69,9 @@ class ConfigSchemaHandler {
       this.relaxProviderSchema();
     }
 
-    const ajv = new Ajv({ allErrors: true });
+    const ajv = new Ajv({ allErrors: true, verbose: true });
+    // Workaround https://github.com/ajv-validator/ajv/issues/1255
+    normalizeSchemaObject(this.schema, this.schema);
     const validate = ajv.compile(this.schema);
 
     validate(userConfig);

--- a/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
+++ b/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
@@ -4,9 +4,10 @@ const _ = require('lodash');
 const resolveDataPathSize = require('./resolveDataPathSize');
 
 const isEventTypeDataPath = RegExp.prototype.test.bind(/^\.functions\[[^\]]+\]\.events\[\d+\]$/);
-const anyOfPathPattern = /\/anyOf(?:\/\d+\/|$)/;
+const oneOfPathPattern = /\/(?:anyOf|oneOf)(?:\/\d+\/|$)/;
 const isAnyOfPathTypePostfix = RegExp.prototype.test.bind(/^\/\d+\/type$/);
 const dataPathPropertyBracketsPattern = /\['([a-zA-Z_0-9]+)'\]/g;
+const oneOfKeywords = new Set(['anyOf', 'oneOf']);
 
 const filterIrreleventEventConfigurationErrors = resultErrorsSet => {
   // 1. Resolve all errors at event type configuration level
@@ -19,7 +20,9 @@ const filterIrreleventEventConfigurationErrors = resultErrorsSet => {
   // 3. Process each error group individually
   for (const [dataPath, eventEventTypeErrors] of _.entries(eventTypeErrorsByEvent)) {
     // 3.1 Resolve error that signals that no event schema was matched
-    const noMatchingEventError = eventEventTypeErrors.find(({ keyword }) => keyword === 'anyOf');
+    const noMatchingEventError = eventEventTypeErrors.find(({ keyword }) =>
+      oneOfKeywords.has(keyword)
+    );
 
     // 3.2 Group errors by event type
     const eventEventTypeErrorsByTypeIndex = _.groupBy(eventEventTypeErrors, ({ schemaPath }) => {
@@ -77,31 +80,31 @@ const filterIrreleventEventConfigurationErrors = resultErrorsSet => {
 };
 
 const filterIrrelevantAnyOfErrors = resultErrorsSet => {
-  // 1. Group errors by anyOf schema path
-  const anyOfErrorsByPath = {};
+  // 1. Group errors by anyOf/oneOf schema path
+  const oneOfErrorsByPath = {};
   for (const error of resultErrorsSet) {
     const schemaPath = error.schemaPath;
     let fromIndex = 0;
-    let anyOfPathIndex = schemaPath.search(anyOfPathPattern);
-    while (anyOfPathIndex !== -1) {
-      const anyOfPath = schemaPath.slice(0, fromIndex + anyOfPathIndex + 'anyOf/'.length);
-      if (!anyOfErrorsByPath[anyOfPath]) anyOfErrorsByPath[anyOfPath] = [];
-      anyOfErrorsByPath[anyOfPath].push(error);
-      fromIndex += anyOfPathIndex + 'anyOf/'.length;
-      anyOfPathIndex = schemaPath.slice(fromIndex).search(anyOfPathPattern);
+    let oneOfPathIndex = schemaPath.search(oneOfPathPattern);
+    while (oneOfPathIndex !== -1) {
+      const oneOfPath = schemaPath.slice(0, fromIndex + oneOfPathIndex + 'anyOf/'.length);
+      if (!oneOfErrorsByPath[oneOfPath]) oneOfErrorsByPath[oneOfPath] = [];
+      oneOfErrorsByPath[oneOfPath].push(error);
+      fromIndex += oneOfPathIndex + 'anyOf/'.length;
+      oneOfPathIndex = schemaPath.slice(fromIndex).search(oneOfPathPattern);
     }
   }
   // 2. Process resolved groups
-  for (const [anyOfPath, anyOfPathErrors] of _.entries(anyOfErrorsByPath)) {
+  for (const [oneOfPath, oneOfPathErrors] of _.entries(oneOfErrorsByPath)) {
     // 2.1. If just one error, set was already filtered by event configuration errors filter
-    if (anyOfPathErrors.length === 1) continue;
+    if (oneOfPathErrors.length === 1) continue;
     // 2.2. Group by dataPath
-    anyOfPathErrors.sort(({ dataPath: dataPathA }, { dataPath: dataPathB }) =>
+    oneOfPathErrors.sort(({ dataPath: dataPathA }, { dataPath: dataPathB }) =>
       dataPathA.localeCompare(dataPathB)
     );
-    let currentDataPath = anyOfPathErrors[0].dataPath;
+    let currentDataPath = oneOfPathErrors[0].dataPath;
     _.values(
-      _.groupBy(anyOfPathErrors, ({ dataPath }) => {
+      _.groupBy(oneOfPathErrors, ({ dataPath }) => {
         if (
           dataPath !== currentDataPath &&
           !dataPath.startsWith(`${currentDataPath}.`) &&
@@ -111,13 +114,13 @@ const filterIrrelevantAnyOfErrors = resultErrorsSet => {
         }
         return currentDataPath;
       })
-    ).forEach(dataPathAnyOfPathErrors => {
+    ).forEach(dataPathOneOfPathErrors => {
       // 2.2.1.If just one error, set was already filtered by event configuration errors filter
-      if (dataPathAnyOfPathErrors.length === 1) return;
+      if (dataPathOneOfPathErrors.length === 1) return;
       // 2.2.2 Group by anyOf variant
-      const groupFromIndex = anyOfPath.length + 1;
-      const dataPathAnyOfPathErrorsByVariant = _.groupBy(
-        dataPathAnyOfPathErrors,
+      const groupFromIndex = oneOfPath.length + 1;
+      const dataPathOneOfPathErrorsByVariant = _.groupBy(
+        dataPathOneOfPathErrors,
         ({ schemaPath }) => {
           if (groupFromIndex > schemaPath.length) return 'root';
           return schemaPath.slice(groupFromIndex, schemaPath.indexOf('/', groupFromIndex));
@@ -125,52 +128,52 @@ const filterIrrelevantAnyOfErrors = resultErrorsSet => {
       );
 
       // 2.2.3 If no root error, set was already filtered by event configuration errors filter
-      if (!dataPathAnyOfPathErrorsByVariant.root) return;
-      const noMatchingVariantError = dataPathAnyOfPathErrorsByVariant.root[0];
-      delete dataPathAnyOfPathErrorsByVariant.root;
-      let dataPathAnyOfPathVariants = _.values(dataPathAnyOfPathErrorsByVariant);
+      if (!dataPathOneOfPathErrorsByVariant.root) return;
+      const noMatchingVariantError = dataPathOneOfPathErrorsByVariant.root[0];
+      delete dataPathOneOfPathErrorsByVariant.root;
+      let dataPathOneOfPathVariants = _.values(dataPathOneOfPathErrorsByVariant);
       // 2.2.4 If no variants, set was already filtered by event configuration errors filter
-      if (!dataPathAnyOfPathVariants.length) return;
+      if (!dataPathOneOfPathVariants.length) return;
 
-      if (dataPathAnyOfPathVariants.length > 1) {
+      if (dataPathOneOfPathVariants.length > 1) {
         // 2.2.5 If errors reported for more than one variant
         // 2.2.5.1 Filter variants where value type was not met
-        dataPathAnyOfPathVariants = dataPathAnyOfPathVariants.filter(
-          dataPathAnyOfPathVariantErrors => {
-            if (dataPathAnyOfPathVariantErrors.length !== 1) return true;
-            if (dataPathAnyOfPathVariantErrors[0].keyword !== 'type') return true;
+        dataPathOneOfPathVariants = dataPathOneOfPathVariants.filter(
+          dataPathOneOfPathVariantErrors => {
+            if (dataPathOneOfPathVariantErrors.length !== 1) return true;
+            if (dataPathOneOfPathVariantErrors[0].keyword !== 'type') return true;
             if (
               !isAnyOfPathTypePostfix(
-                dataPathAnyOfPathVariantErrors[0].schemaPath.slice(anyOfPath.length)
+                dataPathOneOfPathVariantErrors[0].schemaPath.slice(oneOfPath.length)
               )
             ) {
               return true;
             }
-            for (const dataPathAnyOfPathVariantError of dataPathAnyOfPathVariantErrors) {
-              resultErrorsSet.delete(dataPathAnyOfPathVariantError);
+            for (const dataPathOneOfPathVariantError of dataPathOneOfPathVariantErrors) {
+              resultErrorsSet.delete(dataPathOneOfPathVariantError);
             }
             return false;
           }
         );
-        if (dataPathAnyOfPathVariants.length > 1) {
+        if (dataPathOneOfPathVariants.length > 1) {
           // 2.2.5.2 Leave out variants where errors address deepest data paths
           let deepestDataPathSize = 0;
-          for (const dataPathAnyOfPathVariantErrors of dataPathAnyOfPathVariants) {
-            dataPathAnyOfPathVariantErrors.deepestDataPathSize = Math.max(
-              ...dataPathAnyOfPathVariantErrors.map(({ dataPath }) => resolveDataPathSize(dataPath))
+          for (const dataPathOneOfPathVariantErrors of dataPathOneOfPathVariants) {
+            dataPathOneOfPathVariantErrors.deepestDataPathSize = Math.max(
+              ...dataPathOneOfPathVariantErrors.map(({ dataPath }) => resolveDataPathSize(dataPath))
             );
-            if (dataPathAnyOfPathVariantErrors.deepestDataPathSize > deepestDataPathSize) {
-              deepestDataPathSize = dataPathAnyOfPathVariantErrors.deepestDataPathSize;
+            if (dataPathOneOfPathVariantErrors.deepestDataPathSize > deepestDataPathSize) {
+              deepestDataPathSize = dataPathOneOfPathVariantErrors.deepestDataPathSize;
             }
           }
 
-          dataPathAnyOfPathVariants = dataPathAnyOfPathVariants.filter(
+          dataPathOneOfPathVariants = dataPathOneOfPathVariants.filter(
             dataPathAnyOfPathVariantErrors => {
               if (dataPathAnyOfPathVariantErrors.deepestDataPathSize === deepestDataPathSize) {
                 return true;
               }
-              for (const dataPathAnyOfPathVariantError of dataPathAnyOfPathVariantErrors) {
-                resultErrorsSet.delete(dataPathAnyOfPathVariantError);
+              for (const dataPathOneOfPathVariantError of dataPathAnyOfPathVariantErrors) {
+                resultErrorsSet.delete(dataPathOneOfPathVariantError);
               }
               return false;
             }
@@ -179,16 +182,16 @@ const filterIrrelevantAnyOfErrors = resultErrorsSet => {
       }
 
       // 2.2.6 If all variants were filtered, expose just "no matching variant" error
-      if (!dataPathAnyOfPathVariants.length) return;
+      if (!dataPathOneOfPathVariants.length) return;
       // 2.2.7 If just one variant left, expose only errors for that variant
-      if (dataPathAnyOfPathVariants.length === 1) {
+      if (dataPathOneOfPathVariants.length === 1) {
         resultErrorsSet.delete(noMatchingVariantError);
         return;
       }
       // 2.2.8 If more than one variant left, expose just "no matching variant" error
-      for (const dataPathAnyOfPathVariantErrors of dataPathAnyOfPathVariants) {
-        for (const dataPathAnyOfPathVariantError of dataPathAnyOfPathVariantErrors) {
-          resultErrorsSet.delete(dataPathAnyOfPathVariantError);
+      for (const dataPathOneOfPathVariantErrors of dataPathOneOfPathVariants) {
+        for (const dataPathOneOfPathVariantError of dataPathOneOfPathVariantErrors) {
+          resultErrorsSet.delete(dataPathOneOfPathVariantError);
         }
       }
     });
@@ -215,9 +218,11 @@ const improveMessages = resultErrorsSet => {
       case 'anyOf':
         if (isEventTypeDataPath(error.dataPath)) {
           error.message = 'unsupported function event';
-        } else {
-          error.message = 'unsupported configuration format';
+          break;
         }
+      // fallthrough
+      case 'oneOf':
+        error.message = 'unsupported configuration format';
         break;
       case 'enum':
         if (error.params.allowedValues.every(value => typeof value === 'string')) {

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -101,6 +101,7 @@ const schema = {
     configValidationMode: { enum: ['error', 'warn', 'off'] },
   },
   additionalProperties: false,
+  requiredProperties: ['provider', 'service'],
   definitions: {
     awsArn: {
       type: 'string',

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -13,6 +13,16 @@ const schema = {
       },
       additionalProperties: false,
     },
+    frameworkVersion: { type: 'string' },
+    disabledDeprecations: {
+      anyOf: [
+        { $ref: '#/definitions/errorCode' },
+        {
+          type: 'array',
+          items: { $ref: '#/definitions/errorCode' },
+        },
+      ],
+    },
 
     custom: {
       type: 'object',
@@ -106,6 +116,10 @@ const schema = {
     awsArn: {
       type: 'string',
       pattern: '^arn:',
+    },
+    errorCode: {
+      type: 'string',
+      pattern: '^[A-Z0-9_]+$',
     },
   },
 };

--- a/tests/fixtures/configSchemaExtensions/serverless.yml
+++ b/tests/fixtures/configSchemaExtensions/serverless.yml
@@ -1,5 +1,9 @@
 service: configSchemaExtensions
 
+frameworkVersion: ^1.70.0
+disabledDeprecations:
+  - SOME_DEP_ERROR
+
 provider:
   name: someProvider
 


### PR DESCRIPTION
- Recognize `frameworkVersion` and `disabledDeprecations` top level properties
- Ensure errors normalization works with externally referenced types (workaround https://github.com/ajv-validator/ajv/issues/1255)
- Ensure to normalize `oneOf` schema errors (aside of `anyOf` which were already properly normalized)