### PR TITLE
Variables: Ensure to not share property cache across resolutions

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -205,6 +205,7 @@ class Serverless {
     const serverlessLocal = new ServerlessLocal({
       configurationPath: this.configurationPath,
       configuration: this.configurationInput,
+      isConfigurationResolved: this.isConfigurationInputResolved,
       _isInvokedByGlobalInstallation: true,
     });
     serverlessLocal.isLocallyInstalled = true;

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -61,8 +61,11 @@ class VariablesResolver {
         valueMeta.error = variableMeta.error;
       })
     );
-    if (valueMeta.error) {
-      // If resolution of any variables resolved with an error, abort
+    if (!valueMeta.variables) {
+      // Abort, as either:
+      // - Resolution of some variables errored
+      // - Value was already resolved in other resolution batch
+      //   (triggered by depending property resolver)
       return;
     }
     if (valueMeta.variables.some((variableMeta) => variableMeta.sources)) {
@@ -403,7 +406,7 @@ Object.defineProperties(
         );
       },
       {
-        normalizer: ([, propertyPath]) => propertyPath,
+        primitive: true,
         /* We're fine with caching rejections here, hence no "promise: true" option */
       }
     ),

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -59,6 +59,8 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     infiniteResolutionRecursion: '${sourceInfinite:}',
     sharedSourceResolution1: '${sourceShared:}',
     sharedSourceResolution2: '${sourceProperty(sharedSourceResolution1, sharedFinal)}',
+    sharedPropertyResolution1: '${sourceSharedProperty:}',
+    sharedPropertyResolution2: '${sourceProperty(sharedPropertyResolution1, sharedFinal)}',
   };
   let variablesMeta;
   const sources = {
@@ -135,6 +137,12 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         sharedInner: '${sourceProperty(sharedSourceResolution1, sharedFinal)}',
       }),
     },
+    sourceSharedProperty: {
+      resolve: () => ({
+        sharedFinal: 'foo',
+        sharedInner: '${sourceProperty(sharedPropertyResolution2)}',
+      }),
+    },
   };
   before(async () => {
     variablesMeta = resolveMeta(configuration);
@@ -209,6 +217,15 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
   // https://github.com/serverless/serverless/issues/9016
   it('should resolve same sources across resolution batches without shared caching', () => {
     expect(configuration.sharedSourceResolution1).to.deep.equal({
+      sharedFinal: 'foo',
+      sharedInner: 'foo',
+    });
+    expect(configuration.sharedSourceResolution2).to.equal('foo');
+  });
+
+  // https://github.com/serverless/serverless/issues/9047
+  it('should resolve same properties across resolution batches without shared caching', () => {
+    expect(configuration.sharedPropertyResolution1).to.deep.equal({
       sharedFinal: 'foo',
       sharedInner: 'foo',
     });

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -207,7 +207,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
   });
 
   // https://github.com/serverless/serverless/issues/9016
-  it('should resolve same sources across realms without shared caching', () => {
+  it('should resolve same sources across resolution batches without shared caching', () => {
     expect(configuration.sharedSourceResolution1).to.deep.equal({
       sharedFinal: 'foo',
       sharedInner: 'foo',


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Fixes: #9047 

Very similar issue as https://github.com/serverless/serverless/issues/9016, still this time shared property cache imposed a problem

Additionally, fixed a minor omission in https://github.com/serverless/serverless/pull/9040, so that constructor `isConfigurationResolved` config property is also passed locally resolved `Serverless` instance
