### PR TITLE
CLI: Fix resolution of empty valued params as `param=`

### DIFF
--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -4,7 +4,7 @@
 
 const ServerlessError = require('../serverless-error');
 
-const paramRe = /^-(?:-(?<fullName>[a-zA-Z][A-Za-z0-9:_-]+)|(?<aliasNames>[a-z]+))(?:=(?<value>.+)|$)/;
+const paramRe = /^-(?:-(?<fullName>[a-zA-Z][A-Za-z0-9:_-]+)|(?<aliasNames>[a-z]+))(?:=(?<value>.*)|$)/;
 const isParamName = RegExp.prototype.test.bind(paramRe);
 
 module.exports = (
@@ -24,12 +24,13 @@ module.exports = (
       continue;
     }
     const { fullName, aliasNames, value } = paramMatch.groups;
-    const isBoolean = !value && (!args[i + 1] || args[i + 1] === '--' || isParamName(args[i + 1]));
+    const isBoolean =
+      value == null && (!args[i + 1] || args[i + 1] === '--' || isParamName(args[i + 1]));
 
     let paramName;
     if (aliasNames) {
       if (aliasNames.length > 1) {
-        if (value) {
+        if (value != null) {
           throw new ServerlessError(
             `Unexpected value for "-${aliasNames}"`,
             'UNEXPECTED_CLI_PARAM_VALUE'
@@ -58,28 +59,28 @@ module.exports = (
       }
       if (multiple.has(paramName)) {
         if (!result[paramName]) result[paramName] = [];
-        result[paramName].push(value || args[++i]);
+        result[paramName].push(value == null ? args[++i] : value || null);
         continue;
       }
-      if (result[paramName] != null) {
+      if (result[paramName] !== undefined) {
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
         );
       }
-      result[paramName] = value || args[++i];
+      result[paramName] = value == null ? args[++i] : value || null;
       continue;
     }
 
     if (paramName.startsWith('no-') && (boolean.has(paramName.slice(3)) || isBoolean)) {
       paramName = paramName.slice(3);
-      if (value) {
+      if (value != null) {
         throw new ServerlessError(
           `Unexpected value for "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_VALUE'
         );
       }
-      if (result[paramName] != null) {
+      if (result[paramName] !== undefined) {
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
@@ -90,13 +91,13 @@ module.exports = (
     }
 
     if (boolean.has(paramName) || isBoolean) {
-      if (value) {
+      if (value != null) {
         throw new ServerlessError(
           `Unexpected value for "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_VALUE'
         );
       }
-      if (result[paramName] != null) {
+      if (result[paramName] !== undefined) {
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
@@ -106,20 +107,20 @@ module.exports = (
       continue;
     }
 
-    if (result[paramName] != null) {
+    if (result[paramName] !== undefined) {
       if (Array.isArray(result[paramName])) {
-        result[paramName].push(value || args[++i]);
-      } else if (typeof result[paramName] === 'string') {
-        result[paramName] = [result[paramName], value || args[++i]];
-      } else {
+        result[paramName].push(value == null ? args[++i] : value || null);
+      } else if (typeof result[paramName] === 'boolean') {
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
         );
+      } else {
+        result[paramName] = [result[paramName], value == null ? args[++i] : value || null];
       }
       continue;
     }
-    result[paramName] = value || args[++i];
+    result[paramName] = value == null ? args[++i] : value || null;
   }
 
   return result;

--- a/test/unit/lib/cli/parse-args.test.js
+++ b/test/unit/lib/cli/parse-args.test.js
@@ -15,21 +15,30 @@ describe('test/unit/lib/cli/parse-args.test.js', () => {
         '--unspecified-boolean',
         '--unspecified-multiple',
         'one',
+        '--unspecified-multiple=',
+        '--unspecified-multiple=',
         '--unspecified-multiple',
         'test',
         '--unspecified-multiple=another',
         '--unspecified-multiple',
         'another2',
+        '--unspecified-multiple2',
+        'one',
+        '--unspecified-multiple2',
+        'other',
         '--multiple',
         'single',
+        '--string-empty=',
         '-a',
         'value',
+        '--multiple=',
         '--multiple',
         'other',
         '--boolean',
         'elo',
         '--no-other-boolean',
         'foo',
+        '--empty=',
         '-bc',
         '--underscore_separator',
         'underscored_value',
@@ -41,7 +50,7 @@ describe('test/unit/lib/cli/parse-args.test.js', () => {
       ],
       {
         boolean: new Set(['boolean', 'other-boolean']),
-        string: new Set(['string']),
+        string: new Set(['string', 'string-empty']),
         multiple: new Set(['multiple']),
         alias: new Map([['a', 'alias']]),
       }
@@ -66,15 +75,19 @@ describe('test/unit/lib/cli/parse-args.test.js', () => {
   it('should recognize unspecified multiple param', async () => {
     expect(parsedArgs['unspecified-multiple']).to.deep.equal([
       'one',
+      null,
+      null,
       'test',
       'another',
       'another2',
     ]);
+    expect(parsedArgs['unspecified-multiple2']).to.deep.equal(['one', 'other']);
     delete parsedArgs['unspecified-multiple'];
+    delete parsedArgs['unspecified-multiple2'];
   });
 
   it('should recognize multiple param', async () => {
-    expect(parsedArgs.multiple).to.deep.equal(['single', 'other']);
+    expect(parsedArgs.multiple).to.deep.equal(['single', null, 'other']);
     delete parsedArgs.multiple;
   });
 
@@ -98,6 +111,13 @@ describe('test/unit/lib/cli/parse-args.test.js', () => {
     expect(parsedArgs.c).to.equal(true);
     delete parsedArgs.b;
     delete parsedArgs.c;
+  });
+
+  it('should recognize empty value', async () => {
+    expect(parsedArgs.empty).to.equal(null);
+    expect(parsedArgs['string-empty']).to.equal(null);
+    delete parsedArgs.empty;
+    delete parsedArgs['string-empty'];
   });
 
   it('should recognize underscore chars in params', async () => {


### PR DESCRIPTION
Addresses issue reported in comment: https://github.com/serverless/serverless/pull/8927#issuecomment-782972623

In current version parser doesn't recognize empty params (as `--param-=`). This patch fixes that


