### PR TITLE
Upgrade test related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "archiver": "^5.1.0",
     "aws-sdk": "^2.819.0",
     "bluebird": "^3.7.2",
-    "boxen": "^4.2.0",
+    "boxen": "^5.0.0",
     "cachedir": "^2.3.0",
     "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "sinon": "^9.2.2",
     "sinon-chai": "^3.5.0",
     "standard-version": "^9.1.0",
-    "strip-ansi": "^5.2.0",
+    "strip-ansi": "^6.0.0",
     "ws": "^7.4.2",
     "xml2js": "^0.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "process-utils": "^4.0.0",
     "proxyquire": "^2.1.3",
     "semver-regex": "^3.1.2",
-    "sinon": "^8.1.1",
+    "sinon": "^9.2.2",
     "sinon-chai": "^3.5.0",
     "standard-version": "^9.1.0",
     "strip-ansi": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^6.2.3",
+    "@serverless/test": "^7.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cos-nodejs-sdk-v5": "^2.8.4",
@@ -89,7 +89,7 @@
     "lint-staged": "^10.5.3",
     "log": "^6.0.0",
     "log-node": "^7.0.0",
-    "mocha": "^6.2.3",
+    "mocha": "^8.2.1",
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
     "pkg": "^4.4.9",
@@ -124,11 +124,9 @@
     "/lib/plugins/aws/customResources/node_modules/**"
   ],
   "mocha": {
-    "reporter": "./test/mochaReporter",
     "require": [
+      "./test/mochaPatch",
       "@serverless/test/setup/log",
-      "@serverless/test/setup/async-leaks-detector",
-      "@serverless/test/setup/async-leaks-detector/bluebird-patch",
       "@serverless/test/setup/mock-homedir",
       "@serverless/test/setup/mock-cwd",
       "@serverless/test/setup/restore-env"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
       "@serverless/test/setup/mock-cwd",
       "@serverless/test/setup/restore-env"
     ],
-    "timeout": 15000
+    "timeout": 30000
   },
   "nyc": {
     "all": true,
@@ -209,7 +209,7 @@
     "prettier-check:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier -c",
     "prettify": "prettier --write \"**/*.{css,html,js,json,md,yaml,yml}\"",
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier --write",
-    "test": "mocha \"test/unit/**/*.test.js\"",
+    "test": "mocha --parallel \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
     "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\""
   },

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('@serverless/test/get-fixtures-engine')(__dirname);
+module.exports = require('@serverless/test/setup-fixtures-engine')(__dirname);

--- a/test/mochaPatch.js
+++ b/test/mochaPatch.js
@@ -12,9 +12,9 @@ BbPromise.config({
   longStackTraces: true,
 });
 
-module.exports = require('@serverless/test/setup/mocha-reporter');
+const { runnerEmitter } = require('@serverless/test/setup/patch');
 
-module.exports.deferredRunner.then(runner => {
+runnerEmitter.on('runner', runner => {
   runner.on('suite end', suite => {
     if (!suite.parent || !suite.parent.root) return;
 

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -337,7 +337,7 @@ describe('Serverless [new tests]', () => {
       it('Should run without notice', () =>
         fixtures.setup('locallyInstalledServerless').then(({ servicePath }) =>
           runServerless({
-            serverlessPath: path.resolve(servicePath, 'node_modules/serverless'),
+            serverlessDir: path.resolve(servicePath, 'node_modules/serverless'),
             cwd: servicePath,
             cliArgs: ['-v'],
           }).then(({ serverless }) => {

--- a/test/utils/run-serverless.js
+++ b/test/utils/run-serverless.js
@@ -1,33 +1,8 @@
 'use strict';
 
 const path = require('path');
-const runServerless = require('@serverless/test/run-serverless');
-const fixtures = require('../fixtures');
 
-const serverlessPath = path.join(__dirname, '../../');
-
-module.exports = async options => {
-  if (options.fixture && options.cwd) {
-    throw new Error('Either "fixture" or "cwd" should be provided');
-  }
-  const runServerlessOptions = Object.assign({}, options);
-  delete runServerlessOptions.serverlessPath;
-  delete runServerlessOptions.fixture;
-  delete runServerlessOptions.configExt;
-  let fixtureData;
-  if (options.fixture) {
-    fixtureData = await fixtures.setup(options.fixture, { configExt: options.configExt });
-    runServerlessOptions.cwd = fixtureData.servicePath;
-  }
-  try {
-    const result = await runServerless(
-      options.serverlessPath || serverlessPath,
-      runServerlessOptions
-    );
-    result.fixtureData = fixtureData;
-    return result;
-  } catch (error) {
-    error.fixtureData = fixtureData;
-    throw error;
-  }
-};
+module.exports = require('@serverless/test/setup-run-serverless-fixtures-engine')({
+  fixturesDir: path.resolve(__dirname, '../fixtures'),
+  serverlessDir: path.resolve(__dirname, '../../'),
+});


### PR DESCRIPTION
In response to v7.0.0 release of `@serverless/test` -> https://github.com/serverless/test/releases/tag/v7.0.0

Additionally:
- Update `test` script to run tests in _parallel_ (which is possible with Mocha v8) - it significantly speeds up test run (depending on available CPU cores)
- Upgrade `boxen` dependency to v5
