### PR TITLE
CLI: Ensure to not display deprecations specific to programmatic usage

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -100,12 +100,14 @@ class Serverless {
       this.configurationPath = await resolveConfigurationPath();
       if (this.configurationPath) {
         this.config.servicePath = process.cwd();
-        this._logDeprecation(
-          'MISSING_SERVICE_CONFIGURATION_PATH',
-          'Serverless constructor expects resolved service configuration path to be provided ' +
-            'via "config.configurationPath".\n' +
-            'Starting from next major Serverless will no longer auto resolve that path internally.'
-        );
+        if (!this.isInvokedByGlobalInstallation) {
+          this._logDeprecation(
+            'MISSING_SERVICE_CONFIGURATION_PATH',
+            'Serverless constructor expects resolved service configuration path to be provided ' +
+              'via "config.configurationPath".\n' +
+              'Starting from next major Serverless will no longer auto resolve that path internally.'
+          );
+        }
       }
     }
     if (this.configurationPath && !this.configurationInput) {

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -91,7 +91,7 @@ class Serverless {
     this.serverlessDirPath = path.join(os.homedir(), '.serverless');
     this.isStandaloneExecutable = isStandaloneExecutable;
     this.isLocallyInstalled = false;
-    this.isInvokedByGlobalInstallation = false;
+    this._isInvokedByGlobalInstallation = false;
     this.triggeredDeprecations = logDeprecation.triggeredDeprecations;
   }
 
@@ -100,7 +100,7 @@ class Serverless {
       this.configurationPath = await resolveConfigurationPath();
       if (this.configurationPath) {
         this.config.servicePath = process.cwd();
-        if (!this.isInvokedByGlobalInstallation) {
+        if (!this._isInvokedByGlobalInstallation) {
           this._logDeprecation(
             'MISSING_SERVICE_CONFIGURATION_PATH',
             'Serverless constructor expects resolved service configuration path to be provided ' +
@@ -183,7 +183,8 @@ class Serverless {
       configuration: this.configurationInput,
     });
     serverlessLocal.isLocallyInstalled = true;
-    serverlessLocal.isInvokedByGlobalInstallation = true;
+    // TODO: Remove assignment to "isInvokedByGlobalInstallation" with next major
+    serverlessLocal._isInvokedByGlobalInstallation = serverlessLocal.isInvokedByGlobalInstallation = true;
     this.invokedInstance = serverlessLocal;
     await serverlessLocal.init();
   }

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -29,6 +29,7 @@ class Serverless {
   constructor(config) {
     let configObject = config;
     configObject = configObject || {};
+    this._isInvokedByGlobalInstallation = Boolean(configObject._isInvokedByGlobalInstallation);
     this.configurationPath = ensureString(configObject.configurationPath, {
       isOptional: true,
       name: 'config.configurationPath',
@@ -41,7 +42,7 @@ class Serverless {
         name: 'config.configuration',
         Error: ServerlessError,
       });
-      if (!this.configurationInput) {
+      if (!this.configurationInput && !this._isInvokedByGlobalInstallation) {
         this._logDeprecation(
           'MISSING_SERVICE_CONFIGURATION',
           'Serverless constructor expects resolved service configuration to be provided ' +
@@ -58,6 +59,7 @@ class Serverless {
     // Once new variables engine is in, we can remove that patch
     delete configObject.configurationPath;
     delete configObject.configuration;
+    delete configObject._isInvokedByGlobalInstallation;
 
     this.providers = {};
 
@@ -91,7 +93,6 @@ class Serverless {
     this.serverlessDirPath = path.join(os.homedir(), '.serverless');
     this.isStandaloneExecutable = isStandaloneExecutable;
     this.isLocallyInstalled = false;
-    this._isInvokedByGlobalInstallation = false;
     this.triggeredDeprecations = logDeprecation.triggeredDeprecations;
   }
 
@@ -181,10 +182,11 @@ class Serverless {
     const serverlessLocal = new ServerlessLocal({
       configurationPath: this.configurationPath,
       configuration: this.configurationInput,
+      _isInvokedByGlobalInstallation: true,
     });
     serverlessLocal.isLocallyInstalled = true;
-    // TODO: Remove assignment to "isInvokedByGlobalInstallation" with next major
-    serverlessLocal._isInvokedByGlobalInstallation = serverlessLocal.isInvokedByGlobalInstallation = true;
+    // TODO: Remove below assignment with next major
+    serverlessLocal.isInvokedByGlobalInstallation = true;
     this.invokedInstance = serverlessLocal;
     await serverlessLocal.init();
   }

--- a/lib/utils/analytics/generatePayload.js
+++ b/lib/utils/analytics/generatePayload.js
@@ -76,7 +76,7 @@ module.exports = async (serverless) => {
       if (!serverless.isLocallyInstalled) {
         return (await isNpmGlobal()) ? 'global:npm' : 'global:other';
       }
-      if (serverless.isInvokedByGlobalInstallation) return 'local:fallback';
+      if (serverless._isInvokedByGlobalInstallation) return 'local:fallback';
       return 'local:direct';
     })(),
     isAutoUpdateEnabled: Boolean(userConfig.get('autoUpdate.enabled')),

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -231,7 +231,7 @@ describe('Serverless [new tests]', () => {
           modulesCacheStub: {},
         }).then(({ serverless }) => {
           expect(Array.from(serverless.triggeredDeprecations)).to.deep.equal([]);
-          expect(serverless.isInvokedByGlobalInstallation).to.be.true;
+          expect(serverless._isInvokedByGlobalInstallation).to.be.true;
           expect(serverless.isLocallyInstalled).to.be.true;
           expect(serverless.isLocalStub).to.be.true;
         }));
@@ -248,7 +248,7 @@ describe('Serverless [new tests]', () => {
           expect(Array.from(serverless.triggeredDeprecations)).to.deep.equal([
             'DISABLE_LOCAL_INSTALLATION_FALLBACK_SETTING',
           ]);
-          expect(serverless.isInvokedByGlobalInstallation).to.be.false;
+          expect(serverless._isInvokedByGlobalInstallation).to.be.false;
           expect(serverless.isLocallyInstalled).to.be.false;
           expect(serverless.isLocalStub).to.not.exist;
         }));
@@ -266,7 +266,7 @@ describe('Serverless [new tests]', () => {
           expect(Array.from(serverless.triggeredDeprecations)).to.deep.equal([
             'DISABLE_LOCAL_INSTALLATION_FALLBACK_SETTING',
           ]);
-          expect(serverless.isInvokedByGlobalInstallation).to.be.true;
+          expect(serverless._isInvokedByGlobalInstallation).to.be.true;
           expect(serverless.isLocallyInstalled).to.be.true;
           expect(serverless.isLocalStub).to.be.true;
         }));
@@ -281,7 +281,7 @@ describe('Serverless [new tests]', () => {
             cliArgs: ['-v'],
           }).then(({ serverless }) => {
             expect(Array.from(serverless.triggeredDeprecations)).to.deep.equal([]);
-            expect(serverless.isInvokedByGlobalInstallation).to.be.false;
+            expect(serverless._isInvokedByGlobalInstallation).to.be.false;
             expect(serverless.isLocallyInstalled).to.be.true;
             expect(serverless.isLocalStub).to.be.true;
           })
@@ -294,7 +294,7 @@ describe('Serverless [new tests]', () => {
       runServerless({ fixture: 'aws', cliArgs: ['-v'], modulesCacheStub: {} }).then(
         ({ serverless }) => {
           expect(Array.from(serverless.triggeredDeprecations)).to.deep.equal([]);
-          expect(serverless.isInvokedByGlobalInstallation).to.be.false;
+          expect(serverless._isInvokedByGlobalInstallation).to.be.false;
           expect(serverless.isLocallyInstalled).to.be.false;
           expect(serverless.isLocalStub).to.not.exist;
         }


### PR DESCRIPTION
_Fixes issue reported on our internal Slack_

When user has outdated _global_ installation of `serverless` which fallbacks to _local_ one which is latest, there can be a situation where old _global_ version doesn't pass resolved configuration path or object to _local_ one constructor.

That normally triggers a deprecation. Still deprecation is intended to be present to users which attempt to use `Serverless` programmatically, while here situation was effect of valid (and not deprecated) CLI usage.

Patch ensures that given deprecation does not show in such case, also improved internals so in future we can prevent such deprecations if configured directly in constructor (at this point we're unable to prevent `MISSING_SERVICE_CONFIGURATION` deprecation to be shown, which still can happen with specific _global_ and _local_ version combination).

Additionally renamed internal property so it's prefixed with `_` (it's dedicated purely for internal private usage)