### PR TITLE
chore(aws): add deprecation for extending nonexistent resources

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,6 +6,12 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
+<a name="RESOURCES_EXTENSIONS_REFERENCE_TO_NONEXISTENT_RESOURCE"><div>&nbsp;</div></a>
+
+## Defining extensions to nonexistent resources in `resources.extensions`
+
+Starting with v3.0.0, extensions to nonexistent resources in `resources.extensions` will throw an error instead of passing silently.
+
 <a name="DISABLE_LOCAL_INSTALLATION_FALLBACK_SETTING"><div>&nbsp;</div></a>
 
 ## Support for `enableLocalInstallationFallback` setting is to be removed

--- a/lib/plugins/aws/package/lib/mergeCustomProviderResources.js
+++ b/lib/plugins/aws/package/lib/mergeCustomProviderResources.js
@@ -31,6 +31,10 @@ module.exports = {
         for (const [extensionAttributeName, value] of _.entries(resourceDefinition)) {
           if (!template.Resources[resourceName]) {
             template.Resources[resourceName] = {};
+            this.serverless._logDeprecation(
+              'RESOURCES_EXTENSIONS_REFERENCE_TO_NONEXISTENT_RESOURCE',
+              'Starting with next major version, extensions to nonexistent resources will throw an error instead of passing silently.'
+            );
           }
 
           switch (extensionAttributeName) {


### PR DESCRIPTION
Add deprecation for extending nonexistent resources in `resources.extensions`.

Addresses: #8141 
