### PR TITLE
Fix schema for resource tags.

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -356,9 +356,8 @@ class AwsProvider {
           awsResourceTags: {
             type: 'object',
             patternProperties: {
-              '^(?!aws:)[\\w./=+-]{1,128}$': {
+              '^(?!aws:)[\\w./=+:-]{1,128}$': {
                 type: 'string',
-                pattern: '^(?!aws:)[\\w./=+-]*$',
                 maxLength: 256,
               },
             },


### PR DESCRIPTION
AWS allows for resource tags to have colons in them. In fact, they use it themselves for their reserved tags and they recommend their use in their [best practices](https://d1.awsstatic.com/whitepapers/aws-tagging-best-practices.pdf). Serverless config schema validation should also allow for it.

The schema validation is based on the documentation in this page: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Tag.html.

This PR closes #8304.