### PR TITLE
Propagating 'IS_LOCAL' env variable to other potential consumers

### DIFF
--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -119,6 +119,13 @@ class Invoke {
 
     _.merge(process.env, defaultEnvVars);
 
+    // in some circumstances, setting these provider-independent environment variables is not enough
+    // eg. in case of local 'docker' invocation, which relies on this module,
+    // these provider-independent environment variables have to be propagated to the container
+    this.serverless.service.provider.environment =
+      this.serverless.service.provider.environment || {};
+    _.merge(this.serverless.service.provider.environment, defaultEnvVars);
+
     // Turn zero or more --env options into an array
     //   ...then split --env NAME=value and put into process.env.
     [].concat(this.options.env || []).forEach(itm => {

--- a/lib/plugins/invoke/invoke.js
+++ b/lib/plugins/invoke/invoke.js
@@ -124,7 +124,12 @@ class Invoke {
     // these provider-independent environment variables have to be propagated to the container
     this.serverless.service.provider.environment =
       this.serverless.service.provider.environment || {};
-    _.merge(this.serverless.service.provider.environment, defaultEnvVars);
+    const providerEnv = this.serverless.service.provider.environment;
+    for (const [envVariableKey, envVariableValue] of Object.entries(defaultEnvVars)) {
+      if (!Object.prototype.hasOwnProperty.call(providerEnv, envVariableKey)) {
+        providerEnv[envVariableKey] = envVariableValue;
+      }
+    }
 
     // Turn zero or more --env options into an array
     //   ...then split --env NAME=value and put into process.env.

--- a/lib/plugins/invoke/invoke.test.js
+++ b/lib/plugins/invoke/invoke.test.js
@@ -29,9 +29,10 @@ describe('Invoke', () => {
 
   describe('#loadEnvVarsForLocal()', () => {
     it('should set IS_LOCAL', () =>
-      expect(invoke.loadEnvVarsForLocal()).to.be.fulfilled.then(() =>
-        expect(process.env.IS_LOCAL).to.equal('true')
-      ));
+      expect(invoke.loadEnvVarsForLocal()).to.be.fulfilled.then(() => {
+        expect(process.env.IS_LOCAL).to.equal('true');
+        expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
+      }));
   });
 
   describe('hooks', () => {
@@ -41,9 +42,10 @@ describe('Invoke', () => {
       });
 
       it('should set IS_LOCAL', () =>
-        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() =>
-          expect(process.env.IS_LOCAL).to.equal('true')
-        ));
+        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
+          expect(process.env.IS_LOCAL).to.equal('true');
+          expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
+        }));
 
       it('should accept a single env option', () => {
         invoke.options = { env: 'NAME=value' };

--- a/lib/plugins/invoke/invoke.test.js
+++ b/lib/plugins/invoke/invoke.test.js
@@ -33,6 +33,12 @@ describe('Invoke', () => {
         expect(process.env.IS_LOCAL).to.equal('true');
         expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
       }));
+    it('should leave provider env variable untouched if already defined', () => {
+      serverless.service.provider.environment = { IS_LOCAL: 'false' };
+      expect(invoke.loadEnvVarsForLocal()).to.be.fulfilled.then(() => {
+        expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
+      });
+    });
   });
 
   describe('hooks', () => {
@@ -46,6 +52,13 @@ describe('Invoke', () => {
           expect(process.env.IS_LOCAL).to.equal('true');
           expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
         }));
+
+      it('should leave provider env variable untouched if already defined', () => {
+        serverless.service.provider.environment = { IS_LOCAL: 'false' };
+        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
+          expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
+        });
+      });
 
       it('should accept a single env option', () => {
         invoke.options = { env: 'NAME=value' };

--- a/lib/plugins/invoke/invoke.test.js
+++ b/lib/plugins/invoke/invoke.test.js
@@ -35,7 +35,7 @@ describe('Invoke', () => {
       }));
     it('should leave provider env variable untouched if already defined', () => {
       serverless.service.provider.environment = { IS_LOCAL: 'false' };
-      expect(invoke.loadEnvVarsForLocal()).to.be.fulfilled.then(() => {
+      return expect(invoke.loadEnvVarsForLocal()).to.be.fulfilled.then(() => {
         expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
       });
     });
@@ -55,7 +55,7 @@ describe('Invoke', () => {
 
       it('should leave provider env variable untouched if already defined', () => {
         serverless.service.provider.environment = { IS_LOCAL: 'false' };
-        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
+        return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
           expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
         });
       });


### PR DESCRIPTION
Propagating 'IS_LOCAL' env variable to other potential consumers, eg. docker local invocation

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #7227

When running ```sls invoke local -f hello```, ```IS_LOCAL``` environment variable was set to ```true``` as expected. If ```docker``` option was active, however, ```IS_LOCAL``` wasn't propagated to the container.

Currently, ```defaultEnvVars``` dictionary (lib/plugins/invoke/invoke.js) which is supposed to contain "provider-independent" environment variables for local execution, contains only ```IS_LOCAL```. To address the problem more generically, however, we cannot just re-define ```IS_LOCAL``` when starting the container as this collection might grow outside of the aws-specific ```invokeLocal``` module. This is why shared (at least between lib/plugins/invoke/invoke.js and lib/plugins/aws/invokeLocal/index.js) property ```serverless.service.provider.environment``` has been used to propagate these local, default, provider-independent environment variables.

**If somebody could confirm that the aforementioned property can actually be used to share such information - that would be great, thank you.**
