### PR TITLE
Variables: Ensure to recognize "-" in type notation

### DIFF
--- a/lib/configuration/variables/parse.js
+++ b/lib/configuration/variables/parse.js
@@ -6,7 +6,7 @@ const ServerlessError = require('../../serverless-error');
 
 const alphaChars = new Set('abcdefghijklmnopqrstuvwxyz');
 const alphaNumericChars = new Set(
-  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.'
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-'
 );
 const isType = RegExp.prototype.test.bind(/^[a-z][a-zA-Z0-9]*$/);
 

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -335,9 +335,23 @@ Object.defineProperties(
         if (valueEntries) {
           propertyVariablesMeta = parseEntries(valueEntries, propertyPathKeys, new Map());
         } else if (typeof value === 'string') {
-          const valueVariables = parse(value);
+          const valueVariables = (() => {
+            try {
+              return parse(value);
+            } catch (error) {
+              error.message = `Cannot resolve variable at "${humanizePropertyPath(
+                propertyPathKeys
+              )}": Approached variable syntax error in resolved value "${value}": ${error.message}`;
+              delete valueMeta.value;
+              valueMeta.error = error;
+              return null;
+            }
+          })();
+
           if (valueVariables) {
             propertyVariablesMeta = new Map([[propertyPath, { value, variables: valueVariables }]]);
+          } else if (valueMeta.error) {
+            return;
           }
         }
         if (propertyVariablesMeta && propertyVariablesMeta.size) {

--- a/test/unit/lib/configuration/variables/parse.test.js
+++ b/test/unit/lib/configuration/variables/parse.test.js
@@ -325,6 +325,12 @@ describe('test/unit/lib/configuration/variables/parse.test.js', () => {
         { sources: [{ type: 'type.dot', params: [{ value: 'param' }] }] },
       ]));
 
+    // ${type.us-east-1(param)}
+    it('should support hyphens in type notation', () =>
+      expect(parse('${type.us-east-1(param)}')).to.deep.equal([
+        { sources: [{ type: 'type.us-east-1', params: [{ value: 'param' }] }] },
+      ]));
+
     // ${AWS::${type:address}}
     it('should support variable nested in foreign variable', () =>
       expect(parse('${AWS::${type:address}}')).to.deep.equal([
@@ -439,9 +445,13 @@ describe('test/unit/lib/configuration/variables/parse.test.js', () => {
     // ${type:foo, 000()}
     // ${type:foo, aa--}
     it('should reject invalid following source', () => {
-      expect(() => parse('${type:foo, --}'))
+      expect(() => parse('${type:foo, ___}'))
         .to.throw(ServerlessError)
         .with.property('code', 'INVALID_VARIABLE_SOURCE');
+
+      expect(() => parse('${type:foo, --}'))
+        .to.throw(ServerlessError)
+        .with.property('code', 'INVALID_VARIABLE_LITERAL_SOURCE');
 
       expect(() => parse('${type:foo, 000:}'))
         .to.throw(ServerlessError)
@@ -452,6 +462,10 @@ describe('test/unit/lib/configuration/variables/parse.test.js', () => {
         .with.property('code', 'INVALID_VARIABLE_SOURCE');
 
       expect(() => parse('${type:foo, aa--}'))
+        .to.throw(ServerlessError)
+        .with.property('code', 'INVALID_VARIABLE_LITERAL_SOURCE');
+
+      expect(() => parse('${type:foo, aa__}'))
         .to.throw(ServerlessError)
         .with.property('code', 'INVALID_VARIABLE_SOURCE');
 

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -34,6 +34,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     resolvesVariablesObject: '${sourceVariables(object)}',
     resolvesVariablesArray: '${sourceVariables(array)}',
     resolvesVariablesString: '${sourceVariables(string)}',
+    resolvesVariablesStringInvalid: '${sourceVariables(stringInvalid)}',
     incomplete: '${sourceDirect:}elo${sourceIncomplete:}',
     missing: '${sourceDirect:}elo${sourceMissing:}other${sourceMissing:}',
     missingFallback: '${sourceDirect:}elo${sourceMissing:, "foo"}',
@@ -85,6 +86,8 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
             return [1, '${sourceDirect:}'];
           case 'string':
             return '${sourceDirect:}';
+          case 'stringInvalid':
+            return '${sourceDirect:';
           case 'error':
             return [1, '${sourceUnrecognized:}', '${sourceError:}'];
           default:
@@ -299,6 +302,12 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     expect(valueMeta.error.code).to.equal('EXCESSIVE_RESOLVED_PROPERTIES_NEST_DEPTH');
   });
 
+  it('should error on invalid variable notation in returned result', () => {
+    const valueMeta = variablesMeta.get('resolvesVariablesStringInvalid');
+    expect(valueMeta).to.not.have.property('variables');
+    expect(valueMeta.error.code).to.equal('UNTERMINATED_VARIABLE');
+  });
+
   it('should allow to re-resolve fulfilled sources', async () => {
     await resolve({
       servicePath: process.cwd(),
@@ -322,6 +331,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       'propertyDeepCircularB',
       'propertyDeepCircularC',
       'propertyRoot',
+      'resolvesVariablesStringInvalid',
       'missing',
       'nonStringStringPart',
       'nestUnrecognized\0unrecognized',


### PR DESCRIPTION
Addresses: https://github.com/serverless/serverless/issues/9048#issuecomment-789223294

Needed to recognize old variables notation as `${cf.us-east-1:my-project-dev.MyTableArn}`, which will not be practised with new resolver (as all source params will be passed in parens)

Additionally, ensure proper error handling for variables in result string resolution (added with https://github.com/serverless/serverless/pull/9050)