### PR TITLE
AWS Stream: Fix support for `batchWindow: 0`

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -228,7 +228,7 @@ class AwsCompileStreamEvents {
               );
             }
 
-            if (event.stream.batchWindow) {
+            if (event.stream.batchWindow != null) {
               streamResource.Properties.MaximumBatchingWindowInSeconds = event.stream.batchWindow;
             }
 

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -399,6 +399,7 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:dynamodb:region:account:table/buzz/stream/4',
                   bisectBatchOnFunctionError: true,
+                  batchWindow: 0,
                   maximumRecordAgeInSeconds: 120,
                 },
               },
@@ -548,6 +549,10 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.MaximumRecordAgeInSeconds
         ).to.equal(120);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.MaximumBatchingWindowInSeconds
+        ).to.equal(0);
 
         // event 5
         expect(


### PR DESCRIPTION
`0` is a value supported by AWS, yet it was not recognized on our side

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumbatchingwindowinseconds