### PR TITLE
fix(Config Schema): Fix Fn::Join delimiter length schema

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -259,7 +259,7 @@ class AwsProvider {
                 type: 'array',
                 minItems: 2,
                 maxItems: 2,
-                items: [{ type: 'string', minLength: 1 }, { type: 'array' }],
+                items: [{ type: 'string' }, { type: 'array' }],
                 additionalItems: false,
               },
             },


### PR DESCRIPTION
Allows delimiter to be the empty string [as documented by AWS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-join.html).

Closes: #8344 