### PR TITLE
fix: Ensure to handle empty func definition with meaningful error

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -2,6 +2,7 @@
 
 const { ServerlessError, logWarning } = require('./Error');
 const path = require('path');
+const util = require('util');
 const _ = require('lodash');
 const semver = require('semver');
 const isHelpRequest = require('../cli/is-help-request');
@@ -173,9 +174,17 @@ class Service {
     options.stage = options.stage || options.s;
     options.region = options.region || options.r;
 
-    // setup function.name property
+    // Ensure that function is an object and setup function.name property
     const stageNameForFunction = options.stage || this.provider.stage;
     Object.entries(this.functions).forEach(([functionName, functionObj]) => {
+      if (!_.isObject(functionObj)) {
+        throw new ServerlessError(
+          `Unexpected "${functionName}" function configuration: Expected object received ${util.inspect(
+            functionObj
+          )})`,
+          'NON_OBJECT_FUNCTION_CONFIGURATION_ERROR'
+        );
+      }
       if (!functionObj.events) {
         this.functions[functionName].events = [];
       }

--- a/test/unit/lib/classes/Service.test.js
+++ b/test/unit/lib/classes/Service.test.js
@@ -115,14 +115,31 @@ describe('Service', () => {
   });
 
   describe('#setFunctionNames()', () => {
-    it('should make sure function name contains the default stage', () =>
-      runServerless({
+    it('should make sure function name contains the default stage', async () => {
+      const { cfTemplate, awsNaming } = await runServerless({
         fixture: 'function',
         cliArgs: ['package'],
-      }).then(({ cfTemplate, awsNaming }) =>
-        expect(
-          cfTemplate.Resources[awsNaming.getLambdaLogicalId('foo')].Properties.FunctionName
-        ).to.include('dev-foo')
-      ));
+      });
+      expect(
+        cfTemplate.Resources[awsNaming.getLambdaLogicalId('foo')].Properties.FunctionName
+      ).to.include('dev-foo');
+    });
+
+    it('should throw when receives function with non-object configuration', async () => {
+      await expect(
+        runServerless({
+          fixture: 'function',
+          cliArgs: ['package'],
+          configExt: {
+            functions: {
+              bar: null,
+            },
+          },
+        })
+      ).to.be.eventually.rejected.and.have.property(
+        'code',
+        'NON_OBJECT_FUNCTION_CONFIGURATION_ERROR'
+      );
+    });
   });
 });


### PR DESCRIPTION
It was uncovered with https://github.com/serverless/serverless/issues/9130 that the Framework does not handle situation where someone provides an empty function definition gracefully and instead throws an error that it's not very helpful for user. This PR aims to fix this by ensuring that `functionObj` is always an object which lets our schema engine do the rest of the validation. 

Before the error looked like:
```
Type Error ----------------------------------------------
 
  TypeError: Cannot read property 'events' of null
      at testing/node_modules/serverless/lib/classes/Service.js:179:24
      at Array.forEach (<anonymous>)
      at Service.setFunctionNames (testing/node_modules/serverless/lib/classes/Service.js:178:36)
      at Serverless.run (testing/node_modules/serverless/lib/Serverless.js:265:18)
      at testing/node_modules/serverless/scripts/serverless.js:240:24
```

Now it's 
```
Serverless Error ----------------------------------------

  Either "handler" or "image" property needs to be set on function "XYZHandler"

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information ---------------------------
     Operating System:          linux
     Node Version:              10.23.0
     Framework Version:         2.30.3
     Plugin Version:            4.5.1
     SDK Version:               4.2.0
     Components Version:        3.7.3

```

Addresses: #9130 