### PR TITLE
Generate serverless.yml automatically for web components

### DIFF
--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -37,6 +37,10 @@ try {
     componentsV2.runComponents();
     return;
   }
+
+  // if (no serverless.yml found)
+  //   provide an interactive prompt to encourage user to transform the project to a serverless project
+
 } catch (error) {
   if (process.env.SLS_DEBUG) {
     require('../lib/classes/Error').logWarning(`CLI triage crashed with: ${error.stack}`);


### PR DESCRIPTION
When users run `sls deploy` in a directory without a `serverless.yml`, check if it is possible to transform this project into a serverless project and provide a friendly guidance

- Related issue: https://github.com/serverless/roadmap-tencent/issues/603