### PR TITLE
Upgrade "filesize" to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "download": "^7.1.0",
     "essentials": "^1.1.1",
     "fast-levenshtein": "^2.0.6",
-    "filesize": "^3.6.1",
+    "filesize": "^6.1.0",
     "fs-extra": "^8.1.0",
     "get-stdin": "^6.0.0",
     "globby": "^11.0.1",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version