### PR TITLE
feat(Packaging): Include log retention in custom resources log groups

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -192,6 +192,7 @@ function addCustomResourceToService(awsProvider, resourceName, iamRoleStatements
             Type: 'AWS::Logs::LogGroup',
             Properties: {
               LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+              RetentionInDays: awsProvider.getLogRetentionInDays(),
             },
           },
         });


### PR DESCRIPTION
When I was studying AWS custom resources in Serverless Framework, I've noticed that there is no log retention being set for the custom resources lambda functions. And when I took a look at AWS Console I could see there "Never expire" in the log retention field even though I've set the logRetentionInDays: 30 in serverless.yml.

Closes: #8439
