### PR TITLE
feat(aws): increase memory limits for functions 

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront/index.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront/index.js
@@ -5,7 +5,7 @@ const url = require('url');
 const chalk = require('chalk');
 const { ServerlessError } = require('../../../../../../classes/Error');
 
-const originLimits = { maxTimeout: 30, maxMemorySize: 3008 };
+const originLimits = { maxTimeout: 30, maxMemorySize: 10240 };
 const viewerLimits = { maxTimeout: 5, maxMemorySize: 128 };
 
 class AwsCompileCloudFrontEvents {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -397,7 +397,7 @@ class AwsProvider {
             type: 'array',
             items: { $ref: '#/definitions/awsArn' },
           },
-          awsLambdaMemorySize: { type: 'integer', multipleOf: 64, minimum: 128, maximum: 3008 },
+          awsLambdaMemorySize: { type: 'integer', minimum: 128, maximum: 10240 },
           awsLambdaRole: {
             anyOf: [
               { type: 'string', minLength: 1 },

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront/index.test.js
@@ -191,10 +191,10 @@ describe('AwsCompileCloudFrontEvents', () => {
       }).to.throw(Error, 'greater than 5');
     });
 
-    it('should throw if memorySize is greater than 3008 for origin-request or origin-response functions', () => {
+    it('should throw if memorySize is greater than 10240 for origin-request or origin-response functions', () => {
       awsCompileCloudFrontEvents.serverless.service.functions = {
         first: {
-          memorySize: 3009,
+          memorySize: 10241,
           events: [
             {
               cloudFront: {
@@ -208,11 +208,11 @@ describe('AwsCompileCloudFrontEvents', () => {
 
       expect(() => {
         awsCompileCloudFrontEvents.validate();
-      }).to.throw(Error, 'greater than 3008');
+      }).to.throw(Error, 'greater than 10240');
 
       awsCompileCloudFrontEvents.serverless.service.functions = {
         first: {
-          memorySize: 3009,
+          memorySize: 10241,
           events: [
             {
               cloudFront: {
@@ -226,7 +226,7 @@ describe('AwsCompileCloudFrontEvents', () => {
 
       expect(() => {
         awsCompileCloudFrontEvents.validate();
-      }).to.throw(Error, 'greater than 3008');
+      }).to.throw(Error, 'greater than 10240');
     });
 
     it('should throw if timeout is greater than 30 for origin-request or origin response functions', () => {


### PR DESCRIPTION
Following recent [announcements](https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-supports-10gb-memory-6-vcpu-cores-lambda-functions/) from re:Invent, this PR adjusts schema restrictions on `memory`, increasing maximum values and also removing the restriction that the value has to be in multiple of 64. It also adjust restrictions imposed on Lambda@Edge, as the origin quotas for memory are the same as for "plain" Lambda.

From CloudFormation [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize)
![cf](https://user-images.githubusercontent.com/17499590/100854429-4227ca80-3489-11eb-81bb-fe273fe0b847.png)


From CloudFront/Lambda@Edge [docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html)
![origin](https://user-images.githubusercontent.com/17499590/100854415-3dfbad00-3489-11eb-8437-b13caca8beb7.png)

