### PR TITLE
Tests: Update integration tests to not rely on deprecated features

### DIFF
--- a/test/fixtures/apiGateway/serverless.yml
+++ b/test/fixtures/apiGateway/serverless.yml
@@ -5,6 +5,9 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
+  apiGateway:
+    shouldStartNameWithService: true
 
 functions:
   foo:

--- a/test/fixtures/apiGatewayExtended/serverless.yml
+++ b/test/fixtures/apiGatewayExtended/serverless.yml
@@ -8,9 +8,10 @@ provider:
   runtime: nodejs12.x
   versionFunctions: false
   apiGateway:
+    shouldStartNameWithService: true
     apiKeys:
-      - name: ${self:service.name}-api-key-1
-        value: ${self:service.name}-api-key-1
+      - name: ${self:service}-api-key-1
+        value: ${self:service}-api-key-1
 
 functions:
   # core functions

--- a/test/fixtures/checkForChanges/serverless.yml
+++ b/test/fixtures/checkForChanges/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   fn1:

--- a/test/fixtures/cognitoUserPool/serverless.yml
+++ b/test/fixtures/cognitoUserPool/serverless.yml
@@ -12,13 +12,13 @@ functions:
     handler: core.basic
     events:
       - cognitoUserPool:
-          pool: ${self:service.name} CUP Basic
+          pool: ${self:service} CUP Basic
           trigger: PreSignUp
   existingSimple:
     handler: core.existingSimple
     events:
       - cognitoUserPool:
-          pool: ${self:service.name} CUP Existing Simple
+          pool: ${self:service} CUP Existing Simple
           trigger: PreSignUp
           existing: true
   # testing if two functions share one cognito user pool with multiple configs
@@ -26,10 +26,10 @@ functions:
     handler: core.existingMulti
     events:
       - cognitoUserPool:
-          pool: ${self:service.name} CUP Existing Multi
+          pool: ${self:service} CUP Existing Multi
           trigger: PreSignUp
           existing: true
       - cognitoUserPool:
-          pool: ${self:service.name} CUP Existing Multi
+          pool: ${self:service} CUP Existing Multi
           trigger: PreAuthentication
           existing: true

--- a/test/fixtures/eventBridge/serverless.yml
+++ b/test/fixtures/eventBridge/serverless.yml
@@ -22,7 +22,7 @@ functions:
     handler: core.eventBusCustom
     events:
       - eventBridge:
-          eventBus: ${self:service.name}-named-event-bus
+          eventBus: ${self:service}-named-event-bus
           pattern:
             source:
               - serverless.test

--- a/test/fixtures/function/serverless.yml
+++ b/test/fixtures/function/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   foo:

--- a/test/fixtures/functionCloudFront/serverless.yml
+++ b/test/fixtures/functionCloudFront/serverless.yml
@@ -5,6 +5,8 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
+
 functions:
   foo:
     handler: index.handler

--- a/test/fixtures/functionDestinations/serverless.yml
+++ b/test/fixtures/functionDestinations/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   target:

--- a/test/fixtures/functionLayers/serverless.yml
+++ b/test/fixtures/functionLayers/serverless.yml
@@ -1,6 +1,7 @@
 service: service
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 layers:
   testLayer:

--- a/test/fixtures/httpApi/serverless.yml
+++ b/test/fixtures/httpApi/serverless.yml
@@ -6,6 +6,7 @@ frameworkVersion: '*'
 provider:
   name: aws
   logRetentionInDays: 14
+  lambdaHashingVersion: 20201221
 
 functions:
   foo:

--- a/test/fixtures/httpApiCatchAll/serverless.yml
+++ b/test/fixtures/httpApiCatchAll/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   foo:

--- a/test/fixtures/httpApiExport/serverless.yml
+++ b/test/fixtures/httpApiExport/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 resources:
   Resources:

--- a/test/fixtures/invocation/serverless.yml
+++ b/test/fixtures/invocation/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   callback:

--- a/test/fixtures/iot/serverless.yml
+++ b/test/fixtures/iot/serverless.yml
@@ -12,4 +12,4 @@ functions:
     handler: core.iotBasic
     events:
       - iot:
-          sql: "SELECT * FROM '${self:service.name}/test'"
+          sql: "SELECT * FROM '${self:service}/test'"

--- a/test/fixtures/layer/serverless.yml
+++ b/test/fixtures/layer/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   function:

--- a/test/fixtures/packageArtifact/serverless.yml
+++ b/test/fixtures/packageArtifact/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 package:
   artifact: artifact.zip

--- a/test/fixtures/packageArtifactInServerlessDir/serverless.yml
+++ b/test/fixtures/packageArtifactInServerlessDir/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 plugins:
   # Mutates `package.artifact` to point to copied `.serverless/NAME.zip`

--- a/test/fixtures/packaging/serverless.yml
+++ b/test/fixtures/packaging/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 functions:
   fnService:

--- a/test/fixtures/plugin/serverless.yml
+++ b/test/fixtures/plugin/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
 
 plugins:
   - ./plugin

--- a/test/fixtures/provisionedConcurrency/serverless.yml
+++ b/test/fixtures/provisionedConcurrency/serverless.yml
@@ -22,7 +22,7 @@ functions:
                 - kinesis
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
-                - stream/${self:service.name}-kinesis
+                - stream/${self:service}-kinesis
       - sqs:
           arn:
             Fn::Join:
@@ -32,4 +32,4 @@ functions:
                 - sqs
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
-                - ${self:service.name}-provisioned
+                - ${self:service}-provisioned

--- a/test/fixtures/requestSchema/serverless.yml
+++ b/test/fixtures/requestSchema/serverless.yml
@@ -2,6 +2,7 @@ service: service
 
 provider:
   name: aws
+  lambdaHashingVersion: 20201221
   apiGateway:
     request:
       schemas:

--- a/test/fixtures/sns/serverless.yml
+++ b/test/fixtures/sns/serverless.yml
@@ -11,14 +11,14 @@ functions:
   snsMinimal:
     handler: core.snsMinimal
     events:
-      - sns: ${self:service.name}-minimal
+      - sns: ${self:service}-minimal
 
   snsMultipleFilteredLeft:
     handler: core.snsMultipleFilteredLeft
     events:
       - sns:
-          topicName: ${self:service.name}-filtered
-          displayName: 'Integration Test: ${self:service.name}-filtered'
+          topicName: ${self:service}-filtered
+          displayName: 'Integration Test: ${self:service}-filtered'
           filterPolicy:
             side:
               - left
@@ -26,8 +26,8 @@ functions:
     handler: core.snsMultipleFilteredRight
     events:
       - sns:
-          topicName: ${self:service.name}-filtered
-          displayName: 'Integration Test: ${self:service.name}-filtered'
+          topicName: ${self:service}-filtered
+          displayName: 'Integration Test: ${self:service}-filtered'
           filterPolicy:
             side:
               - right
@@ -42,5 +42,5 @@ functions:
               - - 'arn:aws:sns'
                 - Ref: 'AWS::Region'
                 - Ref: 'AWS::AccountId'
-                - ${self:service.name}-existing
-          topicName: ${self:service.name}-existing
+                - ${self:service}-existing
+          topicName: ${self:service}-existing

--- a/test/fixtures/sqs/serverless.yml
+++ b/test/fixtures/sqs/serverless.yml
@@ -20,4 +20,4 @@ functions:
                 - sqs
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
-                - ${self:service.name}-basic
+                - ${self:service}-basic

--- a/test/fixtures/stream/serverless.yml
+++ b/test/fixtures/stream/serverless.yml
@@ -29,7 +29,7 @@ functions:
                 - kinesis
                 - Ref: AWS::Region
                 - Ref: AWS::AccountId
-                - stream/${self:service.name}-kinesis
+                - stream/${self:service}-kinesis
           batchSize: 100
           startingPosition: TRIM_HORIZON
           batchWindow: 1
@@ -48,4 +48,4 @@ resources:
             KeyType: HASH
         StreamSpecification:
           StreamViewType: KEYS_ONLY
-        TableName: ${self:service.name}-table
+        TableName: ${self:service}-table

--- a/test/integrationPackage/fixtures/artifact/serverless.yml
+++ b/test/integrationPackage/fixtures/artifact/serverless.yml
@@ -5,6 +5,7 @@ configValidationMode: error
 provider:
   name: aws
   runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
 
 functions:
   hello:

--- a/test/integrationPackage/fixtures/individually-function/serverless.yml
+++ b/test/integrationPackage/fixtures/individually-function/serverless.yml
@@ -5,6 +5,7 @@ configValidationMode: error
 provider:
   name: aws
   runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
 
 functions:
   hello:

--- a/test/integrationPackage/fixtures/individually/serverless.yml
+++ b/test/integrationPackage/fixtures/individually/serverless.yml
@@ -5,6 +5,7 @@ configValidationMode: error
 provider:
   name: aws
   runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
 
 package:
   individually: true

--- a/test/integrationPackage/fixtures/regular/serverless.yml
+++ b/test/integrationPackage/fixtures/regular/serverless.yml
@@ -5,10 +5,11 @@ configValidationMode: error
 provider:
   name: aws
   runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
 
 functions:
   hello:
     handler: handler.hello
   custom-name:
-    name: ${self:service}-${self:provider.region}-custom-name
+    name: ${self:service}-${opt:region, self:provider.region, 'us-east-1'}-custom-name
     handler: handler.hello

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -425,7 +425,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
           'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json',
       })
       .returns({
-        Metadata: { filesha256: 'o3jgmZRgwiNIhECDFntBIwUJuH2YOhryxKIqZ0wlUbQ=' },
+        Metadata: { filesha256: 'Cs3d4Sap0nwF6NPJnw4JN1gI41zodxGGmmmKw2C8hRs=' },
       });
     s3HeadObjectStub
       .withArgs({

--- a/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -1044,7 +1044,7 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
                   'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json',
               })
               .returns({
-                Metadata: { filesha256: 'p2wLB86RTnPkFQLaGCUQFdk6/nwyVGiX2mGJl2m0bD0=' },
+                Metadata: { filesha256: 'Pa14GST706iFrSIacw7FepUBMx+tYEs7VVv4YYY6wPs=' },
               });
 
             headObjectStub


### PR DESCRIPTION
It covers all integration tests. One test that still shows deprecation is eventBridge test which test custom resource deprecation.

When addressing https://github.com/serverless/serverless/issues/9024 it's important to extend config of this test with `deprecationsNotificationMode: warn`.