### PR TITLE
docs: Explanation why deployFunction doesn't have to resolve images

### DIFF
--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -212,6 +212,8 @@ class AwsDeployFunction {
     };
 
     if (functionObject.image) {
+      // Here we are safe to use images that are not fully resolved (with specific SHA) because
+      // AWS always resolves them on their side (as a part of SDK's `updateFunctionCode`)
       params.ImageUri = functionObject.image;
     } else {
       const artifactFileName = this.provider.naming.getFunctionArtifactName(this.options.function);


### PR DESCRIPTION
During testing and discussion together with @medikoo we figured out that `deployFunction` does not need to resolve imageUri and is currently working correctly.

Closes: #8691 