### PR TITLE
fix(Config Schema): validate resourcePolicy is array

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -140,6 +140,16 @@ class AwsProvider {
 
       // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8016
       serverless.configSchemaHandler.defineProvider('aws', {
+        provider: {
+          properties: {
+            resourcePolicy: {
+              type: 'array',
+              items: {
+                type: 'object',
+              },
+            },
+          },
+        },
         function: {
           // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8017
           properties: { handler: { type: 'string' } },


### PR DESCRIPTION
In the AWS provider, the `resourcePolicy` must be an array. If you paste a resource policy from the console, your stack will fail to create.

Closes: #7795 
Addresses: #8018
