### PR TITLE
Config Schema: Report configuration errors as warnings

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -7,6 +7,7 @@ const normalizeAjvErrors = require('./normalizeAjvErrors');
 
 const FUNCTION_NAME_PATTERN = '^[a-zA-Z0-9-_]+$';
 const ERROR_PREFIX = 'Configuration error';
+const WARNING_PREFIX = 'Configuration warning';
 
 const normalizeSchemaObject = (object, instanceSchema) => {
   for (const [key, value] of _.entries(object)) {
@@ -43,27 +44,29 @@ class ConfigSchemaHandler {
     if (!this.schema.properties.provider.properties.name) {
       if (this.serverless.service.configValidationMode !== 'off') {
         this.serverless.cli.log(
-          `Configuration error: Unrecognized provider '${this.serverless.service.provider.name}'`,
+          `${WARNING_PREFIX}: Unrecognized provider '${this.serverless.service.provider.name}'`,
           'Serverless',
-          { color: 'red' }
+          { color: 'orangered' }
         );
+        this.serverless.cli.log(' ');
         this.serverless.cli.log(
           "You're relying on provider plugin which doesn't " +
             'provide a validation schema for its config.',
           'Serverless',
-          { color: 'grey' }
+          { color: 'orange' }
         );
         this.serverless.cli.log(
           'Please report the issue at its bug tracker linking: ' +
             'https://www.serverless.com/framework/docs/providers/aws/guide/plugins#extending-validation-schema',
           'Serverless',
-          { color: 'grey' }
+          { color: 'orange' }
         );
         this.serverless.cli.log(
-          'You may turn off this message with `configValidationMode: off` setting',
+          'You may turn off this message with "configValidationMode: off" setting',
           'Serverless',
-          { color: 'grey' }
+          { color: 'orange' }
         );
+        this.serverless.cli.log(' ');
       }
 
       this.relaxProviderSchema();
@@ -95,40 +98,45 @@ class ConfigSchemaHandler {
         throw new this.serverless.classes.Error(errorMessage);
       } else {
         if (messages.length === 1) {
-          this.serverless.cli.log(`${ERROR_PREFIX} ${messages[0]}`, 'Serverless', { color: 'red' });
+          this.serverless.cli.log(`${WARNING_PREFIX} ${messages[0]}`, 'Serverless', {
+            color: 'orangered',
+          });
         } else {
-          this.serverless.cli.log(`${ERROR_PREFIX}:`, 'Serverless', { color: 'red' });
+          this.serverless.cli.log(`${WARNING_PREFIX}:`, 'Serverless', {
+            color: 'orangered',
+          });
           for (const message of messages) {
-            this.serverless.cli.log(`- ${message}`, 'Serverless', { color: 'red' });
+            this.serverless.cli.log(`  ${message}`, 'Serverless', { color: 'orangered' });
           }
         }
+        this.serverless.cli.log(' ');
         this.serverless.cli.log(
-          'If you prefer to not continue when error in configuration is approached, ensure ' +
-            '`configValidationMode: error` in your config',
+          'If you prefer to not continue ensure "configValidationMode: error" in your config',
           'Serverless',
-          { color: 'grey' }
+          { color: 'orange' }
         );
         this.serverless.cli.log(
           'If errors are influenced by an external plugin, enquiry at plugin repository so ' +
             'schema extensions are added ' +
             '(https://www.serverless.com/framework/docs/providers/aws/guide/plugins#extending-validation-schema)',
           'Serverless',
-          { color: 'grey' }
+          { color: 'orange' }
         );
         this.serverless.cli.log(
           'If errors seem invalid, please report at ' +
             'https://github.com/serverless/serverless/issues/new?template=bug_report.md',
           'Serverless',
           {
-            color: 'grey',
+            color: 'orange',
           }
         );
         this.serverless.cli.log(
           'If you find this functionality problematic, you may turn it off with ' +
-            '`configValidationMode: off` setting',
+            '"configValidationMode: off" setting',
           'Serverless',
-          { color: 'grey' }
+          { color: 'orange' }
         );
+        this.serverless.cli.log(' ');
       }
     }
   }


### PR DESCRIPTION


<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8084 

Additionally all configuration errors are reported as _warnings_, as by default they behave as warnings (let process continue), while "error" gives an impression action was stopped.