### PR TITLE
feat: Support `kmsKeyArn` for `deploy function`

### DIFF
--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -26,6 +26,23 @@ class AwsDeployFunction {
         await this.validate();
         await this.checkIfFunctionExists();
         this.checkIfFunctionChangesBetweenImageAndHandler();
+
+        if (_.get(this.serverless.service.serviceObject, 'awsKmsKeyArn')) {
+          this.serverless._logDeprecation(
+            'AWS_KMS_KEY_ARN',
+            'Starting with next major version, ' +
+              '"awsKmsKeyArn" service property will be replaced by "provider.kmsKeyArn"'
+          );
+        }
+        if (
+          Object.values(this.serverless.service.functions).some(({ awsKmsKeyArn }) => awsKmsKeyArn)
+        ) {
+          this.serverless._logDeprecation(
+            'AWS_KMS_KEY_ARN',
+            'Starting with next major version, ' +
+              '"awsKmsKeyArn" function property will be replaced by "kmsKeyArn"'
+          );
+        }
       },
 
       'deploy:function:packageFunction': () =>
@@ -152,10 +169,14 @@ class AwsDeployFunction {
       FunctionName: functionObj.name,
     };
 
-    if (functionObj.awsKmsKeyArn && !_.isObject(functionObj.awsKmsKeyArn)) {
-      params.KMSKeyArn = functionObj.awsKmsKeyArn;
-    } else if (serviceObj.awsKmsKeyArn && !_.isObject(serviceObj.awsKmsKeyArn)) {
-      params.KMSKeyArn = serviceObj.awsKmsKeyArn;
+    const kmsKeyArn =
+      functionObj.kmsKeyArn ||
+      providerObj.kmsKeyArn ||
+      functionObj.awsKmsKeyArn ||
+      serviceObj.awsKmsKeyArn;
+
+    if (kmsKeyArn) {
+      params.KMSKeyArn = kmsKeyArn;
     }
 
     if (params.KMSKeyArn && params.KMSKeyArn === remoteFunctionConfiguration.KMSKeyArn) {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -419,6 +419,10 @@ class AwsProvider {
               ],
             },
           },
+          awsKmsArn: {
+            type: 'string',
+            pattern: '^arn:aws:kms:',
+          },
           awsLambdaEnvironment: {
             type: 'object',
             patternProperties: {
@@ -619,6 +623,7 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
+            awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             cfnRole: { $ref: '#/definitions/awsArn' },
             cloudFront: {
               type: 'object',

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -419,10 +419,6 @@ class AwsProvider {
               ],
             },
           },
-          awsKmsArn: {
-            type: 'string',
-            pattern: '^arn:aws:kms:',
-          },
           awsLambdaEnvironment: {
             type: 'object',
             patternProperties: {
@@ -623,7 +619,6 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
-            awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             cfnRole: { $ref: '#/definitions/awsArn' },
             cloudFront: {
               type: 'object',


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #[8692](https://github.com/serverless/serverless/issues/8692): `provider.kmsKeyArn` and `functions[].kmsKeyArn` are not supported with single function deployment}
