### PR TITLE
feat(aws): add support for cf functions for fileSystemConfig

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -331,9 +331,16 @@ class AwsProvider {
               type: 'object',
               properties: {
                 arn: {
-                  type: 'string',
-                  pattern:
-                    '^arn:aws[a-zA-Z-]*:elasticfilesystem:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-[1-9]{1}:[0-9]{12}:access-point/fsap-[a-f0-9]{17}$',
+                  oneOf: [
+                    {
+                      type: 'string',
+                      pattern:
+                        '^arn:aws[a-zA-Z-]*:elasticfilesystem:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-[1-9]{1}:[0-9]{12}:access-point/fsap-[a-f0-9]{17}$',
+                    },
+                    { $ref: '#/definitions/awsCfGetAtt' },
+                    { $ref: '#/definitions/awsCfJoin' },
+                    { $ref: '#/definitions/awsCfImport' },
+                  ],
                 },
                 localMountPath: { type: 'string', pattern: '^/mnt/[a-zA-Z0-9-_.]+$' },
               },


### PR DESCRIPTION
Allow to use CF functions to define `arn` for `fileSystemConfig`. `Ref` is not supported because it does not return ARN for EFS Access Point. Reference doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-accesspoint.html

Closes: #8189
