### PR TITLE
CLI: Resolve ".env" files before initializing "Serverless" constructor

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -25,7 +25,8 @@ frameworkVersion: '2'
 configValidationMode: warn # Modes for config validation. `error` throws an exception, `warn` logs error to console, `off` disables validation at all. The default is warn.
 enableLocalInstallationFallback: false # If set to 'true', guarantees that it's a locally (for service, in its node_modules) installed framework which processes the command
 useDotenv: false # If set to 'true', environment variables will be automatically loaded from .env files
-unresolvedVariablesNotificationMode: warn # If set to 'error', references to variables that cannot be resolved will result in an error being thrown
+variablesResolutionMode: null # To crash on variable resolution errors (as coming from new resolver), set this value to "20210219"
+unresolvedVariablesNotificationMode: warn # If set to 'error', references to variables that cannot be resolved will result in an error being thrown (applies to legacy resolver)
 
 disabledDeprecations: # Disable deprecation logs by their codes. Default is empty.
   - DEP_CODE_1 # Deprecation code to disable

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -22,6 +22,7 @@ Here is a list of all available properties in `serverless.yml` when the provider
 service: myService
 
 frameworkVersion: '2'
+configValidationMode: warn # Modes for config validation. `error` throws an exception, `warn` logs error to console, `off` disables validation at all. The default is warn.
 enableLocalInstallationFallback: false # If set to 'true', guarantees that it's a locally (for service, in its node_modules) installed framework which processes the command
 useDotenv: false # If set to 'true', environment variables will be automatically loaded from .env files
 unresolvedVariablesNotificationMode: warn # If set to 'error', references to variables that cannot be resolved will result in an error being thrown
@@ -529,8 +530,6 @@ functions:
             OriginPath: /framework
             CustomOriginConfig:
               OriginProtocolPolicy: match-viewer
-
-configValidationMode: warn # Modes for config validation. `error` throws an exception, `warn` logs error to console, `off` disables validation at all. The default is warn.
 
 layers:
   hello: # A Lambda layer

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -226,7 +226,7 @@ class Serverless {
       _.get(configurationInput, 'provider.stage', 'dev');
 
     if (configurationInput.useDotenv) {
-      await loadDotenv(stage);
+      loadDotenv(stage);
     } else {
       const defaultEnvFilePath = path.join(process.cwd(), '.env');
       const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`);

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const path = require('path');
-const _ = require('lodash');
 const os = require('os');
 const ensureString = require('type/string/ensure');
 const ensureArray = require('type/array/ensure');
 const ensurePlainObject = require('type/plain-object/ensure');
-const fileExists = require('./utils/fs/fileExists');
 const CLI = require('./classes/CLI');
 const Config = require('./classes/Config');
 const YamlParser = require('./classes/YamlParser');
@@ -25,7 +23,7 @@ const resolveLocalServerlessPath = require('./cli/resolve-local-serverless-path'
 const isHelpRequest = require('./cli/is-help-request');
 const resolveCliInput = require('./cli/resolve-input');
 const readConfiguration = require('./configuration/read');
-const loadDotenv = require('./cli/load-dotenv');
+const conditionallyLoadDotenv = require('./cli/conditionally-load-dotenv');
 
 class Serverless {
   constructor(config) {
@@ -219,32 +217,7 @@ class Serverless {
   async loadEnvVariables() {
     const configurationInput = this.configurationInput;
     if (this.configurationInput == null) return;
-
-    const stage =
-      this.processedInput.options.stage ||
-      this.processedInput.options.s ||
-      _.get(configurationInput, 'provider.stage', 'dev');
-
-    if (configurationInput.useDotenv) {
-      loadDotenv(stage);
-    } else {
-      const defaultEnvFilePath = path.join(process.cwd(), '.env');
-      const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`);
-
-      const [doesStageEnvFileExists, doesDefaultEnvFileExists] = await Promise.all([
-        fileExists(stageEnvFilePath),
-        fileExists(defaultEnvFilePath),
-      ]);
-
-      if (doesDefaultEnvFileExists || doesStageEnvFileExists) {
-        this._logDeprecation(
-          'LOAD_VARIABLES_FROM_ENV_FILES',
-          'Detected ".env" files. In the next major release variables from ".env" ' +
-            'files will be automatically loaded into the serverless build process. ' +
-            'Set "useDotenv: true" to adopt that behavior now.'
-        );
-      }
-    }
+    await conditionallyLoadDotenv(this.processedInput.options, configurationInput);
   }
 
   async run() {

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -25,7 +25,7 @@ const resolveLocalServerlessPath = require('./cli/resolve-local-serverless-path'
 const isHelpRequest = require('./cli/is-help-request');
 const resolveCliInput = require('./cli/resolve-input');
 const readConfiguration = require('./configuration/read');
-const loadEnv = require('./loadEnv');
+const loadDotenv = require('./cli/load-dotenv');
 
 class Serverless {
   constructor(config) {
@@ -226,7 +226,7 @@ class Serverless {
       _.get(configurationInput, 'provider.stage', 'dev');
 
     if (configurationInput.useDotenv) {
-      await loadEnv(stage);
+      await loadDotenv(stage);
     } else {
       const defaultEnvFilePath = path.join(process.cwd(), '.env');
       const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`);

--- a/lib/cli/conditionally-load-dotenv.js
+++ b/lib/cli/conditionally-load-dotenv.js
@@ -1,0 +1,40 @@
+// TODO: Remove with next major release
+
+'use strict';
+
+const path = require('path');
+const _ = require('lodash');
+const memoizee = require('memoizee');
+const fileExists = require('../utils/fs/fileExists');
+const logDeprecation = require('../utils/logDeprecation');
+
+module.exports = memoizee(
+  async (options, configuration) => {
+    const stage = options.stage || _.get(configuration, 'provider.stage', 'dev');
+    if (configuration.useDotenv) {
+      require('./load-dotenv')(stage);
+      return;
+    }
+
+    const defaultEnvFilePath = path.resolve('.env');
+    const stageEnvFilePath = path.resolve(`.env.${stage}`);
+
+    const [doesStageEnvFileExists, doesDefaultEnvFileExists] = await Promise.all([
+      fileExists(stageEnvFilePath),
+      fileExists(defaultEnvFilePath),
+    ]);
+
+    if (doesDefaultEnvFileExists || doesStageEnvFileExists) {
+      logDeprecation(
+        'LOAD_VARIABLES_FROM_ENV_FILES',
+        'Detected ".env" files. In the next major release variables from ".env" ' +
+          'files will be automatically loaded into the serverless build process. ' +
+          'Set "useDotenv: true" to adopt that behavior now.',
+        { serviceConfig: configuration }
+      );
+    }
+  },
+  {
+    length: 0 /* Intentionally no "promise: true" as rejection means critical non-retryable error */,
+  }
+);

--- a/lib/cli/load-dotenv.js
+++ b/lib/cli/load-dotenv.js
@@ -2,7 +2,7 @@
 
 const dotenv = require('dotenv');
 const path = require('path');
-const ServerlessError = require('./serverless-error');
+const ServerlessError = require('../serverless-error');
 
 const isMissingFileError = (error) => error.code === 'ENOENT';
 

--- a/lib/cli/load-dotenv.js
+++ b/lib/cli/load-dotenv.js
@@ -8,10 +8,10 @@ const isMissingFileError = (error) => error.code === 'ENOENT';
 
 const throwDotenvError = (error, filePath) => {
   const errorMessage = `Failed to load environment variables from "${filePath}": ${error}`;
-  throw new ServerlessError(errorMessage);
+  throw new ServerlessError(errorMessage, 'DOTENV_LOAD_ERROR');
 };
 
-module.exports = async (stage) => {
+module.exports = (stage) => {
   const defaultEnvFilePath = path.join(process.cwd(), '.env');
   const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`);
 

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -155,7 +155,8 @@ const processSpanPromise = (async () => {
             throw new ServerlessError(
               `Cannot resolve ${path.basename(
                 configurationPath
-              )}: "provider" section is not accessible (configured behind variables which cannot be resolved at this stage)`
+              )}: "provider" section is not accessible ` +
+                '(configured behind variables which cannot be resolved at this stage)'
             );
           }
           if (variablesMeta.has('provider\0stage')) {
@@ -163,14 +164,16 @@ const processSpanPromise = (async () => {
               throw new ServerlessError(
                 `Cannot resolve ${path.basename(
                   configurationPath
-                )}: "provider.stage" is not accessible (configured behind variables which cannot be resolved at this stage)`
+                )}: "provider.stage" is not accessible ` +
+                  '(configured behind variables which cannot be resolved at this stage)'
               );
             }
             logDeprecation(
               'NEW_VARIABLES_RESOLVER',
               '"provider.stage" is not accessible ' +
                 '(configured behind variables which cannot be resolved at this stage).\n' +
-                'Starting with next major release, this will be communicated with a thrown error.\n' +
+                'Starting with next major release, ' +
+                'this will be communicated with a thrown error.\n' +
                 'Set "variablesResolutionMode: 20210219" in your service config, ' +
                 'to adapt to this behavior now',
               { serviceConfig: configuration }
@@ -181,9 +184,8 @@ const processSpanPromise = (async () => {
         }
         if (variablesMeta.has('useDotenv')) {
           throw new ServerlessError(
-            `Cannot resolve ${path.basename(
-              configurationPath
-            )}: "useDotenv" is not accessible (configured behind variables which cannot be resolved at this stage)`
+            `Cannot resolve ${path.basename(configurationPath)}: "useDotenv" is not accessible ` +
+              '(configured behind variables which cannot be resolved at this stage)'
           );
         }
       }

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -154,7 +154,16 @@ const processSpanPromise = (async () => {
             logDeprecation.triggeredDeprecations.add('VARIABLES_ERROR_ON_UNRESOLVED');
           }
         }
+        if (variablesMeta.has('useDotenv')) {
+          throw new ServerlessError(
+            `Cannot resolve ${path.basename(
+              configurationPath
+            )}: "useDotenv" is not accessible (configured behind variables which cannot be resolved at this stage)`
+          );
+        }
       }
+
+      await require('../lib/cli/conditionally-load-dotenv')(options, configuration);
     }
 
     serverless = new Serverless({

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -96,6 +96,16 @@ const processSpanPromise = (async () => {
           strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
         };
         const variablesMeta = resolveVariablesMeta(configuration);
+
+        if (variablesMeta.has('variablesResolutionMode')) {
+          throw new ServerlessError(
+            `Cannot resolve ${path.basename(
+              configurationPath
+            )}: "variablesResolutionMode" is not accessible ` +
+              '(configured behind variables which cannot be resolved at this stage)'
+          );
+        }
+
         await resolveVariables({
           servicePath: process.cwd(),
           configuration,

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -14,6 +14,7 @@ const Service = require('../../../lib/classes/Service');
 const ConfigSchemaHandler = require('../../../lib/classes/ConfigSchemaHandler');
 const CLI = require('../../../lib/classes/CLI');
 const ServerlessError = require('../../../lib/serverless-error');
+const conditionallyLoadDotenv = require('../../../lib/cli/conditionally-load-dotenv');
 const runServerless = require('../../utils/run-serverless');
 const fixtures = require('../../fixtures');
 const fs = require('fs');
@@ -321,10 +322,7 @@ describe('Serverless [new tests]', () => {
 
       const defaultFileContent = 'DEFAULT_ENV_VARIABLE=valuefromdefault';
       await fs.promises.writeFile(path.join(servicePath, '.env'), defaultFileContent);
-
-      const stage = 'testing';
-      const stageFileContent = 'STAGE_ENV_VARIABLE=valuefromstage';
-      await fs.promises.writeFile(path.join(servicePath, `.env.${stage}`), stageFileContent);
+      conditionallyLoadDotenv.clear();
     });
 
     it('Should load environment variables from default .env file if no matching stage', async () => {
@@ -335,16 +333,6 @@ describe('Serverless [new tests]', () => {
 
       expect(result.serverless.service.custom.fromDefaultEnv).to.equal('valuefromdefault');
       expect(result.serverless.service.custom.fromStageEnv).to.be.undefined;
-    });
-
-    it('Should load environment variables from stage .env file if matching stage', async () => {
-      const result = await runServerless({
-        cwd: servicePath,
-        cliArgs: ['-s', 'testing', 'package'],
-      });
-
-      expect(result.serverless.service.custom.fromDefaultEnv).to.be.undefined;
-      expect(result.serverless.service.custom.fromStageEnv).to.equal('valuefromstage');
     });
   });
 });

--- a/test/unit/lib/cli/conditionally-load-dotenv.test.js
+++ b/test/unit/lib/cli/conditionally-load-dotenv.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const chai = require('chai');
+const path = require('path');
+const overrideEnv = require('process-utils/override-env');
+const fs = require('fs');
+const conditionallyLoadDotenv = require('../../../../lib/cli/conditionally-load-dotenv');
+
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
+
+describe('test/unit/lib/cli/conditionally-load-dotenv.test.js', () => {
+  let restoreEnv;
+
+  before(async () => {
+    const defaultFileContent = 'DEFAULT_ENV_VARIABLE=valuefromdefault';
+    await fs.promises.writeFile(path.resolve('.env'), defaultFileContent);
+
+    const stage = 'testing';
+    const stageFileContent = 'STAGE_ENV_VARIABLE=valuefromstage';
+    await fs.promises.writeFile(path.resolve(`.env.${stage}`), stageFileContent);
+  });
+
+  beforeEach(() => {
+    conditionallyLoadDotenv.clear();
+    ({ restoreEnv } = overrideEnv());
+  });
+  afterEach(() => {
+    restoreEnv && restoreEnv();
+  });
+
+  it('should load environment variables from default .env file if no matching stage', async () => {
+    await conditionallyLoadDotenv({}, { useDotenv: true });
+
+    expect(process.env.DEFAULT_ENV_VARIABLE).to.equal('valuefromdefault');
+    expect(process.env.STAGE_ENV_VARIABLE).to.be.undefined;
+  });
+
+  it('should load environment variables from stage .env file if matching stage', async () => {
+    await conditionallyLoadDotenv({ stage: 'testing' }, { useDotenv: true });
+    expect(process.env.DEFAULT_ENV_VARIABLE).to.be.undefined;
+    expect(process.env.STAGE_ENV_VARIABLE).to.equal('valuefromstage');
+  });
+});

--- a/test/unit/lib/cli/load-dotenv.test.js
+++ b/test/unit/lib/cli/load-dotenv.test.js
@@ -48,7 +48,9 @@ describe('test/unit/lib/cli/load-dotenv.test.js', () => {
     const errorMessage = 'Unexpected error while loading env';
     const dotenvResult = sinon.stub(dotenv, 'config').returns({ error: new Error(errorMessage) });
 
-    expect(loadEnv('testing')).to.be.rejectedWith(ServerlessError, errorMessage);
+    expect(() => loadEnv('testing'))
+      .to.throw(ServerlessError)
+      .with.property('code', 'DOTENV_LOAD_ERROR');
     dotenvResult.restore();
   });
 });

--- a/test/unit/lib/cli/load-dotenv.test.js
+++ b/test/unit/lib/cli/load-dotenv.test.js
@@ -5,14 +5,14 @@ const path = require('path');
 const sinon = require('sinon');
 const overrideEnv = require('process-utils/override-env');
 const fs = require('fs');
-const loadEnv = require('../../../lib/loadEnv');
+const loadEnv = require('../../../../lib/cli/load-dotenv');
 const dotenv = require('dotenv');
-const ServerlessError = require('../../../lib/serverless-error');
+const ServerlessError = require('../../../../lib/serverless-error');
 
 chai.use(require('chai-as-promised'));
 const expect = require('chai').expect;
 
-describe('loadEnv', () => {
+describe('test/unit/lib/cli/load-dotenv.test.js', () => {
   let restoreEnv;
 
   before(async () => {


### PR DESCRIPTION
Addresses 2.4 from https://github.com/serverless/serverless/issues/8364

Kept fallback to resolve `.env` in `Serverless` class, so it remains working for users which e.g. just upgrade the local installation, but run `serverless` global installation, with v3 we will remove it.

Additionally added some inline documentation, to improve readability of currently extending logic (I expect it to be significantly stripped, once we remove all the deprecations with next major)