### PR TITLE
Properly handle error if Java bridge is not present

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -633,9 +633,8 @@ class AwsInvokeLocal {
     const javaBridgePath = await this.resolveRuntimeWrapperPath('java');
     const executablePath = path.join(javaBridgePath, 'target');
 
-    await fse.stat(executablePath);
-
     try {
+      await fse.stat(executablePath);
       return await this.callJavaBridge(artifactPath, className, handlerName, input);
     } catch (err) {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
During refactoring to `async` (https://github.com/serverless/serverless/commit/84d423d3be9d89475a22f29f808d506fb4f56d3c), a little regression sneaked in where we didn't properly handle error that signaled that Java bridge is not present. 

Closes: #8859