### PR TITLE
Variables: Retry JS function resolvers on unresolved dependencies

### DIFF
--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -115,6 +115,7 @@ module.exports = {
             try {
               return await result({ options, resolveConfigurationProperty });
             } catch (error) {
+              if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
               throw new ServerlessError(
                 `Cannot resolve "${path.basename(filePath)}": Returned JS function errored with: ${
                   error && error.stack ? error.stack : error
@@ -163,6 +164,7 @@ module.exports = {
     try {
       return { value: await result({ options, resolveConfigurationProperty }) };
     } catch (error) {
+      if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
       throw new ServerlessError(
         `Cannot resolve "${address}" out of "${path.basename(filePath)}": Received rejection: ${
           error && error.stack ? error.stack : error

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -29,10 +29,14 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       jsFilePromiseRejected: '${file(file-promise-rejected.js)}',
       jsFilePromiseRejectedNonError: '${file(file-promise-rejected-non-error.js)}',
       jsFileFunctionErrored: '${file(file-function-errored.js)}',
+      jsFileFunctionAccessUnresolvableProperty:
+        '${file(file-function-access-unresolvable-property.js)}',
       jsFileFunctionErroredNonError: '${file(file-function-errored-non-error.js)}',
       jsFilePropertyFunctionErrored: '${file(file-property-function-errored.js):property}',
       jsFilePropertyFunctionErroredNonError:
         '${file(file-property-function-errored-non-error.js):property}',
+      jsFilePropertyFunctionAccessUnresolvableProperty:
+        '${file(file-property-function-access-unresolvable-property.js):property}',
       notFile: '${file(dir.yaml)}',
       noParams: '${file:}',
       noParams2: '${file():}',
@@ -42,6 +46,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       invalidJs: '${file(invalid.js)}',
       invalidJs2: '${file(invalid2.js)}',
       nonStandardExt: '${file(non-standard.ext)}',
+      unresolvable: '${unknown:}',
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
@@ -91,6 +96,17 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     // .trim() as depending on local .git settings and OS (Windows or other)
     // checked out fixture may end with differen type of EOL (\n on linux, and \r\n on Windows)
     expect(configuration.nonStandardExt.trim()).to.equal('result: non-standard'.trim()));
+
+  it('should mark as unresolved if function crashes with misisng property dependency', () => {
+    const propertyMeta = variablesMeta.get('jsFileFunctionAccessUnresolvableProperty');
+    if (propertyMeta.error) throw propertyMeta.error;
+    expect(propertyMeta).to.have.property('variables');
+  });
+  it('should mark as unresolved if property function crashes with misisng property dependency', () => {
+    const propertyMeta = variablesMeta.get('jsFilePropertyFunctionAccessUnresolvableProperty');
+    if (propertyMeta.error) throw propertyMeta.error;
+    expect(propertyMeta).to.have.property('variables');
+  });
 
   it('should report with an error address argument on primitive content', () =>
     expect(variablesMeta.get('primitiveAddress').error.code).to.equal('VARIABLE_RESOLUTION_ERROR'));

--- a/test/unit/lib/configuration/variables/sources/fixture/file-function-access-unresolvable-property.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-function-access-unresolvable-property.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports = ({ resolveConfigurationProperty }) =>
+  resolveConfigurationProperty(['unresolvable']);

--- a/test/unit/lib/configuration/variables/sources/fixture/file-property-function-access-unresolvable-property.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-property-function-access-unresolvable-property.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports.property = ({ resolveConfigurationProperty }) =>
+  resolveConfigurationProperty(['unresolvable']);


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Fixes: #9105

When JS function resolvers approach a property that cannot be resolved at given resolution phase, they should be retried (re-run) in next resolution phase