### PR TITLE
fix(Packaging): Not exclude layers when packaging a layer

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -209,7 +209,7 @@ module.exports = {
     const layerObject = this.serverless.service.getLayer(layerName);
     const layerPackageConfig = layerObject.package || {};
 
-    return this.getExcludes(layerPackageConfig.exclude, true)
+    return this.getExcludes(layerPackageConfig.exclude, false)
       .then(exclude => {
         const params = { exclude, include: this.getIncludes(layerPackageConfig.include) };
         return params;


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on solution in corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that proposed change passes CI. Confirm on that by running following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide link to corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with short description of made changes
-->

Adresses: #5583, #5892 and #7837

Can't really add a unit test since the problem is with `globby` resolving and we don't really resolve in the unit tests.

The other problem is that when resolving the patterns (include/exclude) for a layer, they are resolved relative to the layer path, if present. Not only the layer patterns are resolved relative to the layer but also all the others: service-level patterns, pluginsLocalPath, automatically excluded dev dependencies, serverlessConfigFileExclude, etc.
And that seems to confuse people. No easy solution for this though since the folder structure of layers it's important so they shouldn't include any folder upper than they `path`

