### PR TITLE
AWS HTTP API: Drop support for `timeout` setting

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -79,7 +79,6 @@ class HttpApiEvents {
             },
             method: { type: 'string', regexp: methodPattern.toString() },
             path: { type: 'string', regexp: /^(?:\*|\/\S*)$/.toString() },
-            timeout: { type: 'number', minimum: 0.05, maximum: 30 },
           },
           required: ['path'],
           additionalProperties: false,
@@ -303,13 +302,6 @@ Object.defineProperties(
           })}`;
       }
 
-      if (userConfig.timeout) {
-        this.serverless._logDeprecation(
-          'AWS_HTTP_API_TIMEOUT',
-          '"provider.httpApi.timeout" is deprecated. ' +
-            'HTTP API endpoints are configured to follow timeout setting as set for functions.'
-        );
-      }
       for (const [functionName, functionData] of _.entries(this.serverless.service.functions)) {
         const routeTargetData = {
           functionName,
@@ -323,9 +315,8 @@ Object.defineProperties(
           let method;
           let path;
           let authorizer;
-          let timeout;
           if (_.isObject(event.httpApi)) {
-            ({ method, path, authorizer, timeout } = event.httpApi);
+            ({ method, path, authorizer } = event.httpApi);
           } else {
             const methodPath = String(event.httpApi);
             if (methodPath === '*') {
@@ -415,17 +406,6 @@ Object.defineProperties(
             }
             if (scopes) routeConfig.authorizationScopes = toSet(scopes);
           }
-          if (!timeout) timeout = userConfig.timeout || null;
-          if (typeof routeTargetData.timeout !== 'undefined') {
-            if (routeTargetData.timeout !== timeout) {
-              throw new this.serverless.classes.Error(
-                `Inconsistent timeout settings for ${functionName} events`,
-                'INCONSISTENT_HTTP_API_TIMEOUT'
-              );
-            }
-          } else {
-            routeTargetData.timeout = timeout;
-          }
           routes.set(routeKey, routeConfig);
           if (shouldFillCorsMethods) {
             if (event.resolvedMethod === 'ANY') {
@@ -440,42 +420,27 @@ Object.defineProperties(
         if (!hasHttpApiEvents) continue;
         const functionTimeout =
           Number(functionData.timeout) || Number(this.serverless.service.provider.timeout) || 6;
-        if (routeTargetData.timeout) {
-          this.serverless._logDeprecation(
-            'AWS_HTTP_API_TIMEOUT',
-            `"functions[].events.httpApi.timeout" is deprecated (found one defined for '${functionName}'s endpoint). ` +
-              'HTTP API endpoints are configured to follow timeout setting as set for functions.'
+
+        if (functionTimeout > 29) {
+          logWarning(
+            `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
+              'maximum allowed timeout for HTTP API endpoint (29s). ' +
+              'This may introduce a situation where endpoint times out ' +
+              'for a succesful lambda invocation.'
           );
-          if (functionTimeout >= routeTargetData.timeout) {
-            logWarning(
-              `HTTP API endpoint timeout setting (${routeTargetData.timeout}s) is ` +
-                `lower or equal to function (${functionName}) timeout (${functionTimeout}s). ` +
-                'This may introduce a situation where endpoint times out ' +
-                'for a succesful lambda invocation.'
-            );
-          }
-        } else {
-          if (functionTimeout > 29) {
-            logWarning(
-              `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
-                'maximum allowed timeout for HTTP API endpoint (29s). ' +
-                'This may introduce a situation where endpoint times out ' +
-                'for a succesful lambda invocation.'
-            );
-          } else if (functionTimeout === 29) {
-            logWarning(
-              `Function (${functionName}) timeout setting (${functionTimeout}) may not provide ` +
-                'enough room to process an HTTP API request (of which timeout is limited to 29s). ' +
-                'This may introduce a situation where endpoint times out ' +
-                'for a succesful lambda invocation.'
-            );
-          }
-          // Ensure endpoint has slightly larger timeout than a function,
-          // It's a margin needed for some side processing time on AWS side.
-          // Otherwise there's a risk of observing 503 status for successfully resolved invocation
-          // (which just fit function timeout setting)
-          routeTargetData.timeout = Math.min(functionTimeout + 0.5, 29);
+        } else if (functionTimeout === 29) {
+          logWarning(
+            `Function (${functionName}) timeout setting (${functionTimeout}) may not provide ` +
+              'enough room to process an HTTP API request (of which timeout is limited to 29s). ' +
+              'This may introduce a situation where endpoint times out ' +
+              'for a succesful lambda invocation.'
+          );
         }
+        // Ensure endpoint has slightly larger timeout than a function,
+        // It's a margin needed for some side processing time on AWS side.
+        // Otherwise there's a risk of observing 503 status for successfully resolved invocation
+        // (which just fit function timeout setting)
+        routeTargetData.timeout = Math.min(functionTimeout + 0.5, 29);
       }
     }),
     compileIntegration: d(function(routeTargetData) {

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -641,45 +641,4 @@ describe('HttpApiEvents', () => {
       });
     });
   });
-
-  describe('Timeout', () => {
-    let cfResources;
-    let naming;
-
-    before(() =>
-      fixtures
-        .extend('httpApi', {
-          provider: { httpApi: { timeout: 3 } },
-          functions: {
-            other: {
-              events: [
-                {
-                  httpApi: {
-                    timeout: 20.56,
-                  },
-                },
-              ],
-            },
-          },
-        })
-        .then(fixturePath =>
-          runServerless({
-            cwd: fixturePath,
-            cliArgs: ['package'],
-          }).then(({ awsNaming, cfTemplate }) => {
-            ({ Resources: cfResources } = cfTemplate);
-            naming = awsNaming;
-          })
-        )
-    );
-
-    it('Should support timeout set at endpoint', () => {
-      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('other')];
-      expect(resource.Properties.TimeoutInMillis).to.equal(20560);
-    });
-    it('Should support globally set timeout', () => {
-      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
-      expect(resource.Properties.TimeoutInMillis).to.equal(3000);
-    });
-  });
 });

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -275,7 +275,6 @@ class AwsProvider {
                 },
                 name: { type: 'string' },
                 payload: { type: 'string' },
-                timeout: { type: 'number', minimum: 0.05, maximum: 30 },
               },
               additionalProperties: false,
             },


### PR DESCRIPTION
BREAKING CHANGE:
`timeout` setting as configured directly for `httpApi` event,  is no longer supported.  Timeout value is now unconditionally resolved from  function timeout setting. It's to guarantee that configured endpoint has necessary room to process function invocation

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8087
