### PR TITLE
fix typo in 'provider' in var name

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -49,7 +49,7 @@ class AwsCompileS3Events {
     const bucketsLambdaConfigurations = {};
     const bucketsMeta = {};
     const s3EnabledFunctions = [];
-    const provderS3 = this.serverless.service.provider.s3 || {};
+    const providerS3 = this.serverless.service.provider.s3 || {};
     const errorMessageBucketSyntax =
       'The correct syntax is: "s3: bucketName or bucketRef or an object with "bucket" property.';
 
@@ -117,8 +117,8 @@ class AwsCompileS3Events {
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             let bucketName;
-            if (provderS3[bucketRef]) {
-              bucketName = provderS3[bucketRef].name || bucketRef;
+            if (providerS3[bucketRef]) {
+              bucketName = providerS3[bucketRef].name || bucketRef;
               const logicalId = this.provider.naming.getBucketLogicalId(bucketRef);
               bucketsMeta[bucketName] = { logicalId, bucketRef };
             } else {
@@ -175,7 +175,7 @@ class AwsCompileS3Events {
     _.forEach(bucketsLambdaConfigurations, (bucketLambdaConfiguration, bucketName) => {
       let bucketConf = null;
       if (bucketsMeta[bucketName]) {
-        const providerBucket = provderS3[bucketsMeta[bucketName].bucketRef];
+        const providerBucket = providerS3[bucketsMeta[bucketName].bucketRef];
         bucketConf = {};
         for (const [key, value] of _.entries(providerBucket)) {
           if (key !== 'name') {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->
Q1: Provide link to corresponding issue

No issue - trivial change. Fixing typo in variable name: 'provderS3' -> 'providerS3'
