### PR TITLE
Config schema improvements

### DIFF
--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -521,6 +521,11 @@ class NewProviderPlugin {
 
     // Create schema for your provider. For reference use https://github.com/ajv-validator/ajv
     serverless.configSchemaHandler.defineProvider('newProvider', {
+      // Eventual reusable schema definitions (will be put to top level "definitions" object)
+      definitions: {
+        // ...
+      },
+
       // Top level "provider" properties
       provider: {
         properties: {

--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -521,17 +521,20 @@ class NewProviderPlugin {
 
     // Create schema for your provider. For reference use https://github.com/ajv-validator/ajv
     serverless.configSchemaHandler.defineProvider('newProvider', {
+      // Top level "provider" properties
       provider: {
         properties: {
           stage: { type: 'string' },
           remoteFunctionData: { type: 'null' },
         },
       },
+
+      // Function level properties
       function: {
         properties: { handler: { type: 'string' } },
       },
 
-      // You can define event schemas here or via `defineFunctionEvent` helper
+      // Function events definitions (can be defined here or via `defineFunctionEvent` helper)
       functionEvents: {
         someEvent: {
           name: 'someEvent',

--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -554,6 +554,14 @@ class NewProviderPlugin {
           },
         },
       },
+
+      // Definition for eventual top level "resources" section
+      resources: {
+        type: 'object',
+        properties: {
+          // ...
+        },
+      },
     });
   }
 }

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -32,7 +32,6 @@ class ConfigSchemaHandler {
     deepFreeze(this.schema.properties.plugins);
     deepFreeze(this.schema.properties.package);
     Object.freeze(this.schema.properties.layers);
-    Object.freeze(this.schema.properties.resources);
   }
 
   validateConfig(userConfig) {
@@ -173,6 +172,8 @@ class ConfigSchemaHandler {
         this.defineFunctionEvent(name, functionName, options.functionEvents[functionName]);
       }
     }
+
+    if (options.resources) this.schema.properties.resources = options.resources;
 
     // In case provider implementers do not set stage or variableSyntax options,
     // then they are set here. The framework internally sets these options in

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -151,6 +151,10 @@ class ConfigSchemaHandler {
       return;
     }
 
+    if (options.definitions) {
+      Object.assign(this.schema.definitions, options.definitions);
+    }
+
     this.schema.properties.provider.properties.name = { const: name };
 
     if (options.provider) {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -185,16 +185,13 @@ class Service {
   }
 
   validate() {
-    const userConfig = this.initialServerlessConfig || {};
+    const userConfig = Object.assign({}, this.initialServerlessConfig || {});
     userConfig.service = this.serviceObject;
-    userConfig.custom = this.custom;
-    userConfig.plugins = this.plugins;
-    userConfig.resources = this.resources;
-    userConfig.functions = this.functions;
     userConfig.provider = this.provider;
-    userConfig.package = this.package;
-    userConfig.layers = this.layers;
-    userConfig.configValidationMode = this.configValidationMode;
+
+    // Ensure to validate normalized (after mergeArrays) input
+    if (userConfig.functions) userConfig.functions = this.functions;
+    if (userConfig.resources) userConfig.resources = this.resources;
 
     if (this.serviceObject && this.configValidationMode !== 'off') {
       this.serverless.configSchemaHandler.validateConfig(userConfig);

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -33,9 +33,6 @@ const schema = {
     },
     plugins: { type: 'array', items: { type: 'string' } },
 
-    // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8014
-    resources: { type: 'object' },
-
     functions: {
       type: 'object',
       patternProperties: {

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -114,18 +114,6 @@ const schema = {
   additionalProperties: false,
   required: ['provider', 'service'],
   definitions: {
-    awsArn: {
-      type: 'string',
-      pattern: '^arn:',
-    },
-    awsCfImport: {
-      type: 'object',
-      properties: {
-        'Fn::ImportValue': { type: 'string' },
-      },
-      additionalProperties: false,
-      required: ['Fn::ImportValue'],
-    },
     errorCode: {
       type: 'string',
       pattern: '^[A-Z0-9_]+$',

--- a/lib/configSchema.test.js
+++ b/lib/configSchema.test.js
@@ -58,17 +58,10 @@ describe('#configSchema', () => {
 
     {
       isValid: true,
-      description: 'custom and resources properties',
+      description: 'custom properties',
       mutation: {
         custom: {
           some: 'valid property',
-        },
-        resources: {
-          Resources: {
-            SomeBucket: {
-              some: 'prop',
-            },
-          },
         },
       },
     },

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -140,6 +140,20 @@ class AwsProvider {
 
       // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8016
       serverless.configSchemaHandler.defineProvider('aws', {
+        definitions: {
+          awsArn: {
+            type: 'string',
+            pattern: '^arn:',
+          },
+          awsCfImport: {
+            type: 'object',
+            properties: {
+              'Fn::ImportValue': { type: 'string' },
+            },
+            additionalProperties: false,
+            required: ['Fn::ImportValue'],
+          },
+        },
         provider: {
           properties: {
             httpApi: {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -251,6 +251,8 @@ class AwsProvider {
             },
           },
         },
+        // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8014
+        resources: { type: 'object' },
       });
     }
     this.requestCache = {};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@serverless/cli": "^1.5.2",
     "@serverless/components": "^2.34.7",
-    "@serverless/enterprise-plugin": "^3.7.1",
+    "@serverless/enterprise-plugin": "^3.8.1",
     "@serverless/inquirer": "^1.1.2",
     "@serverless/utils": "^1.2.0",
     "ajv": "^6.12.4",

--- a/tests/mocha-reporter.js
+++ b/tests/mocha-reporter.js
@@ -6,6 +6,12 @@ const { _ensureArtifact } = require('../lib/utils/getEnsureArtifact');
 
 disableServerlessStatsRequests(path.resolve(__dirname, '..'));
 
+const BbPromise = require('bluebird');
+
+BbPromise.config({
+  longStackTraces: true,
+});
+
 module.exports = require('@serverless/test/setup/mocha-reporter');
 
 module.exports.deferredRunner.then(runner => {


### PR DESCRIPTION
- Ensure to validate direct user config input (where applicable)
- Allow providers to provide its own definitions. Make AWS specific definitions to be defined by AWS provider
- Define `resources` fully in context of provider (move current definition to AWS provider context)