### PR TITLE
Provisioned Concurrency allowed with zero (#8253)

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -734,7 +734,7 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
-            provisionedConcurrency: { type: 'integer', minimum: 1 },
+            provisionedConcurrency: { type: 'integer', minimum: 0 },
             reservedConcurrency: { type: 'integer', minimum: 0 },
             role: { $ref: '#/definitions/awsLambdaRole' },
             runtime: { $ref: '#/definitions/awsLambdaRuntime' },


### PR DESCRIPTION
Allows provisionedConcurrency to be zero, as this is useful for setting the value depending on the environment, see #8253

Closes: #8253
