### PR TITLE
Ensure to reference v2 in `frameworkVersion` in docs

### DIFF
--- a/docs/providers/aliyun/guide/services.md
+++ b/docs/providers/aliyun/guide/services.md
@@ -140,7 +140,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: '=1.0.3'
+frameworkVersion: '2.1.0'
 ```
 
 #### Version Range
@@ -148,7 +148,7 @@ frameworkVersion: '=1.0.3'
 ```yml
 # serverless.yml
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 ```
 
 ## Installing Serverless in an existing service

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -23,7 +23,7 @@ service:
   name: myService
   awsKmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash # Optional KMS key arn which will be used for encryption for all functions
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: '2'
 enableLocalInstallationFallback: false # If set to 'true', guarantees that it's a locally (for service, in its node_modules) installed framework which processes the command
 
 disabledDeprecations: # Disable deprecation logs by their codes. Default is empty.

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -228,7 +228,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: "=1.0.3"
+frameworkVersion: '2.1.0'
 
 service: users
 
@@ -245,7 +245,7 @@ provider:
 ```yml
 # serverless.yml
 
-frameworkVersion: ">=1.0.0 <2.0.0"
+frameworkVersion: "^2.1.0" # >=2.1.0 && <3.0.0
 
 service: users
 

--- a/docs/providers/azure/guide/function-apps.md
+++ b/docs/providers/azure/guide/function-apps.md
@@ -150,7 +150,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: "=1.0.3"
+frameworkVersion: '2.1.0'
 
 …
 ```
@@ -160,7 +160,7 @@ frameworkVersion: "=1.0.3"
 ```yml
 # serverless.yml
 
-frameworkVersion: ">=1.0.0 <2.0.0"
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 
 …
 ```

--- a/docs/providers/azure/guide/serverless.yml.md
+++ b/docs/providers/azure/guide/serverless.yml.md
@@ -20,7 +20,7 @@ Here is a list of all available properties in `serverless.yml` when the provider
 # serverless.yml
 service: azure-nodejs
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: '2'
 
 provider:
   name: azure

--- a/docs/providers/cloudflare/guide/services.md
+++ b/docs/providers/cloudflare/guide/services.md
@@ -165,7 +165,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: '=1.0.3'
+frameworkVersion: '2.1.0'
 ```
 
 #### Version Range
@@ -173,7 +173,7 @@ frameworkVersion: '=1.0.3'
 ```yml
 # serverless.yml
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 ```
 
 ## Installing Serverless in an existing service

--- a/docs/providers/google/guide/services.md
+++ b/docs/providers/google/guide/services.md
@@ -145,7 +145,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: '=1.0.3'
+frameworkVersion: '2.1.0'
 ```
 
 #### Version Range
@@ -153,7 +153,7 @@ frameworkVersion: '=1.0.3'
 ```yml
 # serverless.yml
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 ```
 
 ## Installing Serverless in an existing service

--- a/docs/providers/knative/guide/services.md
+++ b/docs/providers/knative/guide/services.md
@@ -140,13 +140,13 @@ To configure version pinning define a `frameworkVersion` property in your server
 #### Exact Version
 
 ```yaml
-frameworkVersion: '=1.0.3'
+frameworkVersion: '2.1.0'
 ```
 
 #### Version Range
 
 ```yaml
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 ```
 
 ## Installing Serverless in an existing service

--- a/docs/providers/kubeless/guide/services.md
+++ b/docs/providers/kubeless/guide/services.md
@@ -144,7 +144,8 @@ To configure version pinning define a `frameworkVersion` property in your server
 
 ```yml
 # serverless.yml
-frameworkVersion: "=1.20"
+
+frameworkVersion: '2.1.0'
 
 service: users
 
@@ -159,7 +160,7 @@ provider:
 ```yml
 # serverless.yml
 
-frameworkVersion: ">=1.20 <2.0.0"
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 
 service: users
 

--- a/docs/providers/openwhisk/guide/serverless.yml.md
+++ b/docs/providers/openwhisk/guide/serverless.yml.md
@@ -21,7 +21,7 @@ Here is a list of all available properties in `serverless.yml` when the provider
 
 service: myService
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: '2'
 
 provider:
   name: openwhisk

--- a/docs/providers/openwhisk/guide/services.md
+++ b/docs/providers/openwhisk/guide/services.md
@@ -156,7 +156,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: "=1.0.3"
+frameworkVersion: '2.1.0'
 
 service: users
 
@@ -173,7 +173,7 @@ provider:
 ```yml
 # serverless.yml
 
-frameworkVersion: ">=1.0.0 <2.0.0"
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 
 service: users
 

--- a/docs/providers/tencent/guide/services.md
+++ b/docs/providers/tencent/guide/services.md
@@ -147,7 +147,7 @@ To configure version pinning define a `frameworkVersion` property in your server
 ```yml
 # serverless.yml
 
-frameworkVersion: '=1.0.3'
+frameworkVersion: '2.1.0'
 ```
 
 #### Version Range
@@ -155,7 +155,7 @@ frameworkVersion: '=1.0.3'
 ```yml
 # serverless.yml
 
-frameworkVersion: '>=1.0.0 <2.0.0'
+frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 ```
 
 ## Installing Serverless in an existing service


### PR DESCRIPTION
It was overlooked in v2 branch.

Additionally improved style of semver version ranges