### PR TITLE
fix(AWS Lambda): Throw verbose error when referencing invalid layer

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -721,6 +721,13 @@ function extractLayerConfigurationsFromFunction(functionProperties, cfTemplate) 
   functionProperties.Layers.forEach((potentialLocalLayerObject) => {
     if (potentialLocalLayerObject.Ref) {
       const configuration = cfTemplate.Resources[potentialLocalLayerObject.Ref];
+      if (!configuration) {
+        throw new ServerlessError(
+          `Could not find reference to layer: ${potentialLocalLayerObject.Ref}. Ensure that you are referencing layer defined in your service.`,
+          'LAMBDA_LAYER_REFERENCE_NOT_FOUND'
+        );
+      }
+
       layerConfigurations.push({
         name: configuration._serverlessLayerName,
         ref: potentialLocalLayerObject.Ref,

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -2082,6 +2082,23 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L2325-L2362
     });
 
+    it('should throw an error when nonexistent layer is referenced', async () => {
+      await expect(
+        runServerless({
+          fixture: 'functionDestinations',
+          cliArgs: ['package'],
+          configExt: {
+            functions: {
+              fnInvalidLayer: {
+                handler: 'target.handler',
+                layers: [{ Ref: 'NonexistentLambdaLayer' }],
+              },
+            },
+          },
+        })
+      ).to.be.eventually.rejected.and.have.property('code', 'LAMBDA_LAYER_REFERENCE_NOT_FOUND');
+    });
+
     it.skip('TODO: should support `functions[].conditions`', () => {
       // Replacement for
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L2364-L2379


### PR DESCRIPTION
Throw a more meaningful error when referencing Layer that is not defined as a part of the service. This is just a cosmetic change and full-fledged solution should be implemented as a part of https://github.com/serverless/serverless/issues/8915

Closes: #8960