### PR TITLE
Fix  invalid `frameworkVersion` handling, ensure it in all templates

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ServerlessError = require('./Error').ServerlessError;
+const { ServerlessError, logWarning } = require('./Error');
 const path = require('path');
 const _ = require('lodash');
 const BbPromise = require('bluebird');
@@ -68,7 +68,19 @@ class Service {
     const serverlessFile = serverlessFileParam;
     // basic service level validation
     const version = this.serverless.utils.getVersion();
-    const ymlVersion = serverlessFile.frameworkVersion;
+    let ymlVersion = serverlessFile.frameworkVersion;
+    if (ymlVersion && !semver.validRange(ymlVersion)) {
+      if (serverlessFile.configValidationMode === 'error') {
+        throw new ServerlessError(
+          'Configured "frameworkVersion" does not represent a valid semver version range.',
+          'INVALID_FRAMEWORK_VERSION'
+        );
+      }
+      logWarning(
+        'Configured "frameworkVersion" does not represent a valid semver version range, version validation is skipped'
+      );
+      ymlVersion = null;
+    }
     if (!this.isLocallyInstalled && !ymlVersion) {
       this.serverless._logDeprecation(
         'MISSING_FRAMEWORK_VERSION',

--- a/lib/plugins/create/templates/aliyun-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aliyun-nodejs/serverless.yml
@@ -11,6 +11,8 @@
 
 service: aliyun-nodejs
 
+frameworkVersion: '1'
+
 provider:
   name: aliyun
   runtime: nodejs8

--- a/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
@@ -4,6 +4,8 @@ service:
 #app: your-app-name
 #org: your-org-name
 
+frameworkVersion: '1'
+
 plugins:
   - serverless-webpack
   - serverless-alexa-skills

--- a/lib/plugins/create/templates/aws-clojure-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-clojure-gradle/serverless.yml
@@ -19,7 +19,7 @@ service: aws-clojure
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-clojurescript-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-clojurescript-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-clojurescript-gradle
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -18,7 +18,7 @@ service: aws-csharp # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-fsharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-fsharp/serverless.yml
@@ -18,7 +18,7 @@ service: aws-fsharp # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-go-dep/serverless.yml
+++ b/lib/plugins/create/templates/aws-go-dep/serverless.yml
@@ -18,8 +18,7 @@ service: aws-go-dep # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
-frameworkVersion: '>=1.28.0 <2.0.0'
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-go-mod/serverless.yml
+++ b/lib/plugins/create/templates/aws-go-mod/serverless.yml
@@ -18,8 +18,7 @@ service: aws-go-mod # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
-frameworkVersion: '>=1.28.0 <2.0.0'
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-go/serverless.yml
+++ b/lib/plugins/create/templates/aws-go/serverless.yml
@@ -18,8 +18,7 @@ service: aws-go # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
-frameworkVersion: '>=1.28.0 <2.0.0'
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-groovy-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-groovy-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-groovy-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-java-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -18,7 +18,7 @@ service: aws-java-maven # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle-kts/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle-kts/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-jvm-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-jvm-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-jvm-maven # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-nodejs-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -3,6 +3,7 @@ service:
 # app and org for use with dashboard.serverless.com
 #app: your-app-name
 #org: your-org-name
+frameworkVersion: '1'
 
 # Add the serverless-webpack plugin
 plugins:

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
@@ -7,7 +7,7 @@ const serverlessConfiguration: Serverless = {
     // app: your-app-name,
     // org: your-org-name,
   },
-  frameworkVersion: '>=1.72.0',
+  frameworkVersion: '1',
   custom: {
     webpack: {
       webpackConfig: './webpack.config.js',

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -18,7 +18,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-provided/serverless.yml
+++ b/lib/plugins/create/templates/aws-provided/serverless.yml
@@ -18,7 +18,7 @@ service: aws-provided # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -18,7 +18,7 @@ service: aws-python # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-python3/serverless.yml
+++ b/lib/plugins/create/templates/aws-python3/serverless.yml
@@ -18,7 +18,7 @@ service: aws-python3 # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-ruby/serverless.yml
+++ b/lib/plugins/create/templates/aws-ruby/serverless.yml
@@ -18,7 +18,7 @@ service: aws-ruby # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -18,7 +18,7 @@ service: aws-scala-sbt # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/azure-csharp/serverless.yml
+++ b/lib/plugins/create/templates/azure-csharp/serverless.yml
@@ -15,7 +15,7 @@ service: azure-dotnet # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: azure

--- a/lib/plugins/create/templates/azure-nodejs-typescript/serverless.yml
+++ b/lib/plugins/create/templates/azure-nodejs-typescript/serverless.yml
@@ -15,7 +15,7 @@ service: azure-nodejs-typescript # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 custom:
   webpack:

--- a/lib/plugins/create/templates/azure-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/azure-nodejs/serverless.yml
@@ -15,7 +15,7 @@ service: azure-nodejs # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: azure

--- a/lib/plugins/create/templates/azure-python/serverless.yml
+++ b/lib/plugins/create/templates/azure-python/serverless.yml
@@ -15,7 +15,7 @@ service: azure-python # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-# frameworkVersion: "=X.X.X"
+frameworkVersion: '1'
 
 provider:
   name: azure

--- a/lib/plugins/create/templates/cloudflare-workers-enterprise/serverless.yml
+++ b/lib/plugins/create/templates/cloudflare-workers-enterprise/serverless.yml
@@ -1,6 +1,8 @@
 service:
   name: hello-world
 
+frameworkVersion: '1'
+
 provider:
   name: cloudflare
   config:

--- a/lib/plugins/create/templates/cloudflare-workers-rust/serverless.yml
+++ b/lib/plugins/create/templates/cloudflare-workers-rust/serverless.yml
@@ -1,6 +1,8 @@
 service:
   name: hello-world
 
+frameworkVersion: '1'
+
 provider:
   name: cloudflare
   config:

--- a/lib/plugins/create/templates/cloudflare-workers/serverless.yml
+++ b/lib/plugins/create/templates/cloudflare-workers/serverless.yml
@@ -1,5 +1,6 @@
 service:
   name: hello-world
+frameworkVersion: '1'
 
 provider:
   name: cloudflare

--- a/lib/plugins/create/templates/fn-go/serverless.yml
+++ b/lib/plugins/create/templates/fn-go/serverless.yml
@@ -10,6 +10,8 @@ service:
 #    config:
 #        some: 'val'
 
+frameworkVersion: '1'
+
 # The `provider` block defines where your service will be deployed
 provider:
   name: fn

--- a/lib/plugins/create/templates/fn-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/fn-nodejs/serverless.yml
@@ -10,6 +10,8 @@ service:
 #    config:
 #        some: 'val'
 
+frameworkVersion: '1'
+
 # The `provider` block defines where your service will be deployed
 provider:
   name: fn

--- a/lib/plugins/create/templates/google-go/serverless.yml
+++ b/lib/plugins/create/templates/google-go/serverless.yml
@@ -10,6 +10,8 @@ provider:
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 
+frameworkVersion: '1'
+
 plugins:
   - serverless-google-cloudfunctions
 

--- a/lib/plugins/create/templates/google-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/google-nodejs/serverless.yml
@@ -12,6 +12,8 @@ provider:
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 
+frameworkVersion: '1'
+
 plugins:
   - serverless-google-cloudfunctions
 

--- a/lib/plugins/create/templates/google-python/serverless.yml
+++ b/lib/plugins/create/templates/google-python/serverless.yml
@@ -12,6 +12,7 @@ provider:
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 
+frameworkVersion: '1'
 plugins:
   - serverless-google-cloudfunctions
 

--- a/lib/plugins/create/templates/hello-world/serverless.yml
+++ b/lib/plugins/create/templates/hello-world/serverless.yml
@@ -7,6 +7,8 @@
 # The `service` block is the name of the service
 service: serverless-hello-world
 
+frameworkVersion: '1'
+
 # The `provider` block defines where your service will be deployed
 provider:
   name: aws

--- a/lib/plugins/create/templates/knative-docker/serverless.yml
+++ b/lib/plugins/create/templates/knative-docker/serverless.yml
@@ -1,5 +1,7 @@
 service: knative
 
+frameworkVersion: '1'
+
 provider:
   name: knative
   # optional Docker Hub credentials you need if you're using local Dockerfiles as function handlers

--- a/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
@@ -9,6 +9,8 @@
 # Update the service name below with your own service name
 service: capitalize
 
+frameworkVersion: '1'
+
 # Please ensure the serverless-kubeless provider plugin is installed globally.
 # $ npm install -g serverless-kubeless
 #


### PR DESCRIPTION
Addresses issue exposed by integration test fail: https://github.com/serverless/serverless/runs/1061141362

- Ensure `frameworkVersion` in all templates (as a follow up to #8158, where it's announced it'll be a required property when relying on non global serverless installation)
- Validate `frameworkVersion` prior pursuing a compliant version check, as version check will resolve to `false` with invalid version range, not indicating that our version range was configured improperly