### PR TITLE
Introduces provider.iamRoleName param.

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -91,6 +91,31 @@ provider:
         - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWS::AccountId' }, 'some/path']] }
 ```
 
+### Naming for the Default IAM Role
+
+The name of the IAM Role provided will include the service name, stage, region, and 'lambdaRole' suffix, i.e.
+
+```yml
+  'Fn::Join': [
+    '-',
+    [
+      this.provider.serverless.service.service,
+      this.provider.getStage(),
+      { Ref: 'AWS::Region' },
+      'lambdaRole',
+    ],
+  ],
+```
+
+This can be altered and replaced entirely with `provider.iamRoleName`,
+
+```yml
+service: new-service
+
+provider:
+  iamRoleName: some-abbreviated-name-${self:provider.stage}-role
+```
+
 ## Custom IAM Roles
 
 **WARNING:** You need to take care of the overall role setup as soon as you define custom roles.

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -91,10 +91,7 @@ module.exports = {
     return '/';
   },
   getRoleName() {
-    if (
-      this.provider.iamRoleName &&
-      typeof this.provider.iamRoleName === 'string'
-    ) {
+    if (this.provider.iamRoleName && typeof this.provider.iamRoleName === 'string') {
       return this.provider.iamRoleName;
     }
     return {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -91,6 +91,12 @@ module.exports = {
     return '/';
   },
   getRoleName() {
+    if (
+      this.provider.iamRoleName &&
+      typeof this.provider.iamRoleName === 'string'
+    ) {
+      return this.provider.iamRoleName;
+    }
     return {
       'Fn::Join': [
         '-',


### PR DESCRIPTION
Fixes #8887
Closes: #8887

Simple, small change introduces a new configuration parameter to address #8887 and similar issues reporting/complaining about the inability to customize the name of the default AWS IAM Role.