### PR TITLE
Fix handling of pre-releases in frameworkVersion validation

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -68,7 +68,11 @@ class Service {
     // basic service level validation
     const version = this.serverless.utils.getVersion();
     const ymlVersion = serverlessFile.frameworkVersion;
-    if (ymlVersion && !semver.satisfies(version, ymlVersion)) {
+    if (
+      ymlVersion &&
+      version !== ymlVersion &&
+      !semver.satisfies(semver.coerce(version).raw, ymlVersion)
+    ) {
       const errorMessage = [
         `The Serverless version (${version}) does not satisfy the`,
         ` "frameworkVersion" (${ymlVersion}) in ${this.serviceFilename}`,

--- a/lib/classes/Service.test.js
+++ b/lib/classes/Service.test.js
@@ -140,12 +140,32 @@ describe('Service', () => {
       ).to.eventually.be.rejected.and.have.property('code', 'FRAMEWORK_VERSION_MISMATCH'));
 
     it('should pass if frameworkVersion is satisfied', () =>
-      fixtures.extend('configTypeYml', { frameworkVersion: version }).then(fixturePath =>
-        runServerless({
-          cwd: fixturePath,
-          cliArgs: ['print'],
-        })
-      ));
+      fixtures
+        .extend('configTypeYml', { frameworkVersion: version })
+        .then(fixturePath =>
+          runServerless({
+            cwd: fixturePath,
+            cliArgs: ['print'],
+          })
+        )
+        .then(() =>
+          fixtures.extend('configTypeYml', { frameworkVersion: '*' }).then(fixturePath =>
+            runServerless({
+              cwd: fixturePath,
+              cliArgs: ['print'],
+            })
+          )
+        )
+        .then(() =>
+          fixtures
+            .extend('configTypeYml', { frameworkVersion: version.split('.')[0] })
+            .then(fixturePath =>
+              runServerless({
+                cwd: fixturePath,
+                cliArgs: ['print'],
+              })
+            )
+        ));
   });
 
   describe('#mergeArrays', () => {

--- a/test/integration-all/file-system-config/tests.js
+++ b/test/integration-all/file-system-config/tests.js
@@ -12,7 +12,11 @@ const { createTestService, deployService, removeService } = require('../../utils
 
 const EFS_MAX_PROPAGATION_TIME = 1000 * 60 * 5;
 
-const retryableMountErrors = new Set(['EFSMountFailureException', 'EFSMountTimeoutException']);
+const retryableMountErrors = new Set([
+  'EFSMountFailureException',
+  'EFSMountTimeoutException',
+  'EFSIOException',
+]);
 
 describe('AWS - FileSystemConfig Integration Test', function() {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys


### PR DESCRIPTION
Some of our tests (https://github.com/serverless/serverless/pull/8163/checks?check_run_id=1057358350)  in v2 pre-release branch got broken when `frameworkVersion` was [unconditionally added](https://github.com/serverless/test/commit/a35fb51f5f0809a46823bc55f025ae0cb01c0041) to serverless configurations.

It's due to pre-releases not being matched by `*` version range (reason unknown -> https://github.com/npm/node-semver/issues/329)

This patch ensures, that `*` matches pre-releases as well.

Additionally provided workaround for EFS integration test CI fail:  https://github.com/serverless/serverless/runs/1056731807