### PR TITLE
Config Schema: Fix SNS event schema (allow both `arn` and `topicName` in `sns` event)

### DIFF
--- a/lib/plugins/aws/package/compile/events/sns/index.js
+++ b/lib/plugins/aws/package/compile/events/sns/index.js
@@ -45,7 +45,7 @@ class AwsCompileSNSEvents {
               additionalProperties: false,
             },
           },
-          oneOf: [{ required: ['arn'] }, { required: ['topicName'] }],
+          anyOf: [{ required: ['arn'] }, { required: ['topicName'] }],
           additionalProperties: false,
         },
       ],


### PR DESCRIPTION
Fixes regression introduced with #8323 

There are valid scenarios where `arn` and `topicName` should be provided
