### PR TITLE
feat(AWS IAM): Group IAM-related settings under `provider.iam`

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -54,6 +54,19 @@ Starting with v3.0.0, references to variables that cannot be resolved will resul
 
 Adapt to this behaviour now by adding `unresolvedVariablesNotificationMode: error` to service configuration.
 
+<a name="PROVIDER_IAM_SETTINGS"><div>&nbsp;</div></a>
+
+## Grouping IAM settings under `provider.iam`
+
+Deprecation code: `PROVIDER_IAM_SETTINGS`
+
+Staring with v3.0.0, all IAM-related settings of _provider_ including `iamRoleStatements`, `iamManagedPolicies`, `role` and `cfnRole` will be grouped under `iam` property. Refer to the[IAM Guide](/framework/docs/providers/aws/guide/iam.md).
+
+- `provider.role` -> `provider.iam.role`
+- `provider.iamRoleStatements` -> `provider.iam.role.statements`
+- `provider.iamManagedPolicies` -> `provider.iam.role.managedPolicies`
+- `provider.cfnRole` -> `provider.iam.role.deploymentRole`
+
 <a name="AWS_API_GATEWAY_SPECIFIC_KEYS"><div>&nbsp;</div></a>
 
 ## API Gateway specific configuration

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -63,6 +63,7 @@ Deprecation code: `PROVIDER_IAM_SETTINGS`
 Staring with v3.0.0, all IAM-related settings of _provider_ including `iamRoleStatements`, `iamManagedPolicies`, `role` and `cfnRole` will be grouped under `iam` property. Refer to the[IAM Guide](/framework/docs/providers/aws/guide/iam.md).
 
 - `provider.role` -> `provider.iam.role`
+- `provider.rolePermissionsBoundary` -> `provider.iam.role.permissionBoundary`
 - `provider.iamRoleStatements` -> `provider.iam.role.statements`
 - `provider.iamManagedPolicies` -> `provider.iam.role.managedPolicies`
 - `provider.cfnRole` -> `provider.iam.role.deploymentRole`

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -37,7 +37,13 @@ module.exports = {
         );
       });
 
+    const iamRole = _.get(this.serverless.service.provider.iam, 'role', {});
+
     // resolve early if provider level role is provided
+    if (typeof iamRole === 'string') {
+      return;
+    }
+
     if ('role' in this.serverless.service.provider) {
       return;
     }
@@ -66,7 +72,14 @@ module.exports = {
     iamRoleLambdaExecutionTemplate.Properties.Path = this.provider.naming.getRolePath();
     iamRoleLambdaExecutionTemplate.Properties.RoleName = this.provider.naming.getRoleName();
 
-    if (this.serverless.service.provider.rolePermissionsBoundary) {
+    // set permission boundary
+    if (iamRole.permissionBoundary) {
+      iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionBoundary;
+    } else if (this.serverless.service.provider.rolePermissionsBoundary) {
+      this.serverless._logDeprecation(
+        'PROVIDER_IAM_SETTINGS',
+        'Starting with version 3.0.0, "provider.rolePermissionsBoundary" property will be replaced with "provider.iam.role.permissionBoundary"'
+      );
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = this.serverless.service.provider.rolePermissionsBoundary;
     }
 
@@ -144,7 +157,6 @@ module.exports = {
               `:log-group:${this.provider.naming.getLogGroupName(functionName)}:*`,
           };
         });
-
         this.mergeStatements([
           {
             Effect: 'Deny',
@@ -155,17 +167,26 @@ module.exports = {
       }
     }
 
-    if (this.serverless.service.provider.iamRoleStatements) {
-      // add custom iam role statements
+    // add custom iam role statements
+    if (iamRole.statements) {
+      this.mergeStatements(iamRole.statements);
+    } else if (this.serverless.service.provider.iamRoleStatements) {
+      this.serverless._logDeprecation(
+        'PROVIDER_IAM_SETTINGS',
+        'Starting with version 3.0.0, "provider.iamRoleStatements" property will be replaced with "provider.iam.role.statements"'
+      );
       this.mergeStatements(this.serverless.service.provider.iamRoleStatements);
     }
 
-    if (this.serverless.service.provider.iamManagedPolicies) {
-      // add iam managed policies
-      const iamManagedPolicies = this.serverless.service.provider.iamManagedPolicies;
-      if (iamManagedPolicies.length > 0) {
-        this.mergeManagedPolicies(iamManagedPolicies);
-      }
+    // add iam managed policies
+    if (iamRole.managedPolicies) {
+      this.mergeManagedPolicies(iamRole.managedPolicies);
+    } else if (this.serverless.service.provider.iamManagedPolicies) {
+      this.serverless._logDeprecation(
+        'PROVIDER_IAM_SETTINGS',
+        'Starting with version 3.0.0, "provider.iamManagedPolicies" property will be replaced with "provider.iam.role.managedPolicies"'
+      );
+      this.mergeManagedPolicies(this.serverless.service.provider.iamManagedPolicies);
     }
 
     // check if one of the functions contains vpc configuration
@@ -194,6 +215,7 @@ module.exports = {
   },
 
   mergeManagedPolicies(managedPolicies) {
+    if (!managedPolicies.length) return;
     const resource = this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
       this.provider.naming.getRoleLogicalId()
     ].Properties;

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -76,10 +76,6 @@ module.exports = {
     if (iamRole.permissionBoundary) {
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionBoundary;
     } else if (this.serverless.service.provider.rolePermissionsBoundary) {
-      this.serverless._logDeprecation(
-        'PROVIDER_IAM_SETTINGS',
-        'Starting with version 3.0.0, "provider.rolePermissionsBoundary" property will be replaced with "provider.iam.role.permissionBoundary"'
-      );
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = this.serverless.service.provider.rolePermissionsBoundary;
     }
 
@@ -171,10 +167,6 @@ module.exports = {
     if (iamRole.statements) {
       this.mergeStatements(iamRole.statements);
     } else if (this.serverless.service.provider.iamRoleStatements) {
-      this.serverless._logDeprecation(
-        'PROVIDER_IAM_SETTINGS',
-        'Starting with version 3.0.0, "provider.iamRoleStatements" property will be replaced with "provider.iam.role.statements"'
-      );
       this.mergeStatements(this.serverless.service.provider.iamRoleStatements);
     }
 
@@ -182,10 +174,6 @@ module.exports = {
     if (iamRole.managedPolicies) {
       this.mergeManagedPolicies(iamRole.managedPolicies);
     } else if (this.serverless.service.provider.iamManagedPolicies) {
-      this.serverless._logDeprecation(
-        'PROVIDER_IAM_SETTINGS',
-        'Starting with version 3.0.0, "provider.iamManagedPolicies" property will be replaced with "provider.iam.role.managedPolicies"'
-      );
       this.mergeManagedPolicies(this.serverless.service.provider.iamManagedPolicies);
     }
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -13,6 +13,7 @@ const objectHash = require('object-hash');
 const PromiseQueue = require('promise-queue');
 const getS3EndpointForRegion = require('./utils/getS3EndpointForRegion');
 const readline = require('readline');
+const reportDeprecatedProperties = require('../../utils/report-deprecated-properties');
 const { ALB_LISTENER_REGEXP } = require('./package/compile/events/alb/lib/validate');
 const memoizeeMethods = require('memoizee/methods');
 const d = require('d');
@@ -233,8 +234,21 @@ class AwsProvider {
             }
           }
         }
+
+        reportDeprecatedProperties(
+          'PROVIDER_IAM_SETTINGS',
+          {
+            'provider.role': 'provider.iam.role',
+            'provider.rolePermissionsBoundary': 'provider.iam.role.permissionBoundary',
+            'provider.iamManagedPolicies': 'provider.iam.role.managedPolicies',
+            'provider.iamRoleStatements': 'provider.iam.role.statements',
+            'provider.cfnRole': 'provider.iam.deploymentRole',
+          },
+          { serviceConfig: this.serverless.service }
+        );
       },
     };
+
     if (this.serverless.service.provider.name === 'aws') {
       // Below ideally should be in hooks.intialize, but variables resolution depend on this
       this.serverless.service.provider.region = this.getRegion();
@@ -1616,32 +1630,17 @@ class AwsProvider {
   getCustomDeploymentRole() {
     const { provider } = this.serverless.service;
 
-    if (provider.cfnRole) {
-      this.serverless._logDeprecation(
-        'PROVIDER_IAM_SETTINGS',
-        'Starting with version 3.0.0, "provider.cfnRole" property will be replaced with "provider.iam.deploymentRole"'
-      );
-    }
-
-    if (provider.iam && provider.iam.deploymentRole) {
-      return provider.iam.deploymentRole;
-    }
-
-    return provider.cfnRole;
+    return _.get(provider, 'iam.deploymentRole', provider.cfnRole);
   }
 
   getCustomExecutionRole(functionObj) {
     const { provider } = this.serverless.service;
 
-    if (provider.role) {
-      this.serverless._logDeprecation(
-        'PROVIDER_IAM_SETTINGS',
-        'Starting with version 3.0.0, "provider.role" property will be replaced with "provider.iam.role"'
-      );
-    }
-
     if (functionObj.role) return functionObj.role;
-    if (provider.iam && typeof provider.iam.role === 'string') return provider.iam.role;
+
+    const role = _.get(provider, 'iam.role');
+    if (typeof role === 'string') return role;
+
     return provider.role;
   }
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -770,6 +770,30 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
+            iam: {
+              type: 'object',
+              properties: {
+                role: {
+                  anyOf: [
+                    { $ref: '#/definitions/awsArnString' },
+                    {
+                      type: 'object',
+                      properties: {
+                        managedPolicies: {
+                          type: 'array',
+                          items: { $ref: '#/definitions/awsArnString' },
+                        },
+                        statements: { $ref: '#/definitions/awsIamPolicyStatements' },
+                        permissionBoundary: { $ref: '#/definitions/awsArnString' },
+                      },
+                      additionalProperties: false,
+                    },
+                  ],
+                },
+                deploymentRole: { $ref: '#/definitions/awsArn' },
+              },
+              additionalProperties: false,
+            },
             iamManagedPolicies: { type: 'array', items: { $ref: '#/definitions/awsArnString' } },
             iamRoleStatements: { $ref: '#/definitions/awsIamPolicyStatements' },
             ecr: {
@@ -1590,13 +1614,34 @@ class AwsProvider {
   }
 
   getCustomDeploymentRole() {
-    return this.serverless.service.provider.cfnRole;
+    const { provider } = this.serverless.service;
+
+    if (provider.cfnRole) {
+      this.serverless._logDeprecation(
+        'PROVIDER_IAM_SETTINGS',
+        'Starting with version 3.0.0, "provider.cfnRole" property will be replaced with "provider.iam.deploymentRole"'
+      );
+    }
+
+    if (provider.iam && provider.iam.deploymentRole) {
+      return provider.iam.deploymentRole;
+    }
+
+    return provider.cfnRole;
   }
 
   getCustomExecutionRole(functionObj) {
     const { provider } = this.serverless.service;
 
+    if (provider.role) {
+      this.serverless._logDeprecation(
+        'PROVIDER_IAM_SETTINGS',
+        'Starting with version 3.0.0, "provider.role" property will be replaced with "provider.iam.role"'
+      );
+    }
+
     if (functionObj.role) return functionObj.role;
+    if (provider.iam && typeof provider.iam.role === 'string') return provider.iam.role;
     return provider.role;
   }
 

--- a/lib/utils/report-deprecated-properties.js
+++ b/lib/utils/report-deprecated-properties.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const _ = require('lodash');
+const logDeprecation = require('./logDeprecation');
+
+const getMessage = (props, serviceConfig) => {
+  const warnings = [];
+
+  for (const [oldProp, newProp] of Object.entries(props)) {
+    if (_.get(serviceConfig, oldProp) != null) {
+      warnings.push([oldProp, newProp]);
+    }
+  }
+
+  if (warnings.length) {
+    const what = warnings.length > 1 ? 'properties' : 'property';
+    const details = warnings
+      .map(([oldProp, newProp]) => `  "${oldProp}" -> "${newProp}"`)
+      .join('\n');
+    return `Starting with version 3.0.0, following ${what} will be replaced:\n${details}`;
+  }
+  return null;
+};
+
+module.exports = (code, props, { serviceConfig } = {}) => {
+  const msg = getMessage(props, serviceConfig);
+  if (msg) {
+    logDeprecation(code, msg, { serviceConfig });
+  }
+};

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -232,6 +232,23 @@ describe('AwsCompileFunctions', () => {
       });
     });
 
+    it('should honour provider.iam.role option when set', async () => {
+      const { cfTemplate } = await runServerless({
+        fixture: 'function',
+        configExt: {
+          provider: {
+            role: 'arn:role-a',
+            iam: { role: 'arn:role-b' },
+          },
+        },
+        cliArgs: ['package'],
+      });
+
+      expect(cfTemplate.Resources.FooLambdaFunction.Properties.Role).to.eql({
+        'Fn::GetAtt': ['arn:role-b', 'Arn'],
+      });
+    });
+
     it('should add a logical role name function role', () => {
       awsCompileFunctions.serverless.service.provider.name = 'aws';
       awsCompileFunctions.serverless.service.functions = {

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -169,10 +169,9 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
     describe('Provider properties - deprecated properties', () => {
       let cfResources;
       let naming;
-      let service;
 
       before(async () => {
-        const { cfTemplate, awsNaming, fixtureData } = await runServerless({
+        const { cfTemplate, awsNaming } = await runServerless({
           fixture: 'function',
           cliArgs: ['package'],
           configExt: {
@@ -201,7 +200,6 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
 
         cfResources = cfTemplate.Resources;
         naming = awsNaming;
-        service = fixtureData.serviceConfig.service;
       });
 
       it('should support `provider.iamRoleStatements`', async () => {
@@ -237,22 +235,15 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           'arn:aws:iam::123456789012:policy/XCompanyBoundaries'
         );
       });
-
-      it('should support `provider.logRetentionInDays`', () => {
-        const normalizedName = naming.getLogGroupLogicalId('foo');
-        const iamResource = cfResources[normalizedName];
-        expect(iamResource.Type).to.be.equal('AWS::Logs::LogGroup');
-        expect(iamResource.Properties.RetentionInDays).to.be.equal(5);
-        expect(iamResource.Properties.LogGroupName).to.be.equal(`/aws/lambda/${service}-dev-foo`);
-      });
     });
 
     describe('Provider properties', () => {
       let cfResources;
       let naming;
+      let service;
 
       before(async () => {
-        const { cfTemplate, awsNaming } = await runServerless({
+        const { cfTemplate, awsNaming, fixtureData } = await runServerless({
           fixture: 'function',
           cliArgs: ['package'],
           configExt: {
@@ -285,6 +276,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
 
         cfResources = cfTemplate.Resources;
         naming = awsNaming;
+        service = fixtureData.serviceConfig.service;
       });
 
       it('should support `provider.iam.role.statements`', async () => {
@@ -336,6 +328,14 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
             ],
           ],
         });
+      });
+
+      it('should support `provider.logRetentionInDays`', () => {
+        const normalizedName = naming.getLogGroupLogicalId('foo');
+        const iamResource = cfResources[normalizedName];
+        expect(iamResource.Type).to.be.equal('AWS::Logs::LogGroup');
+        expect(iamResource.Properties.RetentionInDays).to.be.equal(5);
+        expect(iamResource.Properties.LogGroupName).to.be.equal(`/aws/lambda/${service}-dev-foo`);
       });
     });
 

--- a/test/unit/lib/utils/report-deprecated-properties.test.js
+++ b/test/unit/lib/utils/report-deprecated-properties.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const expect = require('chai').expect;
+const report = require('../../../../lib/utils/report-deprecated-properties');
+const { triggeredDeprecations } = require('../../../../lib/utils/logDeprecation');
+const overrideStdoutWrite = require('process-utils/override-stdout-write');
+
+describe('report-deprecated-properties', () => {
+  let stdoutData = '';
+  afterEach(() => {
+    stdoutData = '';
+    triggeredDeprecations.clear();
+  });
+
+  const serviceConfig = {
+    provider: {
+      role: 'role-a',
+      iamRoleStatements: ['something'],
+      apiGateway: {
+        isDodgy: true,
+      },
+    },
+  };
+
+  it('should warn about deprecated usage', () => {
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () =>
+        report(
+          'MY_CODE',
+          {
+            'provider.role': 'provider.iam.role',
+            'provider.cfnRole': 'provider.iam.deploymentRole',
+            'provider.iamRoleStatements': 'provider.iam.role.statements',
+            'provider.apiGateway.isDodgy': 'provider.apiGateway.legitOption',
+          },
+          { serviceConfig }
+        )
+    );
+    expect(triggeredDeprecations).to.include('MY_CODE');
+    expect(stdoutData).to.include(
+      'Starting with version 3.0.0, following properties will be replaced'
+    );
+    expect(stdoutData).to.include('"provider.role" -> "provider.iam.role"');
+    expect(stdoutData).to.include('"provider.iamRoleStatements" -> "provider.iam.role.statements"');
+    expect(stdoutData).to.include(
+      '"provider.apiGateway.isDodgy" -> "provider.apiGateway.legitOption"'
+    );
+    expect(stdoutData).not.to.include('"provider.cfnRole" -> "provider.iam.role.deploymentRole"');
+  });
+
+  it('no deprecated usage', () => {
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () =>
+        report(
+          'MY_CODE',
+          {
+            'provider.bad': 'provider.good',
+            'provider.veryBad': 'provider.veryGood',
+          },
+          { serviceConfig }
+        )
+    );
+
+    expect(triggeredDeprecations).not.to.include('MY_CODE');
+    expect(stdoutData).to.be.equal('');
+  });
+});


### PR DESCRIPTION
Closes: #8681

This change groups all IAM-related properties of `provider` under `iam` property like so:

new way:

```yaml
provider:
  iam:
    role: # can be either an arn string or an object like below:
      statements:
        - Effect: 'Allow',
          Resource: '*',
          NotAction: 'iam:DeleteUser',
      managedPolicies:
        - 'arn:aws:iam::123456789012:user/*',
      permissionBoundary: arn:aws:iam::123456789012:policy/boundaries
    deploymentRole: arn:aws:iam::123456789012:role/my-role
```

old way

```yaml
provider:
    role: arn:aws:iam::123456789012:role/my-role
    iamRoleStatements:
        - Effect: 'Allow',
          Resource: '*',
          NotAction: 'iam:DeleteUser',
     iamManagedPolicies:
        - 'arn:aws:iam::123456789012:user/*',
    rolePermissionsBoundary: arn:aws:iam::123456789012:policy/boundaries
    cfnRole: arn:aws:iam::123456789012:role/my-role
```