### PR TITLE
 Remove "update-notifier"notifications

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -3,12 +3,9 @@
 const path = require('path');
 const BbPromise = require('bluebird');
 const os = require('os');
-const chalk = require('chalk');
 const ensureString = require('type/string/ensure');
-const updateNotifier = require('update-notifier');
 const resolve = require('ncjsm/resolve');
 const isModuleNotFoundError = require('ncjsm/is-module-not-found-error');
-const pkg = require('../package.json');
 const CLI = require('./classes/CLI');
 const Config = require('./classes/Config');
 const YamlParser = require('./classes/YamlParser');
@@ -22,8 +19,6 @@ const Version = require('./../package.json').version;
 const isStandaloneExecutable = require('./utils/isStandaloneExecutable');
 const resolveCliInput = require('./utils/resolveCliInput');
 const logDeprecation = require('./utils/logDeprecation');
-
-const installationMaintananceCommands = new Set(['uninstall', 'upgrade']);
 
 class Serverless {
   constructor(config) {
@@ -84,22 +79,6 @@ class Serverless {
         // set the options and commands which were processed by the CLI
         this.pluginManager.setCliOptions(this.processedInput.options);
         this.pluginManager.setCliCommands(this.processedInput.commands);
-
-        if (!installationMaintananceCommands.has(this.processedInput.commands[0])) {
-          // Check if update is available
-          const notifier = updateNotifier({ pkg });
-          if (notifier.update && notifier.update.type !== 'major') {
-            notifier.notify({
-              message: isStandaloneExecutable
-                ? `Update available ${chalk.dim(notifier.update.current)}${chalk.reset(
-                    ' → '
-                  )}${chalk.green(notifier.update.latest)} \nRun ${chalk.cyan(
-                    'serverless upgrade'
-                  )} to update`
-                : null,
-            });
-          }
-        }
 
         return this.service
           .load(this.processedInput.options)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "timers-ext": "^0.1.7",
     "type": "^2.1.0",
     "untildify": "^3.0.3",
-    "update-notifier": "^2.5.0",
     "uuid": "^3.4.0",
     "write-file-atomic": "^2.4.3",
     "yaml-ast-parser": "0.0.43",


### PR DESCRIPTION
It's replaced with backend notifications, which are more powerful as through which we can also notify about updates across different major releases

