### PR TITLE
feat(installer) Add ability to specify version in standalone installer

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,10 +25,16 @@ Getting started with Serverless Framework’s Open Source CLI and AWS takes only
 
 ### MacOS/Linux
 
-Run this command in your terminal:
+To install the latest version, run this command in your terminal:
 
 ```bash
 curl -o- -L https://slss.io/install | bash
+```
+
+To install an specific version you may set a VERSION variable, for example:
+
+```bash
+curl -o- -L https://slss.io/install | VERSION=2.21.1 bash
 ```
 
 Then open another terminal window to run `serverless` program.

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -44,23 +44,40 @@ else
   fi
 fi
 
+if [[ -z "${VERSION}" ]]
+then
+  # Get latest tag
+  if [[ $IS_IN_CHINA == "1" ]]
+  then
+    TAG=`curl -L --silent https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/latest-tag`
+  else
+    TAG=`curl -L --silent https://api.github.com/repos/serverless/serverless/releases/latest 2>&1 | grep 'tag_name' | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+"`
+  fi
+  VERSION=${TAG:1}
+else
+  TAG=v$VERSION
+fi
+
 if [[ $IS_IN_CHINA == "1" ]]
 then
 	# In China download from location in China (Github API download is slow and times out)
-  LATEST_TAG=`curl -L --silent https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/latest-tag`
-	BINARY_URL=https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/$LATEST_TAG/serverless-$PLATFORM-$ARCH
+	BINARY_URL=https://sls-standalone-sv-1300963013.cos.na-siliconvalley.myqcloud.com/$TAG/serverless-$PLATFORM-$ARCH
 else
-  LATEST_TAG=`curl -L --silent https://api.github.com/repos/serverless/serverless/releases/latest 2>&1 | grep 'tag_name' | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+"`
-	BINARY_URL=https://github.com/serverless/serverless/releases/download/$LATEST_TAG/serverless-$PLATFORM-$ARCH
+	BINARY_URL=https://github.com/serverless/serverless/releases/download/$TAG/serverless-$PLATFORM-$ARCH
 fi
 
 # Dowload binary
 BINARIES_DIR_PATH=$HOME/.serverless/bin
 BINARY_PATH=$BINARIES_DIR_PATH/serverless
 mkdir -p $BINARIES_DIR_PATH
-printf "$yellow Downloading binary...$reset\n"
+printf "$yellow Downloading binary for version $VERSION...$reset\n"
 
-curl -L -o $BINARY_PATH $BINARY_URL
+version_error_msg (){
+  echo "Could not download binary. Is the version correct?"
+}
+trap version_error_msg ERR
+curl --fail -L -o $BINARY_PATH $BINARY_URL
+trap - ERR
 chmod +x $BINARY_PATH
 
 # Ensure aliases

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Download and install standalone binary.
+# The binary version can be specified by setting a VERSION variable.
+# e.g. VERSION=2.21.1 bash install.sh
+# If VERSION is unspecified it will download the latest version.
 
 set -e
 

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -81,8 +81,9 @@ version_error_msg (){
   echo "Could not download binary. Is the version correct?"
 }
 trap version_error_msg ERR
-curl --fail -L -o $BINARY_PATH $BINARY_URL
+curl --fail -L -o $BINARY_PATH.tmp $BINARY_URL
 trap - ERR
+mv $BINARY_PATH.tmp $BINARY_PATH
 chmod +x $BINARY_PATH
 
 # Ensure aliases

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -71,7 +71,7 @@ else
 	BINARY_URL=https://github.com/serverless/serverless/releases/download/$TAG/serverless-$PLATFORM-$ARCH
 fi
 
-# Dowload binary
+# Download binary
 BINARIES_DIR_PATH=$HOME/.serverless/bin
 BINARY_PATH=$BINARIES_DIR_PATH/serverless
 mkdir -p $BINARIES_DIR_PATH

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Download and install standalone binary.
 # The binary version can be specified by setting a VERSION variable.


### PR DESCRIPTION
Closes: #8855 

Added the ability to specify a version in the standalone installer. This is done by setting a `VERSION` variable after the pipe and before `bash`.

```bash
curl -o- -L https://slss.io/install | VERSION=2.21.1 bash 
```

I tested it manually. There are no automated tests for this, right?

Skipped the manual `npm run ...` and `npm test` steps, as this is only touching a single bash script file.

Are there any style guides regarding bash scripts?