### PR TITLE
feat(aws): schema for `resources` when using AWS provider

### DIFF
--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -175,14 +175,16 @@ describe('Service', () => {
           resources: [
             {
               Resources: {
-                aws: {
-                  resourcesProp: 'value',
+                resource1: {
+                  Type: 'value',
                 },
               },
             },
             {
               Resources: {
-                azure: {},
+                resource2: {
+                  Type: 'value2',
+                },
               },
             },
           ],
@@ -195,8 +197,8 @@ describe('Service', () => {
         )
         .then(({ cfTemplate: { Resources } }) => {
           expect(Resources).to.be.an('object');
-          expect(Resources.aws).to.deep.equal({ resourcesProp: 'value' });
-          expect(Resources.azure).to.deep.equal({});
+          expect(Resources.resource1).to.deep.equal({ Type: 'value' });
+          expect(Resources.resource2).to.deep.equal({ Type: 'value2' });
         }));
 
     it('should merge functions given as an array', () =>

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -220,6 +220,15 @@ class AwsProvider {
             required: ['Fn::Sub'],
             additionalProperties: false,
           },
+          awsResourceProperties: {
+            Properties: { type: 'object' },
+            CreationPolicy: { type: 'object' },
+            DeletionPolicy: { type: 'string' },
+            DependsOn: { type: 'array', items: { type: 'string' } },
+            Metadata: { type: 'object' },
+            UpdatePolicy: { type: 'object' },
+            UpdateReplacePolicy: { type: 'string' },
+          },
         },
         provider: {
           properties: {
@@ -323,8 +332,76 @@ class AwsProvider {
             },
           },
         },
-        // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8014
-        resources: { type: 'object' },
+        resources: {
+          properties: {
+            AWSTemplateFormatVersion: {
+              type: 'string',
+            },
+            Description: {
+              type: 'string',
+            },
+            Metadata: {
+              type: 'object',
+            },
+            Parameters: {
+              type: 'object',
+            },
+            Mappings: {
+              type: 'object',
+            },
+            Conditions: {
+              type: 'object',
+            },
+            Transform: {
+              type: 'object',
+            },
+            // Not replicating the full JSON schema from https://s3.amazonaws.com/cfn-resource-specifications-us-east-1-prod/schemas/2.15.0/all-spec.json
+            // as that gets into the specifics for each resource type.
+            //
+            // The only required attribute is `Type`; `Properties` and other common attributes are optional.
+            // See also https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+            Resources: {
+              type: 'object',
+              patternProperties: {
+                '^[a-zA-Z0-9]{1,255}$': {
+                  type: 'object',
+                  properties: {
+                    $ref: '#/definitions/awsResourceProperties',
+                  },
+                  additionalProperties: {
+                    Type: { type: 'string' },
+                  },
+                },
+              },
+              additionalProperties: false,
+            },
+            extensions: {
+              type: 'object',
+              patternProperties: {
+                // names have the same restrictions as CloudFormation Resources section
+                '^[a-zA-Z0-9]{1,255}$': {
+                  type: 'object',
+                  // this lists the supported properties, other properties are "Not supported. An error will be thrown
+                  // if you try to extend an unsupported attribute."
+                  // this is different than the above schema for `Resources`, which allows the `Type` attribute.
+                  // extensions are explicitly meant to extend the definition of existing resources.
+                  properties: {
+                    $ref: '#/definitions/awsResourceProperties',
+                  },
+                  additionalProperties: false,
+                },
+              },
+              additionalProperties: false,
+            },
+            // According to https://s3.amazonaws.com/cfn-resource-specifications-us-east-1-prod/schemas/2.15.0/all-spec.json
+            // `Outputs` is just an "object", though it seems like this is under-specifying that section a bit.
+            // See also https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
+            Outputs: {
+              type: 'object',
+            },
+          },
+          additionalProperties: false,
+        },
       });
     }
     this.requestCache = {};


### PR DESCRIPTION
Adds schema for the `resources` top-level element when using the AWS provider.

Does not add tests as directed in #8051. I've run a small manual test.

Addresses: #8118 (flags input issue but error could be better if validation was done before `mergeArrays`, see [comment](https://github.com/serverless/serverless/issues/8118#issuecomment-681058721))
Closes: #8014 (does not cover non-AWS providers)