### PR TITLE
fix(Config Schema): use ajv formats

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -100,6 +100,7 @@ class ConfigSchemaHandler {
 
     const ajv = new Ajv({ allErrors: true, coerceTypes: 'array', verbose: true, strict: false });
     require('ajv-keywords')(ajv, 'regexp');
+    require('ajv-formats').default(ajv);
     // Workaround https://github.com/ajv-validator/ajv/issues/1255
     normalizeSchemaObject(this.schema, this.schema);
     const validate = ajv.compile(this.schema);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@serverless/enterprise-plugin": "^4.4.0",
     "@serverless/utils": "^2.2.0",
     "ajv": "^7.0.3",
+    "ajv-formats": "^1.5.1",
     "ajv-keywords": "^4.0.0",
     "archiver": "^5.1.0",
     "aws-sdk": "^2.819.0",


### PR DESCRIPTION
This adds missing `ajv-formats` that cause a lot of noise and missed checks for formats such as `ipv4` and similar, which we should avoid when releasing a new version (`sls deploy` creates a lot of noise)

Addresses: #8695