### PR TITLE
fix(AWS Lambda): Ensure correct schema for `vpc` definition

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -495,6 +495,8 @@ class AwsProvider {
                 maxItems: 16,
               },
             },
+            additionalProperties: false,
+            required: ['securityGroupIds', 'subnetIds'],
           },
           awsLogGroupName: {
             type: 'string',


### PR DESCRIPTION
Currently, invalid `vpc` configuration was failing silently in cases where e.g. one of the properties was missing or had a typo in it - behind the scenes Framework was removing the VPC configuration altogether during compilation which wasn't visible to end user. This aims to fix it by ensuring both properties are present (it is a requirement: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-vpcconfig.html) and that no other properties are provided. 