### PR TITLE
docs(AWS SQS): Add `maximumBatchingWindow` in `serverless.yml.md`

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -395,6 +395,7 @@ functions:
       - sqs:
           arn: arn:aws:sqs:region:XXXXXX:myQueue
           batchSize: 10
+          maximumBatchingWindow: 10 # optional, minimum is 0 and the maximum is 300 (seconds)
           enabled: true
       - stream:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo


### PR DESCRIPTION
Adds the documentation for the property `maximumBatchingWindow` added by #8555.
