### PR TITLE
feat(AWS IAM): Allow `tags` parameter on lambda execution role

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -31,6 +31,8 @@ provider:
       managedPolicies:
         - 'arn:aws:iam::123456789012:user/*',
       permissionBoundary: arn:aws:iam::123456789012:policy/boundaries
+      tags:
+        key: value
     deploymentRole: arn:aws:iam::123456789012:role/deploy-role
 ```
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -202,6 +202,8 @@ provider:
               - ''
               - - 'arn:aws:s3:::'
                 - Ref: ServerlessDeploymentBucket
+      tags:
+        key: value
     deploymentRole: arn:aws:iam::XXXXXX:role/role # ARN of an IAM role for CloudFormation service. If specified, CloudFormation uses the role's credentials
   stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except deleting/replacing EC2 instances (use with caution!)
     - Effect: Allow

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -486,7 +486,7 @@ class AwsCompileFunctions {
         functionProperties.layerConfigurations = layerConfigurations;
         versionHash.write(JSON.stringify(deepSortObjectByKey(functionProperties)));
       } else {
-        // sort the layer conifigurations for hash consistency
+        // sort the layer configurations for hash consistency
         const sortedLayerConfigurations = {};
         const byKey = ([key1], [key2]) => key1.localeCompare(key2);
         for (const { name, properties: layerProperties } of layerConfigurations) {
@@ -626,7 +626,7 @@ class AwsCompileFunctions {
     cfResources[this.provider.naming.getLambdaEventConfigLogicalId(functionName)] = resource;
   }
 
-  // Memoized in a construtor
+  // Memoized in a constructor
   ensureTargetExecutionPermission(functionAddress) {
     const iamPolicyStatements = this.serverless.service.provider.compiledCloudFormationTemplate
       .Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement;

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -72,6 +72,14 @@ module.exports = {
     iamRoleLambdaExecutionTemplate.Properties.Path = this.provider.naming.getRolePath();
     iamRoleLambdaExecutionTemplate.Properties.RoleName = this.provider.naming.getRoleName();
 
+    // set role tags
+    if (iamRole.tags) {
+      iamRoleLambdaExecutionTemplate.Properties.Tags = Object.keys(iamRole.tags).map((key) => ({
+        Key: key,
+        Value: iamRole.tags[key],
+      }));
+    }
+
     // set permission boundary
     if (iamRole.permissionBoundary) {
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionBoundary;

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -73,11 +73,12 @@ module.exports = {
     iamRoleLambdaExecutionTemplate.Properties.RoleName = this.provider.naming.getRoleName();
 
     // set role tags
-    const tags = { ...this.serverless.service.provider.tags, ...iamRole.tags };
-    iamRoleLambdaExecutionTemplate.Properties.Tags = Object.keys(tags).map((key) => ({
-      Key: key,
-      Value: tags[key],
-    }));
+    if (iamRole.tags) {
+      iamRoleLambdaExecutionTemplate.Properties.Tags = Object.keys(iamRole.tags).map((key) => ({
+        Key: key,
+        Value: iamRole.tags[key],
+      }));
+    }
 
     // set permission boundary
     if (iamRole.permissionBoundary) {

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -73,12 +73,11 @@ module.exports = {
     iamRoleLambdaExecutionTemplate.Properties.RoleName = this.provider.naming.getRoleName();
 
     // set role tags
-    if (iamRole.tags) {
-      iamRoleLambdaExecutionTemplate.Properties.Tags = Object.keys(iamRole.tags).map((key) => ({
-        Key: key,
-        Value: iamRole.tags[key],
-      }));
-    }
+    const tags = { ...this.serverless.service.provider.tags, ...iamRole.tags };
+    iamRoleLambdaExecutionTemplate.Properties.Tags = Object.keys(tags).map((key) => ({
+      Key: key,
+      Value: tags[key],
+    }));
 
     // set permission boundary
     if (iamRole.permissionBoundary) {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -830,6 +830,7 @@ class AwsProvider {
                         },
                         statements: { $ref: '#/definitions/awsIamPolicyStatements' },
                         permissionBoundary: { $ref: '#/definitions/awsArnString' },
+                        tags: { $ref: '#/definitions/awsResourceTags' },
                       },
                       additionalProperties: false,
                     },

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -263,6 +263,9 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
                     'arn:aws:iam::123456789012:u*',
                   ],
                   permissionBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
+                  tags: {
+                    sweet: 'potato',
+                  },
                 },
               },
               vpc: {
@@ -336,6 +339,12 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         expect(iamResource.Type).to.be.equal('AWS::Logs::LogGroup');
         expect(iamResource.Properties.RetentionInDays).to.be.equal(5);
         expect(iamResource.Properties.LogGroupName).to.be.equal(`/aws/lambda/${service}-dev-foo`);
+      });
+
+      it('should support `provider.iam.role.tags`', () => {
+        const IamRoleLambdaExecution = naming.getRoleLogicalId();
+        const iamResource = cfResources[IamRoleLambdaExecution];
+        expect(iamResource.Properties.Tags).to.eql([{ Key: 'sweet', Value: 'potato' }]);
       });
     });
 

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -248,9 +248,6 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           cliArgs: ['package'],
           configExt: {
             provider: {
-              tags: {
-                snow: 'peas',
-              },
               iam: {
                 role: {
                   statements: [
@@ -347,10 +344,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       it('should support `provider.iam.role.tags`', () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const iamResource = cfResources[IamRoleLambdaExecution];
-        expect(iamResource.Properties.Tags).to.eql([
-          { Key: 'snow', Value: 'peas' },
-          { Key: 'sweet', Value: 'potato' },
-        ]);
+        expect(iamResource.Properties.Tags).to.eql([{ Key: 'sweet', Value: 'potato' }]);
       });
     });
 

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -248,6 +248,9 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           cliArgs: ['package'],
           configExt: {
             provider: {
+              tags: {
+                snow: 'peas',
+              },
               iam: {
                 role: {
                   statements: [
@@ -344,7 +347,10 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       it('should support `provider.iam.role.tags`', () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const iamResource = cfResources[IamRoleLambdaExecution];
-        expect(iamResource.Properties.Tags).to.eql([{ Key: 'sweet', Value: 'potato' }]);
+        expect(iamResource.Properties.Tags).to.eql([
+          { Key: 'snow', Value: 'peas' },
+          { Key: 'sweet', Value: 'potato' },
+        ]);
       });
     });
 


### PR DESCRIPTION
Provide consumers means for setting additional/custom tags to the lambda execution role.

Closes: #8669
