### PR TITLE
AWS Credentials: Fix unrecognized profile error reporting

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -143,7 +143,10 @@ const impl = {
           profileCredentials.roleArn
         )
       ) {
-        throw new Error(`Profile ${profile} does not exist`);
+        throw new ServerlessError(
+          `AWS profile "${profile}" doesn't seem to be configured`,
+          'UNRECOGNIZED_AWS_PROFILE'
+        );
       }
 
       impl.addCredentials(results, profileCredentials);
@@ -1517,9 +1520,7 @@ class AwsProvider {
     try {
       impl.addProfileCredentials(result, awsDefaultProfile);
     } catch (err) {
-      if (err.message !== `Profile ${awsDefaultProfile} does not exist`) {
-        throw err;
-      }
+      if (err.code !== 'UNRECOGNIZED_AWS_PROFILE') throw err;
     }
     impl.addCredentials(result, this.serverless.service.provider.credentials); // config creds
     if (this.serverless.service.provider.profile && !this.options['aws-profile']) {


### PR DESCRIPTION
Addresses issue described at https://github.com/serverless/serverless/issues/9013#issuecomment-785945591