### PR TITLE
Upgrade "uuid" to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "timers-ext": "^0.1.7",
     "type": "^2.1.0",
     "untildify": "^3.0.3",
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.0",
     "write-file-atomic": "^2.4.3",
     "yaml-ast-parser": "0.0.43",
     "yargs-parser": "^18.1.3"


### PR DESCRIPTION
As we dropped support for Node.js v6, we can safely upgrade to latest version