### PR TITLE
fix(Templates): Properly package `gradle-wrapper` into npm package

### DIFF
--- a/lib/plugins/create/templates/aws-groovy-gradle/.gitignore
+++ b/lib/plugins/create/templates/aws-groovy-gradle/.gitignore
@@ -14,3 +14,4 @@
 # Serverless directories
 .serverless
 
+!/gradle/wrapper/gradle-wrapper.jar

--- a/lib/plugins/create/templates/aws-java-gradle/.gitignore
+++ b/lib/plugins/create/templates/aws-java-gradle/.gitignore
@@ -14,3 +14,4 @@
 # Serverless directories
 .serverless
 
+!/gradle/wrapper/gradle-wrapper.jar

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle-kts/.gitignore
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle-kts/.gitignore
@@ -14,3 +14,4 @@
 # Serverless directories
 .serverless
 
+!/gradle/wrapper/gradle-wrapper.jar

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle/.gitignore
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle/.gitignore
@@ -14,3 +14,4 @@
 # Serverless directories
 .serverless
 
+!/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
Bug discovered when working on #8406 - it turns out that it's not possible to package files with `.jar` extensions into npm package. I've tried explicitly including it via `npmignore` in a similar manner to `.gitignore` but it didn't work. I've also confirmed that our latest version published does not include these `jar`s. After implementing the fix, I've confirmed that it's working correctly by running tests against a package generate with `npm pack`.  