### PR TITLE
docs: Document the `noDeploy` switch for `aws` provider

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -23,6 +23,7 @@ serverless deploy
 ## Options
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
+- `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.


### PR DESCRIPTION
This matches the Azure, Kubeless and OpenWhisk providers; the AWS `deploy` command
is checking the flag as well.

See https://github.com/serverless/serverless/blob/134db21ed27874ae64db1c8964523b5b5ae6c2bf/lib/plugins/aws/deploy/index.js#L88-L94

Note that there is also the `shouldNotDeploy` flag on the provider, which seems to be an internal flag only.