### PR TITLE
Variables: Ensure to apply intialization patch unconditionally

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -237,17 +237,19 @@ class Serverless {
       // populate variables after --help, otherwise help may fail to print
       // (https://github.com/serverless/serverless/issues/2041)
       await this.variables.populateService(this.pluginManager.cliOptions);
-    } else if (process.env.SLS_DEBUG) {
+    } else {
       // Some plugins resolve additional variables on their own by runnning `variables.populateObject`
       // e.g. https://github.com/serverless-operations/serverless-step-functions/blob/016da8db78f1972ba80d37941c34c8fd038fd8ca/lib/yamlParser.js#L26
       // and that requires variableSyntax initizalization which is guaranteed by
       // `variables.populateService` which we're skipping here,
       // below line ensures variableSyntax remains setup.
       this.variables.loadVariableSyntax();
-      this.cli.log(
-        'Skipping variables resolution with old resolver ' +
-          '(new resolver reported no more variables to resolve)'
-      );
+      if (process.env.SLS_DEBUG) {
+        this.cli.log(
+          'Skipping variables resolution with old resolver ' +
+            '(new resolver reported no more variables to resolve)'
+        );
+      }
     }
 
     // merge arrays after variables have been populated

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -335,4 +335,19 @@ describe('Serverless [new tests]', () => {
       expect(result.serverless.service.custom.fromStageEnv).to.be.undefined;
     });
   });
+
+  describe('Old variables engine initialiation', () => {
+    let serverless;
+
+    before(async () => {
+      ({ serverless } = await runServerless({
+        fixture: 'aws',
+        cliArgs: ['package'],
+      }));
+    });
+
+    it('Ensure that instance is setup', async () => {
+      expect(serverless.variables).to.have.property('variableSyntax');
+    });
+  });
 });


### PR DESCRIPTION
Continuation of https://github.com/serverless/serverless/pull/9060, where patch was applied only behind `SLS_DEBUG` flag, that shouldn't be the case
