### PR TITLE
Upgrade "is-docker" to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "globby": "^11.0.1",
     "graceful-fs": "^4.2.4",
     "https-proxy-agent": "^5.0.0",
-    "is-docker": "^1.1.0",
+    "is-docker": "^2.1.1",
     "is-wsl": "^2.2.0",
     "js-yaml": "^3.14.0",
     "json-cycle": "^1.3.0",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version