### PR TITLE
AWS HTTP API: Convert "timeout" usage warnings to deprecations

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,6 +6,14 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
+<a name="AWS_HTTP_API_TIMEOUT"><div>&nbsp;</div></a>
+
+## AWS HTTP API `timeout`
+
+`provider.httpApi.timeout` and `functions[].events[].httpApi.timeout` settings will no longer be recognized with v2.0.0.
+
+Endpoints are configured to automatically follow timeout setting as configured on functions (with extra margin needed to process HTTP request on AWS side)
+
 <a name="MISSING_FRAMEWORK_VERSION"><div>&nbsp;</div></a>
 
 ## Missing `frameworkVersion` in service configuration

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -304,8 +304,9 @@ Object.defineProperties(
       }
 
       if (userConfig.timeout) {
-        logWarning(
-          'provider.httpApi.timeout is deprecated. ' +
+        this.serverless._logDeprecation(
+          'AWS_HTTP_API_TIMEOUT',
+          '"provider.httpApi.timeout" is deprecated. ' +
             'HTTP API endpoints are configured to follow timeout setting as set for functions.'
         );
       }
@@ -440,8 +441,9 @@ Object.defineProperties(
         const functionTimeout =
           Number(functionData.timeout) || Number(this.serverless.service.provider.timeout) || 6;
         if (routeTargetData.timeout) {
-          logWarning(
-            `httpApi.timeout is deprecated (found one defined for '${functionName}'s endpoint). ` +
+          this.serverless._logDeprecation(
+            'AWS_HTTP_API_TIMEOUT',
+            `"functions[].events.httpApi.timeout" is deprecated (found one defined for '${functionName}'s endpoint). ` +
               'HTTP API endpoints are configured to follow timeout setting as set for functions.'
           );
           if (functionTimeout >= routeTargetData.timeout) {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses: #8087
