### PR TITLE
fix(AWS CloudFront): Fix check for deprecated CacheBehavior properties

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -196,9 +196,9 @@ class AwsCompileCloudFrontEvents {
               if (!behaviorConfig) return false;
               return (
                 behaviorConfig.ForwardedValues ||
-                behaviorConfig.MinTTL !== null ||
-                behaviorConfig.MaxTTL !== null ||
-                behaviorConfig.DefaultTTL !== null
+                behaviorConfig.MinTTL !== undefined ||
+                behaviorConfig.MaxTTL !== undefined ||
+                behaviorConfig.DefaultTTL !== undefined
               );
             })
           )
@@ -418,9 +418,9 @@ class AwsCompileCloudFrontEvents {
             if (event.cloudFront.behavior) {
               if (
                 event.cloudFront.behavior.ForwardedValues ||
-                event.cloudFront.behavior.MinTTL !== null ||
-                event.cloudFront.behavior.MaxTTL !== null ||
-                event.cloudFront.behavior.DefaultTTL !== null
+                event.cloudFront.behavior.MinTTL !== undefined ||
+                event.cloudFront.behavior.MaxTTL !== undefined ||
+                event.cloudFront.behavior.DefaultTTL !== undefined
               ) {
                 behavior.ForwardedValues = { QueryString: false };
                 shouldAssignCachePolicy = false;

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
@@ -1803,6 +1803,36 @@ describe('lib/plugins/aws/package/compile/events/cloudFront/index.new.test.js', 
         'CACHE_POLICY_ID_AND_DEPRECATED_FIELDS_USED'
       );
     });
+
+    it('Should not throw if lambda config includes AllowedMethods or CachedMethods behavior values and cache policy reference', async () => {
+      const cachePolicyId = '08627262-05a9-4f76-9ded-b50ca2e3a84f';
+      await runServerless({
+        fixture: 'function',
+        cliArgs: ['package'],
+        configExt: {
+          functions: {
+            foo: {
+              handler: 'myLambdaAtEdge.handler',
+              events: [
+                {
+                  cloudFront: {
+                    origin: 's3://bucketname.s3.amazonaws.com/files',
+                    eventType: 'viewer-response',
+                    behavior: {
+                      AllowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+                      CachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+                    },
+                    cachePolicy: {
+                      id: cachePolicyId,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
   });
 
   describe.skip('TODO: Alternative cases', () => {


### PR DESCRIPTION
While trying to add a lambda@edge function with a cloudfront event, I ran into an issue. I assume that this is an edge case, which is why it wasn't caught so far:

My cloudFront event is specifying a cachePolicy and at the same time a behavior with AllowedMethods and CachedMethods. Independently they work as expected, but when combining them, a broken check triggers.

That check tests for deprecated properties, but instead of checking for the values being `undefined`, it checks if they are `null`, which is not a valid value in regards to CloudFormation.

This PR fixes that check and introduces a unit test to make sure it won't break again in the future.
