### PR TITLE
Switch from "fast-levenshtein" to "fastest-levenshtein"

### DIFF
--- a/lib/utils/getCommandSuggestion.js
+++ b/lib/utils/getCommandSuggestion.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const _ = require('lodash');
 const levenshtein = require('fast-levenshtein');
 

--- a/lib/utils/getCommandSuggestion.js
+++ b/lib/utils/getCommandSuggestion.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const levenshtein = require('fast-levenshtein');
+const { distance: getDistance } = require('fastest-levenshtein');
 
 const getCollectCommandWords = (commandObject, commandWordsArray) => {
   let wordsArray =
@@ -20,7 +20,7 @@ const getCommandSuggestion = (inputCommand, allCommandsObject) => {
   const commandWordsArray = getCollectCommandWords(allCommandsObject);
   let minValue = 0;
   commandWordsArray.forEach(correctCommand => {
-    const distance = levenshtein.get(inputCommand, correctCommand);
+    const distance = getDistance(inputCommand, correctCommand);
     if (minValue === 0) {
       suggestion = correctCommand;
       minValue = distance;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "decompress": "^4.2.1",
     "download": "^8.0.0",
     "essentials": "^1.1.1",
-    "fast-levenshtein": "^2.0.6",
+    "fastest-levenshtein": "^1.0.12",
     "filesize": "^6.1.0",
     "fs-extra": "^8.1.0",
     "get-stdin": "^8.0.0",


### PR DESCRIPTION
As `fast-levenshtein` was upgraded to use `fastest-levenshtein` under the hood