### PR TITLE
Knative Quick Start Docs Typo Fix

### DIFF
--- a/docs/providers/knative/guide/quick-start.md
+++ b/docs/providers/knative/guide/quick-start.md
@@ -62,6 +62,7 @@ Now that you’ve completed your setup, let’s create and deploy a serverless S
 ````sh
 # Create a new Serverless service/project
 $ serverless create --template knative-docker --path my-service
+```
 
 2. Install the dependencies
 
@@ -69,7 +70,7 @@ $ serverless create --template knative-docker --path my-service
 # Change into the newly created directory
 $ cd my-service
 $ npm install
-````
+```
 
 ### Set up Knative
 


### PR DESCRIPTION
This fixes a simple typo with two different code blocks in the quick start for knative.