### PR TITLE
feat(AWS HTTP API): Add support for AWS IAM authorization

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -240,6 +240,29 @@ provider:
         managedExternally: true # Applicable only when using externally defined authorizer functions to prevent creation of permission resource
 ```
 
+### AWS IAM Authorization
+
+It is also possible to secure your HTTP API endpoints by taking advantage of AWS IAM Policies.
+
+_For deep details on that follow [AWS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html)_
+
+In order to do that, you need to set `authorizer` with `type: aws_iam` on `httpApi` event, as seen on the example below:
+
+```yaml
+provider:
+  name: aws
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - httpApi:
+          method: get
+          path: /hello
+          authorizer:
+            type: aws_iam
+```
+
 ### Access logs
 
 Deployed stage can have access logging enabled, for that just turn on logs for HTTP API in provider settings as follows:

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -89,9 +89,9 @@ class HttpApiEvents {
                     },
                     name: { type: 'string' },
                     scopes: { type: 'array', items: { type: 'string' } },
-                    type: { type: 'string', enum: ['request', 'jwt'] },
+                    type: { type: 'string', enum: ['request', 'jwt', 'aws_iam'] },
                   },
-                  oneOf: [{ required: ['id'] }, { required: ['name'] }],
+                  anyOf: [{ required: ['id'] }, { required: ['name'] }, { required: ['type'] }],
                   additionalProperties: false,
                 },
               ],
@@ -319,13 +319,29 @@ class HttpApiEvents {
       });
       if (authorizer) {
         const { id, type } = authorizer;
-        Object.assign(resource.Properties, {
-          AuthorizationType: type === 'request' ? 'CUSTOM' : 'JWT',
-          AuthorizerId: id || {
-            Ref: this.provider.naming.getHttpApiAuthorizerLogicalId(authorizer.name),
-          },
-          AuthorizationScopes: authorizationScopes && Array.from(authorizationScopes),
-        });
+
+        const authorizationType = (() => {
+          if (type === 'request') {
+            return 'CUSTOM';
+          }
+
+          if (type === 'aws_iam') {
+            return 'AWS_IAM';
+          }
+
+          return 'JWT';
+        })();
+
+        resource.Properties.AuthorizationType = authorizationType;
+
+        if (type !== 'aws_iam') {
+          Object.assign(resource.Properties, {
+            AuthorizerId: id || {
+              Ref: this.provider.naming.getHttpApiAuthorizerLogicalId(authorizer.name),
+            },
+            AuthorizationScopes: authorizationScopes && Array.from(authorizationScopes),
+          });
+        }
       }
     }
   }
@@ -551,6 +567,23 @@ Object.defineProperties(
               if (_.isObject(authorizer)) return authorizer;
               return { name: authorizer };
             })();
+
+            if (type !== 'aws_iam' && !id && !name) {
+              throw new ServerlessError(
+                `When configuring an authorizer with type: "${
+                  type || 'jwt'
+                }", property "id" or "name" has to be specified.`,
+                'HTTP_API_AUTHORIZER_MISSING_ID_OR_NAME'
+              );
+            }
+
+            if (type === 'aws_iam' && (name || id || scopes)) {
+              throw new ServerlessError(
+                'When configuring authorizer with type: "aws_iam", all other properties are not supported.',
+                'HTTP_API_AUTHORIZER_AWS_IAM_UNEXPECTED_PROPERTIES'
+              );
+            }
+
             if (id) {
               if (!userConfig.id) {
                 throw new ServerlessError(
@@ -559,6 +592,8 @@ Object.defineProperties(
                 );
               }
               routeConfig.authorizer = { id, type };
+            } else if (type === 'aws_iam') {
+              routeConfig.authorizer = authorizer;
             } else if (!authorizers.has(name)) {
               throw new ServerlessError(
                 `Event references not configured authorizer '${name}'`,


### PR DESCRIPTION
Add support for `AWS_IAM` authorization for `httpApi`

Closes: #8210