### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ FROM node:latest
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 
 # install python tooling
-RUN apt-get update -y && apt-get install -y python-dev python-pip && pip install --upgrade pip
+RUN apt-get update -y && apt-get install -y python-dev python-pip && pip install --no-cache-dir --upgrade pip
 
 # install other utils
 RUN apt-get update -y && apt-get install -y screen
 
 # install aws-cli
-RUN pip install awscli
+RUN pip install --no-cache-dir awscli


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>