### PR TITLE
AWS ALB: Ensure to treat `provider.alb.authorizers` as optional

### DIFF
--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -12,7 +12,7 @@ module.exports = {
   validate() {
     const authorizers = {};
     const albAuthConfig = this.serverless.service.provider.alb;
-    if (albAuthConfig) {
+    if (albAuthConfig && albAuthConfig.authorizers) {
       for (const [name, auth] of Object.entries(albAuthConfig.authorizers)) {
         switch (auth.type) {
           case 'cognito':


### PR DESCRIPTION
Regression introduced with #8275 
