### PR TITLE
AWS CF Deployment: Fix resolution of first stack deploy event

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -4,12 +4,6 @@ const BbPromise = require('bluebird');
 const chalk = require('chalk');
 const wait = require('timers-ext/promise/sleep');
 
-const processInitializatonStates = new Set([
-  'CREATE_IN_PROGRESS',
-  'UPDATE_IN_PROGRESS',
-  'DELETE_IN_PROGRESS',
-]);
-
 const validStatuses = new Set(['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'DELETE_COMPLETE']);
 
 module.exports = {
@@ -34,7 +28,7 @@ module.exports = {
                   if (event.EventId !== firstEventId) return false;
                 } else {
                   if (event.ResourceType !== 'AWS::CloudFormation::Stack') return false;
-                  if (!processInitializatonStates.has(event.ResourceStatus)) return false;
+                  if (event.ResourceStatus !== `${action.toUpperCase()}_IN_PROGRESS`) return false;
                   firstEventId = event.EventId;
                 }
                 stackEvents = stackEvents.slice(0, index + 1);

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -100,7 +100,7 @@ module.exports = {
               }
             },
             e => {
-              if (action === 'removal' && e.message.endsWith('does not exist')) {
+              if (action === 'delete' && e.message.endsWith('does not exist')) {
                 // empty console.log for a prettier output
                 if (!this.options.verbose) this.serverless.cli.consoleLog('');
                 this.serverless.cli.log(`Stack ${action} finished...`);

--- a/lib/plugins/aws/remove/index.js
+++ b/lib/plugins/aws/remove/index.js
@@ -20,7 +20,7 @@ class AwsRemove {
           .then(this.validate)
           .then(this.emptyS3Bucket)
           .then(this.removeStack)
-          .then(cfData => this.monitorStack('removal', cfData)),
+          .then(cfData => this.monitorStack('delete', cfData)),
     };
   }
 }

--- a/test/unit/lib/plugins/aws/lib/monitorStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitorStack.test.js
@@ -161,7 +161,7 @@ describe('monitorStack', () => {
       describeStackEventsStub.onCall(0).resolves(updateStartEvent);
       describeStackEventsStub.onCall(1).resolves(updateFinishedEvent);
 
-      return awsPlugin.monitorStack('removal', cfDataMock, { frequency: 10 }).then(stackStatus => {
+      return awsPlugin.monitorStack('delete', cfDataMock, { frequency: 10 }).then(stackStatus => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
         expect(
           describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
@@ -335,7 +335,7 @@ describe('monitorStack', () => {
       describeStackEventsStub.onCall(1).resolves(nestedStackEvent);
       describeStackEventsStub.onCall(2).resolves(updateFinishedEvent);
 
-      return awsPlugin.monitorStack('removal', cfDataMock, { frequency: 10 }).then(stackStatus => {
+      return awsPlugin.monitorStack('delete', cfDataMock, { frequency: 10 }).then(stackStatus => {
         expect(describeStackEventsStub.callCount).to.be.equal(3);
         expect(
           describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
@@ -371,7 +371,7 @@ describe('monitorStack', () => {
       describeStackEventsStub.onCall(0).resolves(updateStartEvent);
       describeStackEventsStub.onCall(1).rejects(stackNotFoundError);
 
-      return awsPlugin.monitorStack('removal', cfDataMock, { frequency: 10 }).then(stackStatus => {
+      return awsPlugin.monitorStack('delete', cfDataMock, { frequency: 10 }).then(stackStatus => {
         expect(describeStackEventsStub.callCount).to.be.equal(2);
         expect(
           describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
@@ -669,7 +669,7 @@ describe('monitorStack', () => {
       describeStackEventsStub.onCall(2).resolves(deleteItemFailedEvent);
       describeStackEventsStub.onCall(3).resolves(deleteFailedEvent);
 
-      return awsPlugin.monitorStack('removal', cfDataMock, { frequency: 10 }).catch(e => {
+      return awsPlugin.monitorStack('delete', cfDataMock, { frequency: 10 }).catch(e => {
         let errorMessage = 'An error occurred: ';
         errorMessage += 'mochaLambda - You are not authorized to perform this operation.';
         expect(e.name).to.be.equal('ServerlessError');
@@ -749,7 +749,7 @@ describe('monitorStack', () => {
         describeStackEventsStub.onCall(2).resolves(deleteItemFailedEvent);
         describeStackEventsStub.onCall(3).resolves(deleteFailedEvent);
 
-        return awsPlugin.monitorStack('removal', cfDataMock, { frequency: 10 }).catch(e => {
+        return awsPlugin.monitorStack('delete', cfDataMock, { frequency: 10 }).catch(e => {
           let errorMessage = 'An error occurred: ';
           errorMessage += 'mochaLambda - You are not authorized to perform this operation.';
           expect(e.name).to.be.equal('ServerlessError');


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #8632 

Error was that, no matter what deploy action was pursued we recognized any, either `CREATE_IN_PROGRESS`, `UPDATE_IN_PROGRESS` or `DELETE_IN_PROGRESS` as first stack operation event.

This lead to situations where for failed _create_ actions, which were followed immediately with _delete_ actions, it was `DELETE_IN_PROGRESS` that was coined as starting one, and due to that real error was not communicated (deploy operation was reported with success by a function which then lead to other obscure errors)