### PR TITLE
Upgrade "chalk" to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "^3.7.2",
     "boxen": "^4.2.0",
     "cachedir": "^2.3.0",
-    "chalk": "^2.4.2",
+    "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",
     "d": "^1.0.1",
     "dayjs": "^1.8.35",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version