### PR TITLE
Fix azure timer event example

### DIFF
--- a/docs/providers/azure/events/timer.md
+++ b/docs/providers/azure/events/timer.md
@@ -33,7 +33,7 @@ functions:
   example:
     handler: handler.hello
     events:
-      - timer:
+      - timer: true
         name: timerObj #<string>, default - "myTimer", specifies which name is available on `context.bindings`
         schedule: 0 */5 * * * * #<string>, cron expression to run on
 ```


### PR DESCRIPTION
Using the sample as provided I was still getting the default timer object.  This seems to fix that.