### PR TITLE
Config Schema: Improve definitions naming

### DIFF
--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -118,7 +118,7 @@ const schema = {
       type: 'string',
       pattern: '^arn:',
     },
-    cfImport: {
+    awsCfImport: {
       type: 'object',
       properties: {
         'Fn::ImportValue': { type: 'string' },

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -186,7 +186,7 @@ class AwsProvider {
                     },
                   ],
                 },
-                id: { oneOf: [{ type: 'string' }, { $ref: '#/definitions/cfImport' }] },
+                id: { oneOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfImport' }] },
                 name: { type: 'string' },
                 payload: { type: 'string' },
                 timeout: { type: 'number', minimum: 0.05, maximum: 30 },


### PR DESCRIPTION
Rename `cfImport` definition to `awsCfImport` (to maintain provider agnostic feel)