### PR TITLE
feat(AWS HTTP API): Add support for custom Lambda authorizers

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -176,13 +176,26 @@ provider:
     payload: '2.0' # Specify payload format version for Lambda integration ('1.0' or '2.0'), default is '2.0'
     cors: true # Implies default behavior, can be fine tuned with specific options
     authorizers:
-      # JWT authorizers to back HTTP API endpoints
+      # JWT authorizer to back HTTP API endpoints
       someJwtAuthorizer:
         identitySource: $request.header.Authorization
         issuerUrl: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxxxx
         audience:
           - xxxx
           - xxxx
+      # Custom Lambda request authorizer to back HTTP API endpoints
+      someCustomLambdaAuthorizer:
+        type: request # Should be set to `request` for custom Lambda authorizers.
+        functionName: authorizerFunc # Mutually exclusive with `functionArn`
+        functionArn: arn:aws:lambda:us-east-1:11111111111:function:external-authorizer # Mutually exclusive with `functionName`
+        name: customAuthorizerName # Optional. Custom name for created authorizer
+        resultTtlInSeconds: 300 # Optional. Time to live for cached authorizer results, accepts values from 0 (no caching) to 3600 (1 hour). When set to non-zero value, `identitySource` must be defined as well.
+        enableSimpleResponses: true # Optional. Flag that specifies if authorizer function will return authorization responses in simple format. Defaults to `false`.
+        payloadVersion: '2.0' # Optional. Version of payload that will be sent to authorizer function. Defaults to `'2.0'`.
+        identitySource: # Optional. One or more mapping expressions of the request parameters in form of e.g `$request.header.Auth`. Specified values are verified to be non-empty and not null by authorizer. It is a required property when `resultTtlInSeconds` is non-zero as `identitySource` is additionally used as cache key for authorizer responses caching.
+          - $request.header.Auth
+          - $request.header.Authorization
+        managedExternally: true # Optional. Applicable only when using externally defined authorizer functions to prevent creation of permission resource
   stackTags: # Optional CF stack tags
     key: value
   iam:

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -493,6 +493,9 @@ module.exports = {
   getLambdaHttpApiPermissionLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionHttpApi`;
   },
+  getLambdaAuthorizerHttpApiPermissionLogicalId(authorizerName) {
+    return `${this.getNormalizedResourceName(authorizerName)}LambdaAuthorizerPermissionHttpApi`;
+  },
   getLambdaAlexaSkillPermissionLogicalId(functionName, alexaSkillIndex) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionAlexaSkill${
       alexaSkillIndex || '0'

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -6,6 +6,7 @@ const memoizee = require('memoizee');
 const memoizeeMethods = require('memoizee/methods');
 const ServerlessError = require('../../../../../serverless-error');
 const { logWarning } = require('../../../../../classes/Error');
+const resolveLambdaTarget = require('../../../utils/resolveLambdaTarget');
 
 const allowedMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'HEAD', 'DELETE']);
 const methodPattern = new RegExp(`^(?:\\*|${Array.from(allowedMethods).join('|')})$`, 'i');
@@ -88,6 +89,7 @@ class HttpApiEvents {
                     },
                     name: { type: 'string' },
                     scopes: { type: 'array', items: { type: 'string' } },
+                    type: { type: 'string', enum: ['request', 'jwt'] },
                   },
                   oneOf: [{ required: ['id'] }, { required: ['name'] }],
                   additionalProperties: false,
@@ -200,23 +202,96 @@ class HttpApiEvents {
   }
   compileAuthorizers() {
     for (const authorizer of this.config.authorizers.values()) {
-      this.cfTemplate.Resources[
-        this.provider.naming.getHttpApiAuthorizerLogicalId(authorizer.name)
-      ] = {
+      const authorizerLogicalId = this.provider.naming.getHttpApiAuthorizerLogicalId(
+        authorizer.name
+      );
+
+      const authorizerResource = {
         Type: 'AWS::ApiGatewayV2::Authorizer',
         Properties: {
           ApiId: this.getApiIdConfig(),
-          AuthorizerType: 'JWT',
-          IdentitySource: [authorizer.identitySource],
-          JwtConfiguration: {
-            Audience: Array.from(authorizer.audience),
-            Issuer: authorizer.issuerUrl,
-          },
           Name: authorizer.name,
+          IdentitySource: authorizer.identitySource,
         },
       };
+
+      if (authorizer.type === 'request') {
+        // Compile custom (request) authorizer
+        authorizerResource.Properties.AuthorizerType = 'REQUEST';
+        authorizerResource.Properties.EnableSimpleResponses = authorizer.enableSimpleResponses;
+        authorizerResource.Properties.AuthorizerResultTtlInSeconds = authorizer.resultTtlInSeconds;
+        authorizerResource.Properties.AuthorizerPayloadFormatVersion = authorizer.payloadVersion;
+        authorizerResource.Properties.AuthorizerUri = {
+          'Fn::Join': [
+            '',
+            [
+              'arn:',
+              { Ref: 'AWS::Partition' },
+              ':apigateway:',
+              { Ref: 'AWS::Region' },
+              ':lambda:path/2015-03-31/functions/',
+              authorizer.functionArn ||
+                resolveLambdaTarget(authorizer.functionName, authorizer.functionObject),
+              '/invocations',
+            ],
+          ],
+        };
+
+        // If authorizer is not managed externally, we need to make sure the correct permission is created that
+        // allows API Gateway to invoke authorizer function
+        if (!authorizer.managedExternally) {
+          this.compileAuthorizerLambdaPermission(authorizer);
+        }
+      } else {
+        // Compile JWT Authorizer
+        authorizerResource.Properties.AuthorizerType = 'JWT';
+        authorizerResource.Properties.JwtConfiguration = {
+          Audience: Array.from(authorizer.audience),
+          Issuer: authorizer.issuerUrl,
+        };
+      }
+
+      this.cfTemplate.Resources[authorizerLogicalId] = authorizerResource;
     }
   }
+
+  compileAuthorizerLambdaPermission({ functionName, functionArn, name, functionObject }) {
+    const authorizerPermissionLogicalId = this.provider.naming.getLambdaAuthorizerHttpApiPermissionLogicalId(
+      name
+    );
+    const permissionResource = {
+      Type: 'AWS::Lambda::Permission',
+      Properties: {
+        FunctionName: functionArn || resolveLambdaTarget(functionName, functionObject),
+        Action: 'lambda:InvokeFunction',
+        Principal: 'apigateway.amazonaws.com',
+        SourceArn: {
+          'Fn::Join': [
+            '',
+            [
+              'arn:',
+              { Ref: 'AWS::Partition' },
+              ':execute-api:',
+              { Ref: 'AWS::Region' },
+              ':',
+              { Ref: 'AWS::AccountId' },
+              ':',
+              this.getApiIdConfig(),
+              '/*',
+            ],
+          ],
+        },
+      },
+    };
+
+    if (functionObject && functionObject.targetAlias) {
+      permissionResource.Properties.DependsOn = this.provider.naming.getLambdaLogicalId(
+        functionName
+      );
+    }
+    this.cfTemplate.Resources[authorizerPermissionLogicalId] = permissionResource;
+  }
+
   compileEndpoints() {
     for (const [routeKey, { targetData, authorizer, authorizationScopes }] of this.config.routes) {
       this.compileLambdaPermissions(targetData);
@@ -243,9 +318,9 @@ class HttpApiEvents {
         DependsOn: this.provider.naming.getHttpApiIntegrationLogicalId(targetData.functionName),
       });
       if (authorizer) {
-        const { id } = authorizer;
+        const { id, type } = authorizer;
         Object.assign(resource.Properties, {
-          AuthorizationType: 'JWT',
+          AuthorizationType: type === 'request' ? 'CUSTOM' : 'JWT',
           AuthorizerId: id || {
             Ref: this.provider.naming.getHttpApiAuthorizerLogicalId(authorizer.name),
           },
@@ -311,11 +386,57 @@ Object.defineProperties(
           );
         }
         for (const [name, authorizerConfig] of Object.entries(userAuthorizers)) {
+          let authorizerFunctionObject;
+
+          if (authorizerConfig.type === 'request') {
+            if (!authorizerConfig.functionArn && !authorizerConfig.functionName) {
+              throw new ServerlessError(
+                `Either "functionArn" or "functionName" property needs to be set on authorizer "${name}"`,
+                'HTTP_API_CUSTOM_AUTHORIZER_NEITHER_FUNCTION_ARN_NOR_FUNCTION_NAME_DEFINED'
+              );
+            }
+
+            if (authorizerConfig.functionArn && authorizerConfig.functionName) {
+              throw new ServerlessError(
+                `Either "functionArn" or "functionName" (not both) property needs to be set on authorizer "${name}"`,
+                'HTTP_API_CUSTOM_AUTHORIZER_BOTH_FUNCTION_ARN_AND_FUNCTION_NAME_DEFINED'
+              );
+            }
+
+            if (authorizerConfig.functionName) {
+              try {
+                authorizerFunctionObject = this.serverless.service.getFunction(
+                  authorizerConfig.functionName
+                );
+              } catch {
+                throw new ServerlessError(
+                  `Function "${authorizerConfig.functionName}" for HTTP API authorizer "${name}" not found in service.`,
+                  'HTTP_API_CUSTOM_AUTHORIZER_FUNCTION_NOT_FOUND_IN_SERVICE'
+                );
+              }
+            }
+
+            if (authorizerConfig.resultTtlInSeconds && !authorizerConfig.identitySource) {
+              throw new ServerlessError(
+                `Property "identitySource" has to be set on authorizer "${name}" when "resultTtlInSeconds" is set to non-zero value.`,
+                'HTTP_API_CUSTOM_AUTHORIZER_IDENTITY_SOURCE_MISSING_WHEN_CACHING_ENABLED'
+              );
+            }
+          }
+
           authorizers.set(name, {
             name: authorizerConfig.name || name,
-            identitySource: authorizerConfig.identitySource,
+            identitySource: authorizerConfig.identitySource || [],
             issuerUrl: authorizerConfig.issuerUrl,
             audience: toSet(authorizerConfig.audience),
+            type: authorizerConfig.type,
+            functionName: authorizerConfig.functionName,
+            functionArn: authorizerConfig.functionArn,
+            managedExternally: authorizerConfig.managedExternally,
+            resultTtlInSeconds: authorizerConfig.resultTtlInSeconds,
+            enableSimpleResponses: authorizerConfig.enableSimpleResponses,
+            payloadVersion: authorizerConfig.payloadVersion || '2.0',
+            functionObject: authorizerFunctionObject,
           });
         }
       }
@@ -426,7 +547,7 @@ Object.defineProperties(
           }
           const routeConfig = { targetData: routeTargetData };
           if (authorizer) {
-            const { name, scopes, id } = (() => {
+            const { name, scopes, id, type } = (() => {
               if (_.isObject(authorizer)) return authorizer;
               return { name: authorizer };
             })();
@@ -437,7 +558,7 @@ Object.defineProperties(
                   'EXTERNAL_HTTP_API_AUTHORIZER_WITHOUT_EXTERNAL_HTTP_API'
                 );
               }
-              routeConfig.authorizer = { id };
+              routeConfig.authorizer = { id, type };
             } else if (!authorizers.has(name)) {
               throw new ServerlessError(
                 `Event references not configured authorizer '${name}'`,

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -769,23 +769,51 @@ class AwsProvider {
                 authorizers: {
                   type: 'object',
                   additionalProperties: {
-                    type: 'object',
-                    properties: {
-                      name: { type: 'string' },
-                      identitySource: { $ref: '#/definitions/awsCfInstruction' },
-                      issuerUrl: { $ref: '#/definitions/awsCfInstruction' },
-                      audience: {
-                        anyOf: [
-                          { $ref: '#/definitions/awsCfInstruction' },
-                          {
+                    oneOf: [
+                      {
+                        type: 'object',
+                        properties: {
+                          type: { const: 'jwt' },
+                          name: { type: 'string' },
+                          identitySource: {
+                            type: 'array',
+                            minItems: 1,
+                            maxItems: 1,
+                            items: { $ref: '#/definitions/awsCfInstruction' },
+                          },
+                          issuerUrl: { $ref: '#/definitions/awsCfInstruction' },
+                          audience: {
+                            anyOf: [
+                              { $ref: '#/definitions/awsCfInstruction' },
+                              {
+                                type: 'array',
+                                items: { $ref: '#/definitions/awsCfInstruction' },
+                              },
+                            ],
+                          },
+                        },
+                        required: ['identitySource', 'issuerUrl', 'audience'],
+                        additionalProperties: false,
+                      },
+                      {
+                        type: 'object',
+                        properties: {
+                          type: { const: 'request' },
+                          name: { type: 'string' },
+                          functionName: { type: 'string' },
+                          functionArn: { $ref: '#/definitions/awsCfInstruction' },
+                          managedExternally: { type: 'boolean' },
+                          resultTtlInSeconds: { type: 'integer', minimum: 0, maximum: 3600 },
+                          enableSimpleResponses: { type: 'boolean' },
+                          payloadVersion: { type: 'string', enum: ['1.0', '2.0'] },
+                          identitySource: {
                             type: 'array',
                             items: { $ref: '#/definitions/awsCfInstruction' },
                           },
-                        ],
+                        },
+                        required: ['type'],
                       },
-                    },
-                    required: ['identitySource', 'issuerUrl', 'audience'],
-                    additionalProperties: false,
+                    ],
                   },
                 },
                 cors: {

--- a/lib/utils/analytics/generatePayload.js
+++ b/lib/utils/analytics/generatePayload.js
@@ -98,12 +98,15 @@ module.exports = async (serverless) => {
         region: isAwsProvider ? provider.getRegion() : providerConfig.region,
       },
       plugins: serviceConfig.plugins ? serviceConfig.plugins.modules || serviceConfig.plugins : [],
-      functions: Object.values(serviceConfig.functions).map((functionConfig) => ({
-        runtime: functionConfig.runtime || defaultRuntime,
-        events: functionConfig.events.map((eventConfig) => ({
-          type: Object.keys(eventConfig)[0] || null,
-        })),
-      })),
+      functions: Object.values(serviceConfig.functions).map((functionConfig) => {
+        const functionEvents = functionConfig.events || [];
+        return {
+          runtime: functionConfig.runtime || defaultRuntime,
+          events: functionEvents.map((eventConfig) => ({
+            type: Object.keys(eventConfig)[0] || null,
+          })),
+        };
+      }),
     },
     dashboard: {
       userId,

--- a/test/fixtures/httpApi/authorizers.js
+++ b/test/fixtures/httpApi/authorizers.js
@@ -1,0 +1,41 @@
+'use strict';
+
+module.exports.simpleAuthorizer = async (event) => {
+  if (event.headers.authorization === 'secretToken') {
+    return { isAuthorized: true };
+  }
+
+  return { isAuthorized: false };
+};
+
+module.exports.standardAuthorizer = async (event) => {
+  if (event.headers.authorization === 'secretToken') {
+    return {
+      principalId: 'userId',
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Action: 'execute-api:Invoke',
+            Effect: 'Allow',
+            Resource: event.routeArn,
+          },
+        ],
+      },
+    };
+  }
+
+  return {
+    principalId: 'userId',
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: 'Deny',
+          Resource: event.routeArn,
+        },
+      ],
+    },
+  };
+};

--- a/test/fixtures/httpApi/serverless.yml
+++ b/test/fixtures/httpApi/serverless.yml
@@ -26,3 +26,9 @@ functions:
       - httpApi:
           method: get
           path: /bar/{marko}
+
+  simpleCustomAuthorizer:
+    handler: authorizers.simpleAuthorizer
+
+  standardCustomAuthorizer:
+    handler: authorizers.standardAuthorizer

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -1010,4 +1010,12 @@ describe('#naming()', () => {
       );
     });
   });
+
+  describe('#getLambdaAuthorizerHttpApiPermissionLogicalId()', () => {
+    it('should normalize the name and append correct suffix', () => {
+      expect(sdk.naming.getLambdaAuthorizerHttpApiPermissionLogicalId('authorizerName')).to.equal(
+        'AuthorizerNameLambdaAuthorizerPermissionHttpApi'
+      );
+    });
+  });
 });

--- a/test/unit/lib/utils/analytics/generatePayload.test.js
+++ b/test/unit/lib/utils/analytics/generatePayload.test.js
@@ -65,6 +65,8 @@ describe('lib/utils/analytics/generatePayload', () => {
         functions: [
           { runtime: 'nodejs12.x', events: [{ type: 'httpApi' }, { type: 'httpApi' }] },
           { runtime: 'nodejs12.x', events: [{ type: 'httpApi' }] },
+          { runtime: 'nodejs12.x', events: [] },
+          { runtime: 'nodejs12.x', events: [] },
         ],
       },
       isAutoUpdateEnabled: false,


### PR DESCRIPTION
Adds support for custom Lambda authorizers for HTTP API. There is a slight change to original proposal, instead of `name` and `arn` I used `functionName` and `functionArn` because `name` was already reserved for overriding authorizer name. 

Additionally it includes a small fix to `generatePayload` to a bug that was exposed after adding authorizer functions to `httpApi` fixture. 

Addresses: #8210