### PR TITLE
Tests: Improve integration tests reliability

### DIFF
--- a/test/integration/schedule.test.js
+++ b/test/integration/schedule.test.js
@@ -26,12 +26,15 @@ describe('AWS - Schedule Integration Test', function () {
     it('should invoke every minute', () => {
       const functionName = 'scheduleMinimal';
 
-      return confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, async () => {}).then(
-        (events) => {
-          const logs = events.reduce((data, event) => data + event.message, '');
-          expect(logs).to.include(functionName);
-        }
-      );
+      return confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, async () => {}, {
+        checkIsComplete: (soFarEvents) => {
+          const logs = soFarEvents.reduce((data, event) => data + event.message, '');
+          return logs.includes(functionName);
+        },
+      }).then((events) => {
+        const logs = events.reduce((data, event) => data + event.message, '');
+        expect(logs).to.include(functionName);
+      });
     });
   });
 

--- a/test/integration/schedule.test.js
+++ b/test/integration/schedule.test.js
@@ -26,12 +26,12 @@ describe('AWS - Schedule Integration Test', function () {
     it('should invoke every minute', () => {
       const functionName = 'scheduleMinimal';
 
-      return confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, async () => {}, {
-        timeout: 3 * 60 * 1000,
-      }).then((events) => {
-        const logs = events.reduce((data, event) => data + event.message, '');
-        expect(logs).to.include(functionName);
-      });
+      return confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, async () => {}).then(
+        (events) => {
+          const logs = events.reduce((data, event) => data + event.message, '');
+          expect(logs).to.include(functionName);
+        }
+      );
     });
   });
 
@@ -40,7 +40,6 @@ describe('AWS - Schedule Integration Test', function () {
       const functionName = 'scheduleExtended';
 
       return confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, async () => {}, {
-        timeout: 3 * 60 * 1000,
         checkIsComplete: (soFarEvents) => {
           const logs = soFarEvents.reduce((data, event) => data + event.message, '');
           return logs.includes('transformedInput');

--- a/test/utils/misc.js
+++ b/test/utils/misc.js
@@ -29,7 +29,7 @@ function replaceEnv(values) {
  */
 function confirmCloudWatchLogs(logGroupName, trigger, options = {}) {
   const startTime = Date.now();
-  const timeout = options.timeout || 60 * 1000;
+  const timeout = options.timeout || 3 * 60 * 1000;
   return trigger()
     .then(() => wait(1000))
     .then(() => awsRequest('CloudWatchLogs', 'filterLogEvents', { logGroupName }))


### PR DESCRIPTION
- Increase wait timeout for Cloudwatch logs (in response to observed "Log items not found" fails, as here: https://github.com/serverless/serverless/runs/2008020368?check_suite_focus=true)
- In AWS schedule tests, ensure to wait for logs that contain expected string (in response to CI fail observed here: https://github.com/serverless/serverless/actions/runs/614260648)