### PR TITLE
fix: Properly resolve local version

### DIFF
--- a/lib/cli/eventually-list-version.js
+++ b/lib/cli/eventually-list-version.js
@@ -7,6 +7,8 @@ const { version: componentsVersion } = require('@serverless/components/package')
 const { sdkVersion } = require('@serverless/enterprise-plugin');
 const isStandaloneExecutable = require('../utils/isStandaloneExecutable');
 const resolveLocalServerlessPath = require('./resolve-local-serverless-path');
+const chalk = require('chalk');
+const ServerlessError = require('../serverless-error');
 
 const serverlessPath = path.resolve(__dirname, '../Serverless.js');
 
@@ -22,9 +24,43 @@ module.exports = async () => {
     if (!cliParams.has('-v')) return false;
   }
 
+  const localServerlessPath = await resolveLocalServerlessPath();
+
+  if (localServerlessPath) {
+    // If the version is already local, do not try to fallback for version resolution to avoid falling into the loop
+    // TODO: Remove local version fallback with next major (when its moved to the top of the process)
+    const isLocal = serverlessPath === localServerlessPath;
+    if (!isLocal) {
+      // Attempt to resolve version with local Serverless instance
+      process.stdout.write(
+        `Serverless: ${chalk.yellow(
+          'Running "serverless" installed locally (in service node_modules)'
+        )}\n`
+      );
+      const localServerlessDir = path.resolve(path.dirname(localServerlessPath), '..');
+
+      try {
+        try {
+          require(path.resolve(localServerlessDir, 'bin/serverless.js'));
+          return true;
+        } catch {
+          // Pass and attempt to use `bin/serverless` that was used by older version of the Framework
+          require(path.resolve(localServerlessDir, 'bin/serverless'));
+          return true;
+        }
+      } catch {
+        // This is just a fallback as for most (all?) versions it shouldn't happen
+        throw new ServerlessError(
+          'Could not resolve path to locally installed serverless.',
+          'INVALID_LOCAL_SERVERLESS_PATH'
+        );
+      }
+    }
+  }
+
   const installationModePostfix = await (async () => {
     if (isStandaloneExecutable) return ' (standalone)';
-    if (serverlessPath === (await resolveLocalServerlessPath())) return ' (local)';
+    if (serverlessPath === localServerlessPath) return ' (local)';
     return '';
   })();
 

--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -10,6 +10,7 @@ const resolveLocalServerlessPath = require('./resolve-local-serverless-path');
 const slsVersion = require('./../../package').version;
 const sfeVersion = require('@serverless/enterprise-plugin/package.json').version;
 const { sdkVersion } = require('@serverless/enterprise-plugin');
+const ServerlessError = require('../serverless-error');
 
 const userErrorNames = new Set(['ServerlessError', 'YAMLException']);
 const serverlessPath = path.resolve(__dirname, '../Serverless.js');
@@ -50,7 +51,39 @@ const writeMessage = (title, message) => {
 
 module.exports = async (exception, options = {}) => {
   if (!isObject(options)) options = {};
-  const { isUncaughtException, isLocallyInstalled } = options;
+  const { isUncaughtException, isLocallyInstalled, isInvokedByGlobalInstallation } = options;
+
+  if (isInvokedByGlobalInstallation) {
+    const localServerlessPath = await resolveLocalServerlessPath();
+
+    try {
+      // Attempt to use error handler from local version
+      // TODO: Remove local version fallback with next major (when its moved to the top of the process)
+      try {
+        require(path.resolve(localServerlessPath, '../cli/handle-error'))(exception, {
+          isLocallyInstalled,
+          isUncaughtException,
+        });
+        return;
+      } catch (error) {
+        // Pass and attempt to use old-style error handler from local version
+
+        // Ugly mock of serverless below is used to ensure that Framework version will be logged with `(local)` suffix
+        require(path.resolve(localServerlessPath, '../classes/Error')).logError(exception, {
+          serverless: { isLocallyInstalled },
+          forceExit: isUncaughtException,
+        });
+        return;
+      }
+    } catch (err) {
+      // This is just a fallback as for most (all?) versions it shouldn't happen
+      throw new ServerlessError(
+        'Could not resolve path to locally installed error handler.',
+        'INVALID_LOCAL_SERVERLESS_ERROR_HANDLER'
+      );
+    }
+  }
+
   const exceptionMeta = resolveExceptionMeta(exception);
   const isUserError = !isUncaughtException && userErrorNames.has(exceptionMeta.name);
 

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -21,6 +21,7 @@ process.once('uncaughtException', (error) =>
   handleError(error, {
     isUncaughtException: true,
     isLocallyInstalled: serverless && serverless.isLocallyInstalled,
+    isInvokedByGlobalInstallation: serverless && serverless.isInvokedByGlobalInstallation,
   })
 );
 
@@ -86,6 +87,9 @@ const processSpanPromise = (async () => {
       throw error;
     }
   } catch (error) {
-    handleError(error);
+    handleError(error, {
+      isLocallyInstalled: serverless && serverless.isLocallyInstalled,
+      isInvokedByGlobalInstallation: serverless && serverless.isInvokedByGlobalInstallation,
+    });
   }
 })();


### PR DESCRIPTION
Attempt to fix situation where `sls --version` or version reported with thrown error is not accurate if local installation of Serverless is involved