### PR TITLE
fix(AWS Deploy) Not to delete .serverless directory after deploy

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -72,17 +72,9 @@ class AwsDeploy {
             if (bucketName) {
               return this.existsDeploymentBucket(bucketName);
             }
-
             return BbPromise.resolve();
           })
-          .then(() => {
-            if (!this.options.package && !this.serverless.service.package.path) {
-              return this.extendedValidate();
-            }
-            return BbPromise.bind(this)
-              .then(() => this.serverless.pluginManager.spawn('aws:common:moveArtifactsToTemp'))
-              .then(this.extendedValidate);
-          }),
+          .then(() => this.extendedValidate()),
 
       // Deploy outer lifecycle
       'deploy:deploy': () =>
@@ -129,21 +121,12 @@ class AwsDeploy {
 
       // Deploy finalize inner lifecycle
       'aws:deploy:finalize:cleanup': () =>
-        BbPromise.bind(this)
-          .then(() => {
-            if (this.options.noDeploy || this.serverless.service.provider.shouldNotDeploy) {
-              return BbPromise.resolve();
-            }
-            return this.cleanupS3Bucket();
-          })
-          .then(() => {
-            if (this.options.package || this.serverless.service.package.path) {
-              return BbPromise.bind(this).then(() =>
-                this.serverless.pluginManager.spawn('aws:common:cleanupTempDir')
-              );
-            }
+        BbPromise.bind(this).then(() => {
+          if (this.options.noDeploy || this.serverless.service.provider.shouldNotDeploy) {
             return BbPromise.resolve();
-          }),
+          }
+          return this.cleanupS3Bucket();
+        }),
     };
   }
 }

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -105,16 +105,12 @@ describe('AwsDeploy', () => {
       let extendedValidateStub;
       let spawnPackageStub;
       let spawnAwsCommonValidateStub;
-      let spawnAwsCommonMoveArtifactsToTemp;
 
       beforeEach(() => {
         extendedValidateStub = sinon.stub(awsDeploy, 'extendedValidate').resolves();
         existsDeploymentBucketStub = sinon.stub(awsDeploy, 'existsDeploymentBucket').resolves();
         spawnPackageStub = spawnStub.withArgs('package').resolves();
         spawnAwsCommonValidateStub = spawnStub.withArgs('aws:common:validate').resolves();
-        spawnAwsCommonMoveArtifactsToTemp = spawnStub
-          .withArgs('aws:common:moveArtifactsToTemp')
-          .resolves();
       });
 
       afterEach(() => {
@@ -128,38 +124,16 @@ describe('AwsDeploy', () => {
         return awsDeploy.hooks['before:deploy:deploy']().then(() => {
           expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
           expect(extendedValidateStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(true);
-          expect(spawnAwsCommonMoveArtifactsToTemp.calledOnce).to.equal(false);
         });
       });
 
-      it('should move the artifacts to the tmp dir if options based config is provided', () => {
+      it('should not move the artifacts to the tmp dir if options based config is provided', () => {
         awsDeploy.options.package = true;
         awsDeploy.serverless.service.package.path = false;
 
         return awsDeploy.hooks['before:deploy:deploy']().then(() => {
           expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
-          expect(
-            spawnAwsCommonMoveArtifactsToTemp.calledAfter(spawnAwsCommonValidateStub)
-          ).to.equal(true);
-          expect(extendedValidateStub.calledAfter(spawnAwsCommonMoveArtifactsToTemp)).to.equal(
-            true
-          );
-          expect(spawnPackageStub.calledOnce).to.equal(false);
-        });
-      });
-
-      it('should move the artifacts to the tmp dir if service based config is provided', () => {
-        awsDeploy.options.package = false;
-        awsDeploy.serverless.service.package.path = true;
-
-        return awsDeploy.hooks['before:deploy:deploy']().then(() => {
-          expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
-          expect(
-            spawnAwsCommonMoveArtifactsToTemp.calledAfter(spawnAwsCommonValidateStub)
-          ).to.equal(true);
-          expect(extendedValidateStub.calledAfter(spawnAwsCommonMoveArtifactsToTemp)).to.equal(
-            true
-          );
+          expect(extendedValidateStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(true);
           expect(spawnPackageStub.calledOnce).to.equal(false);
         });
       });
@@ -172,13 +146,7 @@ describe('AwsDeploy', () => {
 
         return awsDeploy.hooks['before:deploy:deploy']().then(() => {
           expect(spawnAwsCommonValidateStub.calledOnce).to.equal(true);
-          expect(existsDeploymentBucketStub.calledAfter(spawnAwsCommonValidateStub)).to.equal(true);
-          expect(
-            spawnAwsCommonMoveArtifactsToTemp.calledAfter(existsDeploymentBucketStub)
-          ).to.equal(true);
-          expect(extendedValidateStub.calledAfter(spawnAwsCommonMoveArtifactsToTemp)).to.equal(
-            true
-          );
+          expect(extendedValidateStub.calledAfter(existsDeploymentBucketStub)).to.equal(true);
           expect(spawnPackageStub.calledOnce).to.equal(false);
         });
       });
@@ -294,13 +262,9 @@ describe('AwsDeploy', () => {
 
     describe('"aws:deploy:finalize:cleanup" hook', () => {
       let cleanupS3BucketStub;
-      let spawnAwsCommonCleanupTempDirStub;
 
       beforeEach(() => {
         cleanupS3BucketStub = sinon.stub(awsDeploy, 'cleanupS3Bucket').resolves();
-        spawnAwsCommonCleanupTempDirStub = spawnStub
-          .withArgs('aws:common:cleanupTempDir')
-          .resolves();
       });
 
       afterEach(() => {
@@ -313,27 +277,24 @@ describe('AwsDeploy', () => {
 
         return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
           expect(cleanupS3BucketStub.calledOnce).to.equal(true);
-          expect(spawnAwsCommonCleanupTempDirStub.calledOnce).to.equal(false);
         });
       });
 
-      it('should cleanup the tmp dir if options based packaging config is used', () => {
+      it('should cleanup s3 if options based packaging config is used', () => {
         awsDeploy.options.package = true;
         awsDeploy.serverless.service.package.path = false;
 
         return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
           expect(cleanupS3BucketStub.calledOnce).to.equal(true);
-          expect(spawnAwsCommonCleanupTempDirStub.calledAfter(cleanupS3BucketStub)).to.equal(true);
         });
       });
 
-      it('should cleanup the tmp dir if service based packaging config is used', () => {
+      it('should cleanup the s3 if service based packaging config is used', () => {
         awsDeploy.options.package = false;
         awsDeploy.serverless.service.package.path = true;
 
         return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
           expect(cleanupS3BucketStub.calledOnce).to.equal(true);
-          expect(spawnAwsCommonCleanupTempDirStub.calledAfter(cleanupS3BucketStub)).to.equal(true);
         });
       });
 
@@ -342,7 +303,6 @@ describe('AwsDeploy', () => {
 
         return awsDeploy.hooks['aws:deploy:finalize:cleanup']().then(() => {
           expect(cleanupS3BucketStub.called).to.equal(false);
-          expect(spawnAwsCommonCleanupTempDirStub.called).to.equal(false);
         });
       });
     });

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -9,11 +9,8 @@ module.exports = {
   extendedValidate() {
     // Restore state
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
-    const serviceStateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      serviceStateFileName
-    );
+
+    const serviceStateFilePath = path.join(this.packagePath, serviceStateFileName);
     if (!this.serverless.utils.fileExistsSync(serviceStateFilePath)) {
       throw new this.serverless.classes.Error(
         `No ${serviceStateFileName} file found in the package path you provided.`
@@ -29,8 +26,7 @@ module.exports = {
     // only restore the default artifact path if the user is not using a custom path
     if (state.package.artifact && this.serverless.service.artifact) {
       this.serverless.service.package.artifact = path.join(
-        this.serverless.config.servicePath,
-        '.serverless',
+        this.packagePath,
         state.package.artifact
       );
     }

--- a/lib/utils/resolveCliInput.js
+++ b/lib/utils/resolveCliInput.js
@@ -6,8 +6,8 @@ const ServerlessError = require('../classes/Error').ServerlessError;
 
 const yargsOptions = {
   boolean: ['help', 'version', 'verbose'],
-  string: ['config'],
-  alias: { config: 'c', help: 'h', version: 'v' },
+  string: ['config', 'package'],
+  alias: { config: 'c', help: 'h', version: 'v', package: 'p' },
   configuration: { 'parse-numbers': false },
 };
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

## Issue
https://github.com/serverless/serverless/issues/7298

## Summary
- Fix not to copy the context of -p (p is the option for deploy command) directory into `.serverless` directory when executing the command `sls deploy -p /path/to/content`
- Fix not to copy the content that is `package.path` in `serverless.yml` into `.serverless` directory when executing the command `sls deploy`
- Fix to not delete .serverless directory after deployment
