### PR TITLE
fix: Ensure that `list-version` is invoked

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -35,7 +35,7 @@ const processSpanPromise = (async () => {
     const { commands, options } = require('../lib/cli/resolve-input')();
 
     if (options.version) {
-      await require('../lib/cli/list-version');
+      await require('../lib/cli/list-version')();
       return;
     }
 


### PR DESCRIPTION
Minor fix - `list-version` was not invoked after require which resulted in version not being printed