### PR TITLE
fixed added deny iam policy when user opt disable log for a function

### DIFF
--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -87,30 +87,39 @@ module.exports = {
       .Statement;
 
     let hasOneOrMoreCanonicallyNamedFunctions = false;
+    const disableLogsCanonicallyNamedFunctions = [];
 
     // Ensure policies for functions with custom name resolution
     this.serverless.service.getAllFunctions().forEach(functionName => {
-      const { name: resolvedFunctionName } = this.serverless.service.getFunction(functionName);
+      const {
+        name: resolvedFunctionName,
+        disableLogs: isDisableLogsOpt,
+      } = this.serverless.service.getFunction(functionName);
       if (!resolvedFunctionName || resolvedFunctionName.startsWith(canonicalFunctionNamePrefix)) {
+        if (isDisableLogsOpt) {
+          disableLogsCanonicallyNamedFunctions.push(resolvedFunctionName);
+        }
         hasOneOrMoreCanonicallyNamedFunctions = true;
         return;
       }
 
-      const customFunctionNamelogGroupsPrefix = this.provider.naming.getLogGroupName(
-        resolvedFunctionName
-      );
+      if (!isDisableLogsOpt) {
+        const customFunctionNamelogGroupsPrefix = this.provider.naming.getLogGroupName(
+          resolvedFunctionName
+        );
 
-      policyDocumentStatements[0].Resource.push({
-        'Fn::Sub':
-          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${customFunctionNamelogGroupsPrefix}:*`,
-      });
+        policyDocumentStatements[0].Resource.push({
+          'Fn::Sub':
+            'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+            `:log-group:${customFunctionNamelogGroupsPrefix}:*`,
+        });
 
-      policyDocumentStatements[1].Resource.push({
-        'Fn::Sub':
-          'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${customFunctionNamelogGroupsPrefix}:*:*`,
-      });
+        policyDocumentStatements[1].Resource.push({
+          'Fn::Sub':
+            'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+            `:log-group:${customFunctionNamelogGroupsPrefix}:*:*`,
+        });
+      }
     });
 
     if (hasOneOrMoreCanonicallyNamedFunctions) {
@@ -126,6 +135,23 @@ module.exports = {
           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
           `:log-group:${logGroupsPrefix}*:*:*`,
       });
+      if (disableLogsCanonicallyNamedFunctions.length > 0) {
+        // add deny rule for disabled logs function
+        const arnOfdisableLogGroups = disableLogsCanonicallyNamedFunctions.map(functionName => {
+          return {
+            'Fn::Sub':
+              'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+              `:log-group:${this.provider.naming.getLogGroupName(functionName)}:*`,
+          };
+        });
+        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          this.provider.naming.getRoleLogicalId()
+        ].Properties.Policies[0].PolicyDocument.Statement.push({
+          Effect: 'Deny',
+          Action: 'logs:PutLogEvents',
+          Resource: arnOfdisableLogGroups,
+        });
+      }
     }
 
     if (this.serverless.service.provider.iamRoleStatements) {
@@ -145,16 +171,12 @@ module.exports = {
       }
     }
 
-    // check if one of the functions contains vpc or disableLogs configuration
+    // check if one of the functions contains vpc configuration
     const vpcConfigProvided = [];
-    const disableLogsFunctions = [];
     this.serverless.service.getAllFunctions().forEach(functionName => {
       const functionObject = this.serverless.service.getFunction(functionName);
       if ('vpc' in functionObject) {
         vpcConfigProvided.push(true);
-      }
-      if (functionObject.disableLogs) {
-        disableLogsFunctions.push(functionObject);
       }
     });
 
@@ -172,24 +194,6 @@ module.exports = {
           ],
         },
       ]);
-    }
-
-    if (disableLogsFunctions.length > 0) {
-      // add deny rule for disabled logs function
-      const arnOfdisableLogGroups = disableLogsFunctions.map(functionObject => {
-        return {
-          'Fn::Sub':
-            'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-            `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*`,
-        };
-      });
-      this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-        this.provider.naming.getRoleLogicalId()
-      ].Properties.Policies[0].PolicyDocument.Statement.push({
-        Effect: 'Deny',
-        Action: 'logs:PutLogEvents',
-        Resource: arnOfdisableLogGroups,
-      });
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -145,12 +145,16 @@ module.exports = {
       }
     }
 
-    // check if one of the functions contains vpc configuration
+    // check if one of the functions contains vpc or disableLogs configuration
     const vpcConfigProvided = [];
+    const disableLogsFunctions = [];
     this.serverless.service.getAllFunctions().forEach(functionName => {
       const functionObject = this.serverless.service.getFunction(functionName);
       if ('vpc' in functionObject) {
         vpcConfigProvided.push(true);
+      }
+      if (functionObject.disableLogs) {
+        disableLogsFunctions.push(functionObject);
       }
     });
 
@@ -168,6 +172,24 @@ module.exports = {
           ],
         },
       ]);
+    }
+
+    if (disableLogsFunctions.length > 0) {
+      // add deny rule for disabled logs function
+      const arnOfdisableLogGroups = disableLogsFunctions.map(functionObject => {
+        return {
+          'Fn::Sub':
+            'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+            `:log-group:${this.provider.naming.getLogGroupName(functionObject.name)}:*`,
+        };
+      });
+      this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+        this.provider.naming.getRoleLogicalId()
+      ].Properties.Policies[0].PolicyDocument.Statement.push({
+        Effect: 'Deny',
+        Action: 'logs:PutLogEvents',
+        Resource: arnOfdisableLogGroups,
+      });
     }
 
     return BbPromise.resolve();

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -93,17 +93,18 @@ module.exports = {
     this.serverless.service.getAllFunctions().forEach(functionName => {
       const {
         name: resolvedFunctionName,
-        disableLogs: isDisableLogsOpt,
+        disableLogs: areLogsDisabled,
       } = this.serverless.service.getFunction(functionName);
       if (!resolvedFunctionName || resolvedFunctionName.startsWith(canonicalFunctionNamePrefix)) {
-        if (isDisableLogsOpt) {
+        if (areLogsDisabled) {
           disableLogsCanonicallyNamedFunctions.push(resolvedFunctionName);
+        } else {
+          hasOneOrMoreCanonicallyNamedFunctions = true;
         }
-        hasOneOrMoreCanonicallyNamedFunctions = true;
         return;
       }
 
-      if (!isDisableLogsOpt) {
+      if (!areLogsDisabled) {
         const customFunctionNamelogGroupsPrefix = this.provider.naming.getLogGroupName(
           resolvedFunctionName
         );

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -898,6 +898,24 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
 
         expect(cfResources).to.not.have.property(functionLogGroupName);
       });
+      it('should have deny policy when disableLogs option is enabled`', async () => {
+        const functionName = serverless.service.getFunction('fnDisableLogs').name;
+        const functionLogGroupName = naming.getLogGroupName(functionName);
+
+        expect(
+          cfResources[naming.getRoleLogicalId()].Properties.Policies[0].PolicyDocument.Statement
+        ).to.deep.include({
+          Effect: 'Deny',
+          Action: 'logs:PutLogEvents',
+          Resource: [
+            {
+              'Fn::Sub':
+                'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                `:log-group:${functionLogGroupName}:*`,
+            },
+          ],
+        });
+      });
     });
   });
 });

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -869,6 +869,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       let cfResources;
       let naming;
       let serverless;
+      const customFunctionName = 'foo-bar';
       before(async () => {
         const { awsNaming, cfTemplate, serverless: serverlessInstance } = await runServerless({
           fixture: 'function',
@@ -876,6 +877,11 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           configExt: {
             functions: {
               fnDisableLogs: {
+                handler: 'index.handler',
+                disableLogs: true,
+              },
+              fnHaveCustomName: {
+                name: customFunctionName,
                 handler: 'index.handler',
                 disableLogs: true,
               },
@@ -898,6 +904,26 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
 
         expect(cfResources).to.not.have.property(functionLogGroupName);
       });
+
+      it('should not have allow rights to put logs for custom named function when disableLogs option is enabled', async () => {
+        expect(
+          cfResources[naming.getRoleLogicalId()].Properties.Policies[0].PolicyDocument.Statement[0]
+            .Resource
+        ).to.not.deep.include({
+          'Fn::Sub':
+            'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+            `log-group:/aws/lambda/${customFunctionName}:*`,
+        });
+        expect(
+          cfResources[naming.getRoleLogicalId()].Properties.Policies[0].PolicyDocument.Statement[1]
+            .Resource
+        ).to.not.deep.include({
+          'Fn::Sub':
+            'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:' +
+            `log-group:/aws/lambda/${customFunctionName}:*`,
+        });
+      });
+
       it('should have deny policy when disableLogs option is enabled`', async () => {
         const functionName = serverless.service.getFunction('fnDisableLogs').name;
         const functionLogGroupName = naming.getLogGroupName(functionName);


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->
There is no way to disable the CloudWatch logs for a lambda function. One workaround is you can add the policy to your role to disable the CloudWatch logs.

I have added deny policy for that specific lamda so as per now by default all function have **logs:PutLogEvents** permission when there is disableLogs opt to true we are adding deny policy statement for that function


Closes: #8554 
