### PR TITLE
refactor: Typos in schema

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -454,7 +454,7 @@ class AwsProvider {
           },
           awsLambdaTimeout: { type: 'integer', minimum: 1, maximum: 900 },
           awsLambdaTracing: { anyOf: [{ enum: ['Active', 'PassThrough'] }, { type: 'boolean' }] },
-          awsLambdaVersionning: { type: 'boolean' },
+          awsLambdaVersioning: { type: 'boolean' },
           awsLambdaVpcConfig: {
             type: 'object',
             properties: {
@@ -922,7 +922,7 @@ class AwsProvider {
               type: 'array',
               items: { $ref: '#/definitions/awsCfInstruction' },
             },
-            versionFunctions: { $ref: '#/definitions/awsLambdaVersionning' },
+            versionFunctions: { $ref: '#/definitions/awsLambdaVersioning' },
             websocketsApiName: { type: 'string' },
             websocketsApiRouteSelectionExpression: { type: 'string' },
           },
@@ -997,7 +997,7 @@ class AwsProvider {
             tags: { $ref: '#/definitions/awsResourceTags' },
             timeout: { $ref: '#/definitions/awsLambdaTimeout' },
             tracing: { $ref: '#/definitions/awsLambdaTracing' },
-            versionFunction: { $ref: '#/definitions/awsLambdaVersionning' },
+            versionFunction: { $ref: '#/definitions/awsLambdaVersioning' },
             vpc: { $ref: '#/definitions/awsLambdaVpcConfig' },
           },
           additionalProperties: false,

--- a/test/fixtures/configSchemaExtensions/test-plugin.js
+++ b/test/fixtures/configSchemaExtensions/test-plugin.js
@@ -54,9 +54,9 @@ class TestPlugin {
       'existingComplexEvent',
       {
         properties: {
-          somePluginAdditionalComplexeEventProp: { type: 'string' },
+          somePluginAdditionalComplexEventProp: { type: 'string' },
         },
-        required: ['somePluginAdditionalComplexeEventProp'],
+        required: ['somePluginAdditionalComplexEventProp'],
       }
     );
 

--- a/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
@@ -146,7 +146,7 @@ describe('ConfigSchemaHandler', () => {
       expect(existingEventDefinition.required).to.include('somePluginAdditionalEventProp');
     });
 
-    it('should extend schema with defineFunctionEventProperties method on complexe event schema', async () => {
+    it('should extend schema with defineFunctionEventProperties method on complex event schema', async () => {
       const serverless = await runServerless({
         fixture: 'configSchemaExtensions',
         cliArgs: ['info'],
@@ -165,9 +165,9 @@ describe('ConfigSchemaHandler', () => {
             type: 'object',
             properties: {
               existingPropForObjectEventDefinition: { type: 'string' },
-              somePluginAdditionalComplexeEventProp: { type: 'string' },
+              somePluginAdditionalComplexEventProp: { type: 'string' },
             },
-            required: ['somePluginAdditionalComplexeEventProp'],
+            required: ['somePluginAdditionalComplexEventProp'],
           },
         ],
       });

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1943,19 +1943,19 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       // Replacement for
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L1457-L1504
       //
-      // Confirm on TrancingConfig property
+      // Confirm on TracingConfig property
       // Confirm also on needed IAM policies
     });
 
     it.skip('TODO: should support `functions[].onError` as arn', () => {
-      // Replacment for
+      // Replacement for
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L774-L821
       //
       // Confirm on Function `DeadLetterConfig` property and on IAM policy statement being added
     });
 
     it.skip('TODO: should support `functions[].onError` as Ref', () => {
-      // Replacment for
+      // Replacement for
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L823-L863
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L951-L988
       //


### PR DESCRIPTION
As discussed in https://github.com/serverless/serverless/pull/8701 moving unrelated typo changes into separate PR.