### PR TITLE
test: Refactor compile layers tests to use `runServerless`

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "prettier-check:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier -c",
     "prettify": "prettier --write \"**/*.{css,html,js,json,md,yaml,yml}\"",
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier --write",
-    "test": "mocha \"test/unit/**/*.test.js\"",
+    "test": "mocha \"test/unit/**/*layers.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
     "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\""
   },

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "prettier-check:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier -c",
     "prettify": "prettier --write \"**/*.{css,html,js,json,md,yaml,yml}\"",
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier --write",
-    "test": "mocha \"test/unit/**/*layers.test.js\"",
+    "test": "mocha \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
     "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\""
   },

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -2,11 +2,6 @@
 
 const path = require('path');
 const chai = require('chai');
-const sinon = require('sinon');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const AwsCompileLayers = require('../../../../../../../lib/plugins/aws/package/compile/layers');
-const Serverless = require('../../../../../../../lib/Serverless');
-const { getTmpDirPath } = require('../../../../../../utils/fs');
 const runServerless = require('../../../../../../utils/run-serverless');
 
 chai.use(require('chai-as-promised'));
@@ -28,300 +23,6 @@ const awsRequestStubMap = {
   },
 };
 
-describe('AwsCompileLayers', () => {
-  let serverless;
-  let awsCompileLayers;
-  let awsProvider;
-  let providerRequestStub;
-
-  const layerName = 'test';
-  const compiledLayerName = 'TestLambdaLayer';
-
-  beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless(options);
-    awsProvider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', awsProvider);
-    serverless.cli = new serverless.classes.CLI();
-    serverless.config.servicePath = process.cwd();
-    awsCompileLayers = new AwsCompileLayers(serverless, options);
-    awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-      Outputs: {},
-    };
-    providerRequestStub = sinon.stub(awsCompileLayers.provider, 'request');
-
-    const serviceArtifact = 'new-service.zip';
-    const individualArtifact = 'test.zip';
-    awsCompileLayers.packagePath = getTmpDirPath();
-    // The contents of the test artifacts need to be predictable so the hashes stay the same
-    serverless.utils.writeFileSync(
-      path.join(awsCompileLayers.packagePath, serviceArtifact),
-      'foobar'
-    );
-    serverless.utils.writeFileSync(
-      path.join(awsCompileLayers.packagePath, individualArtifact),
-      'barbaz'
-    );
-
-    awsCompileLayers.serverless.service.service = 'new-service';
-    awsCompileLayers.serverless.service.package.artifactDirectoryName = 'somedir';
-    awsCompileLayers.serverless.service.package.artifact = path.join(
-      awsCompileLayers.packagePath,
-      serviceArtifact
-    );
-    awsCompileLayers.serverless.service.layers = {};
-    awsCompileLayers.serverless.service.layers[layerName] = {
-      name: 'test',
-      package: {
-        artifact: path.join(awsCompileLayers.packagePath, individualArtifact),
-      },
-      handler: 'handler.hello',
-    };
-
-    providerRequestStub.withArgs('CloudFormation', 'describeStacks').resolves({
-      Stacks: [
-        {
-          Outputs: [
-            { OutputKey: 'TestLambdaLayerHash', OutputValue: '1qaz' },
-            { OutputKey: 'TestLambdaLayerS3Key', OutputValue: 'a/b/c/foo.zip' },
-          ],
-        },
-      ],
-    });
-  });
-
-  describe('#compileLayers()', () => {
-    it('should use layer artifact if individually', () => {
-      awsCompileLayers.serverless.service.package.individually = true;
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        const layerResource =
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-            compiledLayerName
-          ];
-
-        const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-        const s3FileName = awsCompileLayers.serverless.service.layers[layerName].package.artifact
-          .split(path.sep)
-          .pop();
-
-        expect(layerResource.Properties.Content.S3Key).to.deep.equal(`${s3Folder}/${s3FileName}`);
-      });
-    });
-
-    it('should create a simple layer resource', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-      });
-    });
-
-    it('should create a layer resource with permissions', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-          allowedAccounts: ['*'],
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-      const compiledLayerVersion = {
-        Type: 'AWS::Lambda::LayerVersionPermission',
-        Properties: {
-          Action: 'lambda:GetLayerVersion',
-          LayerVersionArn: {
-            Ref: 'TestLambdaLayer',
-          },
-          Principal: '*',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestWildLambdaLayerPermission
-        ).to.deep.equal(compiledLayerVersion);
-      });
-    });
-
-    it('should create a layer resource with permissions per account', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-          allowedAccounts: ['1111111', '2222222'],
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-      const compiledLayerVersionNumber = {
-        Type: 'AWS::Lambda::LayerVersionPermission',
-        Properties: {
-          Action: 'lambda:GetLayerVersion',
-          LayerVersionArn: {
-            Ref: 'TestLambdaLayer',
-          },
-          Principal: '1111111',
-        },
-      };
-
-      const compiledLayerVersionString = {
-        Type: 'AWS::Lambda::LayerVersionPermission',
-        Properties: {
-          Action: 'lambda:GetLayerVersion',
-          LayerVersionArn: {
-            Ref: 'TestLambdaLayer',
-          },
-          Principal: '2222222',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .Test1111111LambdaLayerPermission
-        ).to.deep.equal(compiledLayerVersionNumber);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .Test2222222LambdaLayerPermission
-        ).to.deep.equal(compiledLayerVersionString);
-      });
-    });
-
-    it('should create a layer resource with metadata options set', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-          description: 'desc',
-          compatibleRuntimes: ['nodejs12.x'],
-          licenseInfo: 'GPL',
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-          Description: 'desc',
-          CompatibleRuntimes: ['nodejs12.x'],
-          LicenseInfo: 'GPL',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-      });
-    });
-  });
-});
-
 describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
   let cfResources;
   let naming;
@@ -339,6 +40,17 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
           individually: true,
         },
         layers: {
+          layerOne: {
+            path: 'layer',
+            allowedAccounts: ['*'],
+          },
+          layerTwo: {
+            description: 'Layer two example',
+            path: 'layer',
+            compatibleRuntimes: ['nodejs12.x'],
+            licenseInfo: 'GPL',
+            allowedAccounts: ['123456789012', '123456789013'],
+          },
           layerRetain: {
             path: 'layer',
             retain: true,
@@ -364,7 +76,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     expect(layerResource.Properties.Content.S3Key).to.be.equal(`${s3Folder}/${s3FileName}`);
   });
 
-  it('TODO: should generate expected layer version resource', () => {
+  it('should generate expected layer version resource', () => {
     const resourceName = 'layer';
     const layerResource = cfResources[naming.getLambdaLayerLogicalId(resourceName)];
     const s3Folder = service.package.artifactDirectoryName;
@@ -373,12 +85,12 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     expect(layerResource.Type).to.be.equals('AWS::Lambda::LayerVersion');
     expect(layerResource.Properties.Content.S3Key).to.be.equal(`${s3Folder}/${s3FileName}`);
     expect(layerResource.Properties.LayerName).to.be.equal('layer');
-    expect(layerResource.Properties.Content.S3Bucket.ref).to.be.equal('ServerlessDeploymentBucket');
+    expect(layerResource.Properties.Content.S3Bucket.Ref).to.be.equal('ServerlessDeploymentBucket');
 
     expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(
       'Current Lambda layer version'
     );
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value).to.be.equals('LayerLambdaLayer');
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
   });
 
   describe('`layers[].retain` property', () => {
@@ -417,33 +129,96 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
         awsRequestStubMap,
       });
       expect(firstCfResources).to.have.property(firstLayerResourceName);
-      // Replaces
-      // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L147-L329
     });
   });
 
-  it.skip('TODO: should generate expected permissions resource', () => {
-    // Replaces
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L331-L383
+  it('should generate expected permissions resource', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerOne');
+    const layerOne = cfResources[layerResourceName];
+    const s3Folder = service.package.artifactDirectoryName;
+    const s3FileName = service.layers.layerOne.package.artifact.split(path.sep).pop();
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.Content.S3Key).to.be.equals(`${s3Folder}/${s3FileName}`);
+    expect(layerOne.Properties.Content.S3Bucket.Ref).to.be.equals('ServerlessDeploymentBucket');
+    expect(layerOne.Properties.LayerName).to.be.equals('layerOne');
+
+    const description = 'Current Lambda layer version';
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(description);
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
+
+    const layerNamePermission = naming.getLambdaLayerPermissionLogicalId('LayerOne', 'Wild');
+    const layerPermission = cfResources[layerNamePermission];
+
+    expect(layerPermission.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermission.Properties.Action).to.be.equals('lambda:GetLayerVersion');
+    expect(layerPermission.Properties.LayerVersionArn.Ref).to.be.equals('LayerOneLambdaLayer');
+    expect(layerPermission.Properties.Principal).to.be.equals('*');
   });
 
-  it.skip('TODO: should support `layers[].allowedAccounts`', () => {
-    // Replaces
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L331-L452
+  it('should support `layers[].allowedAccounts`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+    const s3Folder = service.package.artifactDirectoryName;
+    const s3FileName = service.layers.layerOne.package.artifact.split(path.sep).pop();
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.Content.S3Key).to.be.equals(`${s3Folder}/${s3FileName}`);
+    expect(layerOne.Properties.Content.S3Bucket.Ref).to.be.equals('ServerlessDeploymentBucket');
+    expect(layerOne.Properties.LayerName).to.be.equals('layerTwo');
+
+    const description = 'Current Lambda layer version';
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(description);
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
+
+    const layerNamePermissionFirstUser = naming.getLambdaLayerPermissionLogicalId(
+      'layerTwo',
+      '123456789012'
+    );
+    const layerPermissionFirstUser = cfResources[layerNamePermissionFirstUser];
+
+    expect(layerPermissionFirstUser.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermissionFirstUser.Properties.Action).to.be.equals('lambda:GetLayerVersion');
+    expect(layerPermissionFirstUser.Properties.LayerVersionArn.Ref).to.be.equals(
+      'LayerTwoLambdaLayer'
+    );
+    expect(layerPermissionFirstUser.Properties.Principal).to.be.equals('123456789012');
+
+    const layerNamePermissionUserSecond = naming.getLambdaLayerPermissionLogicalId(
+      'layerTwo',
+      '123456789013'
+    );
+    const layerPermissionSecondUser = cfResources[layerNamePermissionUserSecond];
+
+    expect(layerPermissionSecondUser.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermissionSecondUser.Properties.Action).to.be.equals('lambda:GetLayerVersion');
+    expect(layerPermissionSecondUser.Properties.LayerVersionArn.Ref).to.be.equals(
+      'LayerTwoLambdaLayer'
+    );
+    expect(layerPermissionSecondUser.Properties.Principal).to.be.equals('123456789013');
   });
 
-  it.skip('TODO: should support `layers[].description`', () => {
-    // Replaces partially
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L454-L497
+  it('should support `layers[].description`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.Description).to.be.equals('Layer two example');
   });
 
-  it.skip('TODO: should support `layers[].compatibleRuntimes`', () => {
-    // Replaces partially
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L454-L497
+  it('should support `layers[].compatibleRuntimes`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.CompatibleRuntimes).to.be.deep.equals(['nodejs12.x']);
   });
 
-  it.skip('TODO: should support `layers[].licenseInfo`', () => {
-    // Replaces partially
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L454-L497
+  it('should support `layers[].licenseInfo`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.LicenseInfo).to.be.deep.equals('GPL');
   });
 });

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -2,11 +2,6 @@
 
 const path = require('path');
 const chai = require('chai');
-const sinon = require('sinon');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const AwsCompileLayers = require('../../../../../../../lib/plugins/aws/package/compile/layers');
-const Serverless = require('../../../../../../../lib/Serverless');
-const { getTmpDirPath } = require('../../../../../../utils/fs');
 const runServerless = require('../../../../../../utils/run-serverless');
 
 chai.use(require('chai-as-promised'));
@@ -28,300 +23,6 @@ const awsRequestStubMap = {
   },
 };
 
-describe('AwsCompileLayers', () => {
-  let serverless;
-  let awsCompileLayers;
-  let awsProvider;
-  let providerRequestStub;
-
-  const layerName = 'test';
-  const compiledLayerName = 'TestLambdaLayer';
-
-  beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless(options);
-    awsProvider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', awsProvider);
-    serverless.cli = new serverless.classes.CLI();
-    serverless.config.servicePath = process.cwd();
-    awsCompileLayers = new AwsCompileLayers(serverless, options);
-    awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-      Outputs: {},
-    };
-    providerRequestStub = sinon.stub(awsCompileLayers.provider, 'request');
-
-    const serviceArtifact = 'new-service.zip';
-    const individualArtifact = 'test.zip';
-    awsCompileLayers.packagePath = getTmpDirPath();
-    // The contents of the test artifacts need to be predictable so the hashes stay the same
-    serverless.utils.writeFileSync(
-      path.join(awsCompileLayers.packagePath, serviceArtifact),
-      'foobar'
-    );
-    serverless.utils.writeFileSync(
-      path.join(awsCompileLayers.packagePath, individualArtifact),
-      'barbaz'
-    );
-
-    awsCompileLayers.serverless.service.service = 'new-service';
-    awsCompileLayers.serverless.service.package.artifactDirectoryName = 'somedir';
-    awsCompileLayers.serverless.service.package.artifact = path.join(
-      awsCompileLayers.packagePath,
-      serviceArtifact
-    );
-    awsCompileLayers.serverless.service.layers = {};
-    awsCompileLayers.serverless.service.layers[layerName] = {
-      name: 'test',
-      package: {
-        artifact: path.join(awsCompileLayers.packagePath, individualArtifact),
-      },
-      handler: 'handler.hello',
-    };
-
-    providerRequestStub.withArgs('CloudFormation', 'describeStacks').resolves({
-      Stacks: [
-        {
-          Outputs: [
-            { OutputKey: 'TestLambdaLayerHash', OutputValue: '1qaz' },
-            { OutputKey: 'TestLambdaLayerS3Key', OutputValue: 'a/b/c/foo.zip' },
-          ],
-        },
-      ],
-    });
-  });
-
-  describe('#compileLayers()', () => {
-    it('should use layer artifact if individually', () => {
-      awsCompileLayers.serverless.service.package.individually = true;
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        const layerResource =
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-            compiledLayerName
-          ];
-
-        const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-        const s3FileName = awsCompileLayers.serverless.service.layers[layerName].package.artifact
-          .split(path.sep)
-          .pop();
-
-        expect(layerResource.Properties.Content.S3Key).to.deep.equal(`${s3Folder}/${s3FileName}`);
-      });
-    });
-
-    it('should create a simple layer resource', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-      });
-    });
-
-    it('should create a layer resource with permissions', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-          allowedAccounts: ['*'],
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-      const compiledLayerVersion = {
-        Type: 'AWS::Lambda::LayerVersionPermission',
-        Properties: {
-          Action: 'lambda:GetLayerVersion',
-          LayerVersionArn: {
-            Ref: 'TestLambdaLayer',
-          },
-          Principal: '*',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestWildLambdaLayerPermission
-        ).to.deep.equal(compiledLayerVersion);
-      });
-    });
-
-    it('should create a layer resource with permissions per account', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-          allowedAccounts: ['1111111', '2222222'],
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-      const compiledLayerVersionNumber = {
-        Type: 'AWS::Lambda::LayerVersionPermission',
-        Properties: {
-          Action: 'lambda:GetLayerVersion',
-          LayerVersionArn: {
-            Ref: 'TestLambdaLayer',
-          },
-          Principal: '1111111',
-        },
-      };
-
-      const compiledLayerVersionString = {
-        Type: 'AWS::Lambda::LayerVersionPermission',
-        Properties: {
-          Action: 'lambda:GetLayerVersion',
-          LayerVersionArn: {
-            Ref: 'TestLambdaLayer',
-          },
-          Principal: '2222222',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .Test1111111LambdaLayerPermission
-        ).to.deep.equal(compiledLayerVersionNumber);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .Test2222222LambdaLayerPermission
-        ).to.deep.equal(compiledLayerVersionString);
-      });
-    });
-
-    it('should create a layer resource with metadata options set', () => {
-      const s3Folder = awsCompileLayers.serverless.service.package.artifactDirectoryName;
-      const s3FileName = awsCompileLayers.serverless.service.layers.test.package.artifact
-        .split(path.sep)
-        .pop();
-      awsCompileLayers.serverless.service.layers = {
-        test: {
-          path: 'layer',
-          description: 'desc',
-          compatibleRuntimes: ['nodejs12.x'],
-          licenseInfo: 'GPL',
-        },
-      };
-      const compiledLayer = {
-        Type: 'AWS::Lambda::LayerVersion',
-        Properties: {
-          Content: {
-            S3Key: `${s3Folder}/${s3FileName}`,
-            S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
-          },
-          LayerName: 'test',
-          Description: 'desc',
-          CompatibleRuntimes: ['nodejs12.x'],
-          LicenseInfo: 'GPL',
-        },
-      };
-      const compiledLayerOutput = {
-        Description: 'Current Lambda layer version',
-        Value: {
-          Ref: 'TestLambdaLayer',
-        },
-      };
-
-      return expect(awsCompileLayers.compileLayers()).to.be.fulfilled.then(() => {
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Resources
-            .TestLambdaLayer
-        ).to.deep.equal(compiledLayer);
-        expect(
-          awsCompileLayers.serverless.service.provider.compiledCloudFormationTemplate.Outputs
-            .TestLambdaLayerQualifiedArn
-        ).to.deep.equal(compiledLayerOutput);
-      });
-    });
-  });
-});
-
 describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
   let cfResources;
   let naming;
@@ -339,6 +40,17 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
           individually: true,
         },
         layers: {
+          layerOne: {
+            path: 'layer',
+            allowedAccounts: ['*'],
+          },
+          layerTwo: {
+            description: 'Layer two example',
+            path: 'layer',
+            compatibleRuntimes: ['nodejs12.x'],
+            licenseInfo: 'GPL',
+            allowedAccounts: ['123456789012', '123456789013'],
+          },
           layerRetain: {
             path: 'layer',
             retain: true,
@@ -364,7 +76,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     expect(layerResource.Properties.Content.S3Key).to.be.equal(`${s3Folder}/${s3FileName}`);
   });
 
-  it('TODO: should generate expected layer version resource', () => {
+  it('should generate expected layer version resource', () => {
     const resourceName = 'layer';
     const layerResource = cfResources[naming.getLambdaLayerLogicalId(resourceName)];
     const s3Folder = service.package.artifactDirectoryName;
@@ -373,12 +85,12 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     expect(layerResource.Type).to.be.equals('AWS::Lambda::LayerVersion');
     expect(layerResource.Properties.Content.S3Key).to.be.equal(`${s3Folder}/${s3FileName}`);
     expect(layerResource.Properties.LayerName).to.be.equal('layer');
-    expect(layerResource.Properties.Content.S3Bucket.ref).to.be.equal('ServerlessDeploymentBucket');
+    expect(layerResource.Properties.Content.S3Bucket.Ref).to.be.equal('ServerlessDeploymentBucket');
 
     expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(
       'Current Lambda layer version'
     );
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value).to.be.equals('LayerLambdaLayer');
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
   });
 
   describe('`layers[].retain` property', () => {
@@ -417,33 +129,96 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
         awsRequestStubMap,
       });
       expect(firstCfResources).to.have.property(firstLayerResourceName);
-      // Replaces
-      // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L147-L329
     });
   });
 
-  it.skip('TODO: should generate expected permissions resource', () => {
-    // Replaces
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L331-L383
+  it('should generate expected permissions resource', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerOne');
+    const layerOne = cfResources[layerResourceName];
+    const s3Folder = service.package.artifactDirectoryName;
+    const s3FileName = service.layers.layerOne.package.artifact.split(path.sep).pop();
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.Content.S3Key).to.be.equals(`${s3Folder}/${s3FileName}`);
+    expect(layerOne.Properties.Content.S3Bucket.Ref).to.be.equals('ServerlessDeploymentBucket');
+    expect(layerOne.Properties.LayerName).to.be.equals('layerOne');
+
+    const description = 'Current Lambda layer version';
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(description);
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
+
+    const layerNamePermission = naming.getLambdaLayerPermissionLogicalId('LayerOne', 'Wild');
+    const layerPermission = cfResources[layerNamePermission];
+
+    expect(layerPermission.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermission.Properties.Action).to.be.equals('lambda:GetLayerVersion');
+    expect(layerPermission.Properties.LayerVersionArn.Ref).to.be.equals('LayerOneLambdaLayer');
+    expect(layerPermission.Properties.Principal).to.be.equals('*');
   });
 
-  it.skip('TODO: should support `layers[].allowedAccounts`', () => {
-    // Replaces
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L331-L452
+  it('should support `layers[].allowedAccounts`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerTwo = cfResources[layerResourceName];
+    const s3Folder = service.package.artifactDirectoryName;
+    const s3FileName = service.layers.layerTwo.package.artifact.split(path.sep).pop();
+
+    expect(layerTwo.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerTwo.Properties.Content.S3Key).to.be.equals(`${s3Folder}/${s3FileName}`);
+    expect(layerTwo.Properties.Content.S3Bucket.Ref).to.be.equals('ServerlessDeploymentBucket');
+    expect(layerTwo.Properties.LayerName).to.be.equals('layerTwo');
+
+    const description = 'Current Lambda layer version';
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(description);
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
+
+    const layerNamePermissionFirstUser = naming.getLambdaLayerPermissionLogicalId(
+      'layerTwo',
+      '123456789012'
+    );
+    const layerPermissionFirstUser = cfResources[layerNamePermissionFirstUser];
+
+    expect(layerPermissionFirstUser.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermissionFirstUser.Properties.Action).to.be.equals('lambda:GetLayerVersion');
+    expect(layerPermissionFirstUser.Properties.LayerVersionArn.Ref).to.be.equals(
+      'LayerTwoLambdaLayer'
+    );
+    expect(layerPermissionFirstUser.Properties.Principal).to.be.equals('123456789012');
+
+    const layerNamePermissionUserSecond = naming.getLambdaLayerPermissionLogicalId(
+      'layerTwo',
+      '123456789013'
+    );
+    const layerPermissionSecondUser = cfResources[layerNamePermissionUserSecond];
+
+    expect(layerPermissionSecondUser.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermissionSecondUser.Properties.Action).to.be.equals('lambda:GetLayerVersion');
+    expect(layerPermissionSecondUser.Properties.LayerVersionArn.Ref).to.be.equals(
+      'LayerTwoLambdaLayer'
+    );
+    expect(layerPermissionSecondUser.Properties.Principal).to.be.equals('123456789013');
   });
 
-  it.skip('TODO: should support `layers[].description`', () => {
-    // Replaces partially
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L454-L497
+  it('should support `layers[].description`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.Description).to.be.equals('Layer two example');
   });
 
-  it.skip('TODO: should support `layers[].compatibleRuntimes`', () => {
-    // Replaces partially
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L454-L497
+  it('should support `layers[].compatibleRuntimes`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.CompatibleRuntimes).to.be.deep.equals(['nodejs12.x']);
   });
 
-  it.skip('TODO: should support `layers[].licenseInfo`', () => {
-    // Replaces partially
-    // https://github.com/serverless/serverless/blob/e78f695004bf292c4163daf9705e5e0c6cbe2592/test/unit/lib/plugins/aws/package/compile/layers/index.test.js#L454-L497
+  it('should support `layers[].licenseInfo`', () => {
+    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
+    const layerOne = cfResources[layerResourceName];
+
+    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.LicenseInfo).to.be.deep.equals('GPL');
   });
 });

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -32,7 +32,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
   let cfOutputs;
 
   before(async () => {
-    const test = await runServerless({
+    const { awsNaming, cfTemplate, fixtureData, serverless } = await runServerless({
       fixture: 'layer',
       cliArgs: ['package'],
       configExt: {
@@ -59,7 +59,6 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
       },
       awsRequestStubMap,
     });
-    const { awsNaming, cfTemplate, fixtureData, serverless } = test;
     cfResources = cfTemplate.Resources;
     cfOutputs = cfTemplate.Outputs;
     naming = awsNaming;

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -72,7 +72,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const s3Folder = service.package.artifactDirectoryName;
     const s3FileName = service.layers[resourceName].package.artifact.split(path.sep).pop();
 
-    expect(layerResource.Properties.Content.S3Key).to.be.equal(`${s3Folder}/${s3FileName}`);
+    expect(layerResource.Properties.Content.S3Key).to.equal(`${s3Folder}/${s3FileName}`);
   });
 
   it('should generate expected layer version resource', () => {
@@ -81,15 +81,15 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const s3Folder = service.package.artifactDirectoryName;
     const s3FileName = service.layers[resourceName].package.artifact.split(path.sep).pop();
 
-    expect(layerResource.Type).to.be.equals('AWS::Lambda::LayerVersion');
-    expect(layerResource.Properties.Content.S3Key).to.be.equal(`${s3Folder}/${s3FileName}`);
-    expect(layerResource.Properties.LayerName).to.be.equal('layer');
-    expect(layerResource.Properties.Content.S3Bucket.Ref).to.be.equal('ServerlessDeploymentBucket');
+    expect(layerResource.Type).to.equals('AWS::Lambda::LayerVersion');
+    expect(layerResource.Properties.Content.S3Key).to.equal(`${s3Folder}/${s3FileName}`);
+    expect(layerResource.Properties.LayerName).to.equal('layer');
+    expect(layerResource.Properties.Content.S3Bucket.Ref).to.equal('ServerlessDeploymentBucket');
 
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.equals(
       'Current Lambda layer version'
     );
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
+    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.equals('LayerLambdaLayer');
   });
 
   describe('`layers[].retain` property', () => {
@@ -132,84 +132,44 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
   });
 
   it('should generate expected permissions resource', () => {
-    const layerResourceName = naming.getLambdaLayerLogicalId('LayerOne');
-    const layerOne = cfResources[layerResourceName];
-    const s3Folder = service.package.artifactDirectoryName;
-    const s3FileName = service.layers.layerOne.package.artifact.split(path.sep).pop();
-
-    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.Content.S3Key).to.be.equals(`${s3Folder}/${s3FileName}`);
-    expect(layerOne.Properties.Content.S3Bucket.Ref).to.be.equals('ServerlessDeploymentBucket');
-    expect(layerOne.Properties.LayerName).to.be.equals('layerOne');
-
-    const description = 'Current Lambda layer version';
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(description);
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
-
     const layerNamePermission = naming.getLambdaLayerPermissionLogicalId('LayerOne', 'Wild');
     const layerPermission = cfResources[layerNamePermission];
 
-    expect(layerPermission.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
-    expect(layerPermission.Properties.Action).to.be.equals('lambda:GetLayerVersion');
-    expect(layerPermission.Properties.LayerVersionArn.Ref).to.be.equals('LayerOneLambdaLayer');
-    expect(layerPermission.Properties.Principal).to.be.equals('*');
+    expect(layerPermission.Type).to.equals('AWS::Lambda::LayerVersionPermission');
+    expect(layerPermission.Properties.Action).to.equals('lambda:GetLayerVersion');
+    expect(layerPermission.Properties.LayerVersionArn.Ref).to.equals('LayerOneLambdaLayer');
+    expect(layerPermission.Properties.Principal).to.equals('*');
   });
 
   it('should support `layers[].allowedAccounts`', () => {
-    const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
-    const layerTwo = cfResources[layerResourceName];
-    const s3Folder = service.package.artifactDirectoryName;
-    const s3FileName = service.layers.layerTwo.package.artifact.split(path.sep).pop();
-
-    expect(layerTwo.Type).to.be.equals('AWS::Lambda::LayerVersion');
-    expect(layerTwo.Properties.Content.S3Key).to.be.equals(`${s3Folder}/${s3FileName}`);
-    expect(layerTwo.Properties.Content.S3Bucket.Ref).to.be.equals('ServerlessDeploymentBucket');
-    expect(layerTwo.Properties.LayerName).to.be.equals('layerTwo');
-
-    const description = 'Current Lambda layer version';
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Description).to.be.equals(description);
-    expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.be.equals('LayerLambdaLayer');
-
     const layerNamePermissionFirstUser = naming.getLambdaLayerPermissionLogicalId(
       'layerTwo',
       '123456789012'
     );
     const layerPermissionFirstUser = cfResources[layerNamePermissionFirstUser];
-
-    expect(layerPermissionFirstUser.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
-    expect(layerPermissionFirstUser.Properties.Action).to.be.equals('lambda:GetLayerVersion');
-    expect(layerPermissionFirstUser.Properties.LayerVersionArn.Ref).to.be.equals(
-      'LayerTwoLambdaLayer'
-    );
-    expect(layerPermissionFirstUser.Properties.Principal).to.be.equals('123456789012');
+    expect(layerPermissionFirstUser.Properties.Principal).to.equals('123456789012');
 
     const layerNamePermissionUserSecond = naming.getLambdaLayerPermissionLogicalId(
       'layerTwo',
       '123456789013'
     );
     const layerPermissionSecondUser = cfResources[layerNamePermissionUserSecond];
-
-    expect(layerPermissionSecondUser.Type).to.be.equals('AWS::Lambda::LayerVersionPermission');
-    expect(layerPermissionSecondUser.Properties.Action).to.be.equals('lambda:GetLayerVersion');
-    expect(layerPermissionSecondUser.Properties.LayerVersionArn.Ref).to.be.equals(
-      'LayerTwoLambdaLayer'
-    );
-    expect(layerPermissionSecondUser.Properties.Principal).to.be.equals('123456789013');
+    expect(layerPermissionSecondUser.Properties.Principal).to.equals('123456789013');
   });
 
   it('should support `layers[].description`', () => {
     const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
     const layerOne = cfResources[layerResourceName];
 
-    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.Description).to.be.equals('Layer two example');
+    expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Properties.Description).to.equals('Layer two example');
   });
 
   it('should support `layers[].compatibleRuntimes`', () => {
     const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
     const layerOne = cfResources[layerResourceName];
 
-    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
     expect(layerOne.Properties.CompatibleRuntimes).to.be.deep.equals(['nodejs12.x']);
   });
 
@@ -217,7 +177,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
     const layerOne = cfResources[layerResourceName];
 
-    expect(layerOne.Type).to.be.equals('AWS::Lambda::LayerVersion');
+    expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
     expect(layerOne.Properties.LicenseInfo).to.be.deep.equals('GPL');
   });
 });

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -170,7 +170,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerOne = cfResources[layerResourceName];
 
     expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.CompatibleRuntimes).to.be.deep.equals(['nodejs12.x']);
+    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs12.x']);
   });
 
   it('should support `layers[].licenseInfo`', () => {
@@ -178,6 +178,6 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerOne = cfResources[layerResourceName];
 
     expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.LicenseInfo).to.be.deep.equals('GPL');
+    expect(layerOne.Properties.LicenseInfo).to.deep.equals('GPL');
   });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
This PR is about refactoring test/unit/lib/plugins/aws/package/compile/layers.test.js to runServerless based variant.

Closes: #8585
