### PR TITLE
fix(AWS Lambda): Add schema dependencies for image config

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -236,7 +236,7 @@ functions:
     image: baseimage
 ```
 
-It is also possible to provide additional image configuration via `workingDirectory`, `entryPoint` and `command` properties of to `functions[].image`. The `workingDirectory` accepts path in form of string, where both `entryPoint` and `command` needs to be defined as a list of strings, following "exec form" format. In order to provide additional image config properties, `functions[].image` has to be defined as an object, and needs to define either `uri` pointing to an existing AWS ECR image or `name` property, which references image already defined in `provider.ecr.images`.
+It is also possible to provide additional image configuration via `workingDirectory`, `entryPoint` and `command` properties of to `functions[].image`. The `workingDirectory` accepts path in form of string, where both `entryPoint` and `command` needs to be defined as a list of strings, following "exec form" format. In order to provide additional image config properties, `functions[].image` has to be defined as an object, and needs to define either `uri` pointing to an existing AWS ECR image or `name` property, which references image already defined in `provider.ecr.images`. Due to current limitation of AWS CloudFormation, whenever one of the additional image configuration properties is defined, both `command` and `entryPoint` have to be defined. If you're using one of official AWS base images, the `entryPoint` will be equal to `/lambda-entrypoint.sh`.
 
 Example configuration:
 
@@ -257,9 +257,14 @@ functions:
       command:
         - executable
         - flag
+      entryPoint:
+        - executable
+        - flag
   world:
     image:
       name: baseimage
+      command:
+        - command
       entryPoint:
         - executable
         - flag

--- a/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
+++ b/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
@@ -238,6 +238,17 @@ const improveMessages = (resultErrorsSet) => {
   }
 };
 
+const filterDuplicateErrors = (resultErrorsSet) => {
+  const seenMessages = new Set();
+  resultErrorsSet.forEach((item) => {
+    if (!seenMessages.has(item.message)) {
+      seenMessages.add(item.message);
+    } else {
+      resultErrorsSet.delete(item);
+    }
+  });
+};
+
 /*
  * For error object structure, see https://github.com/ajv-validator/ajv/#error-objects
  */
@@ -252,6 +263,9 @@ module.exports = (ajvErrors) => {
 
   // 3. Improve messages UX
   improveMessages(resultErrorsSet);
+
+  // 4. Filter out errors to prevent displaying the same message more than once
+  filterDuplicateErrors(resultErrorsSet);
 
   return Array.from(resultErrorsSet);
 };

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1036,6 +1036,11 @@ class AwsProvider {
                       },
                     },
                   },
+                  dependencies: {
+                    command: ['entryPoint'],
+                    entryPoint: ['command'],
+                    workingDirectory: ['entryPoint', 'command'],
+                  },
                   additionalProperties: false,
                 },
               ],

--- a/test/unit/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.test.js
@@ -76,6 +76,32 @@ describe('#normalizeAjvErrors', () => {
               handler: {
                 type: 'string',
               },
+              image: {
+                type: 'object',
+                properties: {
+                  workingDirectory: {
+                    type: 'string',
+                  },
+                  command: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                    },
+                  },
+                  entryPoint: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                    },
+                  },
+                },
+                dependencies: {
+                  command: ['entryPoint'],
+                  entryPoint: ['command'],
+                  workingDirectory: ['entryPoint', 'command'],
+                },
+                additionalProperties: false,
+              },
               events: {
                 type: 'array',
                 items: {
@@ -145,6 +171,9 @@ describe('#normalizeAjvErrors', () => {
         'invalid name': {},
         'foo': {
           handler: 'foo',
+          image: {
+            workingDirectory: 'bar',
+          },
           events: [
             {
               bar: {},
@@ -307,6 +336,11 @@ describe('#normalizeAjvErrors', () => {
           })
         ).to.be.true
     );
+    it('should report the duplicated erorr message if more than one dependency is missing only once', () => {
+      const depsErrors = errors.filter((item) => item.keyword === 'dependencies');
+      expect(depsErrors).to.have.lengthOf(1);
+      depsErrors[0].isExpected = true;
+    });
     it('should not report side errors', () =>
       expect(errors.filter((error) => !error.isExpected)).to.deep.equal([]));
   });


### PR DESCRIPTION
When verifying content for blog post, I've noticed a weird behavior around configuration for images and it turns out, that CloudFormation is currently limited in such a way that it always require to provide both `Command` and `EntryPoint`, whenever any of the properties from `ImageConfig` are provided. This Pr adds a clarification around that in docs + improves schema dependencies. 