### PR TITLE
fix(Variables): Ensure necessary resolution interface for plugins

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -243,10 +243,10 @@ class Serverless {
     } else {
       // Some plugins resolve additional variables on their own by runnning `variables.populateObject`
       // e.g. https://github.com/serverless-operations/serverless-step-functions/blob/016da8db78f1972ba80d37941c34c8fd038fd8ca/lib/yamlParser.js#L26
-      // and that requires variableSyntax initizalization which is guaranteed by
-      // `variables.populateService` which we're skipping here,
-      // below line ensures variableSyntax remains setup.
+      // and that requires `variableSyntax` and `options` initizalization which is guaranteed by
+      // `variables.populateService`. Below lines ensure they're set
       this.variables.loadVariableSyntax();
+      this.variables.options = this.pluginManager.cliOptions;
       if (process.env.SLS_DEBUG) {
         this.cli.log(
           'Skipping variables resolution with old resolver ' +


### PR DESCRIPTION
Addresses issue reported internall, when user received an error as on below screenshot

![image (3)](https://user-images.githubusercontent.com/122434/112049963-977b0b00-8b50-11eb-940f-05e0bfa19a5d.png)

Error comes from plugin invoking a variable resolver, which is missing `this.options` due to fact that `populateService()` was not invoked as configuration was assumed to have no properties behind variables.

It also addresses on our side issue originally reported at https://github.com/serverless/serverless/issues/9099

/cc @garethmcc @astuyve 

