### PR TITLE
Very descriptive comment on usage of deploy function

### DIFF
--- a/docs/providers/aws/cli-reference/deploy-function.md
+++ b/docs/providers/aws/cli-reference/deploy-function.md
@@ -23,7 +23,12 @@ serverless deploy function -f functionName
 **Note:** This command **now** deploys both function configuration and code by
 default. Just as before, this puts your function in an inconsistent state that
 is out of sync with your CloudFormation stack. Use this for faster development
-cycles and not production deployments
+cycles and not production deployments. Some parts of serverless configuration
+that represent separate resources on Cloud Formation will NOT be updated. It
+will update functions that are triggered through alias, but not the alias itself
+ie. when you deploy a function using provisionedConcurrency this way, it will
+not update one associated through the alias in apiGateway. The scope of
+configuration updates is limited to properties that can be set on lambda.
 
 ## Options
 

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -56,7 +56,7 @@ class Deploy {
         },
         commands: {
           function: {
-            usage: 'Deploy a single function from the service',
+            usage: 'Deploy a single function from the service. The scope of the changes deployed through this command is limited to function code, memorySize and timeout. Some parts of serverless configuration that represeent separate resources on Cloud Formation will NOT be updated. It will fail updating functions that are triggered through alias - ie. when you deploy a function using provisionedConcurrency this way it will not update one associated through the alias in apiGateway',
             lifecycleEvents: ['initialize', 'packageFunction', 'deploy'],
             options: {
               'function': {

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -56,7 +56,8 @@ class Deploy {
         },
         commands: {
           function: {
-            usage: 'Deploy a single function from the service. The scope of the changes deployed through this command is limited to function code, memorySize and timeout. Some parts of serverless configuration that represeent separate resources on Cloud Formation will NOT be updated. It will fail updating functions that are triggered through alias - ie. when you deploy a function using provisionedConcurrency this way it will not update one associated through the alias in apiGateway',
+            usage:
+              'Deploy a single function from the service. The scope of the changes deployed through this command is limited to function code, memorySize and timeout. Some parts of serverless configuration that represeent separate resources on Cloud Formation will NOT be updated. It will fail updating functions that are triggered through alias - ie. when you deploy a function using provisionedConcurrency this way it will not update one associated through the alias in apiGateway',
             lifecycleEvents: ['initialize', 'packageFunction', 'deploy'],
             options: {
               'function': {

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -57,7 +57,7 @@ class Deploy {
         commands: {
           function: {
             usage:
-              'Deploy a single function from the service. The scope of the changes deployed through this command is limited to function code, memorySize and timeout. Some parts of serverless configuration that represeent separate resources on Cloud Formation will NOT be updated. It will fail updating functions that are triggered through alias - ie. when you deploy a function using provisionedConcurrency this way it will not update one associated through the alias in apiGateway',
+              'Deploy a single function from the service. It has limitations - read more here: https://github.com/serverless/serverless/blob/master/docs/providers/aws/cli-reference/deploy-function.md',
             lifecycleEvents: ['initialize', 'packageFunction', 'deploy'],
             options: {
               'function': {


### PR DESCRIPTION
Q1: https://github.com/serverless/serverless/issues/8752

Based on discussion here https://github.com/serverless/serverless/issues/8752
Basically when you have provisionedConcurrency set you can be confused as to why your lambdas are not updating after you run this command.
Looking for pointers where it belongs if not here

Closes: #{8752}
