### PR TITLE
Tests: Fix fixture service config

### DIFF
--- a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -72,7 +72,7 @@ describe('#generateCoreTemplate()', () => {
         service: 'irrelevant',
         provider: {
           name: 'aws',
-          deploymentBucketObject: {
+          deploymentBucket: {
             blockPublicAccess: true,
           },
         },
@@ -95,7 +95,7 @@ describe('#generateCoreTemplate()', () => {
         service: 'irrelevant',
         provider: {
           name: 'aws',
-          deploymentBucketObject: {
+          deploymentBucket: {
             tags: {
               FOO: 'bar',
               BAZ: 'qux',


### PR DESCRIPTION
Addressing issue reported at https://github.com/serverless/serverless/pull/8330#issuecomment-713132491 by @thewizarodofoz 

It only worked because all  `provider` properties are mapped on `service.provider`

