### PR TITLE
template update: aws-nodejs-typescript - webpack5 updates

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -7,19 +7,19 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "source-map-support": "^0.5.10"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.17",
-    "@types/node": "^10.12.18",
-    "@types/serverless": "^1.72.5",
-    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "@types/aws-lambda": "^8.10.64",
+    "@types/node": "^14.14.6",
+    "@types/serverless": "^1.78.8",
+    "fork-ts-checker-webpack-plugin": "^6.0.0",
     "serverless-webpack": "^5.2.0",
-    "ts-loader": "^5.3.3",
-    "ts-node": "^8.10.2",
-    "typescript": "^3.2.4",
-    "webpack": "^4.29.0",
-    "webpack-node-externals": "^1.7.2"
+    "ts-loader": "^8.0.10",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.5",
+    "webpack": "^5.4.0",
+    "webpack-node-externals": "^2.5.2"
   },
   "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
   "license": "MIT"

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   optimization: {
     concatenateModules: false,
-  },  
+  },
   target: 'node',
   externals: [nodeExternals()],
   module: {

--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -18,6 +18,9 @@ module.exports = {
     path: path.join(__dirname, '.webpack'),
     filename: '[name].js',
   },
+  optimization: {
+    concatenateModules: false,
+  },  
   target: 'node',
   externals: [nodeExternals()],
   module: {


### PR DESCRIPTION
### Template Update Only

A simple PR to update the `aws-nodejs-typescript` template to use webpack5 via `serverless-webpack`

+ Updates the template to use webpack5 and updates corresponding packages to current.
+ Addresses concatenateModules suggestion located here https://github.com/serverless-heaven/serverless-webpack/issues/651

Currently does not pass the integration test due to requirements on non-existent `serverless.yml` file for Typescript: ./integration-test-template aws-nodejs-typescript
