### PR TITLE
Prevent reader confusion

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -63,15 +63,15 @@ For example:
 provider:
   name: aws
   environment:
-    MY_SECRET: ${file(./config.${opt:stage, self:provider.stage, 'dev'}.json):CREDS}
+    MY_SECRET: ${file(./config.${opt:stage, 'dev'}.json):CREDS}
 ```
 
-If `sls deploy --stage qa` is run, the option `stage=qa` is used inside the `${file(./config.${opt:stage, self:provider.stage, 'dev'}.json):CREDS}` variable and it will resolve the `config.qa.json` file and use the `CREDS` key defined.
+If `sls deploy --stage qa` is run, the option `stage=qa` is used inside the `${file(./config.${opt:stage, 'dev'}.json):CREDS}` variable and it will resolve the `config.qa.json` file and use the `CREDS` key defined.
 
 **How that works:**
 
 1. stage is set to `qa` from the option supplied to the `sls deploy --stage qa` command
-2. `${opt:stage, self:provider.stage, 'dev'}` resolves to `qa` and is used in `${file(./config.${opt:stage, self:provider.stage, 'dev'}.json):CREDS}`
+2. `${opt:stage, 'dev'}` resolves to `qa` and is used in `${file(./config.${opt:stage, 'dev'}.json):CREDS}`
 3. `${file(./config.qa.json):CREDS}` is found & the `CREDS` value is read
 4. `MY_SECRET` value is set
 


### PR DESCRIPTION
The section on `Recursively reference properties` is using a feature that is first explained much later in the document at [Overwriting Variables](https://www.serverless.com/framework/docs/providers/aws/guide/variables#overwriting-variables).

I was surprised by the use of `self:provider.stage` which is a dead reference and got no explanation before the end of the document.

Alternative solutions
* Move `Overwriting Variables` to a location before `Recursively reference properties`
* This change making the section more context independent being stateless is a good thing outside of code as well :smile: