### PR TITLE
Added deprecation log for configValidationMode default

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -304,3 +304,13 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 Deprecation code: `BIN_SERVERLESS`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
+
+<a name="CONFIG_VALIDATION_MODE_DEFAULT"><div>&nbsp;</div></a>
+
+## `configValidationMode: error` will be new default`
+
+Deprecation code: `CONFIG_VALIDATION_MODE_DEFAULT`
+
+Starting with v3.0.0, Serverless will throw on configuration errors by default. This is changing from the previous default, configValidationMode: warn
+
+Learn more about configuration validation here: http://slss.io/configuration-validation

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -123,6 +123,12 @@ class ConfigSchemaHandler {
             : `${ERROR_PREFIX} ${messages[0]}`;
 
         throw new ServerlessError(errorMessage);
+      } else if (this.serverless.configurationInput.configValidationMode === undefined) {
+        this.serverless._logDeprecation(
+          'CONFIG_VALIDATION_MODE_DEFAULT',
+          'Starting from next major Serverless will throw by default. Adapt to this behavior now ' +
+            'by adding configValidationMode: error to service configuration'
+        );
       } else {
         if (messages.length === 1) {
           this.serverless.cli.log(`${WARNING_PREFIX} ${messages[0]}`, 'Serverless', {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
Show deprecation log about new configValidationMode default setting, only when user has not explicitly set configValidationMode in their service configuration.
Closes: #8985
