### PR TITLE
Docs params update

### DIFF
--- a/docs/guides/parameters.md
+++ b/docs/guides/parameters.md
@@ -15,21 +15,23 @@ layout: Doc
 
 The Serverless Framework Dashboard enables you to create and manage parameters, helping you to configure and secure your services by securely storing parameters used by your Serverless Framework services. The [Serverless Framework Dashboard](https://app.serverless.com/) provides an interface to store and encrypt parameters and manage access to those parameters from your services. The Serverless Framework loads the parameters when the service is deployed.
 
-All parameters are treated as sensitive values, therefore they are not visible in the dashboard once saved, they are always encrypted at rest, and only decrypted during deployment.
+All parameters are treated as sensitive values, therefore they are always encrypted at rest, and only decrypted during deployment or to load them in the dashboard.
 
-## Creating a new Parameters
+## Managing parameter using the dashboard
 
-Create a new parameter by navigating to **profiles** in the [Serverless Framework Dashboard](https://app.serverless.com).
+Parameters can be added to either services or instances.
 
-1. Navigate into the profile you would like to use for the Parameter.
-2. Navigate into the **parameters** tab.
-3. Set a **key** and **value** and click **add**.
-4. Repeat Step 3 for each parameter you would like to add.
-5. When done, click **save changes**.
+To manage parameters on the service, go to the **apps** section of the dashboard, and select **settings** under the **...** menu.
+
+To manage parameters on the instance, go to the **app** section of the dashboard, select the instance, and go to the **params** tab.
+
+### Inheritance and overriding
+
+Parameters set on instances take precedence over parameters set on services when deploying. If a parameter with the same key is set on both the instance and the service, then the value set on the instance will be used. If a parameter is set on the service, but not the instance, then the value set on the service will be used.
+
+This enables you to treat the parameters on services as defaults. This is especially useful in development when you may deploy instances to ephemeral stages (e.g. "feature-x"). In development the instance might not have any new parameters, therefore it will default to the parameters set on the service. However, in other stages, like "prod", or "staging", you may override the service-level parameters with instance-level parameters to use values unique to that stage.
 
 ## Using a Parameter in serverless.yml
-
-To use a parameter in the serverless.yml, first make sure that the profile containing that parameter is configured as the **default deployment profile** for your application, or it is configured as the **profile** on the stage and application you are using.
 
 In your `serverless.yml` file add the variable `${param:<key>}` anywhere you would like to use the parameter. The `<key>` references the parameter key configured in the profile.
 
@@ -41,14 +43,14 @@ Parameters can also be accessed on the CLI. You can use this at development time
 
 ### List parameters
 
-`sls param list [--org <org>] [--app <app>] [--service <service>] [--stage <stage>]`
+`sls param list [--org <org>] [--app <app>] [--service <service>] [--stage <stage>] [--region <region>]`
 
-If you are in a working directory with a `serverless.yml` then the parameters will be listed for the org, app, and service specified in the serverless.yml file.
+If you are in a working directory with a `serverless.yml` then the parameters will be listed for the org, app, and service specified in the `serverless.yml` file.
 
-If you are not in a working directory, without a `serverless.yml`, or if you want to access parameters from another org, app, service, or stage, you can pass in the optional flags.
+If you are not in a working directory, without a `serverless.yml`, or if you want to access parameters from another org, app, service, stage, or region, you can pass in the optional flags.
 
 ### Get a parameter
 
-`sls param get --name <name> [--org <org>] [--app <app>] [--service <service>] [--stage <stage>]`
+`sls param get --name <name> [--org <org>] [--app <app>] [--service <service>] [--stage <stage>] [--region <region>]`
 
-Individual parameters can also be accessed from the CLI using the `param get` sub-command. This command requires the `--name <name>` flag to identify the parameter name. Like the `sls param list`, you can optionally specify a different org, app, service, or stage using flags.
+Individual parameters can also be accessed from the CLI using the `param get` sub-command. This command requires the `--name <name>` flag to identify the parameter name. Like the `sls param list`, you can optionally specify a different org, app, service, stage, ore region using flags.

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -11,7 +11,8 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:END -->
 
-> This is a deprecated feature of the dashboard. Please look at our documentaion for [Providers](https://www.serverless.com/framework/docs/guides/providers/) which replaces the use of deployment profiles for setting up AWS connections.
+> This is a deprecated feature of the dashboard. Please look at our documentaion for [Providers](https://www.serverless.com/framework/docs/guides/providers/) and
+> [Parameters](https://www.serverless.com/framework/docs/guides/parameters/) which replaces the use of deployment profiles for setting up AWS connections and parameters.
 
 # Deployment Profiles
 

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -18,6 +18,29 @@ layout: Doc
 
 Deployment Profiles enable each stage of your Serverless application to use a unique set of [Safeguards](./safeguards.md), [Parameters](./parameters.md) and [Access Roles](./access-roles.md).
 
+## Deprecation and Migration from Deployment Profile
+
+Prior to the January 5th, 2021 release, deployment profiles supported setting AWS Access Role ARNs and managing parameters. Support for using AWS Access Roles for deployments has moved from deployment profiles to Providers. Support for managing Parameters has moved from deployment profiles to services and instances.
+
+**Deployment profiles will be deprecated on February 1st, 2021**. Migration from deployment profiles to providers and parameters will be automatic; however, there are two required action items to use the new features.
+
+### Action Items
+
+- You **MUST** upgrade to use the Enterprise Plugin version 4.4.1 or higher.
+- You **MUST** relink your AWS Account via the providers UI by no later than February 1st, 2021.
+
+### Automatic Migration
+
+Parameters and Providers will be migrated automatically from deployment profiles when you perform a deployment using the enterprise plugin version 4.4.1 or higher, or January 31st, 2021, whichever is earlier.
+
+The automatic migration will replace deployment profiles with providers by performing the following:
+
+- **A new provider will be created for each deployment profile using the same AWS Access Role ARN**. If the deployment profile doesn’t contain an AWS Access Role ARN, it will be skipped.
+- **A provider will be added to each service for the corresponding default stage in the app**. The provider will be the provider corresponding to the deployment profile which was associated with the default stage of the parent app. For example, if `app1` has `service1` and the _`default`_ stage of `app1` links to the `dev` deployment profile, then the `dev` provider will be added to `service1`. This is repeated for all services in all apps.
+- **A provider will be added to each instance for the corresponding stage in the app**. The provider will be the provider corresponding to the deployment profile which was associated with the stage of the instance. For example, if `app1` has `service1` and `app1` has a stage `prod` linked to the `prod` deployment profile, then the `prod` provider will be added to the `service1` instances deployed to the `prod` stage.
+- **Parameters from the deployment profile associated with the default stage in the app will be copied to the service**.
+- **Parameters from the deployment profile associated with a stage in an app will be copied to the instance**.
+
 ## Use Deployment Profiles
 
 Deployment profiles are managed in the [Serverless Framework Dashboard](https://app.serverless.com). When you run `serverless deploy`, the CLI obtains the Safeguard policies, Parameters, and the generated AWS Credentials.

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -78,21 +78,3 @@ Now if you deploy to a preview stage, like `feature-x` it will automatically use
 To use providers with serverless.yml you do not need to do anything. Upon deployment the Serverless Framework will retrieve the necessary credentials from the provider associate with the instance or service, and it will use those credentials to deploy.
 
 If the providers are not found, then the Serverless Framework will look for credentials locally.
-
-# Migrating from Deployment Profile
-
-Prior to the release of providers, deployment profiles supported setting AWS Access Role ARNs which could be associated with stages in apps. Providers also support AWS Access Role ARNs, as well as AWS secret/access keys, and in the future will also support other cloud service providers like Azure, GCP, Stripe, etc. As such, deployment profiles are no longer needed and will be replaced with providers.
-
-AWS Access Roles in deployment profiles will be automatically migrated to providers and no immediate action is required. _This automatic migration will be performed when you deploy using version 4.1.0 or higher of the Serverless Plugin on the CLI._ You can check your plugin version by running `serverless version`.
-
-This migration will be fully automated and backwards compatible; however, there are a few things that will change as a result of the migration:
-
-- Deployments using deployment profiles will continue to work as-is.
-- If the AWS Access Role must be updated, then it must be updated using Providers instead of Deployment Profiles.
-- If you want to add/edit new Providers, then you must use version 4.1.0 or higher of the Serverless Plugin on the CLI. You can check the version with `sls version`.
-
-The automatic migration will replace deployment profiles with providers by performing the following:
-
-- **A new provider will be created for each deployment profile using the same AWS Access Role ARN**. If the deployment profile doesn’t contain an AWS Access Role ARN, it will be skipped.
-- **A provider will be added to each service for the corresponding default stage in the app**. The provider will be the provider corresponding to the deployment profile which was associated with the default stage of the parent app. For example, if `app1` has `service1` and the _`default`_ stage of `app1` links to the `dev` deployment profile, then the `dev` provider will be added to `service1`. This is repeated for all services in all apps.
-- **A provider will be added to each instance for the corresponding stage in the app**. The provider will be the provider corresponding to the deployment profile which was associated with the stage of the instance. For example, if `app1` has `service1` and `app1` has a stage `prod` linked to the `prod` deployment profile, then the `prod` provider will be added to the `service1` instances deployed to the `prod` stage.


### PR DESCRIPTION
This PR updates the documentation for parameters, providers, and deployment profiles in the dashboard per the upcoming changes, deprecation and migration.

- Updates usage docs on parameters
- Moves the migration details from providers to the deployment profiles page
- Adds a reference to the parameters on the deployment profiles page