### PR TITLE
docs: Updates docs for dashboard providers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,15 +4,15 @@ menuText: Docs
 layout: Doc
 menuItems:
   - {menuText: "Get Started", path: /framework/docs/getting-started/}
-  - {menuText: "Dashboard Reference", path: /framework/docs/dashboard/}
-  - {menuText: "- Insights", path: /framework/docs/dashboard/insights/}
-  - {menuText: "- Notifications", path: /framework/docs/dashboard/notifications/}
-  - {menuText: "- Output Variables", path: /framework/docs/dashboard/output-variables/}
-  - {menuText: "- Secrets", path: /framework/docs/dashboard/secrets/}
-  - {menuText: "- Safeguards", path: /framework/docs/dashboard/safeguards/}
-  - {menuText: "- Access Roles", path: /framework/docs/dashboard/access-roles/}
-  - {menuText: "- Profiles", path: /framework/docs/dashboard/profiles/}
-  - {menuText: "- Pipelines", path: /framework/docs/dashboard/pipelines/}
+  - {menuText: "User Guides", path: /framework/docs/guides/}
+  - {menuText: "- Insights", path: /framework/docs/guides/insights/}
+  - {menuText: "- Notifications", path: /framework/docs/guides/notifications/}
+  - {menuText: "- Output Variables", path: /framework/docs/guides/output-variables/}
+  - {menuText: "- Secrets", path: /framework/docs/guides/secrets/}
+  - {menuText: "- Safeguards", path: /framework/docs/guides/safeguards/}
+  - {menuText: "- Access Roles", path: /framework/docs/guides/access-roles/}
+  - {menuText: "- Profiles", path: /framework/docs/guides/profiles/}
+  - {menuText: "- Pipelines", path: /framework/docs/guides/pipelines/}
   - {menuText: "Provider CLI References", path: /framework/docs/providers}
   - {menuText: "- AWS", path: /framework/docs/providers/aws/}
   - {menuText: "- Azure", path: /framework/docs/providers/azure/}

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,19 @@
+<!--
+title: Serverless Framework - User Guides
+menuText: User Guides
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/)
+
+<!-- DOCS-SITE-LINK:END -->
+
+# Serverless Framework User Guides
+
+Welcome to the Serverless Framework User Guides!
+
+[Get started with Serverless Framework](/framework/docs/getting-started)
+
+If you have questions, join the [chat in Slack](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/guides/access-roles.md
+++ b/docs/guides/access-roles.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - Access Roles
 menuText: Access Roles
-menuOrder: 6
+menuOrder: 2
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/access-roles/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/access-roles/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/README.md
+++ b/docs/guides/cicd/README.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - CI/CD
 menuText: CI/CD
-menuOrder: 7
+menuOrder: 3
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/best-practices.md
+++ b/docs/guides/cicd/best-practices.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/best-practices/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/best-practices/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/branch-deployments.md
+++ b/docs/guides/cicd/branch-deployments.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/branch-deployments/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/branch-deployments/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/custom-scripts.md
+++ b/docs/guides/cicd/custom-scripts.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/custom-scripts/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/custom-scripts/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/faq.md
+++ b/docs/guides/cicd/faq.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/faq/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/faq/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/mono-repo.md
+++ b/docs/guides/cicd/mono-repo.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/mono-repo/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/mono-repo/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/notifications.md
+++ b/docs/guides/cicd/notifications.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/notifications/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/notifications/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/preview-deployments.md
+++ b/docs/guides/cicd/preview-deployments.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/preview-deployments/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/preview-deployments/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/private-packages.md
+++ b/docs/guides/cicd/private-packages.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/private-packages/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/private-packages/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/running-in-your-own-cicd.md
+++ b/docs/guides/cicd/running-in-your-own-cicd.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/running-in-your-own-cicd/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/running-in-your-own-cicd/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/running-tests.md
+++ b/docs/guides/cicd/running-tests.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/running-tests/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/running-tests/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/cicd/troubleshooting.md
+++ b/docs/guides/cicd/troubleshooting.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://serverless.com/framework/docs/dashboard/cicd/troubleshooting/)
+### [Read this on the main serverless docs site](https://serverless.com/framework/docs/guides/cicd/troubleshooting/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/dashboard.md
+++ b/docs/guides/dashboard.md
@@ -1,12 +1,13 @@
 <!--
-title: Serverless - Dashboard Reference
-menuText: Dashboard Reference
+title: Serverless - Dashboard
+menuText: Dashboard
+menuOrder: 1
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/dashboard/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/monitoring/README.md
+++ b/docs/guides/monitoring/README.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - Monitoring
 menuText: Monitoring
-menuOrder: 1
+menuOrder: 4
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/monitoring/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/monitoring/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/monitoring/alerts.md
+++ b/docs/guides/monitoring/alerts.md
@@ -6,7 +6,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/monitoring/alerts/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/monitoring/alerts/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/monitoring/metrics.md
+++ b/docs/guides/monitoring/metrics.md
@@ -6,7 +6,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/monitoring/metrics/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/monitoring/metrics/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/monitoring/notifications.md
+++ b/docs/guides/monitoring/notifications.md
@@ -6,7 +6,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/monitoring/notifications/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/monitoring/notifications/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/output-variables.md
+++ b/docs/guides/output-variables.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - Outputs
 menuText: Outputs
-menuOrder: 3
+menuOrder: 5
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/output-variables/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/output-variables/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/parameters.md
+++ b/docs/guides/parameters.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - Parameters
 menuText: Parameters
-menuOrder: 4
+menuOrder: 6
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/parameters/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/parameters/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -7,7 +7,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/profiles/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/profiles/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,0 +1,100 @@
+<!--
+title: Serverless Dashboard - Providers
+menuText: Providers
+menuOrder: 8
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/providers/)
+
+<!-- DOCS-SITE-LINK:END -->
+
+# Providers
+
+The Serverless Framework is used to create, manage, monitor and troubleshoot serverless infrastructure such as AWS Lambda, DynamoDB Tables, or API Gateway endpoints. Any infrastructure you provision using Serverless Framework requires credentials to that cloud service provider.
+
+Providers enable you to securely manage the accounts to the cloud service providers like Azure, AWS, and GCP in the Serverless Framework Dashboard.
+
+Your organization admin can add a provider to the organization in the Dashboard, either using static credentials like an AWS Access Key/Secret, or using AWS Access Roles to generate short-lived credentials per deployment. Developers in your organization can use the providers by linking them to their services and they will automatically use the credentials from the providers for deployments.
+
+There are many benefits to using providers over managing accounts manually:
+
+- Decouple credential management from development/deployment
+- Automatically use the correct accounts when deploying to different stages
+- No need to store credentials locally
+- No need to share credentials out of band (e.g. sending slack messages)
+- Some providers, like AWS Access Roles, provide an additional layer of security as credentials are generated per deployment and have a short TTL.
+
+# Adding providers in the dashboard
+
+To use providers you must add the providers to your organization and then link the provider to a service. Optionally you can link the provider to an instance instead if you need to use different providers for different stages or regions.
+
+## Adding providers to your organization
+
+To add a provider to your organization go the **org** section of the [dashboard](https://app.serverless.com). Under the **providers** tab, click **add** and follow the instructions.
+
+You’ll be able to select the provider, like AWS, Stripe, and Twilio, name the provider, and set the credentials.
+
+It is recommended that you deploy your Serverless Framework apps to different accounts for each stage. To accomplish this we recommend adding a `dev` and `prod` provider to decouple the prod environment from all other environments.
+
+## Adding a provider to a service
+
+Adding the providers to the organization alone will not be sufficient, you must also link that account with the service.
+
+Go to the **apps** section of the dashboard, and select **settings** under the **...** menu of the service for which you would like to use providers. On the service settings page navigate to the **providers** tab. From there you can click **add provider** which will allow you to add the providers from the organization into your service.
+
+## Adding a provider to an instance
+
+If your service is deployed to the same account for each stage and region, then you do not need to configure providers per instance. However, if you have multiple providers, like one for each stages or regions, then you can add a provider to each instance.
+
+To add a provider to an instance navigate to the instance details page for that service instance. Navigate to the **providers** tab. From the **add providers** dropdown you can add any provider from the organization into the instance.
+
+## Inheritance and overriding
+
+If you are deploying a traditional Serverless Framework app, an instance of the service is created for that stage and region. If you are using a Component-based service, then an instance is created for each stage of the service.
+
+When you are performing a deployment the provider associated with the instance will be used. If no provider is associated with the instance, but one is associated with the service, then that provider will be used. In other words, the providers from the service are inherited at the instance level and they can be overridden on the instance.
+
+### Different accounts per stage
+
+This inheritance model is useful for deploying to different accounts for each stage. For example, if you have a `dev` and `prod` account, then you can setup providers to deploy to `dev` by default, and use the `prod` account for only the `prod` instances.
+
+To accomplish this, you can add the `dev` provider to the service, and then add the `prod` provider to the instances which deploy to the `prod` stage.
+
+If you deploy to a new stage, like `int`, it will then use the `dev` provider from the service.
+
+### Preview account for CI/CD preview deployments
+
+If you are using the Serverless CI/CD service or any 3rd party CI/CD service, you may be deploying to unique stages to isolate the preview deployments from PRs from all other deployments.
+
+To accomplish this, you can create two providers, `preview`, and `prod`, for two different accounts. Add the `preview` provider to the service, and add the `prod` provider to the instances for the `prod` stage.
+
+Now if you deploy to a preview stage, like `feature-x` it will automatically use the provider from the service, `preview`. If you merge your changes and deploy them to the `prod` stage, it will automatically use the `prod` provider as it is associated with that stage.
+
+# Using providers in serverless.yml
+
+To use providers with serverless.yml you do not need to do anything. Upon deployment the Serverless Framework will retrieve the necessary credentials from the provider associate with the instance or service, and it will use those credentials to deploy.
+
+If the providers are not found, then the Serverless Framework will look for credentials locally.
+
+# Migrating from Deployment Profile
+
+Deployment profiles can be used to add AWS Access Roles to stages in an app. Any instance deployed to any service in that app will use the AWS Access Role if the corresponding stage is linked to a deployment profile containing the AWS Access Role.
+
+Providers on the other hand are capable of supporting different providers, like AWS, Stripe, GCP, etc. They are also capable of supporting different types, like Access Roles or Access Key & Secret. As such, the AWS Access Role support in deployment profiles is being deprecated and replaced with Providers.
+
+This migration will be fully automated and backwards compatible; however, there are a few things that will change as a result of the migration:
+
+- Deployments using deployment profiles will continue to work as-is.
+- If the AWS Access Role must be updated, then it must be updated using Providers instead of Deployment Profiles.
+- If you want to add/edit new Providers, then you must use version 4.1.0 or higher of the Serverless Plugin on the CLI. You can check the version with `sls version`.
+
+The automatic migration will replace deployment profiles with providers by performing the following:
+
+- **A new provider will be created for each deployment profile using the same AWS Access Role ARN**. If the deployment profile doesn’t contain an AWS Access Role ARN, it will be skipped.
+- **A provider will be added to each service for the corresponding default stage in the app**. The provider will be the provider corresponding to the deployment profile which was associated with the default stage of the parent app. For example, if `app1` has `service1` and the _`default`_ stage of `app1` links to the `dev` deployment profile, then the `dev` provider will be added to `service1`. This is repeated for all services in all apps.
+- **A provider will be added to each instance for the corresponding stage in the app**. The provider will be the provider corresponding to the deployment profile which was associated with the stage of the instance. For example, if `app1` has `service1` and `app1` has a stage `prod` linked to the `prod` deployment profile, then the `prod` provider will be added to the `service1` instances deployed to the `prod` stage.
+
+_This automatic migration will be performed when you deploy using version 4.1.0 or higher of the Serverless Plugin on the CLI._

--- a/docs/guides/safeguards.md
+++ b/docs/guides/safeguards.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - Safeguards
 menuText: Safeguards
-menuOrder: 5
+menuOrder: 9
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/safeguards/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/safeguards/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/sdk/README.md
+++ b/docs/guides/sdk/README.md
@@ -1,12 +1,13 @@
 <!--
 title: Serverless SDK
 menuText: sdk
+menuOrder: 10
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/sdk/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/sdk/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/sdk/nodejs.md
+++ b/docs/guides/sdk/nodejs.md
@@ -6,7 +6,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/sdk/nodejs/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/sdk/nodejs/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/sdk/python.md
+++ b/docs/guides/sdk/python.md
@@ -6,7 +6,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/sdk/python/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/sdk/python/)
 
 <!-- DOCS-SITE-LINK:END -->
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,13 +1,13 @@
 <!--
 title: Serverless Dashboard - Testing
 menuText: Testing
-menuOrder: 9
+menuOrder: 11
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/dashboard/testing/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/testing/)
 
 <!-- DOCS-SITE-LINK:END -->
 


### PR DESCRIPTION
This updates the documentation for Providers:

- Moves the dashboard docs from /docs/dashboard to /docs/guides
- Adds the providers documentation to /docs/guides
- Website (serverless/site) has a corresponding PR to upgrade redirects from /docs/dashboard to /docs/guides