### PR TITLE
AWS CloudFront: Fix deprecations visibility

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -187,7 +187,7 @@ class AwsCompileCloudFrontEvents {
     });
 
     this.hooks = {
-      'intialize': () => {
+      'initialize': () => {
         if (
           this.serverless.service.provider.name === 'aws' &&
           Object.values(this.serverless.service.functions).some(({ events }) =>


### PR DESCRIPTION
It appears that hook name was mistyped
