### PR TITLE
Upgrade warning message trigger for max cloudformation resources to 500

### DIFF
--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -14,10 +14,10 @@ module.exports = {
     message += `${chalk.yellow('stack:')} ${info.stack}\n`;
     message += `${chalk.yellow('resources:')} ${info.resourceCount}`;
 
-    if (info.resourceCount >= 150) {
+    if (info.resourceCount >= 450) {
       message += `\n${chalk.red('WARNING:')}\n`;
       message += `  You have ${info.resourceCount} resources in your service.\n`;
-      message += '  CloudFormation has a hard limit of 200 resources in a service.\n';
+      message += '  CloudFormation has a hard limit of 500 resources in a service.\n';
       message += '  For advice on avoiding this limit, check out this link: http://bit.ly/2IiYB38.';
     }
 

--- a/lib/plugins/aws/info/display.test.js
+++ b/lib/plugins/aws/info/display.test.js
@@ -57,7 +57,7 @@ describe('#display()', () => {
     expect(message).to.equal(expectedMessage);
   });
 
-  it('should display a warning if 150+ resources', () => {
+  it('should display a warning if 450+ resources', () => {
     let expectedMessage = '';
 
     expectedMessage += `${chalk.yellow.underline('Service Information')}\n`;
@@ -65,14 +65,14 @@ describe('#display()', () => {
     expectedMessage += `${chalk.yellow('stage:')} dev\n`;
     expectedMessage += `${chalk.yellow('region:')} eu-west-1\n`;
     expectedMessage += `${chalk.yellow('stack:')} my-first-dev\n`;
-    expectedMessage += `${chalk.yellow('resources:')} 150`;
+    expectedMessage += `${chalk.yellow('resources:')} 450`;
     expectedMessage += `\n${chalk.red('WARNING:')}\n`;
-    expectedMessage += '  You have 150 resources in your service.\n';
-    expectedMessage += '  CloudFormation has a hard limit of 200 resources in a service.\n';
+    expectedMessage += '  You have 450 resources in your service.\n';
+    expectedMessage += '  CloudFormation has a hard limit of 500 resources in a service.\n';
     expectedMessage +=
       '  For advice on avoiding this limit, check out this link: http://bit.ly/2IiYB38.';
 
-    awsInfo.gatheredData.info.resourceCount = 150;
+    awsInfo.gatheredData.info.resourceCount = 450;
 
     const message = awsInfo.displayServiceInfo();
     expect(consoleLogStub.calledOnce).to.equal(true);


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v6 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

No issue related to this small PR.
AWS increased its Cloudformation resources limit from 200 to 500
https://aws.amazon.com/fr/about-aws/whats-new/2020/10/aws-cloudformation-now-supports-increased-limits-on-five-service-quotas/
