### PR TITLE
refactor: Remove `bluebird` from top-level `lib/plugins`

### DIFF
--- a/lib/plugins/config.js
+++ b/lib/plugins/config.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const BbPromise = require('bluebird');
 const config = require('@serverless/utils/config');
 const ServerlessError = require('../serverless-error');
 const isTabTabCompletionSupported = require('../utils/tabCompletion/isSupported');
@@ -148,57 +147,51 @@ class Config {
   }
 
   async tabtabCompletionInstall() {
-    return BbPromise.try(() => {
-      const shell = this.serverless.processedInput.options.shell || 'bash';
+    const shell = this.serverless.processedInput.options.shell || 'bash';
 
-      if (!validShells.has(shell)) {
-        throw new ServerlessError(
-          `Shell "${shell}" is not supported. Supported shells: ${Array.from(validShells)}.`
-        );
-      }
-      const location = (() => {
-        if (this.serverless.processedInput.options.location) {
-          return this.serverless.processedInput.options.location;
-        }
-        const { BASH_LOCATION, FISH_LOCATION, ZSH_LOCATION } = require('tabtab/lib/constants');
-        switch (shell) {
-          case 'bash':
-            return BASH_LOCATION;
-          case 'zsh':
-            return ZSH_LOCATION;
-          case 'fish':
-            return FISH_LOCATION;
-          default:
-            throw new Error('Unexpected shell choice');
-        }
-      })();
-      const { install } = require('tabtab/lib/installer');
-      return muteConsoleLog(() =>
-        tabtabOptions.reduce(
-          (previousOperation, options) =>
-            previousOperation.then(() => install(Object.assign({ location }, options))),
-          BbPromise.resolve()
-        )
-      ).then(() =>
-        this.serverless.cli.log(
-          `Tab autocompletion setup for ${shell}. Make sure to reload your SHELL.`
-        )
+    if (!validShells.has(shell)) {
+      throw new ServerlessError(
+        `Shell "${shell}" is not supported. Supported shells: ${Array.from(validShells)}.`
       );
+    }
+    const location = (() => {
+      if (this.serverless.processedInput.options.location) {
+        return this.serverless.processedInput.options.location;
+      }
+      const { BASH_LOCATION, FISH_LOCATION, ZSH_LOCATION } = require('tabtab/lib/constants');
+      switch (shell) {
+        case 'bash':
+          return BASH_LOCATION;
+        case 'zsh':
+          return ZSH_LOCATION;
+        case 'fish':
+          return FISH_LOCATION;
+        default:
+          throw new Error('Unexpected shell choice');
+      }
+    })();
+
+    const { install } = require('tabtab/lib/installer');
+    await muteConsoleLog(async () => {
+      for (const options of tabtabOptions) {
+        await install(Object.assign({ location }, options));
+      }
     });
+
+    this.serverless.cli.log(
+      `Tab autocompletion setup for ${shell}. Make sure to reload your SHELL.`
+    );
   }
 
   async tabtabCompletionUninstall() {
-    return BbPromise.try(() => {
-      const { uninstall } = require('tabtab/lib/installer');
-      return muteConsoleLog(() =>
-        tabtabOptions.reduce(
-          (previousOperation, options) => previousOperation.then(() => uninstall(options)),
-          BbPromise.resolve()
-        )
-      ).then(() =>
-        this.serverless.cli.log('Tab autocompletion uninstalled (for all configured shells).')
-      );
+    const { uninstall } = require('tabtab/lib/installer');
+    await muteConsoleLog(async () => {
+      for (const options of tabtabOptions) {
+        await uninstall(options);
+      }
     });
+
+    this.serverless.cli.log('Tab autocompletion uninstalled (for all configured shells).');
   }
 }
 

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -125,8 +125,9 @@ class Deploy {
         }
       },
       'after:deploy:finalize': async () => {
-        if (!this.deferredBackendNotificationRequest) return null;
-        return this.deferredBackendNotificationRequest.then(processBackendNotificationRequest);
+        if (!this.deferredBackendNotificationRequest) return;
+        const notifications = await this.deferredBackendNotificationRequest;
+        processBackendNotificationRequest(notifications);
       },
     };
   }

--- a/lib/plugins/install.js
+++ b/lib/plugins/install.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const BbPromise = require('bluebird');
-
 const download = require('../utils/downloadTemplateFromRepo');
 
 class Install {
@@ -28,25 +26,23 @@ class Install {
     };
 
     this.hooks = {
-      'install:install': async () => BbPromise.bind(this).then(this.install),
+      'install:install': async () => this.install(),
     };
   }
 
   async install() {
-    return download
-      .downloadTemplateFromRepo(this.options.url, this.options.name)
-      .then((serviceName) => {
-        const message = [
-          `Successfully installed "${serviceName}" `,
-          `${
-            this.options.name && this.options.name !== serviceName
-              ? `as "${this.options.name}"`
-              : ''
-          }`,
-        ].join('');
+    const serviceName = await download.downloadTemplateFromRepo(
+      this.options.url,
+      this.options.name
+    );
+    const message = [
+      `Successfully installed "${serviceName}" `,
+      `${
+        this.options.name && this.options.name !== serviceName ? `as "${this.options.name}"` : ''
+      }`,
+    ].join('');
 
-        this.serverless.cli.log(message);
-      });
+    this.serverless.cli.log(message);
   }
 }
 

--- a/lib/plugins/invoke.js
+++ b/lib/plugins/invoke.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const BbPromise = require('bluebird');
 const _ = require('lodash');
 
 class Invoke {
@@ -101,9 +100,9 @@ class Invoke {
     };
 
     this.hooks = {
-      'invoke:local:loadEnvVars': async () => BbPromise.bind(this).then(this.loadEnvVarsForLocal),
-      'after:invoke:invoke': async () => BbPromise.bind(this).then(this.trackInvoke),
-      'after:invoke:local:invoke': async () => BbPromise.bind(this).then(this.trackInvokeLocal),
+      'invoke:local:loadEnvVars': this.loadEnvVarsForLocal.bind(this),
+      'after:invoke:invoke': this.trackInvoke.bind(this),
+      'after:invoke:local:invoke': this.trackInvokeLocal.bind(this),
     };
   }
 

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -2,7 +2,6 @@
 
 const os = require('os');
 const _ = require('lodash');
-const BbPromise = require('bluebird');
 const jc = require('json-cycle');
 const yaml = require('js-yaml');
 const ServerlessError = require('../serverless-error');
@@ -32,7 +31,7 @@ class Print {
       },
     };
     this.hooks = {
-      'print:print': async () => BbPromise.bind(this).then(this.print),
+      'print:print': () => this.print.bind(this),
     };
   }
 

--- a/test/unit/lib/plugins/config.test.js
+++ b/test/unit/lib/plugins/config.test.js
@@ -1,16 +1,13 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const os = require('os');
-const BbPromise = require('bluebird');
 const { expect } = require('chai');
 const config = require('@serverless/utils/config');
 const ServerlessError = require('../../../../lib/serverless-error');
 const runServerless = require('../../../utils/run-serverless');
 const isTabCompletionSupported = require('../../../../lib/utils/tabCompletion/isSupported');
-
-BbPromise.promisifyAll(fs);
 
 const unexpected = () => {
   throw new Error('Unexpected');
@@ -44,12 +41,12 @@ describe('Config', () => {
       }).then(() =>
         Promise.all([
           fs
-            .readFileAsync(path.resolve(os.homedir(), '.bashrc'), 'utf8')
+            .readFile(path.resolve(os.homedir(), '.bashrc'), 'utf8')
             .then((bashRcContent) =>
               expect(bashRcContent).to.include(' ~/.config/tabtab/__tabtab.bash')
             ),
-          fs.readFileAsync(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'), 'utf8'),
-          fs.readFileAsync(path.resolve(os.homedir(), '.config/tabtab/sls.bash'), 'utf8'),
+          fs.readFile(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'), 'utf8'),
+          fs.readFile(path.resolve(os.homedir(), '.config/tabtab/sls.bash'), 'utf8'),
         ])
       ));
 
@@ -66,10 +63,10 @@ describe('Config', () => {
         }).then(() =>
           Promise.all([
             fs
-              .readFileAsync(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'))
+              .readFile(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'))
               .then(unexpected, (error) => expect(error.code).to.equal('ENOENT')),
             fs
-              .readFileAsync(path.resolve(os.homedir(), '.config/tabtab/sls.bash'))
+              .readFile(path.resolve(os.homedir(), '.config/tabtab/sls.bash'))
               .then(unexpected, (error) => expect(error.code).to.equal('ENOENT')),
           ])
         )

--- a/test/unit/lib/plugins/deploy.test.js
+++ b/test/unit/lib/plugins/deploy.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const BbPromise = require('bluebird');
 const chai = require('chai');
 const Deploy = require('../../../../lib/plugins/deploy');
 const Serverless = require('../../../../lib/Serverless');
@@ -71,7 +70,7 @@ describe('Deploy', () => {
       deploy.serverless.service.package.path = false;
 
       return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled.then(() =>
-        BbPromise.all([
+        Promise.all([
           expect(spawnDeployFunctionStub).to.not.be.called,
           expect(spawnPackageStub).to.be.calledOnce,
           expect(spawnPackageStub).to.be.calledWithExactly('package'),
@@ -85,7 +84,7 @@ describe('Deploy', () => {
       deploy.serverless.service.package.path = false;
 
       return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled.then(() =>
-        BbPromise.all([
+        Promise.all([
           expect(spawnPackageStub).to.not.be.called,
           expect(spawnDeployFunctionStub).to.be.calledOnce,
           expect(spawnDeployFunctionStub).to.be.calledWithExactly('deploy:function', {

--- a/test/unit/lib/plugins/invoke.test.js
+++ b/test/unit/lib/plugins/invoke.test.js
@@ -46,32 +46,34 @@ describe('Invoke', () => {
         expect(invoke.commands.invoke.commands.local.lifecycleEvents).to.contain('loadEnvVars');
       });
 
-      it('should set IS_LOCAL', () =>
-        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
-          expect(process.env.IS_LOCAL).to.equal('true');
-          expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
-        }));
+      it('should set IS_LOCAL', () => {
+        invoke.hooks['invoke:local:loadEnvVars']();
+
+        expect(process.env.IS_LOCAL).to.equal('true');
+        expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
+      });
 
       it('should leave provider env variable untouched if already defined', () => {
         serverless.service.provider.environment = { IS_LOCAL: 'false' };
-        return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
-          expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
-        });
+        invoke.hooks['invoke:local:loadEnvVars']();
+
+        expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
       });
 
       it('should accept a single env option', () => {
         invoke.options = { env: 'NAME=value' };
-        return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() =>
-          expect(process.env.NAME).to.equal('value')
-        );
+        invoke.hooks['invoke:local:loadEnvVars']();
+
+        expect(process.env.NAME).to.equal('value');
       });
 
       it('should accept multiple env options', () => {
         invoke.options = { env: ['NAME1=val1', 'NAME2=val2'] };
 
-        return expect(invoke.hooks['invoke:local:loadEnvVars']())
-          .to.be.fulfilled.then(() => expect(process.env.NAME1).to.equal('val1'))
-          .then(() => expect(process.env.NAME2).to.equal('val2'));
+        invoke.hooks['invoke:local:loadEnvVars']();
+
+        expect(process.env.NAME1).to.equal('val1');
+        expect(process.env.NAME2).to.equal('val2');
       });
     });
   });


### PR DESCRIPTION
…older

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses: #7171

I can keep adding the rest of the folders under `lib/plugins` since I sort of have them. Just need to review then.
