### PR TITLE
fix(AWS Lambda Layers): Permissions on lambda layer retained

### DIFF
--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -75,10 +75,14 @@ class AwsCompileLayers {
           const newPermission = this.cfLambdaLayerPermissionTemplate();
           newPermission.Properties.LayerVersionArn = { Ref: layerLogicalId };
           newPermission.Properties.Principal = account;
-          const layerPermLogicalId = this.provider.naming.getLambdaLayerPermissionLogicalId(
+          let layerPermLogicalId = this.provider.naming.getLambdaLayerPermissionLogicalId(
             layerName,
             account
           );
+          if (layerObject.retain) {
+            layerPermLogicalId = `${layerPermLogicalId}${sha}`;
+            newPermission.DeletionPolicy = 'Retain';
+          }
           newLayerObject[layerPermLogicalId] = newPermission;
           return newPermission;
         });


### PR DESCRIPTION
Created as a replacement for https://github.com/serverless/serverless/pull/8579 as I was not able to push new changes into original branch.

Closes: #8578