### PR TITLE
Cast error code to str to allow later startsWith()

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -1146,7 +1146,7 @@ class AwsProvider {
               req.send(cb);
             });
         return promise.catch(err => {
-          let message = err.message != null ? err.message : err.code;
+          let message = err.message != null ? err.message : String(err.code);
           if (message.startsWith('Missing credentials in config')) {
             // Credentials error
             // If failed at last resort (EC2 Metadata check) expose a meaningful error


### PR DESCRIPTION
Currently when deploying against a localstack instance an error causes the following stacktrace

```
  TypeError: message.startsWith is not a function
      at /usr/local/lib/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:1150:23
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

We now cast the error code to a string to allow later calls with `startsWith`

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

fixes bug of calling .startWith on an int