### PR TITLE
Properly resolve SHA for repo with slashes

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1973,7 +1973,7 @@ Object.defineProperties(
           };
         }
 
-        const [repositoryName, imageTag] = image.split('/')[1].split(':');
+        const [repositoryName, imageTag] = image.slice(image.indexOf('/') + 1).split(':');
         const registryId = image.split('.')[0];
         const describeImagesResponse = await this.request('ECR', 'describeImages', {
           imageIds: [


### PR DESCRIPTION
Minor fix that should properly resolve repository name when using images with tags defined and repository has slashes in it's name. 

Closes: #8917 