### PR TITLE
Upgrade "get-stdin" to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-levenshtein": "^2.0.6",
     "filesize": "^3.6.1",
     "fs-extra": "^8.1.0",
-    "get-stdin": "^6.0.0",
+    "get-stdin": "^8.0.0",
     "globby": "^11.0.1",
     "graceful-fs": "^4.2.4",
     "https-proxy-agent": "^5.0.0",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version