### PR TITLE
fix: clean command in aws-go-mod template removes go.sum file

### DIFF
--- a/lib/plugins/create/templates/aws-go-mod/Makefile
+++ b/lib/plugins/create/templates/aws-go-mod/Makefile
@@ -6,7 +6,7 @@ build: gomodgen
 	env GOOS=linux go build -ldflags="-s -w" -o bin/world world/main.go
 
 clean:
-	rm -rf ./bin ./vendor Gopkg.lock
+	rm -rf ./bin ./vendor go.sum
 
 deploy: clean build
 	sls deploy --verbose


### PR DESCRIPTION
Template `aws-go-mod` is for Go Modules.
It has `make clean` command on Makefile, but it cleans `Gopkg.lock` not `go.sum`.
So I fixed.
