### PR TITLE
Ensure to preserve "undefined" values properties when normalizing for schema

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -27,7 +27,7 @@ const normalizeSchemaObject = (object, instanceSchema) => {
 // normalizedObjectsMap allows to handle circular structures without issues
 const normalizeUserConfig = userConfig => {
   const normalizedObjectsSet = new WeakSet();
-  const nullPaths = [];
+  const removedValuesMap = [];
   const normalizeObject = (object, path) => {
     if (normalizedObjectsSet.has(object)) return;
     normalizedObjectsSet.add(object);
@@ -38,7 +38,7 @@ const normalizeUserConfig = userConfig => {
     } else {
       for (const [key, value] of Object.entries(object)) {
         if (value == null) {
-          nullPaths.push(path.concat(key));
+          removedValuesMap.push({ path: path.concat(key), value });
           delete object[key];
         } else if (_.isObject(value)) {
           normalizeObject(value, path.concat(key));
@@ -47,10 +47,12 @@ const normalizeUserConfig = userConfig => {
     }
   };
   normalizeObject(userConfig, []);
-  return { nullPaths };
+  return { removedValuesMap };
 };
-const denormalizeUserConfig = (userConfig, { nullPaths }) => {
-  for (const nullPath of nullPaths) _.set(userConfig, nullPath, null);
+const denormalizeUserConfig = (userConfig, { removedValuesMap }) => {
+  for (const removedValueData of removedValuesMap) {
+    _.set(userConfig, removedValueData.path, removedValueData.value);
+  }
 };
 
 class ConfigSchemaHandler {


### PR DESCRIPTION
Fixes issue introduced with https://github.com/serverless/serverless/pull/8319 where properties with `undefined` value were converted to `null`

Closes: #8370
