### PR TITLE
docs(aws http api): update information about default payload for httpapi

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -264,11 +264,10 @@ resources:
 ### Event / payload format
 
 HTTP API offers only a 'proxy' option for Lambda integration where an event submitted to the function contains the details of HTTP request such as headers, query string parameters etc.
-There are however two formats for this event (see [Working with AWS Lambda proxy integrations for HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)) where the default one (1.0) is the same as for REST API / Lambda proxy integration which makes it easy to migrate from REST API to HTTP API.
-The payload version could be configured globally as:
+There are two formats for this event available (see [Working with AWS Lambda proxy integrations for HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)), with the default being 2.0. It is possible to downgrade to 1.0 version by specifying `payload`. The payload version could be configured globally as:
 
 ```yaml
 provider:
   httpApi:
-    payload: '2.0'
+    payload: '1.0'
 ```


### PR DESCRIPTION
Closes: #8345 
