### PR TITLE
chore(Templates): Remove unused deps in `aws-nodejs-typescript`

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -18,7 +18,6 @@
     "@serverless/typescript": "^2.23.0",
     "@types/aws-lambda": "^8.10.71",
     "@types/node": "^14.14.25",
-    "fork-ts-checker-webpack-plugin": "^6.1.0",
     "json-schema-to-ts": "^1.5.0",
     "serverless": "^2.23.0",
     "serverless-webpack": "^5.3.5",


### PR DESCRIPTION
This is in response to [@fredericbarthelet's response](https://github.com/serverless/serverless/pull/8646#issuecomment-775933062) to my comment on #8646.

I've inferred from your comment, @fredericbarthelet, that the config is needed for the plugin to work, hence the intent is not to include it, so this PR removes it from the `package.json`.

In regards to the `.gitignore` file, I've just found that [the template already has one](https://github.com/serverless/serverless/blob/master/lib/plugins/create/templates/aws-nodejs-typescript/.gitignore) - however it isn't created when the template is installed.  A fix for that is beyond me currently.

Thank you!