### PR TITLE
fix(Variables): Fix when properties are null

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -949,7 +949,7 @@ class Variables {
           reducedValue = this.appendDeepVariable(reducedValue, subProperty);
         } else {
           // get mode
-          if (typeof reducedValue === 'undefined') {
+          if (typeof reducedValue === 'undefined' || reducedValue === null) {
             reducedValue = {};
           } else if (subProperty !== '' || '' in reducedValue) {
             reducedValue = reducedValue[subProperty];

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -949,7 +949,7 @@ class Variables {
           reducedValue = this.appendDeepVariable(reducedValue, subProperty);
         } else {
           // get mode
-          if (typeof reducedValue === 'undefined' || reducedValue === null) {
+          if (reducedValue == null) {
             reducedValue = {};
           } else if (subProperty !== '' || '' in reducedValue) {
             reducedValue = reducedValue[subProperty];


### PR DESCRIPTION
I thought this qualifies for a small and obvious bug, so I did not open an issue.

What is happening is when my file is empty, `reducedValue` is `null` and throws an error that the variable could not be found. See error below.

```
  TypeError: Cannot read property 'XXXXXXXXXXXXXXXXXXXXXXX' of null
      at C:\dev\XXXXX\node_modules\serverless\lib\classes\Variables.js:891:40
      at tryCatcher (C:\dev\XXXXX\node_modules\bluebird\js\release\util.js:16:23)
      at Object.gotValue (C:\dev\XXXXX\node_modules\bluebird\js\release\reduce.js:157:18)
      at Object.gotAccum (C:\dev\XXXXX\node_modules\bluebird\js\release\reduce.js:144:25)
      at Object.tryCatcher (C:\dev\XXXXX\node_modules\bluebird\js\release\util.js:16:23)
      at Promise._settlePromiseFromHandler (C:\dev\XXXXX\node_modules\bluebird\js\release\promise.js:517:31)
      at Promise._settlePromise (C:\dev\XXXXX\node_modules\bluebird\js\release\promise.js:574:18)
      at Promise._settlePromiseCtx (C:\dev\XXXXX\node_modules\bluebird\js\release\promise.js:611:10)
      at _drainQueueStep (C:\dev\XXXXX\node_modules\bluebird\js\release\async.js:142:12)
      at _drainQueue (C:\dev\XXXXX\node_modules\bluebird\js\release\async.js:131:9)
      at Async._drainQueues (C:\dev\XXXXX\node_modules\bluebird\js\release\async.js:147:5)
      at Immediate.Async.drainQueues [as _onImmediate] (C:\dev\XXXXX\node_modules\bluebird\js\release\async.js:17:14)
      at processImmediate (internal/timers.js:456:21)
      at process.topLevelDomainCallback (domain.js:137:15)
```
