### PR TITLE
Upgrade "js-yaml" to v4

### DIFF
--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -46,7 +46,7 @@ const createSchema = () => {
       ['mapping', 'scalar', 'sequence'].map((kind) => yamlType(functionName, kind))
     )
   );
-  return yaml.Schema.create(types);
+  return yaml.DEFAULT_SCHEMA.extend(types);
 };
 
 module.exports = {

--- a/lib/plugins/aws/lib/cloudformationSchema.js
+++ b/lib/plugins/aws/lib/cloudformationSchema.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const _ = require('lodash');
 
 const functionNames = [
@@ -25,7 +25,7 @@ const functionNames = [
 
 const yamlType = (name, kind) => {
   const functionName = ['Ref', 'Condition'].includes(name) ? name : `Fn::${name}`;
-  return new YAML.Type(`!${name}`, {
+  return new yaml.Type(`!${name}`, {
     kind,
     construct: (data) => {
       if (name === 'GetAtt') {
@@ -46,7 +46,7 @@ const createSchema = () => {
       ['mapping', 'scalar', 'sequence'].map((kind) => yamlType(functionName, kind))
     )
   );
-  return YAML.Schema.create(types);
+  return yaml.Schema.create(types);
 };
 
 module.exports = {

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const getServerlessConfigFile = require('../utils/getServerlessConfigFile').getServerlessConfigFile;
 const jc = require('json-cycle');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 
 class Print {
   constructor(serverless, options) {
@@ -150,7 +150,7 @@ class Print {
         } else if (format === 'json') {
           out = jc.stringify(conf, null, '  ');
         } else if (format === 'yaml') {
-          out = YAML.dump(JSON.parse(jc.stringify(conf)), { noRefs: true });
+          out = yaml.dump(JSON.parse(jc.stringify(conf)), { noRefs: true });
         } else {
           return BbPromise.reject(
             new this.serverless.classes.Error('Format must be "yaml", "json" or "text"')

--- a/lib/utils/fs/parse.js
+++ b/lib/utils/fs/parse.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const jc = require('json-cycle');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const _ = require('lodash');
 const cloudFormationSchema = require('../../plugins/aws/lib/cloudformationSchema');
 
@@ -9,7 +9,7 @@ const loadYaml = (contents, options) => {
   let data;
   let error;
   try {
-    data = YAML.load(contents.toString(), options || {});
+    data = yaml.load(contents.toString(), options || {});
   } catch (exception) {
     error = exception;
   }

--- a/lib/utils/fs/writeFile.js
+++ b/lib/utils/fs/writeFile.js
@@ -3,7 +3,7 @@
 const fse = require('fs-extra');
 const path = require('path');
 const jc = require('json-cycle');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 
 function writeFile(filePath, conts, cycles) {
   let contents = conts || '';
@@ -21,7 +21,7 @@ function writeFile(filePath, conts, cycles) {
     const ymlFileExists = filePath.indexOf('.yml') !== -1;
 
     if ((yamlFileExists || ymlFileExists) && typeof contents !== 'string') {
-      contents = YAML.dump(contents);
+      contents = yaml.dump(contents);
     }
 
     return fse.writeFile(filePath, contents);

--- a/lib/utils/fs/writeFileSync.js
+++ b/lib/utils/fs/writeFileSync.js
@@ -3,7 +3,7 @@
 const fse = require('fs-extra');
 const path = require('path');
 const jc = require('json-cycle');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 
 function writeFileSync(filePath, conts, cycles) {
   let contents = conts || '';
@@ -22,7 +22,7 @@ function writeFileSync(filePath, conts, cycles) {
   const ymlFileExists = filePath.indexOf('.yml') !== -1;
 
   if ((yamlFileExists || ymlFileExists) && typeof contents !== 'string') {
-    contents = YAML.dump(contents);
+    contents = yaml.dump(contents);
   }
 
   return fse.writeFileSync(filePath, contents);

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "https-proxy-agent": "^5.0.0",
     "is-docker": "^2.1.1",
     "is-wsl": "^2.2.0",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^4.0.0",
     "json-cycle": "^1.3.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.17.20",

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const Serverless = require('../../../lib/Serverless');
 const semverRegex = require('semver-regex');
 const path = require('path');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
 
@@ -183,7 +183,7 @@ describe('Serverless', () => {
         },
       };
 
-      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'), YAML.dump(serverlessYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'serverless.yml'), yaml.dump(serverlessYml));
 
       serverless.config.update({ servicePath: tmpDirPath });
       serverless.pluginManager.cliOptions = {

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -9,7 +9,7 @@ const os = require('os');
 const path = require('path');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const _ = require('lodash');
 const overrideEnv = require('process-utils/override-env');
 
@@ -1837,7 +1837,7 @@ module.exports = {
           prob: 'prob',
         },
       };
-      SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), YAML.dump(configYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), yaml.dump(configYml));
       serverless.config.update({ servicePath: tmpDirPath });
       return serverless.variables
         .getValueFromFile('file(./config.yml)')
@@ -1912,7 +1912,7 @@ module.exports = {
           prob: 'prob',
         },
       };
-      SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), YAML.dump(configYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), yaml.dump(configYml));
       serverless.config.update({ servicePath: tmpDirPath });
       return serverless.variables
         .getValueFromFile('file(./config.yml):test2.sub')
@@ -2011,7 +2011,7 @@ module.exports = {
           prob: 'prob',
         },
       };
-      SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), YAML.dump(configYml));
+      SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), yaml.dump(configYml));
       serverless.config.update({ servicePath: tmpDirPath });
       return serverless.variables
         .getValueFromFile('file(./config.yml).testObj.sub')

--- a/test/unit/lib/classes/YamlParser.test.js
+++ b/test/unit/lib/classes/YamlParser.test.js
@@ -5,7 +5,7 @@
  */
 
 const chai = require('chai');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const path = require('path');
 const Serverless = require('../../../../lib/Serverless');
 const { getTmpFilePath, getTmpDirPath } = require('../../../utils/fs');
@@ -21,7 +21,7 @@ describe('YamlParser', () => {
     it('should parse a simple .yaml file', () => {
       const tmpFilePath = getTmpFilePath('simple.yaml');
 
-      serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
+      serverless.utils.writeFileSync(tmpFilePath, yaml.dump({ foo: 'bar' }));
 
       return expect(serverless.yamlParser.parse(tmpFilePath))
         .to.eventually.have.property('foo')
@@ -31,7 +31,7 @@ describe('YamlParser', () => {
     it('should parse a simple .yml file', () => {
       const tmpFilePath = getTmpFilePath('simple.yml');
 
-      serverless.utils.writeFileSync(tmpFilePath, YAML.dump({ foo: 'bar' }));
+      serverless.utils.writeFileSync(tmpFilePath, yaml.dump({ foo: 'bar' }));
 
       return expect(serverless.yamlParser.parse(tmpFilePath))
         .to.eventually.have.property('foo')

--- a/test/unit/lib/plugins/aws/lib/cloudformationSchema.test.js
+++ b/test/unit/lib/plugins/aws/lib/cloudformationSchema.test.js
@@ -8,7 +8,6 @@ describe('#cloudformationSchame()', () => {
   describe('#schema()', () => {
     it('should contain schema', () => {
       expect(Object.keys(cloudformationSchema.schema)).to.be.eql([
-        'include',
         'implicit',
         'explicit',
         'compiledImplicit',

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const path = require('path');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const fs = require('fs');
@@ -139,7 +139,7 @@ describe('PluginInstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginInstall.options.name = 'serverless-plugin-1';
 
@@ -160,7 +160,7 @@ describe('PluginInstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginInstall.options.name = '@scope/serverless-plugin-1';
 
@@ -181,7 +181,7 @@ describe('PluginInstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginInstall.options.name = 'serverless-not-in-registry-plugin';
       return expect(pluginInstall.install()).to.be.fulfilled.then(() => {
@@ -200,7 +200,7 @@ describe('PluginInstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
       pluginInstall.options.name = 'serverless-plugin-1';
       return expect(pluginInstall.install()).to.be.fulfilled.then(() => {
         expect(pluginInstall.options.pluginName).to.be.equal('serverless-plugin-1');
@@ -216,7 +216,7 @@ describe('PluginInstall', () => {
           service: 'plugin-service',
           provider: 'aws',
         };
-        serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+        serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
         pluginInstall.options.name = '@scope/serverless-plugin-1';
         return expect(pluginInstall.install()).to.be.fulfilled.then(() => {
           expect(pluginInstall.options.pluginName).to.be.equal('@scope/serverless-plugin-1');
@@ -230,7 +230,7 @@ describe('PluginInstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
       pluginInstall.options.name = 'serverless-plugin-1@1.0.0';
       return expect(pluginInstall.install()).to.be.fulfilled.then(() => {
         expect(pluginInstall.options.pluginName).to.be.equal('serverless-plugin-1');
@@ -324,7 +324,7 @@ describe('PluginInstall', () => {
         provider: 'aws',
         // no plugins array here
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginInstall.options.pluginName = 'serverless-plugin-1';
 
@@ -344,7 +344,7 @@ describe('PluginInstall', () => {
         provider: 'aws',
         plugins: ['serverless-existing-plugin'], // one plugin was already added
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginInstall.options.pluginName = 'serverless-plugin-1';
 
@@ -363,7 +363,7 @@ describe('PluginInstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYamlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYamlFilePath, yaml.dump(serverlessYml));
       pluginInstall.options.pluginName = 'serverless-plugin-1';
       return expect(pluginInstall.addPluginToServerlessFile()).to.be.fulfilled.then(() => {
         expect(serverless.utils.readFileSync(serverlessYamlFilePath, 'utf8')).to.deep.equal(
@@ -447,7 +447,7 @@ describe('PluginInstall', () => {
             modules: [],
           },
         };
-        serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+        serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
         pluginInstall.options.pluginName = 'serverless-plugin-1';
 

--- a/test/unit/lib/plugins/plugin/uninstall.test.js
+++ b/test/unit/lib/plugins/plugin/uninstall.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const BbPromise = require('bluebird');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const path = require('path');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
 const fse = require('fs-extra');
@@ -138,7 +138,7 @@ describe('PluginUninstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginUninstall.options.name = 'serverless-plugin-1';
 
@@ -159,7 +159,7 @@ describe('PluginUninstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginUninstall.options.name = 'serverless-not-in-registry-plugin';
 
@@ -179,7 +179,7 @@ describe('PluginUninstall', () => {
         service: 'plugin-service',
         provider: 'aws',
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
       pluginUninstall.options.name = 'serverless-plugin-1@1.0';
       return expect(pluginUninstall.uninstall()).to.be.fulfilled.then(() => {
         expect(pluginUninstall.options.pluginName).to.be.equal('serverless-plugin-1');
@@ -252,7 +252,7 @@ describe('PluginUninstall', () => {
         provider: 'aws',
         plugins: ['serverless-existing-plugin', 'serverless-plugin-1'],
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginUninstall.options.pluginName = 'serverless-plugin-1';
 
@@ -270,7 +270,7 @@ describe('PluginUninstall', () => {
         provider: 'aws',
         plugins: ['serverless-plugin-1'],
       };
-      serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
       pluginUninstall.options.pluginName = 'serverless-plugin-1';
 
@@ -288,7 +288,7 @@ describe('PluginUninstall', () => {
         provider: 'aws',
         plugins: ['serverless-plugin-1'],
       };
-      serverless.utils.writeFileSync(serverlessYamlFilePath, YAML.dump(serverlessYml));
+      serverless.utils.writeFileSync(serverlessYamlFilePath, yaml.dump(serverlessYml));
       pluginUninstall.options.pluginName = 'serverless-plugin-1';
       return expect(pluginUninstall.removePluginFromServerlessFile()).to.be.fulfilled.then(() => {
         expect(serverless.utils.readFileSync(serverlessYamlFilePath, 'utf8')).to.not.have.property(
@@ -378,7 +378,7 @@ describe('PluginUninstall', () => {
             modules: ['serverless-existing-plugin', 'serverless-plugin-1'],
           },
         };
-        serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+        serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
         pluginUninstall.options.pluginName = 'serverless-plugin-1';
 
@@ -402,7 +402,7 @@ describe('PluginUninstall', () => {
             modules: ['serverless-plugin-1'],
           },
         };
-        serverless.utils.writeFileSync(serverlessYmlFilePath, YAML.dump(serverlessYml));
+        serverless.utils.writeFileSync(serverlessYmlFilePath, yaml.dump(serverlessYml));
 
         pluginUninstall.options.pluginName = 'serverless-plugin-1';
 

--- a/test/unit/lib/plugins/print.test.js
+++ b/test/unit/lib/plugins/print.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Serverless = require('../../../../lib/Serverless');
 const CLI = require('../../../../lib/classes/CLI');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 
 chai.use(require('chai-as-promised'));
 
@@ -51,7 +51,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(YAML.load(message)).to.eql(conf);
+      expect(yaml.load(message)).to.eql(conf);
     });
   });
 
@@ -216,7 +216,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(YAML.load(message)).to.eql(conf);
+      expect(yaml.load(message)).to.eql(conf);
     });
   });
 
@@ -248,7 +248,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(YAML.load(message)).to.eql(expected);
+      expect(yaml.load(message)).to.eql(expected);
     });
   });
 
@@ -283,7 +283,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(YAML.load(message)).to.eql(expected);
+      expect(yaml.load(message)).to.eql(expected);
     });
   });
 
@@ -322,7 +322,7 @@ describe('Print', () => {
 
       expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
       expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-      expect(YAML.load(message)).to.eql(expected);
+      expect(yaml.load(message)).to.eql(expected);
     });
   });
 
@@ -357,7 +357,7 @@ describe('Print', () => {
 
           expect(getServerlessConfigFileStub.calledOnce).to.equal(true);
           expect(print.serverless.cli.consoleLog.called).to.be.equal(true);
-          expect(YAML.load(message)).to.eql(expected);
+          expect(yaml.load(message)).to.eql(expected);
         });
       });
     });

--- a/test/unit/lib/utils/createFromTemplate.test.js
+++ b/test/unit/lib/utils/createFromTemplate.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const chai = require('chai');
 const { existsSync, outputJsonSync, readFileSync } = require('fs-extra');
-const { safeLoad: yamlParse } = require('js-yaml');
+const { load: yamlParse } = require('js-yaml');
 const installTemplate = require('../../../../lib/utils/createFromTemplate');
 const { getTmpDirPath } = require('../../../utils/fs');
 

--- a/test/utils/fs.js
+++ b/test/utils/fs.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const fse = require('fs-extra');
 const crypto = require('crypto');
-const YAML = require('js-yaml');
+const yaml = require('js-yaml');
 const JSZip = require('jszip');
 
 const tmpDirCommonPath = require('@serverless/test/process-tmp-dir');
@@ -36,13 +36,13 @@ function replaceTextInFile(filePath, subString, newSubString) {
 
 function readYamlFile(filePath) {
   const content = fs.readFileSync(filePath, 'utf8');
-  return YAML.safeLoad(content);
+  return yaml.safeLoad(content);
 }
 
 function writeYamlFile(filePath, content) {
-  const yaml = YAML.safeDump(content);
-  fs.writeFileSync(filePath, yaml);
-  return yaml;
+  const data = yaml.safeDump(content);
+  fs.writeFileSync(filePath, data);
+  return data;
 }
 
 function listZipFiles(filename) {

--- a/test/utils/fs.js
+++ b/test/utils/fs.js
@@ -36,11 +36,11 @@ function replaceTextInFile(filePath, subString, newSubString) {
 
 function readYamlFile(filePath) {
   const content = fs.readFileSync(filePath, 'utf8');
-  return yaml.safeLoad(content);
+  return yaml.load(content);
 }
 
 function writeYamlFile(filePath, content) {
-  const data = yaml.safeDump(content);
+  const data = yaml.dump(content);
   fs.writeFileSync(filePath, data);
   return data;
 }


### PR DESCRIPTION
Followed the migration guide: https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md

Used `load` and `dump` references were auto upgraded with more strict variants (in v3 they supported JS injections which were not safe, and I believe we never envisioned to support it)

Additionally improved var naming