### PR TITLE
update naming.getModelLogicalId() to remove whitespace in contentType (plugins/aws/lib/naming)

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -31,6 +31,9 @@ module.exports = {
   normalizeNameToAlphaNumericOnly(name) {
     return this.normalizeName(name.replace(/[^0-9A-Za-z]/g, ''));
   },
+  toStartCase(name) {
+    return _.startCase(name).replace(/\s+/g, '');
+  },
   normalizePathPart(rawPath) {
     return _.upperFirst(
       _.capitalize(rawPath)
@@ -285,10 +288,9 @@ module.exports = {
     return `${this.getMethodLogicalId(resourceId, methodName)}Validator`;
   },
   getModelLogicalId(resourceId, methodName, contentType) {
-    return `${this.getMethodLogicalId(resourceId, methodName)}${_.startCase(contentType).replace(
-      ' ',
-      ''
-    )}Model`;
+    return `${this.getMethodLogicalId(resourceId, methodName)}${this.toStartCase(
+      contentType
+    ).replace(' ', '')}Model`;
   },
   getApiKeyLogicalId(apiKeyNumber, apiKeyName) {
     if (apiKeyName) {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -413,6 +413,9 @@ describe('#naming()', () => {
       expect(sdk.naming.getModelLogicalId('ResourceId', 'get', 'application/json')).to.equal(
         'ApiGatewayMethodResourceIdGetApplicationJsonModel'
       );
+      expect(
+        sdk.naming.getModelLogicalId('Example', 'post', 'application/x-www-form-urlencoded')
+      ).to.equal('ApiGatewayMethodExamplePostApplicationXWwwFormUrlencodedModel');
     });
   });
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8191

This change includes the following:

* a `toStartCase()` method was added to the `naming` object (under `plugins/aws/lib`) to replace the regular usage of `_.startCase()`. This method returns a string in title/start case, without replacing non-alpha-numeric characters with whitespace. If an alternative solution is preferable (e.g. one that doesn't use the existing `_.startCase()` method), I'm definitely open to changing this.

* `naming.getModelLogicalId()` was also updated to use the method mentioned above, and a simple unit test was added to cover the case detailed in #8191

* Since this might affect AWS functionality, I went ahead and ran the AWS integration tests (which passed).

Feel free to point out any issues or suggestions – Thanks! 🙂