### PR TITLE
fix(AWS Deploy): Gracefully handle denied access to ecr

### DIFF
--- a/lib/plugins/aws/lib/checkIfEcrRepositoryExists.js
+++ b/lib/plugins/aws/lib/checkIfEcrRepositoryExists.js
@@ -14,6 +14,17 @@ module.exports = {
       if (err.providerError && err.providerError.code === 'RepositoryNotFoundException') {
         return false;
       }
+      if (err.providerError && err.providerError.code === 'AccessDeniedException') {
+        if (this.serverless.service.provider.ecr && this.serverless.service.provider.ecr.images) {
+          this.serverless.cli.log(
+            'WARNING: Could not access ECR repository due to denied access, but there are images defined in `provider.ecr`. ECR repository removal will be skipped.',
+            'Serverless',
+            { color: 'orange' }
+          );
+        }
+        // Check if user has images defined and issue warning that we could not
+        return false;
+      }
       throw err;
     }
   },


### PR DESCRIPTION
As discussed, I've went with gracefully handling access denied exceptions + emitting warning in cases where there are `images` defined. 

Closes: #8892 