### PR TITLE
Add support for AWS_DEFAULT_PROFILE env variable when resolving profile

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -1086,10 +1086,11 @@ class AwsProvider {
     const stageUpper = this.getStage() ? this.getStage().toUpperCase() : null;
 
     // add specified credentials, overriding with more specific declarations
+    const awsDefaultProfile = process.env.AWS_DEFAULT_PROFILE || 'default';
     try {
-      impl.addProfileCredentials(result, 'default');
+      impl.addProfileCredentials(result, awsDefaultProfile);
     } catch (err) {
-      if (err.message !== 'Profile default does not exist') {
+      if (err.message !== `Profile ${awsDefaultProfile} does not exist`) {
         throw err;
       }
     }

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -1139,6 +1139,35 @@ describe('AwsProvider', () => {
       const credentials = newAwsProvider.getCredentials();
       expect(credentials.signatureVersion).to.equal('v4');
     });
+
+    it('should get credentials from process.env.AWS_DEFAULT_PROFILE, not "default"', () => {
+      process.env.AWS_DEFAULT_PROFILE = 'notDefaultTemporary';
+      newAwsProvider.options['aws-profile'] = undefined;
+
+      serverless.utils.appendFileSync(
+        relevantEnvironment.AWS_SHARED_CREDENTIALS_FILE,
+        '[default]\n' +
+          `aws_access_key_id = ${fakeCredentials.accessKeyId}\n` +
+          `aws_secret_access_key = ${fakeCredentials.secretAccessKey}\n`
+      );
+
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials.profile).to.equal('notDefaultTemporary');
+    });
+
+    it('should get "default" credentials in lieu of anything else', () => {
+      newAwsProvider.options['aws-profile'] = undefined;
+
+      serverless.utils.appendFileSync(
+        relevantEnvironment.AWS_SHARED_CREDENTIALS_FILE,
+        '[default]\n' +
+          `aws_access_key_id = ${fakeCredentials.accessKeyId}\n` +
+          `aws_secret_access_key = ${fakeCredentials.secretAccessKey}\n`
+      );
+
+      const credentials = newAwsProvider.getCredentials();
+      expect(credentials.credentials.profile).to.equal('default');
+    });
   });
 
   describe('values', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #7676

By default, aws-cli does not take [default] profile from credentials file if ```AWS_DEFAULT_PROFILE``` environment variable is defined. Serverless should behave in exactly same manner when resolving profiles - currently [default] is hard-coded. Fallback mechanism to [default] is still there if ```AWS_DEFAULT_PROFILE``` isn't defined.

Important remark 1: each test in ```getCredentials``` suite seems to carry some state, that's why I had to reset ```newAwsProvider.options['aws-profile']```, below is an interesting log before introducing my changes at all:
```
> serverless@2.4.0 test /home/mpiotrowski/Projects/oss/fork-serverless/serverless
> mocha "lib/plugins/aws/provider/*.test.js" -g "newAwsProvider.options"



  AwsProvider
    #getCredentials()
newAwsProvider.options['aws-profile'] =  undefined
      ✓ [newAwsProvider.options 1]should get credentials when profile is provied via --aws-profile option even if profile is defined in serverless.yml
newAwsProvider.options['aws-profile'] =  notDefault
      ✓ [newAwsProvider.options 2]should get credentials when profile is provied via process.env.AWS_PROFILE even if profile is defined in serverless.yml


  2 passing (100ms)
```
logs correspond to the following:
```
    it('[newAwsProvider.options 1]should get credentials when profile is provied via --aws-profile option even if profile is defined in serverless.yml', () => {
      // eslint-disable-line max-len
      console.log("newAwsProvider.options['aws-profile'] = ", newAwsProvider.options['aws-profile'])
      process.env.AWS_PROFILE = 'notDefaultTemporary';
      newAwsProvider.options['aws-profile'] = 'notDefault';

      serverless.service.provider.profile = 'notDefaultTemporary2';

      const credentials = newAwsProvider.getCredentials();
      expect(credentials.credentials.profile).to.equal('notDefault');
    });

    it('[newAwsProvider.options 2]should get credentials when profile is provied via process.env.AWS_PROFILE even if profile is defined in serverless.yml', () => {
      // eslint-disable-line max-len
      console.log("newAwsProvider.options['aws-profile'] = ", newAwsProvider.options['aws-profile'])
      process.env.AWS_PROFILE = 'notDefault';

      serverless.service.provider.profile = 'notDefaultTemporary';

      const credentials = newAwsProvider.getCredentials();
      expect(credentials.credentials.profile).to.equal('notDefault');
    });
```
even though ```newAwsProvider``` is instantiated before each test. Maybe it'd be worth investigating, not sure.

Important remark 2: (okay, less important) there's a typo in few tests names ("provied"). Not sure if I should fix it in the same pull request?