### PR TITLE
CLI: Allow absolute path in `--config`

### DIFF
--- a/lib/cli/resolve-configuration-path.js
+++ b/lib/cli/resolve-configuration-path.js
@@ -18,12 +18,6 @@ module.exports = async () => {
   })();
 
   if (customConfigName) {
-    if (path.isAbsolute(customConfigName)) {
-      throw new ServerlessError(
-        'Invalid "--config" value: expected filename, received an absolute path',
-        'INVALID_SERVICE_CONFIG_PATH'
-      );
-    }
     const customConfigPath = path.resolve(customConfigName);
     if (process.cwd() !== path.dirname(customConfigPath)) {
       throw new ServerlessError(

--- a/lib/cli/resolve-configuration-path.js
+++ b/lib/cli/resolve-configuration-path.js
@@ -24,7 +24,7 @@ module.exports = async () => {
         'INVALID_SERVICE_CONFIG_PATH'
       );
     }
-    const customConfigPath = path.resolve(process.cwd(), customConfigName);
+    const customConfigPath = path.resolve(customConfigName);
     if (process.cwd() !== path.dirname(customConfigPath)) {
       throw new ServerlessError(
         'Invalid "--config" value: config cannot be nested in sub-directory',

--- a/test/unit/lib/cli/resolve-configuration-path.test.js
+++ b/test/unit/lib/cli/resolve-configuration-path.test.js
@@ -66,16 +66,12 @@ describe('test/unit/lib/cli/resolve-service-config-path.test.js', () => {
       ])
     );
 
-    it('should reject absolute path', async () => {
+    it('should accept absolute path, pointing configuration in current working directory', async () => {
       await overrideArgv(
         {
           args: ['serverless', '--config', path.resolve('custom.yml')],
         },
-        () =>
-          expect(resolveServerlessConfigPath()).to.eventually.be.rejected.and.have.property(
-            'code',
-            'INVALID_SERVICE_CONFIG_PATH'
-          )
+        async () => expect(await resolveServerlessConfigPath()).to.equal(path.resolve('custom.yml'))
       );
     });
 


### PR DESCRIPTION
With  https://github.com/serverless/serverless/pull/8770 config path resolution was refactored to standalone util.

Over there it was restricted that no absolute path can be used. Still this restriction doesn't seem valid.

Fact that we're restricting that config needs to be in current working directory should not prevent the ability to pass absolute path to it (concern raised at https://github.com/serverless/serverless/pull/8770#discussion_r560874073)