### PR TITLE
fix(Config Schema): Expand allowable types for vpc config

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -276,16 +276,12 @@ class AwsProvider {
             properties: {
               securityGroupIds: {
                 type: 'array',
-                items: {
-                  type: 'string',
-                },
+                items: { $ref: '#/definitions/awsCfInstruction' },
                 maxItems: 5,
               },
               subnetIds: {
                 type: 'array',
-                items: {
-                  type: 'string',
-                },
+                items: { $ref: '#/definitions/awsCfInstruction' },
                 maxItems: 16,
               },
             },


### PR DESCRIPTION
This enables the use of `Ref`, `Fn::Join`, `Fn::Sub` , `Fn::Import` and `Fn::GetAtt` when defining the `vpc.subnetIds` and `vpc.securityGroupIds`

Closes: #8282
