### PR TITLE
Test: Sanity tests for main "serverless" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,12 +135,11 @@
   "nyc": {
     "all": true,
     "exclude": [
-      "**/*.test.js",
       ".github",
-      "bin/**",
       "coverage/**",
       "dist/**",
-      "scripts/**",
+      "docs/**",
+      "scripts/test/**",
       "test/**",
       "tmp/**",
       "prettier.config.js"

--- a/test/fixtures/exception/plugin.js
+++ b/test/fixtures/exception/plugin.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = class Plugin {
+  constructor() {
+    throw new Error('Stop');
+  }
+};

--- a/test/fixtures/exception/serverless.yml
+++ b/test/fixtures/exception/serverless.yml
@@ -1,0 +1,10 @@
+service: service
+
+configValidationMode: error
+frameworkVersion: '*'
+
+provider:
+  name: aws
+
+plugins:
+  - ./plugin

--- a/test/fixtures/uncaughtException/plugin.js
+++ b/test/fixtures/uncaughtException/plugin.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = class Plugin {
+  constructor() {
+    setTimeout(() => {
+      throw new Error('Stop');
+    });
+  }
+};

--- a/test/fixtures/uncaughtException/serverless.yml
+++ b/test/fixtures/uncaughtException/serverless.yml
@@ -1,0 +1,10 @@
+service: service
+
+configValidationMode: error
+frameworkVersion: '*'
+
+provider:
+  name: aws
+
+plugins:
+  - ./plugin

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const path = require('path');
+const spawn = require('child-process-ext/spawn');
+const { version } = require('../../../package');
+const fixturesEngine = require('../../fixtures');
+
+const serverlessPath = path.resolve(__dirname, '../../../scripts/serverless.js');
+const fixturesPath = path.resolve(__dirname, '../../fixtures');
+
+describe('test/unit/scripts/serverless.test.js', () => {
+  it('Should display version when "--version" option', async () => {
+    const output = String((await spawn('node', [serverlessPath, '-v'])).stdoutBuffer);
+    expect(output).to.include(`Framework Core: ${version}`);
+  });
+
+  it('Invalid configuration should not prevent help output', async () => {
+    const output = String(
+      (
+        await spawn('node', [serverlessPath, '--help'], {
+          cwd: path.resolve(fixturesPath, 'configSyntaxError'),
+        })
+      ).stdoutBuffer
+    );
+    expect(output).to.include('You can run commands with');
+  });
+
+  it('Invalid configuration should be reported when no help output', async () => {
+    try {
+      await spawn('node', [serverlessPath, 'print'], {
+        cwd: path.resolve(fixturesPath, 'configSyntaxError'),
+      });
+      throw new Error('Unexpected');
+    } catch (error) {
+      expect(error.code).to.equal(1);
+      expect(String(error.stdoutBuffer)).to.include('Your Environment Information');
+    }
+  });
+
+  it('Should handle exceptions', async () => {
+    try {
+      await spawn('node', [serverlessPath, 'print'], {
+        cwd: path.resolve(fixturesPath, 'exception'),
+      });
+      throw new Error('Unexpected');
+    } catch (error) {
+      expect(error.code).to.equal(1);
+      expect(String(error.stdoutBuffer)).to.include('Your Environment Information');
+    }
+  });
+  it('Should handle uncaught exceptions', async () => {
+    try {
+      await spawn('node', [serverlessPath, 'print'], {
+        cwd: path.resolve(fixturesPath, 'uncaughtException'),
+      });
+      throw new Error('Unexpected');
+    } catch (error) {
+      expect(error.code).to.equal(1);
+      expect(String(error.stdoutBuffer)).to.include('Your Environment Information');
+    }
+  });
+
+  it('Should handle local serverless installation', async () => {
+    const output = String(
+      (
+        await spawn('node', [serverlessPath, '--help'], {
+          cwd: (await fixturesEngine.setup('locallyInstalledServerless')).servicePath,
+        })
+      ).stdoutBuffer
+    );
+    expect(output).to.include('Running "serverless" installed locally');
+  });
+});


### PR DESCRIPTION
[`serverless`](https://github.com/serverless/serverless/blob/36c78c70d1cf306556a5a9f8a3c3908e8b4c7d05/scripts/serverless.js) main script is about to be further extended with introduction of new variables resolver, and when working on that I've realized it's no longer safe to continue without tests for this file.

Also we already had [a regression](https://github.com/serverless/serverless/pull/8945) due to lack of such sanity tests.

I've also improved the coverage `exclude` configuration (`script/serverless` was excluded), which is likely to drop numbers in our general coverage report, but at least it'll present fair report.