### PR TITLE
Remove help verbose 8497

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -93,7 +93,6 @@ class Serverless {
             // give the CLI the plugins and commands so that it can print out
             // information such as options when the user enters --help
             this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
-            this.cli.setLoadedExternalPlugins(this.pluginManager.getExternalPlugins());
             this.cli.setLoadedCommands(this.pluginManager.getCommands());
             return this.pluginManager.updateAutocompleteCacheFile();
           });

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -93,6 +93,7 @@ class Serverless {
             // give the CLI the plugins and commands so that it can print out
             // information such as options when the user enters --help
             this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
+            this.cli.setLoadedExternalPlugins(this.pluginManager.getExternalPlugins());
             this.cli.setLoadedCommands(this.pluginManager.getCommands());
             return this.pluginManager.updateAutocompleteCacheFile();
           });

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -16,16 +16,11 @@ class CLI {
     this.serverless = serverless;
     this.inputArray = inputArray || null;
     this.loadedPlugins = [];
-    this.loadedExternalPlugins = new Set();
     this.loadedCommands = {};
   }
 
   setLoadedPlugins(plugins) {
     this.loadedPlugins = plugins;
-  }
-
-  setLoadedExternalPlugins(externalPlugins) {
-    this.loadedExternalPlugins = externalPlugins;
   }
 
   setLoadedCommands(commands) {
@@ -236,31 +231,28 @@ class CLI {
     this.consoleLog('');
     this.consoleLog(chalk.yellow.underline('General Commands'));
     this.consoleLog('');
-    if (Object.keys(this.loadedCommands).length) {
-      const internalCommands = Object.entries(this.loadedCommands).filter(
-        command => command && !command.isExternal
-      );
-      const sortedInternalCommands = internalCommands.sort((command1, command2) =>
-        command1[0].localeCompare(command2[0])
-      );
-      sortedInternalCommands.forEach(([command, details]) => {
-        this.displayCommandUsage(details, command);
-      });
-    } else {
-      this.consoleLog('No commands found');
-    }
+
+    const internalCommands = Object.values(this.loadedCommands).filter(
+      command => command && !command.isExternal
+    );
+    const sortedInternalCommands = internalCommands.sort((command1, command2) =>
+      command1.key.localeCompare(command2.key)
+    );
+    sortedInternalCommands.forEach(command => {
+      this.displayCommandUsage(command, command.key);
+    });
 
     this.consoleLog('');
 
-    const externalSortedPlugins = this.loadedPlugins
-      .filter(plugin => this.loadedExternalPlugins.has(plugin))
+    const externalPlugins = this.loadedPlugins
+      .filter(plugin => this.serverless.pluginManager.externalPlugins.has(plugin))
       .sort((plugin1, plugin2) => plugin1.constructor.name.localeCompare(plugin2.constructor.name));
 
-    if (externalSortedPlugins.length) {
+    if (externalPlugins.length) {
       // print all the installed plugins
       this.consoleLog(chalk.yellow.underline('Plugins'));
 
-      this.consoleLog(externalSortedPlugins.map(plugin => plugin.constructor.name).join(', '));
+      this.consoleLog(externalPlugins.map(plugin => plugin.constructor.name).join(', '));
 
       let pluginCommands = {};
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -314,8 +314,6 @@ class CLI {
           this.consoleLog('');
         });
       }
-    } else {
-      this.consoleLog('No plugins added yet');
     }
   }
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -25,7 +25,7 @@ class CLI {
   }
 
   setLoadedExternalPlugins(externalPlugins) {
-    this.externalPlugins = externalPlugins;
+    this.loadedExternalPlugins = externalPlugins;
   }
 
   setLoadedCommands(commands) {
@@ -253,7 +253,7 @@ class CLI {
     this.consoleLog('');
 
     const externalSortedPlugins = this.loadedPlugins
-      .filter(plugin => this.externalPlugins.has(plugin))
+      .filter(plugin => this.loadedExternalPlugins.has(plugin))
       .sort((plugin1, plugin2) => plugin1.constructor.name.localeCompare(plugin2.constructor.name));
 
     if (externalSortedPlugins.length) {

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -326,57 +326,6 @@ functionalities related to given service or current environment.`
     this.displayCommandOptions(command);
   }
 
-  generateVerboseHelp() {
-    this.consoleLog('');
-    this.consoleLog(chalk.yellow.underline('Commands by plugin'));
-    this.consoleLog('');
-
-    let pluginCommands = {};
-
-    // add commands to pluginCommands based on command's plugin
-    const addToPluginCommands = cmd => {
-      const pcmd = _.clone(cmd);
-
-      // remove subcommand from clone
-      delete pcmd.commands;
-
-      // check if a plugin entry is already present in pluginCommands. Use the
-      // existing one or create a new plugin entry.
-      if (pluginCommands[pcmd.pluginName]) {
-        pluginCommands[pcmd.pluginName] = pluginCommands[pcmd.pluginName].concat(pcmd);
-      } else {
-        pluginCommands[pcmd.pluginName] = [pcmd];
-      }
-
-      // check for subcommands
-      if ('commands' in cmd) {
-        Object.values(cmd.commands).forEach(d => {
-          addToPluginCommands(d);
-        });
-      }
-    };
-
-    // fill up pluginCommands with commands in loadedCommands
-    Object.values(this.loadedCommands).forEach(details => {
-      addToPluginCommands(details);
-    });
-
-    // sort plugins alphabetically
-    pluginCommands = _(Object.entries(pluginCommands))
-      .sortBy(0)
-      .fromPairs()
-      .value();
-
-    Object.entries(pluginCommands).forEach(([plugin, details]) => {
-      this.consoleLog(plugin);
-      details.forEach(cmd => {
-        // display command usage with single(1) indent
-        this.displayCommandUsage(cmd, cmd.key.split(':').join(' '), 1);
-      });
-      this.consoleLog('');
-    });
-  }
-
   generateCommandsHelp(commandsArray) {
     const commandName = commandsArray.join(' ');
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -16,11 +16,16 @@ class CLI {
     this.serverless = serverless;
     this.inputArray = inputArray || null;
     this.loadedPlugins = [];
+    this.loadedExternalPlugins = new Set();
     this.loadedCommands = {};
   }
 
   setLoadedPlugins(plugins) {
     this.loadedPlugins = plugins;
+  }
+
+  setLoadedExternalPlugins(externalPlugins) {
+    this.externalPlugins = externalPlugins;
   }
 
   setLoadedCommands(commands) {
@@ -248,7 +253,7 @@ class CLI {
     this.consoleLog('');
 
     const externalSortedPlugins = this.loadedPlugins
-      .filter(plugin => plugin.isExternal)
+      .filter(plugin => this.externalPlugins.has(plugin))
       .sort((plugin1, plugin2) => plugin1.constructor.name.localeCompare(plugin2.constructor.name));
 
     if (externalSortedPlugins.length) {
@@ -256,10 +261,6 @@ class CLI {
       this.consoleLog(chalk.yellow.underline('Plugins'));
 
       this.consoleLog(externalSortedPlugins.map(plugin => plugin.constructor.name).join(', '));
-
-      this.consoleLog('');
-      this.consoleLog(chalk.yellow.underline('Commands by plugin'));
-      this.consoleLog('');
 
       let pluginCommands = {};
 
@@ -299,14 +300,20 @@ class CLI {
         .fromPairs()
         .value();
 
-      Object.entries(pluginCommands).forEach(([plugin, details]) => {
-        this.consoleLog(plugin);
-        details.forEach(cmd => {
-          // display command usage with single(1) indent
-          this.displayCommandUsage(cmd, cmd.key.split(':').join(' '), 1);
-        });
+      if (pluginCommands) {
         this.consoleLog('');
-      });
+        this.consoleLog(chalk.yellow.underline('Commands by plugin'));
+        this.consoleLog('');
+
+        Object.entries(pluginCommands).forEach(([plugin, details]) => {
+          this.consoleLog(plugin);
+          details.forEach(cmd => {
+            // display command usage with single(1) indent
+            this.displayCommandUsage(cmd, cmd.key.split(':').join(' '), 1);
+          });
+          this.consoleLog('');
+        });
+      }
     } else {
       this.consoleLog('No plugins added yet');
     }

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -300,7 +300,7 @@ class CLI {
         .fromPairs()
         .value();
 
-      if (pluginCommands) {
+      if (!_.isEmpty(pluginCommands)) {
         this.consoleLog('');
         this.consoleLog(chalk.yellow.underline('Commands by plugin'));
         this.consoleLog('');

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -97,8 +97,7 @@ class CLI {
           this.generateInteractiveCliHelp();
           return true;
         }
-        if (options.verbose) this.generateVerboseHelp();
-        else this.generateMainHelp();
+        this.generateMainHelp();
         return true;
       case 1:
         if (commands[0] === 'version') {
@@ -106,8 +105,7 @@ class CLI {
           return true;
         }
         if (commands[0] === 'help') {
-          if (options.verbose) this.generateVerboseHelp();
-          else this.generateMainHelp();
+          this.generateMainHelp();
           return true;
         }
       // fallthrough
@@ -186,7 +184,6 @@ class CLI {
 
     this.consoleLog(chalk.yellow.underline('Commands'));
     this.consoleLog(chalk.dim('* You can run commands with "serverless" or the shortcut "sls"'));
-    this.consoleLog(chalk.dim('* Pass "--verbose" to this command to get in-depth plugin info'));
     this.consoleLog(chalk.dim('* Pass "--no-color" to disable CLI colors'));
     this.consoleLog(chalk.dim('* Pass "--help" after any <command> for contextual help'));
     this.consoleLog('');
@@ -232,8 +229,16 @@ class CLI {
     );
 
     this.consoleLog('');
+    this.consoleLog(chalk.yellow.underline('General Commands'));
+    this.consoleLog('');
     if (Object.keys(this.loadedCommands).length) {
-      Object.entries(this.loadedCommands).forEach(([command, details]) => {
+      const internalCommands = Object.entries(this.loadedCommands).filter(
+        command => command && !command.isExternal
+      );
+      const sortedInternalCommands = internalCommands.sort((command1, command2) =>
+        command1[0].localeCompare(command2[0])
+      );
+      sortedInternalCommands.forEach(([command, details]) => {
         this.displayCommandUsage(details, command);
       });
     } else {
@@ -242,14 +247,66 @@ class CLI {
 
     this.consoleLog('');
 
-    // print all the installed plugins
-    this.consoleLog(chalk.yellow.underline('Plugins'));
+    const externalSortedPlugins = this.loadedPlugins
+      .filter(plugin => plugin.isExternal)
+      .sort((plugin1, plugin2) => plugin1.constructor.name.localeCompare(plugin2.constructor.name));
 
-    if (this.loadedPlugins.length) {
-      const sortedPlugins = this.loadedPlugins.sort((plugin1, plugin2) =>
-        plugin1.constructor.name.localeCompare(plugin2.constructor.name)
-      );
-      this.consoleLog(sortedPlugins.map(plugin => plugin.constructor.name).join(', '));
+    if (externalSortedPlugins.length) {
+      // print all the installed plugins
+      this.consoleLog(chalk.yellow.underline('Plugins'));
+
+      this.consoleLog(externalSortedPlugins.map(plugin => plugin.constructor.name).join(', '));
+
+      this.consoleLog('');
+      this.consoleLog(chalk.yellow.underline('Commands by plugin'));
+      this.consoleLog('');
+
+      let pluginCommands = {};
+
+      // add commands to pluginCommands based on command's plugin
+      const addToPluginCommands = cmd => {
+        const pcmd = _.clone(cmd);
+
+        // remove subcommand from clone
+        delete pcmd.commands;
+
+        // check if a plugin entry is already present in pluginCommands. Use the
+        // existing one or create a new plugin entry.
+        if (pluginCommands[pcmd.pluginName]) {
+          pluginCommands[pcmd.pluginName] = pluginCommands[pcmd.pluginName].concat(pcmd);
+        } else {
+          pluginCommands[pcmd.pluginName] = [pcmd];
+        }
+
+        // check for subcommands
+        if ('commands' in cmd) {
+          Object.values(cmd.commands).forEach(d => {
+            addToPluginCommands(d);
+          });
+        }
+      };
+
+      // fill up pluginCommands with commands in loadedCommands
+      Object.values(this.loadedCommands).forEach(details => {
+        if (details.isExternal) {
+          addToPluginCommands(details);
+        }
+      });
+
+      // sort plugins alphabetically
+      pluginCommands = _(Object.entries(pluginCommands))
+        .sortBy(0)
+        .fromPairs()
+        .value();
+
+      Object.entries(pluginCommands).forEach(([plugin, details]) => {
+        this.consoleLog(plugin);
+        details.forEach(cmd => {
+          // display command usage with single(1) indent
+          this.displayCommandUsage(cmd, cmd.key.split(':').join(' '), 1);
+        });
+        this.consoleLog('');
+      });
     } else {
       this.consoleLog('No plugins added yet');
     }

--- a/lib/classes/CLI.test.js
+++ b/lib/classes/CLI.test.js
@@ -649,11 +649,6 @@ describe('CLI', () => {
         expect(stdout).to.contain('deploy');
         expect(stdout).to.contain('--stage');
       }));
-
-    it('should print help --verbose to stdout', () =>
-      spawn(serverlessExec, ['help', '--verbose'], { env }).then(({ stdoutBuffer }) =>
-        expect(String(stdoutBuffer)).to.contain('Commands by plugin')
-      ));
   });
 });
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -286,8 +286,7 @@ class PluginManager {
           }
           return event;
         });
-        this.commands[key] = _.merge({}, this.commands[key], command);
-        this.commands[key] = _.merge({}, this.commands[key], options);
+        this.commands[key] = _.merge({}, this.commands[key], command, options);
       });
     }
   }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -284,7 +284,9 @@ class PluginManager {
           }
           return event;
         });
-        this.commands[key] = _.merge({}, this.commands[key], command, options);
+        this.commands[key] = _.merge({}, this.commands[key], command, {
+          isExternal: options.isExternal,
+        });
       });
     }
   }
@@ -491,10 +493,6 @@ class PluginManager {
 
   getPlugins() {
     return this.plugins;
-  }
-
-  getExternalPlugins() {
-    return this.externalPlugins;
   }
 
   getHooks(events) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -91,7 +91,7 @@ class PluginManager {
     this.cliCommands = commands;
   }
 
-  addPlugin(Plugin, options) {
+  addPlugin(Plugin, options = { isExternal: false }) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
     // isExternal differentiates plugin as OOTB or not
     if (options.isExternal) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -60,6 +60,7 @@ class PluginManager {
     this.pluginIndependentCommands = new Set(['help', 'plugin']);
 
     this.plugins = [];
+    this.externalPlugins = new Set();
     this.commands = {};
     this.aliases = {};
     this.hooks = {};
@@ -93,7 +94,9 @@ class PluginManager {
   addPlugin(Plugin, options) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
     // isExternal differentiates plugin as OOTB or not
-    Object.assign(pluginInstance, options);
+    if (options.isExternal) {
+      this.externalPlugins.add(pluginInstance);
+    }
 
     let pluginProvider = null;
     // check if plugin is provider agnostic
@@ -491,6 +494,10 @@ class PluginManager {
 
   getPlugins() {
     return this.plugins;
+  }
+
+  getExternalPlugins() {
+    return this.externalPlugins;
   }
 
   getHooks(events) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -90,10 +90,10 @@ class PluginManager {
     this.cliCommands = commands;
   }
 
-  addPlugin(Plugin, isExternal = false) {
+  addPlugin(Plugin, options) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
     // isExternal differentiates plugin as OOTB or not
-    Object.assign(pluginInstance, { isExternal });
+    Object.assign(pluginInstance, options);
 
     let pluginProvider = null;
     // check if plugin is provider agnostic
@@ -116,7 +116,7 @@ class PluginManager {
       return;
     }
 
-    this.loadCommands(pluginInstance, isExternal);
+    this.loadCommands(pluginInstance, options);
     this.loadHooks(pluginInstance);
     this.loadVariableResolvers(pluginInstance);
 
@@ -124,17 +124,19 @@ class PluginManager {
   }
 
   loadAllPlugins(servicePlugins) {
+    const internalPluginOptions = { isExternal: false };
+    const externalPluginOptions = { isExternal: true };
     const EnterprisePlugin = this.resolveEnterprisePlugin();
 
     require('../plugins')
       .filter(Boolean)
-      .forEach(Plugin => this.addPlugin(Plugin));
+      .forEach(Plugin => this.addPlugin(Plugin, internalPluginOptions));
 
     this.resolveServicePlugins(servicePlugins)
       .filter(Boolean)
-      .forEach(Plugin => this.addPlugin(Plugin, true));
+      .forEach(Plugin => this.addPlugin(Plugin, externalPluginOptions));
 
-    if (EnterprisePlugin) this.addPlugin(EnterprisePlugin);
+    if (EnterprisePlugin) this.addPlugin(EnterprisePlugin, internalPluginOptions);
 
     return this.asyncPluginInit();
   }
@@ -265,7 +267,7 @@ class PluginManager {
     return Object.assign({}, details, { key, pluginName, commands });
   }
 
-  loadCommands(pluginInstance, isExternal) {
+  loadCommands(pluginInstance, options) {
     const pluginName = pluginInstance.constructor.name;
     if (pluginInstance.commands) {
       Object.entries(pluginInstance.commands).forEach(([key, details]) => {
@@ -282,7 +284,7 @@ class PluginManager {
           return event;
         });
         this.commands[key] = _.merge({}, this.commands[key], command);
-        Object.assign(this.commands[key], { isExternal });
+        this.commands[key] = _.merge({}, this.commands[key], options);
       });
     }
   }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -127,19 +127,17 @@ class PluginManager {
   }
 
   loadAllPlugins(servicePlugins) {
-    const internalPluginOptions = { isExternal: false };
-    const externalPluginOptions = { isExternal: true };
     const EnterprisePlugin = this.resolveEnterprisePlugin();
 
     require('../plugins')
       .filter(Boolean)
-      .forEach(Plugin => this.addPlugin(Plugin, internalPluginOptions));
+      .forEach(Plugin => this.addPlugin(Plugin));
 
     this.resolveServicePlugins(servicePlugins)
       .filter(Boolean)
-      .forEach(Plugin => this.addPlugin(Plugin, externalPluginOptions));
+      .forEach(Plugin => this.addPlugin(Plugin, { isExternal: true }));
 
-    if (EnterprisePlugin) this.addPlugin(EnterprisePlugin, internalPluginOptions);
+    if (EnterprisePlugin) this.addPlugin(EnterprisePlugin);
 
     return this.asyncPluginInit();
   }
@@ -270,7 +268,7 @@ class PluginManager {
     return Object.assign({}, details, { key, pluginName, commands });
   }
 
-  loadCommands(pluginInstance, options) {
+  loadCommands(pluginInstance, options = { isExternal: false }) {
     const pluginName = pluginInstance.constructor.name;
     if (pluginInstance.commands) {
       Object.entries(pluginInstance.commands).forEach(([key, details]) => {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -90,8 +90,10 @@ class PluginManager {
     this.cliCommands = commands;
   }
 
-  addPlugin(Plugin) {
+  addPlugin(Plugin, isExternal = false) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
+    // isExternal differentiates plugin as OOTB or not
+    Object.assign(pluginInstance, { isExternal });
 
     let pluginProvider = null;
     // check if plugin is provider agnostic
@@ -114,7 +116,7 @@ class PluginManager {
       return;
     }
 
-    this.loadCommands(pluginInstance);
+    this.loadCommands(pluginInstance, isExternal);
     this.loadHooks(pluginInstance);
     this.loadVariableResolvers(pluginInstance);
 
@@ -124,9 +126,13 @@ class PluginManager {
   loadAllPlugins(servicePlugins) {
     const EnterprisePlugin = this.resolveEnterprisePlugin();
 
-    [...require('../plugins'), ...this.resolveServicePlugins(servicePlugins)]
+    require('../plugins')
       .filter(Boolean)
       .forEach(Plugin => this.addPlugin(Plugin));
+
+    this.resolveServicePlugins(servicePlugins)
+      .filter(Boolean)
+      .forEach(Plugin => this.addPlugin(Plugin, true));
 
     if (EnterprisePlugin) this.addPlugin(EnterprisePlugin);
 
@@ -259,7 +265,7 @@ class PluginManager {
     return Object.assign({}, details, { key, pluginName, commands });
   }
 
-  loadCommands(pluginInstance) {
+  loadCommands(pluginInstance, isExternal) {
     const pluginName = pluginInstance.constructor.name;
     if (pluginInstance.commands) {
       Object.entries(pluginInstance.commands).forEach(([key, details]) => {
@@ -276,6 +282,7 @@ class PluginManager {
           return event;
         });
         this.commands[key] = _.merge({}, this.commands[key], command);
+        Object.assign(this.commands[key], { isExternal });
       });
     }
   }


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Closes: #8497 

### **The new output looks something like-**

**Commands**
* You can run commands with "serverless" or the shortcut "sls"
* Pass "--no-color" to disable CLI colors
* Pass "--help" after any <command> for contextual help

**Interactive Quickstart**
* Run serverless (or shortcut sls) without any arguments to initialize an interactive setup
  of functionalities related to given service or current environment
* Pass "--help-interactive" for contextual help on interactive CLI options

**Serverless Components**
* Run serverless (or shortcut sls) in context of a component service to initialize a components CLI
* Pass "--help-components" for contextual help on Serverless Components

**Framework**
* Documentation: http://slss.io/docs

**Environment Variables**
* Set SLS_DEBUG=* to see debugging logs
* Set SLS_WARNING_DISABLE=* to hide warnings from the output
* Set SLS_MAX_CONCURRENT_ARTIFACTS_UPLOADS to control the maximum S3 upload SDK requests that are sent in parallel during the deployment of the service's artifacts. The default is 3. Note: increasing this too high might, actually, downgrade the overall upload speed

**General Commands**

config ........................ Configure Serverless
config credentials ............ Configures a new provider profile for the Serverless Framework
config tabcompletion install .. Install a <tab> completion for chosen shell
config tabcompletion uninstall  Uninstall a <tab> completion for chosen shell
create ........................ Create new Serverless service
dashboard ..................... Open the Serverless dashboard
deploy ........................ Deploy a Serverless service
deploy function ............... Deploy a single function from the service
deploy list ................... List deployed version of your Serverless Service
deploy list functions ......... List all the deployed functions and their versions
generate-event ................ Generate event
info .......................... Display information about the service
install ....................... Install a Serverless service from GitHub or a plugin from the Serverless registry
invoke ........................ Invoke a deployed function
invoke local .................. Invoke function locally
login ......................... Login or sign up for Serverless
logout ........................ Logout from Serverless
logs .......................... Output the logs of a deployed function
metrics ....................... Show metrics for a specific function
output ........................
output get .................... Get value of dashboard deployment profile parameter
output list ................... List all dashboard deployment profile parameters
package ....................... Packages a Serverless service
param .........................
param get ..................... Get value of dashboard service output
param list .................... List all dashboard service outputs
plugin ........................ Plugin management for Serverless
plugin install ................ Install and add a plugin to your service
plugin uninstall .............. Uninstall and remove a plugin from your service
plugin list ................... Lists all available plugins
plugin search ................. Search for plugins
print ......................... Print your compiled and resolved config file
remove ........................ Remove Serverless service and all resources
rollback ...................... Rollback the Serverless service to a specific deployment
rollback function ............. Rollback the function to a specific version
ses-template .................. Manage AWS SES templates
ses-template deploy ........... Sync email templates to AWS SES
ses-template delete ........... Delete email template from AWS SES by given name
ses-template list ............. List email templates from AWS SES
slstats ....................... Enable or disable stats
studio ........................ Develop a Serverless application in the cloud.
test .......................... Run HTTP tests

**Plugins**
DynamoDBAutoscaling, ServerlessSesTemplate

**Commands by plugin**

ServerlessSesTemplate
  ses-template .................. Manage AWS SES templates
  ses-template deploy ........... Sync email templates to AWS SES
  ses-template delete ........... Delete email template from AWS SES by given name
  ses-template list ............. List email templates from AWS SES

![sls-help-1](https://user-images.githubusercontent.com/72654781/99883541-2da82e80-2c4e-11eb-9e41-ffce6e5019d0.png)
![sls-help-2](https://user-images.githubusercontent.com/72654781/99883545-326ce280-2c4e-11eb-82dc-35e8fc4184b2.png)
![sls-help-3](https://user-images.githubusercontent.com/72654781/99883566-60522700-2c4e-11eb-985d-08ff499e7162.png)
