### PR TITLE
CLI: fix service path resolution when nested config is involved

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -72,7 +72,8 @@ class Serverless {
 
     this.cliInputArgv = process.argv.slice(2);
     if (this.configurationPath) {
-      configObject.servicePath = path.dirname(this.configurationPath);
+      // TODO: With a new major release switch resolution to `path.dirname(this.configurationPath)`
+      configObject.servicePath = process.cwd();
     }
 
     this.config = new Config(this, configObject);
@@ -98,6 +99,7 @@ class Serverless {
     if (this._shouldResolveConfigurationInternally) {
       this.configurationPath = await resolveConfigurationPath();
       if (this.configurationPath) {
+        this.config.servicePath = process.cwd();
         this._logDeprecation(
           'MISSING_SERVICE_CONFIGURATION_PATH',
           'Serverless constructor expects resolved service configuration path to be provided ' +

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -70,7 +70,6 @@ class Serverless {
     this.pluginManager = new PluginManager(this);
     this.configSchemaHandler = new ConfigSchemaHandler(this);
 
-    // use the servicePath from the options or try to find it in the CWD
     this.cliInputArgv = process.argv.slice(2);
     if (this.configurationPath) {
       configObject.servicePath = path.dirname(this.configurationPath);

--- a/lib/cli/resolve-configuration-path.js
+++ b/lib/cli/resolve-configuration-path.js
@@ -49,6 +49,10 @@ module.exports = async () => {
       );
     }
     if (process.cwd() !== path.dirname(customConfigPath)) {
+      // TODO:
+      // When clearing this deprecation for a new major also ensure that servicePath
+      // (currently set on serverless.config.servicePath) is resolved from configurationPath and not
+      // current working directory
       logDeprecation(
         'NESTED_CUSTOM_CONFIGURATION_PATH',
         'Service configuration is expected to be placed in a root of a service (working directory). All paths, function handlers in a configuration are resolved against service directory".\n' +


### PR DESCRIPTION
Closes: https://github.com/serverless/serverless/issues/8833

Not introducing tests as:
- Issue happened only when deprecated functionality was used
- Cannot be tested via `runServerless`, but only via issuing spawned `sls` and confirming it went fine. Don't want to increase maintenance burden introducing such test setup, especially that case will not be addressable with next major
