### PR TITLE
Coerce configuration input

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -25,24 +25,21 @@ const normalizeSchemaObject = (object, instanceSchema) => {
 
 // Normalizer is introduced to workaround https://github.com/ajv-validator/ajv/issues/1287
 // normalizedObjectsMap allows to handle circular structures without issues
-const normalizedObjectsMap = new WeakMap();
+const normalizedObjectsSet = new WeakSet();
 const normalizeUserConfig = object => {
-  if (normalizedObjectsMap.has(object)) return normalizedObjectsMap.get(object);
+  if (normalizedObjectsSet.has(object)) return object;
+  normalizedObjectsSet.add(object);
   if (Array.isArray(object)) {
-    const normalizedObject = [];
-    normalizedObjectsMap.set(object, normalizedObject);
     for (const value of object) {
-      normalizedObject.push(_.isObject(value) ? normalizeUserConfig(value) : value);
+      if (_.isObject(value)) normalizeUserConfig(value);
     }
-    return normalizedObject;
+  } else {
+    for (const [key, value] of Object.entries(object)) {
+      if (value == null) delete object[key];
+      else if (_.isObject(value)) normalizeUserConfig(value);
+    }
   }
-  const normalizedObject = Object.create(null);
-  normalizedObjectsMap.set(object, normalizedObject);
-  for (const [key, value] of Object.entries(object)) {
-    if (value == null) continue;
-    normalizedObject[key] = _.isObject(value) ? normalizeUserConfig(value) : value;
-  }
-  return normalizedObject;
+  return object;
 };
 
 class ConfigSchemaHandler {

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -91,7 +91,7 @@ class ConfigSchemaHandler {
       this.relaxProviderSchema();
     }
 
-    const ajv = new Ajv({ allErrors: true, verbose: true });
+    const ajv = new Ajv({ allErrors: true, coerceTypes: true, verbose: true });
     require('ajv-keywords')(ajv, 'regexp');
     // Workaround https://github.com/ajv-validator/ajv/issues/1255
     normalizeSchemaObject(this.schema, this.schema);

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -207,13 +207,15 @@ class ConfigSchemaHandler {
   }
 
   relaxProviderSchema() {
+    // provider
     this.schema.properties.provider.additionalProperties = true;
+
+    // functions[]
     this.schema.properties.functions.patternProperties[
       FUNCTION_NAME_PATTERN
     ].additionalProperties = true;
 
-    // Do not report errors regarding unsupported function events as
-    // their schemas are not defined.
+    // functions[].events[]
     if (
       Array.isArray(
         this.schema.properties.functions.patternProperties[FUNCTION_NAME_PATTERN].properties.events


### PR DESCRIPTION
So far version validation was strict, we've just allowed `null` values (properties with `null` were removed for validation), still that imposes not justified burden (as e.g. case described here: https://github.com/serverless/serverless/issues/8285#issuecomment-699452572)

This patch ensures that `null` valued properties are cleared from resolved config not only for validation but also for it's further processing, and more importantly it coerces primitive values so they adhere to schema.

Coercion is done per rules described here: https://ajv.js.org/coercion.html (with _array_ coercion turned off at this point, as it seems it be problematic: https://github.com/ajv-validator/ajv/issues/1294)


