### PR TITLE
Fix using dashes in AWS resource tags, add unit tests

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -521,7 +521,7 @@ class AwsProvider {
           awsResourceTags: {
             type: 'object',
             patternProperties: {
-              '^(?!aws:)[\\w./=+:-_\\x20]{1,128}$': {
+              '^(?!aws:)[\\w./=+:\\-_\\x20]{1,128}$': {
                 type: 'string',
                 maxLength: 256,
               },

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1464,8 +1464,10 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               securityGroupIds: ['sg-0a0a0a0a'],
             },
             tags: {
-              providerTagA: 'providerTagAValue',
-              providerTagB: 'providerTagBValue',
+              'providerTagA': 'providerTagAValue',
+              'providerTagB': 'providerTagBValue',
+              'provider:tagC': 'providerTagCValue',
+              'provider:tag-D': 'providerTagDValue',
             },
             tracing: {
               lambda: 'Active',


### PR DESCRIPTION
This regular expression has been broken before, it's time it gets tested properly

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #8764

I'm not sure whether `naming.js` is the best location to move the regular expression to, but it was the best I could find given that I'm not familiar with the codebase.