### PR TITLE
fix(AWS Lambda): Ensure to attempt ECR login on expired token

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1753,7 +1753,8 @@ class AwsProvider {
       if (
         !options.isLoggedIn &&
         err.stdBuffer &&
-        err.stdBuffer.includes('no basic auth credentials')
+        (err.stdBuffer.includes('no basic auth credentials') ||
+          err.stdBuffer.includes('authorization token has expired'))
       ) {
         await this.dockerLoginToEcr();
         return await this.dockerPushToEcr(remoteTag, { isLoggedIn: true });


### PR DESCRIPTION
When live testing today I've noticed the change to only attempt ECR login had a bug and didn't support case where token was present but expired. This PR aims to fix that problem. 