### PR TITLE
Add detailed metrics to HttpApi

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -281,5 +281,5 @@ Detailed Metrics can be turned on with:
 ```yaml
 provider:
   httpApi:
-    detailedMetrics: true
+    metrics: true
 ```

--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -271,3 +271,15 @@ provider:
   httpApi:
     payload: '1.0'
 ```
+
+### Detailed Metrics
+
+With HTTP API we may configure detailed metrics that can be used setup monitoring and alerting in Cloudwatch.
+
+Detailed Metrics can be turned on with:
+
+```yaml
+provider:
+  httpApi:
+    detailedMetrics: true
+```

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -130,7 +130,11 @@ class HttpApiEvents {
       ApiId: { Ref: this.provider.naming.getHttpApiLogicalId() },
       StageName: '$default',
       AutoDeploy: true,
+      DefaultRouteSettings: {
+        DetailedMetricsEnabled: this.config.detailedMetrics,
+      },
     };
+
     const resource = (this.cfTemplate.Resources[this.provider.naming.getHttpApiStageLogicalId()] = {
       Type: 'AWS::ApiGatewayV2::Stage',
       Properties: properties,
@@ -226,7 +230,11 @@ Object.defineProperties(
       const routes = new Map();
       const providerConfig = this.serverless.service.provider;
       const userConfig = providerConfig.httpApi || {};
-      this.config = { routes, id: userConfig.id };
+      this.config = {
+        routes,
+        id: userConfig.id,
+        detailedMetrics: userConfig.detailedMetrics || false,
+      };
       let cors = null;
       let shouldFillCorsMethods = false;
       const userCors = userConfig.cors;

--- a/lib/plugins/aws/package/compile/events/httpApi/index.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.js
@@ -131,7 +131,7 @@ class HttpApiEvents {
       StageName: '$default',
       AutoDeploy: true,
       DefaultRouteSettings: {
-        DetailedMetricsEnabled: this.config.detailedMetrics,
+        DetailedMetricsEnabled: this.config.metrics,
       },
     };
 
@@ -233,7 +233,7 @@ Object.defineProperties(
       this.config = {
         routes,
         id: userConfig.id,
-        detailedMetrics: userConfig.detailedMetrics || false,
+        metrics: userConfig.metrics || false,
       };
       let cors = null;
       let shouldFillCorsMethods = false;

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -60,6 +60,10 @@ describe('HttpApiEvents', () => {
       expect(resource.Properties.StageName).to.equal('$default');
       expect(resource.Properties.AutoDeploy).to.equal(true);
     });
+    it('Should not have detailed metrics when not asked to', () => {
+      const resource = cfResources[naming.getHttpApiStageLogicalId()];
+      expect(resource.Properties.DefaultRouteSettings.DetailedMetricsEnabled).to.equal(false);
+    });
     it('Should configure output', () => {
       const output = cfOutputs.HttpApiUrl;
       expect(output).to.have.property('Value');
@@ -104,6 +108,25 @@ describe('HttpApiEvents', () => {
 
     it('Should configure API name', () => {
       expect(cfHttpApi.Properties.Name).to.equal('TestHttpApi');
+    });
+  });
+
+  describe('Detailed Metrics', () => {
+    let cfHttpApiStage;
+
+    before(() =>
+      runServerless({
+        fixture: 'httpApi',
+        configExt: { provider: { httpApi: { detailedMetrics: true } } },
+        cliArgs: ['package'],
+      }).then(({ awsNaming, cfTemplate }) => {
+        const { Resources } = cfTemplate;
+        cfHttpApiStage = Resources[awsNaming.getHttpApiStageLogicalId()];
+      })
+    );
+    it('Should configure detailed metrics', () => {
+      expect(cfHttpApiStage.Type).to.equal('AWS::ApiGatewayV2::Stage');
+      expect(cfHttpApiStage.Properties.DefaultRouteSettings.DetailedMetricsEnabled).to.equal(true);
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -111,25 +111,6 @@ describe('HttpApiEvents', () => {
     });
   });
 
-  describe('Detailed Metrics', () => {
-    let cfHttpApiStage;
-
-    before(() =>
-      runServerless({
-        fixture: 'httpApi',
-        configExt: { provider: { httpApi: { metrics: true } } },
-        cliArgs: ['package'],
-      }).then(({ awsNaming, cfTemplate }) => {
-        const { Resources } = cfTemplate;
-        cfHttpApiStage = Resources[awsNaming.getHttpApiStageLogicalId()];
-      })
-    );
-    it('Should configure detailed metrics', () => {
-      expect(cfHttpApiStage.Type).to.equal('AWS::ApiGatewayV2::Stage');
-      expect(cfHttpApiStage.Properties.DefaultRouteSettings.DetailedMetricsEnabled).to.equal(true);
-    });
-  });
-
   describe('Payload format version', () => {
     let cfHttpApiIntegration;
 
@@ -483,7 +464,7 @@ describe('HttpApiEvents', () => {
     });
   });
 
-  describe('Access logs', () => {
+  describe('Access logs and detailed metrics', () => {
     let cfResources;
     let naming;
     before(() =>
@@ -491,6 +472,7 @@ describe('HttpApiEvents', () => {
         fixture: 'httpApi',
         configExt: {
           provider: {
+            httpApi: { metrics: true },
             logs: {
               httpApi: true,
             },
@@ -514,6 +496,11 @@ describe('HttpApiEvents', () => {
       const stageResourceProps = cfResources[naming.getHttpApiStageLogicalId()].Properties;
 
       expect(stageResourceProps.AccessLogSettings).to.have.property('Format');
+    });
+
+    it('Should configure detailed metrics', () => {
+      const resource = cfResources[naming.getHttpApiStageLogicalId()];
+      expect(resource.Properties.DefaultRouteSettings.DetailedMetricsEnabled).to.equal(true);
     });
   });
 

--- a/lib/plugins/aws/package/compile/events/httpApi/index.test.js
+++ b/lib/plugins/aws/package/compile/events/httpApi/index.test.js
@@ -117,7 +117,7 @@ describe('HttpApiEvents', () => {
     before(() =>
       runServerless({
         fixture: 'httpApi',
-        configExt: { provider: { httpApi: { detailedMetrics: true } } },
+        configExt: { provider: { httpApi: { metrics: true } } },
         cliArgs: ['package'],
       }).then(({ awsNaming, cfTemplate }) => {
         const { Resources } = cfTemplate;

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -698,7 +698,7 @@ class AwsProvider {
                 },
                 name: { type: 'string' },
                 payload: { type: 'string' },
-                detailedMetrics: { type: 'boolean' },
+                metrics: { type: 'boolean' },
               },
               additionalProperties: false,
             },

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -698,6 +698,7 @@ class AwsProvider {
                 },
                 name: { type: 'string' },
                 payload: { type: 'string' },
+                detailedMetrics: { type: 'boolean' },
               },
               additionalProperties: false,
             },


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8190 

Hi @medikoo , 
This PR implements the change suggested in #8190  . I used the detailedMetrics flag instead of metrics in httpApi because it is closer to the flag used by Cloudformation ([DetailedMetricsEnabled](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-stage-routesettings.html)).

I had to change my commit because when testing my change I noticed that once you've set DetailedMetricsEnabled to true, removing the property from DefaultRouteSettings will not disable the detailed metrics, to do so you have to set DetailedMetricsEnabled to false.