### PR TITLE
Upgrade "p-limit" to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ncjsm": "^4.1.0",
     "node-fetch": "^2.6.1",
     "object-hash": "^2.0.3",
-    "p-limit": "^2.3.0",
+    "p-limit": "^3.0.2",
     "promise-queue": "^2.2.5",
     "rc": "^1.2.8",
     "replaceall": "^0.1.6",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version