### PR TITLE
Upgrade "yargs-parser" to v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "uuid": "^8.3.0",
     "write-file-atomic": "^2.4.3",
     "yaml-ast-parser": "0.0.43",
-    "yargs-parser": "^18.1.3"
+    "yargs-parser": "^20.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",


### PR DESCRIPTION
As we dropped support for Node.js v8, we can safely upgrade to latest version