### PR TITLE
Variables: Improve resolution states handling

### DIFF
--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const ensureArray = require('type/array/ensure');
+const ensureSet = require('type/set/ensure');
 const ensureMap = require('type/map/ensure');
 const ensureString = require('type/string/ensure');
 const coerceString = require('type/string/coerce');
@@ -19,16 +20,20 @@ const ServerlessError = require('../../serverless-error');
 const humanizePropertyPath = require('./humanize-property-path-keys');
 const parse = require('./parse');
 const { parseEntries } = require('./resolve-meta');
+const VariableSourceResolutionError = require('./source-resolution-error');
+
+const objPropertyIsEnumerable = Object.prototype.propertyIsEnumerable;
 
 let lastResolutionBatchId = 0;
 
 class VariablesResolver {
-  constructor({ servicePath, configuration, variablesMeta, sources, options }) {
+  constructor({ servicePath, configuration, variablesMeta, sources, options, fulfilledSources }) {
     this.servicePath = servicePath;
     this.configuration = configuration;
     this.variablesMeta = variablesMeta;
     this.sources = sources;
     this.options = options;
+    this.fulfilledSources = fulfilledSources;
     this.propertyDependenciesMap = new Map();
     this.propertyResolutionNestDepthMap = new Map();
 
@@ -117,9 +122,9 @@ class VariablesResolver {
         // Unknown source, skip resolution (it'll leave variable as not resolved)
         return;
       }
-      let resolvedValue;
+      let resolvedData;
       try {
-        resolvedValue = await this.resolveVariableSource(
+        resolvedData = await this.resolveVariableSource(
           resolutionBatchId,
           propertyPath,
           sourceData
@@ -141,13 +146,13 @@ class VariablesResolver {
         variableMeta.error = error;
         return;
       }
-      if (resolvedValue != null) {
+      if (resolvedData.value != null) {
         // Source successfully resolved. Accept as final value
         delete variableMeta.sources;
-        variableMeta.value = resolvedValue;
+        variableMeta.value = resolvedData.value;
         return;
       }
-      if (sourceMeta.isIncomplete) {
+      if (resolvedData.isPending) {
         // Source resolved with "null", but is marked as not yet fulfilled
         // (not having all data available at this point)
         // Silently abort (it'll leave variable as not resolved)
@@ -197,34 +202,36 @@ class VariablesResolver {
         throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
       }
     }
-    const resultValue = await (async () => {
-      try {
-        return await this.resolveSource(resolutionBatchId, propertyPath, sourceData);
-      } catch (error) {
-        if (isError(error)) {
-          if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
-          if (
-            error.constructor.name === 'ServerlessError' &&
-            error.message.startsWith('Cannot resolve variable at ')
-          ) {
-            throw error;
+    return JSON.parse(
+      JSON.stringify(
+        await (async () => {
+          try {
+            return await this.resolveSource(resolutionBatchId, propertyPath, sourceData);
+          } catch (error) {
+            if (isError(error)) {
+              if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
+              if (
+                error.constructor.name === 'ServerlessError' &&
+                error.message.startsWith('Cannot resolve variable at ')
+              ) {
+                throw error;
+              }
+            }
+            const originalErrorMessage = (() => {
+              if (!isError(error)) return `Non-error exception: ${util.inspect(error)}`;
+              else if (error.constructor.name === 'ServerlessError') return error.message;
+              return error.stack;
+            })();
+            throw new ServerlessError(
+              `Cannot resolve variable at "${humanizePropertyPath(
+                propertyPath.split('\0')
+              )}": ${originalErrorMessage}`,
+              'VARIABLE_RESOLUTION_ERROR'
+            );
           }
-        }
-        const originalErrorMessage = (() => {
-          if (!isError(error)) return `Non-error exception: ${util.inspect(error)}`;
-          else if (error.constructor.name === 'ServerlessError') return error.message;
-          return error.stack;
-        })();
-        throw new ServerlessError(
-          `Cannot resolve variable at "${humanizePropertyPath(
-            propertyPath.split('\0')
-          )}": ${originalErrorMessage}`,
-          'VARIABLE_RESOLUTION_ERROR'
-        );
-      }
-    })();
-    if (!isObject(resultValue)) return resultValue;
-    return JSON.parse(JSON.stringify(resultValue));
+        })()
+      )
+    );
   }
   validateCrossPropertyDependency(dependentPropertyPath, dependencyPropertyPath) {
     if (dependentPropertyPath === dependencyPropertyPath) {
@@ -413,10 +420,11 @@ Object.defineProperties(
     resolveSource: d(
       async function (resolutionBatchId, propertyPath, sourceData) {
         // Resolve value from variables source, and ensure it's a typical JSON value.
-        const resultValue = await this.sources[sourceData.type].resolve({
+        const result = await this.sources[sourceData.type].resolve({
           params: sourceData.params && sourceData.params.map((param) => param.value),
           address: sourceData.address && sourceData.address.value,
           options: this.options,
+          isSourceFulfilled: this.fulfilledSources.has(sourceData.type),
           servicePath: this.servicePath,
           resolveConfigurationProperty: async (dependencyPropertyPathKeys) =>
             this.resolveDependentProperty(
@@ -425,6 +433,18 @@ Object.defineProperties(
               ensureArray(dependencyPropertyPathKeys, { ensureItem: ensureString })
             ),
         });
+        ensurePlainObject(result, {
+          errorMessage: `Unexpected "${sourceData.type}" source result: %v`,
+          Error: VariableSourceResolutionError,
+          errorCode: 'UNEXPECTED_RESULT',
+        });
+        if (!objPropertyIsEnumerable.call(result, 'value')) {
+          throw new VariableSourceResolutionError(
+            `Unexpected "${sourceData.type}" source result: Missing "value" property`,
+            'UNEXPECTED_RESULT_VALUE'
+          );
+        }
+        const resultValue = result.value;
         if (isPlainObject(resultValue) || Array.isArray(resultValue)) {
           try {
             JSON.parse(JSON.stringify(resultValue));
@@ -436,7 +456,7 @@ Object.defineProperties(
               'UNSUPPORTED_VARIABLE_RESOLUTION_RESULT'
             );
           }
-          return resultValue;
+          return result;
         }
         let normalizedResultValue;
         try {
@@ -457,7 +477,7 @@ Object.defineProperties(
             'UNSUPPORTED_VARIABLE_RESOLUTION_RESULT'
           );
         }
-        return resultValue;
+        return result;
       },
       {
         normalizer: ([resolutionBatchId, , { type, params, address }]) => {
@@ -484,6 +504,7 @@ module.exports = async (data) => {
   ensurePlainObject(data.sources);
   for (const { resolve } of Object.values(data.sources)) ensurePlainFunction(resolve);
   ensurePlainObject(data.options);
+  ensureSet(data.fulfilledSources);
 
   // Note: Below construct returns a promise, and not an actual VariablesResolver instance
   // Class construct is used purely for internal convinence

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -23,6 +23,7 @@ const { parseEntries } = require('./resolve-meta');
 const VariableSourceResolutionError = require('./source-resolution-error');
 
 const objPropertyIsEnumerable = Object.prototype.propertyIsEnumerable;
+const variableProcessingErrorNames = new Set(['ServerlessError', 'VariableSourceResolutionError']);
 
 let lastResolutionBatchId = 0;
 
@@ -131,7 +132,11 @@ class VariablesResolver {
         );
       } catch (error) {
         /* istanbul ignore next */
-        if (!error || !error.constructor || error.constructor.name !== 'ServerlessError') {
+        if (
+          !error ||
+          !error.constructor ||
+          !variableProcessingErrorNames.has(error.constructor.name)
+        ) {
           // Programmer error (ideally dead path)
           throw error;
         }
@@ -217,12 +222,19 @@ class VariablesResolver {
                 throw error;
               }
             }
+            let isServerlessError = false;
             const originalErrorMessage = (() => {
-              if (!isError(error)) return `Non-error exception: ${util.inspect(error)}`;
-              else if (error.constructor.name === 'ServerlessError') return error.message;
+              if (!isError(error)) {
+                return `Non-error exception: ${util.inspect(error)}`;
+              } else if (error.constructor.name === 'ServerlessError') {
+                isServerlessError = true;
+                return error.message;
+              } else if (error.constructor.name === 'VariableSourceResolutionError') {
+                return error.message;
+              }
               return error.stack;
             })();
-            throw new ServerlessError(
+            throw new (isServerlessError ? ServerlessError : VariableSourceResolutionError)(
               `Cannot resolve variable at "${humanizePropertyPath(
                 propertyPath.split('\0')
               )}": ${originalErrorMessage}`,
@@ -449,7 +461,7 @@ Object.defineProperties(
           try {
             JSON.parse(JSON.stringify(resultValue));
           } catch (error) {
-            throw new ServerlessError(
+            throw new VariableSourceResolutionError(
               `Source "${sourceData.type}" returned not supported result: "${util.inspect(
                 resultValue
               )}"`,
@@ -462,7 +474,7 @@ Object.defineProperties(
         try {
           normalizedResultValue = JSON.parse(JSON.stringify(resultValue));
         } catch (error) {
-          throw new ServerlessError(
+          throw new VariableSourceResolutionError(
             `Source "${sourceData.type}" returned not supported result: "${util.inspect(
               resultValue
             )}"`,
@@ -470,7 +482,7 @@ Object.defineProperties(
           );
         }
         if (resultValue !== normalizedResultValue) {
-          throw new ServerlessError(
+          throw new VariableSourceResolutionError(
             `Source "${sourceData.type}" returned not supported result: "${util.inspect(
               resultValue
             )}"`,

--- a/lib/configuration/variables/source-resolution-error.js
+++ b/lib/configuration/variables/source-resolution-error.js
@@ -1,0 +1,16 @@
+'use strict';
+
+class VariableSourceResolutionError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.code = code;
+  }
+}
+
+Object.defineProperty(VariableSourceResolutionError.prototype, 'name', {
+  value: VariableSourceResolutionError.name,
+  configurable: true,
+  writable: true,
+});
+
+module.exports = VariableSourceResolutionError;

--- a/lib/configuration/variables/sources/env.js
+++ b/lib/configuration/variables/sources/env.js
@@ -4,7 +4,7 @@ const ensureString = require('type/string/ensure');
 const ServerlessError = require('../../../serverless-error');
 
 module.exports = {
-  resolve: ({ address }) => {
+  resolve: ({ address, isSourceFulfilled }) => {
     if (!address) {
       throw new ServerlessError(
         'Missing address argument in variable "env" source',
@@ -16,6 +16,6 @@ module.exports = {
       errorMessage: 'Non-string address argument in variable "env" source: %v',
     });
 
-    return process.env[address] || null;
+    return { value: process.env[address] || null, isPending: !isSourceFulfilled };
   },
 };

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -140,7 +140,7 @@ module.exports = {
       }
     })();
 
-    if (!address) return content;
+    if (!address) return { value: content };
     if (!isObject(content)) {
       throw new ServerlessError(
         `Cannot resolve "${address}" out of "${path.basename(
@@ -150,7 +150,7 @@ module.exports = {
       );
     }
     const result = _.get(content, address, null);
-    if (!isPlainFunction(result)) return result;
+    if (!isPlainFunction(result)) return { value: result };
     if (!(await resolveConfigurationProperty(['variablesResolutionMode']))) {
       throw new ServerlessError(
         `Cannot resolve "${address}" out of "${path.basename(
@@ -161,7 +161,7 @@ module.exports = {
       );
     }
     try {
-      return await result({ options, resolveConfigurationProperty });
+      return { value: await result({ options, resolveConfigurationProperty }) };
     } catch (error) {
       throw new ServerlessError(
         `Cannot resolve "${address}" out of "${path.basename(filePath)}": Received rejection: ${

--- a/lib/configuration/variables/sources/opt.js
+++ b/lib/configuration/variables/sources/opt.js
@@ -11,6 +11,6 @@ module.exports = {
       errorMessage: 'Non-string address argument in variable "opt" source: %v',
     });
 
-    return address == null ? options : options[address] || null;
+    return { value: address == null ? options : options[address] || null };
   },
 };

--- a/lib/configuration/variables/sources/self.js
+++ b/lib/configuration/variables/sources/self.js
@@ -3,6 +3,6 @@
 module.exports = {
   resolve: async ({ address, resolveConfigurationProperty }) => {
     const result = await resolveConfigurationProperty(address ? address.split('.') : []);
-    return result == null ? null : result;
+    return { value: result == null ? null : result };
   },
 };

--- a/lib/configuration/variables/sources/str-to-bool.js
+++ b/lib/configuration/variables/sources/str-to-bool.js
@@ -17,8 +17,8 @@ module.exports = {
       errorMessage: 'Non-string "strToBool" input:. Received: %v',
     }).trim();
 
-    if (trueStrings.has(stringValue)) return true;
-    if (falseStrings.has(stringValue)) return false;
+    if (trueStrings.has(stringValue)) return { value: true };
+    if (falseStrings.has(stringValue)) return { value: false };
 
     throw new ServerlessError(
       'Invalid "strToBool" input: Expected either "true", "false", "0", or "1". ' +

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "tabtab": "^3.0.2",
     "tar": "^6.1.0",
     "timers-ext": "^0.1.7",
-    "type": "^2.3.0",
+    "type": "^2.5.0",
     "untildify": "^4.0.0",
     "uuid": "^8.3.2",
     "yaml-ast-parser": "0.0.43"
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.0.1",
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^7.10.0",
+    "@serverless/test": "^7.10.1",
     "chai": "^4.3.3",
     "chai-as-promised": "^7.1.1",
     "cos-nodejs-sdk-v5": "^2.9.10",

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -110,13 +110,14 @@ const processSpanPromise = (async () => {
             configuration,
             variablesMeta,
             sources: {
-              env: { ...require('../lib/configuration/variables/sources/env'), isIncomplete: true },
+              env: require('../lib/configuration/variables/sources/env'),
               file: require('../lib/configuration/variables/sources/file'),
               opt: require('../lib/configuration/variables/sources/opt'),
               self: require('../lib/configuration/variables/sources/self'),
               strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
             },
             options,
+            fulfilledSources: new Set(['file', 'self', 'strToBool']),
           };
           await resolveVariables(resolverConfiguration);
 
@@ -177,7 +178,7 @@ const processSpanPromise = (async () => {
           // Resolve eventually still not resolved configuration variables
           // (now "env" source is assumed as complete)
 
-          delete resolverConfiguration.sources.env.isIncomplete;
+          resolverConfiguration.fulfilledSources.add('env');
           await resolveVariables(resolverConfiguration);
           hasVariableResolutionFailed = eventuallyReportVariableResolutionErrors(
             configurationPath,

--- a/test/unit/lib/configuration/variables/source-resolution-error.test.js
+++ b/test/unit/lib/configuration/variables/source-resolution-error.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const VariableSourceResolutionError = require('../../../../../lib/configuration/variables/source-resolution-error');
+
+describe('test/unit/lib/configuration/variables/source-resolution-error.test.js', () => {
+  it('should store message', () => {
+    const error = new VariableSourceResolutionError('Some message');
+    expect(error.message).to.be.equal('Some message');
+  });
+
+  it('should expose constructor name', () => {
+    const error = new VariableSourceResolutionError('Some message');
+    expect(error.name).to.be.equal('VariableSourceResolutionError');
+  });
+
+  it('should store code', () => {
+    const error = new VariableSourceResolutionError('Some message', 'ERROR_CODE');
+    expect(error.code).to.be.equal('ERROR_CODE');
+  });
+
+  it('message should always resolve as string', () => {
+    const error = new VariableSourceResolutionError({});
+    expect(typeof error.message).to.be.equal('string');
+  });
+
+  it('should have stack trace', () => {
+    function testStackFrame() {
+      throw new VariableSourceResolutionError('Some message');
+    }
+
+    try {
+      testStackFrame();
+    } catch (error) {
+      expect(error.stack).to.have.string('testStackFrame');
+    }
+  });
+});

--- a/test/unit/lib/configuration/variables/sources/env.test.js
+++ b/test/unit/lib/configuration/variables/sources/env.test.js
@@ -26,6 +26,7 @@ describe('test/unit/lib/configuration/variables/sources/env.test.js', () => {
       variablesMeta,
       sources: { env: envSource, self: selfSource },
       options: {},
+      fulfilledSources: new Set(['env']),
     });
   });
 

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -50,6 +50,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       variablesMeta,
       sources: { file: fileSource },
       options: {},
+      fulfilledSources: new Set(['file']),
     });
   });
 
@@ -158,6 +159,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       variablesMeta,
       sources: { file: fileSource },
       options: {},
+      fulfilledSources: new Set(['file']),
     });
     expect(variablesMeta.get('jsFunction').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
     expect(variablesMeta.get('jsPropertyFunction').error.code).to.equal(

--- a/test/unit/lib/configuration/variables/sources/opt.test.js
+++ b/test/unit/lib/configuration/variables/sources/opt.test.js
@@ -25,6 +25,7 @@ describe('test/unit/lib/configuration/variables/sources/opt.test.js', () => {
       variablesMeta,
       sources: { opt: optSource, self: selfSource },
       options: { foobar: 'elo' },
+      fulfilledSources: new Set(['opt']),
     });
   });
 

--- a/test/unit/lib/configuration/variables/sources/self.test.js
+++ b/test/unit/lib/configuration/variables/sources/self.test.js
@@ -27,6 +27,7 @@ describe('test/unit/lib/configuration/variables/sources/self.test.js', () => {
       variablesMeta: resolveMeta(configuration),
       sources: { self: selfSource },
       options: {},
+      fulfilledSources: new Set(['self']),
     });
 
     expect(configuration).to.deep.equal({
@@ -57,6 +58,7 @@ describe('test/unit/lib/configuration/variables/sources/self.test.js', () => {
       variablesMeta,
       sources: { self: selfSource },
       options: {},
+      fulfilledSources: new Set(['self']),
     });
     expect(configuration).to.deep.equal({ foo: '${self:}' });
     expect(variablesMeta.get('foo').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');

--- a/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
+++ b/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
@@ -23,6 +23,7 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
       variablesMeta,
       sources: { strToBool: strToBoolSource },
       options: {},
+      fulfilledSources: new Set(['strToBool']),
     });
   });
 


### PR DESCRIPTION
Part of  #8364

__Notice__: https://github.com/serverless/test/pull/86 is needed to be merged and published, for tests to pass

More powerful handling of _pending_ sources (e.g. `env` before evntual other env variables are loaded from `.env` or `opt` before we know the full options schema of used command)

In so far implementation, source was marked upfront as `isIncomplete` and then any `null` resolved from it was treated as possibly incomplete resolution that should be confirmed after source is incomplete.

Still in case of `opt` source (when we will know full schema of options) it'll be possible to know upfront that value for supported option is `null` (even if we don't have a schema for all possible commands or options available), and so far implementation didn't give a room to communicate that.

After this change it's source resolver which will provide an answer whether it's a final result, or is the value eventually pending, for that reason result from source was refactored to be in format of `{ value[, isPending] }`, instead of just `value`.

Additionally invalid results from source resolvers are now communicated with `VariableSourceResolutionError` and not `ServerlessError`, as they should not be treated as _user_ errors but _programmer_ errors.