### PR TITLE
Config Schema: Revert invalid "oneOf" based validation

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent/index.js
@@ -35,12 +35,6 @@ class AwsCompileCloudWatchEventEvents {
         name: { type: 'string', pattern: '[a-zA-Z0-9-_.]+', minLength: 1, maxLength: 64 },
         enabled: { type: 'boolean' },
       },
-      oneOf: [
-        { required: ['input'] },
-        { required: ['inputPath'] },
-        { required: ['inputTransformer'] },
-        { required: [] },
-      ],
       additionalProperties: false,
     });
   }
@@ -68,6 +62,16 @@ class AwsCompileCloudWatchEventEvents {
             const Description = event.cloudwatchEvent.description;
             Input = event.cloudwatchEvent.input;
             InputTransformer = event.cloudwatchEvent.inputTransformer;
+
+            if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
+              throw new this.serverless.classes.Error(
+                [
+                  'You can only set one of input, inputPath, or inputTransformer ',
+                  'properties at the same time for cloudwatch events. ',
+                  'Please check the AWS docs for more info',
+                ].join('')
+              );
+            }
 
             if (Input && typeof Input === 'object') {
               Input = JSON.stringify(Input);

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -49,17 +49,7 @@ class AwsCompileEventBridgeEvents {
           additionalProperties: false,
         },
       },
-      allOf: [
-        { anyOf: [{ required: ['pattern'] }, { required: ['schedule'] }] },
-        {
-          oneOf: [
-            { required: [] },
-            { required: ['input'] },
-            { required: ['inputPath'] },
-            { required: ['inputTransformer'] },
-          ],
-        },
-      ],
+      anyOf: [{ required: ['pattern'] }, { required: ['schedule'] }],
     });
   }
 
@@ -104,6 +94,15 @@ class AwsCompileEventBridgeEvents {
               functionName,
               idx
             );
+
+            if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
+              throw new this.serverless.classes.Error(
+                [
+                  'You can only set one of input, inputPath, or inputTransformer ',
+                  'properties for eventBridge events.',
+                ].join('')
+              );
+            }
 
             if (InputTransformer) {
               InputTransformer = _.mapKeys(

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -555,11 +555,6 @@ class AwsProvider {
                         role: { $ref: '#/definitions/awsArn' },
                         roleManagedExternally: { type: 'boolean' },
                       },
-                      oneOf: [
-                        { required: [] },
-                        { required: ['role'] },
-                        { required: ['roleManagedExternally'] },
-                      ],
                       additionalProperties: false,
                     },
                   ],


### PR DESCRIPTION
Fixes issues introduced with: #8309, #8114 and #8230 

Idea was to require few properties exchangeably but also allow not provide any of them at all, via:

```json
{ "oneOf": [
  { "required": [] },
  { "required": ["foo"] },
  { "required": ["bar"] }, 
] }
```

That can't work, because if either `foo` or `bar` is provided, two schemas out of listed are matched, and that is invalid against _one of_ rule.

Without using sophisticated `not` constructs there seems no way to reliably validate this by schema, therefore removed it/

Closes: #8373
