### PR TITLE
Optimize ajv schema compilation

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -189,7 +189,7 @@ class Serverless {
     this.service.setFunctionNames(this.processedInput.options);
 
     // If in context of service, validate the service configuration
-    if (this.config.servicePath) this.service.validate();
+    if (this.config.servicePath) await this.service.validate();
 
     // trigger the plugin lifecycle when there's something which should be processed
     await this.pluginManager.run(this.processedInput.commands);

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Ajv = require('ajv').default;
 const _ = require('lodash');
 const schema = require('../../configSchema');
 const normalizeAjvErrors = require('./normalizeAjvErrors');
+const resolveAjvValidate = require('./resolveAjvValidate');
 
 const FUNCTION_NAME_PATTERN = '^[a-zA-Z0-9-_]+$';
 const ERROR_PREFIX = 'Configuration error';
@@ -66,7 +66,7 @@ class ConfigSchemaHandler {
     deepFreeze(this.schema.properties.package);
   }
 
-  validateConfig(userConfig) {
+  async validateConfig(userConfig) {
     if (!this.schema.properties.provider.properties.name) {
       if (this.serverless.service.configValidationMode !== 'off') {
         this.serverless.cli.log(
@@ -98,12 +98,9 @@ class ConfigSchemaHandler {
       this.relaxProviderSchema();
     }
 
-    const ajv = new Ajv({ allErrors: true, coerceTypes: 'array', verbose: true, strict: false });
-    require('ajv-keywords')(ajv, 'regexp');
-    require('ajv-formats').default(ajv);
     // Workaround https://github.com/ajv-validator/ajv/issues/1255
     normalizeSchemaObject(this.schema, this.schema);
-    const validate = ajv.compile(this.schema);
+    const validate = await resolveAjvValidate(this.schema);
 
     const denormalizeOptions = normalizeUserConfig(userConfig);
     validate(userConfig);

--- a/lib/classes/ConfigSchemaHandler/resolveAjvValidate.js
+++ b/lib/classes/ConfigSchemaHandler/resolveAjvValidate.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const Ajv = require('ajv').default;
+const objectHash = require('object-hash');
+const path = require('path');
+const os = require('os');
+const standaloneCode = require('ajv/dist/standalone').default;
+const fs = require('fs');
+const requireFromString = require('require-from-string');
+const deepSortObjectByKey = require('../../utils/deepSortObjectByKey');
+const ensureExists = require('../../utils/ensureExists');
+
+const cacheDir = path.resolve(
+  os.homedir(),
+  `.serverless/artifacts/ajv-validate-${require('ajv/package').version}`
+);
+
+const getValidate = async (schema) => {
+  const schemaHash = objectHash(deepSortObjectByKey(schema));
+  const cachePath = path.resolve(cacheDir, schemaHash);
+
+  const generate = async () => {
+    const ajv = new Ajv({
+      allErrors: true,
+      coerceTypes: 'array',
+      verbose: true,
+      strict: false,
+      code: { source: true },
+    });
+    require('ajv-keywords')(ajv, 'regexp');
+    require('ajv-formats').default(ajv);
+    const validate = ajv.compile(schema);
+    const moduleCode = standaloneCode(ajv, validate);
+    await fs.promises.writeFile(cachePath, moduleCode);
+  };
+  await ensureExists(cachePath, generate);
+  const loadedModuleCode = await fs.promises.readFile(cachePath, 'utf-8');
+  return requireFromString(loadedModuleCode, path.resolve(__dirname, 'resolveAjvValidate.js'));
+};
+
+module.exports = getValidate;

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -211,7 +211,7 @@ class Service {
     });
   }
 
-  validate() {
+  async validate() {
     const userConfig = this.initialServerlessConfig;
     userConfig.service = this.serviceObject;
 
@@ -219,7 +219,7 @@ class Service {
     if (userConfig.functions) userConfig.functions = this.functions;
     if (userConfig.resources) userConfig.resources = this.resources;
 
-    this.serverless.configSchemaHandler.validateConfig(userConfig);
+    await this.serverless.configSchemaHandler.validateConfig(userConfig);
 
     return this;
   }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "p-limit": "^3.1.0",
     "promise-queue": "^2.2.5",
     "replaceall": "^0.1.6",
+    "require-from-string": "^2.0.2",
     "semver": "^7.3.4",
     "tabtab": "^3.0.2",
     "tar": "^6.0.5",

--- a/test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const chai = require('chai');
+const resolveAjvValidate = require('../../../../../lib/classes/ConfigSchemaHandler/resolveAjvValidate');
+const objectHash = require('object-hash');
+const deepSortObjectByKey = require('../../../../../lib/utils/deepSortObjectByKey');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
+
+describe('test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js', () => {
+  const schema = {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'TestSchema',
+    type: 'object',
+    properties: {
+      firstProp: {
+        type: 'string',
+      },
+    },
+  };
+
+  it('generates schema validation file', async () => {
+    await resolveAjvValidate(schema);
+    const schemaHash = objectHash(deepSortObjectByKey(schema));
+
+    const fileStat = await fs.promises.lstat(
+      path.resolve(
+        os.homedir(),
+        `.serverless/artifacts/ajv-validate-${require('ajv/package').version}`,
+        schemaHash
+      )
+    );
+    expect(fileStat.isFile()).to.be.true;
+  });
+
+  it('regenerates schema validation file if schema changes', async () => {
+    await resolveAjvValidate(schema);
+    const updatedSchema = {
+      ...schema,
+      title: 'ChangedTitle',
+    };
+    await resolveAjvValidate(updatedSchema);
+    const schemaHash = objectHash(deepSortObjectByKey(updatedSchema));
+
+    const fileStat = await fs.promises.lstat(
+      path.resolve(
+        os.homedir(),
+        `.serverless/artifacts/ajv-validate-${require('ajv/package').version}`,
+        schemaHash
+      )
+    );
+    expect(fileStat.isFile()).to.be.true;
+  });
+});


### PR DESCRIPTION
Introduces caching of compiled `validate` for `ajv`. Unfortunately, the speedup is less than expected (at least from me), in CI it seems like we're saving at most one extra minute. It's noticeably faster on local environment, but it's not back to previous run times. Do you have any further suggestions @medikoo ? Only idea I have is caching it between test runs as tests still often have to regenerate that schema/validate file, which adds up for each separate module being tested

One additional consideration: Do you think we should scope schemas per `ajv` version as well? If yes, how would you go about it? I've toyed with trying to get it at runtime and the only way I can think of that works is parsing its package.json, which doesn't seem ideal. 

Closes: #8740 