### PR TITLE
test(AWS SQS): add integration test for sqs with provisioned concurrency

### DIFF
--- a/test/fixtures/provisionedConcurrency/core.js
+++ b/test/fixtures/provisionedConcurrency/core.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function handler(event, context, callback) {
+  const functionName = 'provisionedFunc';
+  // eslint-disable-next-line no-console
+  console.log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { handler };

--- a/test/fixtures/provisionedConcurrency/serverless.yml
+++ b/test/fixtures/provisionedConcurrency/serverless.yml
@@ -1,0 +1,24 @@
+service: service
+
+configValidationMode: error
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  versionFunctions: false
+
+functions:
+  provisionedFunc:
+    handler: core.handler
+    provisionedConcurrency: 1
+    events:
+      - sqs:
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - sqs
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - ${self:service.name}-provisioned

--- a/test/integration/provisionedConcurrency.test.js
+++ b/test/integration/provisionedConcurrency.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { expect } = require('chai');
+const log = require('log').get('serverless:test');
+const fixtures = require('../fixtures');
+
+const { createSqsQueue, deleteSqsQueue, sendSqsMessage } = require('../utils/sqs');
+const { confirmCloudWatchLogs } = require('../utils/misc');
+const { deployService, removeService } = require('../utils/integration');
+
+describe('AWS - Provisioned Concurrency Integration Test', function() {
+  this.timeout(1000 * 60 * 100); // Involves time-taking deploys
+  let stackName;
+  let servicePath;
+  let queueName;
+  const stage = 'dev';
+
+  before(async () => {
+    const serviceData = await fixtures.setup('provisionedConcurrency');
+    ({ servicePath } = serviceData);
+    const serviceName = serviceData.serviceConfig.service;
+
+    queueName = `${serviceName}-provisioned`;
+    stackName = `${serviceName}-${stage}`;
+    // create existing SQS queue
+    // NOTE: deployment can only be done once the SQS queue is created
+    log.notice(`Creating SQS queue "${queueName}"...`);
+    await createSqsQueue(queueName);
+    return deployService(servicePath);
+  });
+
+  after(async () => {
+    await removeService(servicePath);
+    log.notice(`Deleting SQS queue "${queueName}"...`);
+    return deleteSqsQueue(queueName);
+  });
+
+  it('should be correctly invoked by sqs event', async () => {
+    const functionName = 'provisionedFunc';
+    const message = 'Hello from SQS!';
+
+    const events = await confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, () =>
+      sendSqsMessage(queueName, message)
+    );
+
+    const logs = events.reduce((data, event) => data + event.message, '');
+    expect(logs).to.include(functionName);
+    expect(logs).to.include(message);
+  });
+});


### PR DESCRIPTION
Add integration test for provisioned concurrency, using `sqs` event.

For additional context: I run this test suite 20 times and on average it takes 7 minutes to run, however, I experienced one run with 8 minutes and one with 9 minutes as well. 

Closes: #8321 
