### PR TITLE
Config Schema: Bring back non-array supported variants

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -304,7 +304,11 @@ class AwsProvider {
             ],
           },
           awsIamPolicyResource: {
-            anyOf: [{ const: '*' }, { type: 'array', items: { $ref: '#/definitions/awsArn' } }],
+            anyOf: [
+              { const: '*' },
+              { $ref: '#/definitions/awsArn' },
+              { type: 'array', items: { $ref: '#/definitions/awsArn' } },
+            ],
           },
           // Definition of Statement taken from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html#policies-grammar-bnf
           awsIamPolicyStatements: {
@@ -473,8 +477,13 @@ class AwsProvider {
                       identitySource: { $ref: '#/definitions/awsCfInstruction' },
                       issuerUrl: { $ref: '#/definitions/awsCfInstruction' },
                       audience: {
-                        type: 'array',
-                        items: { $ref: '#/definitions/awsCfInstruction' },
+                        anyOf: [
+                          { $ref: '#/definitions/awsCfInstruction' },
+                          {
+                            type: 'array',
+                            items: { $ref: '#/definitions/awsCfInstruction' },
+                          },
+                        ],
                       },
                     },
                     required: ['identitySource', 'issuerUrl', 'audience'],


### PR DESCRIPTION
They were removed by mistake with #8319. It's only primitive/array combinations where singular variant should be removed. object/array should be left intact

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8365 
