### PR TITLE
Added enabled flag to apiKey settings #8791

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -7,10 +7,11 @@ function createApiKeyResource(that, apiKey) {
   const value = _.isObject(apiKey) && apiKey.value ? apiKey.value : undefined;
   const description = _.isObject(apiKey) ? apiKey.description : undefined;
   const customerId = _.isObject(apiKey) ? apiKey.customerId : undefined;
+  const enabled = _.isObject(apiKey) && !_.isUndefined(apiKey.enabled) ? apiKey.enabled : true;
   const resourceTemplate = {
     Type: 'AWS::ApiGateway::ApiKey',
     Properties: {
-      Enabled: true,
+      Enabled: enabled,
       Name: name,
       Value: value,
       Description: description,

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -280,6 +280,7 @@ class AwsProvider {
                     value: { type: 'string' },
                     description: { type: 'string' },
                     customerId: { type: 'string' },
+                    enabled: { type: 'boolean' },
                   },
                   anyOf: [{ required: ['name'] }, { required: ['value'] }],
                   additionalProperties: false,

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
@@ -38,6 +38,14 @@ describe('#compileApiKeys()', () => {
           value: 'valueForKey9876543211',
           customerId: 'customerid98765',
         },
+        {
+          name: '4567890123',
+          enabled: false,
+        },
+        {
+          name: '5678901234',
+          enabled: true,
+        },
       ],
       // Added purely to test https://github.com/serverless/serverless/issues/7844 regression
       usagePlan: {
@@ -52,30 +60,49 @@ describe('#compileApiKeys()', () => {
         value: undefined,
         description: undefined,
         customerId: undefined,
+        enabled: true,
       },
       {
         name: '2345678901',
         value: undefined,
         description: undefined,
         customerId: undefined,
+        enabled: true,
       },
       {
         name: undefined,
         value: 'valueForKeyWithoutName',
         description: 'Api key description',
         customerId: undefined,
+        enabled: true,
       },
       {
         name: '3456789012',
         value: 'valueForKey3456789012',
         description: undefined,
         customerId: undefined,
+        enabled: true,
       },
       {
         name: '9876543211',
         value: 'valueForKey9876543211',
         description: undefined,
         customerId: 'customerid98765',
+        enabled: true,
+      },
+      {
+        name: '4567890123',
+        value: undefined,
+        description: undefined,
+        customerId: undefined,
+        enabled: false,
+      },
+      {
+        name: '5678901234',
+        value: undefined,
+        description: undefined,
+        customerId: undefined,
+        enabled: true,
       },
     ];
 
@@ -90,7 +117,7 @@ describe('#compileApiKeys()', () => {
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources[
           awsCompileApigEvents.provider.naming.getApiKeyLogicalId(index + 1)
         ].Properties.Enabled
-      ).to.equal(true);
+      ).to.equal(apiKey.enabled);
 
       expect(
         awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources[
@@ -149,9 +176,12 @@ describe('#compileApiKeys()', () => {
                 description: 'Api key description',
               },
               { name: '3456789012', value: 'valueForKey3456789012' },
+              { name: '4567890123', enabled: false },
             ],
           },
-          { paid: ['0987654321', 'jihgfedcba'] },
+          {
+            paid: ['0987654321', 'jihgfedcba', { name: '5678901234', enabled: true }],
+          },
         ],
         usagePlan: [{ free: [] }, { paid: [] }],
       };
@@ -159,22 +189,31 @@ describe('#compileApiKeys()', () => {
       awsCompileApigEvents.compileApiKeys();
       const expectedApiKeys = {
         free: [
-          { name: '1234567890', value: undefined, description: undefined },
-          { name: '2345678901', value: undefined, description: undefined },
+          { name: '1234567890', value: undefined, description: undefined, enabled: true },
+          { name: '2345678901', value: undefined, description: undefined, enabled: true },
           {
             name: undefined,
             value: 'valueForKeyWithoutName',
             description: 'Api key description',
+            enabled: true,
           },
           {
             name: '3456789012',
             value: 'valueForKey3456789012',
             description: undefined,
+            enabled: true,
+          },
+          {
+            name: '4567890123',
+            value: undefined,
+            description: undefined,
+            enabled: false,
           },
         ],
         paid: [
-          { name: '0987654321', value: undefined, description: undefined },
-          { name: 'jihgfedcba', value: undefined, description: undefined },
+          { name: '0987654321', value: undefined, description: undefined, enabled: true },
+          { name: 'jihgfedcba', value: undefined, description: undefined, enabled: true },
+          { name: '5678901234', value: undefined, description: undefined, enabled: true },
         ],
       };
       awsCompileApigEvents.serverless.service.provider.apiGateway.apiKeys.forEach((plan) => {
@@ -192,7 +231,7 @@ describe('#compileApiKeys()', () => {
               .Resources[
               awsCompileApigEvents.provider.naming.getApiKeyLogicalId(index + 1, planName)
             ].Properties.Enabled
-          ).to.equal(true);
+          ).to.equal(apiKey.enabled);
           expect(
             awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate
               .Resources[


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

• Based on proposed solution, add optional enabled flag to apiKeys or default to true if none provided. 

Closes: #8791
