### PR TITLE
fix(Packaging): Ensure to properly exclude when NODE_ENV set

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -182,7 +182,15 @@ function excludeNodeDevDependencies(servicePath) {
           return childProcess
             .execAsync(
               `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
-              { cwd: dirWithPackageJson }
+              {
+                cwd: dirWithPackageJson,
+                // We are overriding `NODE_ENV` because when it is set to "production"
+                // it causes invalid output of `npm ls` with `--dev=true`
+                env: {
+                  ...process.env,
+                  NODE_ENV: null,
+                },
+              }
             )
             .catch(() => BbPromise.resolve());
         });


### PR DESCRIPTION
During investigation, I discovered that `NODE_ENV` set to `production` breaks the output of `npm ls --dev=true` - this PR aims to address it by zeroing `NODE_ENV` variable for that specific call. 

Closes: #9134 