### PR TITLE
Add "deadline_ms" to the local context

### DIFF
--- a/lib/plugins/aws/invokeLocal/fixture/handler.rb
+++ b/lib/plugins/aws/invokeLocal/fixture/handler.rb
@@ -6,6 +6,10 @@ def withRemainingTime(event:, context:)
   {"start" => start, "stop" => stop}
 end
 
+def withDeadlineMs(event:, context:)
+  {"deadlineMs" => context.deadline_ms}
+end
+
 module MyModule
   class MyClass
     def self.my_class_method(event:, context:)

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1070,6 +1070,26 @@ describe('AwsInvokeLocal', () => {
           );
       });
     });
+
+    describe('context.deadlineMs', () => {
+      it('should return deadline', function() {
+        awsInvokeLocal.serverless.config.servicePath = __dirname;
+
+        return awsInvokeLocal.invokeLocalRuby('ruby', 'fixture/handler', 'withDeadlineMs').then(
+          () => {
+            log.debug('test target %o', serverless.cli.consoleLog.lastCall.args);
+            const result = JSON.parse(serverless.cli.consoleLog.lastCall.args[0]);
+            expect(result.deadlineMs).to.be.closeTo(Date.now() + 6000, 1000);
+          },
+          error => {
+            if (error.code === 'ENOENT' && error.path === 'ruby') {
+              skipWithNotice(this, 'Ruby runtime is not installed', afterEachCallback);
+            }
+            throw error;
+          }
+        );
+      });
+    });
   });
 
   describe('#callJavaBridge()', () => {

--- a/lib/plugins/aws/invokeLocal/runtimeWrappers/invoke.rb
+++ b/lib/plugins/aws/invokeLocal/runtimeWrappers/invoke.rb
@@ -37,6 +37,10 @@ class FakeLambdaContext
     return Time.now.strftime('%Y/%m/%d') +'/[$' + function_version + ']58419525dade4d17a495dceeeed44708'
   end
 
+  def deadline_ms
+    (@created_time + @timeout).to_i * 1000
+  end
+
   def log(message)
     puts message
   end


### PR DESCRIPTION
This property was previously missing from the fake lambda context when running ruby functions locally.

Ref: https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html

To recreate:

* create a new serverless ruby project, e.g.: `serverless create --template aws-ruby --path sls-ruby-fix`
* add the following in to the generated "hello" function: `puts "deadline_ms: #{context.deadline_ms}"`

Prior to this fix, it will fail with `undefined method `deadline_ms' for #<FakeLambdaContext:0x00007ffcf115e078> (NoMethodError)`

After this fix, the deadline will be printed to stdout.

