### PR TITLE
Abstract working temp directory

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -183,6 +183,26 @@ class Serverless {
     return this.version;
   }
 
+  // All uses of the `.serverless` folder should point to either the package
+  // output directory (getPackageOutputDir), or to the working directory
+  // (getWorkingTempDir). The framework and plugins should not assume that the
+  // `.serverless` folder will be used as the behaviour may change in the future
+  getWorkingTempDir() {
+    const serverlessTmpDirPath = path.join(this.config.servicePath || '.', '.serverless');
+    return serverlessTmpDirPath;
+  }
+  getPackageOutputDir() {
+    const packageOption =
+      this.processedInput && this.processedInput.options
+        ? this.processedInput.options.package
+        : undefined;
+    const packagePath =
+      packageOption ||
+      this.service.package.path ||
+      path.join(this.config.servicePath || '.', '.serverless');
+    return packagePath;
+  }
+
   // Only for internal use
   _logDeprecation(code, message) {
     return logDeprecation(code, message, { serviceConfig: this.service });

--- a/lib/plugins/aws/common/lib/artifacts.js
+++ b/lib/plugins/aws/common/lib/artifacts.js
@@ -1,18 +1,14 @@
 'use strict';
 
-const path = require('path');
 const fse = require('fs-extra');
 
 module.exports = {
   async moveArtifactsToPackage() {
-    const packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+    const packagePath = this.serverless.getPackageOutputDir();
 
     // Only move the artifacts if it was requested by the user
     if (this.serverless.config.servicePath && !packagePath.endsWith('.serverless')) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+      const serverlessTmpDirPath = this.serverless.getWorkingTempDir();
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
         if (this.serverless.utils.dirExistsSync(packagePath)) {
@@ -26,14 +22,11 @@ module.exports = {
   },
 
   async moveArtifactsToTemp() {
-    const packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+    const packagePath = this.serverless.getPackageOutputDir();
 
     // Only move the artifacts if it was requested by the user
     if (this.serverless.config.servicePath && !packagePath.endsWith('.serverless')) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+      const serverlessTmpDirPath = this.serverless.getWorkingTempDir();
 
       if (this.serverless.utils.dirExistsSync(packagePath)) {
         if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {

--- a/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/lib/plugins/aws/common/lib/artifacts.test.js
@@ -7,15 +7,27 @@ const AWSCommon = require('../index');
 const Serverless = require('../../../../../lib/Serverless');
 const { getTmpDirPath } = require('../../../../../test/utils/fs');
 
+// In regular startup, the package option is processed from the CLI in the
+// Serverless init / plugin loading. Here in the tests, we don't call that
+// code path and we're setting up the Serverless object before we know what
+// the individual test wants the directory to be.
+const setPackageOptionFn = (serverless, awsCommon) => targetPath => {
+  awsCommon.options.package = targetPath;
+  serverless.processedInput = serverless.processedInput || {};
+  serverless.processedInput.options = serverless.processedInput.options || {};
+  serverless.processedInput.options.package = targetPath;
+};
 describe('#moveArtifactsToPackage()', () => {
   let serverless;
   let awsCommon;
+  let setPackageOption;
   const moveBasePath = path.join(getTmpDirPath(), 'move');
   const moveServerlessPath = path.join(moveBasePath, '.serverless');
 
   beforeEach(() => {
     serverless = new Serverless();
     awsCommon = new AWSCommon(serverless, {});
+    setPackageOption = setPackageOptionFn(serverless, awsCommon);
 
     serverless.config.servicePath = moveBasePath;
     if (!serverless.utils.dirExistsSync(moveServerlessPath)) {
@@ -40,7 +52,7 @@ describe('#moveArtifactsToPackage()', () => {
     const testFileSource = path.join(moveServerlessPath, 'moveTestFile.tmp');
     const targetPath = path.join(moveBasePath, 'target');
 
-    awsCommon.options.package = targetPath;
+    setPackageOption(targetPath);
     serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
     return awsCommon.moveArtifactsToPackage().then(() => {
       const testFileTarget = path.join(targetPath, 'moveTestFile.tmp');
@@ -71,7 +83,7 @@ describe('#moveArtifactsToPackage()', () => {
       fse.removeSync(moveServerlessPath);
     }
 
-    awsCommon.options.package = targetPath;
+    setPackageOption(targetPath);
     return awsCommon.moveArtifactsToPackage().then(() => {
       expect(serverless.utils.dirExistsSync(targetPath)).to.be.equal(false);
     });
@@ -99,6 +111,7 @@ describe('#moveArtifactsToPackage()', () => {
 describe('#moveArtifactsToTemp()', () => {
   let serverless;
   let awsCommon;
+  let setPackageOption;
   const moveBasePath = path.join(getTmpDirPath(), 'move');
   const moveServerlessPath = path.join(moveBasePath, '.serverless');
   const moveTargetPath = path.join(moveBasePath, 'target');
@@ -106,6 +119,7 @@ describe('#moveArtifactsToTemp()', () => {
   beforeEach(() => {
     serverless = new Serverless();
     awsCommon = new AWSCommon(serverless, {});
+    setPackageOption = setPackageOptionFn(serverless, awsCommon);
 
     serverless.config.servicePath = moveBasePath;
     if (!serverless.utils.dirExistsSync(moveTargetPath)) {
@@ -130,7 +144,7 @@ describe('#moveArtifactsToTemp()', () => {
     const testFileSource = path.join(moveTargetPath, 'moveTestFile.tmp');
 
     serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    awsCommon.options.package = moveTargetPath;
+    setPackageOption(moveTargetPath);
     return awsCommon.moveArtifactsToTemp().then(() => {
       const testFileTarget = path.join(moveServerlessPath, 'moveTestFile.tmp');
 
@@ -157,7 +171,7 @@ describe('#moveArtifactsToTemp()', () => {
       fse.removeSync(moveTargetPath);
     }
 
-    awsCommon.options.package = moveTargetPath;
+    setPackageOption(moveTargetPath);
     return awsCommon.moveArtifactsToTemp().then(() => {
       expect(serverless.utils.dirExistsSync(moveTargetPath)).to.be.equal(false);
     });

--- a/lib/plugins/aws/common/lib/cleanupTempDir.js
+++ b/lib/plugins/aws/common/lib/cleanupTempDir.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const path = require('path');
 const fse = require('fs-extra');
 
 module.exports = {
   async cleanupTempDir() {
     if (this.serverless.config.servicePath) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+      const serverlessTmpDirPath = this.serverless.getWorkingTempDir();
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
         fse.removeSync(serverlessTmpDirPath);

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -26,8 +26,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
   const { Resources } = providerConfig.compiledCloudFormationTemplate;
   const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
   const zipFilePath = path.join(
-    serverless.config.servicePath,
-    '.serverless',
+    serverless.getWorkingTempDir(),
     awsProvider.naming.getCustomResourcesArtifactName()
   );
   const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -11,7 +11,6 @@ const uploadArtifacts = require('./lib/uploadArtifacts');
 const validateTemplate = require('./lib/validateTemplate');
 const updateStack = require('../lib/updateStack');
 const existsDeploymentBucket = require('./lib/existsDeploymentBucket');
-const path = require('path');
 
 class AwsDeploy {
   constructor(serverless, options) {
@@ -19,10 +18,7 @@ class AwsDeploy {
     this.options = options;
     this.provider = this.serverless.getProvider('aws');
     this.servicePath = this.serverless.config.servicePath || '';
-    this.packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.servicePath, '.serverless');
+    this.packagePath = this.serverless.getPackageOutputDir();
 
     Object.assign(
       this,

--- a/lib/plugins/aws/deploy/index.test.js
+++ b/lib/plugins/aws/deploy/index.test.js
@@ -19,6 +19,17 @@ describe('AwsDeploy', () => {
   let serverless;
   let options;
 
+  // In regular startup, the package option is processed from the CLI in the
+  // Serverless init / plugin loading. Here in the tests, we don't call that
+  // code path and we're setting up the Serverless object before we know what
+  // the individual test wants the directory to be.
+  const setPackageOption = targetPath => {
+    options.package = targetPath;
+    serverless.processedInput = serverless.processedInput || {};
+    serverless.processedInput.options = serverless.processedInput.options || {};
+    serverless.processedInput.options.package = targetPath;
+  };
+
   beforeEach(() => {
     serverless = new Serverless();
     options = {
@@ -51,7 +62,7 @@ describe('AwsDeploy', () => {
     });
 
     it('should use the options package path if provided', () => {
-      options.package = 'package-options';
+      setPackageOption('package-options');
       awsDeploy = new AwsDeploy(serverless, options);
 
       expect(awsDeploy.packagePath).to.equal('package-options');

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -124,7 +124,7 @@ module.exports = {
     if (objects && objects.length) {
       const remoteHashes = objects.map(object => object.Metadata.filesha256 || '');
 
-      const serverlessDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+      const serverlessDirPath = this.serverless.getWorkingTempDir();
 
       // create a hash of the CloudFormation body
       const compiledCfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -10,8 +10,7 @@ module.exports = {
     // Restore state
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
     const serviceStateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.getWorkingTempDir(),
       serviceStateFileName
     );
     if (!this.serverless.utils.fileExistsSync(serviceStateFilePath)) {
@@ -29,8 +28,7 @@ module.exports = {
     // only restore the default artifact path if the user is not using a custom path
     if (state.package.artifact && this.serverless.service.artifact) {
       this.serverless.service.package.artifact = path.join(
-        this.serverless.config.servicePath,
-        '.serverless',
+        this.serverless.getWorkingTempDir(),
         state.package.artifact
       );
     }

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -140,8 +140,7 @@ module.exports = {
 
   uploadCustomResources() {
     const artifactFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.getWorkingTempDir(),
       this.provider.naming.getCustomResourcesArtifactName()
     );
 

--- a/lib/plugins/aws/deployFunction/index.js
+++ b/lib/plugins/aws/deployFunction/index.js
@@ -12,10 +12,7 @@ class AwsDeployFunction {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+    this.packagePath = this.serverless.getPackageOutputDir();
     this.provider = this.serverless.getProvider('aws');
 
     Object.assign(this, validate);

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -305,7 +305,11 @@ class AwsInvokeLocal {
               return targetLayer.path;
             }
             if (targetLayer.package && targetLayer.package.artifact) {
-              const layerArtifactContentPath = path.join('.serverless', 'layers', layer.Ref);
+              const layerArtifactContentPath = path.join(
+                this.serverless.getWorkingTempDir(),
+                'layers',
+                layer.Ref
+              );
               return dirExists(layerArtifactContentPath).then(exists => {
                 if (exists) {
                   return layerArtifactContentPath;
@@ -320,7 +324,12 @@ class AwsInvokeLocal {
           const arnParts = layer.split(':');
           const layerArn = arnParts.slice(0, -1).join(':');
           const layerVersion = Number(arnParts.slice(-1)[0]);
-          const layerContentsPath = path.join('.serverless', 'layers', arnParts[6], arnParts[7]);
+          const layerContentsPath = path.join(
+            this.serverless.getWorkingTempDir(),
+            'layers',
+            arnParts[6],
+            arnParts[7]
+          );
           const layerContentsCachePath = path.join(cachePath, 'layers', arnParts[6], arnParts[7]);
 
           return dirExists(layerContentsPath)
@@ -369,7 +378,12 @@ class AwsInvokeLocal {
       } /opt`;
     }
 
-    const dockerfilePath = path.join('.serverless', 'invokeLocal', runtime, 'Dockerfile');
+    const dockerfilePath = path.join(
+      this.serverless.getWorkingTempDir(),
+      'invokeLocal',
+      runtime,
+      'Dockerfile'
+    );
     const dockerfileCachePath = path.join(cachePath, 'dockerfiles', runtime, 'Dockerfile');
 
     return fileExists(dockerfileCachePath)
@@ -389,7 +403,7 @@ class AwsInvokeLocal {
           return imageName;
         }
         return BbPromise.all([
-          ensureDir(path.join('.serverless', 'invokeLocal', runtime)),
+          ensureDir(path.join(this.serverless.getWorkingTempDir(), 'invokeLocal', runtime)),
           ensureDir(path.join(cachePath, 'dockerfiles', runtime)),
         ])
           .then(() => {
@@ -432,12 +446,7 @@ class AwsInvokeLocal {
     if (!artifact) {
       return this.serverless.config.servicePath;
     }
-    const destination = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      'invokeLocal',
-      'artifact'
-    );
+    const destination = path.join(this.serverless.getWorkingTempDir(), 'invokeLocal', 'artifact');
     return decompress(artifact, destination).then(() => destination);
   }
 
@@ -454,9 +463,7 @@ class AwsInvokeLocal {
   ensurePackage() {
     if (this.options['skip-package']) {
       return fse
-        .access(
-          path.join(this.serverless.config.servicePath, '.serverless', 'serverless-state.json')
-        )
+        .access(path.join(this.serverless.getWorkingTempDir(), 'serverless-state.json'))
         .catch(() => this.serverless.pluginManager.spawn('package'));
     }
     return this.serverless.pluginManager.spawn('package');

--- a/lib/plugins/aws/invokeLocal/index.test.js
+++ b/lib/plugins/aws/invokeLocal/index.test.js
@@ -1235,7 +1235,13 @@ describe('AwsInvokeLocal', () => {
 
     it('calls docker with packaged artifact', () =>
       awsInvokeLocal.invokeLocalDocker().then(() => {
-        const dockerfilePath = path.join('.serverless', 'invokeLocal', 'nodejs12.x', 'Dockerfile');
+        const dockerfilePath = path.join(
+          serverless.config.servicePath || '.',
+          '.serverless',
+          'invokeLocal',
+          'nodejs12.x',
+          'Dockerfile'
+        );
 
         expect(pluginMangerSpawnPackageStub.calledOnce).to.equal(true);
         expect(spawnExtStub.getCall(0).args).to.deep.equal(['docker', ['version']]);

--- a/lib/plugins/aws/lib/getServiceState.js
+++ b/lib/plugins/aws/lib/getServiceState.js
@@ -5,10 +5,8 @@ const path = require('path');
 module.exports = {
   getServiceState() {
     const stateFileName = this.provider.naming.getServiceStateFileName();
-    const servicePath = this.serverless.config.servicePath;
-    const packageDirName = this.options.package || '.serverless';
 
-    const stateFilePath = path.resolve(servicePath, packageDirName, stateFileName);
+    const stateFilePath = path.resolve(this.serverless.getPackageOutputDir(), stateFileName);
     return this.serverless.utils.readFileSync(stateFilePath);
   },
 };

--- a/lib/plugins/aws/lib/getServiceState.test.js
+++ b/lib/plugins/aws/lib/getServiceState.test.js
@@ -16,6 +16,18 @@ describe('#getServiceState()', () => {
   const options = {};
   const awsPlugin = {};
 
+  // In regular startup, the package option is processed from the CLI in the
+  // Serverless init / plugin loading. Here in the tests, we don't call that
+  // code path and we're setting up the Serverless object before we know what
+  // the individual test wants the directory to be.
+  const setPackageOption = targetPath => {
+    options.package = targetPath;
+    awsPlugin.options.package = targetPath;
+    serverless.processedInput = serverless.processedInput || {};
+    serverless.processedInput.options = serverless.processedInput.options || {};
+    serverless.processedInput.options.package = targetPath;
+  };
+
   beforeEach(() => {
     serverless = new Serverless();
     serverless.config.servicePath = 'my-service';
@@ -40,7 +52,7 @@ describe('#getServiceState()', () => {
 
   it('should use the argument-based state file path if the "package" option is used ', () => {
     const stateFilePath = path.resolve('my-service', 'some-package-path', 'serverless-state.json');
-    options.package = 'some-package-path';
+    setPackageOption('my-service/some-package-path');
 
     awsPlugin.getServiceState();
     expect(readFileSyncStub).to.be.calledWithExactly(stateFilePath);

--- a/lib/plugins/aws/package/compile/functions/index.js
+++ b/lib/plugins/aws/package/compile/functions/index.js
@@ -11,9 +11,7 @@ class AwsCompileFunctions {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    const servicePath = this.serverless.config.servicePath || '';
-    this.packagePath =
-      this.serverless.service.package.path || path.join(servicePath || '.', '.serverless');
+    this.packagePath = this.serverless.getPackageOutputDir();
 
     this.provider = this.serverless.getProvider('aws');
 
@@ -139,11 +137,7 @@ class AwsCompileFunctions {
           artifactFileName = functionArtifactFileName;
         }
 
-        artifactFilePath = path.join(
-          this.serverless.config.servicePath,
-          '.serverless',
-          artifactFileName
-        );
+        artifactFilePath = path.join(this.serverless.getWorkingTempDir(), artifactFileName);
       }
 
       if (this.serverless.service.package.deploymentBucket) {

--- a/lib/plugins/aws/package/compile/layers/index.js
+++ b/lib/plugins/aws/package/compile/layers/index.js
@@ -11,9 +11,7 @@ class AwsCompileLayers {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    const servicePath = this.serverless.config.servicePath || '';
-    this.packagePath =
-      this.serverless.service.package.path || path.join(servicePath || '.', '.serverless');
+    this.packagePath = this.serverless.getPackageOutputDir();
 
     this.provider = this.serverless.getProvider('aws');
 

--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const path = require('path');
 const mergeCustomProviderResources = require('./lib/mergeCustomProviderResources');
 const generateArtifactDirectoryName = require('./lib/generateArtifactDirectoryName');
 const generateCoreTemplate = require('./lib/generateCoreTemplate');
@@ -14,10 +13,7 @@ class AwsPackage {
     this.serverless = serverless;
     this.options = options;
     this.servicePath = this.serverless.config.servicePath || '';
-    this.packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.servicePath || '.', '.serverless');
+    this.packagePath = this.serverless.getPackageOutputDir();
     this.provider = this.serverless.getProvider('aws');
 
     Object.assign(

--- a/lib/plugins/aws/package/index.test.js
+++ b/lib/plugins/aws/package/index.test.js
@@ -13,6 +13,17 @@ describe('AwsPackage', () => {
   let serverless;
   let options;
 
+  // In regular startup, the package option is processed from the CLI in the
+  // Serverless init / plugin loading. Here in the tests, we don't call that
+  // code path and we're setting up the Serverless object before we know what
+  // the individual test wants the directory to be.
+  const setPackageOption = targetPath => {
+    options.package = targetPath;
+    serverless.processedInput = serverless.processedInput || {};
+    serverless.processedInput.options = serverless.processedInput.options || {};
+    serverless.processedInput.options.package = targetPath;
+  };
+
   beforeEach(() => {
     serverless = new Serverless();
     options = {
@@ -46,7 +57,7 @@ describe('AwsPackage', () => {
     });
 
     it('should use the options package path if provided', () => {
-      options.package = 'package-options';
+      setPackageOption('package-options');
       awsPackage = new AwsPackage(serverless, options);
 
       expect(awsPackage.packagePath).to.equal('package-options');

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -118,8 +118,7 @@ module.exports = {
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();
 
     const coreTemplateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.getWorkingTempDir(),
       coreTemplateFileName
     );
 

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.js
@@ -7,8 +7,7 @@ module.exports = {
     const compiledTemplateFileName = this.provider.naming.getCompiledTemplateFileName();
 
     const compiledTemplateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.getWorkingTempDir(),
       compiledTemplateFileName
     );
 

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -9,8 +9,7 @@ module.exports = {
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
 
     const serviceStateFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
+      this.serverless.getWorkingTempDir(),
       serviceStateFileName
     );
 

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -1498,8 +1498,7 @@ class AwsProvider {
     return serverlessLayerObject.package && serverlessLayerObject.package.artifact
       ? serverlessLayerObject.package.artifact
       : path.join(
-          this.serverless.config.servicePath,
-          '.serverless',
+          this.serverless.getWorkingTempDir(),
           this.provider.naming.getLayerArtifactName(layerName)
         );
   }

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -64,11 +64,7 @@ module.exports = {
 
     const zip = archiver.create('zip');
     // Create artifact in temp path and move it to the package path (if any) later
-    const artifactFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      zipFileName
-    );
+    const artifactFilePath = path.join(this.serverless.getWorkingTempDir(), zipFileName);
     this.serverless.utils.writeFileDir(artifactFilePath);
 
     const output = fs.createWriteStream(artifactFilePath);

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const path = require('path');
 const zipService = require('./lib/zipService');
 const packageService = require('./lib/packageService');
 
@@ -10,10 +9,7 @@ class Package {
     this.serverless = serverless;
     this.options = options;
     this.servicePath = this.serverless.config.servicePath || '';
-    this.packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.servicePath || '.', '.serverless');
+    this.packagePath = this.serverless.getPackageOutputDir();
 
     Object.assign(this, packageService, zipService);
 

--- a/test/fixtures/packageArtifactInServerlessDir/package-artifact-plugin.js
+++ b/test/fixtures/packageArtifactInServerlessDir/package-artifact-plugin.js
@@ -21,7 +21,7 @@ class PackageArtifactPlugin {
 
   async package() {
     const zipSrcPath = path.resolve(ZIP_NAME);
-    const serverlessDirPath = path.resolve(this.serverless.config.servicePath, '.serverless');
+    const serverlessDirPath = this.serverless.getWorkingTempDir();
     const zipDestPath = path.join(serverlessDirPath, ZIP_NAME);
 
     // Copy zip to `.serverless` directory


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fix
es are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Addresses: #7298 in part

We want to be able to package / deploy serverless stacks in parallel. But before we can do that we need to track down and abstract all the places that the `.serverless/` directory is used.

The `.serverless/` directory is used as a temporary working directory, but that prevents parallel Serverless commands from being run at the same time with out colliding. A unique temporary directory is needed for each run. However, in order to maintain backwards compatibility the framework will need to default to using the `.serverless` directory as plugins may hook in at various points in the compilation, packaging, deploying, etc. to read or write files in the `.serverless/` directory.

With this change, all uses of `.serverless` either point to the package output directory (`getPackageOutputDir`), or to the temporary working directory (`getWorkingTempDir`).

Related: https://github.com/serverless/serverless/issues/5002, https://github.com/serverless/serverless/issues/7345

I think a better fix for some of these tests would be to convert them to use the `runServerless` approach but after struggling with that for a while, I decided to fall back to this.

