### PR TITLE
test: Separate external API integration tests for API Gateway

### DIFF
--- a/test/fixtures/apiGateway/index.js
+++ b/test/fixtures/apiGateway/index.js
@@ -13,3 +13,13 @@ module.exports.handler = (event, context, callback) => {
   if (event.path === '/bar/timeout') setTimeout(resolve, 2000);
   else resolve();
 };
+
+module.exports.minimal = async (event) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Hello from API Gateway! - (minimal)',
+      event,
+    }),
+  };
+};

--- a/test/fixtures/apiGateway/serverless.yml
+++ b/test/fixtures/apiGateway/serverless.yml
@@ -10,6 +10,13 @@ provider:
     shouldStartNameWithService: true
 
 functions:
+  minimal:
+    handler: index.minimal
+    events:
+      - http: GET /
+      - http:
+          method: POST
+          path: minimal-1
   foo:
     handler: index.handler
     events:

--- a/test/integration/apiGatewayExternal.test.js
+++ b/test/integration/apiGatewayExternal.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { expect } = require('chai');
+const log = require('log').get('serverless:test');
+const awsRequest = require('@serverless/test/aws-request');
+const fixtures = require('../fixtures');
+
+const { deployService, removeService, fetch } = require('../utils/integration');
+const { createRestApi, deleteRestApi, getResources } = require('../utils/apiGateway');
+
+describe('AWS - API Gateway with External REST API Integration Test', function () {
+  this.timeout(1000 * 60 * 10); // Involves time-taking deploys
+  let endpoint;
+  let updateConfig;
+  let stackName;
+  let servicePath;
+  let isDeployed = false;
+  let restApiId;
+  const stage = 'dev';
+
+  const resolveEndpoint = async () => {
+    const result = await awsRequest('CloudFormation', 'describeStacks', { StackName: stackName });
+    const endpointOutput = result.Stacks[0].Outputs.find(
+      (output) => output.OutputKey === 'ServiceEndpoint'
+    ).OutputValue;
+    endpoint = endpointOutput.match(/https:\/\/.+\.execute-api\..+\.amazonaws\.com.+/)[0];
+  };
+
+  before(async () => {
+    const serviceData = await fixtures.setup('apiGateway');
+    ({ servicePath, updateConfig } = serviceData);
+    const serviceName = serviceData.serviceConfig.service;
+    const externalRestApiName = `${stage}-${serviceName}-ext-api`;
+    const restApiMeta = await createRestApi(externalRestApiName);
+    restApiId = restApiMeta.id;
+    const resources = await getResources(restApiId);
+    const restApiRootResourceId = resources[0].id;
+    log.notice(
+      'Created external rest API ' +
+        `(id: ${restApiId}, root resource id: ${restApiRootResourceId})`
+    );
+    await updateConfig({
+      provider: {
+        apiGateway: {
+          restApiId,
+          restApiRootResourceId,
+        },
+      },
+    });
+    stackName = `${serviceName}-${stage}`;
+    await deployService(servicePath);
+    isDeployed = true;
+    return resolveEndpoint();
+  });
+
+  after(async () => {
+    if (!isDeployed) return;
+    log.notice('Removing service...');
+    await removeService(servicePath);
+    log.notice('Deleting external rest API...');
+    await deleteRestApi(restApiId);
+  });
+
+  it('should expose an accessible GET HTTP endpoint', () => {
+    return fetch(endpoint, { method: 'GET' })
+      .then((response) => response.json())
+      .then((json) => expect(json.message).to.equal('Hello from API Gateway! - (minimal)'));
+  });
+
+  it('should expose an accessible POST HTTP endpoint', () => {
+    const testEndpoint = `${endpoint}/minimal-1`;
+
+    return fetch(testEndpoint, { method: 'POST' })
+      .then((response) => response.json())
+      .then((json) => expect(json.message).to.equal('Hello from API Gateway! - (minimal)'));
+  });
+});


### PR DESCRIPTION
Separate external API integration tests and run them as a clean stack instead of using `update` due to bug on AWS side that causes tests to timeout. I've decided to move them to separate module to run them in parallel with the original ones. 