### PR TITLE
chore: replace _.forOwn with Object.entries().forEach

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -362,17 +362,21 @@ class PluginManager {
       const currentCommands = stack.pop();
       const commands = currentCommands.commands;
       const target = currentCommands.target;
-      _.forOwn(commands, (command, name) => {
-        if (command.type !== 'entrypoint') {
-          _.set(target, name, _.omit(command, 'commands'));
-          if (
-            Object.values(command.commands).some(childCommand => childCommand.type !== 'entrypoint')
-          ) {
-            target[name].commands = {};
-            stack.push({ commands: command.commands, target: target[name].commands });
+      if (commands) {
+        Object.entries(commands).forEach(([name, command]) => {
+          if (command.type !== 'entrypoint') {
+            _.set(target, name, _.omit(command, 'commands'));
+            if (
+              Object.values(command.commands).some(
+                childCommand => childCommand.type !== 'entrypoint'
+              )
+            ) {
+              target[name].commands = {};
+              stack.push({ commands: command.commands, target: target[name].commands });
+            }
           }
-        }
-      });
+        });
+      }
     }
     // Iterate through the existing aliases and add them as commands
     _.remove(stack);
@@ -381,19 +385,21 @@ class PluginManager {
       const currentAlias = stack.pop();
       const aliases = currentAlias.aliases;
       const target = currentAlias.target;
-      _.forOwn(aliases, (alias, name) => {
-        if (name === 'command') {
-          return;
-        }
-        if (alias.command) {
-          const commandPath = alias.command.split(':').join('.commands.');
-          _.set(target, name, _.get(this.commands, commandPath));
-        } else {
-          target[name] = target[name] || {};
-          target[name].commands = target[name].commands || {};
-        }
-        stack.push({ aliases: alias, target: target[name].commands });
-      });
+      if (aliases) {
+        Object.entries(aliases).forEach(([name, alias]) => {
+          if (name === 'command') {
+            return;
+          }
+          if (alias.command) {
+            const commandPath = alias.command.split(':').join('.commands.');
+            _.set(target, name, _.get(this.commands, commandPath));
+          } else {
+            target[name] = target[name] || {};
+            target[name].commands = target[name].commands || {};
+          }
+          stack.push({ aliases: alias, target: target[name].commands });
+        });
+      }
     }
     return result;
   }

--- a/lib/plugins/aws/utils/findReferences.js
+++ b/lib/plugins/aws/utils/findReferences.js
@@ -18,24 +18,26 @@ function findReferences(root, value) {
   while (stack.length) {
     const property = stack.pop();
 
-    _.forOwn(property.propValue, (propValue, key) => {
-      let propKey;
-      if (Array.isArray(property.propValue)) {
-        propKey = `[${key}]`;
-      } else {
-        propKey = !property.path ? `${key}` : `.${key}`;
-      }
-      if (propValue === value) {
-        resourcePaths.push(`${property.path}${propKey}`);
-      } else if (_.isObject(propValue)) {
-        // Prevent circular references
-        if (visitedObjects.includes(propValue)) {
-          return;
+    if (property.propValue) {
+      Object.entries(property.propValue).forEach(([key, propValue]) => {
+        let propKey;
+        if (Array.isArray(property.propValue)) {
+          propKey = `[${key}]`;
+        } else {
+          propKey = !property.path ? `${key}` : `.${key}`;
         }
-        visitedObjects.push(propValue);
-        stack.push({ propValue, path: `${property.path}${propKey}` });
-      }
-    });
+        if (propValue === value) {
+          resourcePaths.push(`${property.path}${propKey}`);
+        } else if (_.isObject(propValue)) {
+          // Prevent circular references
+          if (visitedObjects.includes(propValue)) {
+            return;
+          }
+          visitedObjects.push(propValue);
+          stack.push({ propValue, path: `${property.path}${propKey}` });
+        }
+      });
+    }
   }
 
   return resourcePaths;


### PR DESCRIPTION
Replace `_.forOwn` with `Object.entries().forEach` to reduce dependency on `lodash`.

Addresses: #7747 