### PR TITLE
feat(CLI): Report Platform Client instead of SDK version

### DIFF
--- a/lib/cli/list-version.js
+++ b/lib/cli/list-version.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { version } = require('../../package');
 const { version: dashboardPluginVersion } = require('@serverless/enterprise-plugin/package');
 const { version: componentsVersion } = require('@serverless/components/package');
-const { sdkVersion } = require('@serverless/enterprise-plugin');
+const { platformClientVersion } = require('@serverless/enterprise-plugin');
 const isStandaloneExecutable = require('../utils/isStandaloneExecutable');
 const resolveLocalServerlessPath = require('./resolve-local-serverless-path');
 const chalk = require('chalk');
@@ -55,7 +55,7 @@ module.exports = async () => {
   process.stdout.write(
     `Framework Core: ${version}${installationModePostfix}\n` +
       `Plugin: ${dashboardPluginVersion}\n` +
-      `SDK: ${sdkVersion}\n` +
+      `SDK: ${platformClientVersion}\n` +
       `Components: ${componentsVersion}\n`
   );
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@serverless/cli": "^1.5.2",
     "@serverless/components": "^3.7.2",
-    "@serverless/enterprise-plugin": "^4.4.3",
+    "@serverless/enterprise-plugin": "^4.5.0",
     "@serverless/utils": "^3.1.0",
     "ajv": "^6.12.6",
     "ajv-keywords": "^3.5.2",

--- a/test/unit/lib/cli/list-version.test.js
+++ b/test/unit/lib/cli/list-version.test.js
@@ -12,5 +12,6 @@ describe('test/unit/lib/cli/list-version.test.js', () => {
       () => listVersion()
     );
     expect(stdoutData).to.have.string('Framework Core: ');
+    expect(stdoutData).to.have.string('SDK: ');
   });
 });


### PR DESCRIPTION
Upgrade `@serverless/enterprise-plugin` and use `platformClientVersion` instead of deprecated `sdkVersion` for reporting. 

