### PR TITLE
chore: replace usage of _.values with Object.values

### DIFF
--- a/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
+++ b/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
@@ -103,7 +103,7 @@ const filterIrrelevantAnyOfErrors = resultErrorsSet => {
       dataPathA.localeCompare(dataPathB)
     );
     let currentDataPath = oneOfPathErrors[0].dataPath;
-    _.values(
+    Object.values(
       _.groupBy(oneOfPathErrors, ({ dataPath }) => {
         if (
           dataPath !== currentDataPath &&
@@ -131,7 +131,7 @@ const filterIrrelevantAnyOfErrors = resultErrorsSet => {
       if (!dataPathOneOfPathErrorsByVariant.root) return;
       const noMatchingVariantError = dataPathOneOfPathErrorsByVariant.root[0];
       delete dataPathOneOfPathErrorsByVariant.root;
-      let dataPathOneOfPathVariants = _.values(dataPathOneOfPathErrorsByVariant);
+      let dataPathOneOfPathVariants = Object.values(dataPathOneOfPathErrorsByVariant);
       // 2.2.4 If no variants, set was already filtered by event configuration errors filter
       if (!dataPathOneOfPathVariants.length) return;
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -361,7 +361,9 @@ class PluginManager {
       _.forOwn(commands, (command, name) => {
         if (command.type !== 'entrypoint') {
           _.set(target, name, _.omit(command, 'commands'));
-          if (_.values(command.commands).some(childCommand => childCommand.type !== 'entrypoint')) {
+          if (
+            Object.values(command.commands).some(childCommand => childCommand.type !== 'entrypoint')
+          ) {
             target[name].commands = {};
             stack.push({ commands: command.commands, target: target[name].commands });
           }

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -160,7 +160,7 @@ class AwsDeployFunction {
         functionObj.environment
       );
 
-      if (_.values(params.Environment.Variables).some(value => _.isObject(value))) {
+      if (Object.values(params.Environment.Variables).some(value => _.isObject(value))) {
         delete params.Environment;
       } else {
         Object.keys(params.Environment.Variables).forEach(key => {

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -85,7 +85,7 @@ module.exports = {
           const { httpApiEventsPlugin } = this.serverless;
           httpApiEventsPlugin.resolveConfiguration();
 
-          for (const functionData of _.values(this.serverless.service.functions)) {
+          for (const functionData of Object.values(this.serverless.service.functions)) {
             for (const event of functionData.events) {
               if (!event.httpApi) continue;
               endpointsMessage += `\n  ${event.resolvedMethod} - ${endpoint}${event.resolvedPath ||

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -582,7 +582,7 @@ module.exports = {
       if (response.statusCodes) {
         response.statusCodes = Object.assign({}, response.statusCodes);
 
-        if (!_.values(response.statusCodes).some(code => code.pattern === '')) {
+        if (!Object.values(response.statusCodes).some(code => code.pattern === '')) {
           response.statusCodes['200'] = DEFAULT_STATUS_CODES['200'];
         }
       } else {

--- a/lib/plugins/aws/utils/findAndGroupDeployments.js
+++ b/lib/plugins/aws/utils/findAndGroupDeployments.js
@@ -14,7 +14,7 @@ module.exports = (s3Response, prefix, service, stage) => {
       };
     });
     const grouped = _.groupBy(names, 'directory');
-    return _.values(grouped);
+    return Object.values(grouped);
   }
   return [];
 };

--- a/lib/utils/analytics/generatePayload.js
+++ b/lib/utils/analytics/generatePayload.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const _ = require('lodash');
 const isStandalone = require('../isStandaloneExecutable');
 const { triggeredDeprecations } = require('../logDeprecation');
 
@@ -48,7 +47,7 @@ module.exports = serverless => {
         region: isAwsProvider ? provider.getRegion() : providerConfig.region,
       },
       plugins: serviceConfig.plugins ? serviceConfig.plugins.modules || serviceConfig.plugins : [],
-      functions: _.values(serviceConfig.functions).map(functionConfig => ({
+      functions: Object.values(serviceConfig.functions).map(functionConfig => ({
         runtime: functionConfig.runtime || defaultRuntime,
         events: functionConfig.events.map(eventConfig => ({
           type: Object.keys(eventConfig)[0] || null,


### PR DESCRIPTION
Replace `_.values` with `Object.values` in order to reduce dependency on `lodash`

Addresses: #7747 