### PR TITLE
feat(AWS Lambda): Do not require all image properties

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -241,7 +241,7 @@ functions:
     image: baseimage
 ```
 
-It is also possible to provide additional image configuration via `workingDirectory`, `entryPoint` and `command` properties of to `functions[].image`. The `workingDirectory` accepts path in form of string, where both `entryPoint` and `command` needs to be defined as a list of strings, following "exec form" format. In order to provide additional image config properties, `functions[].image` has to be defined as an object, and needs to define either `uri` pointing to an existing AWS ECR image or `name` property, which references image already defined in `provider.ecr.images`. Due to current limitation of AWS CloudFormation, whenever one of the additional image configuration properties is defined, both `command` and `entryPoint` have to be defined. If you're using one of official AWS base images, the `entryPoint` will be equal to `/lambda-entrypoint.sh`.
+It is also possible to provide additional image configuration via `workingDirectory`, `entryPoint` and `command` properties of to `functions[].image`. The `workingDirectory` accepts path in form of string, where both `entryPoint` and `command` needs to be defined as a list of strings, following "exec form" format. In order to provide additional image config properties, `functions[].image` has to be defined as an object, and needs to define either `uri` pointing to an existing AWS ECR image or `name` property, which references image already defined in `provider.ecr.images`.
 
 Example configuration:
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1117,11 +1117,6 @@ class AwsProvider {
                       },
                     },
                   },
-                  dependencies: {
-                    command: ['entryPoint'],
-                    entryPoint: ['command'],
-                    workingDirectory: ['entryPoint', 'command'],
-                  },
                   additionalProperties: false,
                 },
               ],


### PR DESCRIPTION
It looks like AWS fixed the previously quirky behavior of requiring all properties of `ImageConfig` - we no longer need that validation on Framework side. 

Closes: #9173 