### PR TITLE
refactor: Use `async` in `aws/package/compile/events`

### DIFF
--- a/lib/plugins/aws/package/compile/events/alb/index.js
+++ b/lib/plugins/aws/package/compile/events/alb/index.js
@@ -20,7 +20,7 @@ class AwsCompileAlbEvents {
     Object.assign(this, validate, compileTargetGroups, compileListenerRules, compilePermissions);
 
     this.hooks = {
-      'package:compileEvents': () => {
+      'package:compileEvents': async () => {
         return BbPromise.try(() => {
           this.validated = this.validate();
           if (this.validated.events.length === 0) return;

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool.js
@@ -24,7 +24,7 @@ class AwsCompileCognitoUserPoolEvents {
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
-      'package:compileEvents': () => {
+      'package:compileEvents': async () => {
         return BbPromise.bind(this)
           .then(this.newCognitoUserPools)
           .then(this.existingCognitoUserPools);

--- a/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.js
+++ b/lib/plugins/aws/package/compile/events/lib/ensureApiGatewayCloudWatchRole.js
@@ -4,7 +4,7 @@ const { memoize } = require('lodash');
 const BbPromise = require('bluebird');
 const { addCustomResourceToService } = require('../../../../customResources');
 
-module.exports = memoize((provider) =>
+module.exports = memoize(async (provider) =>
   BbPromise.try(() => {
     // There may be a specific role ARN provided in the configuration
     const config = provider.serverless.service.provider;

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -39,7 +39,7 @@ class AwsCompileS3Events {
     });
 
     this.hooks = {
-      'package:compileEvents': () => {
+      'package:compileEvents': async () => {
         return BbPromise.bind(this).then(this.newS3Buckets).then(this.existingS3Buckets);
       },
     };


### PR DESCRIPTION
Covered the following paths:
* `lib/plugins/aws/package/compile/events/*.js`
* `lib/plugins/aws/package/compile/events/alb`
* `lib/plugins/aws/package/compile/events/lib`
* `lib/plugins/aws/package/compile/events/s3`

Addresses: #8368 
