### PR TITLE
Fix handling of lambda permissions removal

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -288,6 +288,7 @@ class AwsCompileS3Events {
     const { compiledCloudFormationTemplate } = provider;
     const { Resources } = compiledCloudFormationTemplate;
     const iamRoleStatements = [];
+    let anyFuncUsesExistingS3Bucket = false;
 
     // used to keep track of the custom resources created for each bucket
     const bucketResources = {};
@@ -295,7 +296,6 @@ class AwsCompileS3Events {
     service.getAllFunctions().forEach(functionName => {
       let numEventsForFunc = 0;
       let currentBucketName = null;
-      let funcUsesExistingS3Bucket = false;
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
 
@@ -306,7 +306,7 @@ class AwsCompileS3Events {
             let rules = null;
             const bucket = event.s3.bucket;
             const notificationEvent = event.s3.event || 's3:ObjectCreated:*';
-            funcUsesExistingS3Bucket = true;
+            anyFuncUsesExistingS3Bucket = true;
 
             if (!currentBucketName) {
               currentBucketName = bucket;
@@ -385,28 +385,28 @@ class AwsCompileS3Events {
           }
         });
       }
-
-      if (funcUsesExistingS3Bucket) {
-        iamRoleStatements.push({
-          Effect: 'Allow',
-          Resource: {
-            'Fn::Join': [
-              ':',
-              [
-                'arn',
-                { Ref: 'AWS::Partition' },
-                'lambda',
-                { Ref: 'AWS::Region' },
-                { Ref: 'AWS::AccountId' },
-                'function',
-                FunctionName,
-              ],
-            ],
-          },
-          Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
-        });
-      }
     });
+
+    if (anyFuncUsesExistingS3Bucket) {
+      iamRoleStatements.push({
+        Effect: 'Allow',
+        Resource: {
+          'Fn::Join': [
+            ':',
+            [
+              'arn',
+              { Ref: 'AWS::Partition' },
+              'lambda',
+              { Ref: 'AWS::Region' },
+              { Ref: 'AWS::AccountId' },
+              'function',
+              '*',
+            ],
+          ],
+        },
+        Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
+      });
+    }
 
     // check if we need to add DependsOn clauses in case more than 1
     // custom resources are created for one bucket (to avoid race conditions)

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -954,7 +954,7 @@ describe('AwsCompileS3Events', () => {
     });
 
     it('should create lambda permissions policy with wild card', async () => {
-      const { cfTemplate, awsNaming } = await runServerless({
+      const { cfTemplate } = await runServerless({
         fixture: 's3',
         cliArgs: ['package'],
       });

--- a/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -7,6 +7,7 @@ const chai = require('chai');
 const proxyquire = require('proxyquire').noCallThru();
 const AwsProvider = require('../../../../provider/awsProvider');
 const Serverless = require('../../../../../../Serverless');
+const runServerless = require('../../../../../../../test/utils/run-serverless');
 
 const { expect } = chai;
 chai.use(require('sinon-chai'));
@@ -535,7 +536,7 @@ describe('AwsCompileS3Events', () => {
                     Ref: 'AWS::AccountId',
                   },
                   'function',
-                  'first',
+                  '*',
                 ],
               ],
             },
@@ -620,7 +621,7 @@ describe('AwsCompileS3Events', () => {
                     Ref: 'AWS::AccountId',
                   },
                   'function',
-                  'second',
+                  '*',
                 ],
               ],
             },
@@ -726,7 +727,7 @@ describe('AwsCompileS3Events', () => {
                     Ref: 'AWS::AccountId',
                   },
                   'function',
-                  'second',
+                  '*',
                 ],
               ],
             },
@@ -866,96 +867,6 @@ describe('AwsCompileS3Events', () => {
           Resources,
         } = awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate;
 
-        expect(addCustomResourceToServiceStub).to.have.been.calledOnce;
-        expect(addCustomResourceToServiceStub.args[0][1]).to.equal('s3');
-        expect(addCustomResourceToServiceStub.args[0][2]).to.deep.equal([
-          {
-            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
-            Effect: 'Allow',
-            Resource: {
-              'Fn::Join': [
-                ':',
-                [
-                  'arn',
-                  {
-                    Ref: 'AWS::Partition',
-                  },
-                  's3',
-                  '',
-                  '',
-                  'existing-s3-bucket',
-                ],
-              ],
-            },
-          },
-          {
-            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
-            Effect: 'Allow',
-            Resource: {
-              'Fn::Join': [
-                ':',
-                [
-                  'arn',
-                  {
-                    Ref: 'AWS::Partition',
-                  },
-                  'lambda',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  {
-                    Ref: 'AWS::AccountId',
-                  },
-                  'function',
-                  'first',
-                ],
-              ],
-            },
-          },
-          {
-            Action: ['s3:PutBucketNotification', 's3:GetBucketNotification'],
-            Effect: 'Allow',
-            Resource: {
-              'Fn::Join': [
-                ':',
-                [
-                  'arn',
-                  {
-                    Ref: 'AWS::Partition',
-                  },
-                  's3',
-                  '',
-                  '',
-                  'existing-s3-bucket',
-                ],
-              ],
-            },
-          },
-          {
-            Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
-            Effect: 'Allow',
-            Resource: {
-              'Fn::Join': [
-                ':',
-                [
-                  'arn',
-                  {
-                    Ref: 'AWS::Partition',
-                  },
-                  'lambda',
-                  {
-                    Ref: 'AWS::Region',
-                  },
-                  {
-                    Ref: 'AWS::AccountId',
-                  },
-                  'function',
-                  'second',
-                ],
-              ],
-            },
-          },
-        ]);
         expect(Object.keys(Resources)).to.have.length(2);
         expect(Resources.FirstCustomS31).to.deep.equal({
           Type: 'Custom::S3',
@@ -1040,6 +951,39 @@ describe('AwsCompileS3Events', () => {
       };
 
       return expect(() => awsCompileS3Events.existingS3Buckets()).to.throw('Only one S3 Bucket');
+    });
+
+    it('should create lambda permissions policy with wild card', async () => {
+      const { cfTemplate, awsNaming } = await runServerless({
+        fixture: 's3',
+        cliArgs: ['package'],
+      });
+
+      const expectedResource = [
+        'arn',
+        {
+          Ref: 'AWS::Partition',
+        },
+        'lambda',
+        {
+          Ref: 'AWS::Region',
+        },
+        {
+          Ref: 'AWS::AccountId',
+        },
+        'function',
+        '*',
+      ];
+
+      const lambdaPermissionsPolicies = cfTemplate.Resources.IamRoleCustomResourcesLambdaExecution.Properties.Policies[
+        '0'
+      ].PolicyDocument.Statement.filter(x => x.Action[0].includes('AddPermission'));
+
+      expect(lambdaPermissionsPolicies).to.have.length(1);
+
+      const actualResource = lambdaPermissionsPolicies[0].Resource['Fn::Join'][1];
+
+      expect(actualResource).to.deep.equal(expectedResource);
     });
   });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8090 

This PR is inspired by #8004 .
Main difference is I did not change the [PutBucketNotification/GetBucketNotification policy](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/events/s3/index.js#L370) because from the issue description I didn't think it was called for.

There was a [test case](https://github.com/serverless/serverless/blob/master/lib/plugins/aws/package/compile/events/s3/index.test.js#L802) which covered the original behaviour, but the test title suggested that the focus was something else (DependsOn) so I decided to write a new test, and remove the part related to this PR from that test.
