### PR TITLE
Improve AWS SDK errors reporting (debugging)

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -194,9 +194,15 @@ async function awsRequest(service, method, ...args) {
             providerError: Object.assign({}, err, { retryable: false }),
           });
         }
-        throw Object.assign(new ServerlessError(message, err.code), {
-          providerError: err,
-        });
+        throw Object.assign(
+          new ServerlessError(
+            process.env.SLS_DEBUG && err.stack ? `${err.stack}\n${'-'.repeat(100)}` : message,
+            err.code
+          ),
+          {
+            providerError: err,
+          }
+        );
       }
     })
   );


### PR DESCRIPTION
With `SLS_DEBUG` we're expected to see full stack traces. Still in case of AWS SDK errors, it's still not the case, which may hide useful information (as it's in case of https://github.com/serverless/serverless/issues/9146#issuecomment-802671513)

This patch improves that.
