### PR TITLE
fix(AWS Lambda): Ensure proper normalization of ecr repo name

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -654,6 +654,8 @@ module.exports = {
   getEcrRepositoryName() {
     const serviceName = this.provider.serverless.service.getServiceName();
     const stage = this.provider.getStage();
-    return `serverless-${serviceName}-${stage}`.toLowerCase();
+    // Ensure no consecutive dashes are present and that there is to trailing slash left
+    // TODO: Remove that with next major, assuming that issue #7056 (https://github.com/serverless/serverless/issues/7056) has been addressed
+    return `serverless-${serviceName}-${stage}`.toLowerCase().replace(/-+/g, '-').replace(/-$/, '');
   },
 };

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -973,4 +973,14 @@ describe('#naming()', () => {
       ).to.equal('custom/FnJoinRefApiGatewayRestApiexecuteapi');
     });
   });
+
+  describe('#getEcrRepositoryName', () => {
+    it('should correctly trim trailing dash and ensure no consecutive dashes are present', () => {
+      serverless.service.serviceObject = { name: 'service--with-weird-dashes---' };
+      sdk.options.stage = 'stage--with-dash-';
+      expect(sdk.naming.getEcrRepositoryName()).to.equal(
+        'serverless-service-with-weird-dashes-stage-with-dash'
+      );
+    });
+  });
 });


### PR DESCRIPTION
I missed the fact that we allow `service` and `stage` to use naming patterns that are incompatible with ECR repository naming patterns (consecutive and trailing dashes). That PR should fix that issue. 

Closes: #8905 