### PR TITLE
Deprecate object notation for `service` 

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -10,7 +10,7 @@ layout: Doc
 
 ## `service` property object notation
 
-Starting from next major object notation for "service" property will no longer be recognized. Set "service" property directly with service name.
+Starting with v3.0.0, object notation for `service` property will no longer be recognized. Set `service` property directly with service name.
 
 <a name="CLOUDFRONT_CACHE_BEHAVIOR_FORWARDED_VALUES_AND_TTL"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -8,7 +8,7 @@ layout: Doc
 
 <a name="SERVICE_OBJECT_NOTATION"><div>&nbsp;</div></a>
 
-## `service.awsKmsKeyArn` property will no longer be used
+## `service` property object notation
 
 Starting from next major object notation for "service" property will no longer be recognized. Set "service" property directly with service name.
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -6,6 +6,12 @@ layout: Doc
 
 # Serverless Framework Deprecations
 
+<a name="SERVICE_OBJECT_NOTATION"><div>&nbsp;</div></a>
+
+## `service.awsKmsKeyArn` property will no longer be used
+
+Starting from next major object notation for "service" property will no longer be recognized. Set "service" property directly with service name.
+
 <a name="CLOUDFRONT_CACHE_BEHAVIOR_FORWARDED_VALUES_AND_TTL"><div>&nbsp;</div></a>
 
 ## `cloudFront` event `behavior.ForwardedValues` property

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -131,6 +131,11 @@ class Service {
     }
 
     if (_.isObject(serverlessFile.service)) {
+      this.serverless._logDeprecation(
+        'SERVICE_OBJECT_NOTATION',
+        'Starting from next major object notation for "service" property will no longer be ' +
+          'recognized. Set "service" property directly with service name.'
+      );
       this.serviceObject = serverlessFile.service;
       this.service = serverlessFile.service.name;
     } else {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8465
