### PR TITLE
chore(aws): remove deprecated support for maximumEventAge & maximumRetryAttempts on destination

### DIFF
--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -581,40 +581,19 @@ class AwsCompileFunctions {
 
   compileFunctionEventInvokeConfig(functionName) {
     const functionObject = this.serverless.service.getFunction(functionName);
-    const {
-      destinations,
-      maximumEventAge: maximumEventAgeOnFunction,
-      maximumRetryAttempts: maximumRetryAttemptsOnFunction,
-    } = functionObject;
-    let maximumEventAgeOnDestinations;
-    let maximumRetryAttemptsOnDestinations;
+    const { destinations, maximumEventAge, maximumRetryAttempts } = functionObject;
 
-    if (!destinations && !maximumEventAgeOnFunction && maximumRetryAttemptsOnFunction == null) {
+    if (!destinations && !maximumEventAge && maximumRetryAttempts == null) {
       return;
     }
 
     const destinationConfig = {};
 
     if (destinations) {
-      if (destinations.maximumRetryAttempts != null) {
-        this.serverless._logDeprecation(
-          'AWS_FUNCTION_DESTINATIONS_ASYNC_CONFIG',
-          'destinations.maximumRetryAttempts is deprecated, use maximumRetryAttempts on function instead'
-        );
-        maximumRetryAttemptsOnDestinations = destinations.maximumRetryAttempts;
-      }
-
-      if (destinations.maximumEventAge) {
-        this.serverless._logDeprecation(
-          'AWS_FUNCTION_DESTINATIONS_ASYNC_CONFIG',
-          'destinations.maximumEventAge is deprecated, use maximumEventAge on function instead'
-        );
-        maximumEventAgeOnDestinations = destinations.maximumEventAge;
-      }
-
       const hasAccessPoliciesHandledExternally = Boolean(
         functionObject.role || this.serverless.service.provider.role
       );
+
       if (destinations.onSuccess) {
         if (!hasAccessPoliciesHandledExternally) {
           this.ensureTargetExecutionPermission(destinations.onSuccess);
@@ -625,6 +604,7 @@ class AwsCompileFunctions {
             : this.provider.resolveFunctionArn(destinations.onSuccess),
         };
       }
+
       if (destinations.onFailure) {
         if (!hasAccessPoliciesHandledExternally) {
           this.ensureTargetExecutionPermission(destinations.onFailure);
@@ -639,13 +619,6 @@ class AwsCompileFunctions {
 
     const cfResources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-
-    const maximumEventAge = maximumEventAgeOnFunction || maximumEventAgeOnDestinations;
-    // For maximumRetryAttempts we cannot rely on "||" as the value can be Falsy, 0
-    const maximumRetryAttempts =
-      maximumRetryAttemptsOnFunction == null
-        ? maximumRetryAttemptsOnDestinations
-        : maximumRetryAttemptsOnFunction;
 
     const resource = {
       Type: 'AWS::Lambda::EventInvokeConfig',

--- a/lib/plugins/aws/package/compile/functions/index.test.js
+++ b/lib/plugins/aws/package/compile/functions/index.test.js
@@ -2725,54 +2725,6 @@ describe('AwsCompileFunctions #2', () => {
         );
     });
 
-    it('Should support maximumEventAge defined on destination', () => {
-      const maximumEventAge = 3600;
-      return fixtures
-        .extend('functionDestinations', {
-          functions: { trigger: { destinations: { maximumEventAge } } },
-        })
-        .then(fixturePath =>
-          runServerless({
-            cwd: fixturePath,
-            cliArgs: ['package'],
-          }).then(({ awsNaming, cfTemplate }) => {
-            const cfResources = cfTemplate.Resources;
-            const naming = awsNaming;
-            const eventInvokeConfig =
-              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
-
-            expect(eventInvokeConfig.MaximumEventAgeInSeconds).to.equal(maximumEventAge);
-          })
-        );
-    });
-
-    it('Should prefer maximumEventAge defined on function over defined on destination', () => {
-      const maximumEventAgeOnFunction = 3600;
-      const maximumEventAgeOnDestination = 7200;
-      return fixtures
-        .extend('functionDestinations', {
-          functions: {
-            trigger: {
-              maximumEventAge: maximumEventAgeOnFunction,
-              destinations: { maximumEventAge: maximumEventAgeOnDestination },
-            },
-          },
-        })
-        .then(fixturePath =>
-          runServerless({
-            cwd: fixturePath,
-            cliArgs: ['package'],
-          }).then(({ awsNaming, cfTemplate }) => {
-            const cfResources = cfTemplate.Resources;
-            const naming = awsNaming;
-            const eventInvokeConfig =
-              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
-
-            expect(eventInvokeConfig.MaximumEventAgeInSeconds).to.equal(maximumEventAgeOnFunction);
-          })
-        );
-    });
-
     it('Should support maximumRetryAttempts defined on function', () => {
       const maximumRetryAttempts = 0;
       return fixtures
@@ -2790,54 +2742,6 @@ describe('AwsCompileFunctions #2', () => {
               cfResources[naming.getLambdaEventConfigLogicalId('foo')].Properties;
 
             expect(eventInvokeConfig.MaximumRetryAttempts).to.equal(maximumRetryAttempts);
-          })
-        );
-    });
-
-    it('Should support maximumRetryAttempts defined on destination', () => {
-      const maximumRetryAttempts = 0;
-      return fixtures
-        .extend('functionDestinations', {
-          functions: { trigger: { destinations: { maximumRetryAttempts } } },
-        })
-        .then(fixturePath =>
-          runServerless({
-            cwd: fixturePath,
-            cliArgs: ['package'],
-          }).then(({ awsNaming, cfTemplate }) => {
-            const cfResources = cfTemplate.Resources;
-            const naming = awsNaming;
-            const eventInvokeConfig =
-              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
-
-            expect(eventInvokeConfig.MaximumRetryAttempts).to.equal(maximumRetryAttempts);
-          })
-        );
-    });
-
-    it('Should prefer maximumRetryAttempts defined on function over on destination', () => {
-      const maximumRetryAttemptsOnFunction = 0;
-      const maximumRetryAttemptsOnDestination = 1;
-      return fixtures
-        .extend('functionDestinations', {
-          functions: {
-            trigger: {
-              maximumRetryAttempts: maximumRetryAttemptsOnFunction,
-              destinations: { maximumRetryAttempts: maximumRetryAttemptsOnDestination },
-            },
-          },
-        })
-        .then(fixturePath =>
-          runServerless({
-            cwd: fixturePath,
-            cliArgs: ['package'],
-          }).then(({ awsNaming, cfTemplate }) => {
-            const cfResources = cfTemplate.Resources;
-            const naming = awsNaming;
-            const eventInvokeConfig =
-              cfResources[naming.getLambdaEventConfigLogicalId('trigger')].Properties;
-
-            expect(eventInvokeConfig.MaximumRetryAttempts).to.equal(maximumRetryAttemptsOnFunction);
           })
         );
     });


### PR DESCRIPTION
Removes support and deprecation message for `maximumEventAge` and `maximumRetryAttempts` set on `function.destinations` level. 

I've decided to leave the note in `docs/deprecations.md` as I'm not sure if the intention is to keep that historic information or clean it up and only show "current" deprecations. Please let me know if it should be removed.

Closes: #8119 
