### PR TITLE
feat(AWS Lambda): Support referencing images with tags

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -199,7 +199,7 @@ See the documentation about [IAM](./iam.md) for function level IAM roles.
 
 Alternatively lambda environment can be configured through docker images. Image published to AWS ECR registry can be referenced as lambda source (check [AWS Lambda – Container Image Support](https://aws.amazon.com/blogs/aws/new-for-aws-lambda-container-image-support/)).
 
-In service configuration existing AWS ECR image should be referenced via `image` property (which should follow `<account>.dkr.ecr.<region>.amazonaws.com/<repository>@<digest>` format). `handler` and `runtime` properties are not supported in such case.
+In service configuration existing AWS ECR image should be referenced via `image` property (which should follow `<account>.dkr.ecr.<region>.amazonaws.com/<repository>@<digest>` or `<account>.dkr.ecr.<region>.amazonaws.com/<repository>:<tag>` format). `handler` and `runtime` properties are not supported in such case.
 
 Example configuration:
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -8,6 +8,8 @@ const _ = require('lodash');
 const path = require('path');
 const deepSortObjectByKey = require('../../../../utils/deepSortObjectByKey');
 const getHashForFilePath = require('../lib/getHashForFilePath');
+const memoizeeMethods = require('memoizee/methods');
+const d = require('d');
 
 class AwsCompileFunctions {
   constructor(serverless, options) {
@@ -156,6 +158,15 @@ class AwsCompileFunctions {
       );
     }
 
+    let functionImageUri;
+    let functionImageSha;
+
+    if (functionObject.image) {
+      ({ functionImageUri, functionImageSha } = await this.resolveImageUriAndSha(
+        functionObject.image
+      ));
+    }
+
     // publish these properties to the platform
     functionObject.memory =
       functionObject.memorySize || this.serverless.service.provider.memorySize || 1024;
@@ -199,7 +210,7 @@ class AwsCompileFunctions {
       }/${artifactFilePath.split(path.sep).pop()}`;
       functionResource.Properties.Runtime = functionObject.runtime;
     } else {
-      functionResource.Properties.Code.ImageUri = functionObject.image;
+      functionResource.Properties.Code.ImageUri = functionImageUri;
       functionResource.Properties.PackageType = 'Image';
     }
     functionResource.Properties.FunctionName = functionObject.name;
@@ -427,10 +438,8 @@ class AwsCompileFunctions {
 
       const versionResource = this.cfLambdaVersionTemplate();
 
-      if (functionObject.image) {
-        versionResource.Properties.CodeSha256 = functionObject.image.slice(
-          functionObject.image.lastIndexOf('@sha256:') + '@sha256:'.length
-        );
+      if (functionImageSha) {
+        versionResource.Properties.CodeSha256 = functionImageSha;
       } else {
         const fileHash = await getHashForFilePath(artifactFilePath);
         versionResource.Properties.CodeSha256 = fileHash;
@@ -710,5 +719,41 @@ function extractLayerConfigurationsFromFunction(functionProperties, cfTemplate) 
   });
   return layerConfigurations;
 }
+
+Object.defineProperties(
+  AwsCompileFunctions.prototype,
+  memoizeeMethods({
+    resolveImageUriAndSha: d(
+      async function(image) {
+        const providedImageSha = image.split('@')[1];
+        if (providedImageSha) {
+          return {
+            functionImageSha: providedImageSha.slice('sha256:'.length),
+            functionImageUri: image,
+          };
+        }
+
+        const [repositoryName, imageTag] = image.split('/')[1].split(':');
+        const registryId = image.split('.')[0];
+        const describeImagesResponse = await this.provider.request('ECR', 'describeImages', {
+          imageIds: [
+            {
+              imageTag,
+            },
+          ],
+          repositoryName,
+          registryId,
+        });
+        const imageDigest = describeImagesResponse.imageDetails[0].imageDigest;
+        const functionImageUri = `${image.split(':')[0]}@${imageDigest}`;
+        return {
+          functionImageUri,
+          functionImageSha: imageDigest.slice('sha256:'.length),
+        };
+      },
+      { promise: true }
+    ),
+  })
+);
 
 module.exports = AwsCompileFunctions;

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -951,7 +951,7 @@ class AwsProvider {
             image: {
               type: 'string',
               pattern:
-                '^\\d+\\.dkr\\.ecr\\.[a-z0-9-]+..amazonaws.com\\/[^@:]+@sha256:[a-f0-9]{64}$',
+                '^\\d+\\.dkr\\.ecr\\.[a-z0-9-]+..amazonaws.com\\/([^@]+)|([^@:]+@sha256:[a-f0-9]{64})$',
             },
             kmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             layers: { $ref: '#/definitions/awsLambdaLayers' },

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1831,6 +1831,13 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
     let serverless;
     let serviceConfig;
     let iamRolePolicyStatements;
+    const imageDigestFromECR =
+      'sha256:2e6b10a4b1ca0f6d3563a8a1f034dde7c4d7c93b50aa91f24311765d0822186b';
+    const awsRequestStubMap = {
+      ECR: {
+        describeImages: { imageDetails: [{ imageDigest: imageDigestFromECR }] },
+      },
+    };
 
     before(async () => {
       const {
@@ -1873,8 +1880,12 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               image:
                 '000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker@sha256:6bb600b4d6e1d7cf521097177dd0c4e9ea373edb91984a505333be8ac9455d38',
             },
+            fnImageWithTag: {
+              image: '000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker:stable',
+            },
           },
         },
+        awsRequestStubMap,
       });
       cfResources = cfTemplate.Resources;
       naming = awsNaming;
@@ -2173,7 +2184,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       });
     });
 
-    it('should support `functions[].image`', () => {
+    it('should support `functions[].image` with sha', () => {
       const functionServiceConfig = serviceConfig.functions.fnImage;
       const functionCfLogicalId = naming.getLambdaLogicalId('fnImage');
       const functionCfConfig = cfResources[functionCfLogicalId].Properties;
@@ -2193,6 +2204,25 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           resource.Properties.FunctionName.Ref === functionCfLogicalId
       ).Properties;
       expect(versionCfConfig.CodeSha256).to.equal(imageDigestSha);
+    });
+
+    it('should support `functions[].image` with tag', () => {
+      const functionServiceConfig = serviceConfig.functions.fnImageWithTag;
+      const functionCfLogicalId = naming.getLambdaLogicalId('fnImageWithTag');
+      const functionCfConfig = cfResources[functionCfLogicalId].Properties;
+
+      expect(functionCfConfig.Code).to.deep.equal({
+        ImageUri: `${functionServiceConfig.image.split(':')[0]}@${imageDigestFromECR}`,
+      });
+      expect(functionCfConfig).to.not.have.property('Handler');
+      expect(functionCfConfig).to.not.have.property('Runtime');
+
+      const versionCfConfig = Object.values(cfResources).find(
+        resource =>
+          resource.Type === 'AWS::Lambda::Version' &&
+          resource.Properties.FunctionName.Ref === functionCfLogicalId
+      ).Properties;
+      expect(versionCfConfig.CodeSha256).to.equal(imageDigestFromECR.slice('sha256:'.length));
     });
   });
 


### PR DESCRIPTION
Adds support for referencing images with tags

To also share a bit more context about it because it seems fairly simple, but there was a little bit more consideration to it. I was also wondering if we should resolve SHA for an image at all times, because it seems like ImageUri can also accept an URI with tag only. My first idea here that maybe (without versioning), if ImageUri would be e.g. `xxx.xxx/repo-name:latest`, then after updating the image under the `latest` tag in that repo will result in new Lambdas being invoked with that newly pushed image. I was a bit surprised to learn that it's not the case, it seems like Lambda internally is somehow still pinning the image to specific sha (maybe during the image optimization process that happens before the first invocation) and you have to force update your Lambda function anyway. In that case, I feel like, at this point, we should always resolve the specific SHA of an image. 

Closes: #8621 