### PR TITLE
Fix AWS credentials resolution

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1321,7 +1321,7 @@ class AwsProvider {
     const serviceOptions = {
       name: service,
       params: {
-        credentials: credentials.credentials,
+        credentials,
         region: _.get(requestOptions, 'region', this.getRegion()),
         isS3TransferAccelerationEnabled: this.isS3TransferAccelerationEnabled(),
       },

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -482,7 +482,7 @@ describe('AwsProvider', () => {
 
   describe('#request()', () => {
     let awsRequestStub;
-    let PAwsProvider;
+    let awsProviderProxied;
     let logStub;
 
     beforeEach(() => {
@@ -495,20 +495,21 @@ describe('AwsProvider', () => {
           '../../aws/request': awsRequestStub,
           '@serverless/utils/log': logStub,
         });
-      PAwsProvider = new AwsProviderProxyquired(serverless, options);
+      awsProviderProxied = new AwsProviderProxyquired(serverless, options);
     });
 
     afterEach(() => {});
 
     it('should trigger the expected AWS SDK invokation', () => {
-      return PAwsProvider.request('S3', 'getObject', {}).then(() => {
+      return awsProviderProxied.request('S3', 'getObject', {}).then(() => {
         expect(awsRequestStub).to.have.been.calledOnce;
       });
     });
 
     it('should use local cache when using {useCache: true}', () => {
-      return PAwsProvider.request('S3', 'getObject', {}, { useCache: true })
-        .then(() => PAwsProvider.request('S3', 'getObject', {}, { useCache: true }))
+      return awsProviderProxied
+        .request('S3', 'getObject', {}, { useCache: true })
+        .then(() => awsProviderProxied.request('S3', 'getObject', {}, { useCache: true }))
         .then(() => {
           expect(awsRequestStub).to.not.have.been.called;
           expect(awsRequestStub.memoized).to.have.been.calledTwice;
@@ -518,7 +519,8 @@ describe('AwsProvider', () => {
     it('should detect incompatible legacy use of aws request and print a debug warning', () => {
       // Enable debug log
       process.env.SLS_DEBUG = true;
-      return PAwsProvider.request('S3', 'getObject', {}, 'incompatible string option')
+      return awsProviderProxied
+        .request('S3', 'getObject', {}, 'incompatible string option')
         .then(() => {
           expect(logStub).to.have.been.calledWith(
             'WARNING: Inappropriate call of provider.request()'

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -500,6 +500,23 @@ describe('AwsProvider', () => {
 
     afterEach(() => {});
 
+    it('should pass resolved credentials as expected', async () => {
+      awsProviderProxied.cachedCredentials = {
+        accessKeyId: 'accessKeyId',
+        secretAccessKey: 'secretAccessKey',
+        sessionToken: 'sessionToken',
+      };
+      await awsProviderProxied.request('S3', 'getObject', {});
+      expect(awsRequestStub.args[0][0]).to.deep.equal({
+        name: 'S3',
+        params: {
+          credentials: awsProviderProxied.cachedCredentials,
+          region: 'us-east-1',
+          isS3TransferAccelerationEnabled: false,
+        },
+      });
+    });
+
     it('should trigger the expected AWS SDK invokation', () => {
       return awsProviderProxied.request('S3', 'getObject', {}).then(() => {
         expect(awsRequestStub).to.have.been.calledOnce;


### PR DESCRIPTION
Unfortunate regression introduced with https://github.com/serverless/serverless/pull/8850

This sensitive part was not really covered by tests, hence it sneaked in.

Technically internal resolution of AWS credentials is ineffective, and if commands work, it's only because AWS SDK resolves credentials on its own

Closes: #9119
