### PR TITLE
Upgrade "fs-extra" to v9

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -45,11 +45,11 @@ class Utils {
   }
 
   writeFileDir(filePath) {
-    return fse.mkdirsSync(path.dirname(filePath));
+    fse.mkdirsSync(path.dirname(filePath));
   }
 
   writeFileSync(filePath, contents, cycles) {
-    return writeFileSync(filePath, contents, cycles);
+    writeFileSync(filePath, contents, cycles);
   }
 
   writeFile(filePath, contents, cycles) {

--- a/lib/classes/Utils.test.js
+++ b/lib/classes/Utils.test.js
@@ -62,15 +62,11 @@ describe('Utils', () => {
   describe('#writeFileDir()', () => {
     it('should create a directory for the path of the given file', () => {
       const tmpDirPath = getTmpDirPath();
-      const rootDir = serverless.utils.writeFileDir(
-        path.join(tmpDirPath, 'foo', 'bar', 'somefile.js')
-      );
-
-      expect(serverless.utils.dirExistsSync(path.join(rootDir, 'foo', 'bar'))).to.equal(true);
+      const fileDir = path.join(tmpDirPath, 'foo', 'bar');
+      serverless.utils.writeFileDir(path.join(fileDir, 'somefile.js'));
+      expect(serverless.utils.dirExistsSync(fileDir)).to.equal(true);
       // it should only create the directories and not the file
-      expect(
-        serverless.utils.fileExistsSync(path.join(rootDir, 'foo', 'bar', 'somefile.js'))
-      ).to.equal(false);
+      expect(serverless.utils.fileExistsSync(path.join(fileDir, 'somefile.js'))).to.equal(false);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "essentials": "^1.1.1",
     "fast-levenshtein": "^2.0.6",
     "filesize": "^6.1.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.0.1",
     "get-stdin": "^8.0.0",
     "globby": "^11.0.1",
     "graceful-fs": "^4.2.4",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version