### PR TITLE
Config schema improvements

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -163,8 +163,8 @@ class Serverless {
       // (https://github.com/serverless/serverless/issues/2997)
       this.service.setFunctionNames(this.processedInput.options);
 
-      // validate the service configuration, now that variables are loaded
-      this.service.validate();
+      // If in context of servie validate the service configuration
+      if (this.config.servicePath) this.service.validate();
 
       // trigger the plugin lifecycle when there's something which should be processed
       return this.pluginManager.run(this.processedInput.commands);

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -112,7 +112,7 @@ class ConfigSchemaHandler {
     const denormalizeOptions = normalizeUserConfig(userConfig);
     validate(userConfig);
     denormalizeUserConfig(userConfig, denormalizeOptions);
-    if (validate.errors) {
+    if (validate.errors && this.serverless.service.configValidationMode !== 'off') {
       const messages = normalizeAjvErrors(validate.errors).map(err => err.message);
       this.handleErrorMessages(messages);
     }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -217,7 +217,7 @@ class Service {
   }
 
   validate() {
-    const userConfig = Object.assign({}, this.initialServerlessConfig || {});
+    const userConfig = this.initialServerlessConfig;
     userConfig.service = this.serviceObject;
 
     // Ensure to validate normalized (after mergeArrays) input

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -153,7 +153,15 @@ class Service {
 
     // merge so that the default settings are still in place and
     // won't be overwritten
-    that.provider = _.merge(that.provider, serverlessFile.provider);
+    if (serverlessFile.provider) {
+      if (serverlessFile.provider.stage == null) {
+        serverlessFile.provider.stage = that.provider.stage;
+      }
+      if (serverlessFile.provider.variableSyntax == null) {
+        serverlessFile.provider.variableSyntax = that.provider.variableSyntax;
+      }
+      that.provider = serverlessFile.provider;
+    }
 
     if (serverlessFile.package) {
       that.package = serverlessFile.package;

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -224,9 +224,7 @@ class Service {
     if (userConfig.functions) userConfig.functions = this.functions;
     if (userConfig.resources) userConfig.resources = this.resources;
 
-    if (this.configValidationMode !== 'off') {
-      this.serverless.configSchemaHandler.validateConfig(userConfig);
-    }
+    this.serverless.configSchemaHandler.validateConfig(userConfig);
 
     return this;
   }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -224,7 +224,7 @@ class Service {
     if (userConfig.functions) userConfig.functions = this.functions;
     if (userConfig.resources) userConfig.resources = this.resources;
 
-    if (this.serviceObject && this.configValidationMode !== 'off') {
+    if (this.configValidationMode !== 'off') {
       this.serverless.configSchemaHandler.validateConfig(userConfig);
     }
 

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -5,15 +5,21 @@ const functionNamePattern = '^[a-zA-Z0-9-_]+$';
 const schema = {
   type: 'object',
   properties: {
-    service: {
+    /*
+     * Modes for config validation:
+     *  - error: the error is thrown
+     *  - warn: logs error to console without throwing an error
+     *  - off: disables validation at all
+     *
+     *  The default is `warn`, and will be set to `error` in v2
+     */
+    configValidationMode: { enum: ['error', 'warn', 'off'] },
+    custom: {
       type: 'object',
-      properties: {
-        name: { pattern: '^[a-zA-Z][0-9a-zA-Z-]+$' },
-        awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
-      },
-      additionalProperties: false,
+      properties: {},
+      required: [],
+      // User is free to add any properties for its own purpose
     },
-    frameworkVersion: { type: 'string' },
     disabledDeprecations: {
       anyOf: [
         { const: '*' },
@@ -24,28 +30,7 @@ const schema = {
       ],
     },
     enableLocalInstallationFallback: { type: 'boolean' },
-
-    custom: {
-      type: 'object',
-      properties: {},
-      required: [],
-      // User is free to add any properties for its own purpose
-    },
-    plugins: {
-      anyOf: [
-        {
-          type: 'object',
-          properties: {
-            localPath: { type: 'string' },
-            modules: { type: 'array', items: { type: 'string' } },
-          },
-          additionalProperties: false,
-          required: ['modules'],
-        },
-        { type: 'array', items: { type: 'string' } },
-      ],
-    },
-
+    frameworkVersion: { type: 'string' },
     functions: {
       type: 'object',
       patternProperties: {
@@ -84,17 +69,6 @@ const schema = {
       },
       additionalProperties: false,
     },
-
-    /*
-     * Provider specific properties are extended in respected provider plugins.
-     */
-    provider: {
-      type: 'object',
-      properties: {},
-      required: ['name'],
-      additionalProperties: false,
-    },
-
     package: {
       type: 'object',
       properties: {
@@ -107,16 +81,37 @@ const schema = {
       },
       additionalProperties: false,
     },
-
+    plugins: {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            localPath: { type: 'string' },
+            modules: { type: 'array', items: { type: 'string' } },
+          },
+          additionalProperties: false,
+          required: ['modules'],
+        },
+        { type: 'array', items: { type: 'string' } },
+      ],
+    },
     /*
-     * Modes for config validation:
-     *  - error: the error is thrown
-     *  - warn: logs error to console without throwing an error
-     *  - off: disables validation at all
-     *
-     *  The default is `warn`, and will be set to `error` in v2
+     * Provider specific properties are extended in respected provider plugins.
      */
-    configValidationMode: { enum: ['error', 'warn', 'off'] },
+    provider: {
+      type: 'object',
+      properties: {},
+      required: ['name'],
+      additionalProperties: false,
+    },
+    service: {
+      type: 'object',
+      properties: {
+        name: { pattern: '^[a-zA-Z][0-9a-zA-Z-]+$' },
+        awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
+      },
+      additionalProperties: false,
+    },
   },
   additionalProperties: false,
   required: ['provider', 'service'],

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -100,7 +100,9 @@ const schema = {
      */
     provider: {
       type: 'object',
-      properties: {},
+      properties: {
+        // "name" is configured as const by loaded provider
+      },
       required: ['name'],
       additionalProperties: false,
     },

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -208,7 +208,26 @@ class AwsProvider {
     this.serverless = serverless;
     this.sdk = AWS;
     this.serverless.setProvider(constants.providerName, this);
+    this.hooks = {
+      initialize: () => {
+        // Support deploymentBucket configuration as an object
+        const provider = this.serverless.service.provider;
+        if (provider && provider.deploymentBucket) {
+          if (_.isObject(provider.deploymentBucket)) {
+            // store the object in a new variable so that it can be reused later on
+            provider.deploymentBucketObject = provider.deploymentBucket;
+            if (provider.deploymentBucket.name) {
+              // (re)set the value of the deploymentBucket property to the name (which is a string)
+              provider.deploymentBucket = provider.deploymentBucket.name;
+            } else {
+              provider.deploymentBucket = null;
+            }
+          }
+        }
+      },
+    };
     if (this.serverless.service.provider.name === 'aws') {
+      // Below ideally should be in hooks.intialize, but variables resolution depend on this
       this.serverless.service.provider.region = this.getRegion();
       require('../../../utils/awsSdkPatch');
 
@@ -1102,21 +1121,6 @@ class AwsProvider {
     const timeout = process.env.AWS_CLIENT_TIMEOUT || process.env.aws_client_timeout;
     if (timeout) {
       AWS.config.httpOptions.timeout = parseInt(timeout, 10);
-    }
-
-    // Support deploymentBucket configuration as an object
-    const provider = this.serverless.service.provider;
-    if (provider && provider.deploymentBucket) {
-      if (_.isObject(provider.deploymentBucket)) {
-        // store the object in a new variable so that it can be reused later on
-        provider.deploymentBucketObject = provider.deploymentBucket;
-        if (provider.deploymentBucket.name) {
-          // (re)set the value of the deploymentBucket property to the name (which is a string)
-          provider.deploymentBucket = provider.deploymentBucket.name;
-        } else {
-          provider.deploymentBucket = null;
-        }
-      }
     }
   }
 

--- a/lib/plugins/aws/provider/awsProvider.test.js
+++ b/lib/plugins/aws/provider/awsProvider.test.js
@@ -204,37 +204,6 @@ describe('AwsProvider', () => {
           'my.deployment.bucket'
         );
       });
-
-      it('should save a given object and use name from it', () => {
-        const deploymentBucketObject = {
-          name: 'my.deployment.bucket',
-          serverSideEncryption: 'AES256',
-        };
-        serverless.service.provider.deploymentBucket = deploymentBucketObject;
-
-        const newAwsProvider = new AwsProvider(serverless, options);
-
-        expect(newAwsProvider.serverless.service.provider.deploymentBucket).to.equal(
-          'my.deployment.bucket'
-        );
-        expect(newAwsProvider.serverless.service.provider.deploymentBucketObject).to.deep.equal(
-          deploymentBucketObject
-        );
-      });
-
-      it('should save a given object and nullify the name if one is not provided', () => {
-        const deploymentBucketObject = {
-          serverSideEncryption: 'AES256',
-        };
-        serverless.service.provider.deploymentBucket = deploymentBucketObject;
-
-        const newAwsProvider = new AwsProvider(serverless, options);
-
-        expect(newAwsProvider.serverless.service.provider.deploymentBucket).to.equal(null);
-        expect(newAwsProvider.serverless.service.provider.deploymentBucketObject).to.deep.equal(
-          deploymentBucketObject
-        );
-      });
     });
   });
 


### PR DESCRIPTION
- Ensure to trigger config validation, only if we're in service context
- Move AWS Provider plugin config modifications so they happen after schema is validated and not before
- Run schema config validation unconditionally (even with `configValidationMode === 'off'`. It's to ensure that config normalization is applied in all cases (internals depend on them)
- Ensure alphabetical order in top level schema definitions