### PR TITLE
feat(AWS Lambda): Add support for `nodejs14.x` runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -450,6 +450,7 @@ class AwsProvider {
               'java8.al2',
               'nodejs10.x',
               'nodejs12.x',
+              'nodejs14.x',
               'provided',
               'provided.al2',
               'python2.7',


### PR DESCRIPTION
AWS Lambda now supports nodejs14.x

Updated the validation so that serverless does not throw a warning when using in projects with nodejs14.