### PR TITLE
refactor: Custom execution role getter

### DIFF
--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -304,12 +304,9 @@ class AwsDeployFunction {
       }
     }
 
-    if (functionObj.role && !_.isObject(functionObj.role)) {
-      const roleArn = await this.normalizeArnRole(functionObj.role);
-      params.Role = roleArn;
-    } else if (providerObj.role && !_.isObject(providerObj.role)) {
-      const roleArn = await this.normalizeArnRole(providerObj.role);
-      params.Role = roleArn;
+    const executionRole = this.provider.getCustomExecutionRole(functionObj);
+    if (executionRole) {
+      params.Role = await this.normalizeArnRole(executionRole);
     }
 
     if (params.Role === remoteFunctionConfiguration.Role) {

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -352,10 +352,8 @@ class AwsCompileFunctions {
       );
     }
 
-    this.compileRole(
-      functionResource,
-      functionObject.role || this.serverless.service.provider.role || 'IamRoleLambdaExecution'
-    );
+    const role = this.provider.getCustomExecutionRole(functionObject);
+    this.compileRole(functionResource, role || 'IamRoleLambdaExecution');
 
     if (!functionObject.vpc) functionObject.vpc = {};
     if (!this.serverless.service.provider.vpc) this.serverless.service.provider.vpc = {};
@@ -579,9 +577,8 @@ class AwsCompileFunctions {
     const destinationConfig = {};
 
     if (destinations) {
-      const hasAccessPoliciesHandledExternally = Boolean(
-        functionObject.role || this.serverless.service.provider.role
-      );
+      const executionRole = this.provider.getCustomExecutionRole(functionObject);
+      const hasAccessPoliciesHandledExternally = Boolean(executionRole);
 
       if (destinations.onSuccess) {
         if (!hasAccessPoliciesHandledExternally) {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1584,6 +1584,13 @@ class AwsProvider {
     return this.serverless.service.provider.cfnRole;
   }
 
+  getCustomExecutionRole(functionObj) {
+    const { provider } = this.serverless.service;
+
+    if (functionObj.role) return functionObj.role;
+    return provider.role;
+  }
+
   resolveFunctionArn(functionAddress) {
     if (isLambdaArn(functionAddress)) return functionAddress;
     const functionData = this.serverless.service.getFunction(functionAddress);
@@ -1609,7 +1616,7 @@ class AwsProvider {
   }
 
   resolveFunctionIamRoleResourceName(functionObj) {
-    const customRole = functionObj.role || this.serverless.service.provider.role;
+    const customRole = this.getCustomExecutionRole(functionObj);
     if (customRole) {
       if (typeof customRole === 'string') {
         // check whether the custom role is an ARN


### PR DESCRIPTION
Consolidate basic logic for getting custom execution role in one place.

Continuation of work started in #8701 and #8751 - doing some cosmetic changes in sake of making deprecations clearer and concise. 
