### PR TITLE
fix(Templates): Bring back `gitignore` to include in package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /node_modules
 npm-debug.log
 /package-lock.json
-!/lib/plugins/create/templates/**/.gitignore

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@
 /scripts/test
 /test
 /VERSIONING.md
+!/lib/plugins/create/templates/**/.gitignore


### PR DESCRIPTION
It reverts the previous change as it turned out that it's impossible to include `.gitignore` in npm packages. I've tried adding it to `.npmignore` as well and after some searching it seems like our current approach is the standard (e.g. yeoman, create-react-app are using the same approach). I've also adjusted a few templates that had `.gitignore` with a `.` initially. 