### PR TITLE
fix: renameService now renames package-lock.json if it exists.

### DIFF
--- a/lib/utils/renameService.js
+++ b/lib/utils/renameService.js
@@ -38,6 +38,11 @@ function renameService(name, servicePath) {
     const json = readFileSync(packageFile);
     writeFileSync(packageFile, Object.assign(json, { name }));
   }
+  const packageLockFile = path.join(servicePath, 'package-lock.json');
+  if (fileExistsSync(packageLockFile)) {
+    const json = readFileSync(packageLockFile);
+    writeFileSync(packageLockFile, Object.assign(json, { name }));
+  }
 
   const ymlServiceFile = path.join(servicePath, 'serverless.yml');
   if (fileExistsSync(ymlServiceFile)) {

--- a/lib/utils/renameService.test.js
+++ b/lib/utils/renameService.test.js
@@ -32,7 +32,7 @@ describe('renameService', () => {
     process.chdir(cwd);
   });
 
-  it('should set new service in serverless.yml and name in package.json', () => {
+  it('should set new service in serverless.yml and name in package.json and package-lock.json', () => {
     const defaultServiceYml = 'service: service-name\n\nprovider:\n  name: aws\n';
     const newServiceYml = 'service: new-service-name\n\nprovider:\n  name: aws\n';
 
@@ -40,19 +40,23 @@ describe('renameService', () => {
     const newServiceName = 'new-service-name';
 
     const packageFile = path.join(servicePath, 'package.json');
+    const packageLockFile = path.join(servicePath, 'package-lock.json');
     const serviceFile = path.join(servicePath, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
     renameService(newServiceName, servicePath);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
+    const packageLockJson = serverless.utils.readFileSync(packageLockFile);
     expect(serviceYml).to.equal(newServiceYml);
     expect(packageJson.name).to.equal(newServiceName);
+    expect(packageLockJson.name).to.equal(newServiceName);
   });
 
-  it('should set new service in serverless.ts and name in package.json', () => {
+  it('should set new service in serverless.ts and name in package.json and package-lock.json', () => {
     const defaultServiceTs =
       "const service = {\nservice: 'service-name',\n\nprovider: {\n  name: 'aws',\n}\n}\n";
     const newServiceTs =
@@ -62,19 +66,23 @@ describe('renameService', () => {
     const newServiceName = 'new-service-name';
 
     const packageFile = path.join(servicePath, 'package.json');
+    const packageLockFile = path.join(servicePath, 'package-lock.json');
     const serviceFile = path.join(servicePath, 'serverless.ts');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceTs);
 
     renameService(newServiceName, servicePath);
     const serviceTs = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
+    const packageLockJson = serverless.utils.readFileSync(packageLockFile);
     expect(serviceTs).to.equal(newServiceTs);
     expect(packageJson.name).to.equal(newServiceName);
+    expect(packageLockJson.name).to.equal(newServiceName);
   });
 
-  it('should set new service in commented serverless.yml and name in package.json', () => {
+  it('should set new service in commented serverless.yml and name in package.json and package-lock.json', () => {
     const defaultServiceYml =
       '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml =
@@ -84,19 +92,23 @@ describe('renameService', () => {
     const newServiceName = 'new-service-name';
 
     const packageFile = path.join(servicePath, 'package.json');
+    const packageLockFile = path.join(servicePath, 'package-lock.json');
     const serviceFile = path.join(servicePath, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
     renameService(newServiceName, servicePath);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
+    const packageLockJson = serverless.utils.readFileSync(packageLockFile);
     expect(serviceYml).to.equal(newServiceYml);
     expect(packageJson.name).to.equal(newServiceName);
+    expect(packageLockJson.name).to.equal(newServiceName);
   });
 
-  it('should set new service in commented serverless.yml without existing package.json', () => {
+  it('should set new service in commented serverless.yml without existing package.json or package-lock.json', () => {
     const defaultServiceYml =
       '# comment\nservice: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml =
@@ -112,7 +124,7 @@ describe('renameService', () => {
     expect(serviceYml).to.equal(newServiceYml);
   });
 
-  it('should set new name of service in serverless.yml and name in package.json', () => {
+  it('should set new name of service in serverless.yml and name in package.json and package-lock.json', () => {
     const defaultServiceYml = 'service:\n  name: service-name\n\nprovider:\n  name: aws\n';
     const newServiceYml = 'service:\n  name: new-service-name\n\nprovider:\n  name: aws\n';
 
@@ -120,19 +132,23 @@ describe('renameService', () => {
     const newServiceName = 'new-service-name';
 
     const packageFile = path.join(servicePath, 'package.json');
+    const packageLockFile = path.join(servicePath, 'package-lock.json');
     const serviceFile = path.join(servicePath, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
     renameService(newServiceName, servicePath);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
+    const packageLockJson = serverless.utils.readFileSync(packageLockFile);
     expect(serviceYml).to.equal(newServiceYml);
     expect(packageJson.name).to.equal(newServiceName);
+    expect(packageLockJson.name).to.equal(newServiceName);
   });
 
-  it('should set new name of service in serverless.ts and name in package.json', () => {
+  it('should set new name of service in serverless.ts and name in package.json and package-lock.json', () => {
     const defaultServiceTs =
       "const service = {\nservice: {\n   name: 'service-name',\n},\nprovider: {\n  name: 'aws',\n}\n}\n";
     const newServiceTs =
@@ -142,19 +158,23 @@ describe('renameService', () => {
     const newServiceName = 'new-service-name';
 
     const packageFile = path.join(servicePath, 'package.json');
+    const packageLockFile = path.join(servicePath, 'package-lock.json');
     const serviceFile = path.join(servicePath, 'serverless.ts');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceTs);
 
     renameService(newServiceName, servicePath);
     const serviceTs = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
+    const packageLockJson = serverless.utils.readFileSync(packageLockFile);
     expect(serviceTs).to.equal(newServiceTs);
     expect(packageJson.name).to.equal(newServiceName);
+    expect(packageLockJson.name).to.equal(newServiceName);
   });
 
-  it('should set new name of service in commented serverless.yml and name in package.json', () => {
+  it('should set new name of service in commented serverless.yml and name in package.json and package-lock.json', () => {
     const defaultServiceYml =
       '# comment\nservice:\n  name: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml =
@@ -164,16 +184,20 @@ describe('renameService', () => {
     const newServiceName = 'new-service-name';
 
     const packageFile = path.join(servicePath, 'package.json');
+    const packageLockFile = path.join(servicePath, 'package-lock.json');
     const serviceFile = path.join(servicePath, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
+    serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
     renameService(newServiceName, servicePath);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
+    const packageLockJson = serverless.utils.readFileSync(packageLockFile);
     expect(serviceYml).to.equal(newServiceYml);
     expect(packageJson.name).to.equal(newServiceName);
+    expect(packageLockJson.name).to.equal(newServiceName);
   });
 
   it('should fail to set new service name in serverless.yml', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes

Closes: #{ISSUE_NUMBER}
-->

I believe this falls under the "obvious bug fix" category. Upon a service rename after `sls create` from a template, `package-lock.json` does not get renamed even though `package.json`. I confirmed this behaviour before this change, and confirmed `package-lock.json` also gets renamed after this change. I also updated the unit tests and watched them fail before updating the code to make the tests pass.