### PR TITLE
CI: Handle  upload errors of binaries to China region as not fatal

### DIFF
--- a/scripts/pkg/upload/china.js
+++ b/scripts/pkg/upload/china.js
@@ -35,16 +35,6 @@ module.exports = async (versionTag, { isLegacyVersion }) => {
   };
 
   await Promise.all([
-    !isLegacyVersion &&
-      cos
-        .putObjectAsync({
-          Key: 'latest-tag',
-          Body: Buffer.from(versionTag),
-          ...bucketConf,
-        })
-        .then(() => {
-          process.stdout.write(chalk.green("'latest-tag' uploaded to Tencent\n"));
-        }),
     cos
       .putObjectAsync({
         Key: `${versionTag}/serverless-linux-x64`,
@@ -64,4 +54,11 @@ module.exports = async (versionTag, { isLegacyVersion }) => {
         process.stdout.write(chalk.green("'serverless-macos-x64' uploaded to Tencent\n"));
       }),
   ]);
+  if (isLegacyVersion) return;
+  await cos.putObjectAsync({
+    Key: 'latest-tag',
+    Body: Buffer.from(versionTag),
+    ...bucketConf,
+  });
+  process.stdout.write(chalk.green("'latest-tag' uploaded to Tencent\n"));
 };

--- a/scripts/pkg/upload/index.js
+++ b/scripts/pkg/upload/index.js
@@ -41,4 +41,15 @@ if (!/^v\d+\.\d+\.\d+$/.test(versionTag)) {
 }
 
 require('./world')(versionTag, { isLegacyVersion: argv.legacy });
-require('./china')(versionTag, { isLegacyVersion: argv.legacy });
+require('./china')(versionTag, { isLegacyVersion: argv.legacy }).catch(error => {
+  // TODO: Remove after China region accessibility issue is solved
+  process.stdout.error(`
+**************************************************
+
+ERROR: Upload of binaries to China region failed with:
+
+${error.stack}
+
+**************************************************
+`);
+});


### PR DESCRIPTION
At this point it seems we're unable to upload binaries to China region, until that's sorted let's treat upload errors as non fatal

Additionally improved script to write _latest tag_ information only after successful binary uploads

/cc @timqian @zongUMR @hkbarton 