### PR TITLE
DX: Throw if missing RoleName in Custom function role

### DIFF
--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -77,13 +77,10 @@ class AwsDeployFunction {
         if (roleResource.Type !== 'AWS::IAM::Role') {
           throw new Error('Provided resource is not IAM Role.');
         }
-
-        const roleProperties = roleResource.Properties;
-        
         if (!roleProperties.RoleName) {
           throw new Error('Role resource missing RoleName properties');
         }
-          
+        const roleProperties = roleResource.Properties;
         const compiledFullRoleName = `${roleProperties.Path || '/'}${roleProperties.RoleName}`;
 
         return this.provider

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -79,6 +79,11 @@ class AwsDeployFunction {
         }
 
         const roleProperties = roleResource.Properties;
+        
+        if (!roleProperties.RoleName) {
+          throw new Error('Role resource missing RoleName properties');
+        }
+          
         const compiledFullRoleName = `${roleProperties.Path || '/'}${roleProperties.RoleName}`;
 
         return this.provider

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -77,10 +77,10 @@ class AwsDeployFunction {
         if (roleResource.Type !== 'AWS::IAM::Role') {
           throw new Error('Provided resource is not IAM Role.');
         }
-        if (!roleProperties.RoleName) {
-          throw new Error('Role resource missing RoleName properties');
-        }
         const roleProperties = roleResource.Properties;
+        if (!roleProperties.RoleName) {
+          throw new this.serverless.classes.Error('Role resource missing RoleName property');
+        }
         const compiledFullRoleName = `${roleProperties.Path || '/'}${roleProperties.RoleName}`;
 
         return this.provider


### PR DESCRIPTION
If `RoleName` is missing in a [custom function role](https://www.serverless.com/framework/docs/providers/aws/guide/iam/#custom-iam-roles) this passes through `undefined` and single `sls deploy -f funcName` fails with a hard to decipher error: 

```
  Serverless Error ---------------------------------------

  ServerlessError: The role defined for the function cannot be assumed by Lambda.
      at /service/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:330:27
      at processTicksAndRejections (internal/process/task_queues.js:85:5)
```

After turning on SLS_DEBUG I found the issue where the IAM role name was  `undefined`

```
Serverless: [AWS lambda 400 0.417s 0 retries] updateFunctionConfiguration({
  FunctionName: 'service-dev-addNewUser',
  Description: 'Add user test function. Gated by imported Managed policy',
  Handler: 'examples/new-user.handler',
  Role: 'arn:aws:iam::01200101001:role/undefined'
})
```

This PR will throw an error if this value is missing (aka `undefined`) & the `updateFunctionConfiguration` won't be called with incorrect values


---

![image](https://user-images.githubusercontent.com/532272/92787993-6e3a2080-f35e-11ea-9159-cee5ec0b7ac8.png)


