### PR TITLE
Allows overriding the API GW stage

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -84,8 +84,8 @@ module.exports = {
             throw new ServerlessError(errorMessage);
           }
 
-          this.apiGatewayStageName =
-            this.state.service.provider.apiGateway.stage || this.options.stage;
+          const apiGatewaySettings = this.state.service.provider.apiGateway || {};
+          this.apiGatewayStageName = apiGatewaySettings.stage || this.options.stage;
 
           return resolveStage
             .call(this)

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -83,6 +83,9 @@ module.exports = {
 
             throw new ServerlessError(errorMessage);
           }
+
+          this.apiGatewayStageName = this.state.service.provider.apiGateway.stage || this.options.stage;
+
           return resolveStage
             .call(this)
             .then(ensureStage.bind(this))
@@ -171,7 +174,7 @@ function resolveStage() {
   return this.provider
     .request('APIGateway', 'getStage', {
       restApiId,
-      stageName: this.options.stage,
+      stageName: this.apiGatewayStageName,
     })
     .then(res => {
       this.apiGatewayStageState = res;
@@ -214,7 +217,7 @@ function ensureStage() {
     return this.provider.request('APIGateway', 'createStage', {
       deploymentId,
       restApiId,
-      stageName: this.options.stage,
+      stageName: this.apiGatewayStageName,
     });
   }
 
@@ -256,10 +259,10 @@ function handleLogs() {
 
   if (logs) {
     const service = this.state.service.service;
-    const stage = this.options.stage;
+    const slsStage = this.options.stage;
     const region = this.options.region;
     const partition = this.partition;
-    const logGroupName = `/aws/api-gateway/${service}-${stage}`;
+    const logGroupName = `/aws/api-gateway/${service}-${slsStage}`;
 
     operations = [];
 
@@ -326,7 +329,7 @@ function handleTags() {
   );
 
   const restApiId = this.apiGatewayRestApiId;
-  const stageName = this.options.stage;
+  const stageName = this.apiGatewayStageName;
   const region = this.options.region;
   const partition = this.partition;
   const resourceArn = `arn:${partition}:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;
@@ -366,7 +369,7 @@ function applyUpdates() {
   if (patchOperations.length) {
     return this.provider.request('APIGateway', 'updateStage', {
       restApiId,
-      stageName: this.options.stage,
+      stageName: this.apiGatewayStageName,
       patchOperations,
     });
   }
@@ -377,8 +380,8 @@ function applyUpdates() {
 function removeAccessLoggingLogGroup() {
   const service = this.state.service.service;
   const provider = this.state.service.provider;
-  const stage = this.options.stage;
-  const logGroupName = `/aws/api-gateway/${service}-${stage}`;
+  const slsStage = this.options.stage;
+  const logGroupName = `/aws/api-gateway/${service}-${slsStage}`;
 
   let accessLogging = provider.logs && provider.logs.restApi;
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -84,7 +84,8 @@ module.exports = {
             throw new ServerlessError(errorMessage);
           }
 
-          this.apiGatewayStageName = this.state.service.provider.apiGateway.stage || this.options.stage;
+          this.apiGatewayStageName =
+            this.state.service.provider.apiGateway.stage || this.options.stage;
 
           return resolveStage
             .call(this)

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -748,8 +748,8 @@ describe('#updateStage()', () => {
   it('should allow a apiGw stage name that differs from the sls stage', () => {
     context.state.service.provider.apiGateway = {
       stage: 'someOtherStage',
-      metrics: true
-    }
+      metrics: true,
+    };
     // context.state.service.provider = {
     //   metrics: true,
     // };
@@ -774,9 +774,7 @@ describe('#updateStage()', () => {
       .resolves({});
 
     return updateStage.call(context).then(() => {
-      const patchOperations = [
-        { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' },
-      ];
+      const patchOperations = [{ op: 'replace', path: '/*/*/metrics/enabled', value: 'true' }];
 
       expect(providerRequestStub.args).to.have.length.gte(5);
       expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
@@ -790,7 +788,7 @@ describe('#updateStage()', () => {
       expect(providerRequestStub.args[3][2]).to.deep.equal({
         deploymentId: 'someDeploymentId',
         restApiId: 'devRestApiId',
-        stageName: 'someOtherStage'
+        stageName: 'someOtherStage',
       });
       expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
       expect(providerRequestStub.args[4][1]).to.equal('updateStage');

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -744,4 +744,61 @@ describe('#updateStage()', () => {
   it('should enable tracing if fullExecutionData is set to true', () => {
     return checkDataTrace(true);
   });
+
+  it('should allow a apiGw stage name that differs from the sls stage', () => {
+    context.state.service.provider.apiGateway = {
+      stage: 'someOtherStage',
+      metrics: true
+    }
+    // context.state.service.provider = {
+    //   metrics: true,
+    // };
+    // context.state.service.provider.tracing = { apiGateway: false };
+    providerRequestStub
+      .withArgs('APIGateway', 'getStage', {
+        restApiId: 'devRestApiId',
+        stageName: sinon.match.any,
+      })
+      .rejects({});
+    providerRequestStub
+      .withArgs('APIGateway', 'createStage', {
+        restApiId: 'devRestApiId',
+        stageName: sinon.match.any,
+      })
+      .resolves({});
+    providerRequestStub
+      .withArgs('APIGateway', 'updateStage', {
+        restApiId: 'devRestApiId',
+        stageName: sinon.match.any,
+      })
+      .resolves({});
+
+    return updateStage.call(context).then(() => {
+      const patchOperations = [
+        { op: 'replace', path: '/*/*/metrics/enabled', value: 'true' },
+      ];
+
+      expect(providerRequestStub.args).to.have.length.gte(5);
+      expect(providerRequestStub.args[2][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[2][1]).to.equal('getStage');
+      expect(providerRequestStub.args[2][2]).to.deep.equal({
+        restApiId: 'devRestApiId',
+        stageName: 'someOtherStage',
+      });
+      expect(providerRequestStub.args[3][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[3][1]).to.equal('createStage');
+      expect(providerRequestStub.args[3][2]).to.deep.equal({
+        deploymentId: 'someDeploymentId',
+        restApiId: 'devRestApiId',
+        stageName: 'someOtherStage'
+      });
+      expect(providerRequestStub.args[4][0]).to.equal('APIGateway');
+      expect(providerRequestStub.args[4][1]).to.equal('updateStage');
+      expect(providerRequestStub.args[4][2]).to.deep.equal({
+        restApiId: 'devRestApiId',
+        stageName: 'someOtherStage',
+        patchOperations,
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Allows the API Gateway stage to differ from the Serverless stage.

Closes: #8346
