### PR TITLE
Replace newlines in SQL statements with spaces

### DIFF
--- a/lib/plugins/aws/package/compile/events/iot/index.js
+++ b/lib/plugins/aws/package/compile/events/iot/index.js
@@ -70,7 +70,7 @@ class AwsCompileIoTEvents {
                     }
                     ${Description ? `"Description": "${Description.replace(/\r?\n/g, '')}",` : ''}
                     "RuleDisabled": "${RuleDisabled}",
-                    "Sql": "${Sql.replace(/\r?\n/g, '')}",
+                    "Sql": "${Sql.replace(/\r?\n/g, ' ').replace(/ +/g, ' ')}",
                     "Actions": [
                       {
                         "Lambda": {

--- a/lib/plugins/aws/package/compile/events/iot/index.test.js
+++ b/lib/plugins/aws/package/compile/events/iot/index.test.js
@@ -249,6 +249,41 @@ describe('AwsCompileIoTEvents', () => {
       ).to.equal('iotEventName');
     });
 
+    it('should replace newlines with spaces if multi-line variables without leading spaces is given', () => {
+      awsCompileIoTEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              iot: {
+                description: 'iot event description\n with newline',
+                sql: "SELECT * FROM 'topic_1'\nWHERE value = 2\n  AND another_value = 3",
+                sqlVersion: 'beta\n',
+                name: 'iotEventName\n',
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileIoTEvents.compileIoTEvents();
+      expect(
+        awsCompileIoTEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstIotTopicRule1.Properties.TopicRulePayload.Sql
+      ).to.equal("SELECT * FROM 'topic_1' WHERE value = 2 AND another_value = 3");
+      expect(
+        awsCompileIoTEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstIotTopicRule1.Properties.TopicRulePayload.AwsIotSqlVersion
+      ).to.equal('beta');
+      expect(
+        awsCompileIoTEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstIotTopicRule1.Properties.TopicRulePayload.Description
+      ).to.equal('iot event description with newline');
+      expect(
+        awsCompileIoTEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstIotTopicRule1.Properties.RuleName
+      ).to.equal('iotEventName');
+    });
+
     it('should not create corresponding resources when iot events are not given', () => {
       awsCompileIoTEvents.serverless.service.functions = {
         first: {


### PR DESCRIPTION
This change updates the IoT rule SQL normalization
to allow for multi-line SQL statements *without*
having to pad lines with whitespace.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8073
