### PR TITLE
feat(AWS API Gateway): Remove deprecation for old naming convention

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -215,6 +215,8 @@ Deprecation code: `CLOUDFRONT_CACHE_BEHAVIOR_FORWARDED_VALUES_AND_TTL`
 
 Deprecation code: `AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE`
 
+_Note_: This deprecation notice has been removed and the behavior won't be enforced with next major. Below you can find original description of the deprecation. You can still continue using `shouldStartNameWithService` property to adapt to the new convention of API Gateway name.
+
 Starting with v3.0.0, API Gateway naming will be changed from `${stage}-${service}` to `${service}-${stage}`.
 
 Adapt to this convention now by setting `provider.apiGateway.shouldStartNameWithService` to `true`.

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -240,23 +240,6 @@ class AwsCompileApigEvents {
       'initialize': () => {
         if (
           this.serverless.service.provider.name === 'aws' &&
-          !this.serverless.service.provider.apiName &&
-          !_.get(this.serverless.service.provider.apiGateway, 'shouldStartNameWithService') &&
-          !_.get(this.serverless.service.provider.apiGateway, 'restApiId') &&
-          Object.values(this.serverless.service.functions).some(({ events }) =>
-            events.some(({ http }) => http)
-          )
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE',
-            'Starting with next major version, API Gateway naming will be changed from ' +
-              '"{stage}-{service}" to "{service}-{stage}".\n' +
-              'Set "provider.apiGateway.shouldStartNameWithService" to "true" ' +
-              'to adapt to the new behavior now.'
-          );
-        }
-        if (
-          this.serverless.service.provider.name === 'aws' &&
           (this.serverless.service.provider.apiKeys ||
             this.serverless.service.provider.resourcePolicy ||
             this.serverless.service.provider.usagePlan)


### PR DESCRIPTION
As discussed, this PR removes deprecation log for not opting in with new naming convention for API Gateway. 