### PR TITLE
docs: Missing `kafka` link on provider landing page

### DIFF
--- a/docs/providers/aws/README.md
+++ b/docs/providers/aws/README.md
@@ -94,6 +94,7 @@ layout: Doc
         <li><a href="./events/event-bridge.md">EventBridge</a></li>
         <li><a href="./events/cloudfront.md">CloudFront</a></li>
         <li><a href="./events/cognito-user-pool.md">Cognito User Pool</a></li>
+        <li><a href="./events/kafka.md">Self Managed Apache Kafka</a></li>
         <li><a href="./events/msk.md">MSK</a></li>
         <li><a href="./events/iot-fleet-provisioning.md">IoT Fleet Provisioning</a></li>
       </ul>


### PR DESCRIPTION
…ng page

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

I just saw this link was missing the other day.
