### PR TITLE
Recognize command extensions from plugins and validate CLI input against result commands schema

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,6 +17,21 @@ disabledDeprecations:
   - '*' # To disable all deprecation messages
 ```
 
+<a name="UNSUPPORTED_CLI_OPTIONS"><div>&nbsp;</div></a>
+
+## Handling of unrecognized CLI options
+
+Deprecation code: `UNSUPPORTED_CLI_OPTIONS`
+
+So far Framework ignored any not recognized CLI options as passed with a CLI command. Still such handling
+is error prone, as due to e.g. accidental typos, important information may not be passed to the command and lead to unwanted results.
+
+Starting with v3.0.0, Serverless will report unrecognized options with a thrown error.
+
+_Note: If you've used such options to aid dynamic resolution of service configuration (passing custom values to `${opt:..}` resolvers)._
+_We suggest to rely on environment variables instead. Setup of environment variables is also way more
+convenient since we've added support for [`.env`](/framework/docs/environment-variables#support-for-env-files) files._
+
 <a name="CLI_OPTIONS_BEFORE_COMMAND"><div>&nbsp;</div></a>
 
 ## CLI command options should follow command

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -104,7 +104,6 @@ class PluginManager {
 
   addPlugin(Plugin, options = { isExternal: false }) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
-    // isExternal differentiates plugin as OOTB or not
     if (options.isExternal) {
       this.externalPlugins.add(pluginInstance);
     }

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -78,6 +78,8 @@ class TerminateHookChain extends Error {
   }
 }
 
+let isRegisteringExternalPlugins = false;
+
 class PluginManager {
   constructor(serverless) {
     this.serverless = serverless;
@@ -102,9 +104,9 @@ class PluginManager {
     this.cliCommands = commands;
   }
 
-  addPlugin(Plugin, options = { isExternal: false }) {
+  addPlugin(Plugin) {
     const pluginInstance = new Plugin(this.serverless, this.cliOptions);
-    if (options.isExternal) {
+    if (isRegisteringExternalPlugins) {
       this.externalPlugins.add(pluginInstance);
     }
 
@@ -129,7 +131,7 @@ class PluginManager {
       return;
     }
 
-    this.loadCommands(pluginInstance, options);
+    this.loadCommands(pluginInstance);
     this.loadHooks(pluginInstance);
     this.loadVariableResolvers(pluginInstance);
 
@@ -143,12 +145,13 @@ class PluginManager {
       .filter(Boolean)
       .forEach((Plugin) => this.addPlugin(Plugin));
 
+    isRegisteringExternalPlugins = true;
     this.resolveServicePlugins(servicePlugins)
       .filter(Boolean)
-      .forEach((Plugin) => this.addPlugin(Plugin, { isExternal: true }));
-
+      .forEach((Plugin) => this.addPlugin(Plugin));
+    isRegisteringExternalPlugins = false;
     if (EnterprisePlugin) this.addPlugin(EnterprisePlugin);
-
+    isRegisteringExternalPlugins = true;
     return this.asyncPluginInit();
   }
 
@@ -278,7 +281,7 @@ class PluginManager {
     return Object.assign({}, details, { key, pluginName, commands });
   }
 
-  loadCommands(pluginInstance, options = { isExternal: false }) {
+  loadCommands(pluginInstance) {
     const pluginName = pluginInstance.constructor.name;
     if (pluginInstance.commands) {
       Object.entries(pluginInstance.commands).forEach(([key, details]) => {
@@ -297,7 +300,7 @@ class PluginManager {
         this.commands[key] = mergeCommands(
           this.commands[key],
           _.merge({}, command, {
-            isExternal: Boolean(options.isExternal),
+            isExternal: isRegisteringExternalPlugins,
           })
         );
       });

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -492,6 +492,7 @@ class PluginManager {
           commandName,
           this.serverless.cli.loadedCommands
         );
+        // TODO: Remove with next major (functionality is replicated in main script)
         const errorMessage = [
           `Serverless command "${commandName}" not found. Did you mean "${suggestedCommand}"?`,
           ' Run "serverless help" for a list of all available commands.',

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -34,6 +34,16 @@ commands.set('deploy', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: [
+    'deprecated#cleanup->package:cleanup',
+    'deprecated#initialize->package:initialize',
+    'deprecated#setupProviderConfiguration->package:setupProviderConfiguration',
+    'deprecated#createDeploymentArtifacts->package:createDeploymentArtifacts',
+    'deprecated#compileFunctions->package:compileFunctions',
+    'deprecated#compileEvents->package:compileEvents',
+    'deploy',
+    'finalize',
+  ],
 });
 
 commands.set('deploy function', {
@@ -54,13 +64,16 @@ commands.set('deploy function', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['initialize', 'packageFunction', 'deploy'],
 });
 
 commands.set('deploy list', {
   usage: 'List deployed version of your Serverless Service',
+  lifecycleEvents: ['log'],
 });
 commands.set('deploy list functions', {
   usage: 'List all the deployed functions and their versions',
+  lifecycleEvents: ['log'],
 });
 
 commands.set('info', {
@@ -71,6 +84,7 @@ commands.set('info', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['info'],
 });
 
 commands.set('invoke', {
@@ -113,6 +127,7 @@ commands.set('invoke', {
       usage: 'Path to JSON or YAML file holding context data',
     },
   },
+  lifecycleEvents: ['invoke'],
 });
 
 commands.set('invoke local', {
@@ -152,6 +167,7 @@ commands.set('invoke local', {
       usage: 'Arguments to docker run command. e.g. --docker-arg "-p 9229:9229"',
     },
   },
+  lifecycleEvents: ['loadEnvVars', 'invoke'],
 });
 
 commands.set('logs', {
@@ -179,6 +195,7 @@ commands.set('logs', {
       shortcut: 'i',
     },
   },
+  lifecycleEvents: ['logs'],
 });
 
 commands.set('metrics', {
@@ -195,6 +212,7 @@ commands.set('metrics', {
       usage: 'End time for the metrics retrieval (e.g. 1970-01-01)',
     },
   },
+  lifecycleEvents: ['metrics'],
 });
 
 commands.set('remove', {
@@ -206,6 +224,7 @@ commands.set('remove', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['remove'],
 });
 
 commands.set('rollback', {
@@ -222,6 +241,7 @@ commands.set('rollback', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['initialize', 'rollback'],
 });
 
 commands.set('rollback function', {
@@ -237,6 +257,7 @@ commands.set('rollback function', {
       required: true,
     },
   },
+  lifecycleEvents: ['rollback'],
 });
 
 commands.set('studio', {
@@ -248,6 +269,7 @@ commands.set('studio', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['studio'],
 });
 
 commands.get('test', {
@@ -262,6 +284,7 @@ commands.get('test', {
       shortcut: 't',
     },
   },
+  lifecycleEvents: ['test'],
 });
 
 for (const schema of commands.values()) {

--- a/lib/cli/commands-schema/common-options/aws-service.js
+++ b/lib/cli/commands-schema/common-options/aws-service.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-  ...require('./service'),
   'region': {
     usage: 'Region of the service',
     shortcut: 'r',
@@ -14,4 +13,5 @@ module.exports = {
       'Dashboard provider settings (applies only to services integrated with Dashboard)',
     type: 'boolean',
   },
+  ...require('./service'),
 };

--- a/lib/cli/commands-schema/common-options/service.js
+++ b/lib/cli/commands-schema/common-options/service.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-  ...require('./global'),
   config: {
     usage: 'Path to serverless config file',
     shortcut: 'c',
@@ -10,4 +9,5 @@ module.exports = {
     usage: 'Stage of the service',
     shortcut: 's',
   },
+  ...require('./global'),
 };

--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -13,6 +13,7 @@ commands.set('', {
   options: {
     'help-interactive': { usage: 'Show this message', type: 'boolean' },
   },
+  lifecycleEvents: ['initializeService', 'setupAws', 'autoUpdate', 'tabCompletion', 'end'],
 });
 
 commands.set('config', {
@@ -23,6 +24,7 @@ commands.set('config', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['config'],
 });
 
 commands.set('config credentials', {
@@ -54,6 +56,7 @@ commands.set('config credentials', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['config'],
 });
 
 (() => {
@@ -76,11 +79,13 @@ commands.set('config credentials', {
         shortcut: 'l',
       },
     },
+    lifecycleEvents: ['install'],
   });
   commands.set('config tabcompletion uninstall', {
     usage: 'Uninstall a <tab> completion',
     isHidden,
     noSupportNotice,
+    lifecycleEvents: ['uninstall'],
   });
 })();
 
@@ -109,14 +114,17 @@ commands.set('create', {
       shortcut: 'n',
     },
   },
+  lifecycleEvents: ['create'],
 });
 
 commands.set('dashboard', {
   usage: 'Open the Serverless dashboard',
+  lifecycleEvents: ['dashboard'],
 });
 
 commands.get('generate-event', {
   usage: 'Generate event',
+  lifecycleEvents: ['generate-event'],
   options: {
     type: {
       usage:
@@ -151,14 +159,17 @@ commands.set('install', {
       shortcut: 'n',
     },
   },
+  lifecycleEvents: ['install'],
 });
 
 commands.set('login', {
   usage: 'Login or sign up for Serverless',
+  lifecycleEvents: ['login'],
 });
 
 commands.set('logout', {
   usage: 'Logout from Serverless',
+  lifecycleEvents: ['logout'],
 });
 
 commands.set('output get', {
@@ -169,6 +180,7 @@ commands.set('output get', {
     name: { usage: 'Ouptut name', required: true },
     service: { usage: 'Dashboard service' },
   },
+  lifecycleEvents: ['get'],
 });
 
 commands.set('output list', {
@@ -178,6 +190,7 @@ commands.set('output list', {
   options: {
     service: { usage: 'Dashboard service' },
   },
+  lifecycleEvents: ['list'],
 });
 
 commands.set('param get', {
@@ -187,16 +200,19 @@ commands.set('param get', {
   options: {
     name: { usage: 'Ouptut name', required: true },
   },
+  lifecycleEvents: ['get'],
 });
 
 commands.set('param list', {
   usage: 'List all dashboard deployment profile parameters',
   serviceDependencyMode: 'optional',
   hasAwsExtension: true,
+  lifecycleEvents: ['list'],
 });
 
 commands.set('plugin list', {
   usage: 'Lists all available plugins',
+  lifecycleEvents: ['list'],
 });
 
 commands.set('plugin search', {
@@ -208,6 +224,7 @@ commands.set('plugin search', {
       shortcut: 'q',
     },
   },
+  lifecycleEvents: ['search'],
 });
 
 commands.set('slstats', {
@@ -224,6 +241,7 @@ commands.set('slstats', {
       type: 'boolean',
     },
   },
+  lifecycleEvents: ['slstats'],
 });
 
 (() => {
@@ -242,11 +260,13 @@ commands.set('slstats', {
         type: 'boolean',
       },
     },
+    lifecycleEvents: ['upgrade'],
   });
   commands.set('uninstall', {
     usage: 'Uninstall Serverless',
     isHidden,
     noSupportNotice,
+    lifecycleEvents: ['uninstall'],
   });
 })();
 

--- a/lib/cli/commands-schema/resolve-final.js
+++ b/lib/cli/commands-schema/resolve-final.js
@@ -1,0 +1,103 @@
+// Resolves final schema of commands for given service configuration
+
+'use strict';
+
+const _ = require('lodash');
+
+const serviceCommands = require('./service');
+const awsServiceCommands = require('./aws-service');
+const serviceOptions = require('./common-options/service');
+const awsServiceOptions = require('./common-options/aws-service');
+
+const deprecatedEventPattern = /^deprecated#(.*?)(?:->(.*?))?$/;
+
+module.exports = (loadedPlugins, { providerName }) => {
+  const commands = new Map(providerName === 'aws' ? awsServiceCommands : serviceCommands);
+
+  if (providerName !== 'aws') {
+    // Recognize AWS provider commands adapted in context of other provider
+    // Those commands do not have to be defined as "commands" in plugin.
+    // It's good enough if hooks for command lifecycle events are setup
+    // and our detection confirms on that.
+    const optionalServiceCommandsHooksMap = new Map(
+      _.flattenDepth(
+        Array.from(awsServiceCommands)
+          .filter(([name]) => !serviceCommands.has(name))
+          .map(([name, schema]) => {
+            const lifecycleEventNamePrefix = name.split(' ').join(':');
+            return (schema.lifecycleEvents || []).map((lifecycleEventBaseName) => {
+              if (lifecycleEventBaseName.startsWith('deprecated#')) {
+                lifecycleEventBaseName = lifecycleEventBaseName.match(deprecatedEventPattern)[1];
+              }
+              const lifecycleEventName = `${lifecycleEventNamePrefix}:${lifecycleEventBaseName}`;
+              return [
+                [`before:${lifecycleEventName}`, name],
+                [lifecycleEventName, name],
+                [`after:${lifecycleEventName}`, name],
+              ];
+            });
+          }),
+        2
+      )
+    );
+
+    const awsSpecificOptionNames = new Set(
+      Object.keys(awsServiceOptions).filter((optionName) => !serviceOptions[optionName])
+    );
+
+    for (const loadedPlugin of loadedPlugins) {
+      if (!loadedPlugin.hooks) continue;
+      for (const hookName of Object.keys(loadedPlugin.hooks)) {
+        const awsCommandName = optionalServiceCommandsHooksMap.get(hookName);
+        if (awsCommandName && !commands.has(awsCommandName)) {
+          const awsCommandSchema = awsServiceCommands.get(awsCommandName);
+          const schema = {
+            ...awsCommandSchema,
+            options: { ...awsCommandSchema.options },
+          };
+          for (const awsSpecificOptionName of awsSpecificOptionNames) {
+            delete schema.options[awsSpecificOptionName];
+          }
+          commands.set(awsCommandName, schema);
+        }
+      }
+    }
+  }
+
+  const resolveCommands = (config, commandPrefix = '') => {
+    if (!config.commands) return;
+    for (const [commandName, commandConfig] of Object.entries(config.commands)) {
+      if (commandConfig.type === 'entrypoint') continue;
+      const fullCommandName = `${commandPrefix}${commandName}`;
+      if (commandConfig.type !== 'container') {
+        const schema = commands.get(fullCommandName) || {
+          usage: commandConfig.usage,
+          serviceDependencyMode: 'required',
+          isHidden: commandConfig.isHidden,
+          noSupportNotice: commandConfig.noSupportNotice,
+          options: {},
+        };
+
+        if (commandConfig.lifecycleEvents) schema.lifecycleEvents = commandConfig.lifecycleEvents;
+        if (commandConfig.options) {
+          for (const [optionName, optionConfig] of Object.entries(commandConfig.options)) {
+            if (!schema.options[optionName]) schema.options[optionName] = optionConfig;
+          }
+        }
+
+        const commonOptions = providerName === 'aws' ? awsServiceOptions : serviceOptions;
+
+        // Put common options to end of index
+        for (const optionName of Object.keys(commonOptions)) delete schema.options[optionName];
+        Object.assign(schema.options, commonOptions);
+
+        commands.set(fullCommandName, schema);
+      }
+      resolveCommands(commandConfig, `${fullCommandName} `);
+    }
+  };
+
+  for (const loadedPlugin of loadedPlugins) resolveCommands(loadedPlugin);
+
+  return commands;
+};

--- a/lib/cli/commands-schema/service.js
+++ b/lib/cli/commands-schema/service.js
@@ -15,6 +15,16 @@ commands.set('package', {
       shortcut: 'p',
     },
   },
+  lifecycleEvents: [
+    'cleanup',
+    'initialize',
+    'setupProviderConfiguration',
+    'createDeploymentArtifacts',
+    'compileLayers',
+    'compileFunctions',
+    'compileEvents',
+    'finalize',
+  ],
 });
 
 commands.set('plugin install', {
@@ -26,6 +36,7 @@ commands.set('plugin install', {
       shortcut: 'n',
     },
   },
+  lifecycleEvents: ['install'],
 });
 
 commands.set('plugin uninstall', {
@@ -37,6 +48,7 @@ commands.set('plugin uninstall', {
       shortcut: 'n',
     },
   },
+  lifecycleEvents: ['uninstall'],
 });
 
 commands.set('print', {
@@ -53,6 +65,7 @@ commands.set('print', {
       usage: 'Optional transform-function to apply to the value ("keys")',
     },
   },
+  lifecycleEvents: ['print'],
 });
 
 for (const schema of commands.values()) {

--- a/lib/cli/ensure-supported-command.js
+++ b/lib/cli/ensure-supported-command.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { distance: getDistance } = require('fastest-levenshtein');
+const resolveInput = require('./resolve-input');
+const ServerlessError = require('../serverless-error');
+const logDeprecation = require('../utils/logDeprecation');
+
+const getCommandSuggestion = (command, commandsSchema) => {
+  let suggestion;
+  let minValue = 0;
+  for (const correctCommand of commandsSchema.keys()) {
+    const distance = getDistance(command, correctCommand);
+    if (minValue === 0) {
+      suggestion = correctCommand;
+      minValue = distance;
+    }
+
+    if (minValue > distance) {
+      suggestion = correctCommand;
+      minValue = distance;
+    }
+  }
+  if (minValue >= 3) return '';
+  return ` Did you mean "${suggestion}"?`;
+};
+
+module.exports = (configuration = null) => {
+  const { command, options, isHelpRequest, commandSchema, commandsSchema } = resolveInput();
+
+  if (!commandSchema) {
+    if (isHelpRequest) return;
+    throw new ServerlessError(
+      `Serverless command "${command}" not found.` +
+        `${getCommandSuggestion(command, commandsSchema)} ` +
+        'Run "serverless help" for a list of all available commands.',
+      'UNRECOGNIZED_CLI_COMMAND'
+    );
+  }
+  const supportedOptions = new Set(Object.keys(commandSchema.options || {}));
+  const unrecognizedOptions = Object.keys(options).filter(
+    (optionName) => !supportedOptions.has(optionName)
+  );
+  if (!unrecognizedOptions.length) return;
+  logDeprecation(
+    'UNSUPPORTED_CLI_OPTIONS',
+    `Detected unrecgonized CLI options: "--${unrecognizedOptions.join('", "--')}".\n` +
+      'Starting with the next major, Serverless Framework will report them with a thrown error',
+    { serviceConfig: configuration }
+  );
+};

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -66,7 +66,7 @@ module.exports = memoizee((commandsSchema = require('./commands-schema')) => {
     commandSchema = commandsSchema.get(resolvedCommand);
   }
 
-  const result = { commands, options, command, commandSchema };
+  const result = { commands, options, command, commandSchema, commandsSchema };
 
   if (
     (!command && options['help-interactive']) ||

--- a/lib/plugins/aws/configCredentials.js
+++ b/lib/plugins/aws/configCredentials.js
@@ -18,7 +18,6 @@ class AwsConfigCredentials {
         commands: {
           credentials: {
             ...cliCommandsSchema.get('config credentials'),
-            lifecycleEvents: ['config'],
           },
         },
       },

--- a/lib/plugins/config.js
+++ b/lib/plugins/config.js
@@ -31,7 +31,6 @@ class Config {
     this.commands = {
       config: {
         ...cliCommandsSchema.get('config'),
-        lifecycleEvents: ['config'],
         commands: {
           credentials: {
             // Command defined in AWS context
@@ -46,11 +45,9 @@ class Config {
       commands: {
         install: {
           ...cliCommandsSchema.get('config tabcompletion install'),
-          lifecycleEvents: ['install'],
         },
         uninstall: {
           ...cliCommandsSchema.get('config tabcompletion uninstall'),
-          lifecycleEvents: ['uninstall'],
         },
       },
     };

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -33,7 +33,6 @@ class Create {
     this.commands = {
       create: {
         ...cliCommandsSchema.get('create'),
-        lifecycleEvents: ['create'],
       },
     };
 

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -14,28 +14,16 @@ class Deploy {
     this.commands = {
       deploy: {
         ...cliCommandsSchema.get('deploy'),
-        lifecycleEvents: [
-          'deprecated#cleanup->package:cleanup',
-          'deprecated#initialize->package:initialize',
-          'deprecated#setupProviderConfiguration->package:setupProviderConfiguration',
-          'deprecated#createDeploymentArtifacts->package:createDeploymentArtifacts',
-          'deprecated#compileFunctions->package:compileFunctions',
-          'deprecated#compileEvents->package:compileEvents',
-          'deploy',
-          'finalize',
-        ],
         commands: {
           function: {
             ...cliCommandsSchema.get('deploy function'),
-            lifecycleEvents: ['initialize', 'packageFunction', 'deploy'],
           },
           list: {
             ...cliCommandsSchema.get('deploy list'),
-            lifecycleEvents: ['log'],
+
             commands: {
               functions: {
                 ...cliCommandsSchema.get('deploy list functions'),
-                lifecycleEvents: ['log'],
               },
             },
           },

--- a/lib/plugins/info.js
+++ b/lib/plugins/info.js
@@ -9,7 +9,6 @@ class Info {
     this.commands = {
       info: {
         ...cliCommandsSchema.get('info'),
-        lifecycleEvents: ['info'],
       },
     };
   }

--- a/lib/plugins/install.js
+++ b/lib/plugins/install.js
@@ -13,7 +13,6 @@ class Install {
     this.commands = {
       install: {
         ...cliCommandsSchema.get('install'),
-        lifecycleEvents: ['install'],
       },
     };
 

--- a/lib/plugins/interactiveCli/index.js
+++ b/lib/plugins/interactiveCli/index.js
@@ -15,7 +15,6 @@ module.exports = class InteractiveCli {
       interactiveCli: {
         ...cliCommandsSchema.get(''),
         isHidden: true,
-        lifecycleEvents: ['initializeService', 'setupAws', 'autoUpdate', 'tabCompletion', 'end'],
       },
     };
 

--- a/lib/plugins/invoke.js
+++ b/lib/plugins/invoke.js
@@ -12,11 +12,9 @@ class Invoke {
     this.commands = {
       invoke: {
         ...cliCommandsSchema.get('invoke'),
-        lifecycleEvents: ['invoke'],
         commands: {
           local: {
             ...cliCommandsSchema.get('invoke local'),
-            lifecycleEvents: ['loadEnvVars', 'invoke'],
           },
         },
       },

--- a/lib/plugins/logs.js
+++ b/lib/plugins/logs.js
@@ -9,7 +9,6 @@ class Logs {
     this.commands = {
       logs: {
         ...cliCommandsSchema.get('logs'),
-        lifecycleEvents: ['logs'],
       },
     };
   }

--- a/lib/plugins/metrics.js
+++ b/lib/plugins/metrics.js
@@ -10,7 +10,6 @@ class Metrics {
     this.commands = {
       metrics: {
         ...cliCommandsSchema.get('metrics'),
-        lifecycleEvents: ['metrics'],
       },
     };
   }

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -21,16 +21,6 @@ class Package {
     this.commands = {
       package: {
         ...cliCommandsSchema.get('package'),
-        lifecycleEvents: [
-          'cleanup',
-          'initialize',
-          'setupProviderConfiguration',
-          'createDeploymentArtifacts',
-          'compileLayers',
-          'compileFunctions',
-          'compileEvents',
-          'finalize',
-        ],
         commands: {
           function: {
             type: 'entrypoint',

--- a/lib/plugins/plugin/install.js
+++ b/lib/plugins/plugin/install.js
@@ -23,7 +23,6 @@ class PluginInstall {
         commands: {
           install: {
             ...cliCommandsSchema.get('plugin install'),
-            lifecycleEvents: ['install'],
           },
         },
       },

--- a/lib/plugins/plugin/list.js
+++ b/lib/plugins/plugin/list.js
@@ -16,7 +16,6 @@ class PluginList {
         commands: {
           list: {
             ...cliCommandsSchema.get('plugin list'),
-            lifecycleEvents: ['list'],
           },
         },
       },

--- a/lib/plugins/plugin/search.js
+++ b/lib/plugins/plugin/search.js
@@ -17,7 +17,6 @@ class PluginSearch {
         commands: {
           search: {
             ...cliCommandsSchema.get('plugin search'),
-            lifecycleEvents: ['search'],
           },
         },
       },

--- a/lib/plugins/plugin/uninstall.js
+++ b/lib/plugins/plugin/uninstall.js
@@ -21,7 +21,6 @@ class PluginUninstall {
         commands: {
           uninstall: {
             ...cliCommandsSchema.get('plugin uninstall'),
-            lifecycleEvents: ['uninstall'],
           },
         },
       },

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -16,7 +16,6 @@ class Print {
     this.commands = {
       print: {
         ...cliCommandsSchema.get('print'),
-        lifecycleEvents: ['print'],
       },
     };
     this.hooks = {

--- a/lib/plugins/remove.js
+++ b/lib/plugins/remove.js
@@ -9,7 +9,6 @@ class Remove {
     this.commands = {
       remove: {
         ...cliCommandsSchema.get('remove'),
-        lifecycleEvents: ['remove'],
       },
     };
   }

--- a/lib/plugins/rollback.js
+++ b/lib/plugins/rollback.js
@@ -9,11 +9,9 @@ class Rollback {
     this.commands = {
       rollback: {
         ...cliCommandsSchema.get('rollback'),
-        lifecycleEvents: ['initialize', 'rollback'],
         commands: {
           function: {
             ...cliCommandsSchema.get('rollback function'),
-            lifecycleEvents: ['rollback'],
           },
         },
       },

--- a/lib/plugins/slstats.js
+++ b/lib/plugins/slstats.js
@@ -11,7 +11,6 @@ class SlStats {
     this.commands = {
       slstats: {
         ...cliCommandsSchema.get('slstats'),
-        lifecycleEvents: ['slstats'],
       },
     };
 

--- a/lib/plugins/standalone.js
+++ b/lib/plugins/standalone.js
@@ -26,11 +26,9 @@ module.exports = class Standalone {
     this.commands = {
       upgrade: {
         ...cliCommandsSchema.get('upgrade'),
-        lifecycleEvents: ['upgrade'],
       },
       uninstall: {
         ...cliCommandsSchema.get('uninstall'),
-        lifecycleEvents: ['uninstall'],
       },
     };
 

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -168,6 +168,7 @@ const processSpanPromise = (async () => {
           // "variablesResolutionMode" must not be configured with variables as it influences
           // variable resolution choices
           if (!ensureResolvedProperty('variablesResolutionMode')) return;
+          if (!ensureResolvedProperty('disabledDeprecations')) return;
 
           let providerName;
 
@@ -322,6 +323,14 @@ const processSpanPromise = (async () => {
           if (!variablesMeta.size) return; // All properties successuflly resolved
 
           if (!ensureResolvedProperty('plugins')) return;
+
+          if (!ensureResolvedProperty('frameworkVersion')) return;
+          if (!ensureResolvedProperty('configValidationMode')) return;
+          if (!ensureResolvedProperty('app')) return;
+          if (!ensureResolvedProperty('org')) return;
+          if (!ensureResolvedProperty('service', { shouldSilentlyReturnIfLegacyMode: true })) {
+            return;
+          }
         })();
       } else if (!commandSchema) {
         // If command was not recognized and not in service context

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -339,6 +339,7 @@ const processSpanPromise = (async () => {
         ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
           require('../lib/cli/commands-schema/aws-service')
         ));
+        require('../lib/cli/ensure-supported-command')();
       }
     }
 
@@ -374,6 +375,7 @@ const processSpanPromise = (async () => {
             ));
             serverless.processedInput.commands = serverless.pluginManager.cliCommands = commands;
             serverless.processedInput.options = serverless.pluginManager.cliOptions = options;
+            require('../lib/cli/ensure-supported-command')();
           } else {
             // Invocation fallen back to old Framework version. As we do not have easily
             // accessible info on loaded plugins, skip further variables resolution

--- a/test/unit/lib/cli/commands-schema/resolve-final.test.js
+++ b/test/unit/lib/cli/commands-schema/resolve-final.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const { expect } = require('chai');
+const resolveFinal = require('../../../../../lib/cli/commands-schema/resolve-final');
+
+describe('test/unit/lib/cli/commands-schema/resolve-final.test.js', () => {
+  describe('Non-AWS provider', () => {
+    let commands;
+    before(() => {
+      commands = resolveFinal(
+        new Set([
+          {
+            commands: {
+              deploy: {
+                commands: {
+                  list: {
+                    usage: 'List deployments',
+                    lifecycleEvents: ['list'],
+                    options: {
+                      resourceGroup: {
+                        usage: 'Resource group for the service',
+                        shortcut: 'g',
+                      },
+                    },
+                  },
+                  apim: {
+                    usage: 'Deploys APIM',
+                    lifecycleEvents: ['apim'],
+                  },
+                },
+                options: {
+                  dryrun: {
+                    usage: 'Get a summary for what the deployment would look like',
+                    shortcut: 'd',
+                  },
+                },
+              },
+            },
+            hooks: {
+              'deploy:deploy': () => {},
+              'logs:logs': () => {},
+            },
+          },
+        ]),
+        { providerName: 'foo' }
+      );
+    });
+
+    it('should expose no service commands', () =>
+      expect(commands.get('create')).to.have.property('options'));
+    it('should expose service commands', () =>
+      expect(commands.get('package')).to.have.property('options'));
+    it('should not expose not adapted AWS service commands', () =>
+      expect(commands.has('metrics')).to.be.false);
+    it('should expose adapted AWS service commands', () =>
+      expect(commands.get('logs')).to.have.property('options'));
+
+    it('should extend adapted and extended AWS service commands', () => {
+      expect(commands.get('deploy').options).to.have.property('dryrun');
+      expect(commands.get('deploy list').options).to.have.property('resourceGroup');
+    });
+
+    it('should not expose AWS specific optionson extended AWS service commands', () => {
+      expect(commands.get('deploy').options).to.not.have.property('app');
+      expect(commands.get('logs').options).to.not.have.property('app');
+    });
+
+    it('should support introduction of new commands', () => {
+      expect(commands.get('deploy apim').usage).to.equal('Deploys APIM');
+    });
+
+    it('should expose no service options on new service commands', () =>
+      expect(commands.get('deploy apim').options).to.have.property('help'));
+    it('should expose service options on new service commands', () =>
+      expect(commands.get('deploy apim').options).to.have.property('config'));
+  });
+
+  describe('AWS provider', () => {
+    let commands;
+    before(() => {
+      commands = resolveFinal(
+        new Set([
+          {
+            commands: {
+              deploy: {
+                commands: {
+                  list: {
+                    usage: 'List deployments',
+                    lifecycleEvents: ['list'],
+                    options: {
+                      resourceGroup: {
+                        usage: 'Resource group for the service',
+                        shortcut: 'g',
+                      },
+                    },
+                  },
+                  apim: {
+                    usage: 'Deploys APIM',
+                    lifecycleEvents: ['apim'],
+                  },
+                },
+                options: {
+                  dryrun: {
+                    usage: 'Get a summary for what the deployment would look like',
+                    shortcut: 'd',
+                  },
+                },
+              },
+            },
+            hooks: {
+              'deploy:deploy': () => {},
+              'logs:logs': () => {},
+            },
+          },
+        ]),
+        { providerName: 'aws' }
+      );
+    });
+
+    it('should expose no service commands', () =>
+      expect(commands.get('create')).to.have.property('options'));
+    it('should expose service commands', () =>
+      expect(commands.get('package')).to.have.property('options'));
+    it('should expose all AWS service commands', () =>
+      expect(commands.get('metrics')).to.have.property('options'));
+
+    it('should extend existing commands', () => {
+      expect(commands.get('deploy').options).to.have.property('dryrun');
+      expect(commands.get('deploy list').options).to.have.property('resourceGroup');
+    });
+
+    it('should support introduction of new commands', () => {
+      expect(commands.get('deploy apim').usage).to.equal('Deploys APIM');
+    });
+
+    it('should expose AWS specific options on newly introduced commands', () => {
+      expect(commands.get('deploy apim').options).to.have.property('app');
+    });
+
+    it('should expose no service options on new service commands', () =>
+      expect(commands.get('deploy apim').options).to.have.property('help'));
+    it('should expose service options on new service commands', () =>
+      expect(commands.get('deploy apim').options).to.have.property('config'));
+  });
+});

--- a/test/unit/lib/cli/ensure-supported-command.test.js
+++ b/test/unit/lib/cli/ensure-supported-command.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { expect } = require('chai');
+const overrideArgv = require('process-utils/override-argv');
+const ServerlessError = require('../../../../lib/serverless-error');
+const resolveInput = require('../../../../lib/cli/resolve-input');
+const { triggeredDeprecations } = require('../../../../lib/utils/logDeprecation');
+const ensureSupportedCommand = require('../../../../lib/cli/ensure-supported-command');
+
+describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
+  it('should do nothing on valid command', async () => {
+    resolveInput.clear();
+    triggeredDeprecations.clear();
+    overrideArgv(
+      {
+        args: ['serverless', 'info'],
+      },
+      () => resolveInput()
+    );
+    ensureSupportedCommand();
+    expect(triggeredDeprecations.has('UNSUPPORTED_CLI_OPTIONS')).to.be.false;
+  });
+
+  it('should reject invalid command', async () => {
+    resolveInput.clear();
+    triggeredDeprecations.clear();
+    overrideArgv(
+      {
+        args: ['serverless', 'hablo'],
+      },
+      () => resolveInput()
+    );
+    expect(() => ensureSupportedCommand())
+      .to.throw(ServerlessError)
+      .with.property('code', 'UNRECOGNIZED_CLI_COMMAND');
+  });
+
+  it('should report invalid options', async () => {
+    resolveInput.clear();
+    triggeredDeprecations.clear();
+    overrideArgv(
+      {
+        args: ['serverless', 'info', '--hadsfa'],
+      },
+      () => resolveInput()
+    );
+    ensureSupportedCommand();
+    expect(triggeredDeprecations.has('UNSUPPORTED_CLI_OPTIONS')).to.be.true;
+  });
+});

--- a/test/unit/lib/cli/resolve-input.test.js
+++ b/test/unit/lib/cli/resolve-input.test.js
@@ -81,6 +81,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
           command: 'deploy function',
           commands: ['deploy', 'function'],
           options: { force: true, function: 'foo' },
+          commandsSchema,
         });
       });
     });
@@ -161,6 +162,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         commands: [],
         options: { version: true },
         isHelpRequest: true,
+        commandsSchema,
       });
     });
 
@@ -177,6 +179,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         command: '',
         commands: [],
         options: { app: 'foo' },
+        commandsSchema,
       });
     });
   });
@@ -195,6 +198,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         command: 'package',
         commands: ['package'],
         options: {},
+        commandsSchema,
       });
     });
 
@@ -212,6 +216,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         commands: [],
         options: { help: true },
         isHelpRequest: true,
+        commandsSchema,
       });
     });
 
@@ -229,6 +234,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         commands: ['package'],
         options: { help: true },
         isHelpRequest: true,
+        commandsSchema,
       });
     });
 
@@ -246,6 +252,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         commands: [],
         options: { 'help-interactive': true },
         isHelpRequest: true,
+        commandsSchema,
       });
     });
 
@@ -263,6 +270,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         commands: ['help'],
         options: {},
         isHelpRequest: true,
+        commandsSchema,
       });
     });
   });
@@ -285,6 +293,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         command: 'invoke local',
         commands: ['invoke', 'local'],
         options: { env: ['foo=bar', 'bar=baz'] },
+        commandsSchema,
       });
     });
   });


### PR DESCRIPTION
Finalizes 4.0.0 & 5.1.0 from https://github.com/serverless/serverless/issues/8364

- Parse commands and options as provided via external plugins. For that, needed to move `lifecycleEvents` configuration to config schema, as it's crucial in detecting which AWS provider commands were adapted in context of other provider (note in such cases other provider doesn't have to configure _command_ explicitly, it's enough that it attaches some function to pre-configured command lifecycle events)
- Finalize resolution of `opt` variable source (after having all commands schema resolved, last resolution phase was configured to resolve any final properties behind `opt` sources)
- Having all commands data, validate unrecognized command in context of main script. Additionally validate unrecognized options, signalling that with next major such usage will throw
- Maintenance improvements to main process file
