### PR TITLE
CLI: Recognize "-s" as "--stage" alias, and other common params

### DIFF
--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -5,12 +5,14 @@
 const memoizee = require('memoizee');
 const parseArgs = require('./parse-args');
 
+const customSAliasCommands = new Set(['config credentials'], ['config tabcompletion install']);
+
 module.exports = memoizee(() => {
   const args = process.argv.slice(2);
 
   const baseArgsSchema = {
     boolean: new Set(['help', 'help-interactive', 'v', 'version']),
-    string: new Set(['app', 'config', 'org']),
+    string: new Set(['app', 'config', 'org', 'stage']),
     alias: new Map([
       ['c', 'config'],
       ['h', 'help'],
@@ -28,6 +30,11 @@ module.exports = memoizee(() => {
     // Until that's addressed we can recognize "-v" only with no commands
     baseArgsSchema.boolean.delete('v');
     baseArgsSchema.alias.set('v', 'version');
+  }
+  if (!customSAliasCommands.has(command)) {
+    // Unfortunately, there are few command for which "-s" aliases different param than "--stage"
+    // This handling ensures we do not break those commands
+    baseArgsSchema.alias.set('s', 'stage');
   }
 
   options = parseArgs(args, baseArgsSchema);

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -6,7 +6,7 @@ const memoizee = require('memoizee');
 const parseArgs = require('./parse-args');
 
 const baseArgsSchema = {
-  boolean: new Set(['version', 'help', 'help-interactive', 'v']),
+  boolean: new Set(['help', 'help-interactive', 'v', 'version']),
   string: new Set(['app', 'config', 'org']),
   alias: new Map([
     ['c', 'config'],

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -5,27 +5,34 @@
 const memoizee = require('memoizee');
 const parseArgs = require('./parse-args');
 
-const baseArgsSchema = {
-  boolean: new Set(['help', 'help-interactive', 'v', 'version']),
-  string: new Set(['app', 'config', 'org']),
-  alias: new Map([
-    ['c', 'config'],
-    ['h', 'help'],
-  ]),
-};
 module.exports = memoizee(() => {
   const args = process.argv.slice(2);
-  const options = parseArgs(args, baseArgsSchema);
-  const commands = options._;
-  delete options._;
-  if (!commands.length && options.v && !options.version) {
+
+  const baseArgsSchema = {
+    boolean: new Set(['help', 'help-interactive', 'v', 'version']),
+    string: new Set(['app', 'config', 'org']),
+    alias: new Map([
+      ['c', 'config'],
+      ['h', 'help'],
+    ]),
+  };
+
+  let options = parseArgs(args, baseArgsSchema);
+
+  const command = options._.join(' ');
+  if (!command) {
     // Ideally we should output version info in whatever context "--version" or "-v" params
     // are used. Still "-v" is defined also as a "--verbose" alias for some commands.
     // Support for "--verbose" is expected to go away with
     // https://github.com/serverless/serverless/issues/1720
     // Until that's addressed we can recognize "-v" only with no commands
-    options.version = true;
-    delete options.v;
+    baseArgsSchema.boolean.delete('v');
+    baseArgsSchema.alias.set('v', 'version');
   }
+
+  options = parseArgs(args, baseArgsSchema);
+
+  const commands = options._;
+  delete options._;
   return { commands, options };
 });

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -7,7 +7,7 @@ const parseArgs = require('./parse-args');
 
 const baseArgsSchema = {
   boolean: new Set(['version', 'help', 'help-interactive', 'v']),
-  string: new Set(['config']),
+  string: new Set(['app', 'config', 'org']),
   alias: new Map([
     ['c', 'config'],
     ['h', 'help'],

--- a/test/unit/lib/cli/resolve-input.test.js
+++ b/test/unit/lib/cli/resolve-input.test.js
@@ -63,6 +63,40 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
       });
     });
   });
+
+  describe('"-s" handling', () => {
+    describe('Normal command', () => {
+      let data;
+      before(() => {
+        resolveInput.clear();
+        data = overrideArgv(
+          {
+            args: ['serverless', 'cmd1', 'cmd2', '-s', 'stage'],
+          },
+          () => resolveInput()
+        );
+      });
+      it('should recognize stage alias', async () => {
+        expect(data.options.stage).to.equal('stage');
+      });
+    });
+    describe('Command with custom -s alias', () => {
+      let data;
+      before(() => {
+        resolveInput.clear();
+        data = overrideArgv(
+          {
+            args: ['serverless', 'config', 'credentials', '-s', 'stage'],
+          },
+          () => resolveInput()
+        );
+      });
+      it('should recognize stage alias', async () => {
+        expect(data.options).to.not.have.property('stage');
+      });
+    });
+  });
+
   describe('when no commands', () => {
     let data;
     before(() => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #8995

- Recognize `--stage` and on special terms `-s` alias (unfortunately some commands use it for something else)
- Refactor handling of `-v` stage to follow same methodology as `-s` handling
- Add recognition of `app` and `org`