### PR TITLE
Variables: Reject unresolved "plugins" property

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -141,7 +141,7 @@ const processSpanPromise = (async () => {
                 throw new ServerlessError(
                   `Cannot resolve ${path.basename(
                     configurationPath
-                  )}: "provider.stage" is not accessible ` +
+                  )}: "provider.stage" property is not accessible ` +
                     '(configured behind variables which cannot be resolved at this stage)'
                 );
               }

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -129,4 +129,20 @@ describe('test/unit/scripts/serverless.test.js', () => {
       String((await spawn('node', [serverlessPath, 'print'], { cwd: servicePath })).stdoutBuffer)
     ).to.include('fromDefaultEnv: valuefromdefault');
   });
+
+  it('Should reject unresolved "plugins" property', async () => {
+    try {
+      await spawn('node', [serverlessPath, 'print'], {
+        cwd: (
+          await fixturesEngine.setup('aws', {
+            configExt: { variablesResolutionMode: '20210219', plugins: '${foo:bar}' },
+          })
+        ).servicePath,
+      });
+      throw new Error('Unexpected');
+    } catch (error) {
+      expect(error.code).to.equal(1);
+      expect(String(error.stdoutBuffer)).to.include('"plugins" property is not accessible');
+    }
+  });
 });

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -111,7 +111,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
       throw new Error('Unexpected');
     } catch (error) {
       expect(error.code).to.equal(1);
-      expect(String(error.stdoutBuffer)).to.include('"provider.stage" is not accessible');
+      expect(String(error.stdoutBuffer)).to.include('"provider.stage" property is not accessible');
     }
   });
 


### PR DESCRIPTION
Addresses 2.6 from https://github.com/serverless/serverless/issues/8364

At same time it addresses an old bug where we do not report meaningfully error if someone puts `plugins` section behind variables.
