### PR TITLE
chore: Update code comment about file stat chmod

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -90,7 +90,7 @@ module.exports = {
               .forEach((file) => {
                 const name = file.filePath.slice(prefix ? `${prefix}${path.sep}`.length : 0);
                 // Ensure file is executable if it is locally executable or
-                // it's forced (via normalizedFilesToChmodPlusX) to be executable
+                // we force it to be executable if platform is windows
                 const mode = file.stat.mode & 0o100 || process.platform === 'win32' ? 0o755 : 0o644;
                 zip.append(file.data, {
                   name,


### PR DESCRIPTION
It seems that `normalizedFilesToChmodPlusX` was removed and does not exist anymore so removing it from the comment seemed appropriate
