### PR TITLE
docs: Serverless command "updage" not found

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,12 +63,6 @@ _Note: Users in China are presented with setup centered around chinese [Tencent]
 
 ## Upgrade
 
-### MacOS/Linux
-
-```bash
-serverless upgrade
-```
-
 ### Windows
 
 ```bash
@@ -79,6 +73,8 @@ choco upgrade serverless
 
 ```bash
 npm update -g serverless
+# or
+npm i -g serverless@latest
 ```
 
 ## Set up your free Pro account


### PR DESCRIPTION
As I ran a script that described in the docs 
```
serverless upgrade
```
I got an error

![image](https://user-images.githubusercontent.com/9384365/94360723-3d8a1300-00e2-11eb-80f1-aab5a5cf0f68.png)

At last, I use npm to upgrade from v1 to v2
```
npm i -g serverless@latest
```