### PR TITLE
fix(AWS SQS): ensure sqs event depends on provisioned alias if needed

### DIFF
--- a/lib/plugins/aws/package/compile/events/sqs/index.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.js
@@ -70,13 +70,22 @@ class AwsCompileSQSEvents {
 
             const queueLogicalId = this.provider.naming.getQueueLogicalId(functionName, queueName);
 
-            const dependsOn = JSON.stringify(
-              this.provider.resolveFunctionIamRoleResourceName(functionObj) || []
+            const dependsOn = [];
+            const functionIamRoleResourceName = this.provider.resolveFunctionIamRoleResourceName(
+              functionObj
             );
+            if (functionIamRoleResourceName) {
+              dependsOn.push(functionIamRoleResourceName);
+            }
+            const { targetAlias } = this.serverless.service.functions[functionName];
+            if (targetAlias) {
+              dependsOn.push(targetAlias.logicalId);
+            }
+
             const sqsTemplate = `
               {
                 "Type": "AWS::Lambda::EventSourceMapping",
-                "DependsOn": ${dependsOn},
+                "DependsOn": ${JSON.stringify(dependsOn)},
                 "Properties": {
                   "BatchSize": ${BatchSize},
                   "EventSourceArn": ${JSON.stringify(EventSourceArn)},

--- a/lib/plugins/aws/package/compile/events/sqs/index.test.js
+++ b/lib/plugins/aws/package/compile/events/sqs/index.test.js
@@ -115,7 +115,11 @@ describe('AwsCompileSQSEvents', () => {
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingSQSMyQueue.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSMyQueue.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -144,7 +148,11 @@ describe('AwsCompileSQSEvents', () => {
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingSQSMyQueue.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSMyQueue.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -237,7 +245,11 @@ describe('AwsCompileSQSEvents', () => {
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingSQSMyQueue.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSMyQueue.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -267,7 +279,11 @@ describe('AwsCompileSQSEvents', () => {
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingSQSMyQueue.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingSQSMyQueue.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -308,7 +324,11 @@ describe('AwsCompileSQSEvents', () => {
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FirstEventSourceMappingSQSMyFirstQueue.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyFirstQueue.Properties.EventSourceArn
@@ -330,7 +350,11 @@ describe('AwsCompileSQSEvents', () => {
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMySecondQueue.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FirstEventSourceMappingSQSMySecondQueue.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMySecondQueue.Properties.EventSourceArn
@@ -353,7 +377,11 @@ describe('AwsCompileSQSEvents', () => {
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyThirdQueue.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+            .FirstEventSourceMappingSQSMyThirdQueue.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileSQSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
             .FirstEventSourceMappingSQSMyThirdQueue.Properties.EventSourceArn
@@ -558,23 +586,37 @@ describe('AwsCompileSQSEvents', () => {
 });
 
 describe('AwsCompileSQSEvents #2', () => {
-  it('Should reference provisioned alias when pointing function with provisioned concurrency', () =>
-    runServerless({
-      fixture: 'function',
-      configExt: {
-        functions: {
-          foo: {
-            provisionedConcurrency: 1,
-            events: [{ sqs: 'arn:aws:sqs:region:account:MyQueue' }],
+  describe('with provisioned concurrency', () => {
+    let naming;
+    let eventSourceMappingResource;
+
+    before(async () => {
+      const { awsNaming, cfTemplate } = await runServerless({
+        fixture: 'function',
+        configExt: {
+          functions: {
+            foo: {
+              provisionedConcurrency: 1,
+              events: [{ sqs: 'arn:aws:sqs:region:account:MyQueue' }],
+            },
           },
         },
-      },
-      cliArgs: ['package'],
-    }).then(({ awsNaming, cfTemplate }) => {
+        cliArgs: ['package'],
+      });
+      naming = awsNaming;
       const queueLogicalId = awsNaming.getQueueLogicalId('foo', 'MyQueue');
-      const eventSourceMappingResource = cfTemplate.Resources[queueLogicalId];
+      eventSourceMappingResource = cfTemplate.Resources[queueLogicalId];
+    });
+
+    it('should reference provisioned alias', () => {
       expect(
         JSON.stringify(eventSourceMappingResource.Properties.FunctionName['Fn::Join'])
       ).to.include('provisioned');
-    }));
+    });
+
+    it('should depend on provisioned alias', () => {
+      const aliasLogicalId = naming.getLambdaProvisionedConcurrencyAliasLogicalId('foo');
+      expect(eventSourceMappingResource.DependsOn).to.include(aliasLogicalId);
+    });
+  });
 });


### PR DESCRIPTION
Ensure that `EventSourceMapping` depends on provisioned alias if it exists. 

One question: do you think it makes sense to add an integration test with `provisionedConcurrency` as well? I reproduced/tested the fix based on adjusted existing SQS integration test which made me wonder about adding it permanently. 

Closes: #8249 