### PR TITLE
Extend config schema to support deprecation warnings

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -99,6 +99,8 @@ class ConfigSchemaHandler {
     }
 
     const ajv = new Ajv({ allErrors: true, coerceTypes: 'array', verbose: true });
+    ajv.addKeyword('deprecation', { validate: () => false, errors: false });
+
     require('ajv-keywords')(ajv, 'regexp');
     // Workaround https://github.com/ajv-validator/ajv/issues/1255
     normalizeSchemaObject(this.schema, this.schema);
@@ -107,10 +109,17 @@ class ConfigSchemaHandler {
     const denormalizeOptions = normalizeUserConfig(userConfig);
     validate(userConfig);
     denormalizeUserConfig(userConfig, denormalizeOptions);
-    if (validate.errors && this.serverless.service.configValidationMode !== 'off') {
-      const messages = normalizeAjvErrors(validate.errors).map((err) => err.message);
+
+    const result = validate.errors || [];
+    const errors = result.filter(error => error.keyword !== 'deprecation');
+    const deprecations = result.filter(error => error.keyword === 'deprecation');
+
+    if (errors.length && this.serverless.service.configValidationMode !== 'off') {
+      const messages = normalizeAjvErrors(errors).map(err => err.message);
       this.handleErrorMessages(messages);
     }
+
+    this.handleDeprecationErrors(deprecations);
   }
 
   handleErrorMessages(messages) {
@@ -144,6 +153,12 @@ class ConfigSchemaHandler {
         this.serverless.cli.log(' ');
       }
     }
+  }
+
+  handleDeprecationErrors(errors) {
+    errors.forEach(error =>
+      this.serverless._logDeprecation(error.schema.code, error.schema.message)
+    );
   }
 
   defineTopLevelProperty(name, subSchema) {

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -19,7 +19,9 @@ const normalizeSchemaObject = (object, instanceSchema) => {
     if (!value.$ref.startsWith('#/definitions/')) {
       throw new Error(`Unsupported reference ${value.$ref}`);
     }
-    object[key] = _.get(instanceSchema, value.$ref.slice(2).split('/'));
+    // Extend refs - same as ajv's extendRefs option.
+    object[key] = Object.assign(value, _.get(instanceSchema, value.$ref.slice(2).split('/')));
+    delete object[key].$ref;
   }
 };
 
@@ -99,7 +101,7 @@ class ConfigSchemaHandler {
     }
 
     const ajv = new Ajv({ allErrors: true, coerceTypes: 'array', verbose: true });
-    ajv.addKeyword('deprecation', { validate: () => false, errors: false });
+    ajv.addKeyword('deprecation', { validate: () => false });
 
     require('ajv-keywords')(ajv, 'regexp');
     // Workaround https://github.com/ajv-validator/ajv/issues/1255
@@ -111,11 +113,11 @@ class ConfigSchemaHandler {
     denormalizeUserConfig(userConfig, denormalizeOptions);
 
     const result = validate.errors || [];
-    const errors = result.filter(error => error.keyword !== 'deprecation');
-    const deprecations = result.filter(error => error.keyword === 'deprecation');
+    const errors = result.filter((error) => error.keyword !== 'deprecation');
+    const deprecations = result.filter((error) => error.keyword === 'deprecation');
 
     if (errors.length && this.serverless.service.configValidationMode !== 'off') {
-      const messages = normalizeAjvErrors(errors).map(err => err.message);
+      const messages = normalizeAjvErrors(errors).map((err) => err.message);
       this.handleErrorMessages(messages);
     }
 
@@ -156,7 +158,7 @@ class ConfigSchemaHandler {
   }
 
   handleDeprecationErrors(errors) {
-    errors.forEach(error =>
+    errors.forEach((error) =>
       this.serverless._logDeprecation(error.schema.code, error.schema.message)
     );
   }

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -42,7 +42,7 @@ const schema = {
               type: 'array',
               items: {
                 /*
-                 * `anyOf` array by JSON schema spec cannot be empty, threfore we start
+                 * `anyOf` array by JSON schema spec cannot be empty, therefore we start
                  * with one dummy item as workaround to ensure it validates against
                  * any undefined function events.
                  */

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -39,15 +39,6 @@ class AwsCompileFunctions {
           );
         }
         if (
-          Object.values(this.serverless.service.functions).some(({ awsKmsKeyArn }) => awsKmsKeyArn)
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_KMS_KEY_ARN',
-            'Starting with next major version, ' +
-              '"awsKmsKeyArn" function property will be replaced by "kmsKeyArn"'
-          );
-        }
-        if (
           !this.serverless.service.provider.lambdaHashingVersion &&
           (this.serverless.service.provider.versionFunctions ||
             Object.values(this.serverless.service.functions).some(

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -59,9 +59,9 @@ const MAX_RETRIES = (() => {
 
 const impl = {
   /**
-   * Determine whether the given credentials are valid.  It turned out that detecting invalid
-   * credentials was more difficult than detecting the positive cases we know about.  Hooray for
-   * whak-a-mole!
+   * Determine whether the given credentials are valid. It turned out that detecting invalid
+   * credentials was more difficult than detecting the positive cases we know about. Hooray for
+   * whack-a-mole!
    * @param credentials The credentials to test for validity
    * @return {boolean} Whether the given credentials were valid
    */
@@ -929,7 +929,14 @@ class AwsProvider {
         },
         function: {
           properties: {
-            awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
+            awsKmsKeyArn: {
+              $ref: '#/definitions/awsKmsArn',
+              deprecation: {
+                code: 'AWS_KMS_KEY_ARN',
+                message:
+                  'Starting with next major version, "awsKmsKeyArn" function property will be replaced with "provider.kmsKeyArn"',
+              },
+            },
             condition: { $ref: '#/definitions/awsResourceCondition' },
             dependsOn: { $ref: '#/definitions/awsResourceDependsOn' },
             description: { type: 'string', maxLength: 256 },

--- a/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
@@ -75,6 +75,27 @@ describe('ConfigSchemaHandler', () => {
         cliArgs: ['info'],
       });
     });
+
+    it('should produce deprecation warnings', async () => {
+      const { stdoutData } = await runServerless({
+        fixture: 'aws',
+        configExt: {
+          functions: {
+            func: {
+              awsKmsKeyArn: 'arn:aws:kms',
+            },
+          },
+        },
+        cliArgs: ['print'],
+      });
+
+      expect(stdoutData).to.contain(
+        'Starting with next major version, "awsKmsKeyArn" function property will be replaced with "provider.kmsKeyArn"'
+      );
+      expect(stdoutData).to.contain(
+        'More Info: https://www.serverless.com/framework/docs/deprecations/#AWS_KMS_KEY_ARN'
+      );
+    });
   });
 
   describe('#defineFunctionEvent', () => {


### PR DESCRIPTION
As part of https://github.com/serverless/serverless/pull/8701 I'll need to introduce several (5+?) config deprecations. Doing `if .. else` in several places with `serverless._logDeprecation` feels a bit dodgy. Exploring if it can be solved in one place.
