### PR TITLE
Config Schema: Ensure to preserve `null` values for config validation

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -25,21 +25,32 @@ const normalizeSchemaObject = (object, instanceSchema) => {
 
 // Normalizer is introduced to workaround https://github.com/ajv-validator/ajv/issues/1287
 // normalizedObjectsMap allows to handle circular structures without issues
-const normalizedObjectsSet = new WeakSet();
-const normalizeUserConfig = object => {
-  if (normalizedObjectsSet.has(object)) return object;
-  normalizedObjectsSet.add(object);
-  if (Array.isArray(object)) {
-    for (const value of object) {
-      if (_.isObject(value)) normalizeUserConfig(value);
+const normalizeUserConfig = userConfig => {
+  const normalizedObjectsSet = new WeakSet();
+  const nullPaths = [];
+  const normalizeObject = (object, path) => {
+    if (normalizedObjectsSet.has(object)) return;
+    normalizedObjectsSet.add(object);
+    if (Array.isArray(object)) {
+      for (const [index, value] of object.entries()) {
+        if (_.isObject(value)) normalizeObject(value, path.concat(index));
+      }
+    } else {
+      for (const [key, value] of Object.entries(object)) {
+        if (value == null) {
+          nullPaths.push(path.concat(key));
+          delete object[key];
+        } else if (_.isObject(value)) {
+          normalizeObject(value, path.concat(key));
+        }
+      }
     }
-  } else {
-    for (const [key, value] of Object.entries(object)) {
-      if (value == null) delete object[key];
-      else if (_.isObject(value)) normalizeUserConfig(value);
-    }
-  }
-  return object;
+  };
+  normalizeObject(userConfig, []);
+  return { nullPaths };
+};
+const denormalizeUserConfig = (userConfig, { nullPaths }) => {
+  for (const nullPath of nullPaths) _.set(userConfig, nullPath, null);
 };
 
 class ConfigSchemaHandler {
@@ -96,7 +107,9 @@ class ConfigSchemaHandler {
     normalizeSchemaObject(this.schema, this.schema);
     const validate = ajv.compile(this.schema);
 
-    validate(normalizeUserConfig(userConfig));
+    const denormalizeOptions = normalizeUserConfig(userConfig);
+    validate(userConfig);
+    denormalizeUserConfig(userConfig, denormalizeOptions);
     if (validate.errors) {
       const messages = normalizeAjvErrors(validate.errors).map(err => err.message);
       this.handleErrorMessages(messages);

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1342,37 +1342,6 @@ describe('#compileMethods()', () => {
       });
     });
 
-    it('should delete the default "application/x-www-form-urlencoded" template if it\'s overriden with null', () => {
-      awsCompileApigEvents.validated.events = [
-        {
-          functionName: 'Second',
-          http: {
-            method: 'get',
-            path: 'users/list',
-            integration: 'AWS',
-            request: {
-              template: {
-                'application/x-www-form-urlencoded': null,
-              },
-            },
-            response: {
-              statusCodes: {
-                200: {
-                  pattern: '',
-                },
-              },
-            },
-          },
-        },
-      ];
-      return awsCompileApigEvents.compileMethods().then(() => {
-        expect(
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .ApiGatewayMethodUsersListGet.Properties.Integration.RequestTemplates
-        ).to.not.have.key('application/x-www-form-urlencoded');
-      });
-    });
-
     it('should use defined pass-through behavior', () => {
       awsCompileApigEvents.validated.events = [
         {
@@ -1927,6 +1896,39 @@ describe('#compileMethods()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources
           .ApiGatewayMethodUsersCreatePost.Properties
       ).to.not.have.key('OperationName');
+    });
+  });
+});
+
+describe('#compileMethods v2()', () => {
+  describe('request configuration', () => {
+    it('should delete the default "application/x-www-form-urlencoded" template if it\'s overriden with null', async () => {
+      const {
+        awsNaming,
+        cfTemplate: { Resources: cfResources },
+      } = await runServerless({
+        fixture: 'apiGateway',
+        configExt: {
+          functions: {
+            foo: {
+              events: [
+                {
+                  http: {
+                    integration: 'AWS',
+                    request: { template: { 'application/x-www-form-urlencoded': null } },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        cliArgs: ['package'],
+      });
+      const apiGatewayMethodConfig = cfResources[awsNaming.getMethodLogicalId('Foo', 'GET')];
+
+      expect(apiGatewayMethodConfig.Properties.Integration.RequestTemplates).to.not.have.property(
+        'application/x-www-form-urlencoded'
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes regression introduced with https://github.com/serverless/serverless/pull/8272 (published with v2.2.0) that brought back https://github.com/serverless/serverless/issues/7008 (as `null` properties got removed)

Additionally fixed test introduced with https://github.com/serverless/serverless/pull/8159 so it properly exposes eventual issue