### PR TITLE
Improve authorizer error messages to include function name and better grammar

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -403,14 +403,14 @@ Object.defineProperties(
             if (id) {
               if (!userConfig.id) {
                 throw new this.serverless.classes.Error(
-                  `Event references external authorizer '${id}', but httpApi is part of the current stack.`,
+                  `Event in function '${functionName}' references an external authorizer '${id}', but httpApi is part of the current stack.`,
                   'EXTERNAL_HTTP_API_AUTHORIZER_WITHOUT_EXTERNAL_HTTP_API'
                 );
               }
               routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(
-                `Event references not configured authorizer '${name}'`,
+                `Event in function '${functionName}' references an authorizer '${name}' that is not configured`,
                 'UNRECOGNIZED_HTTP_API_AUTHORIZER'
               );
             } else {

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -295,16 +295,18 @@ Object.defineProperties(
           //     'INVALID_HTTP_API_AUTHORIZER'
           //   );
           // }
-          if (/*authorizerConfig.type.toUpperCase() != "REQUEST" && */ !authorizerConfig.identitySource) {
+          if (
+            /*authorizerConfig.type.toUpperCase() != "REQUEST" && */ !authorizerConfig.identitySource
+          ) {
             throw new this.serverless.classes.Error(
-//              `Authorizer '${name}' for httpApi in provider with type '${authorizerConfig.type}' must have an identitySource`,
+              //              `Authorizer '${name}' for httpApi in provider with type '${authorizerConfig.type}' must have an identitySource`,
               `Authorizer '${name}' for httpApi in provider must have an identitySource`,
               'INVALID_HTTP_API_AUTHORIZER'
             );
           }
           authorizers.set(name, {
             name: authorizerConfig.name || name,
-        //    type: authorizerConfig.type,
+            //    type: authorizerConfig.type,
             identitySource: authorizerConfig.identitySource,
             issuerUrl: authorizerConfig.issuerUrl,
             audience: toSet(authorizerConfig.audience),

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -410,7 +410,7 @@ Object.defineProperties(
               routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(
-                `Event in function '${functionName}' references an authorizer '${name}' that is not configured`,
+                `Event in function '${functionName}' references an authorizer '${name}' that does not have a name`,
                 'UNRECOGNIZED_HTTP_API_AUTHORIZER'
               );
             } else {

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -410,7 +410,7 @@ Object.defineProperties(
               routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(
-                `Event in function '${functionName}' references an authorizer '${name}' that does not have a name`,
+                `Event in function '${functionName}' references an authorizer '${name}' that is not configured`,
                 'UNRECOGNIZED_HTTP_API_AUTHORIZER'
               );
             } else {

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -287,26 +287,16 @@ Object.defineProperties(
           );
         }
         for (const [name, authorizerConfig] of Object.entries(userAuthorizers)) {
-          // todo uncomment code when authorizer type is supported
-
-          // if (!authorizerConfig.type) {
-          //   throw new this.serverless.classes.Error(
-          //     `Authorizer '${name}' for httpApi in provider must have type specified`,
-          //     'INVALID_HTTP_API_AUTHORIZER'
-          //   );
-          // }
           if (
-            /* authorizerConfig.type.toUpperCase() != "REQUEST" && */ !authorizerConfig.identitySource
+            !authorizerConfig.identitySource
           ) {
             throw new this.serverless.classes.Error(
-              //              `Authorizer '${name}' for httpApi in provider with type '${authorizerConfig.type}' must have an identitySource`,
               `Authorizer '${name}' for httpApi in provider must have an identitySource`,
               'INVALID_HTTP_API_AUTHORIZER'
             );
           }
           authorizers.set(name, {
             name: authorizerConfig.name || name,
-            //    type: authorizerConfig.type,
             identitySource: authorizerConfig.identitySource,
             issuerUrl: authorizerConfig.issuerUrl,
             audience: toSet(authorizerConfig.audience),

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -274,6 +274,12 @@ Object.defineProperties(
       const userAuthorizers = userConfig.authorizers;
       const authorizers = (this.config.authorizers = new Map());
       if (userAuthorizers) {
+        if (typeof userAuthorizers != 'object') {
+          throw new this.serverless.classes.Error(
+            `serverless.yaml is malformed at provider httpApi authorizers - should be an object with names as keys`,
+            'MALFORMED_YAML'
+          );
+        }
         if (userConfig.id) {
           throw new this.serverless.classes.Error(
             'Cannot setup authorizers for externally configured HTTP API',
@@ -281,8 +287,24 @@ Object.defineProperties(
           );
         }
         for (const [name, authorizerConfig] of Object.entries(userAuthorizers)) {
+          //todo uncomment code when authorizer type is supported
+
+          // if (!authorizerConfig.type) {
+          //   throw new this.serverless.classes.Error(
+          //     `Authorizer '${name}' for httpApi in provider must have type specified`,
+          //     'INVALID_HTTP_API_AUTHORIZER'
+          //   );
+          // }
+          if (/*authorizerConfig.type.toUpperCase() != "REQUEST" && */ !authorizerConfig.identitySource) {
+            throw new this.serverless.classes.Error(
+//              `Authorizer '${name}' for httpApi in provider with type '${authorizerConfig.type}' must have an identitySource`,
+              `Authorizer '${name}' for httpApi in provider must have an identitySource`,
+              'INVALID_HTTP_API_AUTHORIZER'
+            );
+          }
           authorizers.set(name, {
             name: authorizerConfig.name || name,
+        //    type: authorizerConfig.type,
             identitySource: authorizerConfig.identitySource,
             issuerUrl: authorizerConfig.issuerUrl,
             audience: toSet(authorizerConfig.audience),
@@ -410,7 +432,7 @@ Object.defineProperties(
               routeConfig.authorizer = { id };
             } else if (!authorizers.has(name)) {
               throw new this.serverless.classes.Error(
-                `Event in function '${functionName}' references an authorizer '${name}' that is not configured`,
+                `Event in function '${functionName}' references an authorizer '${name}' that is not configured in the provider httpApi section`,
                 'UNRECOGNIZED_HTTP_API_AUTHORIZER'
               );
             } else {

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -274,9 +274,9 @@ Object.defineProperties(
       const userAuthorizers = userConfig.authorizers;
       const authorizers = (this.config.authorizers = new Map());
       if (userAuthorizers) {
-        if (typeof userAuthorizers != 'object') {
+        if (typeof userAuthorizers !== 'object') {
           throw new this.serverless.classes.Error(
-            `serverless.yaml is malformed at provider httpApi authorizers - should be an object with names as keys`,
+            'serverless.yaml is malformed at provider httpApi authorizers - should be an object with names as keys',
             'MALFORMED_YAML'
           );
         }
@@ -287,7 +287,7 @@ Object.defineProperties(
           );
         }
         for (const [name, authorizerConfig] of Object.entries(userAuthorizers)) {
-          //todo uncomment code when authorizer type is supported
+          // todo uncomment code when authorizer type is supported
 
           // if (!authorizerConfig.type) {
           //   throw new this.serverless.classes.Error(
@@ -296,7 +296,7 @@ Object.defineProperties(
           //   );
           // }
           if (
-            /*authorizerConfig.type.toUpperCase() != "REQUEST" && */ !authorizerConfig.identitySource
+            /* authorizerConfig.type.toUpperCase() != "REQUEST" && */ !authorizerConfig.identitySource
           ) {
             throw new this.serverless.classes.Error(
               //              `Authorizer '${name}' for httpApi in provider with type '${authorizerConfig.type}' must have an identitySource`,

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -287,9 +287,7 @@ Object.defineProperties(
           );
         }
         for (const [name, authorizerConfig] of Object.entries(userAuthorizers)) {
-          if (
-            !authorizerConfig.identitySource
-          ) {
+          if (!authorizerConfig.identitySource) {
             throw new this.serverless.classes.Error(
               `Authorizer '${name}' for httpApi in provider must have an identitySource`,
               'INVALID_HTTP_API_AUTHORIZER'


### PR DESCRIPTION
Very simple improvement to make error messages more informative.

Assists with diagnosing https://github.com/serverless/serverless/issues/8781
