### PR TITLE
fix(AWS CloudFront): Ensure unique names for cache policy

### DIFF
--- a/docs/providers/aws/events/cloudfront.md
+++ b/docs/providers/aws/events/cloudfront.md
@@ -222,6 +222,8 @@ functions:
             name: myCachePolicy
 ```
 
+This configuration will create a Cache Policy named `servicename-stage-myCachePolicy`.
+
 You can reference [AWS Managed Policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policies-list) using an `id` property instead of `name`
 
 ```yml

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -605,6 +605,11 @@ module.exports = {
   getCloudFrontCachePolicyLogicalId(cachePolicyName) {
     return `CloudFrontCachePolicy${this.getNormalizedFunctionName(cachePolicyName)}`;
   },
+  getCloudFrontCachePolicyName(cachePolicyName) {
+    const serviceName = this.provider.serverless.service.getServiceName();
+    const stage = this.provider.getStage();
+    return `${serviceName}-${stage}-${cachePolicyName}`;
+  },
 
   // HTTP API
   getHttpApiName() {

--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -296,7 +296,7 @@ class AwsCompileCloudFrontEvents {
             Properties: {
               CachePolicyConfig: {
                 ...cachePolicyConfig,
-                Name: name,
+                Name: this.provider.naming.getCloudFrontCachePolicyName(name),
               },
             },
           },

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
@@ -2078,7 +2078,7 @@ describe('lib/plugins/aws/package/compile/events/cloudFront/index.new.test.js', 
       const cachePolicyConfigProperties =
         cfResources[cachePolicyLogicalId].Properties.CachePolicyConfig;
       expect(cachePolicyConfigProperties).to.deep.eq({
-        Name: cachePolicyName,
+        Name: `${serviceName}-${stage}-${cachePolicyName}`,
         ...cachePolicyConfig,
       });
     });


### PR DESCRIPTION
Closes: #8818
