### PR TITLE
Config Schema: Treat `null` or `undefined` as lack of value

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -79,9 +79,7 @@ class ConfigSchemaHandler {
 
     validate(userConfig);
     if (validate.errors) {
-      const messages = normalizeAjvErrors(validate.errors, userConfig, this.schema).map(
-        err => err.message
-      );
+      const messages = normalizeAjvErrors(validate.errors).map(err => err.message);
       this.handleErrorMessages(messages);
     }
   }

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -23,6 +23,28 @@ const normalizeSchemaObject = (object, instanceSchema) => {
   }
 };
 
+// Normalizer is introduced to workaround https://github.com/ajv-validator/ajv/issues/1287
+// normalizedObjectsMap allows to handle circular structures without issues
+const normalizedObjectsMap = new WeakMap();
+const normalizeUserConfig = object => {
+  if (normalizedObjectsMap.has(object)) return normalizedObjectsMap.get(object);
+  if (Array.isArray(object)) {
+    const normalizedObject = [];
+    normalizedObjectsMap.set(object, normalizedObject);
+    for (const value of object) {
+      normalizedObject.push(_.isObject(value) ? normalizeUserConfig(value) : value);
+    }
+    return normalizedObject;
+  }
+  const normalizedObject = Object.create(null);
+  normalizedObjectsMap.set(object, normalizedObject);
+  for (const [key, value] of Object.entries(object)) {
+    if (value == null) continue;
+    normalizedObject[key] = _.isObject(value) ? normalizeUserConfig(value) : value;
+  }
+  return normalizedObject;
+};
+
 class ConfigSchemaHandler {
   constructor(serverless) {
     this.serverless = serverless;
@@ -77,7 +99,7 @@ class ConfigSchemaHandler {
     normalizeSchemaObject(this.schema, this.schema);
     const validate = ajv.compile(this.schema);
 
-    validate(userConfig);
+    validate(normalizeUserConfig(userConfig));
     if (validate.errors) {
       const messages = normalizeAjvErrors(validate.errors).map(err => err.message);
       this.handleErrorMessages(messages);


### PR DESCRIPTION
Issue was exposed by CI fail: https://github.com/serverless/serverless/runs/1134654637

(in test we reset `websocketApiId` with a `null` value: https://github.com/serverless/serverless/blob/e1ca63c06a824e18fdd92f5c6c3efbf7f5f644d2/test/integration/websocket.test.js#L151 which seems as totally valid approach)

Workaround to: https://github.com/ajv-validator/ajv/issues/1287