### PR TITLE
Revert "Fix Automatically exclude aws-sdk from Node.js lambda bundles"

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -16,7 +16,6 @@ module.exports = {
     'yarn-*.log',
     '.serverless/**',
     '.serverless_plugins/**',
-    'node_modules/aws-sdk/**',
   ],
 
   getIncludes(include) {


### PR DESCRIPTION
Reverts serverless/serverless#8103

Due to reasons mentioned here: https://github.com/serverless/serverless/issues/8096#issuecomment-682219305

Including `aws-sdk` as dependency signals intent to bundle it