### PR TITLE
Tests: Do not use Mocha parallel mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "prettier-check:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier -c",
     "prettify": "prettier --write \"**/*.{css,html,js,json,md,yaml,yml}\"",
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier --write",
-    "test": "mocha --parallel \"test/unit/**/*.test.js\"",
+    "test": "mocha \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
     "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\""
   },


### PR DESCRIPTION
I've observed locally that unhandled rejections are not reported in some scenarios with Mocha `--parallel` mode 

e.g. I've added:

```javascript
require('fs').promises.readFile('foo');
```

at https://github.com/serverless/serverless/blob/461a3965a52eb9707121700608dc8bdbafc367d1/test/unit/lib/plugins/package/lib/packageService.test.js#L673 and `npm test` passed green. After removing `--parallel` from `test` script configuration, unhandled rejection is reported deterministically.


Wanted to report to Mocha, and for that tested without our [patch](https://github.com/serverless/test/blob/ecdb52dc8fda4d7f73662e41930528b2b91a6d45/setup/patch.js#L47-L50) applied, but then tens of other fails surfaced clearly showing that  something is broken in `--parallel` mode in general

