### PR TITLE
AWS API Gateway: Fix API Gateway naming convention

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,6 +6,14 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
+<a name="AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE"><div>&nbsp;</div></a>
+
+## API Gateway naming will be changed to `${service}-${stage}`
+
+Starting with v3.0.0, API Gateway naming will be changed from `${service}-${stage}` to `${stage}-${service}`.
+
+Adapt to this convention now by setting `provider.apiGateway.shouldStartNameWithService` to `true`.
+
 <a name="ALEXA_SKILL_EVENT_WITHOUT_APP_ID"><div>&nbsp;</div></a>
 
 ## Support for `alexaSkill` event without `appId` is to be removed

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -10,7 +10,7 @@ layout: Doc
 
 ## API Gateway naming will be changed to `${service}-${stage}`
 
-Starting with v3.0.0, API Gateway naming will be changed from `${service}-${stage}` to `${stage}-${service}`.
+Starting with v3.0.0, API Gateway naming will be changed from `${stage}-${service}` to `${service}-${stage}`.
 
 Adapt to this convention now by setting `provider.apiGateway.shouldStartNameWithService` to `true`.
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -83,6 +83,7 @@ provider:
     binaryMediaTypes: # Optional binary media types the API might return
       - '*/*'
     metrics:  false # Optional detailed Cloud Watch Metrics
+    shouldStartNameWithService: false # Use `${service}-${stage}` naming for API Gateway. Will be `true` by default in next major version.
   alb:
     targetGroupPrefix: xxxxxxxxxx # Optional prefix to prepend when generating names for target groups
     authorizers:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -83,7 +83,7 @@ provider:
     binaryMediaTypes: # Optional binary media types the API might return
       - '*/*'
     metrics:  false # Optional detailed Cloud Watch Metrics
-    shouldStartNameWithService: true # Use `${service}-${stage}` naming for API Gateway. Will be `true` by default in next major version.
+    shouldStartNameWithService: false # Use `${service}-${stage}` naming for API Gateway. Will be `true` by default in next major version.
   alb:
     targetGroupPrefix: xxxxxxxxxx # Optional prefix to prepend when generating names for target groups
     authorizers:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -83,7 +83,7 @@ provider:
     binaryMediaTypes: # Optional binary media types the API might return
       - '*/*'
     metrics:  false # Optional detailed Cloud Watch Metrics
-    shouldStartNameWithService: false # Use `${service}-${stage}` naming for API Gateway. Will be `true` by default in next major version.
+    shouldStartNameWithService: true # Use `${service}-${stage}` naming for API Gateway. Will be `true` by default in next major version.
   alb:
     targetGroupPrefix: xxxxxxxxxx # Optional prefix to prepend when generating names for target groups
     authorizers:

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -259,7 +259,8 @@ module.exports = {
 
     this.provider.serverless._logDeprecation(
       'AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE',
-      'Starting with next major version, API Gateway naming will be changed from `${service}-${stage}` to `${stage}-${service}`.'
+      'Starting with next major version, API Gateway naming will be changed from "{stage}-{service}" to "{service}-{stage}".\n' +
+        'Set "provider.apiGateway.shouldStartNameWithService" to "true" to adapt to the new behavior now.'
     );
 
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -250,10 +250,7 @@ module.exports = {
       return `${this.provider.serverless.service.provider.apiName}`;
     }
 
-    if (
-      this.provider.serverless.service.provider.apiGateway &&
-      this.provider.serverless.service.provider.apiGateway.shouldStartNameWithService === true
-    ) {
+    if (_.get(this.provider.serverless.service.provider.apiGateway, 'shouldStartNameWithService')) {
       return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
     }
 

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -249,6 +249,19 @@ module.exports = {
     if (this.provider.serverless.service.provider.apiName) {
       return `${this.provider.serverless.service.provider.apiName}`;
     }
+
+    if (
+      this.provider.serverless.service.provider.apiGateway &&
+      this.provider.serverless.service.provider.apiGateway.shouldStartNameWithService === true
+    ) {
+      return `${this.provider.serverless.service.service}-${this.provider.getStage()}`;
+    }
+
+    this.provider.serverless._logDeprecation(
+      'AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE',
+      'Starting with next major version, API Gateway naming will be changed from `${service}-${stage}` to `${stage}-${service}`.'
+    );
+
     return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;
   },
   generateApiGatewayDeploymentLogicalId(id) {

--- a/lib/plugins/aws/lib/naming.test.js
+++ b/lib/plugins/aws/lib/naming.test.js
@@ -312,6 +312,14 @@ describe('#naming()', () => {
   });
 
   describe('#getApiGatewayName()', () => {
+    it('should return the composition of service & stage name if custom name not provided and shouldStartNameWithService is true', () => {
+      serverless.service.service = 'myService';
+      serverless.service.provider.apiGateway = { shouldStartNameWithService: true };
+      expect(sdk.naming.getApiGatewayName()).to.equal(
+        `${serverless.service.service}-${sdk.naming.provider.getStage()}`
+      );
+    });
+
     it('should return the composition of stage & service name if custom name not provided', () => {
       serverless.service.service = 'myService';
       expect(sdk.naming.getApiGatewayName()).to.equal(

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -484,6 +484,7 @@ class AwsProvider {
                   ],
                 },
                 restApiRootResourceId: { $ref: '#/definitions/awsCfInstruction' },
+                shouldStartNameWithService: { type: 'boolean' },
                 websocketApiId: { $ref: '#/definitions/awsCfInstruction' },
               },
               additionalProperties: false,

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -484,7 +484,7 @@ class AwsProvider {
                   ],
                 },
                 restApiRootResourceId: { $ref: '#/definitions/awsCfInstruction' },
-                shouldStartNameWithService: { type: 'boolean' },
+                shouldStartNameWithService: { const: true },
                 websocketApiId: { $ref: '#/definitions/awsCfInstruction' },
               },
               additionalProperties: false,


### PR DESCRIPTION
The naming of API Gateway will be changed from `${stage}-${service}` to `${service}-${stage}` in the next major version.
    
This commit adds a deprecation notice and an option to already adapt to this this convetion.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Adresses: #2918
