### PR TITLE
Fix BC since Webpack5: The devtool option is more strict

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   context: __dirname,
   mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
   entry: slsw.lib.entries,
-  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  devtool: slsw.lib.webpack.isLocal ? 'eval-cheap-module-source-map' : 'source-map',
   resolve: {
     extensions: ['.mjs', '.json', '.ts'],
     symlinks: false,


### PR DESCRIPTION
Tiny fix of error:

```
Serverless: Bundling with Webpack...
 
  Validation Error ---------------------------------------
 
  ValidationError: Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
   - configuration.devtool should match pattern "^(inline-|hidden-|eval-)?(nosources-)?(cheap-(module-)?)?source-map$".
     BREAKING CHANGE since webpack 5: The devtool option is more strict.
     Please strictly follow the order of the keywords in the pattern.
```

See https://github.com/aligent/serverless-aws-nodejs-service-template/pull/52 too