### PR TITLE
fix(AWS ALB): Conform to CF schema with multiple host header

### DIFF
--- a/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.js
@@ -85,7 +85,9 @@ module.exports = {
       if (event.conditions.host) {
         Conditions.push({
           Field: 'host-header',
-          Values: event.conditions.host,
+          HostHeaderConfig: {
+            Values: event.conditions.host,
+          },
         });
       }
       if (event.conditions.method) {

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -106,7 +106,9 @@ describe('#compileListenerRules()', () => {
           },
           {
             Field: 'host-header',
-            Values: ['example.com'],
+            HostHeaderConfig: {
+              Values: ['example.com'],
+            },
           },
         ],
         ListenerArn:


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #8954 

Changes the host-header condition to always use HostHeaderConfig dictionary, per documentation at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-rulecondition.html
Updated tests to account for the new structure and added a second host condition test that verifies a multiple-host condition.

