### PR TITLE
fix(Variables): Properly resolve vars if `prototype` in path

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -308,7 +308,10 @@ class Variables {
     return BbPromise.all(populations).then((results) =>
       results.forEach((result) => {
         if (result.value !== result.populated) {
-          _.set(target, result.path, result.populated);
+          const pathArray = Array.isArray(result.path) ? result.path : result.path.split('.');
+          let obj = target;
+          for (const property of pathArray.slice(0, -1)) obj = obj[property];
+          obj[_.last(pathArray)] = result.populated;
         }
       })
     );

--- a/test/fixtures/variables/serverless.yml
+++ b/test/fixtures/variables/serverless.yml
@@ -17,3 +17,5 @@ custom:
   nestedVal:
     prop: resolvedNested
   nestedReference: ${self:custom.${self:custom.nestedRef}.prop}
+  prototype:
+    nestedInPrototype: ${file(config.json):foo}-in-prototype

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -2816,6 +2816,10 @@ describe('test/unit/lib/classes/Variables.test.js', () => {
     expect(processedConfig.custom.nestedReference).to.equal('resolvedNested');
   });
 
+  it('should handle resolving variables when `prototype` is part of the path', async () => {
+    expect(processedConfig.custom.prototype.nestedInPrototype).to.equal('bar-in-prototype');
+  });
+
   describe('variable resolving', () => {
     describe('when unresolvedVariablesNotificationMode is set to "error"', () => {
       it('should error for missing "environment variable" type variables', async () => {


### PR DESCRIPTION
Properly resolve variables if `prototype` is present in `path` to property where that variable should be replaced. Bug was caused by `_.set` preventing updates if `prototype` is present and resulted in infinite loop in variables resolver.

Closes: #8956 