### PR TITLE
Variables: Fix support for "${self:}"

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -20,7 +20,7 @@ class Service {
     this.serviceObject = null;
     this.provider = {
       stage: 'dev',
-      variableSyntax: '\\${([^{}:]+?(?:\\(|:)[^:{}][^{}]*?)}',
+      variableSyntax: '\\${([^{}:]+?(?:\\(|:)(?:[^:{}][^{}]*?)?)}',
     };
     this.custom = {};
     this.plugins = [];

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -241,7 +241,7 @@ class Variables {
    * Generate an array of objects noting the terminal properties of the given root object and their
    * paths
    * @param root The object to generate a terminal property path/value set for
-   * @param current The current part of the given root that terminal properties are being sought
+   * @param initCurrent The current part of the given root that terminal properties are being sought
    * within
    * @param [context] An array containing the path to the current object root (intended for internal
    * use)
@@ -249,32 +249,30 @@ class Variables {
    * @returns {TerminalProperty[]} The terminal properties of the given root object, with the path
    * and value of each
    */
-  getProperties(root, atRoot, current, cntxt, rslts) {
-    let context = cntxt;
-    if (!context) {
-      context = [];
-    }
-    let results = rslts;
-    if (!results) {
-      results = [];
-    }
-    const addContext = (value, key) =>
-      this.getProperties(root, false, value, context.concat(key), results);
-    if (Array.isArray(current)) {
-      current.map(addContext);
-    } else if (
-      _.isObject(current) &&
-      !_.isDate(current) &&
-      !_.isRegExp(current) &&
-      typeof current !== 'function'
-    ) {
-      if (atRoot || current !== root) {
-        _.mapValues(current, addContext);
+  getProperties(root, initAtRoot, initCurrent, initContext, initResults) {
+    const processedMap = new WeakMap();
+    return (function self(atRoot, current, context, results) {
+      if (processedMap.has(current)) return processedMap.get(current);
+      if (!context) context = [];
+      if (!results) results = [];
+      if (_.isObject(current)) processedMap.set(current, results);
+      const addContext = (value, key) => self(false, value, context.concat(key), results);
+      if (Array.isArray(current)) {
+        current.map(addContext);
+      } else if (
+        _.isObject(current) &&
+        !_.isDate(current) &&
+        !_.isRegExp(current) &&
+        typeof current !== 'function'
+      ) {
+        if (atRoot || current !== root) {
+          _.mapValues(current, addContext);
+        }
+      } else {
+        results.push({ path: context, value: current });
       }
-    } else {
-      results.push({ path: context, value: current });
-    }
-    return results;
+      return results;
+    })(initAtRoot, initCurrent, initContext, initResults);
   }
 
   /**

--- a/lib/classes/Variables.test.js
+++ b/lib/classes/Variables.test.js
@@ -2769,5 +2769,8 @@ module.exports = {
     it('should support ${self:key} syntax', () => {
       expect(processedConfig.custom.selfReference).to.equal('bar');
     });
+    it('should support ${self:} syntax', () => {
+      expect(processedConfig.custom.serviceReference).to.equal(processedConfig);
+    });
   });
 });

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -59,7 +59,7 @@ describe('AwsProvider', () => {
     });
 
     it('should have no AWS logger', () => {
-      expect(awsProvider.sdk.config.logger).to.be.null;
+      expect(awsProvider.sdk.config.logger == null).to.be.true;
     });
 
     it('should set AWS logger', () => {

--- a/test/fixtures/variables/serverless.yml
+++ b/test/fixtures/variables/serverless.yml
@@ -10,3 +10,4 @@ custom:
   awsVariable: ${AWS::Region}
   cloudFormationReference: ${AnotherResource}
   selfReference: ${self:custom.importedFileWithKey}
+  serviceReference: ${self:}


### PR DESCRIPTION
It was not working for many commands, not long after introduction with https://github.com/serverless/serverless/pull/3208 (published with v1.9.0) - due to not proper handling of circular references (fixed in this PR)

Internal recognition for some commands was additionally wiped out with https://github.com/serverless/serverless/pull/8279 (published with v2.3.0) - due to fine tuning of variables regex (fixed in this PR)

This brings it back, although this functionality feels controversial, and we may consider to deprecate it at some point in a future.
