### PR TITLE
fix: Complete async refactor for `aws/deploy` and `customResources`

### DIFF
--- a/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
+++ b/lib/plugins/aws/customResources/resources/apiGatewayCloudWatchRole/handler.js
@@ -3,7 +3,7 @@
 const { awsRequest, wait } = require('../utils');
 const { getEnvironment, handlerWrapper } = require('../utils');
 
-function handler(event, context) {
+async function handler(event, context) {
   if (event.RequestType === 'Create') {
     return create(event, context);
   } else if (event.RequestType === 'Update') {

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/userPool.js
@@ -26,7 +26,7 @@ function getUpdateConfigFromCurrentSetup(currentSetup) {
   return updatedConfig;
 }
 
-function findUserPoolByName(config) {
+async function findUserPoolByName(config) {
   const { userPoolName, region } = config;
 
   const payload = {
@@ -52,7 +52,7 @@ function findUserPoolByName(config) {
   return recursiveFind();
 }
 
-function getConfiguration(config) {
+async function getConfiguration(config) {
   const { region } = config;
 
   return findUserPoolByName(config).then((userPool) =>
@@ -62,7 +62,7 @@ function getConfiguration(config) {
   );
 }
 
-function updateConfiguration(config) {
+async function updateConfiguration(config) {
   const { lambdaArn, userPoolConfigs, region } = config;
 
   return getConfiguration(config).then((res) => {
@@ -92,7 +92,7 @@ function updateConfiguration(config) {
   });
 }
 
-function removeConfiguration(config) {
+async function removeConfiguration(config) {
   const { lambdaArn, region } = config;
 
   return getConfiguration(config).then((res) => {

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -74,8 +74,8 @@ function getEnvironment(context) {
   };
 }
 
-async function handlerWrapper(handler, PhysicalResourceId) {
-  return (event, context, callback) => {
+function handlerWrapper(handler, PhysicalResourceId) {
+  return async (event, context, callback) => {
     // extend the `event` object to include the PhysicalResourceId
     event = Object.assign({}, event, { PhysicalResourceId });
     return Promise.resolve(handler(event, context, callback))

--- a/lib/plugins/aws/deploy/lib/createStack.js
+++ b/lib/plugins/aws/deploy/lib/createStack.js
@@ -3,7 +3,7 @@
 const BbPromise = require('bluebird');
 
 module.exports = {
-  create() {
+  async create() {
     // Note: using three dots instead of ellipsis to support non uni-code consoles.
     this.serverless.cli.log('Creating Stack...');
     const stackName = this.provider.naming.getStackName();
@@ -65,7 +65,7 @@ module.exports = {
         " with an alphabetic character and shouldn't",
         ' exceed 128 characters.',
       ].join('');
-      throw new this.serverless.classes.Error(errorMessage);
+      throw new this.serverless.classes.Error(errorMessage, 'INVALID_STACK_NAME_ERROR');
     }
 
     return BbPromise.bind(this)

--- a/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -157,8 +157,8 @@ describe('uploadArtifacts', () => {
       uploadStub.restore();
     });
 
-    it('should throw for null artifact paths', () => {
-      expect(async () => await awsDeploy.uploadZipFile(null).to.throw(Error));
+    it('should throw for null artifact paths', async () => {
+      await expect(awsDeploy.uploadZipFile(null)).to.be.rejectedWith(Error);
     });
 
     it('should upload the .zip file to the S3 bucket', () => {


### PR DESCRIPTION
As in title, fixes regression introduced by https://github.com/serverless/serverless/pull/8698 + completes a few missing functions marked as async 