### PR TITLE
feat(AWS IAM): Add support for `iam.role.name` definition

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -93,6 +93,33 @@ provider:
         - { 'Fn::Join': [':', ['arn:aws:iam:', { Ref: 'AWS::AccountId' }, 'some/path']] }
 ```
 
+### Naming for the Default IAM Role
+
+By default, it uses the following naming convention:
+
+```yml
+  'Fn::Join': [
+    '-',
+    [
+      this.provider.serverless.service.service,
+      this.provider.getStage(),
+      { Ref: 'AWS::Region' },
+      'lambdaRole',
+    ],
+  ],
+```
+
+In order to override default name set `provider.iam.role.name` value:
+
+```yml
+service: new-service
+
+provider:
+  iam:
+    role:
+      name: your-custom-name-${self:provider.stage}-role
+```
+
 ## Custom IAM Roles
 
 **WARNING:** You need to take care of the overall role setup as soon as you define custom roles.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -190,6 +190,7 @@ provider:
     role: arn:aws:iam::XXXXXX:role/role
     # .. OR configure logical role
     role:
+      name: your-custom-name-role # Optional custom name for default IAM role
       managedPolicies: # Optional IAM Managed Policies, which allows to include the policies into IAM Role
         - arn:aws:iam:*****:policy/some-managed-policy
       permissionsBoundary: arn:aws:iam::XXXXXX:policy/policy # ARN of an Permissions Boundary for the role.

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -91,7 +91,7 @@ module.exports = {
     return '/';
   },
   getRoleName() {
-    const customRoleName = _.get(this.provider, 'iam.role.name');
+    const customRoleName = _.get(this.provider, 'serverless.service.provider.iam.role.name');
     return (
       customRoleName || {
         'Fn::Join': [

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -91,17 +91,20 @@ module.exports = {
     return '/';
   },
   getRoleName() {
-    return {
-      'Fn::Join': [
-        '-',
-        [
-          this.provider.serverless.service.service,
-          this.provider.getStage(),
-          { Ref: 'AWS::Region' },
-          'lambdaRole',
+    const customRoleName = _.get(this.provider, 'iam.role.name');
+    return (
+      customRoleName || {
+        'Fn::Join': [
+          '-',
+          [
+            this.provider.serverless.service.service,
+            this.provider.getStage(),
+            { Ref: 'AWS::Region' },
+            'lambdaRole',
+          ],
         ],
-      ],
-    };
+      }
+    );
   },
   getRoleLogicalId() {
     return 'IamRoleLambdaExecution';

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -828,7 +828,10 @@ class AwsProvider {
                     {
                       type: 'object',
                       properties: {
-                        name: { type: 'string' },
+                        name: {
+                          type: 'string',
+                          pattern: '^[A-Za-z0-9/_+=,.@-]{1,64}$',
+                        },
                         managedPolicies: {
                           type: 'array',
                           items: { $ref: '#/definitions/awsArn' },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -828,6 +828,7 @@ class AwsProvider {
                     {
                       type: 'object',
                       properties: {
+                        name: { type: 'string' },
                         managedPolicies: {
                           type: 'array',
                           items: { $ref: '#/definitions/awsArn' },

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -125,7 +125,7 @@ describe('#naming()', () => {
     });
     it('uses custom role name', () => {
       const customRoleName = 'custom-default-role';
-      _.set(sdk.naming.provider, 'iam.role.name', customRoleName);
+      _.set(sdk.naming.provider, 'serverless.service.provider.iam.role.name', customRoleName);
       expect(sdk.naming.getRoleName()).to.eql(customRoleName);
     });
   });

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const _ = require('lodash');
 
 const SDK = require('../../../../../../lib/plugins/aws/provider');
 const Serverless = require('../../../../../../lib/Serverless');
@@ -121,6 +122,11 @@ describe('#naming()', () => {
           ],
         ],
       });
+    });
+    it('uses custom role name', () => {
+      const customRoleName = 'custom-default-role';
+      _.set(sdk.naming.provider, 'iam.role.name', customRoleName);
+      expect(sdk.naming.getRoleName()).to.eql(customRoleName);
     });
   });
 

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -284,7 +284,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
 
       it('should support `provider.iam.role.name`', async () => {
         const customRoleName = 'custom-default-role';
-        const result = await runServerless({
+        const { cfTemplate, awsNaming } = await runServerless({
           fixture: 'function',
           cliArgs: ['package'],
           configExt: {
@@ -298,10 +298,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           },
         });
 
-        const { cfTemplate, awsNaming } = result;
         const iamRoleLambdaResource = cfTemplate.Resources[awsNaming.getRoleLogicalId()];
-        const roleName = awsNaming.getRoleName();
-        expect(roleName).to.be.eq(customRoleName);
         expect(iamRoleLambdaResource.Properties.RoleName).to.be.eq(customRoleName);
       });
 

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -282,6 +282,29 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         service = fixtureData.serviceConfig.service;
       });
 
+      it('should support `provider.iam.role.name`', async () => {
+        const customRoleName = 'custom-default-role';
+        const result = await runServerless({
+          fixture: 'function',
+          cliArgs: ['package'],
+          configExt: {
+            provider: {
+              iam: {
+                role: {
+                  name: customRoleName,
+                },
+              },
+            },
+          },
+        });
+
+        const { cfTemplate, awsNaming } = result;
+        const iamRoleLambdaResource = cfTemplate.Resources[awsNaming.getRoleLogicalId()];
+        const roleName = awsNaming.getRoleName();
+        expect(roleName).to.be.eq(customRoleName);
+        expect(iamRoleLambdaResource.Properties.RoleName).to.be.eq(customRoleName);
+      });
+
       it('should support `provider.iam.role.statements`', async () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const iamResource = cfResources[IamRoleLambdaExecution];


### PR DESCRIPTION
Inspired by https://github.com/serverless/serverless/pull/8888

Fixes #8887
Closes: #8887