### PR TITLE
feat(Config Schema): Accept `accountId` as policy principal

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -395,7 +395,6 @@ class AwsProvider {
                   AWS: {
                     anyOf: [
                       { const: '*' },
-                      { type: 'array', items: { $ref: '#/definitions/awsArn' } },
                       {
                         type: 'array',
                         items: {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -256,10 +256,13 @@ class AwsProvider {
       // Below ideally should be in hooks.intialize, but variables resolution depend on this
       this.serverless.service.provider.region = this.getRegion();
       require('../../utils/awsSdkPatch');
-
       // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8016
       serverless.configSchemaHandler.defineProvider('aws', {
         definitions: {
+          awsAccountId: {
+            type: 'string',
+            pattern: '^\\d{12}$',
+          },
           awsAlbListenerArn: {
             type: 'string',
             pattern: ALB_LISTENER_REGEXP.source,
@@ -393,6 +396,7 @@ class AwsProvider {
                     anyOf: [
                       { const: '*' },
                       { type: 'array', items: { $ref: '#/definitions/awsArn' } },
+                      { type: 'array', items: { $ref: '#/definitions/awsAccountId' } },
                     ],
                   },
                   Federated: { type: 'array', items: { type: 'string' } },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -396,7 +396,15 @@ class AwsProvider {
                     anyOf: [
                       { const: '*' },
                       { type: 'array', items: { $ref: '#/definitions/awsArn' } },
-                      { type: 'array', items: { $ref: '#/definitions/awsAccountId' } },
+                      {
+                        type: 'array',
+                        items: {
+                          anyOf: [
+                            { $ref: '#/definitions/awsAccountId' },
+                            { $ref: '#/definitions/awsArn' },
+                          ],
+                        },
+                      },
                     ],
                   },
                   Federated: { type: 'array', items: { type: 'string' } },


### PR DESCRIPTION
Issue around using 
```yaml
    resourcePolicy:
      - Effect: Allow
        Principal:
          AWS: 
           - 123456789012
           - 987654321098
```
causing a schema validation warning
I have added `#/definitions/awsAccountId` and updated `awsIamPolicyPrincipal` to include it as a possible option

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: [#9077](https://github.com/serverless/serverless/issues/9077)