### PR TITLE
Fix dashboard error handling reporting

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const path = require('path');
-const { inspect } = require('util');
-const isError = require('type/error/is');
 const isObject = require('type/object/is');
 const chalk = require('chalk');
 const isStandaloneExecutable = require('../utils/isStandaloneExecutable');
@@ -11,24 +9,9 @@ const slsVersion = require('./../../package').version;
 const sfeVersion = require('@serverless/enterprise-plugin/package.json').version;
 const { sdkVersion } = require('@serverless/enterprise-plugin');
 const ServerlessError = require('../serverless-error');
+const tokenizeException = require('../utils/tokenize-exception');
 
-const userErrorNames = new Set(['ServerlessError', 'YAMLException']);
 const serverlessPath = path.resolve(__dirname, '../Serverless.js');
-
-const resolveExceptionMeta = (exception) => {
-  if (isError(exception)) {
-    return {
-      name: exception.name,
-      title: exception.name.replace(/([A-Z])/g, ' $1'),
-      stack: exception.stack,
-      message: exception.message,
-    };
-  }
-  return {
-    title: 'Exception',
-    message: inspect(exception),
-  };
-};
 
 const consoleLog = (message) => process.stdout.write(`${message}\n`);
 
@@ -84,14 +67,14 @@ module.exports = async (exception, options = {}) => {
     }
   }
 
-  const exceptionMeta = resolveExceptionMeta(exception);
-  const isUserError = !isUncaughtException && userErrorNames.has(exceptionMeta.name);
+  const exceptionTokens = tokenizeException(exception);
+  const isUserError = !isUncaughtException && exceptionTokens.isUserError;
 
   writeMessage(
-    exceptionMeta.title,
-    exceptionMeta.stack && (!isUserError || process.env.SLS_DEBUG)
-      ? exceptionMeta.stack
-      : exceptionMeta.message
+    exceptionTokens.title,
+    exceptionTokens.stack && (!isUserError || process.env.SLS_DEBUG)
+      ? exceptionTokens.stack
+      : exceptionTokens.message
   );
 
   if (!isUserError && !process.env.SLS_DEBUG) {

--- a/lib/utils/tokenize-exception.js
+++ b/lib/utils/tokenize-exception.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { inspect } = require('util');
+const isError = require('type/error/is');
+
+const userErrorNames = new Set(['ServerlessError', 'YAMLException']);
+
+module.exports = (exception) => {
+  if (isError(exception)) {
+    return {
+      title: exception.name.replace(/([A-Z])/g, ' $1').trim(),
+      name: exception.name,
+      stack: exception.stack,
+      message: exception.message,
+      isUserError: userErrorNames.has(exception.name),
+    };
+  }
+  return {
+    title: 'Exception',
+    message: inspect(exception),
+    isUserError: false,
+  };
+};

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -232,7 +232,17 @@ const processSpanPromise = (async () => {
       try {
         await enterpriseErrorHandler(error, serverless.invocationId);
       } catch (enterpriseErrorHandlerError) {
-        process.stdout.write(`${enterpriseErrorHandlerError.stack}\n`);
+        const log = require('@serverless/utils/log');
+        const tokenizeException = require('../lib/utils/tokenize-exception');
+        const exceptionTokens = tokenizeException(enterpriseErrorHandlerError);
+        log(
+          `Publication to Serverless Dashboard errored with:\n${' '.repeat('Serverless: '.length)}${
+            exceptionTokens.isUserError || !exceptionTokens.stack
+              ? exceptionTokens.message
+              : exceptionTokens.stack
+          }`,
+          { color: 'orange' }
+        );
       }
       throw error;
     }

--- a/test/unit/lib/utils/tokenize-exception.test.js
+++ b/test/unit/lib/utils/tokenize-exception.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const ServerlessError = require('../../../../lib/serverless-error');
+const tokenizeError = require('../../../../lib/utils/tokenize-exception');
+
+describe('test/unit/lib/utils/tokenize-exception.test.js', () => {
+  it('Should tokenize user error', () => {
+    const errorTokens = tokenizeError(new ServerlessError('Some error'));
+    expect(errorTokens.title).to.equal('Serverless Error');
+    expect(errorTokens.name).to.equal('ServerlessError');
+    expect(errorTokens.stack).to.include('tokenize-exception.test.js:');
+    expect(errorTokens.message).to.equal('Some error');
+    expect(errorTokens.isUserError).to.equal(true);
+  });
+
+  it('Should tokenize programmer error', () => {
+    const errorTokens = tokenizeError(new TypeError('Some error'));
+    expect(errorTokens.title).to.equal('Type Error');
+    expect(errorTokens.name).to.equal('TypeError');
+    expect(errorTokens.stack).to.include('tokenize-exception.test.js:');
+    expect(errorTokens.message).to.equal('Some error');
+    expect(errorTokens.isUserError).to.equal(false);
+  });
+
+  it('Should tokenize non-error exception', () => {
+    const errorTokens = tokenizeError(null);
+    expect(errorTokens.title).to.equal('Exception');
+    expect(errorTokens.message).to.equal('null');
+    expect(errorTokens.isUserError).to.equal(false);
+  });
+});


### PR DESCRIPTION
If dashboard error handler errors during reporting, we exposed that error with plain meaningful log.
This patch improves this DX.

Before:

<img width="910" alt="Screenshot 2021-03-05 at 13 50 29" src="https://user-images.githubusercontent.com/122434/110117935-e20f3000-7db9-11eb-96b5-2160406f1c9d.png">

After:

<img width="875" alt="Screenshot 2021-03-05 at 13 52 38" src="https://user-images.githubusercontent.com/122434/110118077-1682ec00-7dba-11eb-86d4-da49bd52942f.png">


