### PR TITLE
fix(Packaging): Consider absolute artifact paths (#8325)

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -133,6 +133,8 @@ module.exports = {
         this.serverless.service.package.artifact
       );
       funcPackageConfig.artifact = filePath;
+      functionObject.package = funcPackageConfig;
+
       return filePath;
     }
 

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -133,7 +133,6 @@ module.exports = {
         this.serverless.service.package.artifact
       );
       funcPackageConfig.artifact = filePath;
-      functionObject.package = funcPackageConfig;
 
       return filePath;
     }

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -120,7 +120,7 @@ module.exports = {
 
     // use the artifact in function config if provided
     if (funcPackageConfig.artifact) {
-      const filePath = path.join(this.serverless.config.servicePath, funcPackageConfig.artifact);
+      const filePath = path.resolve(this.serverless.config.servicePath, funcPackageConfig.artifact);
       functionObject.package.artifact = filePath;
       return filePath;
     }
@@ -128,7 +128,7 @@ module.exports = {
     // use the artifact in service config if provided
     // and if the function is not set to be packaged individually
     if (this.serverless.service.package.artifact && !funcPackageConfig.individually) {
-      const filePath = path.join(
+      const filePath = path.resolve(
         this.serverless.config.servicePath,
         this.serverless.service.package.artifact
       );

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -704,7 +704,9 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
 
           // One with CF template, one with function artifact and one with provided function artifact
           expect(s3UploadStub).to.be.calledThrice;
-          const callArgs = s3UploadStub.args.find(item => item[0].Key.endsWith('newArtifact.zip'));
+          const callArgs = s3UploadStub.args.find((item) =>
+            item[0].Key.endsWith('newArtifact.zip')
+          );
           expect(callArgs[0].Body.path).to.equal(absoluteArtifactFilePath);
         });
 
@@ -723,7 +725,9 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
 
           // One with CF template, one with service artifact
           expect(s3UploadStub).to.be.calledTwice;
-          const callArgs = s3UploadStub.args.find(item => item[0].Key.endsWith('newArtifact.zip'));
+          const callArgs = s3UploadStub.args.find((item) =>
+            item[0].Key.endsWith('newArtifact.zip')
+          );
           expect(callArgs[0].Body.path).to.equal(absoluteArtifactFilePath);
         });
       });

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -2,7 +2,6 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
-const JsZip = require('jszip');
 const path = require('path');
 const fs = require('fs');
 const fse = require('fs-extra');
@@ -13,6 +12,7 @@ const Serverless = require('../../../../../../lib/Serverless');
 const serverlessConfigFileUtils = require('../../../../../../lib/utils/getServerlessConfigFile');
 const { createTmpDir, listZipFiles } = require('../../../../../utils/fs');
 const runServerless = require('../../../../../utils/run-serverless');
+const fixtures = require('../../../../../fixtures');
 
 // Configure chai
 chai.use(require('chai-as-promised'));
@@ -623,34 +623,38 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       });
     });
 
-    it.skip('should support `package.artifact`', () => {
+    it.skip('TODO: should support `package.artifact`', () => {
       // Confirm that file pointed at `package.artifact` is configured as service level artifact
       //
       // Replace
       // https://github.com/serverless/serverless/blob/b12d565ea0ad588445fb120e049db157afc7bf37/test/unit/lib/plugins/package/lib/packageService.test.js#L227-L235
     });
 
-    it.skip('should ignore `package.artifact` if `functions[].package.individually', () => {
+    it.skip('TODO: should ignore `package.artifact` if `functions[].package.individually', () => {
       // Confirm that fnIndividual was packaged independently
       //
       // Replace
       // https://github.com/serverless/serverless/blob/b12d565ea0ad588445fb120e049db157afc7bf37/test/unit/lib/plugins/package/lib/packageService.test.js#L262-L287
     });
 
-    it.skip('should support `functions[].package.artifact`', () => {
+    it.skip('TODO: should support `functions[].package.artifact`', () => {
       // Confirm that file pointed at `functions.fnArtifact.package.artifact` is configured as function level artifact
     });
 
     describe('with absolute artifact path', () => {
       let absoluteArtifactFilePath;
       let zipContent;
+      let servicePath;
+      let updateConfig;
 
       before(async () => {
-        const zip = new JsZip();
-        zip.file('index.js', '');
-        zipContent = await zip.generateAsync({ type: 'base64' });
-        absoluteArtifactFilePath = path.join(process.cwd(), 'newArtifact.zip');
-        await fs.promises.writeFile(absoluteArtifactFilePath, zipContent);
+        ({ servicePath, updateConfig } = await fixtures.setup('packageArtifact'));
+        absoluteArtifactFilePath = path.join(servicePath, 'newArtifact.zip');
+        await fs.promises.copyFile(
+          path.join(servicePath, 'artifact.zip'),
+          absoluteArtifactFilePath
+        );
+        zipContent = await fs.promises.readFile(absoluteArtifactFilePath);
       });
 
       describe('while deploying whole service', () => {
@@ -686,24 +690,22 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
         });
 
         it('for function', async () => {
-          await runServerless({
-            fixture: 'function',
-            cliArgs: ['deploy'],
-            lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
-            awsRequestStubMap,
-            configExt: {
-              functions: {
-                other: {
-                  package: {
-                    artifact: absoluteArtifactFilePath,
-                  },
+          await updateConfig({
+            functions: {
+              other: {
+                package: {
+                  artifact: absoluteArtifactFilePath,
                 },
               },
             },
           });
+          await runServerless({
+            cwd: servicePath,
+            cliArgs: ['deploy'],
+            lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
+            awsRequestStubMap,
+          });
 
-          // One with CF template, one with function artifact and one with provided function artifact
-          expect(s3UploadStub).to.be.calledThrice;
           const callArgs = s3UploadStub.args.find((item) =>
             item[0].Key.endsWith('newArtifact.zip')
           );
@@ -711,20 +713,18 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
         });
 
         it('service-wide', async () => {
+          await updateConfig({
+            package: {
+              artifact: absoluteArtifactFilePath,
+            },
+          });
           await runServerless({
-            fixture: 'function',
+            cwd: servicePath,
             cliArgs: ['deploy'],
             lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
             awsRequestStubMap,
-            configExt: {
-              package: {
-                artifact: absoluteArtifactFilePath,
-              },
-            },
           });
 
-          // One with CF template, one with service artifact
-          expect(s3UploadStub).to.be.calledTwice;
           const callArgs = s3UploadStub.args.find((item) =>
             item[0].Key.endsWith('newArtifact.zip')
           );
@@ -751,34 +751,34 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
         });
 
         it('for function', async () => {
-          await runServerless({
-            fixture: 'function',
-            cliArgs: ['deploy', '-f', 'other'],
-            awsRequestStubMap,
-            configExt: {
-              functions: {
-                other: {
-                  package: {
-                    artifact: absoluteArtifactFilePath,
-                  },
+          await updateConfig({
+            functions: {
+              other: {
+                package: {
+                  artifact: absoluteArtifactFilePath,
                 },
               },
             },
+          });
+          await runServerless({
+            cwd: servicePath,
+            cliArgs: ['deploy', '-f', 'other'],
+            awsRequestStubMap,
           });
           expect(updateFunctionCodeStub).to.have.been.calledOnce;
           expect(updateFunctionCodeStub.args[0][0].ZipFile).to.deep.equal(Buffer.from(zipContent));
         });
 
         it('service-wide', async () => {
+          await updateConfig({
+            package: {
+              artifact: absoluteArtifactFilePath,
+            },
+          });
           await runServerless({
-            fixture: 'function',
+            cwd: servicePath,
             cliArgs: ['deploy', '-f', 'foo'],
             awsRequestStubMap,
-            configExt: {
-              package: {
-                artifact: absoluteArtifactFilePath,
-              },
-            },
           });
           expect(updateFunctionCodeStub).to.have.been.calledOnce;
           expect(updateFunctionCodeStub.args[0][0].ZipFile).to.deep.equal(Buffer.from(zipContent));


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8325 
Addresses #6752 

Would also close https://github.com/softprops/serverless-rust/issues/82

Although it looks like there may be more than one trigger for issue #6752, this change addresses one case seen as a result of the serverless-rust plugin setting artifacts with an absolute path which wasn't considered by `lib/packageService.js`.

An alternative fix might change serverless-rust to set a relative path, but this seems like a more general fix.
