### PR TITLE
Convert the synchronous reading of the stream into memory into an async read stream to calculate the hash of the file.

### DIFF
--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const BbPromise = require('bluebird');
 const filesize = require('filesize');
 const normalizeFiles = require('../../lib/normalizeFiles');
+const getHashForFilePath = require('../../package/lib/getHashForFilePath');
 const getLambdaLayerArtifactPath = require('../../utils/getLambdaLayerArtifactPath');
 
 const MAX_CONCURRENT_ARTIFACTS_UPLOADS =
@@ -53,9 +54,7 @@ module.exports = {
   async uploadZipFile(artifactFilePath) {
     const fileName = artifactFilePath.split(path.sep).pop();
 
-    // TODO refactor to be async (use util function to compute checksum async)
-    const data = fs.readFileSync(artifactFilePath);
-    const fileHash = crypto.createHash('sha256').update(data).digest('base64');
+    const fileHash = await getHashForFilePath(artifactFilePath);
 
     const artifactStream = fs.createReadStream(artifactFilePath);
     // As AWS SDK request might be postponed (requests are queued)


### PR DESCRIPTION
Before we would fully load the entire contents of the file into memory in order to hash it. This change converts that into a stream and incrementally updates the hash. It should save a lot of memory and allow for very large artifacts to be hashed and uploaded to S3.