### PR TITLE
Recognize deployment valid env variables format

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -183,26 +183,24 @@ class AwsInvokeLocal {
 
       const configuredEnvVars = this.getConfiguredEnvVars();
 
-      const promises = Object.entries(configuredEnvVars).map(([name, value]) => {
-        let resolver;
-        if (value['Fn::ImportValue']) {
-          resolver = resolveCfImportValue(this.provider, value['Fn::ImportValue']);
-        } else if (value.Ref) {
-          resolver = resolveCfRefValue(this.provider, value.Ref);
-        } else {
-          resolver = BbPromise.resolve(value);
-        }
-
-        return resolver.then(
-          resolvedValue => {
-            configuredEnvVars[name] = resolvedValue;
-          },
-          error => {
-            throw new this.serverless.classes.Error(
-              `Could not resolve ${name} environment variable. ${error.message}`
+      const promises = Object.entries(configuredEnvVars).map(async ([name, value]) => {
+        if (!_.isObject(value)) return;
+        try {
+          if (value['Fn::ImportValue']) {
+            configuredEnvVars[name] = await resolveCfImportValue(
+              this.provider,
+              value['Fn::ImportValue']
             );
+          } else if (value.Ref) {
+            configuredEnvVars[name] = await resolveCfRefValue(this.provider, value.Ref);
+          } else {
+            throw new Error(`Unsupported format: ${inspect(value)}`);
           }
-        );
+        } catch (error) {
+          throw new this.serverless.classes.Error(
+            `Could not resolve "${name}" environment variable: ${error.message}`
+          );
+        }
       });
 
       return BbPromise.all(promises).then(() => {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -285,13 +285,7 @@ class AwsProvider {
           awsLambdaEnvironment: {
             type: 'object',
             patternProperties: {
-              '^[A-Za-z_][a-zA-Z0-9_]*$': {
-                anyOf: [
-                  { type: 'string' },
-                  { $ref: '#/definitions/awsCfImport' },
-                  { $ref: '#/definitions/awsCfRef' },
-                ],
-              },
+              '^[A-Za-z_][a-zA-Z0-9_]*$': { $ref: '#/definitions/awsCfInstruction' },
             },
             additionalProperties: false,
           },


### PR DESCRIPTION
Addresses: https://github.com/serverless/serverless/issues/8285#issuecomment-700391139

Schema was relaxed to recognize all formats as supported for deployment. Improved validation at local invocation where unsupported format is approached