### PR TITLE
chore: replace _.entries, _.entriesIn and _.toPairs with Object.entries

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -10,7 +10,7 @@ const ERROR_PREFIX = 'Configuration error';
 const WARNING_PREFIX = 'Configuration warning';
 
 const normalizeSchemaObject = (object, instanceSchema) => {
-  for (const [key, value] of _.entries(object)) {
+  for (const [key, value] of Object.entries(object)) {
     if (!_.isObject(value)) continue;
     if (!value.$ref) {
       normalizeSchemaObject(value, instanceSchema);

--- a/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
+++ b/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
@@ -18,7 +18,7 @@ const filterIrreleventEventConfigurationErrors = resultErrorsSet => {
   const eventTypeErrorsByEvent = _.groupBy(eventTypeErrors, ({ dataPath }) => dataPath);
 
   // 3. Process each error group individually
-  for (const [dataPath, eventEventTypeErrors] of _.entries(eventTypeErrorsByEvent)) {
+  for (const [dataPath, eventEventTypeErrors] of Object.entries(eventTypeErrorsByEvent)) {
     // 3.1 Resolve error that signals that no event schema was matched
     const noMatchingEventError = eventEventTypeErrors.find(({ keyword }) =>
       oneOfKeywords.has(keyword)
@@ -35,7 +35,7 @@ const filterIrreleventEventConfigurationErrors = resultErrorsSet => {
     delete eventEventTypeErrorsByTypeIndex.root;
 
     // 3.3 Resolve eventual type configuration errors for intended event type
-    const eventConfiguredEventTypeErrors = _.entries(
+    const eventConfiguredEventTypeErrors = Object.entries(
       eventEventTypeErrorsByTypeIndex
     ).find(([, errors]) => errors.every(({ keyword }) => keyword !== 'required'));
 
@@ -95,7 +95,7 @@ const filterIrrelevantAnyOfErrors = resultErrorsSet => {
     }
   }
   // 2. Process resolved groups
-  for (const [oneOfPath, oneOfPathErrors] of _.entries(oneOfErrorsByPath)) {
+  for (const [oneOfPath, oneOfPathErrors] of Object.entries(oneOfErrorsByPath)) {
     // 2.1. If just one error, set was already filtered by event configuration errors filter
     if (oneOfPathErrors.length === 1) continue;
     // 2.2. Group by dataPath

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -303,7 +303,7 @@ class PluginManager {
 
   loadVariableResolvers(pluginInstance) {
     const pluginName = pluginInstance.constructor.name;
-    for (const [variablePrefix, resolverOrOptions] of _.entries(
+    for (const [variablePrefix, resolverOrOptions] of Object.entries(
       pluginInstance.variableResolvers || {}
     )) {
       let options = resolverOrOptions;

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -183,7 +183,7 @@ class AwsInvokeLocal {
 
       const configuredEnvVars = this.getConfiguredEnvVars();
 
-      const promises = _.entries(configuredEnvVars).map(([name, value]) => {
+      const promises = Object.entries(configuredEnvVars).map(([name, value]) => {
         let resolver;
         if (value['Fn::ImportValue']) {
           resolver = resolveCfImportValue(this.provider, value['Fn::ImportValue']);

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -13,7 +13,7 @@ module.exports = {
     const authorizers = {};
     const albAuthConfig = this.serverless.service.provider.alb;
     if (albAuthConfig) {
-      for (const [name, auth] of _.entries(albAuthConfig.authorizers)) {
+      for (const [name, auth] of Object.entries(albAuthConfig.authorizers)) {
         switch (auth.type) {
           case 'cognito':
           case 'oidc':

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.js
@@ -94,7 +94,7 @@ module.exports = {
       this.apiGatewayMethodLogicalIds.push(methodLogicalId);
 
       if (event.http.request && event.http.request.schema) {
-        for (const requestSchema of _.entries(event.http.request.schema)) {
+        for (const requestSchema of Object.entries(event.http.request.schema)) {
           const contentType = requestSchema[0];
           const schema = requestSchema[1];
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/integration.js
@@ -209,7 +209,7 @@ module.exports = {
 
     // set custom request templates if provided
     if (http.request && typeof http.request.template === 'object') {
-      _.entries(http.request.template).forEach(([contentType, template]) => {
+      Object.entries(http.request.template).forEach(([contentType, template]) => {
         if (template === null) {
           delete integrationRequestTemplates[contentType];
         } else {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // Tags
     const tagsMerged = Object.assign({}, provider.stackTags, provider.tags);
-    const Tags = _.entriesIn(tagsMerged).map(pair => ({
+    const Tags = Object.entries(tagsMerged).map(pair => ({
       Key: pair[0],
       Value: pair[1],
     }));

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
@@ -35,7 +35,7 @@ module.exports = {
 
       this.serverless.service.provider.apiKeys.forEach(apiKeyDefinition => {
         // if multiple API key types are used
-        const apiKey = _.entries(apiKeyDefinition)[0];
+        const apiKey = Object.entries(apiKeyDefinition)[0];
         const name = apiKey[0];
         const value = _.last(apiKey);
         const usagePlansIncludeName = this.apiGatewayUsagePlanNames.includes(name);

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -270,7 +270,7 @@ Object.defineProperties(
             'EXTERNAL_HTTP_API_AUTHORIZERS_CONFIG'
           );
         }
-        for (const [name, authorizerConfig] of _.entries(userAuthorizers)) {
+        for (const [name, authorizerConfig] of Object.entries(userAuthorizers)) {
           authorizers.set(name, {
             name: authorizerConfig.name || name,
             identitySource: authorizerConfig.identitySource,
@@ -302,7 +302,9 @@ Object.defineProperties(
           })}`;
       }
 
-      for (const [functionName, functionData] of _.entries(this.serverless.service.functions)) {
+      for (const [functionName, functionData] of Object.entries(
+        this.serverless.service.functions
+      )) {
         const routeTargetData = {
           functionName,
           functionAlias: functionData.targetAlias,

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -177,7 +177,7 @@ class AwsCompileS3Events {
       if (bucketsMeta[bucketName]) {
         const providerBucket = providerS3[bucketsMeta[bucketName].bucketRef];
         bucketConf = {};
-        for (const [key, value] of _.entries(providerBucket)) {
+        for (const [key, value] of Object.entries(providerBucket)) {
           if (key !== 'name') {
             if (!this.allowedBucketProperties.has(key)) {
               const errorMessage = [

--- a/lib/plugins/aws/package/lib/mergeCustomProviderResources.js
+++ b/lib/plugins/aws/package/lib/mergeCustomProviderResources.js
@@ -27,8 +27,8 @@ module.exports = {
     if (extensions) {
       const template = this.serverless.service.provider.compiledCloudFormationTemplate;
 
-      for (const [resourceName, resourceDefinition] of _.entries(extensions)) {
-        for (const [extensionAttributeName, value] of _.entries(resourceDefinition)) {
+      for (const [resourceName, resourceDefinition] of Object.entries(extensions)) {
+        for (const [extensionAttributeName, value] of Object.entries(resourceDefinition)) {
           if (!template.Resources[resourceName]) {
             template.Resources[resourceName] = {};
             this.serverless._logDeprecation(

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -267,7 +267,7 @@ module.exports = {
             filePathStates[key] = !exclude;
           });
         });
-      const filePaths = _.toPairs(filePathStates)
+      const filePaths = Object.entries(filePathStates)
         .filter(r => r[1] === true)
         .map(r => r[0]);
       if (filePaths.length !== 0) return filePaths;


### PR DESCRIPTION
Replace `_.entries`, `_.entriesIn` and `_.toPairs` with `Object.entries` to reduce lodash usage.

Note about `toPairs`: I decided to not split it into multiple PRs as `toPairs` in lodash has the same functionality as `entries`. 

Note about `entriesIn`: There was only one instance of it and I didn't notice any use/reliance on prototypal inheritance for tags so I think it's safe to replace it with `Object.entries` as the only difference is in it not including inherited properties. 

Addresses: #7747 
