### PR TITLE
Improve docs and template for `plugins`

### DIFF
--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -114,19 +114,26 @@ In this case `plugin1` is loaded before `plugin2`.
 
 ## Writing Plugins
 
+**Note:** In order to ensure that your plugin works correctly with Framework in `v2.x`, keep the following things in mind:
+
+- Do not depend on `Bluebird` API for Promises returned by Framework internals - we are actively migrating away from `Bluebird` at this point
+- If your plugin adds new properties, ensure to define corresponding schema definitions, please refer to: [Extending validation schema](#extending-validation-schema)
+- Avoid using `subcommands` as the support for them might become deprecated or removed in next major version of the Framework
+- Add `serverless` to `peerDependencies` in order to ensure officially supported Framework version(s)
+
 ### Concepts
 
 #### Plugin
 
 Code which defines _Commands_, any _Events_ within a _Command_, and any _Hooks_ assigned to a _Lifecycle Event_.
 
-- Command // CLI configuration, commands, subcommands, options
+- Command // CLI configuration, commands, options
   - LifecycleEvent(s) // Events that happen sequentially when the command is run
     - Hook(s) // Code that runs when a Lifecycle Event happens during a Command
 
 #### Command
 
-A CLI _Command_ that can be called by a user, e.g. `serverless deploy`. A Command has no logic, but simply defines the CLI configuration (e.g. command, subcommands, parameters) and the _Lifecycle Events_ for the command. Every command defines its own lifecycle events.
+A CLI _Command_ that can be called by a user, e.g. `serverless deploy`. A Command has no logic, but simply defines the CLI configuration (e.g. command, parameters) and the _Lifecycle Events_ for the command. Every command defines its own lifecycle events.
 
 ```javascript
 'use strict';
@@ -197,7 +204,7 @@ module.exports = Deploy;
 
 ### Custom Variable Types
 
-As of version 1.52.0 of the Serverless framework, plugins can officially implement their own
+As of version `1.52.0` of the Serverless Framework, plugins can officially implement their own
 variable types for use in serverless config files.
 
 Example:
@@ -252,34 +259,9 @@ If the value is an `Object`, it can have the following keys:
   if they try to use the variable type in one of the fields disabled for populating
   stage/region/credentials.
 
-### Nesting Commands
-
-You can also nest commands, e.g. if you want to provide a command `serverless deploy function`. Those nested commands have their own lifecycle events and do not inherit them from their parents.
-
-```javascript
-'use strict';
-
-class MyPlugin {
-  constructor() {
-    this.commands = {
-      deploy: {
-        lifecycleEvents: ['resources', 'functions'],
-        commands: {
-          function: {
-            lifecycleEvents: ['package', 'deploy'],
-          },
-        },
-      },
-    };
-  }
-}
-
-module.exports = MyPlugin;
-```
-
 ### Defining Options
 
-Each (sub)command can have multiple Options.
+Each command can have multiple Options.
 
 Options are passed in with a double dash (`--`) like this: `serverless function deploy --function functionName`.
 

--- a/lib/plugins/create/templates/plugin/README.md
+++ b/lib/plugins/create/templates/plugin/README.md
@@ -1,0 +1,15 @@
+# Serverless Plugin
+
+This plugin has been generated using the `plugin` template from the [Serverless Framework](https://www.serverless.com/).
+
+## Implementing your plugin
+
+When developing your plugin, please refer to the following sources:
+
+- [Plugins Documentation](https://www.serverless.com/framework/docs/providers/aws/guide/plugins/)
+- [Blog - How to create serverless plugins - Part 1](https://serverless.com/blog/writing-serverless-plugins/)
+- [Blog - How to create serverless plugins - Part 2](https://serverless.com/blog/writing-serverless-plugins-2/)
+
+## Sharing your plugin
+
+After implementing your plugin, you might consider sharing it with a wider audience. You might do it by adding it to `Community Contributed Plugins` in official [plugins repository](https://github.com/serverless/plugins).

--- a/lib/plugins/create/templates/plugin/package.json
+++ b/lib/plugins/create/templates/plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "serverless-plugin",
+  "version": "1.0.0",
+  "description": "Serverless plugin template",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "serverless": "2.x"
+  },
+  "engines": {
+    "node": ">=10.0"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
As discussed, this adds a few small changes to documentation and `plugin` template:
- Introduce `package.json` with `peerDependencies` specified for `plugin` template
- Introduce a simple `README.md` with a few resources on how to build a plugin or how to share it 
- Remove references to `subcommands` in plugins (in relation to recent discussion about removing support for subcommands altogether)
- Add notes regarding development of plugins for Serverless Framework `2.x` (and potential further majors)

I also considered moving the general doc outside of `aws` provider section - what do you think? Do you have any other suggestion to the structure of our current information and/or proposed changes? 