### PR TITLE
Revert from `frameworkVersion` requirement

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -22,14 +22,6 @@ You may adapt to this behavior now by setting `enableLocalInstallationFallback: 
 
 Endpoints are configured to automatically follow timeout setting as configured on functions (with extra margin needed to process HTTP request on AWS side)
 
-<a name="MISSING_FRAMEWORK_VERSION"><div>&nbsp;</div></a>
-
-## Missing `frameworkVersion` in service configuration
-
-Starting from v2.0.0 `frameworkVersion` will be a required in service configuration, when relying on a globally installed `serverless` package.
-
-It's to ensure that major release upgrades do not accidentally break service deployments (and new major releases are planned to be published more frequently that it was in a past)
-
 <a name="SLSS_CLI_ALIAS"><div>&nbsp;</div></a>
 
 ## `slss` alias

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -81,12 +81,11 @@ class Service {
       );
       ymlVersion = null;
     }
-    if (!this.isLocallyInstalled && !ymlVersion) {
-      this.serverless._logDeprecation(
-        'MISSING_FRAMEWORK_VERSION',
-        'Ensure "frameworkVersion" setting in your service configuration ' +
-          `(recommended setup:  "frameworkVersion: ^${currentVersion}")\n` +
-          "It'll be a required setting (when relying on globally installed Framework) starting with next major release"
+    if (!this.isLocallyInstalled && !ymlVersion && process.env.SLS_DEBUG) {
+      this.serverless.cli.log(
+        'To ensure safe major version upgrades ensure "frameworkVersion" setting in ' +
+          'service configuration ' +
+          `(recommended setup: "frameworkVersion: ^${currentVersion}")\n`
       );
     }
     if (


### PR DESCRIPTION
It was internally decided to not imply this requirement. Instead `frameworkVersion` recommendation is shown when Framework is used in _debug_ model.

/cc @ac360 