### PR TITLE
feat(aws stream): provisioned concurrency support for aws stream event

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const resolveLambdaTarget = require('../../../../utils/resolveLambdaTarget');
 
 class AwsCompileStreamEvents {
   constructor(serverless) {
@@ -182,13 +183,13 @@ class AwsCompileStreamEvents {
               return EventSourceArn.split('/')[1];
             })();
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const streamLogicalId = this.provider.naming.getStreamLogicalId(
               functionName,
               streamType,
               streamName
             );
 
+            // TODO: properly resolve dependsOn when alias is targetAlias available
             const dependsOn = this.provider.resolveFunctionIamRoleResourceName(functionObj) || [];
             const streamResource = {
               Type: 'AWS::Lambda::EventSourceMapping',
@@ -197,9 +198,7 @@ class AwsCompileStreamEvents {
                 BatchSize,
                 ParallelizationFactor,
                 EventSourceArn,
-                FunctionName: {
-                  'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                },
+                FunctionName: resolveLambdaTarget(functionName, functionObj),
                 StartingPosition,
                 Enabled,
               },

--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -189,8 +189,18 @@ class AwsCompileStreamEvents {
               streamName
             );
 
-            // TODO: properly resolve dependsOn when alias is targetAlias available
-            const dependsOn = this.provider.resolveFunctionIamRoleResourceName(functionObj) || [];
+            const dependsOn = [];
+            const functionIamRoleResourceName = this.provider.resolveFunctionIamRoleResourceName(
+              functionObj
+            );
+            if (functionIamRoleResourceName) {
+              dependsOn.push(functionIamRoleResourceName);
+            }
+            const { targetAlias } = this.serverless.service.functions[functionName];
+            if (targetAlias) {
+              dependsOn.push(targetAlias.logicalId);
+            }
+
             const streamResource = {
               Type: 'AWS::Lambda::EventSourceMapping',
               DependsOn: dependsOn,

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -167,10 +167,6 @@ describe('AwsCompileStreamEvents', () => {
       ).to.include(roleLogicalId);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.have.lengthOf(1);
-      expect(
-        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
       ).to.equal(null);
     });
@@ -199,10 +195,6 @@ describe('AwsCompileStreamEvents', () => {
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbFoo.DependsOn
       ).to.include(roleLogicalId);
-      expect(
-        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.have.lengthOf(1);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -330,10 +322,6 @@ describe('AwsCompileStreamEvents', () => {
       ).to.include(roleLogicalId);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.have.lengthOf(1);
-      expect(
-        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
       ).to.equal(null);
     });
@@ -363,10 +351,6 @@ describe('AwsCompileStreamEvents', () => {
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbFoo.DependsOn
       ).to.include(roleLogicalId);
-      expect(
-        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-          .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.have.lengthOf(1);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -429,10 +413,6 @@ describe('AwsCompileStreamEvents', () => {
         ).to.include('IamRoleLambdaExecution');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn
-        ).to.have.lengthOf(1);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.EventSourceArn
         ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.arn);
         expect(
@@ -462,10 +442,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbBar.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.EventSourceArn
@@ -502,10 +478,6 @@ describe('AwsCompileStreamEvents', () => {
         ).to.include('IamRoleLambdaExecution');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbBaz.DependsOn
-        ).to.have.lengthOf(1);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.EventSourceArn
         ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[2].stream);
         expect(
@@ -538,10 +510,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbBuzz.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.EventSourceArn
@@ -580,10 +548,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFizz.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingDynamodbFizz.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFizz.Properties.EventSourceArn
@@ -1203,10 +1167,6 @@ describe('AwsCompileStreamEvents', () => {
         ).to.include('IamRoleLambdaExecution');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
-        ).to.have.lengthOf(1);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.EventSourceArn
         ).to.equal(awsCompileStreamEvents.serverless.service.functions.first.events[0].stream.arn);
         expect(
@@ -1241,12 +1201,8 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+            .Resources.FirstEventSourceMappingKinesisBar.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.EventSourceArn
@@ -1283,12 +1239,8 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+            .Resources.FirstEventSourceMappingKinesisBaz.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.EventSourceArn
@@ -1321,12 +1273,8 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+            .Resources.FirstEventSourceMappingKinesisBuzz.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBuzz.Properties.EventSourceArn
@@ -1363,12 +1311,8 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+            .Resources.FirstEventSourceMappingKinesisFizz.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFizz.Properties.EventSourceArn
@@ -1431,10 +1375,6 @@ describe('AwsCompileStreamEvents', () => {
         ).to.include('IamRoleLambdaExecution');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisXyz.DependsOn
-        ).to.have.lengthOf(1);
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisXyz.Properties.EventSourceArn
         ).to.equal('arn:aws:kinesis:region:account:stream/xyz/consumer/foobar:1558544531');
         expect(
@@ -1459,10 +1399,6 @@ describe('AwsCompileStreamEvents', () => {
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.DependsOn
         ).to.include('IamRoleLambdaExecution');
-        expect(
-          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisDef.DependsOn
-        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.EventSourceArn

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const AwsProvider = require('../../../../provider/awsProvider');
 const AwsCompileStreamEvents = require('./index');
 const Serverless = require('../../../../../../Serverless');
+const runServerless = require('../../../../../../../test/utils/run-serverless');
 
 describe('AwsCompileStreamEvents', () => {
   let serverless;
@@ -1577,6 +1578,43 @@ describe('AwsCompileStreamEvents', () => {
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
       ).to.have.any.keys('FirstEventSourceMappingKinesisSomelongname');
+    });
+  });
+});
+
+describe('AwsCompileStreamEvents #2', () => {
+  describe('with provisioned concurrency', () => {
+    let eventSourceMappingResource;
+
+    before(async () => {
+      const { awsNaming, cfTemplate } = await runServerless({
+        fixture: 'function',
+        configExt: {
+          functions: {
+            foo: {
+              provisionedConcurrency: 1,
+              events: [{ stream: 'arn:aws:kinesis:us-east-1:123456789012:stream/myStream' }],
+            },
+          },
+        },
+        cliArgs: ['package'],
+      });
+      const streamLogicalId = awsNaming.getStreamLogicalId('foo', 'kinesis', 'myStream');
+      eventSourceMappingResource = cfTemplate.Resources[streamLogicalId];
+    });
+
+    it('should reference provisioned alias', () => {
+      expect(eventSourceMappingResource.Properties.FunctionName).to.deep.equal({
+        'Fn::Join': [
+          ':',
+          [
+            {
+              'Fn::GetAtt': ['FooLambdaFunction', 'Arn'],
+            },
+            'provisioned',
+          ],
+        ],
+      });
     });
   });
 });

--- a/lib/plugins/aws/package/compile/events/stream/index.test.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.test.js
@@ -164,7 +164,11 @@ describe('AwsCompileStreamEvents', () => {
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbFoo.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -194,7 +198,11 @@ describe('AwsCompileStreamEvents', () => {
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbFoo.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -319,7 +327,11 @@ describe('AwsCompileStreamEvents', () => {
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbFoo.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -350,7 +362,11 @@ describe('AwsCompileStreamEvents', () => {
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .FirstEventSourceMappingDynamodbFoo.DependsOn
-      ).to.equal(roleLogicalId);
+      ).to.include(roleLogicalId);
+      expect(
+        awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .FirstEventSourceMappingDynamodbFoo.DependsOn
+      ).to.have.lengthOf(1);
       expect(
         awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .IamRoleLambdaExecution
@@ -410,7 +426,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbFoo.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFoo.Properties.EventSourceArn
@@ -441,7 +461,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBar.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBar.Properties.EventSourceArn
@@ -475,7 +499,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBaz.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBaz.Properties.EventSourceArn
@@ -509,7 +537,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbBuzz.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbBuzz.Properties.EventSourceArn
@@ -547,7 +579,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFizz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingDynamodbFizz.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingDynamodbFizz.Properties.EventSourceArn
@@ -1164,7 +1200,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFoo.Properties.EventSourceArn
@@ -1201,8 +1241,12 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisBar.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBar.Properties.EventSourceArn
@@ -1239,8 +1283,12 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisBaz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBaz.Properties.EventSourceArn
@@ -1273,8 +1321,12 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisBuzz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisBuzz.Properties.EventSourceArn
@@ -1311,8 +1363,12 @@ describe('AwsCompileStreamEvents', () => {
         ).to.equal('AWS::Lambda::EventSourceMapping');
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
-            .Resources.FirstEventSourceMappingKinesisFizz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisFoo.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisFizz.Properties.EventSourceArn
@@ -1372,7 +1428,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisXyz.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisXyz.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisXyz.Properties.EventSourceArn
@@ -1398,7 +1458,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.DependsOn
-        ).to.equal('IamRoleLambdaExecution');
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.DependsOn
+        ).to.have.lengthOf(1);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.EventSourceArn
@@ -1584,6 +1648,7 @@ describe('AwsCompileStreamEvents', () => {
 
 describe('AwsCompileStreamEvents #2', () => {
   describe('with provisioned concurrency', () => {
+    let naming;
     let eventSourceMappingResource;
 
     before(async () => {
@@ -1599,6 +1664,7 @@ describe('AwsCompileStreamEvents #2', () => {
         },
         cliArgs: ['package'],
       });
+      naming = awsNaming;
       const streamLogicalId = awsNaming.getStreamLogicalId('foo', 'kinesis', 'myStream');
       eventSourceMappingResource = cfTemplate.Resources[streamLogicalId];
     });
@@ -1615,6 +1681,11 @@ describe('AwsCompileStreamEvents #2', () => {
           ],
         ],
       });
+    });
+
+    it('should depend on provisioned alias', () => {
+      const aliasLogicalId = naming.getLambdaProvisionedConcurrencyAliasLogicalId('foo');
+      expect(eventSourceMappingResource.DependsOn).to.include(aliasLogicalId);
     });
   });
 });

--- a/test/fixtures/provisionedConcurrency/core.js
+++ b/test/fixtures/provisionedConcurrency/core.js
@@ -1,19 +1,19 @@
 'use strict';
 
-function sqsHandler(event, context, callback) {
-  const functionName = 'provisionedSqs';
-  // eslint-disable-next-line no-console
-  console.log(functionName, JSON.stringify(event));
-  return callback(null, event);
-}
-
-function kinesisHandler(event, context, callback) {
-  const functionName = 'provisionedKinesis';
+function handler(event, context, callback) {
+  const functionName = 'provisionedFunc';
   const { Records } = event;
-  const messages = Records.map(({ kinesis: { data } }) => Buffer.from(data, 'base64').toString());
+  const messages = Records.map(record => {
+    if (record.eventSource === 'aws:sqs') {
+      return record.body;
+    } else if (record.eventSource === 'aws:kinesis') {
+      return Buffer.from(record.kinesis.data, 'base64').toString();
+    }
+    return '';
+  });
   // eslint-disable-next-line no-console
   console.log(functionName, JSON.stringify(messages));
   return callback(null, event);
 }
 
-module.exports = { sqsHandler, kinesisHandler };
+module.exports = { handler };

--- a/test/fixtures/provisionedConcurrency/core.js
+++ b/test/fixtures/provisionedConcurrency/core.js
@@ -1,10 +1,19 @@
 'use strict';
 
-function handler(event, context, callback) {
-  const functionName = 'provisionedFunc';
+function sqsHandler(event, context, callback) {
+  const functionName = 'provisionedSqs';
   // eslint-disable-next-line no-console
   console.log(functionName, JSON.stringify(event));
   return callback(null, event);
 }
 
-module.exports = { handler };
+function kinesisHandler(event, context, callback) {
+  const functionName = 'provisionedKinesis';
+  const { Records } = event;
+  const messages = Records.map(({ kinesis: { data } }) => Buffer.from(data, 'base64').toString());
+  // eslint-disable-next-line no-console
+  console.log(functionName, JSON.stringify(messages));
+  return callback(null, event);
+}
+
+module.exports = { sqsHandler, kinesisHandler };

--- a/test/fixtures/provisionedConcurrency/serverless.yml
+++ b/test/fixtures/provisionedConcurrency/serverless.yml
@@ -8,8 +8,8 @@ provider:
   versionFunctions: false
 
 functions:
-  provisionedFunc:
-    handler: core.handler
+  provisionedSqs:
+    handler: core.sqsHandler
     provisionedConcurrency: 1
     events:
       - sqs:
@@ -22,3 +22,18 @@ functions:
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
                 - ${self:service.name}-provisioned
+  provisionedKinesis:
+    handler: core.kinesisHandler
+    provisionedConcurrency: 1
+    events:
+      - stream:
+          type: kinesis
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - kinesis
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - stream/${self:service.name}-kinesis

--- a/test/fixtures/provisionedConcurrency/serverless.yml
+++ b/test/fixtures/provisionedConcurrency/serverless.yml
@@ -8,22 +8,8 @@ provider:
   versionFunctions: false
 
 functions:
-  provisionedSqs:
-    handler: core.sqsHandler
-    provisionedConcurrency: 1
-    events:
-      - sqs:
-          arn:
-            Fn::Join:
-              - ':'
-              - - arn
-                - aws
-                - sqs
-                - Ref: AWS::Region
-                - Ref: AWS::AccountId
-                - ${self:service.name}-provisioned
-  provisionedKinesis:
-    handler: core.kinesisHandler
+  provisionedFunc:
+    handler: core.handler
     provisionedConcurrency: 1
     events:
       - stream:
@@ -37,3 +23,13 @@ functions:
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
                 - stream/${self:service.name}-kinesis
+      - sqs:
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - sqs
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - ${self:service.name}-provisioned

--- a/test/integration/provisionedConcurrency.test.js
+++ b/test/integration/provisionedConcurrency.test.js
@@ -26,19 +26,15 @@ describe('AWS - Provisioned Concurrency Integration Test', function() {
     queueName = `${serviceName}-provisioned`;
     stackName = `${serviceName}-${stage}`;
     // NOTE: deployment can only be done once the SQS queue and Kinesis Stream is created
-    log.notice(`Creating SQS queue "${queueName}"...`);
-    await createSqsQueue(queueName);
-    log.notice(`Creating Kinesis stream "${streamName}"...`);
-    await createKinesisStream(streamName);
+    log.notice(`Creating SQS queue "${queueName}" and Kinesis stream "${streamName}"...`);
+    await Promise.all([createSqsQueue(queueName), createKinesisStream(streamName)]);
     return deployService(servicePath);
   });
 
   after(async () => {
     await removeService(servicePath);
-    log.notice(`Deleting Kinesis stream "${streamName}"...`);
-    await deleteKinesisStream(streamName);
-    log.notice(`Deleting SQS queue "${queueName}"...`);
-    return deleteSqsQueue(queueName);
+    log.notice(`Deleting SQS queue "${queueName}" and Kinesis stream "${streamName}"...`);
+    return Promise.all([deleteKinesisStream(streamName), deleteSqsQueue(queueName)]);
   });
 
   it('should be correctly invoked by sqs event', async () => {

--- a/test/integration/provisionedConcurrency.test.js
+++ b/test/integration/provisionedConcurrency.test.js
@@ -42,11 +42,15 @@ describe('AWS - Provisioned Concurrency Integration Test', function() {
   });
 
   it('should be correctly invoked by sqs event', async () => {
-    const functionName = 'provisionedSqs';
+    const functionName = 'provisionedFunc';
     const message = 'Hello from SQS!';
 
-    const events = await confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, () =>
-      sendSqsMessage(queueName, message)
+    const events = await confirmCloudWatchLogs(
+      `/aws/lambda/${stackName}-${functionName}`,
+      () => sendSqsMessage(queueName, message),
+      {
+        checkIsComplete: items => items.find(item => item.message.includes(message)),
+      }
     );
 
     const logs = events.reduce((data, event) => data + event.message, '');
@@ -55,11 +59,15 @@ describe('AWS - Provisioned Concurrency Integration Test', function() {
   });
 
   it('should be correctly invoked by kinesis event', async () => {
-    const functionName = 'provisionedKinesis';
+    const functionName = 'provisionedFunc';
     const message = 'Hello from Kinesis!';
 
-    const events = await confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, () =>
-      putKinesisRecord(streamName, message)
+    const events = await confirmCloudWatchLogs(
+      `/aws/lambda/${stackName}-${functionName}`,
+      () => putKinesisRecord(streamName, message),
+      {
+        checkIsComplete: items => items.find(item => item.message.includes(message)),
+      }
     );
 
     const logs = events.reduce((data, event) => data + event.message, '');


### PR DESCRIPTION
Ensures that `EventSourceMapping` for `stream` events has proper `alias` attached if one exists, It also ensures that the mapping resource will depend on that alias. This PR also adds a corresponding integration test case for `provisionedConcurrency.test.js`.

Note: The average time it takes to run the test now is pretty much the same, around 7-8 minutes.

Closes: #7802 
