### PR TITLE
docs: Update docs around `provider.iam` usage

### DIFF
--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -143,7 +143,7 @@ Currently, `invoke local` only supports the NodeJs and Python runtimes.
 
 ## Resource permissions
 
-Lambda functions assume an _IAM role_ during execution: the framework creates this role, and set all the permission provided in the `iamRoleStatements` section of `serverless.yml`.
+Lambda functions assume an _IAM role_ during execution: the framework creates this role, and set all the permission provided in the `iam.role.statements` section of `serverless.yml`.
 
 Unless you explicitly state otherwise, every call to the AWS SDK inside the lambda function is made using this role (a temporary pair of key / secret is generated and set by AWS as environment variables, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
 

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1765,7 +1765,7 @@ To be able to write logs, API Gateway [needs a CloudWatch role configured](https
         roleManagedExternally: true # disables automatic role creation/checks done by Serverless
   ```
 
-**Note:** Serverless configures the API Gateway CloudWatch role setting using a custom resource lambda function. If you're using `cfnRole` to specify a limited-access IAM role for your serverless deployment, the custom resource lambda will assume this role during execution.
+**Note:** Serverless configures the API Gateway CloudWatch role setting using a custom resource lambda function. If you're using `iam.deploymentRole` to specify a limited-access IAM role for your serverless deployment, the custom resource lambda will assume this role during execution.
 
 By default, API Gateway access logs will use the following format:
 
@@ -1797,7 +1797,7 @@ provider:
 
 Valid values are INFO, ERROR.
 
-If you want to disable access logging completly you can do with the following:
+If you want to disable access logging completely you can do with the following:
 
 ```yml
 # serverless.yml
@@ -1826,7 +1826,7 @@ Websockets have the same configuration options as the the REST API. Example:
 provider:
   name: aws
   logs:
-    websoocket:
+    websocket:
       level: INFO
       fullExecutionData: false
 ```

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -126,7 +126,7 @@ deleteFoo:
 
 ## Permissions
 
-Every AWS Lambda function needs permission to interact with other AWS infrastructure resources within your account. These permissions are set via an AWS IAM Role. You can set permission policy statements within this role via the `provider.iamRoleStatements` property.
+Every AWS Lambda function needs permission to interact with other AWS infrastructure resources within your account. These permissions are set via an AWS IAM Role. You can set permission policy statements within this role via the `provider.iam.role.statements` property.
 
 ```yml
 # serverless.yml
@@ -135,17 +135,19 @@ service: myService
 provider:
   name: aws
   runtime: nodejs12.x
-  iamRoleStatements: # permissions for all of your functions can be set here
-    - Effect: Allow
-      Action: # Gives permission to DynamoDB tables in a specific region
-        - dynamodb:DescribeTable
-        - dynamodb:Query
-        - dynamodb:Scan
-        - dynamodb:GetItem
-        - dynamodb:PutItem
-        - dynamodb:UpdateItem
-        - dynamodb:DeleteItem
-      Resource: 'arn:aws:dynamodb:us-east-1:*:*'
+  iam:
+    role:
+      statements: # permissions for all of your functions can be set here
+        - Effect: Allow
+          Action: # Gives permission to DynamoDB tables in a specific region
+            - dynamodb:DescribeTable
+            - dynamodb:Query
+            - dynamodb:Scan
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+            - dynamodb:DeleteItem
+          Resource: 'arn:aws:dynamodb:us-east-1:*:*'
 
 functions:
   functionOne:
@@ -160,22 +162,24 @@ Another example:
 service: myService
 provider:
   name: aws
-  iamRoleStatements:
-    - Effect: 'Allow'
-      Action:
-        - 's3:ListBucket'
-      # You can put CloudFormation syntax in here.  No one will judge you.
-      # Remember, this all gets translated to CloudFormation.
-      Resource: { 'Fn::Join': ['', ['arn:aws:s3:::', { 'Ref': 'ServerlessDeploymentBucket' }]] }
-    - Effect: 'Allow'
-      Action:
-        - 's3:PutObject'
-      Resource:
-        Fn::Join:
-          - ''
-          - - 'arn:aws:s3:::'
-            - 'Ref': 'ServerlessDeploymentBucket'
-            - '/*'
+  iam:
+    role:
+      statements:
+        - Effect: 'Allow'
+          Action:
+            - 's3:ListBucket'
+          # You can put CloudFormation syntax in here.  No one will judge you.
+          # Remember, this all gets translated to CloudFormation.
+          Resource: { 'Fn::Join': ['', ['arn:aws:s3:::', { 'Ref': 'ServerlessDeploymentBucket' }]] }
+        - Effect: 'Allow'
+          Action:
+            - 's3:PutObject'
+          Resource:
+            Fn::Join:
+              - ''
+              - - 'arn:aws:s3:::'
+                - 'Ref': 'ServerlessDeploymentBucket'
+                - '/*'
 
 functions:
   functionOne:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -60,10 +60,7 @@ provider:
       key1: value1
       key2: value2
   deploymentPrefix: serverless # The S3 prefix under which deployed artifacts should be stored. Default is serverless
-  role: arn:aws:iam::XXXXXX:role/role # Overwrite the default IAM role which is used for all functions
-  rolePermissionsBoundary: arn:aws:iam::XXXXXX:policy/policy # ARN of an Permissions Boundary for the role.
   lambdaHashingVersion: 20201221 # optional, version of hashing algorithm that should be used by the framework
-  cfnRole: arn:aws:iam::XXXXXX:role/role # ARN of an IAM role for CloudFormation service. If specified, CloudFormation uses the role's credentials
   ecr:
     images: # Definitions of images that later can be referenced by key in `function.image`
       baseimage:
@@ -177,7 +174,7 @@ provider:
     id: 'my-id' # If we want to attach to externally created HTTP API its id should be provided here
     name: 'dev-my-service' # Use custom name for the API Gateway API, default is ${opt:stage, self:provider.stage, 'dev'}-${self:service}
     payload: '1.0' # Specify payload format version for Lambda integration ('1.0' or '2.0'), default is '1.0'
-    cors: true # Implies default behavior, can be fine tuned with specficic options
+    cors: true # Implies default behavior, can be fine tuned with specific options
     authorizers:
       # JWT authorizers to back HTTP API endpoints
       someJwtAuthorizer:
@@ -188,17 +185,24 @@ provider:
           - xxxx
   stackTags: # Optional CF stack tags
     key: value
-  iamManagedPolicies: # Optional IAM Managed Policies, which allows to include the policies into IAM Role
-    - arn:aws:iam:*****:policy/some-managed-policy
-  iamRoleStatements: # IAM role statements so that services can be accessed in the AWS account
-    - Effect: 'Allow'
-      Action:
-        - 's3:ListBucket'
-      Resource:
-        Fn::Join:
-          - ''
-          - - 'arn:aws:s3:::'
-            - Ref: ServerlessDeploymentBucket
+  iam:
+    # Overwrite the default IAM role which is used for all functions
+    role: arn:aws:iam::XXXXXX:role/role
+    # .. OR configure logical role
+    role:
+      managedPolicies: # Optional IAM Managed Policies, which allows to include the policies into IAM Role
+        - arn:aws:iam:*****:policy/some-managed-policy
+      permissionsBoundary: arn:aws:iam::XXXXXX:policy/policy # ARN of an Permissions Boundary for the role.
+      statements: # IAM role statements so that services can be accessed in the AWS account
+        - Effect: 'Allow'
+          Action:
+            - 's3:ListBucket'
+          Resource:
+            Fn::Join:
+              - ''
+              - - 'arn:aws:s3:::'
+                - Ref: ServerlessDeploymentBucket
+    deploymentRole: arn:aws:iam::XXXXXX:role/role # ARN of an IAM role for CloudFormation service. If specified, CloudFormation uses the role's credentials
   stackPolicy: # Optional CF stack policy. The example below allows updates to all resources except deleting/replacing EC2 instances (use with caution!)
     - Effect: Allow
       Principal: '*'
@@ -344,7 +348,7 @@ functions:
             template: # Optional custom request mapping templates that overwrite default templates
               application/json: '{ "httpMethod" : "$context.httpMethod" }'
             passThrough: NEVER # Optional define pass through behavior when content-type does not match any of the specified mapping templates
-            schemas: # Optional request schema validation, mappped by content type
+            schemas: # Optional request schema validation, mapped by content type
               application/json:
                 name: ModelName  # Optional: Name of the API Gateway model
                 description: "Some description" # Optional: Description of the API Gateway model

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -471,7 +471,7 @@ functions:
 With a new variables resolver (_which will be the only used resolver in v3 of a Framework, and which can be turned on now by setting `variablesResolutionMode: 20210219` in service config_) functions receives an object, with two properties:
 
 - `options` - An object referencing resolved CLI params as passed to the command
-- `resolveConfigurationProperty([key1, key2, ...keyN])` - Async function which resolves specific service configuraton property. It returns a fully resolved value of configuration property. If circular reference is detected resolution will be rejected.
+- `resolveConfigurationProperty([key1, key2, ...keyN])` - Async function which resolves specific service configuration property. It returns a fully resolved value of configuration property. If circular reference is detected resolution will be rejected.
 
 Example, of how to obtain a value of AWS region that will be used by Serverless Framework:
 


### PR DESCRIPTION
Sync up docs with modern iam configuration options. 

Inconsistencies were discovered as part of https://github.com/serverless/serverless/pull/9039