### PR TITLE
Refactor: Remove superfluous fs utils

### DIFF
--- a/lib/utils/fs/removeFile.js
+++ b/lib/utils/fs/removeFile.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const fse = require('fs-extra');
-
-function removeFile(filePath) {
-  return fse.remove(filePath);
-}
-
-module.exports = removeFile;

--- a/lib/utils/fs/removeFileSync.js
+++ b/lib/utils/fs/removeFileSync.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const fse = require('fs-extra');
-
-function removeFileSync(filePath) {
-  return fse.removeSync(filePath);
-}
-
-module.exports = removeFileSync;

--- a/test/unit/lib/utils/fs/copyDirContentsSync.test.js
+++ b/test/unit/lib/utils/fs/copyDirContentsSync.test.js
@@ -2,17 +2,17 @@
 
 const expect = require('chai').expect;
 const fs = require('fs');
+const fse = require('fs-extra');
 const path = require('path');
 const copyDirContentsSync = require('../../../../../lib/utils/fs/copyDirContentsSync');
 const fileExistsSync = require('../../../../../lib/utils/fs/fileExistsSync');
-const removeFileSync = require('../../../../../lib/utils/fs/removeFileSync');
 const writeFileSync = require('../../../../../lib/utils/fs/writeFileSync');
 const skipOnDisabledSymlinksInWindows = require('@serverless/test/skip-on-disabled-symlinks-in-windows');
 
 describe('#copyDirContentsSync()', () => {
   const afterCallback = () => {
-    removeFileSync(path.join(process.cwd(), 'testSrc'));
-    removeFileSync(path.join(process.cwd(), 'testDest'));
+    fse.removeSync(path.join(process.cwd(), 'testSrc'));
+    fse.removeSync(path.join(process.cwd(), 'testDest'));
   };
   afterEach(afterCallback);
 


### PR DESCRIPTION
Related to #8588 

`removeFile` utils were not really used, and if, their usage could simply be replaced with `fs-extra`