### PR TITLE
Variables: Resolve all env variables with new resolver

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -42,7 +42,9 @@ class Serverless {
         name: 'config.configuration',
         Error: ServerlessError,
       });
-      if (!this.configurationInput && !this._isInvokedByGlobalInstallation) {
+      if (this.configurationInput) {
+        this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);
+      } else if (!this._isInvokedByGlobalInstallation) {
         this._shouldReportMissingServiceDeprecation = true;
       }
     } else if (configObject.configurationPath === undefined) {
@@ -65,6 +67,7 @@ class Serverless {
     delete configObject.configuration;
     delete configObject._isInvokedByGlobalInstallation;
     delete configObject.commands;
+    delete configObject.isConfigurationResolved;
     delete configObject.options;
 
     this.providers = {};
@@ -229,9 +232,16 @@ class Serverless {
     // make sure the command exists before doing anything else
     this.pluginManager.validateCommand(this.processedInput.commands);
 
-    // populate variables after --help, otherwise help may fail to print
-    // (https://github.com/serverless/serverless/issues/2041)
-    await this.variables.populateService(this.pluginManager.cliOptions);
+    if (!this.isConfigurationInputResolved) {
+      // populate variables after --help, otherwise help may fail to print
+      // (https://github.com/serverless/serverless/issues/2041)
+      await this.variables.populateService(this.pluginManager.cliOptions);
+    } else if (process.env.SLS_DEBUG) {
+      this.cli.log(
+        'Skipping variables resolution with old resolver ' +
+          '(new resolver reported no more variables to resolve)'
+      );
+    }
 
     // merge arrays after variables have been populated
     // (https://github.com/serverless/serverless/issues/3511)

--- a/lib/configuration/variables/eventually-report-resolution-errors.js
+++ b/lib/configuration/variables/eventually-report-resolution-errors.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const path = require('path');
+const log = require('@serverless/utils/log');
+const ServerlessError = require('../../serverless-error');
+const isHelpRequest = require('../../cli/is-help-request');
+const logDeprecation = require('../../utils/logDeprecation');
+
+module.exports = (configurationPath, configuration, variablesMeta) => {
+  const resolutionErrors = new Set(
+    Array.from(variablesMeta.values(), ({ error }) => error).filter(Boolean)
+  );
+
+  if (!resolutionErrors.size) return false;
+
+  if (isHelpRequest()) {
+    log(
+      'Resolution of service configuration failed when resolving variables: ' +
+        `${Array.from(resolutionErrors, (error) => `\n  - ${error.message}`)}\n`,
+      { color: 'orange' }
+    );
+  } else {
+    if (configuration.variablesResolutionMode) {
+      throw new ServerlessError(
+        `Cannot resolve ${path.basename(
+          configurationPath
+        )}: Variables resolution errored with:${Array.from(
+          resolutionErrors,
+          (error) => `\n  - ${error.message}`
+        )}`,
+        'VARIABLES_RESOLUTION_ERROR'
+      );
+    }
+    logDeprecation(
+      'NEW_VARIABLES_RESOLVER',
+      'Variables resolver reports following resolution errors:' +
+        `${Array.from(resolutionErrors, (error) => `\n  - ${error.message}`)}\n` +
+        'From a next major it we will be communicated with a thrown error.\n' +
+        'Set "variablesResolutionMode: 20210219" in your service config, ' +
+        'to adapt to this behavior now',
+      { serviceConfig: configuration }
+    );
+    // Hack to not duplicate the warning with similar deprecation
+    logDeprecation.triggeredDeprecations.add('VARIABLES_ERROR_ON_UNRESOLVED');
+  }
+
+  return true;
+};

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -170,6 +170,20 @@ const processSpanPromise = (async () => {
 
       // Load eventual environment variables from .env files
       await require('../lib/cli/conditionally-load-dotenv')(options, configuration);
+
+      if (
+        !_.get(configuration.provider, 'variableSyntax') &&
+        variablesMeta.size &&
+        !hasVariableResolutionFailed
+      ) {
+        delete resolverConfiguration.sources.env.isIncomplete;
+        await resolveVariables(resolverConfiguration);
+        hasVariableResolutionFailed = eventuallyReportVariableResolutionErrors(
+          configurationPath,
+          configuration,
+          variablesMeta
+        );
+      }
     }
 
     serverless = new Serverless({

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -69,6 +69,7 @@ const processSpanPromise = (async () => {
         })()
       : null;
 
+    let variablesMeta;
     if (configuration) {
       if (_.get(configuration.provider, 'variableSyntax')) {
         logDeprecation(
@@ -95,7 +96,7 @@ const processSpanPromise = (async () => {
           self: require('../lib/configuration/variables/sources/self'),
           strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
         };
-        const variablesMeta = resolveVariablesMeta(configuration);
+        variablesMeta = resolveVariablesMeta(configuration);
 
         if (variablesMeta.has('variablesResolutionMode')) {
           throw new ServerlessError(
@@ -198,6 +199,7 @@ const processSpanPromise = (async () => {
     serverless = new Serverless({
       configuration,
       configurationPath: configuration && configurationPath,
+      isConfigurationResolved: Boolean(variablesMeta && !variablesMeta.size),
       commands,
       options,
     });

--- a/test/unit/lib/configuration/variables/eventually-report-resolution-errors.test.js
+++ b/test/unit/lib/configuration/variables/eventually-report-resolution-errors.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const overrideArgv = require('process-utils/override-argv');
+const overrideStdoutWrite = require('process-utils/override-stdout-write');
+const ServerlessError = require('../../../../../lib/serverless-error');
+const resolveCliInput = require('../../../../../lib/cli/resolve-input');
+const resolveMeta = require('../../../../../lib/configuration/variables/resolve-meta');
+const eventuallyReportResolutionErrors = require('../../../../../lib/configuration/variables/eventually-report-resolution-errors');
+
+describe('test/unit/lib/configuration/variables/eventually-report-resolution-errors.test.js', () => {
+  beforeEach(() => {
+    resolveCliInput.clear();
+  });
+  it('should return "false" on no errors', () => {
+    const configuration = { foo: 'bar' };
+    const variablesMeta = resolveMeta(configuration);
+
+    expect(eventuallyReportResolutionErrors(process.cwd(), configuration, variablesMeta)).to.equal(
+      false
+    );
+  });
+
+  describe('On errors', () => {
+    it('should log errors with help command', () => {
+      const configuration = { foo: '${foo:raz' };
+      const variablesMeta = resolveMeta(configuration);
+      let stdoutData = '';
+      overrideArgv({ args: ['serverless', '--help'] }, () =>
+        overrideStdoutWrite(
+          (data) => (stdoutData += data),
+          () =>
+            expect(
+              eventuallyReportResolutionErrors(process.cwd(), configuration, variablesMeta)
+            ).to.equal(true)
+        )
+      );
+
+      expect(stdoutData).to.include('Resolution of service configuration failed');
+    });
+
+    it('should log deprecation with no "variablesResolutionMode" set', () => {
+      const configuration = { foo: '${foo:raz' };
+      const variablesMeta = resolveMeta(configuration);
+      let stdoutData = '';
+      overrideArgv({ args: ['serverless', 'foo'] }, () =>
+        overrideStdoutWrite(
+          (data) => (stdoutData += data),
+          () =>
+            expect(
+              eventuallyReportResolutionErrors(process.cwd(), configuration, variablesMeta)
+            ).to.equal(true)
+        )
+      );
+
+      expect(stdoutData).to.include('NEW_VARIABLES_RESOLVER');
+    });
+    it('should throw with no "variablesResolutionMode" set', () => {
+      const configuration = { foo: '${foo:raz', variablesResolutionMode: 20210219 };
+      const variablesMeta = resolveMeta(configuration);
+      overrideArgv({ args: ['serverless', 'foo'] }, () =>
+        expect(() => eventuallyReportResolutionErrors(process.cwd(), configuration, variablesMeta))
+          .to.throw(ServerlessError)
+          .with.property('code', 'VARIABLES_RESOLUTION_ERROR')
+      );
+    });
+  });
+});


### PR DESCRIPTION
Addresses 2.5.0 from #8364

Additionally:
- Ensure no old variables resolver is initialized if per new resolver there are no variables to resolve in a config (this should improve performance on big configuration)
- Improve serverless process logic part responsible for variable resolution, make some parts reusable for further process flow