### PR TITLE
Fix Automatically exclude aws-sdk from Node.js lambda bundles

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -16,6 +16,7 @@ module.exports = {
     'yarn-*.log',
     '.serverless/**',
     '.serverless_plugins/**',
+    'node_modules/aws-sdk/**',
   ],
 
   getIncludes(include) {


### PR DESCRIPTION
Closes: #8096 