### PR TITLE
CLI: Fix handling of command options in help display

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -149,7 +149,7 @@ class CLI {
             shortcut: 'c',
           },
         })
-      : commandObject.options;
+      : Object.assign({}, commandObject.options);
 
     Object.entries(commandOptions).forEach(([option, optionsObject]) => {
       let optionsDots = '.'.repeat(Math.max(dotsLength - option.length, 0));

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -697,4 +697,12 @@ describe('CLI [new tests]', () => {
       .then(({ stdoutData }) => {
         expect(stdoutData).to.not.include('Framework Core: ');
       }));
+
+  it('Should handle incomplete command configurations', async () => {
+    const { stdoutData } = await runServerless({
+      fixture: 'plugin',
+      cliArgs: ['customCommand', '--help'],
+    });
+    expect(stdoutData).to.include('Description of custom command');
+  });
 });

--- a/test/fixtures/plugin/plugin.js
+++ b/test/fixtures/plugin/plugin.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = class Plugin {
+  constructor() {
+    this.commands = {
+      customCommand: {
+        usage: 'Description of custom command',
+        configDependent: false,
+      },
+    };
+  }
+};

--- a/test/fixtures/plugin/serverless.yml
+++ b/test/fixtures/plugin/serverless.yml
@@ -1,0 +1,10 @@
+service: service
+
+configValidationMode: error
+frameworkVersion: '*'
+
+provider:
+  name: aws
+
+plugins:
+  - ./plugin


### PR DESCRIPTION
Listing help for commands with no `options` object configured, resulted with following error:

```
 Type Error ---------------------------------------------
 
  TypeError: Cannot convert undefined or null to object
      at Function.entries (<anonymous>)
      at CLI.displayCommandOptions (/Users/medikoo/npm-packages/serverless/lib/classes/CLI.js:154:12)
      at CLI.generateCommandsHelp (/Users/medikoo/npm-packages/serverless/lib/classes/CLI.js:353:10)
      at CLI.displayHelp (/Users/medikoo/npm-packages/serverless/lib/classes/CLI.js:116:16)
      at Serverless.run (/Users/medikoo/npm-packages/serverless/lib/Serverless.js:147:18)
      at /Users/medikoo/npm-packages/serverless/scripts/serverless.js:50:26
 
```

It's a regression introduced with https://github.com/serverless/serverless/pull/8280

This patch fixes that