### PR TITLE
fix(AWS Lambda): Ensure ECR repository name is lowercased

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -641,6 +641,6 @@ module.exports = {
   getEcrRepositoryName() {
     const serviceName = this.provider.serverless.service.getServiceName();
     const stage = this.provider.getStage();
-    return `serverless-${serviceName}-${stage}`;
+    return `serverless-${serviceName}-${stage}`.toLowerCase();
   },
 };


### PR DESCRIPTION
Fix issue that was revealed by: https://github.com/serverless/serverless/runs/1720823233?check_suite_focus=true

It can be caused if `service` name contains uppercased letters.