### PR TITLE
Adding file() support for other file formats/extensions and support for ES6/TypeScript default exports

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -15,6 +15,8 @@ const resolvedValuesWeak = new WeakSet();
 // Used when resolving variables from a JS file
 const unsupportedJsTypes = new Set(['undefined', 'symbol', 'function']);
 
+const interpret = require('interpret');
+
 /**
  * Maintainer's notes:
  *
@@ -99,6 +101,7 @@ class Variables {
       },
       { regex: this.deepRefSyntax, resolver: this.getValueFromDeep.bind(this) },
     ];
+    this.registered = [];
   }
 
   loadVariableSyntax() {
@@ -674,6 +677,46 @@ class Variables {
     return this.getDeeperValue(deepProperties, valueToPopulate);
   }
 
+  registerExtension(ext) {
+    if( this.registered.indexOf(ext) < 0 ) {
+      const register = (extinfo) => {
+        if( extinfo === null ) {
+          // Default formats should be interpreted by node
+          return true
+        } else if( typeof extinfo === 'string' ) {
+          try {
+            require(extinfo)
+            return true
+          } catch(e) {
+            // If Errors we should ignore (module doesn't exist)
+          }
+        } else if( Array.isArray(extinfo) ) {
+          for(const subext of extinfo) {
+            if( register(subext) ) {
+              return true
+            }
+          }
+        } else if( extinfo.module && extinfo.register ) {
+          try {
+            const mod = require(extinfo.module)
+            extinfo.register(mod)
+            return true
+          } catch(e) {
+            // If Errors we should ignore (module doesn't exist)
+          }
+        }
+        return false
+      }
+      if( register(interpret.extensions[ext]) ) {
+        this.registered.push(ext)
+        return true
+      }
+    } else {
+      return true
+    }
+    return false
+  }
+
   getValueFromFile(variableString) {
     const matchedFileRefString = variableString.match(this.fileRefSyntax)[0];
     const referencedFileRelativePath = matchedFileRefString
@@ -689,17 +732,24 @@ class Variables {
       ? fse.realpathSync(referencedFileFullPath)
       : referencedFileFullPath;
 
-    let fileExtension = referencedFileRelativePath.split('.');
-    fileExtension = fileExtension[fileExtension.length - 1];
     // Validate file exists
     if (!this.serverless.utils.fileExistsSync(referencedFileFullPath)) {
       return BbPromise.resolve(undefined);
     }
 
+    let toProcess = false
+
+    for(const ext of Object.keys(interpret.extensions)) {
+      if( referencedFileRelativePath.substring(referencedFileRelativePath.length-ext.length) === ext ) {
+        toProcess = this.registerExtension(ext)
+        break
+      }
+    }
+
     let valueToPopulate;
 
-    // Process JS files
-    if (fileExtension === 'js') {
+    // Process Module files
+    if (toProcess) {
       // eslint-disable-next-line global-require, import/no-dynamic-require
       const jsFile = require(referencedFileFullPath);
       const variableArray = variableString.split(':');
@@ -714,6 +764,8 @@ class Variables {
 
       if (typeof returnValue === 'function') {
         valueToPopulate = returnValue.call(jsFile, this.serverless);
+      } else if (typeof returnValue === 'object' && typeof returnValue.default === 'function') {
+        valueToPopulate = returnValue.default.call(jsFile, this.serverless);
       } else {
         valueToPopulate = returnValue;
       }
@@ -739,7 +791,7 @@ class Variables {
     }
 
     // Process everything except JS
-    if (fileExtension !== 'js') {
+    if (!toProcess) {
       valueToPopulate = this.serverless.utils.readFileSync(referencedFileFullPath);
       if (matchedFileRefString !== variableString) {
         let deepProperties = variableString.replace(matchedFileRefString, '');

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -748,8 +748,8 @@ class Variables {
 
     let valueToPopulate;
 
-    // Process Module files
     if (toProcess) {
+      // Process Module files
       // eslint-disable-next-line global-require, import/no-dynamic-require
       const jsFile = require(referencedFileFullPath);
       const variableArray = variableString.split(':');
@@ -789,23 +789,20 @@ class Variables {
         );
       });
     }
-
-    // Process everything except JS
-    if (!toProcess) {
-      valueToPopulate = this.serverless.utils.readFileSync(referencedFileFullPath);
-      if (matchedFileRefString !== variableString) {
-        let deepProperties = variableString.replace(matchedFileRefString, '');
-        if (deepProperties.substring(0, 1) !== ':') {
-          const errorMessage = [
-            'Invalid variable syntax when referencing',
-            ` file "${referencedFileRelativePath}" sub properties`,
-            ' Please use ":" to reference sub properties.',
-          ].join('');
-          return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
-        }
-        deepProperties = deepProperties.slice(1).split('.');
-        return this.getDeeperValue(deepProperties, valueToPopulate);
+    // Process everything except Modules
+    valueToPopulate = this.serverless.utils.readFileSync(referencedFileFullPath);
+    if (matchedFileRefString !== variableString) {
+      let deepProperties = variableString.replace(matchedFileRefString, '');
+      if (deepProperties.substring(0, 1) !== ':') {
+        const errorMessage = [
+          'Invalid variable syntax when referencing',
+          ` file "${referencedFileRelativePath}" sub properties`,
+          ' Please use ":" to reference sub properties.',
+        ].join('');
+        return BbPromise.reject(new this.serverless.classes.Error(errorMessage));
       }
+      deepProperties = deepProperties.slice(1).split('.');
+      return this.getDeeperValue(deepProperties, valueToPopulate);
     }
     return BbPromise.resolve(valueToPopulate);
   }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -678,43 +678,43 @@ class Variables {
   }
 
   registerExtension(ext) {
-    if( this.registered.indexOf(ext) < 0 ) {
-      const register = (extinfo) => {
-        if( extinfo === null ) {
+    if (this.registered.indexOf(ext) < 0) {
+      const register = extinfo => {
+        if (extinfo === null) {
           // Default formats should be interpreted by node
-          return true
-        } else if( typeof extinfo === 'string' ) {
+          return true;
+        } else if (typeof extinfo === 'string') {
           try {
-            require(extinfo)
-            return true
-          } catch(e) {
+            require(extinfo);
+            return true;
+          } catch (e) {
             // If Errors we should ignore (module doesn't exist)
           }
-        } else if( Array.isArray(extinfo) ) {
-          for(const subext of extinfo) {
-            if( register(subext) ) {
-              return true
+        } else if (Array.isArray(extinfo)) {
+          for (const subext of extinfo) {
+            if (register(subext)) {
+              return true;
             }
           }
-        } else if( extinfo.module && extinfo.register ) {
+        } else if (extinfo.module && extinfo.register) {
           try {
-            const mod = require(extinfo.module)
-            extinfo.register(mod)
-            return true
-          } catch(e) {
+            const mod = require(extinfo.module);
+            extinfo.register(mod);
+            return true;
+          } catch (e) {
             // If Errors we should ignore (module doesn't exist)
           }
         }
-        return false
-      }
-      if( register(interpret.extensions[ext]) ) {
-        this.registered.push(ext)
-        return true
+        return false;
+      };
+      if (register(interpret.extensions[ext])) {
+        this.registered.push(ext);
+        return true;
       }
     } else {
-      return true
+      return true;
     }
-    return false
+    return false;
   }
 
   getValueFromFile(variableString) {
@@ -737,12 +737,14 @@ class Variables {
       return BbPromise.resolve(undefined);
     }
 
-    let toProcess = false
+    let toProcess = false;
 
-    for(const ext of Object.keys(interpret.extensions)) {
-      if( referencedFileRelativePath.substring(referencedFileRelativePath.length-ext.length) === ext ) {
-        toProcess = this.registerExtension(ext)
-        break
+    for (const ext of Object.keys(interpret.extensions)) {
+      if (
+        referencedFileRelativePath.substring(referencedFileRelativePath.length - ext.length) === ext
+      ) {
+        toProcess = this.registerExtension(ext);
+        break;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "globby": "^9.2.0",
     "graceful-fs": "^4.2.4",
     "https-proxy-agent": "^5.0.0",
+    "interpret": "^2.2.0",
     "is-docker": "^1.1.0",
     "is-wsl": "^2.2.0",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Possibly closes #8071

Adding feature to allow for supporting module files in different formats in accordance with the interpret module.  This module is used in several projects including webpack.

The use of this feature requires the user in install the required registered file processor in order to use that file type, otherwise is treated normally as a file to be included (what the original code did).

Existing supported file formats will work the same.

Examples

TypeScript
```
npm install ts-node typescript @types/serverless
"${file(./config.ts)}"  // can now include typescript modules
```

CoffeeScript
```
npm install coffeescript
"${file(./config.coffee)}" // can now include coffee modules
```

Others
```
"${file(./config.mjs)}"  // Javascript module
"${file(./config.babel.js)}"  // Babel JS file
"${file(./config.iced)}"  // Iced Coffee file
```