### PR TITLE
Provide support for custom tsconfig files in serverless.ts definitions

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -139,7 +139,7 @@ class Serverless {
     if (this.configurationPath && !this.configurationInput) {
       this.configurationInput = await (async () => {
         try {
-          return await readConfiguration(this.configurationPath);
+          return await readConfiguration(this.configurationPath, this.config);
         } catch (error) {
           if (isHelpRequest()) return null;
           throw error;

--- a/lib/configuration/read.js
+++ b/lib/configuration/read.js
@@ -43,6 +43,38 @@ const resolveTsNode = async (serviceDir) => {
   }
 };
 
+const resolveTsConfigPaths = async (serviceDir) => {
+  // 1. If installed aside of a Framework, use it
+  try {
+    return (await resolveModulePath(__dirname, 'tsconfig-paths')).realPath;
+  } catch (slsDepError) {
+    if (slsDepError.code !== 'MODULE_NOT_FOUND') throw slsDepError;
+
+    // 2. If installed in a service, use it
+    try {
+      return (await resolveModulePath(serviceDir, 'tsconfig-paths')).realPath;
+    } catch (serviceDepError) {
+      if (serviceDepError.code !== 'MODULE_NOT_FOUND') throw serviceDepError;
+
+      // 3. If installed globally, use it
+      const { stdoutBuffer } = await (async () => {
+        try {
+          return await spawn('npm', ['root', '-g']);
+        } catch (error) {
+          if (error.code !== 'ENOENT') throw error;
+          throw new Error('"tsconfig-paths" not found');
+        }
+      })();
+      try {
+        return require.resolve(`${String(stdoutBuffer).trim()}/tsconfig-paths`);
+      } catch (globalDepError) {
+        if (globalDepError.code !== 'MODULE_NOT_FOUND') throw globalDepError;
+        throw new ServerlessError('"tsconfig-paths" not found');
+      }
+    }
+  }
+};
+
 const readConfigurationFile = async (configurationPath) => {
   try {
     return await fs.readFile(configurationPath, 'utf8');
@@ -60,7 +92,7 @@ const readConfigurationFile = async (configurationPath) => {
   }
 };
 
-const parseConfigurationFile = async (configurationPath) => {
+const parseConfigurationFile = async (configurationPath, config) => {
   switch (path.extname(configurationPath)) {
     case '.yml':
     case '.yaml': {
@@ -101,8 +133,30 @@ const parseConfigurationFile = async (configurationPath) => {
           );
         }
       })();
+
+      // process the tsconfig-paths module being available
+      const tsConfigPaths = await (async () => {
+        try {
+          return await resolveTsConfigPaths(path.dirname(configurationPath));
+        } catch (error) {
+          throw new ServerlessError(
+            `Cannot parse "${path.basename(
+              configurationPath
+            )}": Resolution of "tsconfig-paths" failed with: ${error.message}`,
+            'CONFIGURATION_RESOLUTION_ERROR'
+          );
+        }
+      })();
+
       try {
-        require(tsNodePath).register();
+        const registerParams = { require: [] };
+        if (config && config.tsConfigPath) {
+          registerParams.project = config.tsConfigPath;
+        }
+        if (tsConfigPaths) {
+          registerParams.require.push('tsconfig-paths/register');
+        }
+        require(tsNodePath).register(registerParams);
       } catch (error) {
         throw new ServerlessError(
           `Cannot parse "${path.basename(configurationPath)}": Register of "ts-node" failed with: ${
@@ -145,20 +199,20 @@ const parseConfigurationFile = async (configurationPath) => {
     }
     default:
       throw new ServerlessError(
-        `Cannot parse "${path.basename(configurationPath)}": Usupported file extension`,
+        `Cannot parse "${path.basename(configurationPath)}": Unsupported file extension`,
         'UNSUPPORTED_CONFIGURATION_TYPE'
       );
   }
 };
 
-module.exports = async (configurationPath) => {
+module.exports = async (configurationPath, config) => {
   configurationPath = path.resolve(
     ensureString(configurationPath, {
       name: 'configurationPath',
     })
   );
 
-  let configuration = await parseConfigurationFile(configurationPath);
+  let configuration = await parseConfigurationFile(configurationPath, config);
 
   if (!isPlainObject(configuration)) {
     throw new ServerlessError(

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -46,10 +46,23 @@ const processSpanPromise = (async () => {
     const readConfiguration = require('../lib/configuration/read');
 
     const configurationPath = await resolveConfigurationPath();
+    const configurationOptions = {};
+
+    // For typescript (serverless.ts) templates, look for the existence of the tsconfig file to parse the template with
+    if (configurationPath.toString().endsWith('.ts')) {
+      for (const [index, value] of process.argv.entries()) {
+        if (value === '--ts-config-path') {
+          configurationOptions.tsConfigPath = process.argv[index + 1];
+        }
+        if (value.startsWith('--ts-config-path=')) {
+          configurationOptions.tsConfigPath = value.slice('--ts-config-path='.length);
+        }
+      }
+    }
     const configuration = configurationPath
       ? await (async () => {
           try {
-            return await readConfiguration(configurationPath);
+            return await readConfiguration(configurationPath, configurationOptions);
           } catch (error) {
             // Configuration syntax error should not prevent help from being displayed
             // (if possible configuration should be read for help request as registered

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -49,7 +49,7 @@ const processSpanPromise = (async () => {
     const configurationOptions = {};
 
     // For typescript (serverless.ts) templates, look for the existence of the tsconfig file to parse the template with
-    if (configurationPath.toString().endsWith('.ts')) {
+    if (configurationPath && configurationPath.toString().endsWith('.ts')) {
       for (const [index, value] of process.argv.entries()) {
         if (value === '--ts-config-path') {
           configurationOptions.tsConfigPath = process.argv[index + 1];


### PR DESCRIPTION
Small change to allow the specifying of different tsconfig*.json files (tsconfig.app.json, tsconfig.serverless.json, etc) via the command line and the loading of tsconfig-paths if it's found within the project.

Primary use case is to support [tsconfig paths](https://www.npmjs.com/package/tsconfig-paths), allowing the typescript compiler to use different paths when compiling the serverless.ts definition file.

Monorepos such as [nx](https://nx.dev) rely heavily on multiple modules referenced via the [paths](https://www.typescriptlang.org/tsconfig#paths) but currently serverless.ts won't be able to utilise it without tsconfig-paths  


<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses #8932 
