### PR TITLE
docs: update pull request template to ensure Node v10 support instead of Node v6.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,6 @@ https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
 https://github.com/serverless/serverless/blob/master/test/README.md
 -->
 
-<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->
-
 <!--
 ⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
 • npm run prettier-check

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,8 @@ https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
 https://github.com/serverless/serverless/blob/master/test/README.md
 -->
 
+<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->
+
 <!--
 ⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
 • npm run prettier-check


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes

Closes: #{ISSUE_NUMBER}
-->

Node v6 support was dropped in [2.0.0](https://github.com/serverless/serverless/releases/tag/v2.0.0). Should the template be updated to reflect this as well?

`git grep v6` also shows a few hits in some installation and quick-start guides:

```
docs/providers/aws/guide/installation.md:**Note:** Serverless runs on Node v6 or higher.
docs/providers/azure/guide/installation.md:**Note:** The Azure Functions Serverless Framework plugin requires Node v6.5.0
docs/providers/fn/guide/quick-start.md:1. Node.js `v6.5.0` or later.
docs/providers/kubeless/guide/quick-start.md:1. Node.js `v6.5.0` or later.
docs/providers/openwhisk/guide/quick-start.md:1. Node.js `v6.5.0` or later.
docs/providers/tencent/guide/installation.md:**Note:** Serverless runs on Node v6 or higher.
```

Should those be updated as well? If so, would you like me to do it as part of this pull request or another pull request?