### PR TITLE
Deprecate awsKmsKeyArn for provider and functoin kmsKeyArn

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -74,8 +74,8 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
 
-<a name="SERVICE_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN"><div>&nbsp;</div></a>
+<a name="AWS_KMS_KEY_ARN"><div>&nbsp;</div></a>
 
 ## awsKmsKeyArn references
 
-Plase use `provider.kmsKeyArn` and `functions[].kmsKeyArn`. `service.awsKmsKeyArn` and `functions[].awsKmsKeyArn` will be removed with v2.0.0
+Plase use `provider.kmsKeyArn` and `functions[].kmsKeyArn`. `service.awsKmsKeyArn` and `functions[].awsKmsKeyArn` will be removed with v3.0.0

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -73,3 +73,9 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 ## `bin/serverless`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
+
+<a name="SERVICE_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN"><div>&nbsp;</div></a>
+
+## awsKmsKeyArn references
+
+Plase use `provider.kmsKeyArn` and `functions[].kmsKeyArn`. `service.awsKmsKeyArn` and `functions[].awsKmsKeyArn` will be removed with v2.0.0

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -125,7 +125,7 @@ const schema = {
   additionalProperties: false,
   required: ['provider', 'service'],
   definitions: {
-    // TODO: awsKmsArn definition to be moved to lib/plugins/aws/provider/awsProvider.js once service.awsKmsKeyArn removed with v2.0.0, see https://github.com/serverless/serverless/issues/8261
+    // TODO: awsKmsArn definition to be moved to lib/plugins/aws/provider/awsProvider.js once service.awsKmsKeyArn removed with v3.0.0, see https://github.com/serverless/serverless/issues/8261
     // TODO: awsKmsArn to include #/definitions/awsCfFunction instead of type: object as one of the possible definition, see https://github.com/serverless/serverless/issues/8261
     awsKmsArn: {
       anyOf: [{ type: 'object' }, { type: 'string', pattern: '^arn:aws[a-z-]*:kms' }],

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -125,7 +125,7 @@ const schema = {
   additionalProperties: false,
   required: ['provider', 'service'],
   definitions: {
-    // TODO: awsKmsArn definition to be moved to lib/plugins/aws/provider/awsProvider.js once service.awsKmsKeyArn moved to provider.awsKmsKeyArn, see https://github.com/serverless/serverless/issues/8261
+    // TODO: awsKmsArn definition to be moved to lib/plugins/aws/provider/awsProvider.js once service.awsKmsKeyArn removed with v2.0.0, see https://github.com/serverless/serverless/issues/8261
     // TODO: awsKmsArn to include #/definitions/awsCfFunction instead of type: object as one of the possible definition, see https://github.com/serverless/serverless/issues/8261
     awsKmsArn: {
       anyOf: [{ type: 'object' }, { type: 'string', pattern: '^arn:aws[a-z-]*:kms' }],

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -210,12 +210,27 @@ class AwsCompileFunctions {
         }
       }
 
+      let kmsKeyArn;
       const serviceObj = this.serverless.service.serviceObject;
-      if (functionObject.awsKmsKeyArn || (serviceObj && serviceObj.awsKmsKeyArn)) {
-        const arn = functionObject.awsKmsKeyArn || (serviceObj && serviceObj.awsKmsKeyArn);
+      if (functionObject.kmsKeyArn || this.serverless.service.provider.kmsKeyArn) {
+        kmsKeyArn = functionObject.kmsKeyArn || this.serverless.service.provider.kmsKeyArn;
+      } else if (functionObject.awsKmsKeyArn) {
+        this.serverless._logDeprecation(
+          'FUNCTION_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
+          'Starting with next major version, awsKmsKeyArn function property will be replaced by kmsKeyArn.'
+        );
+        kmsKeyArn = functionObject.awsKmsKeyArn;
+      } else if (serviceObj && serviceObj.awsKmsKeyArn) {
+        this.serverless._logDeprecation(
+          'SERVICE_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
+          'Starting with next major version, awsKmsKeyArn service property will be replaced by provider.kmsKeyArn.'
+        );
+        kmsKeyArn = serviceObj.awsKmsKeyArn;
+      }
 
-        if (typeof arn === 'string') {
-          functionResource.Properties.KmsKeyArn = arn;
+      if (kmsKeyArn) {
+        if (typeof kmsKeyArn === 'string') {
+          functionResource.Properties.KmsKeyArn = kmsKeyArn;
 
           // update the PolicyDocument statements (if default policy is used)
           const iamRoleLambdaExecution = cfTemplate.Resources.IamRoleLambdaExecution;
@@ -226,14 +241,14 @@ class AwsCompileFunctions {
                 {
                   Effect: 'Allow',
                   Action: ['kms:Decrypt'],
-                  Resource: [arn],
+                  Resource: [kmsKeyArn],
                 },
               ],
               _.isEqual
             );
           }
         } else {
-          functionResource.Properties.KmsKeyArn = arn;
+          functionResource.Properties.KmsKeyArn = kmsKeyArn;
         }
       }
 

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -214,7 +214,7 @@ class AwsCompileFunctions {
       const serviceObj = this.serverless.service.serviceObject;
       if (serviceObj && serviceObj.awsKmsKeyArn) {
         this.serverless._logDeprecation(
-          'SERVICE_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
+          'AWS_KMS_KEY_ARN',
           'Starting with next major version, awsKmsKeyArn service property will be replaced by provider.kmsKeyArn'
         );
         kmsKeyArn = serviceObj.awsKmsKeyArn;
@@ -224,7 +224,7 @@ class AwsCompileFunctions {
       }
       if (functionObject.awsKmsKeyArn) {
         this.serverless._logDeprecation(
-          'FUNCTION_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
+          'AWS_KMS_KEY_ARN',
           'Starting with next major version, awsKmsKeyArn function property will be replaced by kmsKeyArn'
         );
         kmsKeyArn = functionObject.awsKmsKeyArn;

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -212,20 +212,25 @@ class AwsCompileFunctions {
 
       let kmsKeyArn;
       const serviceObj = this.serverless.service.serviceObject;
-      if (functionObject.kmsKeyArn || this.serverless.service.provider.kmsKeyArn) {
-        kmsKeyArn = functionObject.kmsKeyArn || this.serverless.service.provider.kmsKeyArn;
-      } else if (functionObject.awsKmsKeyArn) {
-        this.serverless._logDeprecation(
-          'FUNCTION_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
-          'Starting with next major version, awsKmsKeyArn function property will be replaced by kmsKeyArn.'
-        );
-        kmsKeyArn = functionObject.awsKmsKeyArn;
-      } else if (serviceObj && serviceObj.awsKmsKeyArn) {
+      if (serviceObj && serviceObj.awsKmsKeyArn) {
         this.serverless._logDeprecation(
           'SERVICE_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
-          'Starting with next major version, awsKmsKeyArn service property will be replaced by provider.kmsKeyArn.'
+          'Starting with next major version, awsKmsKeyArn service property will be replaced by provider.kmsKeyArn'
         );
         kmsKeyArn = serviceObj.awsKmsKeyArn;
+      }
+      if (this.serverless.service.provider.kmsKeyArn) {
+        kmsKeyArn = this.serverless.service.provider.kmsKeyArn;
+      }
+      if (functionObject.awsKmsKeyArn) {
+        this.serverless._logDeprecation(
+          'FUNCTION_DEPRECATED_PROPERTY_AWS_KMS_KEY_ARN',
+          'Starting with next major version, awsKmsKeyArn function property will be replaced by kmsKeyArn'
+        );
+        kmsKeyArn = functionObject.awsKmsKeyArn;
+      }
+      if (functionObject.kmsKeyArn) {
+        kmsKeyArn = functionObject.kmsKeyArn;
       }
 
       if (kmsKeyArn) {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -385,6 +385,7 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
+            kmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             layers: { $ref: '#/definitions/awsLambdaLayers' },
             logs: {
               type: 'object',
@@ -469,6 +470,7 @@ class AwsProvider {
               required: ['localMountPath', 'arn'],
             },
             handler: { type: 'string' },
+            kmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             layers: { $ref: '#/definitions/awsLambdaLayers' },
             memorySize: { $ref: '#/definitions/awsLambdaMemorySize' },
             onError: {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses: #8261
