### PR TITLE
fix(CLI): Properly report SDK version when handling errors

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -7,7 +7,7 @@ const isStandaloneExecutable = require('../utils/isStandaloneExecutable');
 const resolveLocalServerlessPath = require('./resolve-local-serverless-path');
 const slsVersion = require('./../../package').version;
 const sfeVersion = require('@serverless/enterprise-plugin/package.json').version;
-const { sdkVersion } = require('@serverless/enterprise-plugin');
+const { platformClientVersion } = require('@serverless/enterprise-plugin');
 const ServerlessError = require('../serverless-error');
 const tokenizeException = require('../utils/tokenize-exception');
 
@@ -109,7 +109,7 @@ module.exports = async (exception, options = {}) => {
     chalk.yellow(`     Framework Version:         ${slsVersion}${installationModePostfix}`)
   );
   consoleLog(chalk.yellow(`     Plugin Version:            ${sfeVersion}`));
-  consoleLog(chalk.yellow(`     SDK Version:               ${sdkVersion}`));
+  consoleLog(chalk.yellow(`     SDK Version:               ${platformClientVersion}`));
 
   const componentsVersion = (() => {
     try {

--- a/test/unit/lib/cli/handle-error.test.js
+++ b/test/unit/lib/cli/handle-error.test.js
@@ -23,6 +23,7 @@ describe('test/unit/lib/cli/handle-error.test.js', () => {
     expect(stdoutData).to.have.string('Node Version:');
     expect(stdoutData).to.have.string('Framework Version:');
     expect(stdoutData).to.have.string('Plugin Version:');
+    expect(stdoutData).to.have.string('SDK Version:');
     expect(stdoutData).to.have.string('Components Version:');
   });
 


### PR DESCRIPTION
Follow up to: https://github.com/serverless/serverless/pull/9092

I've missed the fact that for errors we're using a bit different reporting and I didn't update it - this PR aims to fix it.