### PR TITLE
fix(Packaging): Properly exclude devDependencies on Windows

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -194,7 +194,7 @@ function excludeNodeDevDependencies(servicePath) {
             return fs
               .readFileAsync(depFile)
               .then((fileContent) =>
-                _.uniq(fileContent.toString('utf8').split('\n')).filter(Boolean)
+                _.uniq(fileContent.toString('utf8').split(os.EOL)).filter(Boolean)
               )
               .catch(() => BbPromise.resolve());
           })

--- a/test/unit/lib/plugins/package/lib/zipService.test.js
+++ b/test/unit/lib/plugins/package/lib/zipService.test.js
@@ -282,7 +282,7 @@ describe('zipService', () => {
           path.join(servicePath, 'node_modules', 'module-2'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
-        ].join('\n');
+        ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
         readFileAsyncStub.onCall(2).resolves('{}');
@@ -359,7 +359,7 @@ describe('zipService', () => {
         const depPaths = [
           path.join(servicePath, 'node_modules', 'module-1'),
           path.join(servicePath, 'node_modules', 'module-2'),
-        ].join('\n');
+        ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
         readFileAsyncStub.onCall(2).resolves('{}');
@@ -424,7 +424,7 @@ describe('zipService', () => {
           path.join(servicePath, '1st', 'node_modules', 'module-2'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
-        ].join('\n');
+        ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
         readFileAsyncStub.onCall(2).resolves('{}');
@@ -494,7 +494,7 @@ describe('zipService', () => {
         const devDepPaths = [
           path.join(servicePath, 'node_modules', 'module-1'),
           path.join(servicePath, 'node_modules', 'module-2'),
-        ].join('\n');
+        ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
 
         const prodDepPaths = [path.join(servicePath, 'node_modules', 'module-2')];
@@ -551,10 +551,10 @@ describe('zipService', () => {
 
         const mapper = (depPath) => path.join(`${servicePath}`, depPath);
 
-        const devDepPaths = devPaths.map(mapper).join('\n');
+        const devDepPaths = devPaths.map(mapper).join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
 
-        const prodDepPaths = prodPaths.map(mapper).join('\n');
+        const prodDepPaths = prodPaths.map(mapper).join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
 
         readFileAsyncStub.onCall(2).resolves('{"name": "bro-module", "bin": "main.js"}');
@@ -619,7 +619,7 @@ describe('zipService', () => {
           '1st/2nd/node_modules/module-2',
         ];
         const depPaths = deps.map((depPath) => path.join(`${servicePath}`, depPath));
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths.join('\n'));
+        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths.join(os.EOL));
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
 
         const module1PackageJson = JSON.stringify({


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
Use proper OS EOL to split OS-produced output files. 
In this case there was a local temp file produced by this part, on `lib/plugins/package/lib/zipService.js`
```
          return childProcess
            .execAsync(
              `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
              { cwd: dirWithPackageJson }
            )
            .catch(() => BbPromise.resolve());
```
But it was being splitted incorrectly using `\n` instead of `\r\n` which is the separator used on Windows. This PR solves the issue by using node native `os.EOL` instead.

Output after testing the fix locally:

```
Serverless: Installing dependencies for custom CloudFormation resources...
Serverless: Uploading CloudFormation file to S3...
Serverless: Uploading artifacts...
Serverless: Uploading service p*******s.zip file to S3 (6.44 MB)...
Serverless: Uploading custom CloudFormation resources...
Serverless: Validating template...
Serverless: Updating Stack...
Serverless: Checking Stack update progress...
..............................
```
Before the fix: zip file size ~**65MB**.

Closes: https://github.com/serverless/serverless/issues/8802
