### PR TITLE
Uses createRequire

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -13,8 +13,8 @@ const getCacheFilePath = require('../utils/getCacheFilePath');
 const getCommandSuggestion = require('../utils/getCommandSuggestion');
 
 const resolveRelativeTo = createRequire
-  ? (req, source) => createRequire(source).resolve(req)
-  : (req, source) => cjsResolve(path.dirname(source), req).realPath;
+  ? (req, source) => createRequire(path.join(source, 'file')).resolve(req)
+  : (req, source) => cjsResolve(source, req).realPath;
 
 const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
@@ -36,7 +36,7 @@ const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
   }
 
   // Search in "node_modules" in which framework is placed
-  return require(cjsResolve(__dirname, pluginPath).realPath);
+  return require(resolveRelativeTo(pluginPath, __dirname));
 };
 
 /**

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -6,10 +6,15 @@ const cjsResolve = require('ncjsm/resolve/sync');
 const BbPromise = require('bluebird');
 const _ = require('lodash');
 const crypto = require('crypto');
+const { createRequire } = require('module');
 const isModuleNotFoundError = require('ncjsm/is-module-not-found-error');
 const writeFile = require('../utils/fs/writeFile');
 const getCacheFilePath = require('../utils/getCacheFilePath');
 const getCommandSuggestion = require('../utils/getCommandSuggestion');
+
+const resolveRelativeTo = createRequire
+  ? (req, source) => createRequire(source).resolve(req)
+  : (req, source) => cjsResolve(path.dirname(source), req).realPath;
 
 const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
@@ -19,13 +24,13 @@ const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
     try {
       return require(absoluteLocalPluginPath);
     } catch (error) {
-      if (!isModuleNotFoundError(error, absoluteLocalPluginPath)) throw error;
+      if (error.code !== 'MODULE_NOT_FOUND') throw error;
     }
   }
   try {
-    return require(cjsResolve(servicePath, pluginPath).realPath);
+    return require(resolveRelativeTo(pluginPath, servicePath));
   } catch (error) {
-    if (!isModuleNotFoundError(error, pluginPath) || pluginPath.startsWith('.')) {
+    if (error.code !== 'MODULE_NOT_FOUND' || pluginPath.startsWith('.')) {
       throw error;
     }
   }

--- a/test/unit/lib/classes/CLI.test.js
+++ b/test/unit/lib/classes/CLI.test.js
@@ -611,7 +611,7 @@ describe('CLI [new tests]', () => {
       expect(stdoutData).to.include('Documentation: http://slss.io/docs');
     }));
 
-  it.only('Should handle incomplete command configurations', async () => {
+  it('Should handle incomplete command configurations', async () => {
     const { stdoutData } = await runServerless({
       fixture: 'plugin',
       cliArgs: ['customCommand', '--help'],

--- a/test/unit/lib/classes/CLI.test.js
+++ b/test/unit/lib/classes/CLI.test.js
@@ -611,7 +611,7 @@ describe('CLI [new tests]', () => {
       expect(stdoutData).to.include('Documentation: http://slss.io/docs');
     }));
 
-  it('Should handle incomplete command configurations', async () => {
+  it.only('Should handle incomplete command configurations', async () => {
     const { stdoutData } = await runServerless({
       fixture: 'plugin',
       cliArgs: ['customCommand', '--help'],

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -399,10 +399,19 @@ describe('PluginManager', () => {
     }
   };
 
+  const moduleStub = {
+    createRequire: (source) => ({
+      resolve: (req) => {
+        return resolveStub(path.dirname(source), req).realPath;
+      },
+    }),
+  };
+
   let restoreEnv;
   let servicePath;
   let PluginManager = proxyquire('../../../../lib/classes/PluginManager', {
     'ncjsm/resolve/sync': resolveStub,
+    'module': moduleStub,
   });
 
   beforeEach(() => {
@@ -411,7 +420,7 @@ describe('PluginManager', () => {
     serverless.cli = new CLI();
     serverless.processedInput = { commands: [], options: {} };
     pluginManager = new PluginManager(serverless);
-    servicePath = pluginManager.serverless.config.servicePath = 'foo';
+    servicePath = pluginManager.serverless.config.servicePath = '/foo';
   });
 
   afterEach(() => restoreEnv());
@@ -466,9 +475,10 @@ describe('PluginManager', () => {
       PluginManager = proxyquire('../../../../lib/classes/PluginManager.js', {
         '../utils/fs/writeFile': writeFileStub,
         'ncjsm/resolve/sync': resolveStub,
+        'module': moduleStub,
       });
       pluginManager = new PluginManager(serverless);
-      pluginManager.serverless.config = { servicePath: 'somePath' };
+      pluginManager.serverless.config = { servicePath: '/somePath' };
       servicePath = pluginManager.serverless.config.servicePath;
       cacheFilePath = getCacheFilePath(servicePath);
       getCommandsStub = sinon.stub(pluginManager, 'getCommands');
@@ -1346,7 +1356,7 @@ describe('PluginManager', () => {
     beforeEach(() => {
       serverlessInstance = new Serverless();
       serverlessInstance.configurationInput = null;
-      serverlessInstance.config.servicePath = 'my-service';
+      serverlessInstance.config.servicePath = '/my-service';
       pluginManagerInstance = new PluginManager(serverlessInstance);
     });
 
@@ -1402,7 +1412,7 @@ describe('PluginManager', () => {
 
     it('should load if the configDependent property is true and config exists', () => {
       pluginManagerInstance.serverless.configurationInput = {
-        servicePath: 'foo',
+        servicePath: '/foo',
       };
 
       pluginManagerInstance.commands = {


### PR DESCRIPTION
The plugin loader mechanism was always using ncjsm, even under Node 12+ where `createRequire` is a thing. This diff adds a branch to prefer the native version when available.

Additionally, the validation for `MODULE_NOT_FOUND` errors was too strict, causing errors when the message wording changes (which it does under PnP mode, since instead of the generic "Module not found" we specify the exact reason why the module isn't found).

Closes: #5634
See also: https://github.com/serverless/utils/pull/75
