### PR TITLE
fix(AWS EventBridge): Clarify CF functions support for `eventBus`

### DIFF
--- a/docs/providers/aws/events/event-bridge.md
+++ b/docs/providers/aws/events/event-bridge.md
@@ -16,6 +16,8 @@ layout: Doc
 
 The [EventBridge](https://aws.amazon.com/eventbridge/) makes it possible to connect applications using data from external sources (e.g. own applications, SaaS) or AWS services. The `eventBridge` event types helps setting up AWS Lambda functions to react to events coming in via the EventBridge.
 
+_Note_: Prior to `2.27.0` version of the Framework, `eventBridge` resources were provisioned with Custom Resources. With `2.27.0` an optional support for native CloudFormation was introduced and can be turned on by setting `provider.eventBridge.useCloudFormation` property to `true`. It is recommended to migrate to native CloudFormation as it will become a default with next major version. It also adds the ability to define `eventBus` with CF intrinsic functions as values.
+
 ## Setting up a scheduled event
 
 ```yml
@@ -51,9 +53,7 @@ functions:
 
 The `eventBridge` event source will use the `default` event bus (the one AWS uses internally) when none is explicitly specified.
 
-The Serverless Framework will create the `eventBus` for you if you just provide a name for it. It will re-use an existing event bus if you provide an event bus `arn`.
-
-**NOTE:** The Serverless Framework won't manage (e.g. create or remove) the event bus if it's provided via an `arn`.
+The Serverless Framework will create the `eventBus` for your if you provide a name for it. Otherwise, if literal `arn` or reference to an existing event bus name via CF intrinsic function is provided, Framework will attach to it.
 
 ### Creating an event bus
 
@@ -71,9 +71,43 @@ functions:
 
 ### Re-using an existing event bus
 
+If you want to reuse an existing event bus, you can define it with literal `arn` or with a reference to an existing event bus name via CF intrinsic functions. Referencing via intrinsic functions in available only if you use native CloudFormation support with `provider.eventBridge.useCloudFormation: true` setting.
+
+Using literal `arn`:
+
 ```yml
 - eventBridge:
     eventBus: arn:aws:events:us-east-1:12345:event-bus/custom-private-events
+    pattern:
+      source:
+        - custom.private
+    inputTransformer:
+      inputPathsMap:
+        eventTime: '$.time'
+      inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
+```
+
+Using reference to event bus' name via `GetAtt` CF intrinsic function:
+
+```yml
+- eventBridge:
+    eventBus: !GetAtt EventBusResource.Name
+    pattern:
+      source:
+        - custom.private
+    inputTransformer:
+      inputPathsMap:
+        eventTime: '$.time'
+      inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
+```
+
+_Note_: It is not possible to reference event bus ARN with CF intrinsic function as it makes it impossible for Serverless Framework to construct valid `SourceArn` for `AWS::Lambda::Permission` resource.
+
+Using reference to event bus' name via `Ref` CF intrinsic functions:
+
+```yml
+- eventBridge:
+    eventBus: !Ref EventBusResource
     pattern:
       source:
         - custom.private

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -32,7 +32,29 @@ class AwsCompileEventBridgeEvents {
       type: 'object',
       properties: {
         eventBus: {
-          anyOf: [{ type: 'string', minLength: 1 }, { $ref: '#/definitions/awsArn' }],
+          anyOf: [
+            { type: 'string', minLength: 1 },
+            { $ref: '#/definitions/awsArnString' },
+            { $ref: '#/definitions/awsCfImport' },
+            { $ref: '#/definitions/awsCfRef' },
+            // GetAtt should only reference "Name" property of EventBus
+            {
+              type: 'object',
+              properties: {
+                'Fn::GetAtt': {
+                  type: 'array',
+                  minItems: 2,
+                  maxItems: 2,
+                  items: [
+                    { type: 'string', minLength: 1 },
+                    { type: 'string', enum: ['Name'] },
+                  ],
+                },
+              },
+              required: ['Fn::GetAtt'],
+              additionalProperties: false,
+            },
+          ],
         },
         schedule: { pattern: '^(?:cron|rate)\\(.+\\)$' },
         pattern: {


### PR DESCRIPTION
Clarify the support for CF intrinsic functions for `eventBridge.eventBus` setting + throw an error when someone defines it with a reference to ARN via CF function