### PR TITLE
Switch default payload mode to 2.0

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -12,6 +12,14 @@ layout: Doc
 
 `maximumEventAge` and `maximumRetryAttempts` should be defined directly at function level. Support for those settings on `destinations` level, will be removed with v2.0.0
 
+<a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
+
+## AWS HTTP API payload format
+
+Default HTTP API Payload version will be switched to 2.0 with next major release (For more details see [payload format documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format))
+
+Configure `httpApi.payload` explicitly to ensure seamless migration.
+
 <a name="OUTDATED_NODEJS"><div>&nbsp;</div></a>
 
 ## Outdated Node.js version

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -12,14 +12,6 @@ layout: Doc
 
 `maximumEventAge` and `maximumRetryAttempts` should be defined directly at function level. Support for those settings on `destinations` level, will be removed with v2.0.0
 
-<a name="AWS_HTTP_API_VERSION"><div>&nbsp;</div></a>
-
-## AWS HTTP API payload format
-
-Default HTTP API Payload version will be switched to 2.0 with next major release (For more details see [payload format documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format))
-
-Configure `httpApi.payload` explicitly to ensure seamless migration.
-
 <a name="OUTDATED_NODEJS"><div>&nbsp;</div></a>
 
 ## Outdated Node.js version

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -478,18 +478,11 @@ Object.defineProperties(
       const providerConfig = this.serverless.service.provider;
       const userConfig = providerConfig.httpApi || {};
 
-      if (!userConfig.payload) {
-        this.serverless._logDeprecation(
-          'AWS_HTTP_API_VERSION',
-          'Default HTTP API Payload version will be switched to 2.0 with next major release. Configure "httpApi.payload" explicitly to hide this message.'
-        );
-      }
-
       const properties = {
         ApiId: this.getApiIdConfig(),
         IntegrationType: 'AWS_PROXY',
         IntegrationUri: resolveTargetConfig(routeTargetData),
-        PayloadFormatVersion: userConfig.payload || '1.0',
+        PayloadFormatVersion: userConfig.payload || '2.0',
       };
       if (routeTargetData.timeout) {
         properties.TimeoutInMillis = Math.round(routeTargetData.timeout * 1000);

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -77,7 +77,7 @@ describe('HttpApiEvents', () => {
       const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
       expect(resource.Type).to.equal('AWS::ApiGatewayV2::Integration');
       expect(resource.Properties.IntegrationType).to.equal('AWS_PROXY');
-      expect(resource.Properties.PayloadFormatVersion).to.equal('1.0');
+      expect(resource.Properties.PayloadFormatVersion).to.equal('2.0');
     });
     it('Should ensure higher timeout than function', () => {
       const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];


### PR DESCRIPTION
- Changed default payload version to 2.0
- Removed deprecation warning from both code & documentation

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/tests/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/tests/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #7917
