### PR TITLE
fix(packaging): remove devDependencies when npm v7.0 is used

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -191,7 +191,7 @@ function excludeNodeDevDependencies(servicePath) {
           const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
           return childProcess
             .execAsync(
-              `npm ls --${env}=true --parseable=true --long=false --silent >> ${depFile}`,
+              `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
               { cwd: dirWithPackageJson }
             )
             .catch(() => BbPromise.resolve());

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -184,11 +184,11 @@ describe('zipService', () => {
               nosort: true,
             });
             expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
@@ -313,27 +313,27 @@ describe('zipService', () => {
               nosort: true,
             });
             expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[2][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[2][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[3][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[3][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[4][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[4][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[5][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
@@ -382,11 +382,11 @@ describe('zipService', () => {
               nosort: true,
             });
             expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
@@ -445,27 +445,27 @@ describe('zipService', () => {
               nosort: true,
             });
             expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[2][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[2][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[3][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[3][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[4][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[4][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[5][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
@@ -515,11 +515,11 @@ describe('zipService', () => {
               nosort: true,
             });
             expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent >> .+/
+              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
             expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent >> .+/
+              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
             );
             expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([


### PR DESCRIPTION
Closes: #8500 

In npm v7.0 default `depth` value has been changed from `Infinity` to `null` which causes `npm ls` command to list only root packages by default. By adding `--all` parameter to `npm ls` command we now can properly exclude all devDependencies from the artifacts.