### PR TITLE
feat(AWS API Gateway): Add HttpApiId to httpApi CF Outputs

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -148,7 +148,7 @@ class HttpApiEvents {
       };
       resource.DependsOn = this.provider.naming.getHttpApiLogGroupLogicalId();
     }
-    this.cfTemplate.Outputs.HttpApi = {
+    this.cfTemplate.Outputs.HttpApiId = {
       Description: 'Id of the HTTP API',
       Value: { Ref: this.provider.naming.getHttpApiLogicalId() },
     };

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -148,6 +148,10 @@ class HttpApiEvents {
       };
       resource.DependsOn = this.provider.naming.getHttpApiLogGroupLogicalId();
     }
+    this.cfTemplate.Outputs.HttpApi = {
+      Description: 'Id of the HTTP API',
+      Value: { Ref: this.provider.naming.getHttpApiLogicalId() }
+    }
     this.cfTemplate.Outputs.HttpApiUrl = {
       Description: 'URL of the HTTP API',
       Value: {

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -150,8 +150,8 @@ class HttpApiEvents {
     }
     this.cfTemplate.Outputs.HttpApi = {
       Description: 'Id of the HTTP API',
-      Value: { Ref: this.provider.naming.getHttpApiLogicalId() }
-    }
+      Value: { Ref: this.provider.naming.getHttpApiLogicalId() },
+    };
     this.cfTemplate.Outputs.HttpApiUrl = {
       Description: 'URL of the HTTP API',
       Value: {

--- a/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
@@ -58,7 +58,12 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
       expect(resource.Properties.AutoDeploy).to.equal(true);
     });
 
-    it('should configure output', () => {
+    it('should configure output for HttpApi', () => {
+      const output = cfOutputs.HttpApi;
+      expect(output).to.have.property('Value');
+    });
+
+    it('should configure output for HttpApiUrl', () => {
       const output = cfOutputs.HttpApiUrl;
       expect(output).to.have.property('Value');
     });
@@ -481,6 +486,7 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
         expect(cfResources).to.not.have.property(naming.getHttpApiStageLogicalId());
       });
       it('should not configure output', () => {
+        expect(cfOutputs).to.not.have.property('HttpApi');
         expect(cfOutputs).to.not.have.property('HttpApiUrl');
       });
       it('should configure endpoint that attaches to external API', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
@@ -58,8 +58,8 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
       expect(resource.Properties.AutoDeploy).to.equal(true);
     });
 
-    it('should configure output for HttpApi', () => {
-      const output = cfOutputs.HttpApi;
+    it('should configure output for HttpApiId', () => {
+      const output = cfOutputs.HttpApiId;
       expect(output).to.have.property('Value');
     });
 
@@ -486,7 +486,7 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
         expect(cfResources).to.not.have.property(naming.getHttpApiStageLogicalId());
       });
       it('should not configure output', () => {
-        expect(cfOutputs).to.not.have.property('HttpApi');
+        expect(cfOutputs).to.not.have.property('HttpApiId');
         expect(cfOutputs).to.not.have.property('HttpApiUrl');
       });
       it('should configure endpoint that attaches to external API', () => {


### PR DESCRIPTION
Link to the issue: https://github.com/serverless/serverless/issues/8650

This tiny PR adds HttpApi output to the cloudformation template when using AWS ApiGateway's httpApi, in addition to the existing HttpApiUrl output.

Closes: #8650
