### PR TITLE
Revert recent refactorings of `bluebird` 

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const config = require('@serverless/utils/config');
 const cjsResolve = require('ncjsm/resolve/sync');
+const BbPromise = require('bluebird');
 const _ = require('lodash');
 const crypto = require('crypto');
 const isModuleNotFoundError = require('ncjsm/is-module-not-found-error');
@@ -478,7 +479,7 @@ class PluginManager {
     return _.flatMap([].concat(events), (event) => this.hooks[event] || []);
   }
 
-  async invoke(commandsArray, allowEntryPoints) {
+  invoke(commandsArray, allowEntryPoints) {
     const command = this.getCommand(commandsArray, allowEntryPoints);
 
     this.convertShortcutsIntoOptions(command);
@@ -497,48 +498,42 @@ class PluginManager {
       }
     }
 
-    try {
-      for (const hook of hooks) {
-        await hook.hook();
-      }
-    } catch (err) {
-      if (err instanceof TerminateHookChain) {
+    return BbPromise.reduce(hooks, (__, hook) => hook.hook(), null).catch(
+      TerminateHookChain,
+      () => {
         if (process.env.SLS_DEBUG) {
           this.serverless.cli.log(`Terminate ${commandsArray.join(':')}`);
         }
-        return;
+        return BbPromise.resolve();
       }
-      throw err;
-    }
+    );
   }
 
   /**
    * Invokes the given command and starts the command's lifecycle.
    * This method can be called by plugins directly to spawn a separate sub lifecycle.
    */
-  async spawn(commandsArray, options) {
+  spawn(commandsArray, options) {
     let commands = commandsArray;
     if (typeof commandsArray === 'string') {
       commands = commandsArray.split(':');
     }
-
-    await this.invoke(commands, true);
-
-    if (_.get(options, 'terminateLifecycleAfterExecution', false)) {
-      throw new TerminateHookChain(commands);
-    }
+    return this.invoke(commands, true).then(() => {
+      if (_.get(options, 'terminateLifecycleAfterExecution', false)) {
+        return BbPromise.reject(new TerminateHookChain(commands));
+      }
+      return BbPromise.resolve();
+    });
   }
 
   /**
    * Called by the CLI to start a public command.
    */
-  async run(commandsArray) {
+  run(commandsArray) {
     // first initialize hooks
-    const hooks = this.getHooks(['initialize']);
-    for (const { hook } of hooks) {
-      await hook();
-    }
-    await this.invoke(commandsArray);
+    return this.getHooks(['initialize'])
+      .reduce((chain, { hook }) => chain.then(hook), BbPromise.resolve())
+      .then(() => this.invoke(commandsArray));
   }
 
   /**
@@ -649,8 +644,8 @@ class PluginManager {
     }
   }
 
-  async asyncPluginInit() {
-    await Promise.all(this.plugins.map((plugin) => plugin.asyncInit && plugin.asyncInit()));
+  asyncPluginInit() {
+    return BbPromise.all(this.plugins.map((plugin) => plugin.asyncInit && plugin.asyncInit()));
   }
 }
 

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -4,6 +4,7 @@ const os = require('os');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const fileExistsSync = require('../utils/fs/fileExistsSync');
 const writeFileSync = require('../utils/fs/writeFileSync');
@@ -50,7 +51,7 @@ class Utils {
   }
 
   writeFile(filePath, contents, cycles) {
-    return new Promise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       try {
         this.writeFileSync(filePath, contents, cycles);
       } catch (e) {
@@ -63,7 +64,7 @@ class Utils {
   appendFileSync(filePath, conts) {
     const contents = conts || '';
 
-    return new Promise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       try {
         fs.appendFileSync(filePath, contents);
       } catch (e) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const BbPromise = require('bluebird');
 const os = require('os');
 const path = require('path');
 const replaceall = require('replaceall');
@@ -105,21 +106,19 @@ class Variables {
     this.variableSyntax = RegExp(this.service.provider.variableSyntax, 'g');
   }
 
-  async initialCall(func) {
+  initialCall(func) {
     this.deep = [];
     this.tracker.start();
-    try {
-      return await func();
-    } finally {
+    return func().finally(() => {
       this.tracker.stop();
       this.deep = [];
-    }
+    });
   }
 
   // #############
   // ## SERVICE ##
   // #############
-  async disableDepedentServices(func) {
+  disableDepedentServices(func) {
     const dependencyMessage = (configValue, serviceName) =>
       `Variable dependency failure: variable '${configValue}' references ${serviceName} but using that service requires a concrete value to be called.`;
     // replace and then restore the methods for obtaining values from dependent services.  the
@@ -131,24 +130,20 @@ class Variables {
         // save original
         resolver.original = resolver.resolver;
         // knock out
-        resolver.resolver = (variableString) => {
-          throw dependencyMessage(variableString, resolver.serviceName);
-        };
+        resolver.resolver = (variableString) =>
+          BbPromise.reject(dependencyMessage(variableString, resolver.serviceName));
       }
     }
-
-    try {
-      await func();
-    } finally {
+    return func().finally(() => {
       // restore
       for (const resolver of this.variableResolvers) {
         if (resolver.isDisabledAtPrepopulation) {
           resolver.resolver = resolver.original;
         }
       }
-    }
+    });
   }
-  async prepopulateService() {
+  prepopulateService() {
     const provider = this.serverless.getProvider('aws');
     if (provider) {
       const requiredConfigs = [
@@ -180,14 +175,15 @@ class Variables {
           path: 'serverless.service.provider.credentials.sessionToken',
         },
       ];
-      await this.disableDepedentServices(() => {
-        const prepopulations = requiredConfigs.map(async (config) => {
-          const populated = await this.populateValue(config.value, true);
-          return { ...config, populated };
-        });
+      return this.disableDepedentServices(() => {
+        const prepopulations = requiredConfigs.map((config) =>
+          this.populateValue(config.value, true) // populate
+            .then((populated) => Object.assign(config, { populated }))
+        );
         return this.assignProperties(provider, prepopulations);
       });
     }
+    return BbPromise.resolve();
   }
   /**
    * Populate all variables in the service, conveniently remove and restore the service attributes
@@ -195,7 +191,7 @@ class Variables {
    * @param processedOptions An options hive to use for ${opt:...} variables.
    * @returns {Promise.<TResult>|*} A promise resolving to the populated service.
    */
-  async populateService(processedOptions) {
+  populateService(processedOptions) {
     // #######################################################################
     // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
     // #######################################################################
@@ -207,17 +203,17 @@ class Variables {
     // remove
     this.service.provider.variableSyntax = undefined; // otherwise matches itself
     this.service.serverless = undefined;
-    return this.initialCall(async () => {
-      await this.prepopulateService();
-      try {
-        await this.populateObjectImpl(this.service);
-      } finally {
-        // restore
-        this.service.serverless = this.serverless;
-        this.service.provider.variableSyntax = variableSyntaxProperty;
-      }
-      return this.service;
-    });
+    return this.initialCall(() =>
+      this.prepopulateService()
+        .then(() =>
+          this.populateObjectImpl(this.service).finally(() => {
+            // restore
+            this.service.serverless = this.serverless;
+            this.service.provider.variableSyntax = variableSyntaxProperty;
+          })
+        )
+        .then(() => this.service)
+    );
   }
   // ############
   // ## OBJECT ##
@@ -291,15 +287,14 @@ class Variables {
    * populated values of the given terminal properties
    */
   populateVariables(properties) {
-    return properties
-      .filter(
-        (property) =>
-          typeof property.value === 'string' && property.value.match(this.variableSyntax)
+    const variables = properties.filter(
+      (property) => typeof property.value === 'string' && property.value.match(this.variableSyntax)
+    );
+    return variables.map((variable) =>
+      this.populateValue(variable.value, false).then((populated) =>
+        Object.assign({}, variable, { populated })
       )
-      .map(async (variable) => {
-        const populated = await this.populateValue(variable.value, false);
-        return { ...variable, populated };
-      });
+    );
   }
   /**
    * Assign the populated values back to the target object
@@ -308,34 +303,36 @@ class Variables {
    * @returns {Promise<number>} resolving with the number of changes that were applied to the given
    * target
    */
-  async assignProperties(target, populations) {
+  assignProperties(target, populations) {
     // eslint-disable-line class-methods-use-this
-    const results = await Promise.all(populations);
-    results.forEach((result) => {
-      if (result.value !== result.populated) {
-        const pathArray = Array.isArray(result.path) ? result.path : result.path.split('.');
-        let obj = target;
-        for (const property of pathArray.slice(0, -1)) obj = obj[property];
-        obj[_.last(pathArray)] = result.populated;
-      }
-    });
+    return BbPromise.all(populations).then((results) =>
+      results.forEach((result) => {
+        if (result.value !== result.populated) {
+          const pathArray = Array.isArray(result.path) ? result.path : result.path.split('.');
+          let obj = target;
+          for (const property of pathArray.slice(0, -1)) obj = obj[property];
+          obj[_.last(pathArray)] = result.populated;
+        }
+      })
+    );
   }
   /**
    * Populate the variables in the given object.
    * @param objectToPopulate The object to populate variables within.
    * @returns {Promise.<TResult>|*} A promise resolving to the in-place populated object.
    */
-  async populateObject(objectToPopulate) {
+  populateObject(objectToPopulate) {
     return this.initialCall(() => this.populateObjectImpl(objectToPopulate));
   }
-  async populateObjectImpl(objectToPopulate) {
+  populateObjectImpl(objectToPopulate) {
     const leaves = this.getProperties(objectToPopulate, true, objectToPopulate);
     const populations = this.populateVariables(leaves);
     if (populations.length === 0) {
-      return objectToPopulate;
+      return BbPromise.resolve(objectToPopulate);
     }
-    await this.assignProperties(objectToPopulate, populations);
-    return this.populateObjectImpl(objectToPopulate);
+    return this.assignProperties(objectToPopulate, populations).then(() =>
+      this.populateObjectImpl(objectToPopulate)
+    );
   }
   // ##############
   // ## PROPERTY ##
@@ -409,26 +406,28 @@ class Variables {
    * @returns {PromiseLike<T>} A promise that resolves to the populated value, recursively if root
    * is true
    */
-  async populateValue(valueToPopulate, root) {
+  populateValue(valueToPopulate, root) {
     const property = valueToPopulate;
     const matches = this.getMatches(property);
     if (!Array.isArray(matches)) {
-      return property;
+      return BbPromise.resolve(property);
     }
     const populations = this.populateMatches(matches, valueToPopulate);
-    const results = await Promise.all(populations);
-    const result = await this.renderMatches(property, matches, results);
-    if (root && matches.length) {
-      return this.populateValue(result, root);
-    }
-    return result;
+    return BbPromise.all(populations)
+      .then((results) => this.renderMatches(property, matches, results))
+      .then((result) => {
+        if (root && matches.length) {
+          return this.populateValue(result, root);
+        }
+        return result;
+      });
   }
   /**
    * Populate variables in the given property.
    * @param propertyToPopulate The property to populate (replace variables with their values).
    * @returns {Promise.<TResult>|*} A promise resolving to the populated result.
    */
-  async populateProperty(propertyToPopulate) {
+  populateProperty(propertyToPopulate) {
     return this.initialCall(() => this.populateValue(propertyToPopulate, true));
   }
 
@@ -440,7 +439,7 @@ class Variables {
    * @param property The original property string the given variable was extracted from
    * @returns {Promise} A promise resolving to the final value of the given variable
    */
-  async splitAndGet(match, property) {
+  splitAndGet(match, property) {
     const parts = this.splitByComma(match.variable);
     if (parts.length > 1) {
       return this.overwrite(parts, match.match, property);
@@ -533,7 +532,7 @@ class Variables {
    * @returns {Promise.<TResult>|*} A promise resolving to the first validly populating variable
    *  in the given variable strings string.
    */
-  async overwrite(variableStrings, variableMatch, propertyString) {
+  overwrite(variableStrings, variableMatch, propertyString) {
     // A sentinel to rid rejected Promises, so any of resolved value can be used as fallback.
     const FAIL_TOKEN = {};
     const variableValues = variableStrings.map((variableString) =>
@@ -545,31 +544,32 @@ class Variables {
       typeof value !== 'undefined' &&
       (Array.isArray(value) || !(typeof value === 'object' && !Object.keys(value).length));
 
-    const values = await Promise.all(variableValues);
-    const filteredValues = values.filter((v) => v !== FAIL_TOKEN);
-
-    let deepPropertyString = variableMatch;
-    let deepProperties = 0;
-    filteredValues.forEach((value, index) => {
-      if (typeof value === 'string' && value.match(this.variableSyntax)) {
-        deepProperties += 1;
-        const deepVariable = this.makeDeepVariable(value);
-        deepPropertyString = deepPropertyString.replace(
-          variableStrings[index],
-          this.cleanVariable(deepVariable)
-        );
-      }
-    });
-    return deepProperties > 0
-      ? deepPropertyString // return deep variable replacement of original
-      : filteredValues.find(validValue); // resolve first valid value, else undefined
+    return BbPromise.all(variableValues)
+      .then((values) => values.filter((v) => v !== FAIL_TOKEN))
+      .then((values) => {
+        let deepPropertyString = variableMatch;
+        let deepProperties = 0;
+        values.forEach((value, index) => {
+          if (typeof value === 'string' && value.match(this.variableSyntax)) {
+            deepProperties += 1;
+            const deepVariable = this.makeDeepVariable(value);
+            deepPropertyString = deepPropertyString.replace(
+              variableStrings[index],
+              this.cleanVariable(deepVariable)
+            );
+          }
+        });
+        return deepProperties > 0
+          ? BbPromise.resolve(deepPropertyString) // return deep variable replacement of original
+          : BbPromise.resolve(values.find(validValue)); // resolve first valid value, else undefined
+      });
   }
   /**
    * Given any variable string, return the value it should be populated with.
    * @param variableString The variable string to retrieve a value for.
    * @returns {Promise.<TResult>|*} A promise resolving to the given variables value.
    */
-  async getValueFromSource(variableString, propertyString) {
+  getValueFromSource(variableString, propertyString) {
     let ret;
     if (this.tracker.contains(variableString)) {
       ret = this.tracker.get(variableString, propertyString);
@@ -586,63 +586,73 @@ class Variables {
           ' You can only reference env vars, options, & files.',
           ' You can check our docs for more info.',
         ].join('');
-        ret = Promise.reject(new ServerlessError(errorMessage));
+        ret = BbPromise.reject(new ServerlessError(errorMessage));
       }
       ret = this.tracker.add(variableString, ret, propertyString);
     }
-    const resolvedValue = await ret;
-    if (!Array.isArray(resolvedValue) && !_.isPlainObject(resolvedValue)) return resolvedValue;
-    if (resolvedValuesWeak.has(resolvedValue)) {
-      try {
-        return _.cloneDeep(resolvedValue);
-      } catch (error) {
-        return resolvedValue;
+    return ret.then((resolvedValue) => {
+      if (!Array.isArray(resolvedValue) && !_.isPlainObject(resolvedValue)) return resolvedValue;
+      if (resolvedValuesWeak.has(resolvedValue)) {
+        try {
+          return _.cloneDeep(resolvedValue);
+        } catch (error) {
+          return resolvedValue;
+        }
       }
-    }
-    resolvedValuesWeak.add(resolvedValue);
-    return resolvedValue;
+      resolvedValuesWeak.add(resolvedValue);
+      return resolvedValue;
+    });
   }
 
-  async getValueFromSls(variableString) {
+  getValueFromSls(variableString) {
     let valueToPopulate = {};
     const requestedSlsVar = variableString.split(':')[1];
     if (requestedSlsVar === 'instanceId') {
       valueToPopulate = this.serverless.instanceId;
     }
-    return valueToPopulate;
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  async getValueFromEnv(variableString) {
+  getValueFromEnv(variableString) {
+    // eslint-disable-line class-methods-use-this
     const requestedEnvVar = variableString.split(':')[1];
+    let valueToPopulate;
     if (requestedEnvVar !== '' || '' in process.env) {
-      return process.env[requestedEnvVar];
+      valueToPopulate = process.env[requestedEnvVar];
+    } else {
+      valueToPopulate = process.env;
     }
-
-    return process.env;
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  async getValueFromString(variableString) {
-    return variableString.replace(/^['"]|['"]$/g, '');
+  getValueFromString(variableString) {
+    // eslint-disable-line class-methods-use-this
+    const valueToPopulate = variableString.replace(/^['"]|['"]$/g, '');
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  async getValueFromBool(variableString) {
-    return variableString === 'true';
+  getValueFromBool(variableString) {
+    const valueToPopulate = variableString === 'true';
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  async getValueFromInt(variableString) {
-    return parseInt(variableString, 10);
+  getValueFromInt(variableString) {
+    const valueToPopulate = parseInt(variableString, 10);
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  async getValueFromOptions(variableString) {
+  getValueFromOptions(variableString) {
     const requestedOption = variableString.split(':')[1];
+    let valueToPopulate;
     if (requestedOption !== '' || '' in this.options) {
-      return this.options[requestedOption];
+      valueToPopulate = this.options[requestedOption];
+    } else {
+      valueToPopulate = this.options;
     }
-
-    return this.options;
+    return BbPromise.resolve(valueToPopulate);
   }
 
-  async getValueFromSelf(variableString) {
+  getValueFromSelf(variableString) {
     const selfServiceRex = /self:service\./;
     let variable = variableString;
     // ###################################################################
@@ -666,7 +676,7 @@ class Variables {
     return this.getDeeperValue(deepProperties, valueToPopulate);
   }
 
-  async getValueFromFile(variableString) {
+  getValueFromFile(variableString) {
     const matchedFileRefString = variableString.match(this.fileRefSyntax)[0];
     const referencedFileRelativePath = matchedFileRefString
       .replace(this.fileRefSyntax, (match, varName) => varName.trim())
@@ -685,7 +695,7 @@ class Variables {
     fileExtension = fileExtension[fileExtension.length - 1];
     // Validate file exists
     if (!this.serverless.utils.fileExistsSync(referencedFileFullPath)) {
-      return undefined;
+      return BbPromise.resolve(undefined);
     }
 
     let valueToPopulate;
@@ -710,19 +720,24 @@ class Variables {
         valueToPopulate = returnValue;
       }
 
-      let deepProperties = variableString.replace(matchedFileRefString, '');
-      deepProperties = deepProperties.slice(1).split('.');
-      deepProperties.splice(0, 1);
-      const deepValueToPopulateResolved = this.getDeeperValue(deepProperties, valueToPopulate);
-      if (unsupportedJsTypes.has(typeof deepValueToPopulateResolved)) {
-        const errorMessage = [
-          'Invalid variable syntax when referencing',
-          ` file "${referencedFileRelativePath}".`,
-          ' Check if your javascript is returning the correct data.',
-        ].join('');
-        throw new ServerlessError(errorMessage);
-      }
-      return deepValueToPopulateResolved;
+      return BbPromise.resolve(valueToPopulate).then((valueToPopulateResolved) => {
+        let deepProperties = variableString.replace(matchedFileRefString, '');
+        deepProperties = deepProperties.slice(1).split('.');
+        deepProperties.splice(0, 1);
+        return this.getDeeperValue(deepProperties, valueToPopulateResolved).then(
+          (deepValueToPopulateResolved) => {
+            if (unsupportedJsTypes.has(typeof deepValueToPopulateResolved)) {
+              const errorMessage = [
+                'Invalid variable syntax when referencing',
+                ` file "${referencedFileRelativePath}".`,
+                ' Check if your javascript is returning the correct data.',
+              ].join('');
+              return BbPromise.reject(new ServerlessError(errorMessage));
+            }
+            return BbPromise.resolve(deepValueToPopulateResolved);
+          }
+        );
+      });
     }
 
     // Process everything except JS
@@ -736,13 +751,13 @@ class Variables {
             ` file "${referencedFileRelativePath}" sub properties`,
             ' Please use ":" to reference sub properties.',
           ].join('');
-          throw new ServerlessError(errorMessage);
+          return BbPromise.reject(new ServerlessError(errorMessage));
         }
         deepProperties = deepProperties.slice(1).split('.');
         return this.getDeeperValue(deepProperties, valueToPopulate);
       }
     }
-    return valueToPopulate;
+    return BbPromise.resolve(valueToPopulate);
   }
 
   buildOptions(regionSuffix) {
@@ -753,40 +768,42 @@ class Variables {
     return options;
   }
 
-  async getValueFromCf(variableString) {
+  getValueFromCf(variableString) {
     const groups = variableString.match(this.cfRefSyntax);
     const regionSuffix = groups[1];
     const stackName = groups[2];
     const outputLogicalId = groups[3];
-    const result = await this.serverless
+    return this.serverless
       .getProvider('aws')
       .request(
         'CloudFormation',
         'describeStacks',
         { StackName: stackName },
         this.buildOptions(regionSuffix)
-      );
+      )
+      .then((result) => {
+        const outputs = result.Stacks[0].Outputs;
+        const output = outputs.find((x) => x.OutputKey === outputLogicalId);
 
-    const outputs = result.Stacks[0].Outputs;
-    const output = outputs.find((x) => x.OutputKey === outputLogicalId);
-
-    if (!output) {
-      const errorMessage = [
-        'Trying to request a non exported variable from CloudFormation.',
-        ` Stack name: "${stackName}"`,
-        ` Requested variable: "${outputLogicalId}".`,
-      ].join('');
-      throw new ServerlessError(errorMessage);
-    }
-    return output.OutputValue;
+        if (!output) {
+          const errorMessage = [
+            'Trying to request a non exported variable from CloudFormation.',
+            ` Stack name: "${stackName}"`,
+            ` Requested variable: "${outputLogicalId}".`,
+          ].join('');
+          return BbPromise.reject(new ServerlessError(errorMessage));
+        }
+        return BbPromise.resolve(output.OutputValue);
+      });
   }
 
-  async getValueFromS3(variableString) {
+  getValueFromS3(variableString) {
     const groups = variableString.match(this.s3RefSyntax);
     const bucket = groups[1];
     const key = groups[2];
-    try {
-      const response = await this.serverless.getProvider('aws').request(
+    return this.serverless
+      .getProvider('aws')
+      .request(
         'S3',
         'getObject',
         {
@@ -794,22 +811,23 @@ class Variables {
           Key: key,
         },
         { useCache: true }
-      ); // Use request cache
-      return response.Body.toString();
-    } catch (err) {
-      throw new ServerlessError(`Error getting value for ${variableString}. ${err.message}`);
-    }
+      ) // Use request cache
+      .then((response) => BbPromise.resolve(response.Body.toString()))
+      .catch((err) => {
+        const errorMessage = `Error getting value for ${variableString}. ${err.message}`;
+        return BbPromise.reject(new ServerlessError(errorMessage));
+      });
   }
 
-  async getValueFromSsm(variableString) {
+  getValueFromSsm(variableString) {
     const groups = variableString.match(this.ssmRefSyntax);
     const regionSuffix = groups[1];
     const param = groups[2];
     const decrypt = groups[3] === 'true';
     const split = groups[3] === 'split';
-
-    try {
-      const response = await this.serverless.getProvider('aws').request(
+    return this.serverless
+      .getProvider('aws')
+      .request(
         'SSM',
         'getParameter',
         {
@@ -817,52 +835,56 @@ class Variables {
           WithDecryption: decrypt,
         },
         this.buildOptions(regionSuffix)
-      ); // Use request cache
+      ) // Use request cache
+      .then(
+        (response) => {
+          const plainText = response.Parameter.Value;
+          const type = response.Parameter.Type;
+          // Only if Secrets Manager. Parameter Store does not support JSON.
+          // We cannot parse StringList types, so don't try
+          if (type !== 'StringList' && param.startsWith('/aws/reference/secretsmanager')) {
+            try {
+              return JSON.parse(plainText);
+            } catch {
+              // return as plain text if value is not JSON
+            }
+          }
+          if (split) {
+            if (type === 'StringList') return plainText.split(',');
 
-      const plainText = response.Parameter.Value;
-      const type = response.Parameter.Type;
-      // Only if Secrets Manager. Parameter Store does not support JSON.
-      // We cannot parse StringList types, so don't try
-      if (type !== 'StringList' && param.startsWith('/aws/reference/secretsmanager')) {
-        try {
-          return JSON.parse(plainText);
-        } catch {
-          // return as plain text if value is not JSON
+            logWarning(
+              `Cannot split SSM parameter '${param}' of type '${type}'. Must be 'StringList'.`
+            );
+          }
+          return plainText;
+        },
+        (err) => {
+          if (!err.providerError || err.providerError.statusCode !== 400) {
+            throw new ServerlessError(err.message);
+          }
         }
-      }
-      if (split) {
-        if (type === 'StringList') return plainText.split(',');
-
-        logWarning(
-          `Cannot split SSM parameter '${param}' of type '${type}'. Must be 'StringList'.`
-        );
-      }
-      return plainText;
-    } catch (err) {
-      if (!err.providerError || err.providerError.statusCode !== 400) {
-        throw new ServerlessError(err.message);
-      }
-      return undefined;
-    }
+      );
   }
 
-  async getValueStrToBool(variableString) {
-    if (typeof variableString === 'string') {
-      const groups = variableString.match(this.strToBoolRefSyntax);
-      const param = groups[1].trim();
-      if (/^(true|false|0|1)$/.test(param)) {
-        if (param === 'false' || param === '0') {
-          return false;
+  getValueStrToBool(variableString) {
+    return BbPromise.try(() => {
+      if (typeof variableString === 'string') {
+        const groups = variableString.match(this.strToBoolRefSyntax);
+        const param = groups[1].trim();
+        if (/^(true|false|0|1)$/.test(param)) {
+          if (param === 'false' || param === '0') {
+            return false;
+          }
+          // truthy or non-empty strings
+          return true;
         }
-        // truthy or non-empty strings
-        return true;
+        throw new ServerlessError(
+          'Unexpected strToBool input; expected either "true", "false", "0", or "1".'
+        );
       }
-      throw new ServerlessError(
-        'Unexpected strToBool input; expected either "true", "false", "0", or "1".'
-      );
-    }
-    // Cast non-string inputs
-    return Boolean(variableString);
+      // Cast non-string inputs
+      return Boolean(variableString);
+    });
   }
 
   getDeepIndex(variableString) {
@@ -873,20 +895,22 @@ class Variables {
     const index = this.getDeepIndex(variableString);
     return this.deep[index];
   }
-  async getValueFromDeep(variableString) {
+  getValueFromDeep(variableString) {
     const deepPrefixReplace = RegExp(/(?:^deep:)\d+\.?/g);
     const variable = this.getVariableFromDeep(variableString);
     const deepRef = variableString.replace(deepPrefixReplace, '');
-    const result = await this.populateValue(variable);
+    let ret = this.populateValue(variable);
     if (deepRef.length) {
       // if there is a deep reference remaining
-      if (typeof result === 'string' && result.match(this.variableSyntax)) {
-        const deepVariable = this.makeDeepVariable(result);
-        return this.appendDeepVariable(deepVariable, deepRef);
-      }
-      return this.getDeeperValue(deepRef.split('.'), result);
+      ret = ret.then((result) => {
+        if (typeof result === 'string' && result.match(this.variableSyntax)) {
+          const deepVariable = this.makeDeepVariable(result);
+          return BbPromise.resolve(this.appendDeepVariable(deepVariable, deepRef));
+        }
+        return this.getDeeperValue(deepRef.split('.'), result);
+      });
     }
-    return result;
+    return ret;
   }
 
   makeDeepVariable(variable) {
@@ -918,23 +942,28 @@ class Variables {
    * will later resolve to the deeper value
    */
   getDeeperValue(deepProperties, valueToPopulate) {
-    return deepProperties.reduce((reducedValueParam, subProperty) => {
-      let reducedValue = reducedValueParam;
-      if (typeof reducedValue === 'string' && reducedValue.match(this.deepRefSyntax)) {
-        // build mode
-        return this.appendDeepVariable(reducedValue, subProperty);
-      }
-      // get mode
-      if (reducedValue == null) {
-        reducedValue = {};
-      } else if (subProperty !== '' || '' in reducedValue) {
-        reducedValue = reducedValue[subProperty];
-      }
-      if (typeof reducedValue === 'string' && reducedValue.match(this.variableSyntax)) {
-        return this.makeDeepVariable(reducedValue);
-      }
-      return reducedValue;
-    }, valueToPopulate);
+    return BbPromise.reduce(
+      deepProperties,
+      (reducedValueParam, subProperty) => {
+        let reducedValue = reducedValueParam;
+        if (typeof reducedValue === 'string' && reducedValue.match(this.deepRefSyntax)) {
+          // build mode
+          reducedValue = this.appendDeepVariable(reducedValue, subProperty);
+        } else {
+          // get mode
+          if (reducedValue == null) {
+            reducedValue = {};
+          } else if (subProperty !== '' || '' in reducedValue) {
+            reducedValue = reducedValue[subProperty];
+          }
+          if (typeof reducedValue === 'string' && reducedValue.match(this.variableSyntax)) {
+            reducedValue = this.makeDeepVariable(reducedValue);
+          }
+        }
+        return BbPromise.resolve(reducedValue);
+      },
+      valueToPopulate
+    );
   }
 
   handleUnresolved(variableString, valueToPopulate) {
@@ -961,7 +990,9 @@ class Variables {
       varType = 'file';
     } else if (variableString.match(this.ssmRefSyntax)) {
       varType = 'SSM parameter';
-    } else {
+    }
+
+    if (!varType) {
       return;
     }
 

--- a/lib/plugins/aws/metrics.js
+++ b/lib/plugins/aws/metrics.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const chalk = require('chalk');
 const _ = require('lodash');
 const dayjs = require('dayjs');
@@ -87,7 +88,7 @@ class AwsMetrics {
         const getMetrics = (params) =>
           this.provider.request('CloudWatch', 'getMetricStatistics', params);
 
-        return Promise.all([
+        return BbPromise.all([
           getMetrics(invocationsParams),
           getMetrics(throttlesParams),
           getMetrics(errorsParams),

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
 const chalk = require('chalk');
@@ -58,6 +59,8 @@ const apiGatewayUsagePlan = {
   },
   additionalProperties: false,
 };
+
+PromiseQueue.configure(BbPromise.Promise);
 
 const MAX_RETRIES = (() => {
   const userValue = Number(process.env.SLS_AWS_REQUEST_MAX_RETRIES);
@@ -1377,38 +1380,38 @@ class AwsProvider {
     const paramsHash = objectHash.sha1(paramsWithRegion);
     const BASE_BACKOFF = 5000;
     const persistentRequest = (f) =>
-      new Promise((resolve, reject) => {
-        const doCall = async (numTry) => {
-          try {
-            resolve(await f());
-          } catch (e) {
-            const { providerError } = e;
-            if (
-              numTry < MAX_RETRIES &&
-              providerError &&
-              ((providerError.retryable &&
-                providerError.statusCode !== 403 &&
-                providerError.code !== 'CredentialsError') ||
-                providerError.statusCode === 429)
-            ) {
-              const nextTryNum = numTry + 1;
-              const jitter = Math.random() * 3000 - 1000;
-              // backoff is between 4 and 7 seconds
-              const backOff = BASE_BACKOFF + jitter;
+      new BbPromise((resolve, reject) => {
+        const doCall = (numTry) => {
+          f()
+            // We're resembling if/else logic, therefore single `then` instead of `then`/`catch` pair
+            .then(resolve, (e) => {
+              const { providerError } = e;
+              if (
+                numTry < MAX_RETRIES &&
+                providerError &&
+                ((providerError.retryable &&
+                  providerError.statusCode !== 403 &&
+                  providerError.code !== 'CredentialsError') ||
+                  providerError.statusCode === 429)
+              ) {
+                const nextTryNum = numTry + 1;
+                const jitter = Math.random() * 3000 - 1000;
+                // backoff is between 4 and 7 seconds
+                const backOff = BASE_BACKOFF + jitter;
 
-              this.serverless.cli.log(
-                [
-                  `Recoverable error occurred (${e.message}), sleeping for ~${Math.round(
-                    backOff / 1000
-                  )} seconds.`,
-                  `Try ${nextTryNum} of ${MAX_RETRIES}`,
-                ].join(' ')
-              );
-              setTimeout(doCall, backOff, nextTryNum);
-            } else {
-              reject(e);
-            }
-          }
+                this.serverless.cli.log(
+                  [
+                    `Recoverable error occurred (${e.message}), sleeping for ~${Math.round(
+                      backOff / 1000
+                    )} seconds.`,
+                    `Try ${nextTryNum} of ${MAX_RETRIES}`,
+                  ].join(' ')
+                );
+                setTimeout(doCall, backOff, nextTryNum);
+              } else {
+                reject(e);
+              }
+            });
         };
         return doCall(0);
       });
@@ -1427,12 +1430,12 @@ class AwsProvider {
     if (shouldCache) {
       const cachedRequest = _.get(this.requestCache, `${service}.${method}.${paramsHash}`);
       if (cachedRequest) {
-        return cachedRequest;
+        return BbPromise.resolve(cachedRequest);
       }
     }
 
-    const request = this.requestQueue.add(() => {
-      const result = persistentRequest(async () => {
+    const request = this.requestQueue.add(() =>
+      persistentRequest(() => {
         if (options && options.region) {
           credentials.region = options.region;
         }
@@ -1445,19 +1448,10 @@ class AwsProvider {
 
         const promise = req.promise
           ? req.promise()
-          : new Promise((resolve, reject) => {
-              req.send((err, ...args) => {
-                if (err) {
-                  reject(err);
-                  return;
-                }
-                resolve(...args);
-              });
+          : BbPromise.fromCallback((cb) => {
+              req.send(cb);
             });
-
-        try {
-          return await promise;
-        } catch (err) {
+        return promise.catch((err) => {
           let message = err.message != null ? err.message : String(err.code);
           if (message.startsWith('Missing credentials in config')) {
             // Credentials error
@@ -1479,22 +1473,27 @@ class AwsProvider {
               : bottomError.message;
             message = errorMessage;
             // We do not want to trigger the retry mechanism for credential errors
-            throw Object.assign(new ServerlessError(errorMessage), {
-              providerError: Object.assign({}, err, { retryable: false }),
-            });
+            return BbPromise.reject(
+              Object.assign(new ServerlessError(errorMessage), {
+                providerError: Object.assign({}, err, { retryable: false }),
+              })
+            );
           }
 
-          throw Object.assign(new ServerlessError(message), {
-            providerError: err,
-          });
+          return BbPromise.reject(
+            Object.assign(new ServerlessError(message), {
+              providerError: err,
+            })
+          );
+        });
+      }).then((data) => {
+        const result = BbPromise.resolve(data);
+        if (shouldCache) {
+          _.set(this.requestCache, `${service}.${method}.${paramsHash}`, result);
         }
-      });
-
-      if (shouldCache) {
-        _.set(this.requestCache, `${service}.${method}.${paramsHash}`, result);
-      }
-      return result;
-    });
+        return result;
+      })
+    );
 
     if (shouldCache) {
       _.set(this.requestCache, `${service}.${method}.${paramsHash}`, request);
@@ -1641,13 +1640,12 @@ class AwsProvider {
 
   async getServerlessDeploymentBucketName() {
     if (this.serverless.service.provider.deploymentBucket) {
-      return this.serverless.service.provider.deploymentBucket;
+      return BbPromise.resolve(this.serverless.service.provider.deploymentBucket);
     }
-    const result = await this.request('CloudFormation', 'describeStackResource', {
+    return this.request('CloudFormation', 'describeStackResource', {
       StackName: this.naming.getStackName(),
       LogicalResourceId: this.naming.getDeploymentBucketLogicalId(),
-    });
-    return result.StackResourceDetail.PhysicalResourceId;
+    }).then((result) => result.StackResourceDetail.PhysicalResourceId);
   }
 
   getDeploymentPrefix() {
@@ -1757,17 +1755,18 @@ class AwsProvider {
     return stageSourceValue.value || defaultStage;
   }
 
-  async getAccountInfo() {
-    const result = await this.request('STS', 'getCallerIdentity', {});
-    const arn = result.Arn;
-    const accountId = result.Account;
-    const partition = arn.split(':')[1]; // ex: arn:aws:iam:acctId:user/xyz
-    return {
-      accountId,
-      partition,
-      arn: result.Arn,
-      userId: result.UserId,
-    };
+  getAccountInfo() {
+    return this.request('STS', 'getCallerIdentity', {}).then((result) => {
+      const arn = result.Arn;
+      const accountId = result.Account;
+      const partition = arn.split(':')[1]; // ex: arn:aws:iam:acctId:user/xyz
+      return {
+        accountId,
+        partition,
+        arn: result.Arn,
+        userId: result.UserId,
+      };
+    });
   }
 
   /**
@@ -1842,7 +1841,7 @@ class AwsProvider {
     return { Ref: this.naming.getWebsocketsApiLogicalId() };
   }
 
-  async getStackResources(next, resourcesParam) {
+  getStackResources(next, resourcesParam) {
     let resources = resourcesParam;
     const params = {
       StackName: this.naming.getStackName(),
@@ -1850,12 +1849,13 @@ class AwsProvider {
     if (!resources) resources = [];
     if (next) params.NextToken = next;
 
-    const res = await this.request('CloudFormation', 'listStackResources', params);
-    const allResources = resources.concat(res.StackResourceSummaries);
-    if (!res.NextToken) {
-      return allResources;
-    }
-    return this.getStackResources(res.NextToken, allResources);
+    return this.request('CloudFormation', 'listStackResources', params).then((res) => {
+      const allResources = resources.concat(res.StackResourceSummaries);
+      if (!res.NextToken) {
+        return allResources;
+      }
+      return this.getStackResources(res.NextToken, allResources);
+    });
   }
 
   async dockerPushToEcr(remoteTag, options = {}) {

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -1,11 +1,11 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const validate = require('./lib/validate');
 const setBucketName = require('./lib/setBucketName');
 const updateStack = require('./lib/updateStack');
 const monitorStack = require('./lib/monitorStack');
 const findAndGroupDeployments = require('./utils/findAndGroupDeployments');
-const ServerlessError = require('../../serverless-error');
 
 class AwsRollback {
   constructor(serverless, options) {
@@ -16,7 +16,7 @@ class AwsRollback {
     Object.assign(this, validate, setBucketName, updateStack, monitorStack);
 
     this.hooks = {
-      'before:rollback:initialize': async () => this.validate(),
+      'before:rollback:initialize': async () => BbPromise.bind(this).then(this.validate),
       'rollback:rollback': async () => {
         if (!this.options.timestamp) {
           const command = this.serverless.pluginManager.spawn('deploy:list');
@@ -26,13 +26,13 @@ class AwsRollback {
               'Run `sls rollback -t YourTimeStampHere`',
             ].join('\n')
           );
-          await command;
-          return;
+          return command;
         }
 
-        await this.setBucketName();
-        await this.setStackToUpdate();
-        await this.updateStack();
+        return BbPromise.bind(this)
+          .then(this.setBucketName)
+          .then(this.setStackToUpdate)
+          .then(this.updateStack);
       },
     };
   }
@@ -44,42 +44,45 @@ class AwsRollback {
     const deploymentPrefix = this.provider.getDeploymentPrefix();
     const prefix = `${deploymentPrefix}/${serviceName}/${stage}`;
 
-    const response = await this.provider.request('S3', 'listObjectsV2', {
-      Bucket: this.bucketName,
-      Prefix: prefix,
-    });
+    return this.provider
+      .request('S3', 'listObjectsV2', {
+        Bucket: this.bucketName,
+        Prefix: prefix,
+      })
+      .then((response) => {
+        const deployments = findAndGroupDeployments(response, deploymentPrefix, serviceName, stage);
 
-    const deployments = findAndGroupDeployments(response, deploymentPrefix, serviceName, stage);
+        if (deployments.length === 0) {
+          const msg = "Couldn't find any existing deployments.";
+          const hint = 'Please verify that stage and region are correct.';
+          return BbPromise.reject(`${msg} ${hint}`);
+        }
 
-    if (deployments.length === 0) {
-      const msg = "Couldn't find any existing deployments.";
-      const hint = 'Please verify that stage and region are correct.';
-      throw new ServerlessError(`${msg} ${hint}`);
-    }
+        let date = new Date(this.options.timestamp);
 
-    let date = new Date(this.options.timestamp);
+        // The if below is added due issues#5664 - Check it for more details
+        if (date instanceof Date === false || isNaN(date.valueOf())) {
+          date = new Date(Number(this.options.timestamp));
+        }
 
-    // The if below is added due issues#5664 - Check it for more details
-    if (date instanceof Date === false || isNaN(date.valueOf())) {
-      date = new Date(Number(this.options.timestamp));
-    }
+        const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
+        const exists = deployments.some((deployment) =>
+          deployment.some(
+            (item) =>
+              item.directory === dateString &&
+              item.file === this.provider.naming.getCompiledTemplateS3Suffix()
+          )
+        );
 
-    const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
-    const exists = deployments.some((deployment) =>
-      deployment.some(
-        (item) =>
-          item.directory === dateString &&
-          item.file === this.provider.naming.getCompiledTemplateS3Suffix()
-      )
-    );
+        if (!exists) {
+          const msg = `Couldn't find a deployment for the timestamp: ${this.options.timestamp}.`;
+          const hint = 'Please verify that the timestamp, stage and region are correct.';
+          return BbPromise.reject(`${msg} ${hint}`);
+        }
 
-    if (!exists) {
-      const msg = `Couldn't find a deployment for the timestamp: ${this.options.timestamp}.`;
-      const hint = 'Please verify that the timestamp, stage and region are correct.';
-      throw new ServerlessError(`${msg} ${hint}`);
-    }
-
-    service.package.artifactDirectoryName = `${prefix}/${dateString}`;
+        service.package.artifactDirectoryName = `${prefix}/${dateString}`;
+        return BbPromise.resolve();
+      });
   }
 }
 

--- a/lib/plugins/aws/rollbackFunction.js
+++ b/lib/plugins/aws/rollbackFunction.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const validate = require('./lib/validate');
 const fetch = require('node-fetch');
 
@@ -42,12 +43,12 @@ class AwsRollbackFunction {
     };
 
     this.hooks = {
-      'rollback:function:rollback': async () => {
-        await this.validate();
-        const func = await this.getFunctionToBeRestored();
-        const funcCode = await this.fetchFunctionCode(func);
-        await this.restoreFunction(funcCode);
-      },
+      'rollback:function:rollback': async () =>
+        BbPromise.bind(this)
+          .then(this.validate)
+          .then(this.getFunctionToBeRestored)
+          .then(this.fetchFunctionCode)
+          .then(this.restoreFunction),
     };
   }
 
@@ -67,27 +68,27 @@ class AwsRollbackFunction {
       Qualifier: funcVersion,
     };
 
-    try {
-      return this.provider.request('Lambda', 'getFunction', params);
-    } catch (error) {
-      if (error.message.match(/not found/)) {
-        const errorMessage = [
-          `Function "${funcName}" with version "${funcVersion}" not found.`,
-          ` Please check if you've deployed "${funcName}"`,
-          ` and version "${funcVersion}" is available for this function.`,
-          ' Please check the docs for more info.',
-        ].join('');
-        throw new Error(errorMessage);
-      }
-      throw new Error(error.message);
-    }
+    return this.provider
+      .request('Lambda', 'getFunction', params)
+      .then((func) => func)
+      .catch((error) => {
+        if (error.message.match(/not found/)) {
+          const errorMessage = [
+            `Function "${funcName}" with version "${funcVersion}" not found.`,
+            ` Please check if you've deployed "${funcName}"`,
+            ` and version "${funcVersion}" is available for this function.`,
+            ' Please check the docs for more info.',
+          ].join('');
+          throw new Error(errorMessage);
+        }
+        throw new Error(error.message);
+      });
   }
 
   async fetchFunctionCode(func) {
     const codeUrl = func.Code.Location;
 
-    const response = await fetch(codeUrl);
-    return response.buffer();
+    return fetch(codeUrl).then((response) => response.buffer());
   }
 
   async restoreFunction(zipBuffer) {
@@ -102,8 +103,9 @@ class AwsRollbackFunction {
       ZipFile: zipBuffer,
     };
 
-    await this.provider.request('Lambda', 'updateFunctionCode', params);
-    this.serverless.cli.log(`Successfully rolled back function "${this.options.function}"`);
+    return this.provider.request('Lambda', 'updateFunctionCode', params).then(() => {
+      this.serverless.cli.log(`Successfully rolled back function "${this.options.function}"`);
+    });
   }
 }
 

--- a/lib/plugins/aws/utils/credentials.js
+++ b/lib/plugins/aws/utils/credentials.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const { join } = require('path');
-const fs = require('fs');
+const { constants, readFile, writeFile, mkdir } = require('fs');
 const os = require('os');
-
-const { readFile, writeFile, mkdir } = fs.promises;
+const BbPromise = require('bluebird');
 
 const homedir = os.homedir();
 const awsConfigDirPath = join(homedir, '.aws');
@@ -44,37 +43,52 @@ const parseFileProfiles = (content) => {
   return profiles;
 };
 
-const writeCredentialsContent = async (content) => {
-  try {
-    await writeFile(
+const writeCredentialsContent = (content) =>
+  new BbPromise((resolve, reject) =>
+    writeFile(
       credentialsFilePath,
       content,
-      !isWindows ? { mode: fs.constants.S_IRUSR | fs.constants.S_IWUSR } : null
-    );
-  } catch (writeFileError) {
-    if (writeFileError.code === 'ENOENT') {
-      await mkdir(awsConfigDirPath, !isWindows ? { mode: fs.constants.S_IRWXU } : null);
-      await writeCredentialsContent(content);
-    } else {
-      throw writeFileError;
-    }
-  }
-};
+      !isWindows ? { mode: constants.S_IRUSR | constants.S_IWUSR } : null,
+      (writeFileError) => {
+        if (writeFileError) {
+          if (writeFileError.code === 'ENOENT') {
+            mkdir(
+              awsConfigDirPath,
+              !isWindows ? { mode: constants.S_IRWXU } : null,
+              (mkdirError) => {
+                if (mkdirError) reject(mkdirError);
+                else resolve(writeCredentialsContent(content));
+              }
+            );
+          } else {
+            reject(writeFileError);
+          }
+        } else {
+          resolve();
+        }
+      }
+    )
+  );
 
 module.exports = {
-  async resolveFileProfiles() {
-    if (!credentialsFilePath) {
-      return new Map();
-    }
-    try {
-      const content = await readFile(credentialsFilePath, { encoding: 'utf8' });
-      return parseFileProfiles(content);
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        return new Map();
+  resolveFileProfiles() {
+    return new BbPromise((resolve, reject) => {
+      if (!credentialsFilePath) {
+        resolve(new Map());
+        return;
       }
-      throw err;
-    }
+      readFile(credentialsFilePath, { encoding: 'utf8' }, (error, content) => {
+        if (error) {
+          if (error.code === 'ENOENT') {
+            resolve(new Map());
+            return;
+          }
+          reject(error);
+          return;
+        }
+        resolve(parseFileProfiles(content));
+      });
+    });
   },
 
   resolveEnvCredentials() {
@@ -85,23 +99,26 @@ module.exports = {
     };
   },
 
-  async saveFileProfiles(profiles) {
-    if (!credentialsFilePath) throw new Error('Could not resolve path to user credentials file');
-
-    await writeCredentialsContent(
-      `${Array.from(profiles)
-        .map(([name, data]) => {
-          const lineTokens = [`[${name}]`];
-          if (data.sessionToken) lineTokens.push(`aws_session_token=${data.sessionToken}`);
-          else {
-            lineTokens.push(
-              `aws_access_key_id=${data.accessKeyId}`,
-              `aws_secret_access_key=${data.secretAccessKey}`
-            );
-          }
-          return `${lineTokens.join('\n')}\n`;
-        })
-        .join('\n')}`
-    );
+  saveFileProfiles(profiles) {
+    return new BbPromise((resolve) => {
+      if (!credentialsFilePath) throw new Error('Could not resolve path to user credentials file');
+      resolve(
+        writeCredentialsContent(
+          `${Array.from(profiles)
+            .map(([name, data]) => {
+              const lineTokens = [`[${name}]`];
+              if (data.sessionToken) lineTokens.push(`aws_session_token=${data.sessionToken}`);
+              else {
+                lineTokens.push(
+                  `aws_access_key_id=${data.accessKeyId}`,
+                  `aws_secret_access_key=${data.secretAccessKey}`
+                );
+              }
+              return `${lineTokens.join('\n')}\n`;
+            })
+            .join('\n')}`
+        )
+      );
+    });
   },
 };

--- a/lib/plugins/config.js
+++ b/lib/plugins/config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const config = require('@serverless/utils/config');
 const ServerlessError = require('../serverless-error');
 const isTabTabCompletionSupported = require('../utils/tabCompletion/isSupported');
@@ -147,51 +148,57 @@ class Config {
   }
 
   async tabtabCompletionInstall() {
-    const shell = this.serverless.processedInput.options.shell || 'bash';
+    return BbPromise.try(() => {
+      const shell = this.serverless.processedInput.options.shell || 'bash';
 
-    if (!validShells.has(shell)) {
-      throw new ServerlessError(
-        `Shell "${shell}" is not supported. Supported shells: ${Array.from(validShells)}.`
+      if (!validShells.has(shell)) {
+        throw new ServerlessError(
+          `Shell "${shell}" is not supported. Supported shells: ${Array.from(validShells)}.`
+        );
+      }
+      const location = (() => {
+        if (this.serverless.processedInput.options.location) {
+          return this.serverless.processedInput.options.location;
+        }
+        const { BASH_LOCATION, FISH_LOCATION, ZSH_LOCATION } = require('tabtab/lib/constants');
+        switch (shell) {
+          case 'bash':
+            return BASH_LOCATION;
+          case 'zsh':
+            return ZSH_LOCATION;
+          case 'fish':
+            return FISH_LOCATION;
+          default:
+            throw new Error('Unexpected shell choice');
+        }
+      })();
+      const { install } = require('tabtab/lib/installer');
+      return muteConsoleLog(() =>
+        tabtabOptions.reduce(
+          (previousOperation, options) =>
+            previousOperation.then(() => install(Object.assign({ location }, options))),
+          BbPromise.resolve()
+        )
+      ).then(() =>
+        this.serverless.cli.log(
+          `Tab autocompletion setup for ${shell}. Make sure to reload your SHELL.`
+        )
       );
-    }
-    const location = (() => {
-      if (this.serverless.processedInput.options.location) {
-        return this.serverless.processedInput.options.location;
-      }
-      const { BASH_LOCATION, FISH_LOCATION, ZSH_LOCATION } = require('tabtab/lib/constants');
-      switch (shell) {
-        case 'bash':
-          return BASH_LOCATION;
-        case 'zsh':
-          return ZSH_LOCATION;
-        case 'fish':
-          return FISH_LOCATION;
-        default:
-          throw new Error('Unexpected shell choice');
-      }
-    })();
-
-    const { install } = require('tabtab/lib/installer');
-    await muteConsoleLog(async () => {
-      for (const options of tabtabOptions) {
-        await install(Object.assign({ location }, options));
-      }
     });
-
-    this.serverless.cli.log(
-      `Tab autocompletion setup for ${shell}. Make sure to reload your SHELL.`
-    );
   }
 
   async tabtabCompletionUninstall() {
-    const { uninstall } = require('tabtab/lib/installer');
-    await muteConsoleLog(async () => {
-      for (const options of tabtabOptions) {
-        await uninstall(options);
-      }
+    return BbPromise.try(() => {
+      const { uninstall } = require('tabtab/lib/installer');
+      return muteConsoleLog(() =>
+        tabtabOptions.reduce(
+          (previousOperation, options) => previousOperation.then(() => uninstall(options)),
+          BbPromise.resolve()
+        )
+      ).then(() =>
+        this.serverless.cli.log('Tab autocompletion uninstalled (for all configured shells).')
+      );
     });
-
-    this.serverless.cli.log('Tab autocompletion uninstalled (for all configured shells).');
   }
 }
 

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const path = require('path');
 const fse = require('fs-extra');
 const untildify = require('untildify');
@@ -139,43 +140,38 @@ class Create {
     };
 
     this.hooks = {
-      'create:create': async () => this.create(),
+      'create:create': () => BbPromise.bind(this).then(this.create),
     };
   }
 
-  async create() {
+  create() {
     this.serverless.cli.log('Generating boilerplate...');
 
     if ('template' in this.options) {
-      await this.createFromTemplate();
-      return;
-    }
-
-    if ('template-url' in this.options) {
-      try {
-        const serviceName = await download.downloadTemplateFromRepo(
+      return this.createFromTemplate();
+    } else if ('template-url' in this.options) {
+      return download
+        .downloadTemplateFromRepo(
           this.options['template-url'],
           this.options.name,
           this.options.path
-        );
+        )
+        .then((serviceName) => {
+          const message = [
+            `Successfully installed "${serviceName}" `,
+            `${
+              this.options.name && this.options.name !== serviceName
+                ? `as "${this.options.name}"`
+                : ''
+            }`,
+          ].join('');
 
-        const message = [
-          `Successfully installed "${serviceName}" `,
-          `${
-            this.options.name && this.options.name !== serviceName
-              ? `as "${this.options.name}"`
-              : ''
-          }`,
-        ].join('');
-
-        this.serverless.cli.log(message);
-        return;
-      } catch (err) {
-        throw new ServerlessError(err);
-      }
-    }
-
-    if ('template-path' in this.options) {
+          this.serverless.cli.log(message);
+        })
+        .catch((err) => {
+          throw new ServerlessError(err);
+        });
+    } else if ('template-path' in this.options) {
       // Copying template from a local directory
       const servicePath = this.options.path
         ? path.resolve(process.cwd(), untildify(this.options.path))
@@ -190,17 +186,17 @@ class Create {
       if (this.options.name) {
         renameService(this.options.name, servicePath);
       }
-      return;
+    } else {
+      const errorMessage = [
+        'You must either pass a template name (--template), ',
+        'a URL (--template-url) or a local path (--template-path).',
+      ].join('');
+      throw new ServerlessError(errorMessage);
     }
-
-    const errorMessage = [
-      'You must either pass a template name (--template), ',
-      'a URL (--template-url) or a local path (--template-path).',
-    ].join('');
-    throw new ServerlessError(errorMessage);
+    return BbPromise.resolve();
   }
 
-  async createFromTemplate() {
+  createFromTemplate() {
     const notPlugin = this.options.template !== 'plugin';
 
     if (validTemplates.indexOf(this.options.template) === -1) {
@@ -226,7 +222,7 @@ class Create {
     if (boilerplatePath) {
       const newPath = path.resolve(process.cwd(), untildify(boilerplatePath));
 
-      if (dirExistsSync(newPath)) {
+      if (this.serverless.utils.dirExistsSync(newPath)) {
         const errorMessage = [
           `The directory "${newPath}" already exists, and serverless will not overwrite it. `,
           'Rename or move the directory and try again if you want serverless to create it"',
@@ -257,35 +253,35 @@ class Create {
     }
 
     if (!notPlugin) {
-      try {
-        await fse.copy(
-          path.join(__dirname, '../../../lib/plugins/create/templates', this.options.template),
-          process.cwd()
-        );
-        return;
-      } catch (error) {
-        handleServiceCreationError(error);
-      }
+      return BbPromise.try(() => {
+        try {
+          fse.copySync(
+            path.join(__dirname, '../../../lib/plugins/create/templates', this.options.template),
+            process.cwd()
+          );
+        } catch (error) {
+          handleServiceCreationError(error);
+        }
+      });
     }
 
     this.serverless.config.update({ servicePath: process.cwd() });
 
-    try {
-      await createFromTemplate(this.options.template, process.cwd(), { name: serviceName });
-    } catch (err) {
-      handleServiceCreationError(err);
-    }
+    return createFromTemplate(this.options.template, process.cwd(), { name: serviceName }).then(
+      () => {
+        this.serverless.cli.asciiGreeting();
+        this.serverless.cli.log(
+          `Successfully generated boilerplate for template: "${this.options.template}"`
+        );
 
-    this.serverless.cli.asciiGreeting();
-    this.serverless.cli.log(
-      `Successfully generated boilerplate for template: "${this.options.template}"`
+        if (!(boilerplatePath || serviceName) && notPlugin) {
+          this.serverless.cli.log(
+            'NOTE: Please update the "service" property in serverless.yml with your service name'
+          );
+        }
+      },
+      handleServiceCreationError
     );
-
-    if (!(boilerplatePath || serviceName) && notPlugin) {
-      this.serverless.cli.log(
-        'NOTE: Please update the "service" property in serverless.yml with your service name'
-      );
-    }
   }
 }
 

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -125,9 +125,8 @@ class Deploy {
         }
       },
       'after:deploy:finalize': async () => {
-        if (!this.deferredBackendNotificationRequest) return;
-        const notifications = await this.deferredBackendNotificationRequest;
-        processBackendNotificationRequest(notifications);
+        if (!this.deferredBackendNotificationRequest) return null;
+        return this.deferredBackendNotificationRequest.then(processBackendNotificationRequest);
       },
     };
   }

--- a/lib/plugins/install.js
+++ b/lib/plugins/install.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const BbPromise = require('bluebird');
+
 const download = require('../utils/downloadTemplateFromRepo');
 
 class Install {
@@ -26,23 +28,25 @@ class Install {
     };
 
     this.hooks = {
-      'install:install': async () => this.install(),
+      'install:install': async () => BbPromise.bind(this).then(this.install),
     };
   }
 
   async install() {
-    const serviceName = await download.downloadTemplateFromRepo(
-      this.options.url,
-      this.options.name
-    );
-    const message = [
-      `Successfully installed "${serviceName}" `,
-      `${
-        this.options.name && this.options.name !== serviceName ? `as "${this.options.name}"` : ''
-      }`,
-    ].join('');
+    return download
+      .downloadTemplateFromRepo(this.options.url, this.options.name)
+      .then((serviceName) => {
+        const message = [
+          `Successfully installed "${serviceName}" `,
+          `${
+            this.options.name && this.options.name !== serviceName
+              ? `as "${this.options.name}"`
+              : ''
+          }`,
+        ].join('');
 
-    this.serverless.cli.log(message);
+        this.serverless.cli.log(message);
+      });
   }
 }
 

--- a/lib/plugins/interactiveCli/setupAws.js
+++ b/lib/plugins/interactiveCli/setupAws.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const chalk = require('chalk');
 const inquirer = require('@serverless/utils/inquirer');
 const awsCredentials = require('../aws/utils/credentials');
@@ -9,66 +10,61 @@ const openBrowser = require('../../utils/openBrowser');
 const isValidAwsAccessKeyId = RegExp.prototype.test.bind(/^[A-Z0-9]{10,}$/);
 const isValidAwsSecretAccessKey = RegExp.prototype.test.bind(/^[a-zA-Z0-9/+]{10,}$/);
 
-async function awsAccessKeyIdInput() {
-  const { accessKeyId } = await inquirer.prompt({
-    message: 'AWS Access Key Id:',
-    type: 'input',
-    name: 'accessKeyId',
-    validate(input) {
-      if (isValidAwsAccessKeyId(input.trim())) return true;
-      return 'AWS Access Key Id seems not valid.\n   Expected something like AKIAIOSFODNN7EXAMPLE';
-    },
-  });
+const awsAccessKeyIdInput = () =>
+  inquirer
+    .prompt({
+      message: 'AWS Access Key Id:',
+      type: 'input',
+      name: 'accessKeyId',
+      validate: (input) => {
+        if (isValidAwsAccessKeyId(input.trim())) return true;
+        return 'AWS Access Key Id seems not valid.\n   Expected something like AKIAIOSFODNN7EXAMPLE';
+      },
+    })
+    .then(({ accessKeyId }) => accessKeyId.trim());
 
-  return accessKeyId.trim();
-}
-
-async function awsSecretAccessKeyInput() {
-  const { secretAccessKey } = await inquirer.prompt({
-    message: 'AWS Secret Access Key:',
-    type: 'input',
-    name: 'secretAccessKey',
-    validate(input) {
-      if (isValidAwsSecretAccessKey(input.trim())) return true;
-      return (
-        'AWS Secret Access Key seems not valid.\n' +
-        '   Expected something like wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-      );
-    },
-  });
-
-  return secretAccessKey.trim();
-}
+const awsSecretAccessKeyInput = () =>
+  inquirer
+    .prompt({
+      message: 'AWS Secret Access Key:',
+      type: 'input',
+      name: 'secretAccessKey',
+      validate: (input) => {
+        if (isValidAwsSecretAccessKey(input.trim())) return true;
+        return (
+          'AWS Secret Access Key seems not valid.\n' +
+          '   Expected something like wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+        );
+      },
+    })
+    .then(({ secretAccessKey }) => secretAccessKey.trim());
 
 const steps = {
-  writeOnSetupSkip() {
+  writeOnSetupSkip: () =>
     process.stdout.write(`\nYou can setup your AWS account later. More details available here:
 
-  http://slss.io/aws-creds-setup\n`);
-  },
-  async shouldSetupAwsCredentials() {
-    const isConfirmed = await confirm('Do you want to set them up now?', {
-      name: 'shouldSetupAwsCredentials',
-    });
-
-    if (!isConfirmed) steps.writeOnSetupSkip();
-    return isConfirmed;
-  },
-  async ensureAwsAccount() {
-    const hasAccount = await confirm('Do you have an AWS account?', { name: 'hasAwsAccount' });
-
-    if (!hasAccount) {
-      await openBrowser('https://portal.aws.amazon.com/billing/signup');
-      return inquirer.prompt({
-        message: 'Press Enter to continue after creating an AWS account',
-        name: 'createAwsAccountPrompt',
-      });
-    }
-    return null;
-  },
-  async ensureAwsCredentials(serverless) {
+  http://slss.io/aws-creds-setup\n`),
+  shouldSetupAwsCredentials: () =>
+    confirm('Do you want to set them up now?', { name: 'shouldSetupAwsCredentials' }).then(
+      (isConfirmed) => {
+        if (!isConfirmed) steps.writeOnSetupSkip();
+        return isConfirmed;
+      }
+    ),
+  ensureAwsAccount: () =>
+    confirm('Do you have an AWS account?', { name: 'hasAwsAccount' }).then((hasAccount) => {
+      if (!hasAccount) {
+        openBrowser('https://portal.aws.amazon.com/billing/signup');
+        return inquirer.prompt({
+          message: 'Press Enter to continue after creating an AWS account',
+          name: 'createAwsAccountPrompt',
+        });
+      }
+      return null;
+    }),
+  ensureAwsCredentials: (serverless) => {
     const region = serverless.getProvider('aws').getRegion();
-    await openBrowser(
+    openBrowser(
       `https://console.aws.amazon.com/iam/home?region=${region}#/users$new?step=final&accessKey&userNames=serverless&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess`
     );
     return inquirer.prompt({
@@ -76,46 +72,52 @@ const steps = {
       name: 'generateAwsCredsPrompt',
     });
   },
-  async inputAwsCredentials() {
-    const accessKeyId = await awsAccessKeyIdInput();
-    const secretAccessKey = await awsSecretAccessKeyInput();
-
-    await awsCredentials.saveFileProfiles(new Map([['default', { accessKeyId, secretAccessKey }]]));
-
-    process.stdout.write(
-      `\n${chalk.green(
-        `AWS credentials saved on your machine at ${chalk.bold(
-          process.platform === 'win32' ? '%userprofile%\\.aws\\credentials' : '~/.aws/credentials'
-        )}. Go there to change them at any time.`
-      )}\n`
+  inputAwsCredentials: () => {
+    return awsAccessKeyIdInput().then((accessKeyId) =>
+      awsSecretAccessKeyInput().then((secretAccessKey) =>
+        awsCredentials
+          .saveFileProfiles(new Map([['default', { accessKeyId, secretAccessKey }]]))
+          .then(() =>
+            process.stdout.write(
+              `\n${chalk.green(
+                `AWS credentials saved on your machine at ${chalk.bold(
+                  process.platform === 'win32'
+                    ? '%userprofile%\\.aws\\credentials'
+                    : '~/.aws/credentials'
+                )}. Go there to change them at any time.`
+              )}\n`
+            )
+          )
+      )
     );
   },
 };
 
 module.exports = {
-  async check(serverless) {
-    if (serverless.service.provider.name !== 'aws') return false;
-    if (serverless.getProvider('aws').cachedCredentials) return false;
-    const [fileProfiles, envCredentials] = await Promise.all([
-      awsCredentials.resolveFileProfiles(),
-      awsCredentials.resolveEnvCredentials(),
-    ]);
-    return !fileProfiles.size && !envCredentials;
+  check(serverless) {
+    return BbPromise.try(() => {
+      if (serverless.service.provider.name !== 'aws') return false;
+      if (serverless.getProvider('aws').cachedCredentials) return false;
+      return BbPromise.all([
+        awsCredentials.resolveFileProfiles(),
+        awsCredentials.resolveEnvCredentials(),
+      ]).then(([fileProfiles, envCredentials]) => !fileProfiles.size && !envCredentials);
+    });
   },
-  async run(serverless) {
+  run(serverless) {
     process.stdout.write(
       'No AWS credentials were found on your computer, ' +
         'you need these to host your application.\n\n'
     );
-    await module.exports.runSteps(serverless);
+    return module.exports.runSteps(serverless);
   },
   steps,
-  async runSteps(serverless) {
-    const isConfirmed = await steps.shouldSetupAwsCredentials();
-
-    if (!isConfirmed) return;
-    await steps.ensureAwsAccount();
-    await steps.ensureAwsCredentials(serverless);
-    await steps.inputAwsCredentials();
-  },
+  runSteps: (serverless) =>
+    steps.shouldSetupAwsCredentials().then((isConfirmed) => {
+      if (!isConfirmed) return null;
+      return steps
+        .ensureAwsAccount()
+        .then(() => steps.ensureAwsCredentials(serverless))
+        .then(steps.inputAwsCredentials);
+    }),
 };

--- a/lib/plugins/interactiveCli/tabCompletion.js
+++ b/lib/plugins/interactiveCli/tabCompletion.js
@@ -2,8 +2,9 @@
 
 const path = require('path');
 const os = require('os');
-const fs = require('fs').promises;
+const fs = require('fs');
 const chalk = require('chalk');
+const BbPromise = require('bluebird');
 const requireUncached = require('ncjsm/require-uncached');
 const resolve = require('ncjsm/resolve/sync');
 const configUtils = require('@serverless/utils/config');
@@ -14,52 +15,64 @@ const promptDisabledConfigPropertyName = require('../../utils/tabCompletion/prom
 const inquirer = require('@serverless/utils/inquirer');
 const { confirm } = require('./utils');
 
+BbPromise.promisifyAll(fs);
+
 module.exports = {
-  async check() {
-    if (!isTabTabCompletionSupported) return false;
+  check() {
+    return BbPromise.try(() => {
+      if (!isTabTabCompletionSupported) return false;
 
-    const shellExtension = require('tabtab/lib/utils/systemShell')();
-    try {
-      await fs.stat(path.resolve(os.homedir(), `.config/tabtab/serverless.${shellExtension}`));
-      return false;
-    } catch (error) {
-      if (error.code !== 'ENOENT') throw error;
-      return !configUtils.get(promptDisabledConfigPropertyName);
-    }
+      const shellExtension = require('tabtab/lib/utils/systemShell')();
+      return fs
+        .statAsync(path.resolve(os.homedir(), `.config/tabtab/serverless.${shellExtension}`))
+        .then(
+          () => false,
+          (error) => {
+            if (error.code !== 'ENOENT') throw error;
+            return !configUtils.get(promptDisabledConfigPropertyName);
+          }
+        );
+    });
   },
-  async run() {
-    const isConfirmed = await confirm('Would you like to setup a command line <tab> completion?', {
-      name: 'shouldSetupTabCompletion',
+  run() {
+    return BbPromise.try(() => {
+      return confirm('Would you like to setup a command line <tab> completion?', {
+        name: 'shouldSetupTabCompletion',
+      }).then((isConfirmed) => {
+        if (!isConfirmed) {
+          configUtils.set(promptDisabledConfigPropertyName, true);
+          return null;
+        }
+
+        const promptPath = require.resolve('tabtab/lib/prompt');
+        const tabtabsInquirerPath = resolve(path.dirname(promptPath), 'inquirer').realPath;
+
+        // Hack tabtabs prompt to use our inquirer customization
+        const prompt = requireUncached([promptPath, tabtabsInquirerPath], () => {
+          require(tabtabsInquirerPath);
+          require.cache[tabtabsInquirerPath].exports = inquirer;
+          return require(promptPath);
+        });
+        const { install } = require('tabtab/lib/installer');
+        return prompt().then(({ location }) =>
+          muteConsoleLog(() =>
+            tabtabOptions.reduce(
+              (previousOperation, options) =>
+                previousOperation.then(() => install(Object.assign({ location }, options))),
+              BbPromise.resolve()
+            )
+          ).then(() =>
+            process.stdout.write(
+              `\n${chalk.green(
+                `Command line <tab> completion was successfully setup. ${chalk.bold(
+                  'Make sure to reload your SHELL'
+                )}.\n` +
+                  'You may uninstall it by running: serverless config tabcompletion uninstall'
+              )}\n`
+            )
+          )
+        );
+      });
     });
-
-    if (!isConfirmed) {
-      configUtils.set(promptDisabledConfigPropertyName, true);
-      return;
-    }
-
-    const promptPath = require.resolve('tabtab/lib/prompt');
-    const tabtabsInquirerPath = resolve(path.dirname(promptPath), 'inquirer').realPath;
-
-    // Hack tabtabs prompt to use our inquirer customization
-    const prompt = requireUncached([promptPath, tabtabsInquirerPath], () => {
-      require(tabtabsInquirerPath);
-      require.cache[tabtabsInquirerPath].exports = inquirer;
-      return require(promptPath);
-    });
-    const { install } = require('tabtab/lib/installer');
-    const { location } = await prompt();
-    await muteConsoleLog(async () => {
-      for (const options of tabtabOptions) {
-        await install({ location, ...options });
-      }
-    });
-
-    process.stdout.write(
-      `\n${chalk.green(
-        `Command line <tab> completion was successfully setup. ${chalk.bold(
-          'Make sure to reload your SHELL'
-        )}.\nYou may uninstall it by running: serverless config tabcompletion uninstall`
-      )}\n`
-    );
   },
 };

--- a/lib/plugins/invoke.js
+++ b/lib/plugins/invoke.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const _ = require('lodash');
 
 class Invoke {
@@ -100,9 +101,9 @@ class Invoke {
     };
 
     this.hooks = {
-      'invoke:local:loadEnvVars': this.loadEnvVarsForLocal.bind(this),
-      'after:invoke:invoke': this.trackInvoke.bind(this),
-      'after:invoke:local:invoke': this.trackInvokeLocal.bind(this),
+      'invoke:local:loadEnvVars': async () => BbPromise.bind(this).then(this.loadEnvVarsForLocal),
+      'after:invoke:invoke': async () => BbPromise.bind(this).then(this.trackInvoke),
+      'after:invoke:local:invoke': async () => BbPromise.bind(this).then(this.trackInvokeLocal),
     };
   }
 

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -92,18 +92,20 @@ module.exports = {
     if (shouldPackageService && !this.serverless.service.package.artifact) await this.packageAll();
   },
 
-  async packageAll() {
+  packageAll() {
     const zipFileName = `${this.serverless.service.service}.zip`;
 
-    const filePaths = await this.resolveFilePathsAll();
-    const filePath = await this.zipFiles(filePaths, zipFileName);
-    // only set the default artifact for backward-compatibility
-    // when no explicit artifact is defined
-    if (!this.serverless.service.package.artifact) {
-      this.serverless.service.package.artifact = filePath;
-      this.serverless.service.artifact = filePath;
-    }
-    return filePath;
+    return this.resolveFilePathsAll().then((filePaths) =>
+      this.zipFiles(filePaths, zipFileName).then((filePath) => {
+        // only set the default artifact for backward-compatibility
+        // when no explicit artifact is defined
+        if (!this.serverless.service.package.artifact) {
+          this.serverless.service.package.artifact = filePath;
+          this.serverless.service.artifact = filePath;
+        }
+        return filePath;
+      })
+    );
   },
 
   async packageFunction(functionName) {
@@ -139,23 +141,23 @@ module.exports = {
     return artifactPath;
   },
 
-  async packageLayer(layerName) {
+  packageLayer(layerName) {
     const layerObject = this.serverless.service.getLayer(layerName);
 
     const zipFileName = `${layerName}.zip`;
 
-    const filePaths = await this.resolveFilePathsLayer(layerName);
-    const resolvedFilePaths = filePaths.map((f) => path.resolve(path.join(layerObject.path, f)));
-
-    const artifactPath = await this.zipFiles(
-      resolvedFilePaths,
-      zipFileName,
-      path.resolve(layerObject.path)
-    );
-    layerObject.package = {
-      artifact: artifactPath,
-    };
-    return artifactPath;
+    return this.resolveFilePathsLayer(layerName)
+      .then((filePaths) => filePaths.map((f) => path.resolve(path.join(layerObject.path, f))))
+      .then((filePaths) =>
+        this.zipFiles(filePaths, zipFileName, path.resolve(layerObject.path)).then(
+          (artifactPath) => {
+            layerObject.package = {
+              artifact: artifactPath,
+            };
+            return artifactPath;
+          }
+        )
+      );
   },
 
   async resolveFilePathsAll() {
@@ -192,7 +194,7 @@ module.exports = {
     );
   },
 
-  async resolveFilePathsFromPatterns(params, prefix) {
+  resolveFilePathsFromPatterns(params, prefix) {
     const patterns = [];
 
     params.exclude.forEach((pattern) => {
@@ -212,31 +214,32 @@ module.exports = {
     // NOTE: please keep this order of concatenating the include params
     // rather than doing it the other way round!
     // see https://github.com/serverless/serverless/pull/5825 for more information
-    const allFilePaths = await globby(['**'].concat(params.include), {
+    return globby(['**'].concat(params.include), {
       cwd: path.join(this.serverless.config.servicePath, prefix || ''),
       dot: true,
       silent: true,
       follow: true,
       nodir: true,
       expandDirectories: false,
-    });
-    const filePathStates = allFilePaths.reduce((p, c) => Object.assign(p, { [c]: true }), {});
-    patterns
-      // micromatch only does / style path delimiters, so convert them if on windows
-      .map((p) => {
-        return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
-      })
-      .forEach((p) => {
-        const exclude = p.startsWith('!');
-        const pattern = exclude ? p.slice(1) : p;
-        micromatch(allFilePaths, [pattern], { dot: true }).forEach((key) => {
-          filePathStates[key] = !exclude;
+    }).then((allFilePaths) => {
+      const filePathStates = allFilePaths.reduce((p, c) => Object.assign(p, { [c]: true }), {});
+      patterns
+        // micromatch only does / style path delimiters, so convert them if on windows
+        .map((p) => {
+          return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
+        })
+        .forEach((p) => {
+          const exclude = p.startsWith('!');
+          const pattern = exclude ? p.slice(1) : p;
+          micromatch(allFilePaths, [pattern], { dot: true }).forEach((key) => {
+            filePathStates[key] = !exclude;
+          });
         });
-      });
-    const filePaths = Object.entries(filePathStates)
-      .filter((r) => r[1] === true)
-      .map((r) => r[0]);
-    if (filePaths.length !== 0) return filePaths;
-    throw new ServerlessError('No file matches include / exclude patterns');
+      const filePaths = Object.entries(filePathStates)
+        .filter((r) => r[1] === true)
+        .map((r) => r[0]);
+      if (filePaths.length !== 0) return filePaths;
+      throw new ServerlessError('No file matches include / exclude patterns');
+    });
   },
 };

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -1,18 +1,16 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const archiver = require('archiver');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
-const fs = require('fs');
-const { promisify } = require('util');
-const { exec } = require('child_process');
+const fs = BbPromise.promisifyAll(require('fs'));
+const childProcess = BbPromise.promisifyAll(require('child_process'));
 const globby = require('globby');
 const _ = require('lodash');
 const ServerlessError = require('../../../serverless-error');
 
-const fsAsync = fs.promises;
-const execAsync = promisify(exec);
 const excludeNodeDevDependenciesMemoized = _.memoize(excludeNodeDevDependencies);
 
 module.exports = {
@@ -39,14 +37,16 @@ module.exports = {
       const exAndInNode = await excludeNodeDevDependenciesMemoized(servicePath);
       params.exclude = _.union(params.exclude, exAndInNode.exclude); //eslint-disable-line
       params.include = _.union(params.include, exAndInNode.include); //eslint-disable-line
+      return params;
     }
 
     return params;
   },
 
-  async zip(params) {
-    const filePaths = await this.resolveFilePathsFromPatterns(params);
-    return this.zipFiles(filePaths, params.zipFileName);
+  zip(params) {
+    return this.resolveFilePathsFromPatterns(params).then((filePaths) =>
+      this.zipFiles(filePaths, params.zipFileName)
+    );
   },
 
   /**
@@ -55,9 +55,10 @@ module.exports = {
    * @param zipFiles - the filename to save the zip at
    * @param prefix - a prefix to strip from the file names. use for layers support
    */
-  async zipFiles(files, zipFileName, prefix) {
+  zipFiles(files, zipFileName, prefix) {
     if (files.length === 0) {
-      throw new ServerlessError('No files to package');
+      const error = new ServerlessError('No files to package');
+      return BbPromise.reject(error);
     }
 
     const zip = archiver.create('zip');
@@ -71,69 +72,66 @@ module.exports = {
 
     const output = fs.createWriteStream(artifactFilePath);
 
-    return new Promise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       output.on('close', () => resolve(artifactFilePath));
       output.on('error', (err) => reject(err));
       zip.on('error', (err) => reject(err));
 
-      output.on('open', async () => {
+      output.on('open', () => {
         zip.pipe(output);
 
         // normalize both maps to avoid problems with e.g. Path Separators in different shells
         const normalizedFiles = _.uniq(files.map((file) => path.normalize(file)));
 
-        try {
-          const contents = await Promise.all(
-            normalizedFiles.map(this.getFileContentAndStat.bind(this))
-          );
-          contents
-            .sort((content1, content2) => content1.filePath.localeCompare(content2.filePath))
-            .forEach((file) => {
-              const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
-              // Ensure file is executable if it is locally executable or
-              // it's forced (via normalizedFilesToChmodPlusX) to be executable
-              const mode = file.stat.mode & 0o100 || process.platform === 'win32' ? 0o755 : 0o644;
-              zip.append(file.data, {
-                name,
-                mode,
-                date: new Date(0), // necessary to get the same hash when zipping the same content
+        return BbPromise.all(normalizedFiles.map(this.getFileContentAndStat.bind(this)))
+          .then((contents) => {
+            contents
+              .sort((content1, content2) => content1.filePath.localeCompare(content2.filePath))
+              .forEach((file) => {
+                const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
+                // Ensure file is executable if it is locally executable or
+                // it's forced (via normalizedFilesToChmodPlusX) to be executable
+                const mode = file.stat.mode & 0o100 || process.platform === 'win32' ? 0o755 : 0o644;
+                zip.append(file.data, {
+                  name,
+                  mode,
+                  date: new Date(0), // necessary to get the same hash when zipping the same content
+                });
               });
-            });
 
-          zip.finalize();
-        } catch (err) {
-          reject(err);
-        }
+            zip.finalize();
+          })
+          .catch(reject);
       });
     });
   },
 
-  async getFileContentAndStat(filePath) {
+  getFileContentAndStat(filePath) {
     const fullPath = path.resolve(this.serverless.config.servicePath, filePath);
 
-    try {
-      const result = await Promise.all([
-        // Get file contents and stat in parallel
-        this.getFileContent(fullPath),
-        fsAsync.stat(fullPath),
-      ]);
-      return {
+    return BbPromise.all([
+      // Get file contents and stat in parallel
+      this.getFileContent(fullPath),
+      fs.statAsync(fullPath),
+    ]).then(
+      (result) => ({
         data: result[0],
         stat: result[1],
         filePath,
-      };
-    } catch (error) {
-      throw new ServerlessError(`Cannot read file ${filePath} due to: ${error.message}`);
-    }
+      }),
+      (error) => {
+        throw new ServerlessError(`Cannot read file ${filePath} due to: ${error.message}`);
+      }
+    );
   },
 
   // Useful point of entry for e.g. transpilation plugins
   getFileContent(fullPath) {
-    return fsAsync.readFile(fullPath);
+    return fs.readFileAsync(fullPath);
   },
 };
 
-async function excludeNodeDevDependencies(servicePath) {
+function excludeNodeDevDependencies(servicePath) {
   const exAndIn = {
     include: [],
     exclude: [],
@@ -167,83 +165,99 @@ async function excludeNodeDevDependencies(servicePath) {
     });
 
     if (!packageJsonPaths.length) {
-      return exAndIn;
+      return BbPromise.resolve(exAndIn);
     }
 
-    const devAndProDependencies = [];
-    for (const env of ['dev', 'prod']) {
-      const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
-      for (const packageJsonPath of packageJsonPaths) {
+    // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
+    return (
+      BbPromise.mapSeries(packageJsonPaths, (packageJsonPath) => {
         // the path where the package.json file lives
         const fullPath = path.join(servicePath, packageJsonPath);
         const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
-        try {
-          await execAsync(
-            `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
-            { cwd: dirWithPackageJson }
-          );
-        } catch {
-          // ignore error
-        }
-      }
-      try {
-        const fileContent = await fsAsync.readFile(depFile);
-        devAndProDependencies.push(
-          _.uniq(fileContent.toString('utf8').split(/[\r\n]+/)).filter(Boolean)
-        );
-      } catch {
-        // ignore error
-      }
-    }
-    const devDependencies = devAndProDependencies[0];
-    const prodDependencies = devAndProDependencies[1];
 
-    // NOTE: the order for _.difference is important
-    const dependencies = _.difference(devDependencies, prodDependencies);
-    const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
+        // we added a catch which resolves so that npm commands with an exit code of 1
+        // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
+        return BbPromise.map(['dev', 'prod'], (env) => {
+          const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
+          return childProcess
+            .execAsync(
+              `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
+              { cwd: dirWithPackageJson }
+            )
+            .catch(() => BbPromise.resolve());
+        });
+      })
+        // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
+        .then(() =>
+          BbPromise.mapSeries(['dev', 'prod'], (env) => {
+            const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
+            return fs
+              .readFileAsync(depFile)
+              .then((fileContent) =>
+                _.uniq(fileContent.toString('utf8').split(/[\r\n]+/)).filter(Boolean)
+              )
+              .catch(() => BbPromise.resolve());
+          })
+        )
+        .then((devAndProDependencies) => {
+          const devDependencies = devAndProDependencies[0];
+          const prodDependencies = devAndProDependencies[1];
 
-    if (dependencies.length) {
-      const items = await Promise.all(
-        dependencies.map((item) => item.replace(path.join(servicePath, path.sep), ''))
-      );
+          // NOTE: the order for _.difference is important
+          const dependencies = _.difference(devDependencies, prodDependencies);
+          const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
 
-      const filteredItems = items.filter((item) => item.length > 0 && item.match(nodeModulesRegex));
-      const globs = [];
-      for (const item of filteredItems) {
-        const packagePath = path.join(servicePath, item, 'package.json');
-        try {
-          const packageJsonFile = await fsAsync.readFile(packagePath, 'utf-8');
-          const lastIndex = item.lastIndexOf(path.sep) + 1;
-          const moduleName = item.substr(lastIndex);
-          const modulePath = item.substr(0, lastIndex);
+          if (dependencies.length) {
+            return BbPromise.map(dependencies, (item) =>
+              item.replace(path.join(servicePath, path.sep), '')
+            )
+              .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
+              .reduce((globs, item) => {
+                const packagePath = path.join(servicePath, item, 'package.json');
+                return fs.readFileAsync(packagePath, 'utf-8').then(
+                  (packageJsonFile) => {
+                    const lastIndex = item.lastIndexOf(path.sep) + 1;
+                    const moduleName = item.substr(lastIndex);
+                    const modulePath = item.substr(0, lastIndex);
 
-          const packageJson = JSON.parse(packageJsonFile);
-          const bin = packageJson.bin;
+                    const packageJson = JSON.parse(packageJsonFile);
+                    const bin = packageJson.bin;
 
-          const baseGlobs = [path.join(item, '**')];
+                    const baseGlobs = [path.join(item, '**')];
 
-          // NOTE: pkg.bin can be object, string, or undefined
-          if (typeof bin === 'object') {
-            Object.keys(bin).forEach((executable) => {
-              baseGlobs.push(path.join(modulePath, '.bin', executable));
-            });
-            // only 1 executable with same name as lib
-          } else if (typeof bin === 'string') {
-            baseGlobs.push(path.join(modulePath, '.bin', moduleName));
+                    // NOTE: pkg.bin can be object, string, or undefined
+                    if (typeof bin === 'object') {
+                      Object.keys(bin).forEach((executable) => {
+                        baseGlobs.push(path.join(modulePath, '.bin', executable));
+                      });
+                      // only 1 executable with same name as lib
+                    } else if (typeof bin === 'string') {
+                      baseGlobs.push(path.join(modulePath, '.bin', moduleName));
+                    }
+
+                    return globs.concat(baseGlobs);
+                  },
+                  () => globs
+                );
+              }, [])
+              .then((globs) => {
+                exAndIn.exclude = exAndIn.exclude.concat(globs);
+                return exAndIn;
+              });
           }
 
-          globs.push(...baseGlobs);
-        } catch {
-          // ignore error
-        }
-      }
-      exAndIn.exclude = exAndIn.exclude.concat(globs);
-    }
-    // cleanup
-    fs.unlinkSync(nodeDevDepFile);
-    fs.unlinkSync(nodeProdDepFile);
+          return exAndIn;
+        })
+        .then(() => {
+          // cleanup
+          fs.unlinkSync(nodeDevDepFile);
+          fs.unlinkSync(nodeProdDepFile);
+          return exAndIn;
+        })
+        .catch(() => exAndIn)
+    );
   } catch (e) {
     // fail silently
+    return BbPromise.resolve(exAndIn);
   }
-  return exAndIn;
 }

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const path = require('path');
 const zipService = require('./lib/zipService');
 const packageService = require('./lib/packageService');
@@ -54,14 +55,14 @@ class Package {
     };
 
     this.hooks = {
-      'package:createDeploymentArtifacts': async () => this.packageService(),
+      'package:createDeploymentArtifacts': () => BbPromise.bind(this).then(this.packageService),
 
-      'package:function:package': async () => {
+      'package:function:package': () => {
         if (this.options.function) {
           this.serverless.cli.log(`Packaging function: ${this.options.function}...`);
-          return this.packageFunction(this.options.function);
+          return BbPromise.resolve(this.packageFunction(this.options.function));
         }
-        throw new Error('Function name must be set');
+        return BbPromise.reject(new Error('Function name must be set'));
       },
     };
   }

--- a/lib/plugins/plugin/install.js
+++ b/lib/plugins/plugin/install.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { promisify } = require('util');
-const { exec } = require('child_process');
+const BbPromise = require('bluebird');
+const childProcess = BbPromise.promisifyAll(require('child_process'));
 const fse = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
@@ -9,8 +9,6 @@ const yamlAstParser = require('../../utils/yamlAstParser');
 const fileExists = require('../../utils/fs/fileExists');
 const pluginUtils = require('./lib/utils');
 const npmCommandDeferred = require('../../utils/npm-command-deferred');
-
-const execAsync = promisify(exec);
 
 class PluginInstall {
   constructor(serverless, options) {
@@ -37,58 +35,68 @@ class PluginInstall {
       },
     };
     this.hooks = {
-      'plugin:install:install': async () => this.install(),
+      'plugin:install:install': () => BbPromise.bind(this).then(this.install),
     };
   }
 
-  async install() {
+  install() {
     const pluginInfo = pluginUtils.getPluginInfo(this.options.name);
     this.options.pluginName = pluginInfo[0];
     this.options.pluginVersion = pluginInfo[1] || 'latest';
 
-    this.validate();
-    const plugins = await this.getPlugins();
-
-    const plugin = plugins.find((item) => item.name === this.options.pluginName);
-    if (!plugin) {
-      this.serverless.cli.log('Plugin not found in serverless registry, continuing to install');
-    }
-
-    await this.pluginInstall();
-    await this.addPluginToServerlessFile();
-    await this.installPeerDependencies();
-
-    this.serverless.cli.log(
-      `Successfully installed "${this.options.pluginName}@${this.options.pluginVersion}"`
-    );
+    return BbPromise.bind(this)
+      .then(this.validate)
+      .then(this.getPlugins)
+      .then((plugins) => {
+        const plugin = plugins.find((item) => item.name === this.options.pluginName);
+        if (!plugin) {
+          this.serverless.cli.log('Plugin not found in serverless registry, continuing to install');
+        }
+        return BbPromise.bind(this)
+          .then(this.pluginInstall)
+          .then(this.addPluginToServerlessFile)
+          .then(this.installPeerDependencies)
+          .then(() => {
+            const message = [
+              'Successfully installed',
+              ` "${this.options.pluginName}@${this.options.pluginVersion}"`,
+            ].join('');
+            this.serverless.cli.log(message);
+          });
+      });
   }
 
-  async pluginInstall() {
+  pluginInstall() {
     const servicePath = this.serverless.config.servicePath;
     const packageJsonFilePath = path.join(servicePath, 'package.json');
 
-    const exists = await fileExists(packageJsonFilePath);
-    // check if package.json is already present. Otherwise create one
-    if (!exists) {
-      this.serverless.cli.log('Creating an empty package.json file in your service directory');
+    return fileExists(packageJsonFilePath)
+      .then((exists) => {
+        // check if package.json is already present. Otherwise create one
+        if (!exists) {
+          this.serverless.cli.log('Creating an empty package.json file in your service directory');
 
-      const packageJsonFileContent = {
-        name: this.serverless.service.service,
-        description: '',
-        version: '0.1.0',
-        dependencies: {},
-        devDependencies: {},
-      };
-      await fse.writeJson(packageJsonFilePath, packageJsonFileContent);
-    }
-
-    // install the package through npm
-    const pluginFullName = `${this.options.pluginName}@${this.options.pluginVersion}`;
-
-    this.serverless.cli.log(
-      `Installing plugin "${pluginFullName}" (this might take a few seconds...)`
-    );
-    await this.npmInstall(pluginFullName);
+          const packageJsonFileContent = {
+            name: this.serverless.service.service,
+            description: '',
+            version: '0.1.0',
+            dependencies: {},
+            devDependencies: {},
+          };
+          return fse.writeJson(packageJsonFilePath, packageJsonFileContent);
+        }
+        return BbPromise.resolve();
+      })
+      .then(() => {
+        // install the package through npm
+        const pluginFullName = `${this.options.pluginName}@${this.options.pluginVersion}`;
+        const message = [
+          `Installing plugin "${pluginFullName}"`,
+          ' (this might take a few seconds...)',
+        ].join('');
+        this.serverless.cli.log(message);
+        return this.npmInstall(pluginFullName);
+      });
   }
 
   async addPluginToServerlessFile() {
@@ -139,25 +147,31 @@ class PluginInstall {
     );
   }
 
-  async installPeerDependencies() {
+  installPeerDependencies() {
     const pluginPackageJsonFilePath = path.join(
       this.serverless.config.servicePath,
       'node_modules',
       this.options.pluginName,
       'package.json'
     );
-    const pluginPackageJson = await fse.readJson(pluginPackageJsonFilePath);
-    if (pluginPackageJson.peerDependencies) {
-      const pluginsArray = Object.entries(pluginPackageJson.peerDependencies).map(
-        ([k, v]) => `${k}@"${v}"`
-      );
-      await Promise.all(pluginsArray.map(this.npmInstall));
-    }
+    return fse.readJson(pluginPackageJsonFilePath).then((pluginPackageJson) => {
+      if (pluginPackageJson.peerDependencies) {
+        const pluginsArray = [];
+        Object.entries(pluginPackageJson.peerDependencies).forEach(([k, v]) => {
+          pluginsArray.push(`${k}@"${v}"`);
+        });
+        return BbPromise.map(pluginsArray, this.npmInstall);
+      }
+      return BbPromise.resolve();
+    });
   }
 
-  async npmInstall(name) {
-    const npmCommand = await npmCommandDeferred;
-    await execAsync(`${npmCommand} install --save-dev ${name}`, { stdio: 'ignore' });
+  npmInstall(name) {
+    return npmCommandDeferred.then((npmCommand) =>
+      childProcess.execAsync(`${npmCommand} install --save-dev ${name}`, {
+        stdio: 'ignore',
+      })
+    );
   }
 }
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fetch = require('node-fetch');
+const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
 const chalk = require('chalk');
@@ -12,6 +13,8 @@ module.exports = {
     if (!this.serverless.config.servicePath) {
       throw new ServerlessError('This command can only be run inside a service directory');
     }
+
+    return BbPromise.resolve();
   },
 
   getServerlessFilePath() {
@@ -19,7 +22,7 @@ module.exports = {
     throw new ServerlessError('Could not find any serverless service definition file.');
   },
 
-  async getPlugins() {
+  getPlugins() {
     const endpoint = 'https://raw.githubusercontent.com/serverless/plugins/master/plugins.json';
 
     // Use HTTPS Proxy (Optional)
@@ -35,8 +38,9 @@ module.exports = {
       options.agent = new HttpsProxyAgent(url.parse(proxy));
     }
 
-    const result = await fetch(endpoint, options);
-    return result.json();
+    return fetch(endpoint, options)
+      .then((result) => result.json())
+      .then((json) => json);
   },
 
   getPluginInfo(name) {
@@ -70,6 +74,6 @@ It will be automatically downloaded and added to your package.json and serverles
       message = 'There are no plugins available to display';
       this.serverless.cli.consoleLog(message);
     }
-    return message;
+    return BbPromise.resolve(message);
   },
 };

--- a/lib/plugins/plugin/list.js
+++ b/lib/plugins/plugin/list.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const pluginUtils = require('./lib/utils');
 
 class PluginList {
@@ -21,13 +22,14 @@ class PluginList {
     };
 
     this.hooks = {
-      'plugin:list:list': () => this.list(),
+      'plugin:list:list': () => BbPromise.bind(this).then(this.list),
     };
   }
 
-  async list() {
-    const plugins = await this.getPlugins();
-    return this.display(plugins);
+  list() {
+    return BbPromise.bind(this)
+      .then(this.getPlugins)
+      .then((plugins) => this.display(plugins));
   }
 }
 

--- a/lib/plugins/plugin/plugin.js
+++ b/lib/plugins/plugin/plugin.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const BbPromise = require('bluebird');
+
 class Plugin {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -12,7 +14,10 @@ class Plugin {
       },
     };
     this.hooks = {
-      'plugin:plugin': () => this.serverless.cli.generateCommandsHelp(['plugin']),
+      'plugin:plugin': () => {
+        this.serverless.cli.generateCommandsHelp(['plugin']);
+        return BbPromise.resolve();
+      },
     };
   }
 }

--- a/lib/plugins/plugin/search.js
+++ b/lib/plugins/plugin/search.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const chalk = require('chalk');
 const pluginUtils = require('./lib/utils');
 
@@ -29,28 +30,32 @@ class PluginSearch {
     };
 
     this.hooks = {
-      'plugin:search:search': async () => this.search(),
+      'plugin:search:search': () => BbPromise.bind(this).then(this.search),
     };
   }
 
-  async search() {
-    const plugins = await this.getPlugins();
+  search() {
+    return BbPromise.bind(this)
+      .then(this.getPlugins)
+      .then((plugins) => {
+        // filter out plugins which match the query
+        const regex = new RegExp(this.options.query);
 
-    // filter out plugins which match the query
-    const regex = new RegExp(this.options.query);
+        const filteredPlugins = plugins.filter(
+          (plugin) => plugin.name.match(regex) || plugin.description.match(regex)
+        );
 
-    const filteredPlugins = plugins.filter(
-      (plugin) => plugin.name.match(regex) || plugin.description.match(regex)
-    );
+        // print a message with the search result
+        const pluginCount = filteredPlugins.length;
+        const query = this.options.query;
+        const message = `${pluginCount} plugin(s) found for your search query "${query}"\n`;
+        this.serverless.cli.consoleLog(chalk.yellow(message));
 
-    // print a message with the search result
-    const pluginCount = filteredPlugins.length;
-    const query = this.options.query;
-    this.serverless.cli.consoleLog(
-      chalk.yellow(`${pluginCount} plugin(s) found for your search query "${query}"\n`)
-    );
-
-    return this.display(filteredPlugins);
+        return filteredPlugins;
+      })
+      .then((plugins) => {
+        this.display(plugins);
+      });
   }
 }
 

--- a/lib/plugins/plugin/uninstall.js
+++ b/lib/plugins/plugin/uninstall.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const { promisify } = require('util');
-const { exec } = require('child_process');
+const BbPromise = require('bluebird');
+const childProcess = BbPromise.promisifyAll(require('child_process'));
 const fse = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
 const yamlAstParser = require('../../utils/yamlAstParser');
 const pluginUtils = require('./lib/utils');
-
-const execAsync = promisify(exec);
 
 class PluginUninstall {
   constructor(serverless, options) {
@@ -36,31 +34,40 @@ class PluginUninstall {
     };
 
     this.hooks = {
-      'plugin:uninstall:uninstall': async () => this.uninstall(this),
+      'plugin:uninstall:uninstall': () => BbPromise.bind(this).then(this.uninstall),
     };
   }
 
-  async uninstall() {
+  uninstall() {
     const pluginInfo = pluginUtils.getPluginInfo(this.options.name);
     this.options.pluginName = pluginInfo[0];
 
-    this.validate();
-    const plugins = await this.getPlugins();
-    const plugin = plugins.find((item) => item.name === this.options.pluginName);
-    if (!plugin) {
-      this.serverless.cli.log('Plugin not found in serverless registry, continuing to uninstall');
-    }
-    await this.uninstallPeerDependencies();
-    await this.pluginUninstall();
-    await this.removePluginFromServerlessFile();
-    this.serverless.cli.log(`Successfully uninstalled "${this.options.pluginName}"`);
+    return BbPromise.bind(this)
+      .then(this.validate)
+      .then(this.getPlugins)
+      .then((plugins) => {
+        const plugin = plugins.find((item) => item.name === this.options.pluginName);
+        if (!plugin) {
+          this.serverless.cli.log(
+            'Plugin not found in serverless registry, continuing to uninstall'
+          );
+        }
+        return BbPromise.bind(this)
+          .then(this.uninstallPeerDependencies)
+          .then(this.pluginUninstall)
+          .then(this.removePluginFromServerlessFile)
+          .then(() => {
+            this.serverless.cli.log(`Successfully uninstalled "${this.options.pluginName}"`);
+            return BbPromise.resolve();
+          });
+      });
   }
 
-  async pluginUninstall() {
+  pluginUninstall() {
     this.serverless.cli.log(
       `Uninstalling plugin "${this.options.pluginName}" (this might take a few seconds...)`
     );
-    await this.npmUninstall(this.options.pluginName);
+    return this.npmUninstall(this.options.pluginName);
   }
 
   async removePluginFromServerlessFile() {
@@ -103,26 +110,32 @@ class PluginUninstall {
     );
   }
 
-  async uninstallPeerDependencies() {
+  uninstallPeerDependencies() {
     const pluginPackageJsonFilePath = path.join(
       this.serverless.config.servicePath,
       'node_modules',
       this.options.pluginName,
       'package.json'
     );
-    try {
-      const pluginPackageJson = await fse.readJson(pluginPackageJsonFilePath);
-      if (pluginPackageJson.peerDependencies) {
-        const pluginsArray = Object.keys(pluginPackageJson.peerDependencies);
-        await Promise.all(pluginsArray.map(this.npmUninstall));
-      }
-    } catch {
-      // fail silently
-    }
+    return fse
+      .readJson(pluginPackageJsonFilePath)
+      .then((pluginPackageJson) => {
+        if (pluginPackageJson.peerDependencies) {
+          const pluginsArray = [];
+          Object.keys(pluginPackageJson.peerDependencies).forEach((k) => {
+            pluginsArray.push(k);
+          });
+          return BbPromise.map(pluginsArray, this.npmUninstall);
+        }
+        return BbPromise.resolve();
+      })
+      .catch(() => BbPromise.resolve());
   }
 
-  async npmUninstall(name) {
-    await execAsync(`npm uninstall --save-dev ${name}`, { stdio: 'ignore' });
+  npmUninstall(name) {
+    return childProcess.execAsync(`npm uninstall --save-dev ${name}`, {
+      stdio: 'ignore',
+    });
   }
 }
 

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -2,6 +2,7 @@
 
 const os = require('os');
 const _ = require('lodash');
+const BbPromise = require('bluebird');
 const jc = require('json-cycle');
 const yaml = require('js-yaml');
 const ServerlessError = require('../serverless-error');

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -2,7 +2,6 @@
 
 const os = require('os');
 const _ = require('lodash');
-const BbPromise = require('bluebird');
 const jc = require('json-cycle');
 const yaml = require('js-yaml');
 const ServerlessError = require('../serverless-error');

--- a/lib/utils/createFromTemplate.js
+++ b/lib/utils/createFromTemplate.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { basename, join } = require('path');
+const BbPromise = require('bluebird');
 const { copy, readFile } = require('fs-extra');
 const { renameService } = require('./renameService');
 
@@ -14,27 +15,35 @@ const resolveServiceName = (path) => {
   return serviceName;
 };
 
-module.exports = async (templateName, destPath, options = {}) => {
-  if (!options) options = {};
-  const templateSrcDir = join(serverlessPath, 'lib/plugins/create/templates', templateName);
+module.exports = (templateName, destPath, options = {}) =>
+  new BbPromise((resolve, reject) => {
+    if (!options) options = {};
+    const templateSrcDir = join(serverlessPath, 'lib/plugins/create/templates', templateName);
 
-  if (!options.name) {
-    let content;
-    try {
-      content = await readFile(join(destPath, 'package.json'), 'utf8');
-    } catch (readFileError) {
-      if (readFileError.code !== 'ENOENT') {
-        throw readFileError;
+    readFile(join(destPath, 'package.json'), 'utf8', (readFileError, content) => {
+      if (readFileError) {
+        if (readFileError.code !== 'ENOENT') {
+          reject(readFileError);
+          return;
+        }
+      } else if (!options.name) {
+        const packageName = (() => {
+          try {
+            return JSON.parse(content).name;
+          } catch (error) {
+            return null;
+          }
+        })();
+        if (packageName) options.name = packageName;
       }
-    }
-
-    try {
-      options.name = JSON.parse(content).name;
-    } catch {
-      // Leave name empty if parsing failed
-    }
-  }
-
-  await copy(templateSrcDir, destPath);
-  return renameService(options.name || resolveServiceName(destPath), destPath);
-};
+      copy(templateSrcDir, destPath, (copyError) => {
+        if (copyError) {
+          reject(copyError);
+          return;
+        }
+        resolve(
+          BbPromise.try(() => renameService(options.name || resolveServiceName(destPath), destPath))
+        );
+      });
+    });
+  });

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -4,6 +4,7 @@ const path = require('path');
 const os = require('os');
 const URL = require('url');
 const download = require('download');
+const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const qs = require('querystring');
 const fetch = require('node-fetch');
@@ -142,12 +143,12 @@ function parseBitbucketServerURL(url) {
  * @param {Object} url
  * @returns {Boolean}
  */
-async function retrieveBitbucketServerInfo(url) {
+function retrieveBitbucketServerInfo(url) {
   const versionInfoPath = `${url.protocol}//${url.hostname}/rest/api/1.0/application-properties`;
 
-  const resp = await fetch(versionInfoPath);
-  const body = await resp.json();
-  return body.displayName === 'Bitbucket';
+  return fetch(versionInfoPath)
+    .then((resp) => resp.json())
+    .then((body) => body.displayName === 'Bitbucket');
 }
 
 /**
@@ -207,42 +208,44 @@ function parsePlainGitURL(url) {
  * @throws {ServerlessError}
  * @returns {Promise}
  */
-async function parseRepoURL(inputUrl) {
-  if (!inputUrl) {
-    throw new ServerlessError('URL is required');
-  }
-
-  const url = URL.parse(inputUrl.replace(/\/$/, ''));
-
-  // check if url parameter is a valid url
-  if (!url.host && !url.href.startsWith('git@')) {
-    throw new ServerlessError('The URL you passed is not valid');
-  }
-
-  if (isPlainGitURL(url.href)) {
-    return parsePlainGitURL(inputUrl);
-  } else if (url.hostname === 'github.com' || url.hostname.indexOf('github.') !== -1) {
-    return parseGitHubURL(url);
-  } else if (url.hostname === 'bitbucket.org') {
-    return parseBitbucketURL(url);
-  } else if (url.hostname === 'gitlab.com') {
-    return parseGitlabURL(url);
-  }
-
-  try {
-    // test if it's a private bitbucket server
-    const isBitbucket = await retrieveBitbucketServerInfo(url);
-    if (!isBitbucket) {
-      throw new ServerlessError('Is not Bitbucket');
+function parseRepoURL(inputUrl) {
+  return new BbPromise((resolve, reject) => {
+    if (!inputUrl) {
+      return reject(new ServerlessError('URL is required'));
     }
 
-    // build download URL
-    return parseBitbucketServerURL(url);
-  } catch (err) {
-    throw new ServerlessError(
-      'The URL you passed is not one of the valid providers: "GitHub", "GitHub Entreprise", "Bitbucket", "Bitbucket Server" or "GitLab".'
-    );
-  }
+    const url = URL.parse(inputUrl.replace(/\/$/, ''));
+
+    // check if url parameter is a valid url
+    if (!url.host && !url.href.startsWith('git@')) {
+      return reject(new ServerlessError('The URL you passed is not valid'));
+    }
+
+    if (isPlainGitURL(url.href)) {
+      return resolve(parsePlainGitURL(inputUrl));
+    } else if (url.hostname === 'github.com' || url.hostname.indexOf('github.') !== -1) {
+      return resolve(parseGitHubURL(url));
+    } else if (url.hostname === 'bitbucket.org') {
+      return resolve(parseBitbucketURL(url));
+    } else if (url.hostname === 'gitlab.com') {
+      return resolve(parseGitlabURL(url));
+    }
+
+    const msg =
+      'The URL you passed is not one of the valid providers: "GitHub", "GitHub Entreprise", "Bitbucket", "Bitbucket Server" or "GitLab".';
+    const err = new ServerlessError(msg);
+    // test if it's a private bitbucket server
+    return retrieveBitbucketServerInfo(url)
+      .then((isBitbucket) => {
+        if (!isBitbucket) {
+          return reject(err);
+        }
+
+        // build download URL
+        return resolve(parseBitbucketServerURL(url));
+      })
+      .catch(() => reject(err));
+  });
 }
 
 /**
@@ -251,60 +254,64 @@ async function parseRepoURL(inputUrl) {
  * @param {string} [path]
  * @returns {Promise}
  */
-async function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
-  const repoInformation = await parseRepoURL(inputUrl);
+function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
+  return parseRepoURL(inputUrl).then((repoInformation) => {
+    let serviceName;
+    let dirName;
+    let downloadServicePath;
+    const { auth } = repoInformation;
 
-  let serviceName;
-  let dirName;
-  let downloadServicePath;
-  const { auth } = repoInformation;
+    if (repoInformation.isSubdirectory) {
+      const folderName = repoInformation.pathToDirectory.split('/').splice(-1)[0];
+      serviceName = folderName;
+      dirName = downloadPath || templateName || folderName;
+      downloadServicePath = path.join(os.tmpdir(), repoInformation.repo);
+    } else {
+      serviceName = repoInformation.repo;
+      dirName = downloadPath || templateName || repoInformation.repo;
+      downloadServicePath = path.join(process.cwd(), dirName);
+    }
 
-  if (repoInformation.isSubdirectory) {
-    const folderName = repoInformation.pathToDirectory.split('/').splice(-1)[0];
-    serviceName = folderName;
-    dirName = downloadPath || templateName || folderName;
-    downloadServicePath = path.join(os.tmpdir(), repoInformation.repo);
-  } else {
-    serviceName = repoInformation.repo;
-    dirName = downloadPath || templateName || repoInformation.repo;
-    downloadServicePath = path.join(process.cwd(), dirName);
-  }
+    const servicePath = path.join(process.cwd(), dirName);
+    const renamed = dirName !== repoInformation.repo;
 
-  const servicePath = path.join(process.cwd(), dirName);
-  const renamed = dirName !== repoInformation.repo;
+    if (dirExistsSync(path.join(process.cwd(), dirName))) {
+      const errorMessage = `A folder named "${dirName}" already exists.`;
+      throw new ServerlessError(errorMessage);
+    }
 
-  if (dirExistsSync(path.join(process.cwd(), dirName))) {
-    const errorMessage = `A folder named "${dirName}" already exists.`;
-    throw new ServerlessError(errorMessage);
-  }
+    log(`Downloading and installing "${serviceName}"...`);
 
-  log(`Downloading and installing "${serviceName}"...`);
+    if (isPlainGitURL(inputUrl)) {
+      return spawn('git', ['clone', inputUrl, downloadServicePath]).then(() => {
+        if (renamed) renameService(dirName, servicePath);
+        return serviceName;
+      });
+    }
 
-  if (isPlainGitURL(inputUrl)) {
-    await spawn('git', ['clone', inputUrl, downloadServicePath]);
-    if (renamed) renameService(dirName, servicePath);
-    return serviceName;
-  }
+    const downloadOptions = {
+      timeout: 30000,
+      extract: true,
+      strip: 1,
+      mode: '755',
+      auth,
+    };
+    // download service
+    return download(repoInformation.downloadUrl, downloadServicePath, downloadOptions)
+      .then(() => {
+        // if it's a directory inside of git
+        if (repoInformation.isSubdirectory) {
+          const directory = path.join(downloadServicePath, repoInformation.pathToDirectory);
+          copyDirContentsSync(directory, servicePath);
+          fse.removeSync(downloadServicePath);
+        }
+      })
+      .then(() => {
+        if (renamed) renameService(dirName, servicePath);
 
-  const downloadOptions = {
-    timeout: 30000,
-    extract: true,
-    strip: 1,
-    mode: '755',
-    auth,
-  };
-  // download service
-  await download(repoInformation.downloadUrl, downloadServicePath, downloadOptions);
-  // if it's a directory inside of git
-  if (repoInformation.isSubdirectory) {
-    const directory = path.join(downloadServicePath, repoInformation.pathToDirectory);
-    copyDirContentsSync(directory, servicePath);
-    fse.removeSync(downloadServicePath);
-  }
-
-  if (renamed) renameService(dirName, servicePath);
-
-  return serviceName;
+        return BbPromise.resolve(serviceName);
+      });
+  });
 }
 
 module.exports = {

--- a/lib/utils/fs/createZipFile.js
+++ b/lib/utils/fs/createZipFile.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
+const BbPromise = require('bluebird');
 const walkDirSync = require('../fs/walkDirSync');
 
 function createZipFile(srcDirPath, outputFilePath) {
@@ -11,7 +12,7 @@ function createZipFile(srcDirPath, outputFilePath) {
     output: file.replace(path.join(srcDirPath, path.sep), ''),
   }));
 
-  return new Promise((resolve, reject) => {
+  return new BbPromise((resolve, reject) => {
     const output = fs.createWriteStream(outputFilePath);
     const archive = archiver('zip', {
       zlib: { level: 9 },

--- a/lib/utils/open.js
+++ b/lib/utils/open.js
@@ -2,19 +2,20 @@
 // copied from https://raw.githubusercontent.com/sindresorhus/open/master/index.js
 // and adapted for node 6 support. Because open>6 requries node >= 8 but open<6 fails npm audit
 // changes:
+//  * use bluebird.promisify instead of util.promisfy
 //  * Object.assign instead of spread
 //  * use Array.prototype.push.apply(a,b) instead of a.push(...b)
 //  * async/await -> then :|
 //  * prettified with our config
 
-const { promisify } = require('util');
+const { promisify } = require('bluebird');
 const chalk = require('chalk');
 const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const isWsl = require('is-wsl');
 
-const { access } = fs.promises;
+const pAccess = promisify(fs.access);
 const pExecFile = promisify(childProcess.execFile);
 
 // Path to included `xdg-open`
@@ -104,7 +105,7 @@ module.exports = (target, options) => {
             const isBundled = !__dirname || __dirname === '/';
 
             // Check if local `xdg-open` exists and is executable.
-            return access(localXdgOpenPath, fs.constants.X_OK)
+            return pAccess(localXdgOpenPath, fs.constants.X_OK)
               .then(() => true)
               .catch(() => false)
               .then((exeLocalXdgOpen) => {

--- a/lib/utils/yamlAstParser.js
+++ b/lib/utils/yamlAstParser.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const yaml = require('yaml-ast-parser');
-const fs = require('fs').promises;
+const BbPromise = require('bluebird');
+const fs = BbPromise.promisifyAll(require('fs'));
 const _ = require('lodash');
 const os = require('os');
 const chalk = require('chalk');
@@ -78,95 +79,99 @@ const constructPlainObject = (ymlAstContent, branchObject) => {
   return newbranchObject;
 };
 
-const addNewArrayItem = async (ymlFile, pathInYml, newValue) => {
-  const yamlContent = await fs.readFile(ymlFile, 'utf8');
-  const rawAstObject = yaml.load(yamlContent);
-  const astObject = parseAST(rawAstObject);
-  const plainObject = constructPlainObject(rawAstObject);
-  const pathInYmlArray = pathInYml.split('.');
-
-  let currentNode = plainObject;
-  for (let i = 0; i < pathInYmlArray.length - 1; i++) {
-    const propertyName = pathInYmlArray[i];
-    const property = currentNode[propertyName];
-    if (!property || _.isObject(property)) {
-      currentNode[propertyName] = property || {};
-      currentNode = currentNode[propertyName];
-    } else {
-      throw new Error(`${property} can only be undefined or an object!`);
-    }
-  }
-
-  const arrayPropertyName = _.last(pathInYmlArray);
-  let arrayProperty = currentNode[arrayPropertyName];
-  if (!arrayProperty || Array.isArray(arrayProperty)) {
-    arrayProperty = arrayProperty || [];
-  } else {
-    throw new Error(`${arrayProperty} can only be undefined or an array!`);
-  }
-  currentNode[arrayPropertyName] = _.union(arrayProperty, [newValue]);
-
-  const branchToReplaceName = pathInYmlArray[0];
-  const newObject = {};
-  newObject[branchToReplaceName] = plainObject[branchToReplaceName];
-  const newText = yaml.dump(newObject);
-  if (astObject[branchToReplaceName]) {
-    const beginning = yamlContent.substring(
-      0,
-      astObject[branchToReplaceName].parent.key.startPosition
-    );
-    const end = yamlContent.substring(
-      astObject[branchToReplaceName].endPosition,
-      yamlContent.length
-    );
-    return fs.writeFile(ymlFile, `${beginning}${newText}${end}`);
-  }
-  return fs.writeFile(ymlFile, `${yamlContent}${os.EOL}${newText}`);
-};
-
-const removeExistingArrayItem = async (ymlFile, pathInYml, removeValue) => {
-  const yamlContent = await fs.readFile(ymlFile, 'utf8');
-  const rawAstObject = yaml.load(yamlContent);
-  const astObject = parseAST(rawAstObject);
-
-  if (astObject[pathInYml] && astObject[pathInYml].items) {
+const addNewArrayItem = (ymlFile, pathInYml, newValue) =>
+  fs.readFileAsync(ymlFile, 'utf8').then((yamlContent) => {
+    const rawAstObject = yaml.load(yamlContent);
+    const astObject = parseAST(rawAstObject);
     const plainObject = constructPlainObject(rawAstObject);
     const pathInYmlArray = pathInYml.split('.');
 
     let currentNode = plainObject;
-    const pathInObjectTree = [];
     for (let i = 0; i < pathInYmlArray.length - 1; i++) {
-      pathInObjectTree.push(currentNode);
-      currentNode = currentNode[pathInYmlArray[i]];
-    }
-    const arrayPropertyName = _.last(pathInYmlArray);
-    const arrayProperty = currentNode[arrayPropertyName];
-    _.pull(arrayProperty, removeValue);
-
-    if (!arrayProperty.length) {
-      delete currentNode[arrayPropertyName];
-      pathInObjectTree.push(currentNode);
-      for (let i = pathInObjectTree.length - 1; i > 0; i--) {
-        if (Object.keys(pathInObjectTree[i]).length > 0) {
-          break;
-        }
-        delete pathInObjectTree[i - 1][pathInYmlArray[i - 1]];
+      const propertyName = pathInYmlArray[i];
+      const property = currentNode[propertyName];
+      if (!property || _.isObject(property)) {
+        currentNode[propertyName] = property || {};
+        currentNode = currentNode[propertyName];
+      } else {
+        throw new Error(`${property} can only be undefined or an object!`);
       }
     }
 
-    const headObjectPath = pathInYmlArray[0];
-    let newText = '';
-
-    if (plainObject[headObjectPath]) {
-      const newObject = {};
-      newObject[headObjectPath] = plainObject[headObjectPath];
-      newText = yaml.dump(newObject);
+    const arrayPropertyName = _.last(pathInYmlArray);
+    let arrayProperty = currentNode[arrayPropertyName];
+    if (!arrayProperty || Array.isArray(arrayProperty)) {
+      arrayProperty = arrayProperty || [];
+    } else {
+      throw new Error(`${arrayProperty} can only be undefined or an array!`);
     }
-    const beginning = yamlContent.substring(0, astObject[headObjectPath].parent.key.startPosition);
-    const end = yamlContent.substring(astObject[pathInYml].endPosition, yamlContent.length);
-    await fs.writeFile(ymlFile, `${beginning}${newText}${end}`);
-  }
-};
+    currentNode[arrayPropertyName] = _.union(arrayProperty, [newValue]);
+
+    const branchToReplaceName = pathInYmlArray[0];
+    const newObject = {};
+    newObject[branchToReplaceName] = plainObject[branchToReplaceName];
+    const newText = yaml.dump(newObject);
+    if (astObject[branchToReplaceName]) {
+      const beginning = yamlContent.substring(
+        0,
+        astObject[branchToReplaceName].parent.key.startPosition
+      );
+      const end = yamlContent.substring(
+        astObject[branchToReplaceName].endPosition,
+        yamlContent.length
+      );
+      return fs.writeFileAsync(ymlFile, `${beginning}${newText}${end}`);
+    }
+    return fs.writeFileAsync(ymlFile, `${yamlContent}${os.EOL}${newText}`);
+  });
+
+const removeExistingArrayItem = (ymlFile, pathInYml, removeValue) =>
+  fs.readFileAsync(ymlFile, 'utf8').then((yamlContent) => {
+    const rawAstObject = yaml.load(yamlContent);
+    const astObject = parseAST(rawAstObject);
+
+    if (astObject[pathInYml] && astObject[pathInYml].items) {
+      const plainObject = constructPlainObject(rawAstObject);
+      const pathInYmlArray = pathInYml.split('.');
+
+      let currentNode = plainObject;
+      const pathInObjectTree = [];
+      for (let i = 0; i < pathInYmlArray.length - 1; i++) {
+        pathInObjectTree.push(currentNode);
+        currentNode = currentNode[pathInYmlArray[i]];
+      }
+      const arrayPropertyName = _.last(pathInYmlArray);
+      const arrayProperty = currentNode[arrayPropertyName];
+      _.pull(arrayProperty, removeValue);
+
+      if (!arrayProperty.length) {
+        delete currentNode[arrayPropertyName];
+        pathInObjectTree.push(currentNode);
+        for (let i = pathInObjectTree.length - 1; i > 0; i--) {
+          if (Object.keys(pathInObjectTree[i]).length > 0) {
+            break;
+          }
+          delete pathInObjectTree[i - 1][pathInYmlArray[i - 1]];
+        }
+      }
+
+      const headObjectPath = pathInYmlArray[0];
+      let newText = '';
+
+      if (plainObject[headObjectPath]) {
+        const newObject = {};
+        newObject[headObjectPath] = plainObject[headObjectPath];
+        newText = yaml.dump(newObject);
+      }
+      const beginning = yamlContent.substring(
+        0,
+        astObject[headObjectPath].parent.key.startPosition
+      );
+      const end = yamlContent.substring(astObject[pathInYml].endPosition, yamlContent.length);
+      return fs.writeFileAsync(ymlFile, `${beginning}${newText}${end}`);
+    }
+    return BbPromise.resolve();
+  });
 
 module.exports = {
   addNewArrayItem,

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -1808,7 +1808,9 @@ describe('PluginManager', () => {
 
       const commandsArray = ['foo'];
 
-      expect(pluginManager.spawn(commandsArray)).to.be.rejectedWith(Error);
+      expect(() => {
+        pluginManager.spawn(commandsArray);
+      }).to.throw(Error);
     });
 
     it('should show warning in debug mode and when the given command has no hooks', () => {
@@ -1876,9 +1878,7 @@ describe('PluginManager', () => {
 
         const commandsArray = ['mycontainer'];
 
-        return expect(pluginManager.spawn(commandsArray)).to.be.rejectedWith(
-          /command ".*" not found/
-        );
+        return expect(() => pluginManager.spawn(commandsArray)).to.throw(/command ".*" not found/);
       });
 
       it('should spawn nested commands', () => {

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -2626,7 +2626,7 @@ module.exports = {
       serverless.variables.loadVariableSyntax();
       return serverless.variables
         .getDeeperValue(['custom', 'subProperty', 'deep'], valueToPopulateMock)
-        .should.equal('deepValue');
+        .should.become('deepValue');
     });
     it('should not throw error if referencing invalid properties', () => {
       const valueToPopulateMock = {
@@ -2638,7 +2638,7 @@ module.exports = {
       serverless.variables.loadVariableSyntax();
       return serverless.variables
         .getDeeperValue(['custom', 'subProperty', 'deep', 'deeper'], valueToPopulateMock)
-        .should.deep.equal({});
+        .should.eventually.deep.equal({});
     });
     it('should return a simple deep variable when final deep value is variable', () => {
       serverless.variables.service = {
@@ -2654,7 +2654,7 @@ module.exports = {
       serverless.variables.loadVariableSyntax();
       return serverless.variables
         .getDeeperValue(['custom', 'subProperty', 'deep'], serverless.variables.service)
-        .should.equal('${deep:0}');
+        .should.become('${deep:0}');
     });
     it('should return a deep continuation when middle deep value is variable', () => {
       serverless.variables.service = {
@@ -2667,7 +2667,7 @@ module.exports = {
       serverless.variables.loadVariableSyntax();
       return serverless.variables
         .getDeeperValue(['custom', 'anotherVar', 'veryDeep'], serverless.variables.service)
-        .should.equal('${deep:0.veryDeep}');
+        .should.become('${deep:0.veryDeep}');
     });
   });
 

--- a/test/unit/lib/plugins/aws/rollback.test.js
+++ b/test/unit/lib/plugins/aws/rollback.test.js
@@ -125,7 +125,7 @@ describe('AwsRollback', () => {
           assert.isNotOk(true, 'setStackToUpdate should not resolve');
         })
         .catch((errorMessage) => {
-          expect(errorMessage.message).to.include("Couldn't find any existing deployments");
+          expect(errorMessage).to.include("Couldn't find any existing deployments");
           expect(listObjectsStub.calledOnce).to.be.equal(true);
           expect(
             listObjectsStub.calledWithExactly('S3', 'listObjectsV2', {
@@ -160,7 +160,7 @@ describe('AwsRollback', () => {
           assert.isNotOk(true, 'setStackToUpdate should not resolve');
         })
         .catch((errorMessage) => {
-          expect(errorMessage.message).to.include("Couldn't find a deployment for the timestamp");
+          expect(errorMessage).to.include("Couldn't find a deployment for the timestamp");
           expect(listObjectsStub.calledOnce).to.be.equal(true);
           expect(
             listObjectsStub.calledWithExactly('S3', 'listObjectsV2', {

--- a/test/unit/lib/plugins/aws/utils/credentials.test.js
+++ b/test/unit/lib/plugins/aws/utils/credentials.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const BbPromise = require('bluebird');
 const os = require('os');
 const path = require('path');
 const { outputFile, lstat, remove: rmDir } = require('fs-extra');
@@ -56,7 +57,7 @@ describe('#credentials', () => {
       `aws_secret_access_key = ${profile2.secretAccessKey}`,
     ].join('\n')}\n`;
 
-    return new Promise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       outputFile(credentialsFilePath, credentialsFileContent, (error) => {
         if (error) reject(error);
         else resolve();

--- a/test/unit/lib/plugins/aws/utils/resolveCfImportValue.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolveCfImportValue.test.js
@@ -1,23 +1,25 @@
 'use strict';
 
 const expect = require('chai').expect;
+const BbPromise = require('bluebird');
 const resolveCfImportValue = require('../../../../../../lib/plugins/aws/utils/resolveCfImportValue');
 
 describe('#resolveCfImportValue', () => {
   it('should return matching exported value if found', () => {
     const provider = {
-      request: async () => ({
-        Exports: [
-          {
-            Name: 'anotherName',
-            Value: 'anotherValue',
-          },
-          {
-            Name: 'exportName',
-            Value: 'exportValue',
-          },
-        ],
-      }),
+      request: () =>
+        BbPromise.resolve({
+          Exports: [
+            {
+              Name: 'anotherName',
+              Value: 'anotherValue',
+            },
+            {
+              Name: 'exportName',
+              Value: 'exportValue',
+            },
+          ],
+        }),
     };
     return resolveCfImportValue(provider, 'exportName').then((result) => {
       expect(result).to.equal('exportValue');

--- a/test/unit/lib/plugins/aws/utils/resolveCfRefValue.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolveCfRefValue.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const BbPromise = require('bluebird');
 const resolveCfRefValue = require('../../../../../../lib/plugins/aws/utils/resolveCfRefValue');
 
 describe('#resolveCfRefValue', () => {
@@ -9,18 +10,19 @@ describe('#resolveCfRefValue', () => {
       naming: {
         getStackName: () => 'stack-name',
       },
-      request: async () => ({
-        StackResourceSummaries: [
-          {
-            LogicalResourceId: 'myS3',
-            PhysicalResourceId: 'stack-name-s3-id',
-          },
-          {
-            LogicalResourceId: 'myDB',
-            PhysicalResourceId: 'stack-name-db-id',
-          },
-        ],
-      }),
+      request: () =>
+        BbPromise.resolve({
+          StackResourceSummaries: [
+            {
+              LogicalResourceId: 'myS3',
+              PhysicalResourceId: 'stack-name-s3-id',
+            },
+            {
+              LogicalResourceId: 'myDB',
+              PhysicalResourceId: 'stack-name-db-id',
+            },
+          ],
+        }),
     };
     return resolveCfRefValue(provider, 'myDB').then((result) => {
       expect(result).to.equal('stack-name-db-id');

--- a/test/unit/lib/plugins/config.test.js
+++ b/test/unit/lib/plugins/config.test.js
@@ -1,13 +1,16 @@
 'use strict';
 
-const fs = require('fs').promises;
+const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const BbPromise = require('bluebird');
 const { expect } = require('chai');
 const config = require('@serverless/utils/config');
 const ServerlessError = require('../../../../lib/serverless-error');
 const runServerless = require('../../../utils/run-serverless');
 const isTabCompletionSupported = require('../../../../lib/utils/tabCompletion/isSupported');
+
+BbPromise.promisifyAll(fs);
 
 const unexpected = () => {
   throw new Error('Unexpected');
@@ -41,12 +44,12 @@ describe('Config', () => {
       }).then(() =>
         Promise.all([
           fs
-            .readFile(path.resolve(os.homedir(), '.bashrc'), 'utf8')
+            .readFileAsync(path.resolve(os.homedir(), '.bashrc'), 'utf8')
             .then((bashRcContent) =>
               expect(bashRcContent).to.include(' ~/.config/tabtab/__tabtab.bash')
             ),
-          fs.readFile(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'), 'utf8'),
-          fs.readFile(path.resolve(os.homedir(), '.config/tabtab/sls.bash'), 'utf8'),
+          fs.readFileAsync(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'), 'utf8'),
+          fs.readFileAsync(path.resolve(os.homedir(), '.config/tabtab/sls.bash'), 'utf8'),
         ])
       ));
 
@@ -63,10 +66,10 @@ describe('Config', () => {
         }).then(() =>
           Promise.all([
             fs
-              .readFile(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'))
+              .readFileAsync(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'))
               .then(unexpected, (error) => expect(error.code).to.equal('ENOENT')),
             fs
-              .readFile(path.resolve(os.homedir(), '.config/tabtab/sls.bash'))
+              .readFileAsync(path.resolve(os.homedir(), '.config/tabtab/sls.bash'))
               .then(unexpected, (error) => expect(error.code).to.equal('ENOENT')),
           ])
         )

--- a/test/unit/lib/plugins/create/create.test.js
+++ b/test/unit/lib/plugins/create/create.test.js
@@ -9,11 +9,9 @@ const Serverless = require('../../../../../lib/Serverless');
 const sinon = require('sinon');
 const walkDirSync = require('../../../../../lib/utils/fs/walkDirSync');
 const download = require('../../../../../lib/utils/downloadTemplateFromRepo');
-const { ServerlessError } = require('../../../../../lib/serverless-error');
 const { getTmpDirPath } = require('../../../../utils/fs');
 
 chai.use(require('sinon-chai'));
-chai.use(require('chai-as-promised'));
 const { expect } = require('chai');
 
 const templatesPath = path.resolve(__dirname, '../../../../../lib/plugins/create/templates');
@@ -114,7 +112,7 @@ describe('Create', () => {
 
     it('should throw error if user passed unsupported template', () => {
       create.options.template = 'invalid-template';
-      expect(create.create()).to.be.eventually.rejectedWith(ServerlessError);
+      expect(() => create.create()).to.throw(Error);
     });
 
     it('should overwrite the name for the service if user passed name', () => {
@@ -1083,7 +1081,7 @@ describe('Create', () => {
       const dirContent = fs.readdirSync(tmpDir);
 
       expect(dirContent).to.include('serverless.yml');
-      expect(create.create()).to.be.eventually.rejectedWith(ServerlessError);
+      expect(() => create.create()).to.throw(Error);
     });
 
     it('should throw error if the directory for the service already exists in cwd', () => {
@@ -1094,7 +1092,7 @@ describe('Create', () => {
       fse.mkdirsSync(path.join(tmpDir, create.options.path));
       process.chdir(tmpDir);
 
-      expect(create.create()).to.be.eventually.rejectedWith(ServerlessError);
+      expect(() => create.create()).to.throw(Error);
     });
 
     it('should copy "aws-nodejs" template from local path', () => {

--- a/test/unit/lib/plugins/deploy.test.js
+++ b/test/unit/lib/plugins/deploy.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const chai = require('chai');
 const Deploy = require('../../../../lib/plugins/deploy');
 const Serverless = require('../../../../lib/Serverless');
@@ -70,7 +71,7 @@ describe('Deploy', () => {
       deploy.serverless.service.package.path = false;
 
       return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled.then(() =>
-        Promise.all([
+        BbPromise.all([
           expect(spawnDeployFunctionStub).to.not.be.called,
           expect(spawnPackageStub).to.be.calledOnce,
           expect(spawnPackageStub).to.be.calledWithExactly('package'),
@@ -84,7 +85,7 @@ describe('Deploy', () => {
       deploy.serverless.service.package.path = false;
 
       return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled.then(() =>
-        Promise.all([
+        BbPromise.all([
           expect(spawnPackageStub).to.not.be.called,
           expect(spawnDeployFunctionStub).to.be.calledOnce,
           expect(spawnDeployFunctionStub).to.be.calledWithExactly('deploy:function', {

--- a/test/unit/lib/plugins/interactiveCli/autoUpdate.test.js
+++ b/test/unit/lib/plugins/interactiveCli/autoUpdate.test.js
@@ -5,6 +5,8 @@ const sinon = require('sinon');
 const runServerless = require('../../../../utils/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 
+const fs = require('fs');
+const BbPromise = require('bluebird');
 const configUtils = require('@serverless/utils/config');
 const inquirer = require('@serverless/utils/inquirer');
 
@@ -14,6 +16,8 @@ const lifecycleHookNamesBlacklist = [
   'interactiveCli:setupAws',
   'interactiveCli:tabCompletion',
 ];
+
+BbPromise.promisifyAll(fs);
 
 const modulesCacheStub = {
   './lib/utils/npmPackage/isGlobal.js': async () => true,

--- a/test/unit/lib/plugins/interactiveCli/setupAws.test.js
+++ b/test/unit/lib/plugins/interactiveCli/setupAws.test.js
@@ -4,6 +4,7 @@ const { join } = require('path');
 const { homedir: getHomedir } = require('os');
 const { expect } = require('chai');
 const sinon = require('sinon');
+const BbPromise = require('bluebird');
 const { remove: rmDir, lstat, outputFile: writeFile } = require('fs-extra');
 const { resolveFileProfiles } = require('../../../../../lib/plugins/aws/utils/credentials');
 const inquirer = require('@serverless/utils/inquirer');
@@ -20,7 +21,10 @@ const lifecycleHookNamesBlacklist = [
 
 const openBrowserUrls = [];
 const modulesCacheStub = {
-  './lib/utils/openBrowser': async (url) => openBrowserUrls.push(url),
+  './lib/utils/openBrowser': (url) =>
+    BbPromise.try(() => {
+      openBrowserUrls.push(url);
+    }),
   // Ensure to rely on same inquirer module that we mock in tests
   '@serverless/utils/inquirer': inquirer,
 };

--- a/test/unit/lib/plugins/interactiveCli/tabCompletion.test.js
+++ b/test/unit/lib/plugins/interactiveCli/tabCompletion.test.js
@@ -6,8 +6,9 @@ const runServerless = require('../../../../utils/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 
 const os = require('os');
-const fs = require('fs').promises;
+const fs = require('fs');
 const path = require('path');
+const BbPromise = require('bluebird');
 const configUtils = require('@serverless/utils/config');
 const promptDisabledConfigPropertyName = require('../../../../../lib/utils/tabCompletion/promptDisabledConfigPropertyName');
 const isTabCompletionSupported = require('../../../../../lib/utils/tabCompletion/isSupported');
@@ -19,6 +20,8 @@ const lifecycleHookNamesBlacklist = [
   'interactiveCli:setupAws',
   'interactiveCli:autoUpdate',
 ];
+
+BbPromise.promisifyAll(fs);
 
 describe('interactiveCli: tabCompletion', () => {
   let backupIsTTY;
@@ -84,12 +87,12 @@ describe('interactiveCli: tabCompletion', () => {
     }).then(() =>
       Promise.all([
         fs
-          .readFile(path.resolve(os.homedir(), '.bashrc'), 'utf8')
+          .readFileAsync(path.resolve(os.homedir(), '.bashrc'), 'utf8')
           .then((bashRcContent) =>
             expect(bashRcContent).to.include(' ~/.config/tabtab/__tabtab.bash')
           ),
-        fs.readFile(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'), 'utf8'),
-        fs.readFile(path.resolve(os.homedir(), '.config/tabtab/sls.bash'), 'utf8'),
+        fs.readFileAsync(path.resolve(os.homedir(), '.config/tabtab/serverless.bash'), 'utf8'),
+        fs.readFileAsync(path.resolve(os.homedir(), '.config/tabtab/sls.bash'), 'utf8'),
       ])
     );
   });

--- a/test/unit/lib/plugins/invoke.test.js
+++ b/test/unit/lib/plugins/invoke.test.js
@@ -46,34 +46,32 @@ describe('Invoke', () => {
         expect(invoke.commands.invoke.commands.local.lifecycleEvents).to.contain('loadEnvVars');
       });
 
-      it('should set IS_LOCAL', () => {
-        invoke.hooks['invoke:local:loadEnvVars']();
-
-        expect(process.env.IS_LOCAL).to.equal('true');
-        expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
-      });
+      it('should set IS_LOCAL', () =>
+        expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
+          expect(process.env.IS_LOCAL).to.equal('true');
+          expect(serverless.service.provider.environment.IS_LOCAL).to.equal('true');
+        }));
 
       it('should leave provider env variable untouched if already defined', () => {
         serverless.service.provider.environment = { IS_LOCAL: 'false' };
-        invoke.hooks['invoke:local:loadEnvVars']();
-
-        expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
+        return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() => {
+          expect(serverless.service.provider.environment.IS_LOCAL).to.equal('false');
+        });
       });
 
       it('should accept a single env option', () => {
         invoke.options = { env: 'NAME=value' };
-        invoke.hooks['invoke:local:loadEnvVars']();
-
-        expect(process.env.NAME).to.equal('value');
+        return expect(invoke.hooks['invoke:local:loadEnvVars']()).to.be.fulfilled.then(() =>
+          expect(process.env.NAME).to.equal('value')
+        );
       });
 
       it('should accept multiple env options', () => {
         invoke.options = { env: ['NAME1=val1', 'NAME2=val2'] };
 
-        invoke.hooks['invoke:local:loadEnvVars']();
-
-        expect(process.env.NAME1).to.equal('val1');
-        expect(process.env.NAME2).to.equal('val2');
+        return expect(invoke.hooks['invoke:local:loadEnvVars']())
+          .to.be.fulfilled.then(() => expect(process.env.NAME1).to.equal('val1'))
+          .then(() => expect(process.env.NAME2).to.equal('val2'));
       });
     });
   });

--- a/test/unit/lib/plugins/plugin/list.test.js
+++ b/test/unit/lib/plugins/plugin/list.test.js
@@ -2,6 +2,7 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
+const BbPromise = require('bluebird');
 const PluginList = require('../../../../../lib/plugins/plugin/list');
 const Serverless = require('../../../../../lib/Serverless');
 const CLI = require('../../../../../lib/classes/CLI');
@@ -23,7 +24,7 @@ describe('PluginList', () => {
     let listStub;
 
     beforeEach(() => {
-      listStub = sinon.stub(pluginList, 'list').resolves();
+      listStub = sinon.stub(pluginList, 'list').returns(BbPromise.resolve());
     });
 
     afterEach(() => {
@@ -58,8 +59,8 @@ describe('PluginList', () => {
     let displayStub;
 
     beforeEach(() => {
-      getPluginsStub = sinon.stub(pluginList, 'getPlugins').resolves();
-      displayStub = sinon.stub(pluginList, 'display').resolves();
+      getPluginsStub = sinon.stub(pluginList, 'getPlugins').returns(BbPromise.resolve());
+      displayStub = sinon.stub(pluginList, 'display').returns(BbPromise.resolve());
     });
 
     afterEach(() => {

--- a/test/unit/lib/plugins/plugin/plugin.test.js
+++ b/test/unit/lib/plugins/plugin/plugin.test.js
@@ -2,6 +2,7 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
+const BbPromise = require('bluebird');
 const Plugin = require('../../../../../lib/plugins/plugin/plugin');
 const Serverless = require('../../../../../lib/Serverless');
 const CLI = require('../../../../../lib/classes/CLI');
@@ -25,7 +26,7 @@ describe('Plugin', () => {
     beforeEach(() => {
       generateCommandsHelpStub = sinon
         .stub(plugin.serverless.cli, 'generateCommandsHelp')
-        .resolves();
+        .returns(BbPromise.resolve());
     });
 
     afterEach(() => {

--- a/test/unit/lib/plugins/plugin/search.test.js
+++ b/test/unit/lib/plugins/plugin/search.test.js
@@ -2,6 +2,7 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
+const BbPromise = require('bluebird');
 const PluginSearch = require('../../../../../lib/plugins/plugin/search');
 const Serverless = require('../../../../../lib/Serverless');
 const CLI = require('../../../../../lib/classes/CLI');
@@ -47,7 +48,7 @@ describe('PluginSearch', () => {
     let searchStub;
 
     beforeEach(() => {
-      searchStub = sinon.stub(pluginSearch, 'search').resolves();
+      searchStub = sinon.stub(pluginSearch, 'search').returns(BbPromise.resolve());
     });
 
     afterEach(() => {
@@ -84,8 +85,8 @@ describe('PluginSearch', () => {
     let displayStub;
 
     beforeEach(() => {
-      getPluginsStub = sinon.stub(pluginSearch, 'getPlugins').resolves(plugins);
-      displayStub = sinon.stub(pluginSearch, 'display').resolves();
+      getPluginsStub = sinon.stub(pluginSearch, 'getPlugins').returns(BbPromise.resolve(plugins));
+      displayStub = sinon.stub(pluginSearch, 'display').returns(BbPromise.resolve());
     });
 
     afterEach(() => {

--- a/test/utils/kinesis.js
+++ b/test/utils/kinesis.js
@@ -1,22 +1,24 @@
 'use strict';
 
+const BbPromise = require('bluebird');
 const awsRequest = require('@serverless/test/aws-request');
-const wait = require('timers-ext/promise/sleep');
 
-async function waitForKinesisStream(streamName) {
+function waitForKinesisStream(streamName) {
   const params = {
     StreamName: streamName,
   };
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const data = await awsRequest('Kinesis', 'describeStream', params);
-    const status = data.StreamDescription.StreamStatus;
-    if (status === 'ACTIVE') {
-      return data;
-    }
-    await wait(2000);
-  }
+  return new BbPromise((resolve) => {
+    const interval = setInterval(() => {
+      awsRequest('Kinesis', 'describeStream', params).then((data) => {
+        const status = data.StreamDescription.StreamStatus;
+        if (status === 'ACTIVE') {
+          clearInterval(interval);
+          return resolve(data);
+        }
+        return null;
+      });
+    }, 2000);
+  });
 }
 
 function createKinesisStream(streamName) {


### PR DESCRIPTION
Reverts #9054, #9029, #9028, #8996, #8984, #8973, #8972, #8943

With a heavy heart, due to a few regressions introduced with recent Bluebird refactorings, we've decided to revert a few of the recent PRs with such refactorings and put on pause bigger changes related to `Bluebird` migration. Unfortunately, it's very easy to miss things during the review process of such refactors, some of the changes are also not caught by our test suite and we want to be more careful moving forward. We'd like to follow the process outlined in https://github.com/serverless/serverless/issues/7171 to limit the potential impacts and unexpected regressions for Framework users.

Potentially fixes #9073 