### PR TITLE
refactor: Remove dependency to stream-promise

### DIFF
--- a/lib/plugins/standalone/index.js
+++ b/lib/plugins/standalone/index.js
@@ -3,7 +3,8 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const streamPromise = require('stream-promise');
+const stream = require('stream');
+const { promisify } = require('util');
 const fse = require('fs-extra');
 const fetch = require('node-fetch');
 const currentVersion = require('../../../package').version;
@@ -11,7 +12,10 @@ const isStandaloneExecutable =
   require('../../utils/isStandaloneExecutable') && process.platform !== 'win32';
 const standaloneUtils = require('../../utils/standalone');
 
+const pipeline = promisify(stream.pipeline);
+
 const BINARY_TMP_PATH = path.resolve(os.tmpdir(), 'serverless-binary-tmp');
+
 const BINARY_PATH = standaloneUtils.path;
 
 module.exports = class Standalone {
@@ -79,7 +83,7 @@ module.exports = class Standalone {
       );
     }
     await fse.remove(BINARY_TMP_PATH);
-    await streamPromise(standaloneResponse.body.pipe(fs.createWriteStream(BINARY_TMP_PATH)));
+    await pipeline(standaloneResponse.body, fs.createWriteStream(BINARY_TMP_PATH));
     await fse.rename(BINARY_TMP_PATH, BINARY_PATH);
     await fse.chmod(BINARY_PATH, 0o755);
     this.serverless.cli.log(`Successfully upgraded to ${tagName}`);

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "promise-queue": "^2.2.5",
     "replaceall": "^0.1.6",
     "semver": "^7.3.4",
-    "stream-promise": "^3.2.0",
     "tabtab": "^3.0.2",
     "tar": "^6.0.5",
     "timers-ext": "^0.1.7",


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Just noticed that `stream-promise` was used only once in the solution and it's something that we can do using native node