### PR TITLE
[aws-nodejs-typescript] Add configValidationMode by default for avoiding type error

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
@@ -8,6 +8,7 @@ const serverlessConfiguration: Serverless = {
     // org: your-org-name,
   },
   frameworkVersion: '2',
+  configValidationMode: 'warn',
   custom: {
     webpack: {
       webpackConfig: './webpack.config.js',


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/serverless/plugins/aws/provider/awsProvider.d.ts#L10
Currently type of `configValidationMode` is required.
Current config file of template `aws-nodejs-typescript` does not contain `configValidationMode` and throws typescript compile error, which is not developer-friendly.
Therefore, I added.