### PR TITLE
fix(AWS IAM): Accept `arn:${AWS::Partition}` in function roles

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -70,7 +70,7 @@ class AwsCompileFunctions {
   compileRole(newFunction, role) {
     const compiledFunction = newFunction;
     if (typeof role === 'string') {
-      if (role.startsWith('arn:aws')) {
+      if (role.startsWith('arn:')) {
         // role is a statically defined iam arn
         compiledFunction.Properties.Role = role;
       } else if (role === 'IamRoleLambdaExecution') {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -237,15 +237,15 @@ describe('AwsCompileFunctions', () => {
         fixture: 'function',
         configExt: {
           provider: {
-            role: 'arn:role-a',
-            iam: { role: 'arn:role-b' },
+            role: 'role-a',
+            iam: { role: 'role-b' },
           },
         },
         cliArgs: ['package'],
       });
 
       expect(cfTemplate.Resources.FooLambdaFunction.Properties.Role).to.eql({
-        'Fn::GetAtt': ['arn:role-b', 'Arn'],
+        'Fn::GetAtt': ['role-b', 'Arn'],
       });
     });
 


### PR DESCRIPTION
This small fix allows you to use role ARNs that contain ${AWS::Partition} pseudo-variables. For example:

```
functions:
  myfunc:
    role: arn:${AWS::Partition}:iam::${AWS::AccountId}:/role/myfuncrole
```