### PR TITLE
hotfix(env): (#9146) revert WHATWG URL to use  url to verify usage of https-proxy-agent

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -7,6 +7,7 @@ const sdk = require('aws-sdk');
 const ServerlessError = require('../../lib/serverless-error');
 const log = require('@serverless/utils/log');
 const HttpsProxyAgent = require('https-proxy-agent');
+const url = require('url');
 const https = require('https');
 const fs = require('fs');
 const deepSortObjectByKey = require('../../lib/utils/deepSortObjectByKey');
@@ -30,7 +31,7 @@ const proxy =
 
 const proxyOptions = {};
 if (proxy) {
-  Object.assign(proxyOptions, new URL(proxy));
+  Object.assign(proxyOptions, url.parse(proxy));
 }
 
 const ca = process.env.ca || process.env.HTTPS_CA || process.env.https_ca;

--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -31,6 +31,10 @@ const proxy =
 
 const proxyOptions = {};
 if (proxy) {
+  // TODO: switch to recomended WHATWG URL
+  // Currently not possible because https-proxy-agent is not able to handle WHATWG URL object
+  // https://github.com/TooTallNate/node-https-proxy-agent/issues/117
+  // Please also keep in mind: Object.assign with WHATWG URL is not working as expectedd
   Object.assign(proxyOptions, url.parse(proxy));
 }
 

--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -31,10 +31,9 @@ const proxy =
 
 const proxyOptions = {};
 if (proxy) {
-  // TODO: switch to recomended WHATWG URL
-  // Currently not possible because https-proxy-agent is not able to handle WHATWG URL object
+  // not relying on recommended WHATWG URL
+  // due to missing support for it in https-proxy-agent
   // https://github.com/TooTallNate/node-https-proxy-agent/issues/117
-  // Please also keep in mind: Object.assign with WHATWG URL is not working as expectedd
   Object.assign(proxyOptions, url.parse(proxy));
 }
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -35,10 +35,9 @@ module.exports = {
 
     const options = {};
     if (proxy) {
-      // TODO: switch to recomended WHATWG URL
-      // Currently not possible because https-proxy-agent is not able to handle WHATWG URL object
+      // not relying on recommended WHATWG URL
+      // due to missing support for it in https-proxy-agent
       // https://github.com/TooTallNate/node-https-proxy-agent/issues/117
-      // Please also keep in mind: Object.assign with WHATWG URL is not working as expected
       options.agent = new HttpsProxyAgent(url.parse(proxy));
     }
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -35,6 +35,10 @@ module.exports = {
 
     const options = {};
     if (proxy) {
+      // TODO: switch to recomended WHATWG URL
+      // Currently not possible because https-proxy-agent is not able to handle WHATWG URL object
+      // https://github.com/TooTallNate/node-https-proxy-agent/issues/117
+      // Please also keep in mind: Object.assign with WHATWG URL is not working as expected
       options.agent = new HttpsProxyAgent(url.parse(proxy));
     }
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9146 

This is a hotfix.
Nevertheless the `url.parse` method is deprecated. 
