### PR TITLE
fix(Standalone): Ensure proper resolution of runtime wrappers

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -26,12 +26,9 @@ const cachePath = path.join(cachedir('serverless'), 'invokeLocal');
 
 const ensureRuntimeWrappers = isStandalone
   ? () =>
-      ensureArtifact('runtimeWrappers/validationFile', async (artifactsPath) => {
-        await fse.copy(
-          path.resolve(__dirname, 'runtimeWrappers'),
-          path.resolve(artifactsPath, 'runtimeWrappers')
-        );
-        return fse.ensureFile(path.resolve(artifactsPath, 'runtimeWrappers/validationFile'));
+      ensureArtifact('runtimeWrappers/validationFile', async (runtimeCachePath) => {
+        await fse.copy(path.resolve(__dirname, 'runtimeWrappers'), runtimeCachePath);
+        return fse.ensureFile(path.resolve(runtimeCachePath, 'validationFile'));
       })
   : () => Promise.resolve(__dirname);
 


### PR DESCRIPTION
It solves a bug I've introduced as a part of https://github.com/serverless/serverless/pull/8744/files 

Closes: #8806