### PR TITLE
fix(Packaging): Exclude .env files only when useDotenv is set

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -10,7 +10,7 @@ layout: Doc
 
 ## Automatic loading environment variables from .env and .env.{stage} files
 
-Starting with v3.0.0, environment variables will be automatically loaded from `.env` and `.env.{stage}` files if they're present.
+Starting with v3.0.0, environment variables will be automatically loaded from `.env` and `.env.{stage}` files if they're present. In addition, `.env` files will be excluded from package in order to avoid uploading sensitive data as a part of the package by mistake.
 
 Adapt to this behavior now by adding `useDotenv: true` to service configuration.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -6,7 +6,7 @@ layout: Doc
 
 # Resolution of environment variables
 
-With `useDotenv: true` set in your `serverless.yml` file, framework automatically loads environment variables from `.env` files with the help of [dotenv](https://www.npmjs.com/package/dotenv). Starting with next major version, `.env` files will be loaded by default and `useDotenv` setting will be ignored.
+With `useDotenv: true` set in your `serverless.yml` file, framework automatically loads environment variables from `.env` files with the help of [dotenv](https://www.npmjs.com/package/dotenv). In addition, `.env` files are excluded from the package when `useDotenv` is set in order to avoid uploading sensitive data as a part of package by mistake. Starting with next major version, `.env` files will be loaded by default and `useDotenv` setting will be ignored.
 
 ## Support for `.env` files
 

--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -54,7 +54,7 @@ By default, serverless will exclude the following patterns:
 - .serverless/\*\*
 - .serverless_plugins/\*\*
 
-and the serverless configuration file being used (i.e. `serverless.yml`)
+and the serverless configuration file being used (i.e. `serverless.yml`). In addition, if `useDotenv` is set, all files satisfying pattern `.env*` will be excluded as well.
 
 ### Examples
 

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -15,7 +15,6 @@ module.exports = {
     'yarn-*.log',
     '.serverless/**',
     '.serverless_plugins/**',
-    '.env*',
   ],
 
   getIncludes(include) {
@@ -48,12 +47,17 @@ module.exports = {
 
         const serverlessConfigFileExclude = configFilePath ? [path.basename(configFilePath)] : [];
 
+        const serverlessConfigFile = this.serverless.pluginManager.serverlessConfigFile;
+        const envFilesExclude =
+          serverlessConfigFile && serverlessConfigFile.useDotenv ? ['.env*'] : [];
+
         return _.union(
           this.defaultExcludes,
           serverlessConfigFileExclude,
           localPathExcludes,
           packageExcludes,
           layerExcludes,
+          envFilesExclude,
           exclude
         );
       });

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -440,12 +440,40 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
 
     it('should exclude defaults', () => {
       expect(fnIndividualZippedFiles).to.not.include('.gitignore');
-      expect(fnIndividualZippedFiles).to.not.include('.env');
-      expect(fnIndividualZippedFiles).to.not.include('.env.stage');
     });
 
     it('should exclude service config', () => {
       expect(fnIndividualZippedFiles).to.not.include('serverless.yml');
+    });
+
+    describe('with useDotenv', () => {
+      it('should exclude .env files', async () => {
+        before(async () => {
+          const {
+            fixtureData: { servicePath },
+          } = await runServerless({
+            fixture: 'packaging',
+            cliArgs: ['package'],
+            awsRequestStubMap: mockedDescribeStacksResponse,
+            configExt: {
+              useDotenv: true,
+              functions: {
+                fnIndividual: {
+                  handler: 'index.handler',
+                  package: { individually: true },
+                },
+              },
+            },
+          });
+
+          const zippedFiles = await listZipFiles(
+            path.join(servicePath, '.serverless', 'fnIndividual.zip')
+          );
+
+          expect(zippedFiles).to.not.include('.env');
+          expect(zippedFiles).to.not.include('.env.stage');
+        });
+      });
     });
 
     it.skip('TODO: should exclude default plugins localPath', () => {


### PR DESCRIPTION
As reported by @mnapoli in https://github.com/serverless/serverless/pull/8634, recent release (v2.16.0) introduced a backward-incompatible change with excluding `.env` files unconditionally. This change ensures that it takes effect only if `useDotenv` is set. 

Addresses: #8566