### PR TITLE
Improve testing standalone and package artifacts

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -179,6 +179,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SLS_AWS_REQUEST_MAX_RETRIES: 21 #Increase number of retries, do to observed "Rate exceeded" fails
+      SERVERLESS_BINARY_PATH: ./dist/serverless-linux2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -206,9 +207,12 @@ jobs:
       # Note: No need to install dependencies as we have retrieved cached `node_modules` for very
       #       same `package.json` as stored with previous job
 
-      - name: Basic integration tests
+      - name: Build standalone artifacts
+        run: npm run pkg:build
+
+      - name: Basic integration tests against standalone binary
         run: npm run integration-test-run-basic
-      - name: Full integration tests
+      - name: Full integration tests against standalone binary
         run: npm run integration-test-run-all
 
       - name: Resolve last validated commit hash (for `git diff` purposes)

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -179,7 +179,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SLS_AWS_REQUEST_MAX_RETRIES: 21 #Increase number of retries, do to observed "Rate exceeded" fails
-      SERVERLESS_BINARY_PATH: ./dist/serverless-linux2
+      SERVERLESS_BINARY_PATH: ./dist/serverless-linux
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,49 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
+  prePublishPackageTest:
+    name: Prepublish package test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        if: steps.cacheNpm.outputs.cache-hit != 'true'
+        run: |
+          npm update --no-save
+          npm update --save-dev --no-save
+
+      - name: Build local package
+        run: npm pack
+
+      - name: Run tests against version packaged with npm pack
+        run: |
+          PACKAGE_VERSION=$(npm view . version)
+          mkdir "serverless-${PACKAGE_VERSION}"
+          tar zxf "serverless-${PACKAGE_VERSION}.tgz" -C "serverless-${PACKAGE_VERSION}"
+          cp -R test "serverless-${PACKAGE_VERSION}/package"
+          ln -s "$(pwd)"/node_modules "serverless-${PACKAGE_VERSION}/package/node_modules"
+          cd "serverless-${PACKAGE_VERSION}/package"
+          script -e -c "npm test -- -b"
+
   npmPublish:
     name: Publish to npm
+    needs: prePublishPackageTest
     runs-on: ubuntu-latest
     env:
       # It'll work with secrets.GITHUB_TOKEN (which is provided by GitHub unconditionally)


### PR DESCRIPTION
As discussed, it introduces running integration tests against our standalone binary + adds an extra `prePublish` job, that runs unit tests against the artifact built with `npm pack`. I've tested the CI jobs here: https://github.com/serverless/serverless/actions?query=branch%3Aimprove-testing-of-published-packages++ - I'll remove that branch after merging this PR. 

Closes: #8406 